### PR TITLE
refactor(types): eliminate all explicit `any` types (45 → 0)

### DIFF
--- a/app/src/components/ChapterSkeleton.tsx
+++ b/app/src/components/ChapterSkeleton.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, type ViewStyle, type DimensionValue } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -17,15 +17,15 @@ import Animated, {
 import { base, spacing, radii } from '../theme';
 
 function Bone({ width, height = 14, style }: {
-  width: number | string;
+  width: DimensionValue;
   height?: number;
-  style?: any;
+  style?: ViewStyle;
 }) {
   return (
     <View
       style={[
         {
-          width: width as any,
+          width,
           height,
           backgroundColor: base.bgSurface,
           borderRadius: radii.sm,

--- a/app/src/components/ScholarInfoSheet.tsx
+++ b/app/src/components/ScholarInfoSheet.tsx
@@ -8,7 +8,7 @@ import { View, Text, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { getScholar } from '../db/content';
 import { getScholarColor, base, spacing, radii, fontFamily } from '../theme';
-import type { Scholar } from '../types';
+import type { Scholar, ScholarBio } from '../types';
 import { logger } from '../utils/logger';
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 
 export function ScholarInfoSheet({ visible, onClose, scholarId, onGoToFullBio }: Props) {
   const [scholar, setScholar] = useState<Scholar | null>(null);
-  const [bio, setBio] = useState<any>(null);
+  const [bio, setBio] = useState<ScholarBio | null>(null);
 
   useEffect(() => {
     if (!scholarId || !visible) return;

--- a/app/src/components/SectionBlock.tsx
+++ b/app/src/components/SectionBlock.tsx
@@ -11,7 +11,7 @@ import { View, StyleSheet } from 'react-native';
 import { SectionHeader } from './SectionHeader';
 import { VerseBlock } from './VerseBlock';
 import { base, spacing } from '../theme';
-import type { Section, SectionPanel, Verse, VHLGroup } from '../types';
+import type { Section, SectionPanel, Verse, VHLGroup, ParsedRef } from '../types';
 
 interface Props {
   section: Section;
@@ -24,7 +24,7 @@ interface Props {
   fontSize?: number;
   onPanelToggle: (sectionId: string, panelType: string) => void;
   onNotePress?: (verseNum: number) => void;
-  onRefPress?: (ref: any) => void;
+  onRefPress?: (ref: ParsedRef) => void;
   /** Render prop for button row — injected by parent to avoid circular deps */
   renderButtonRow?: (panels: SectionPanel[], sectionId: string) => React.ReactNode;
   /** Render prop for active panel content */

--- a/app/src/components/ThreadViewerSheet.tsx
+++ b/app/src/components/ThreadViewerSheet.tsx
@@ -11,6 +11,12 @@ import { getCrossRefThread } from '../db/content';
 import { BadgeChip } from './BadgeChip';
 import { base, spacing, radii, fontFamily } from '../theme';
 import type { CrossRefThread } from '../types';
+
+interface CrossRefStep {
+  ref: string;
+  note?: string;
+  text?: string;
+}
 import { logger } from '../utils/logger';
 
 interface Props {
@@ -24,7 +30,7 @@ interface Props {
 
 export function ThreadViewerSheet({ visible, onClose, threadId, currentBookId, currentChapter, onGoToRef }: Props) {
   const [thread, setThread] = useState<CrossRefThread | null>(null);
-  const [steps, setSteps] = useState<any[]>([]);
+  const [steps, setSteps] = useState<CrossRefStep[]>([]);
 
   useEffect(() => {
     if (!threadId || !visible) return;

--- a/app/src/components/panels/DebatePanel.tsx
+++ b/app/src/components/panels/DebatePanel.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { getPanelColors, base, spacing, fontFamily } from '../../theme';
+import type { DebateEntry } from '../../types';
 
-interface Props { entries: any[]; onScholarPress?: (scholarId: string) => void; }
+interface Props { entries: DebateEntry[]; onScholarPress?: (scholarId: string) => void; }
 
 export function DebatePanel({ entries, onScholarPress }: Props) {
   const colors = getPanelColors('debate');
@@ -13,17 +14,17 @@ export function DebatePanel({ entries, onScholarPress }: Props) {
       {entries.map((d, i) => {
         // Handle both shapes: { topic, positions: [{scholar, position}] }
         // and legacy: { title, positions: [{name, proponents, argument}] }
-        const heading = d.topic ?? d.title ?? 'Debate';
-        const positions: any[] = d.positions ?? [];
+        const heading = d.topic ?? 'Debate';
+        const positions = d.positions ?? [];
 
         return (
           <View key={i} style={{ gap: spacing.sm }}>
             <Text style={{ color: colors.accent, fontFamily: fontFamily.displayMedium, fontSize: 13 }}>
               {heading}
             </Text>
-            {positions.map((p: any, j: number) => {
-              const label = p.scholar ?? p.name ?? 'Scholar';
-              const body = p.position ?? p.argument ?? p.proponents ?? '';
+            {positions.map((p, j: number) => {
+              const label = p.scholar ?? 'Scholar';
+              const body = p.position ?? '';
 
               return (
                 <View key={j} style={{ gap: 4, paddingLeft: spacing.sm }}>

--- a/app/src/components/panels/ReceptionPanel.tsx
+++ b/app/src/components/panels/ReceptionPanel.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { TappableReference } from '../TappableReference';
 import { getPanelColors, base, spacing, fontFamily } from '../../theme';
-import type { ParsedRef } from '../../types';
+import type { ParsedRef, RecEntry } from '../../types';
 
-interface Props { entries: any[]; onRefPress?: (ref: ParsedRef) => void; }
+interface Props { entries: RecEntry[]; onRefPress?: (ref: ParsedRef) => void; }
 
 export function ReceptionPanel({ entries, onRefPress }: Props) {
   const colors = getPanelColors('rec');
@@ -18,11 +18,9 @@ export function ReceptionPanel({ entries, onRefPress }: Props) {
 
   return (
     <View style={{ gap: spacing.md }}>
-      {entries.map((e: any, i: number) => {
-        // Handle both shapes: { title, quote, note }
-        // and legacy: { who, text }
-        const heading = e.title ?? e.who ?? '';
-        const body = e.quote ?? e.text ?? '';
+      {entries.map((e, i: number) => {
+        const heading = e.title ?? '';
+        const body = e.quote ?? '';
         const note = e.note ?? '';
 
         return (

--- a/app/src/components/panels/TranslationPanel.tsx
+++ b/app/src/components/panels/TranslationPanel.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { getPanelColors, base, spacing, fontFamily } from '../../theme';
+import type { TransPanel } from '../../types';
 
 interface TransRow {
   verse_ref?: string;
   translations: { version: string; text: string }[];
 }
 
-interface Props { data: any; }
+interface Props { data: string | TransPanel; }
 
 /**
  * Parse legacy HTML table format: <tr><td class="t-label">NIV</td><td>...</td></tr>

--- a/app/src/hooks/useBookIntro.ts
+++ b/app/src/hooks/useBookIntro.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { getBookIntro } from '../db/content';
 import { safeParse } from '../utils/logger';
+import type { ParsedBookIntro } from '../types';
 
 export function useBookIntro(bookId: string | null) {
-  const [intro, setIntro] = useState<any>(null);
+  const [intro, setIntro] = useState<ParsedBookIntro | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -30,9 +30,9 @@ export type HomeStackParamList = {
 
 export type ExploreStackParamList = {
   ExploreMenu: undefined;
-  GenealogyTree: undefined;
+  GenealogyTree: { personId?: string } | undefined;
   PersonDetail: { personId: string };
-  Map: { storyId?: string };
+  Map: { storyId?: string; placeId?: string };
   Timeline: { eventId?: string };
   WordStudyBrowse: undefined;
   WordStudyDetail: { wordId: string };

--- a/app/src/screens/AllNotesScreen.tsx
+++ b/app/src/screens/AllNotesScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { Search, X, Plus, Folder, Tag, FileText } from 'lucide-react-native';
 import { ScreenHeader } from '../components/ScreenHeader';
 import {
@@ -64,7 +65,7 @@ function parseTags(json: string): string[] {
 }
 
 export default function AllNotesScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'AllNotes'>>();
   const [activeTab, setActiveTab] = useState<TabKey>('all');
 
   // All tab state

--- a/app/src/screens/BookIntroScreen.tsx
+++ b/app/src/screens/BookIntroScreen.tsx
@@ -10,6 +10,7 @@ import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import type { BookIntroSection, BookIntroOutlineItem, BookIntroPlanItem } from '../types';
 import { useBookIntro } from '../hooks/useBookIntro';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -72,7 +73,7 @@ export default function BookIntroScreen() {
         )}
 
         {/* Sections */}
-        {intro.sections?.map((section: any, i: number) => (
+        {intro.sections?.map((section: BookIntroSection, i: number) => (
           <View key={i} style={styles.section}>
             {section.heading && (
               <Text style={styles.sectionHeading}>{section.heading}</Text>
@@ -88,7 +89,7 @@ export default function BookIntroScreen() {
             {/* Outline (structured list with label + chapters + note) */}
             {section.outline && Array.isArray(section.outline) && (
               <View style={styles.outlineBlock}>
-                {section.outline.map((item: any, j: number) => (
+                {section.outline.map((item: BookIntroOutlineItem, j: number) => (
                   <View key={j} style={styles.outlineItem}>
                     <View style={styles.outlineRow}>
                       <Text style={styles.outlineLabel}>{item.label}</Text>
@@ -118,7 +119,7 @@ export default function BookIntroScreen() {
             {/* Reading Plan (ref + label list) */}
             {section.plan && Array.isArray(section.plan) && (
               <View style={styles.planBlock}>
-                {section.plan.map((item: any, j: number) => (
+                {section.plan.map((item: BookIntroPlanItem, j: number) => (
                   <View key={j} style={styles.planItem}>
                     <Text style={styles.planRef}>{item.ref}</Text>
                     <Text style={styles.planLabel}>{item.label}</Text>

--- a/app/src/screens/BookListScreen.tsx
+++ b/app/src/screens/BookListScreen.tsx
@@ -12,6 +12,7 @@ import React, { useState, useMemo, useRef } from 'react';
 import { View, Text, TouchableOpacity, SectionList, FlatList, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useScrollToTop } from '@react-navigation/native';
 import { useBooks, type BookWithProgress } from '../hooks/useBooks';
 import { useSettingsStore } from '../stores';
@@ -36,9 +37,9 @@ const NT_GROUPS = [
 ];
 
 export default function BookListScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Read', 'BookList'>>();
   const scrollRef = useRef<FlatList>(null);
-  useScrollToTop(scrollRef as any);
+  useScrollToTop(scrollRef);
 
   const { books } = useBooks();
   const mode = useSettingsStore((s) => s.bookListMode);

--- a/app/src/screens/BookmarkListScreen.tsx
+++ b/app/src/screens/BookmarkListScreen.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, FlatList, Alert, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { getBookmarks, removeBookmark } from '../db/user';
 import { parseVerseRef, displayRef } from '../utils/verseRef';
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -13,7 +14,7 @@ import { base, spacing, fontFamily } from '../theme';
 import type { Bookmark } from '../types';
 
 export default function BookmarkListScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'Bookmarks'>>();
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
 
   const reload = () => getBookmarks().then(setBookmarks);

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useMemo, useRef, useEffect, useState } from 'react'
 import { View, ScrollView, LayoutAnimation, Platform, UIManager, StyleSheet, type NativeSyntheticEvent, type NativeScrollEvent, type GestureResponderEvent } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import type { Book } from '../types';
 
 import { useChapterData } from '../hooks/useChapterData';
 import { useNotedVerses } from '../hooks/useNotedVerses';
@@ -58,7 +59,7 @@ export default function ChapterScreen() {
   const scrollRef = useRef<ScrollView>(null);
   const sectionYMap = useRef<Record<string, number>>({});
   const btnRowYMap = useRef<Record<string, number>>({});
-  const [bookData, setBookData] = React.useState<any>(null);
+  const [bookData, setBookData] = React.useState<Book | null>(null);
   const [scrollProgress, setScrollProgress] = useState(0);
 
   // Scroll progress tracking

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -9,6 +9,7 @@ import React, { useRef } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useScrollToTop } from '@react-navigation/native';
 import { base, spacing, radii, fontFamily } from '../theme';
 
@@ -70,7 +71,7 @@ const GRID_FEATURES: Feature[] = [
 ];
 
 export default function ExploreMenuScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'ExploreMenu'>>();
   const scrollRef = useRef<ScrollView>(null);
   useScrollToTop(scrollRef);
 

--- a/app/src/screens/GenealogyTreeScreen.tsx
+++ b/app/src/screens/GenealogyTreeScreen.tsx
@@ -46,8 +46,12 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { base, spacing } from '../theme';
 import type { Person } from '../types';
 import type { TreePerson } from '../utils/treeBuilder';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 
-export default function GenealogyTreeScreen({ route, navigation }: any) {
+export default function GenealogyTreeScreen({ route, navigation }: {
+  route: ScreenRouteProp<'Explore', 'GenealogyTree'>;
+  navigation: ScreenNavProp<'Explore', 'GenealogyTree'>;
+}) {
   useLandscapeUnlock();
   const initialPersonId = route?.params?.personId;
   const { people, isLoading } = usePeople();

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -13,6 +13,7 @@ import React, { useState, useCallback, useRef } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, RefreshControl, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useScrollToTop } from '@react-navigation/native';
 import { ArrowRight } from 'lucide-react-native';
 import { useHomeData } from '../hooks/useHomeData';
@@ -22,7 +23,7 @@ import { base, spacing, radii, fontFamily } from '../theme';
 const TOTAL_BIBLE_CHAPTERS = 1189;
 
 export default function HomeScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Home', 'HomeMain'>>();
   const { greeting, subtitle, verse, recentChapters, readingStats, isLoading, refresh } = useHomeData();
   const [refreshing, setRefreshing] = useState(false);
   const scrollRef = useRef<ScrollView>(null);

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -35,6 +35,7 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton';
 
 import { base, spacing } from '../theme';
 import type { MapStory, Place } from '../types';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 
 const INITIAL_REGION = {
@@ -44,7 +45,10 @@ const INITIAL_REGION = {
   longitudeDelta: 30,
 };
 
-export default function MapScreen({ route, navigation }: any) {
+export default function MapScreen({ route, navigation }: {
+  route: ScreenRouteProp<'Explore', 'Map'>;
+  navigation: ScreenNavProp<'Explore', 'Map'>;
+}) {
   useLandscapeUnlock();
   const initialStoryId = route?.params?.storyId;
   const initialPlaceId = route?.params?.placeId;

--- a/app/src/screens/MoreMenuScreen.tsx
+++ b/app/src/screens/MoreMenuScreen.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { Bookmark, Clock, Calendar, Settings, ArrowRight, StickyNote } from 'lucide-react-native';
 import { base, spacing, radii, MIN_TOUCH_TARGET, fontFamily } from '../theme';
 
@@ -27,7 +28,7 @@ const MENU_ITEMS: MenuItem[] = [
 ];
 
 export default function MoreMenuScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'MoreMenu'>>();
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/src/screens/ParallelPassageScreen.tsx
+++ b/app/src/screens/ParallelPassageScreen.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, TouchableOpacity, FlatList, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { getSynopticEntries } from '../db/content';
 import { resolveVerseText, parseReference } from '../utils/verseResolver';
 import { useSettingsStore } from '../stores';
@@ -24,7 +25,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 export default function ParallelPassageScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Read', 'ParallelPassage'>>();
   const [entries, setEntries] = useState<SynopticEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [catFilter, setCatFilter] = useState<string>('all');

--- a/app/src/screens/PlanListScreen.tsx
+++ b/app/src/screens/PlanListScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { getPlans, getActivePlanId, getPlanProgress } from '../db/user';
 import { PlanProgressBar } from '../components/PlanProgressBar';
 import { BadgeChip } from '../components/BadgeChip';
@@ -10,7 +11,7 @@ import { base, spacing, radii, fontFamily } from '../theme';
 import type { ReadingPlan, PlanProgress } from '../db/user';
 
 export default function PlanListScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'PlanList'>>();
   const [plans, setPlans] = useState<ReadingPlan[]>([]);
   const [activePlanId, setActivePlanId] = useState<string | null>(null);
   const [progress, setProgress] = useState<PlanProgress[]>([]);

--- a/app/src/screens/ProphecyBrowseScreen.tsx
+++ b/app/src/screens/ProphecyBrowseScreen.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useProphecyChains } from '../hooks/useProphecyChains';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -57,7 +58,7 @@ function getRefRange(links: ProphecyChainLink[]): string {
 }
 
 export default function ProphecyBrowseScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'ProphecyBrowse'>>();
   const { chains, isLoading } = useProphecyChains();
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
 

--- a/app/src/screens/ProphecyDetailScreen.tsx
+++ b/app/src/screens/ProphecyDetailScreen.tsx
@@ -98,7 +98,7 @@ export default function ProphecyDetailScreen() {
   const handleVersePress = (link: ProphecyChainLink) => {
     // Navigate to Chapter screen in ExploreStack
     try {
-      (navigation as any).navigate('Chapter', {
+      navigation.navigate('Chapter', {
         bookId: link.book_dir,
         chapterNum: link.chapter_num,
       });

--- a/app/src/screens/ReadingHistoryScreen.tsx
+++ b/app/src/screens/ReadingHistoryScreen.tsx
@@ -6,13 +6,14 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { getRecentChapters, getReadingStats } from '../db/user';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { base, spacing, fontFamily } from '../theme';
 import type { RecentChapter, ReadingStats } from '../db/user';
 
 export default function ReadingHistoryScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'ReadingHistory'>>();
   const [history, setHistory] = useState<RecentChapter[]>([]);
   const [stats, setStats] = useState<ReadingStats | null>(null);
 

--- a/app/src/screens/ScholarBioScreen.tsx
+++ b/app/src/screens/ScholarBioScreen.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet, type DimensionValue } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
@@ -11,7 +11,7 @@ import { getScholar, getAllScholars } from '../db/content';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { getScholarColor, base, spacing, radii, fontFamily } from '../theme';
-import type { Scholar } from '../types';
+import type { Scholar, ScholarBio } from '../types';
 import { logger } from '../utils/logger';
 
 export default function ScholarBioScreen() {
@@ -19,7 +19,7 @@ export default function ScholarBioScreen() {
   const route = useRoute<ScreenRouteProp<'Explore', 'ScholarBio'>>();
   const { scholarId } = route.params ?? {};
   const [scholar, setScholar] = useState<Scholar | null>(null);
-  const [bio, setBio] = useState<any>(null);
+  const [bio, setBio] = useState<ScholarBio | null>(null);
   const [allScholars, setAllScholars] = useState<Scholar[]>([]);
 
   useEffect(() => {
@@ -68,7 +68,7 @@ export default function ScholarBioScreen() {
         <View style={styles.divider} />
 
         {/* Bio sections */}
-        {bio?.sections?.map((section: any, i: number) => (
+        {bio?.sections?.map((section: ScholarBio['sections'][number], i: number) => (
           <View key={i} style={styles.section}>
             <Text style={styles.sectionTitle}>{section.title}</Text>
             <Text style={styles.sectionBody}>{section.body}</Text>
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   otherCard: {
-    width: '48%' as any,
+    width: '48%' as DimensionValue,
     borderLeftWidth: 3,
     borderRadius: radii.md,
     padding: spacing.sm,

--- a/app/src/screens/ScholarBrowseScreen.tsx
+++ b/app/src/screens/ScholarBrowseScreen.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, FlatList, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useScholars } from '../hooks/useScholars';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { SearchInput } from '../components/SearchInput';
@@ -14,7 +15,7 @@ import { getScholarColor, base, spacing, radii, fontFamily } from '../theme';
 import { logger } from '../utils/logger';
 
 export default function ScholarBrowseScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'ScholarBrowse'>>();
   const { scholars, isLoading } = useScholars();
   const [search, setSearch] = useState('');
   const [tradition, setTradition] = useState<string>('all');

--- a/app/src/screens/SearchScreen.tsx
+++ b/app/src/screens/SearchScreen.tsx
@@ -11,17 +11,19 @@ import React, { useState, useRef } from 'react';
 import { View, Text, TextInput, TouchableOpacity, SectionList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useScrollToTop } from '@react-navigation/native';
 import { Search as SearchIcon } from 'lucide-react-native';
 import { useSearch } from '../hooks/useSearch';
 import { SearchInput } from '../components/SearchInput';
 import { base, spacing, radii, fontFamily, eras } from '../theme';
+import type { Person, WordStudy, Verse } from '../types';
 
 const INITIAL_VERSE_LIMIT = 20;
 const LOAD_MORE_INCREMENT = 30;
 
 export default function SearchScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Search', 'SearchMain'>>();
   const [query, setQuery] = useState('');
   const [verseLimit, setVerseLimit] = useState(INITIAL_VERSE_LIMIT);
   const { results, isLoading } = useSearch(query);
@@ -110,7 +112,7 @@ export default function SearchScreen() {
               );
             }
             if (type === 'person') {
-              const p = item as any;
+              const p = item as Person;
               return (
                 <TouchableOpacity
                   onPress={() => navigation.navigate('ExploreTab', {
@@ -131,7 +133,7 @@ export default function SearchScreen() {
               );
             }
             if (type === 'word') {
-              const w = item as any;
+              const w = item as WordStudy;
               return (
                 <TouchableOpacity
                   onPress={() => navigation.navigate('ExploreTab', {
@@ -146,7 +148,7 @@ export default function SearchScreen() {
               );
             }
             // Verse
-            const v = item as any;
+            const v = item as Verse;
             const displayName = v.book_name ?? v.book_id;
             return (
               <TouchableOpacity

--- a/app/src/screens/SettingsScreen.tsx
+++ b/app/src/screens/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { Download } from 'lucide-react-native';
 import { useSettingsStore } from '../stores';
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -44,7 +45,7 @@ const ABOUT_PARAGRAPHS = [
 /* ── Component ──────────────────────────────────────────────────── */
 
 export default function SettingsScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'More', 'Settings'>>();
   const translation = useSettingsStore((s) => s.translation);
   const fontSize = useSettingsStore((s) => s.fontSize);
   const vhlEnabled = useSettingsStore((s) => s.vhlEnabled);

--- a/app/src/screens/TimelineScreen.tsx
+++ b/app/src/screens/TimelineScreen.tsx
@@ -9,6 +9,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, { Rect, Line, Circle, G, Text as SvgText } from 'react-native-svg';
 
 import { useRoute, useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { getAllTimelineEntries } from '../db/content';
 import { EraFilterBar } from '../components/tree/EraFilterBar';
 import { BadgeChip } from '../components/BadgeChip';
@@ -25,7 +26,7 @@ import type { TimelineEntry } from '../types';
 export default function TimelineScreen() {
   useLandscapeUnlock();
   const route = useRoute<ScreenRouteProp<'Explore', 'Timeline'>>();
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'Timeline'>>();
   const initialEventId = route?.params?.eventId;
 
   const [events, setEvents] = useState<TimelineEntry[]>([]);

--- a/app/src/screens/WordStudyBrowseScreen.tsx
+++ b/app/src/screens/WordStudyBrowseScreen.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import type { ScreenNavProp } from '../navigation/types';
 import { useWordStudies } from '../hooks/useWordStudies';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { SearchInput } from '../components/SearchInput';
@@ -14,7 +15,7 @@ import { base, spacing, radii, fontFamily } from '../theme';
 import { logger } from '../utils/logger';
 
 export default function WordStudyBrowseScreen() {
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'WordStudyBrowse'>>();
   const { studies, isLoading } = useWordStudies();
   const [langFilter, setLangFilter] = useState<'all' | 'hebrew' | 'greek'>('all');
   const [search, setSearch] = useState('');

--- a/app/src/theme/typography.ts
+++ b/app/src/theme/typography.ts
@@ -60,7 +60,7 @@ export { presets as typography };
 // ── Dynamic Type scaling ────────────────────────────────────────────
 
 export function scaledTypography(scale: number): Record<keyof typeof presets, TypographyPreset> {
-  const result: any = {};
+  const result = {} as Record<keyof typeof presets, TypographyPreset>;
   for (const [key, preset] of Object.entries(presets)) {
     result[key] = {
       ...preset,

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -231,7 +231,7 @@ export interface RecentChapter extends ReadingProgress {
 
 /** Section with its panels pre-loaded and parsed. */
 export interface SectionWithPanels extends Section {
-  panels: Record<string, any>;
+  panels: Record<string, unknown>;
 }
 
 // ══════════════════════════════════════════════════════════════
@@ -418,4 +418,47 @@ export interface DifficultPassage {
   responses_json: string;
   related_chapters_json: string | null;
   tags_json: string | null;
+}
+
+// ══════════════════════════════════════════════════════════════
+// PARSED BIO / INTRO TYPES
+// ══════════════════════════════════════════════════════════════
+
+export interface ScholarBio {
+  eyebrow?: string;
+  sections: { title: string; body: string }[];
+}
+
+export interface BookIntroOutlineItem {
+  label: string;
+  chapters?: [number, number];
+  note?: string;
+}
+
+export interface BookIntroPlanItem {
+  ref: string;
+  label: string;
+}
+
+export interface BookIntroSection {
+  heading?: string;
+  content?: string;
+  body?: string;
+  outline?: BookIntroOutlineItem[];
+  themes?: string[];
+  plan?: BookIntroPlanItem[];
+}
+
+export interface BookIntroAuthorship {
+  author?: string;
+  date?: string;
+  prompt?: string;
+}
+
+export interface ParsedBookIntro {
+  title?: string;
+  subtitle?: string;
+  authorship?: string | BookIntroAuthorship;
+  sections?: BookIntroSection[];
+  text?: string;
 }

--- a/app/src/utils/treeBuilder.ts
+++ b/app/src/utils/treeBuilder.ts
@@ -10,7 +10,7 @@
  *   spouseYSpread: 58
  */
 
-import { hierarchy, tree } from 'd3-hierarchy';
+import { hierarchy, tree, type HierarchyPointNode } from 'd3-hierarchy';
 import type { Person } from '../types';
 
 // ── Constants ───────────────────────────────────────────────────────
@@ -153,13 +153,13 @@ export function layoutTree(root: HierNode): LayoutNode[] {
 
   // Flatten to array
   const nodes: LayoutNode[] = [];
-  d3Root.each((d: any) => {
+  d3Root.each((d: HierarchyPointNode<HierNode>) => {
     nodes.push({
       data: d.data.data,
       x: d.x,
       y: d.y,
-      parent: d.parent ? { ...d.parent, data: d.parent.data.data } as any : null,
-      children: d.children?.map((c: any) => c) ?? [],
+      parent: d.parent ? { data: d.parent.data.data, x: d.parent.x, y: d.parent.y } as LayoutNode : null,
+      children: d.children?.map((c) => ({ data: c.data.data, x: c.x, y: c.y }) as LayoutNode) ?? [],
       depth: d.depth,
       isSpouse: false,
     });


### PR DESCRIPTION
Category A — useNavigation<any>() (15 screens):
  All replaced with proper ScreenNavProp<Stack, Screen> types.
  ProphecyDetailScreen: removed unnecessary (navigation as any) cast.

Category B — component/screen prop and state types (13 files):
  ChapterSkeleton: style → ViewStyle, width → DimensionValue
  ScholarInfoSheet + ScholarBioScreen: bio → ScholarBio | null
  useBookIntro: intro → ParsedBookIntro | null
  BookIntroScreen: section/outline/plan items properly typed
  SectionBlock: onRefPress → ParsedRef
  ThreadViewerSheet: steps → CrossRefStep[]
  DebatePanel: entries → DebateEntry[]
  ReceptionPanel: entries → RecEntry[]
  TranslationPanel: data → string | TransPanel
  ChapterScreen: bookData → Book | null
  GenealogyTreeScreen + MapScreen: proper route/nav prop types

Category C — utility types (5 files):
  SearchScreen: Person, WordStudy, Verse casts replace `as any`
  BookListScreen: removed unnecessary `as any` on useScrollToTop
  typography.ts: result typed as Record<keyof typeof presets, ...>
  treeBuilder.ts: d3 HierarchyPointNode<HierNode> replaces `any`
  types/index.ts: SectionWithPanels.panels → Record<string, unknown>

New types added to types/index.ts:
  ScholarBio, ParsedBookIntro, BookIntroSection,
  BookIntroOutlineItem, BookIntroPlanItem, BookIntroAuthorship

Nav types updated:
  GenealogyTree: accepts optional { personId }
  Map: accepts optional { placeId }