### PR TITLE
feat(concordance): Phase 21 — Strong's number concordance search

### DIFF
--- a/_tools/NEXT_SESSION_PROMPT.md
+++ b/_tools/NEXT_SESSION_PROMPT.md
@@ -55,7 +55,8 @@ Prophecy chains (50 chains, 283 links, browse + detail screens) · Enhanced note
 | 18 | Search Filters (OT/NT/Book) | **Complete** |
 | 19 | Highlight UX Polish (6 colors, collections, migration 5) | **Complete** |
 | 20 | Personalized Recommendations (heuristic engine) | **Complete** |
-| 21-23 | See `_tools/DEEP_STUDY_FEATURES_PLAN.md` | Planned |
+| 21 | Concordance Search (Strong's number lookup) | **Complete** |
+| 22-23 | See `_tools/DEEP_STUDY_FEATURES_PLAN.md` | Planned |
 
 ### Content Remediation
 
@@ -69,7 +70,7 @@ Batches 0–5 complete (word study bugfix, scholar bios, ghost panels, people en
 
 ## What's Next
 
-1. **Deep Study Features Phase 21** — Concordance Search (depends on Phase 13) — Session O
+1. **Deep Study Features Phase 22** — Discourse Analysis Expansion (Galatians, Ephesians, Hebrews, 1 Corinthians)
 2. **Thin Panel Enrichment** (~259 panels) — 138 section panels (mostly thin cross-refs in Chronicles/Nehemiah/Esther) + 121 chapter panels (mostly thin ppl/rec in prophets)
 3. **Inline Style Migration** (Arch Batch 7) — 318 inline `style={{ }}` objects, migrate to `StyleSheet.create()`
 4. **Cross-reference thread expansion** (Batch 13)

--- a/app/src/components/ConcordanceEntry.tsx
+++ b/app/src/components/ConcordanceEntry.tsx
@@ -1,0 +1,97 @@
+/**
+ * ConcordanceEntry — Single result card for concordance search.
+ *
+ * Shows book name + chapter:verse reference, verse text with the
+ * target word's gloss highlighted in gold.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { base, spacing, radii, fontFamily } from '../theme';
+import type { ConcordanceResult } from '../types';
+
+interface Props {
+  result: ConcordanceResult;
+  gloss: string | null;
+  onPress: () => void;
+}
+
+export function ConcordanceEntry({ result, gloss, onPress }: Props) {
+  const ref = `${result.book_name} ${result.chapter_num}:${result.verse_num}`;
+
+  // Highlight the gloss word within the verse text
+  const renderText = () => {
+    if (!gloss || !result.text) {
+      return <Text style={styles.verseText}>{result.text}</Text>;
+    }
+
+    // Case-insensitive split on the gloss word
+    const regex = new RegExp(`(${escapeRegex(gloss)})`, 'gi');
+    const parts = result.text.split(regex);
+
+    return (
+      <Text style={styles.verseText}>
+        {parts.map((part, i) =>
+          regex.test(part) ? (
+            <Text key={i} style={styles.highlighted}>{part}</Text>
+          ) : (
+            <Text key={i}>{part}</Text>
+          )
+        )}
+      </Text>
+    );
+  };
+
+  return (
+    <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
+      <View style={styles.refRow}>
+        <Text style={styles.ref}>{ref}</Text>
+        {result.gloss ? (
+          <Text style={styles.gloss}>{result.gloss}</Text>
+        ) : null}
+      </View>
+      {renderText()}
+    </TouchableOpacity>
+  );
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: base.bgElevated,
+    borderWidth: 1,
+    borderColor: base.border,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  refRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: spacing.xs,
+  },
+  ref: {
+    color: base.gold,
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 13,
+  },
+  gloss: {
+    color: base.textMuted,
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 12,
+  },
+  verseText: {
+    color: base.textDim,
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  highlighted: {
+    color: base.gold,
+    fontFamily: fontFamily.bodyMedium,
+  },
+});

--- a/app/src/components/InterlinearSheet.tsx
+++ b/app/src/components/InterlinearSheet.tsx
@@ -17,6 +17,13 @@ import { LoadingSkeleton } from './LoadingSkeleton';
 import { base, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
 import type { InterlinearWord } from '../types';
 
+interface ConcordanceParams {
+  strongs: string;
+  original: string;
+  transliteration: string;
+  gloss: string | null;
+}
+
 interface Props {
   visible: boolean;
   bookId: string;
@@ -25,11 +32,12 @@ interface Props {
   verseRef: string;
   onClose: () => void;
   onWordStudyPress?: (wordStudyId: string) => void;
+  onConcordancePress?: (params: ConcordanceParams) => void;
 }
 
 export function InterlinearSheet({
   visible, bookId, chapter, verse, verseRef,
-  onClose, onWordStudyPress,
+  onClose, onWordStudyPress, onConcordancePress,
 }: Props) {
   const [words, setWords] = useState<InterlinearWord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -112,14 +120,29 @@ export function InterlinearSheet({
                       {/* Transliteration */}
                       <Text style={styles.transliteration}>{w.transliteration}</Text>
 
-                      {/* Strong's number */}
+                      {/* Strong's number + concordance link */}
                       {w.strongs ? (
-                        <Text style={[
-                          styles.strongs,
-                          w.word_study_id ? styles.strongsLinked : null,
-                        ]}>
-                          {w.strongs}
-                        </Text>
+                        <TouchableOpacity
+                          onPress={onConcordancePress
+                            ? () => onConcordancePress({
+                                strongs: w.strongs!,
+                                original: w.original,
+                                transliteration: w.transliteration,
+                                gloss: w.gloss,
+                              })
+                            : undefined}
+                          activeOpacity={onConcordancePress ? 0.6 : 1}
+                        >
+                          <Text style={[
+                            styles.strongs,
+                            onConcordancePress ? styles.strongsLinked : null,
+                          ]}>
+                            {w.strongs}
+                          </Text>
+                          {onConcordancePress ? (
+                            <Text style={styles.concordanceLink}>All occurrences</Text>
+                          ) : null}
+                        </TouchableOpacity>
                       ) : null}
 
                       {/* Morphology */}
@@ -232,6 +255,13 @@ const styles = StyleSheet.create({
   },
   strongsLinked: {
     color: base.gold,
+  },
+  concordanceLink: {
+    color: base.gold,
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
+    textAlign: 'center',
+    marginTop: 1,
   },
   morphology: {
     color: base.textMuted,

--- a/app/src/db/content/chapters.ts
+++ b/app/src/db/content/chapters.ts
@@ -5,6 +5,7 @@
 import { getDb } from '../database';
 import type {
   Chapter, Section, SectionPanel, ChapterPanel, Verse, VHLGroup, InterlinearWord,
+  ConcordanceResult,
 } from '../../types';
 
 export async function getChapter(bookId: string, ch: number): Promise<Chapter | null> {
@@ -84,6 +85,32 @@ export async function getInterlinearWords(
     'SELECT * FROM interlinear_words WHERE book_id = ? AND chapter_num = ? AND verse_num = ? ORDER BY word_position',
     [bookId, ch, verse]
   );
+}
+
+export async function getConcordanceResults(strongs: string): Promise<ConcordanceResult[]> {
+  return getDb().getAllAsync<ConcordanceResult>(
+    `SELECT DISTINCT iw.book_id, iw.chapter_num, iw.verse_num,
+       iw.original, iw.transliteration, iw.gloss,
+       v.text, b.name as book_name
+     FROM interlinear_words iw
+     JOIN verses v ON v.book_id = iw.book_id
+       AND v.chapter_num = iw.chapter_num
+       AND v.verse_num = iw.verse_num
+       AND v.translation = 'niv'
+     JOIN books b ON b.id = iw.book_id
+     WHERE iw.strongs = ?
+     ORDER BY b.book_order, iw.chapter_num, iw.verse_num`,
+    [strongs]
+  );
+}
+
+export async function getConcordanceCount(strongs: string): Promise<number> {
+  const row = await getDb().getFirstAsync<{ cnt: number }>(
+    `SELECT COUNT(DISTINCT book_id || ':' || chapter_num || ':' || verse_num) as cnt
+     FROM interlinear_words WHERE strongs = ?`,
+    [strongs]
+  );
+  return row?.cnt ?? 0;
 }
 
 export async function getVHLGroups(chapterId: string): Promise<VHLGroup[]> {

--- a/app/src/db/content/index.ts
+++ b/app/src/db/content/index.ts
@@ -10,6 +10,7 @@ export {
   getChapter, getChapterById, getSections, getSectionPanels,
   getSectionPanelsByType, getChapterPanels, getChapterPanelByType,
   getVerses, getVerse, getInterlinearWords, getVHLGroups,
+  getConcordanceResults, getConcordanceCount,
 } from './chapters';
 export { getAllScholars, getScholar, getScholarsForBook } from './scholars';
 export { getAllPeople, getPerson, getPersonChildren, getSpousesOf } from './people';

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -15,6 +15,7 @@ import ConceptBrowseScreen from '../screens/ConceptBrowseScreen';
 import ConceptDetailScreen from '../screens/ConceptDetailScreen';
 import DifficultPassagesBrowseScreen from '../screens/DifficultPassagesBrowseScreen';
 import DifficultPassageDetailScreen from '../screens/DifficultPassageDetailScreen';
+import ConcordanceScreen from '../screens/ConcordanceScreen';
 import ChapterScreen from '../screens/ChapterScreen';
 import { base } from '../theme';
 import type { ExploreStackParamList } from './types';
@@ -46,6 +47,7 @@ export function ExploreStack() {
       <Stack.Screen name="ConceptDetail" component={ConceptDetailScreen} />
       <Stack.Screen name="DifficultPassagesBrowse" component={DifficultPassagesBrowseScreen} />
       <Stack.Screen name="DifficultPassageDetail" component={DifficultPassageDetailScreen} />
+      <Stack.Screen name="Concordance" component={ConcordanceScreen} />
       <Stack.Screen name="Chapter" component={ChapterScreen} />
     </Stack.Navigator>
   );

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -45,6 +45,12 @@ export type ExploreStackParamList = {
   ConceptDetail: { conceptId: string };
   DifficultPassagesBrowse: undefined;
   DifficultPassageDetail: { passageId: string };
+  Concordance: {
+    strongs?: string;
+    original?: string;
+    transliteration?: string;
+    gloss?: string;
+  } | undefined;
   Chapter: { bookId: string; chapterNum: number };
 };
 

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -419,6 +419,10 @@ export default function ChapterScreen() {
           setInterlinearVerse(null);
           navigation.navigate('ExploreTab', { screen: 'WordStudyDetail', params: { id: wsId } });
         }}
+        onConcordancePress={(params) => {
+          setInterlinearVerse(null);
+          navigation.navigate('ExploreTab', { screen: 'Concordance', params });
+        }}
       />
 
       <VerseLongPressMenu

--- a/app/src/screens/ConcordanceScreen.tsx
+++ b/app/src/screens/ConcordanceScreen.tsx
@@ -1,0 +1,293 @@
+/**
+ * ConcordanceScreen — Shows every verse where a Hebrew/Greek word
+ * (identified by Strong's number) appears across the Bible.
+ *
+ * Entry points:
+ *   - InterlinearSheet "See all N occurrences" button
+ *   - WordStudyDetailScreen concordance link
+ *   - ExploreMenuScreen (manual search, no pre-filter)
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  View, Text, FlatList, TextInput, TouchableOpacity,
+  StyleSheet, ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Search, X } from 'lucide-react-native';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { getConcordanceResults, getConcordanceCount } from '../db/content';
+import { ConcordanceEntry } from '../components/ConcordanceEntry';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { base, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import type { ConcordanceResult } from '../types';
+
+export default function ConcordanceScreen() {
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'Concordance'>>();
+  const route = useRoute<ScreenRouteProp<'Explore', 'Concordance'>>();
+  const { strongs: initialStrongs, original, transliteration, gloss } = route.params ?? {};
+
+  const [strongs, setStrongs] = useState(initialStrongs ?? '');
+  const [searchInput, setSearchInput] = useState(initialStrongs ?? '');
+  const [results, setResults] = useState<ConcordanceResult[]>([]);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const inputRef = useRef<TextInput>(null);
+
+  const runSearch = useCallback(async (s: string) => {
+    const trimmed = s.trim().toUpperCase();
+    if (!trimmed) return;
+    setStrongs(trimmed);
+    setLoading(true);
+    setSearched(true);
+    const [r, c] = await Promise.all([
+      getConcordanceResults(trimmed),
+      getConcordanceCount(trimmed),
+    ]);
+    setResults(r);
+    setCount(c);
+    setLoading(false);
+  }, []);
+
+  // Auto-search if opened with a Strong's number
+  useEffect(() => {
+    if (initialStrongs) runSearch(initialStrongs);
+  }, [initialStrongs, runSearch]);
+
+  const handleSubmit = () => runSearch(searchInput);
+
+  const navigateToChapter = (item: ConcordanceResult) => {
+    navigation.navigate('Chapter', {
+      bookId: item.book_id,
+      chapterNum: item.chapter_num,
+    });
+  };
+
+  // Determine the accent color (Hebrew = pink, Greek = blue)
+  const isHebrew = strongs.startsWith('H');
+  const accentColor = isHebrew ? '#e890b8' : '#70b8e8';
+
+  const headerTitle = original
+    ? `${original} (${strongs})`
+    : strongs
+    ? strongs
+    : 'Concordance';
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScreenHeader
+        title="Concordance"
+        onBack={() => navigation.goBack()}
+        style={styles.header}
+      />
+
+      {/* Word info header (when opened with a specific word) */}
+      {original ? (
+        <View style={styles.wordInfo}>
+          <Text style={[styles.originalWord, { color: accentColor }]}>{original}</Text>
+          {transliteration ? (
+            <Text style={styles.transliteration}>{transliteration}</Text>
+          ) : null}
+          <View style={styles.metaRow}>
+            <Text style={styles.strongsBadge}>{strongs}</Text>
+            {gloss ? <Text style={styles.glossText}>{gloss}</Text> : null}
+            {count > 0 ? (
+              <View style={[styles.countBadge, { backgroundColor: accentColor + '22' }]}>
+                <Text style={[styles.countText, { color: accentColor }]}>
+                  {count} {count === 1 ? 'verse' : 'verses'}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+      ) : null}
+
+      {/* Search bar (always visible, especially for manual entry) */}
+      <View style={styles.searchRow}>
+        <View style={styles.searchInputWrap}>
+          <Search size={16} color={base.textMuted} />
+          <TextInput
+            ref={inputRef}
+            style={styles.searchInput}
+            placeholder="Enter Strong's number (e.g. H2617)"
+            placeholderTextColor={base.textMuted}
+            value={searchInput}
+            onChangeText={setSearchInput}
+            onSubmitEditing={handleSubmit}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            returnKeyType="search"
+          />
+          {searchInput ? (
+            <TouchableOpacity onPress={() => { setSearchInput(''); inputRef.current?.focus(); }}>
+              <X size={16} color={base.textMuted} />
+            </TouchableOpacity>
+          ) : null}
+        </View>
+        <TouchableOpacity style={styles.searchBtn} onPress={handleSubmit}>
+          <Text style={styles.searchBtnText}>Search</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Results */}
+      {loading ? (
+        <View style={styles.loadingWrap}>
+          <LoadingSkeleton lines={5} height={60} />
+        </View>
+      ) : results.length > 0 ? (
+        <FlatList
+          data={results}
+          keyExtractor={(item) => `${item.book_id}-${item.chapter_num}-${item.verse_num}`}
+          renderItem={({ item }) => (
+            <ConcordanceEntry
+              result={item}
+              gloss={gloss ?? item.gloss}
+              onPress={() => navigateToChapter(item)}
+            />
+          )}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+        />
+      ) : searched ? (
+        <View style={styles.emptyWrap}>
+          <Text style={styles.emptyText}>
+            No results found for {strongs}.
+          </Text>
+          <Text style={styles.emptyHint}>
+            Make sure the Strong's number is correct (e.g. H2617 for Hebrew, G26 for Greek).
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.emptyWrap}>
+          <Text style={styles.emptyText}>
+            Find every verse where a Hebrew or Greek word appears across the entire Bible.
+          </Text>
+          <Text style={styles.emptyHint}>
+            Enter a Strong's number above, or tap a word in the Interlinear view to see all its occurrences.
+          </Text>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: base.bg,
+  },
+  header: {
+    marginBottom: 0,
+    paddingHorizontal: spacing.md,
+  },
+  wordInfo: {
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+  },
+  originalWord: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: 32,
+    textAlign: 'center',
+  },
+  transliteration: {
+    color: base.goldDim,
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 14,
+    marginTop: 2,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: spacing.xs,
+  },
+  strongsBadge: {
+    color: base.textMuted,
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+  glossText: {
+    color: base.textDim,
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+  },
+  countBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radii.sm,
+  },
+  countText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  searchInputWrap: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: base.bgElevated,
+    borderWidth: 1,
+    borderColor: base.border,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.sm,
+    height: MIN_TOUCH_TARGET,
+    gap: 6,
+  },
+  searchInput: {
+    flex: 1,
+    color: base.text,
+    fontFamily: fontFamily.ui,
+    fontSize: 14,
+    paddingVertical: 0,
+  },
+  searchBtn: {
+    backgroundColor: base.gold + '22',
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    height: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+  },
+  searchBtnText: {
+    color: base.gold,
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  loadingWrap: {
+    padding: spacing.md,
+  },
+  listContent: {
+    padding: spacing.md,
+    paddingBottom: spacing.xxl,
+  },
+  emptyWrap: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  emptyText: {
+    color: base.textDim,
+    fontFamily: fontFamily.body,
+    fontSize: 15,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  emptyHint: {
+    color: base.textMuted,
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: spacing.sm,
+    lineHeight: 18,
+  },
+});

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -68,6 +68,11 @@ const GRID_FEATURES: Feature[] = [
     subtitle: 'Wrestling with hard texts',
     screen: 'DifficultPassagesBrowse',
   },
+  {
+    title: 'Concordance',
+    subtitle: 'Every occurrence of a word in Scripture',
+    screen: 'Concordance',
+  },
 ];
 
 export default function ExploreMenuScreen() {

--- a/app/src/screens/WordStudyDetailScreen.tsx
+++ b/app/src/screens/WordStudyDetailScreen.tsx
@@ -3,7 +3,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { BookOpen } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
@@ -61,6 +62,25 @@ export default function WordStudyDetailScreen() {
         <Text style={styles.transliteration}>{word.transliteration}</Text>
         {word.strongs && (
           <Text style={styles.strongs}>Strong's: {word.strongs}</Text>
+        )}
+
+        {/* Concordance link */}
+        {word.strongs && (
+          <TouchableOpacity
+            style={styles.concordanceBtn}
+            onPress={() => navigation.navigate('Concordance', {
+              strongs: word.strongs!,
+              original: word.original,
+              transliteration: word.transliteration,
+              gloss: glosses[0] ?? null,
+            })}
+            activeOpacity={0.7}
+          >
+            <BookOpen size={14} color={base.gold} />
+            <Text style={styles.concordanceBtnText}>
+              See every occurrence in Scripture
+            </Text>
+          </TouchableOpacity>
         )}
 
         {/* Glosses */}
@@ -142,6 +162,19 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textAlign: 'center',
     marginTop: 4,
+  },
+  concordanceBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  concordanceBtnText: {
+    color: base.gold,
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
   },
   section: {
     marginTop: spacing.lg,

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -202,6 +202,19 @@ export interface TimelineEntry {
   region: string | null;
 }
 
+// ── Concordance (Phase 21) ───────────────────────────────────
+
+export interface ConcordanceResult {
+  book_id: string;
+  chapter_num: number;
+  verse_num: number;
+  original: string;
+  transliteration: string;
+  gloss: string | null;
+  text: string;
+  book_name: string;
+}
+
 // ══════════════════════════════════════════════════════════════
 // USER DATA TYPES
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Add concordance search that shows every verse where a Hebrew/Greek word appears across the Bible, querying the interlinear_words table by Strong's number.

New files:
- ConcordanceScreen.tsx: Full search screen with word info header, search bar for manual Strong's entry, and scrollable FlatList of results
- ConcordanceEntry.tsx: Result card with book/chapter:verse ref, verse text with target word's gloss highlighted in gold

Entry points:
- InterlinearSheet: "All occurrences" link on each word's Strong's number
- WordStudyDetailScreen: "See every occurrence in Scripture" button
- ExploreMenuScreen: "Concordance" grid card for manual search

Also adds getConcordanceResults/getConcordanceCount queries, ConcordanceResult type, and Concordance route to ExploreStack navigation.

https://claude.ai/code/session_01MHrSdsp1EFuVmUsKRLQE64