### PR TITLE
fix: resolve concordance duplicate key error and prevent similar issues

### DIFF
--- a/app/src/components/ConcordanceEntry.tsx
+++ b/app/src/components/ConcordanceEntry.tsx
@@ -26,13 +26,14 @@ export function ConcordanceEntry({ result, gloss, onPress }: Props) {
     }
 
     // Case-insensitive split on the gloss word
-    const regex = new RegExp(`(${escapeRegex(gloss)})`, 'gi');
-    const parts = result.text.split(regex);
+    const splitRegex = new RegExp(`(${escapeRegex(gloss)})`, 'gi');
+    const testRegex = new RegExp(`^${escapeRegex(gloss)}$`, 'i');
+    const parts = result.text.split(splitRegex);
 
     return (
       <Text style={styles.verseText}>
         {parts.map((part, i) =>
-          regex.test(part) ? (
+          testRegex.test(part) ? (
             <Text key={i} style={styles.highlighted}>{part}</Text>
           ) : (
             <Text key={i}>{part}</Text>

--- a/app/src/components/notes/NoteCard.tsx
+++ b/app/src/components/notes/NoteCard.tsx
@@ -130,8 +130,8 @@ export function NoteCard({
 
           {noteTags.length > 0 && (
             <View style={styles.tagRow}>
-              {noteTags.map((t) => (
-                <Text key={t} style={[styles.tagLabel, { color: base.goldDim }]}>
+              {noteTags.map((t, i) => (
+                <Text key={`${i}-${t}`} style={[styles.tagLabel, { color: base.goldDim }]}>
                   #{t}
                 </Text>
               ))}

--- a/app/src/db/content/chapters.ts
+++ b/app/src/db/content/chapters.ts
@@ -96,8 +96,9 @@ export async function getInterlinearWords(
 
 export async function getConcordanceResults(strongs: string): Promise<ConcordanceResult[]> {
   return getDb().getAllAsync<ConcordanceResult>(
-    `SELECT DISTINCT iw.book_id, iw.chapter_num, iw.verse_num,
-       iw.original, iw.transliteration, ig.gloss,
+    `SELECT iw.book_id, iw.chapter_num, iw.verse_num,
+       iw.original, iw.transliteration,
+       MIN(ig.gloss) as gloss,
        v.text, b.name as book_name
      FROM interlinear_words iw
      LEFT JOIN interlinear_glosses ig ON ig.id = iw.gloss_id
@@ -107,6 +108,7 @@ export async function getConcordanceResults(strongs: string): Promise<Concordanc
        AND v.translation = 'niv'
      JOIN books b ON b.id = iw.book_id
      WHERE iw.strongs = ?
+     GROUP BY iw.book_id, iw.chapter_num, iw.verse_num
      ORDER BY b.book_order, iw.chapter_num, iw.verse_num`,
     [strongs]
   );

--- a/app/src/screens/AllNotesScreen.tsx
+++ b/app/src/screens/AllNotesScreen.tsx
@@ -314,8 +314,8 @@ export default function AllNotesScreen() {
 
                   {noteTags.length > 0 && (
                     <View style={styles.noteTagRow}>
-                      {noteTags.map((t) => (
-                        <Text key={t} style={[styles.noteTag, { color: base.goldDim }]}>#{t}</Text>
+                      {noteTags.map((t, i) => (
+                        <Text key={`${i}-${t}`} style={[styles.noteTag, { color: base.goldDim }]}>#{t}</Text>
                       ))}
                     </View>
                   )}

--- a/app/src/screens/CollectionDetailScreen.tsx
+++ b/app/src/screens/CollectionDetailScreen.tsx
@@ -170,8 +170,8 @@ export default function CollectionDetailScreen() {
               <Text style={[styles.noteText, { color: base.textDim }]}>{note.note_text}</Text>
               {tags.length > 0 && (
                 <View style={styles.tagRow}>
-                  {tags.map((t) => (
-                    <Text key={t} style={[styles.tag, { color: base.goldDim }]}>#{t}</Text>
+                  {tags.map((t, i) => (
+                    <Text key={`${i}-${t}`} style={[styles.tag, { color: base.goldDim }]}>#{t}</Text>
                   ))}
                 </View>
               )}

--- a/app/src/screens/ConcordanceScreen.tsx
+++ b/app/src/screens/ConcordanceScreen.tsx
@@ -140,7 +140,7 @@ export default function ConcordanceScreen() {
       ) : results.length > 0 ? (
         <FlatList
           data={results}
-          keyExtractor={(item, i) => `${item.book_id}-${item.chapter_num}-${item.verse_num}-${i}`}
+          keyExtractor={(item) => `${item.book_id}-${item.chapter_num}-${item.verse_num}`}
           renderItem={({ item }) => (
             <ConcordanceEntry
               result={item}

--- a/app/src/screens/ReadingHistoryScreen.tsx
+++ b/app/src/screens/ReadingHistoryScreen.tsx
@@ -51,7 +51,7 @@ export default function ReadingHistoryScreen() {
 
       <FlatList
         data={history}
-        keyExtractor={(_, i) => String(i)}
+        keyExtractor={(item, i) => `${item.book_id}-${item.chapter_num}-${i}`}
         contentContainerStyle={styles.listContent}
         ListEmptyComponent={
           <View style={styles.emptyWrap}>


### PR DESCRIPTION
The concordance SQL query used SELECT DISTINCT but could return multiple rows for the same verse when a word appeared with different glosses. Changed to GROUP BY on (book_id, chapter_num, verse_num) so each verse appears once. Simplified keyExtractor to drop the index suffix since results are now unique.

Also fixed: regex.test() bug in ConcordanceEntry (g flag lastIndex issue), duplicate tag keys in NoteCard/AllNotesScreen/CollectionDetailScreen, and index-only keyExtractor in ReadingHistoryScreen.

https://claude.ai/code/session_01MYfqVkA99irineKXmTvCXT