### PR TITLE
feat(reader): Add parallel translation comparison view

### DIFF
--- a/app/__tests__/components/ChapterNavBar.test.tsx
+++ b/app/__tests__/components/ChapterNavBar.test.tsx
@@ -21,6 +21,9 @@ const defaultProps = {
   onQnav: jest.fn(),
   translation: 'kjv',
   onTranslationChange: jest.fn(),
+  comparisonTranslation: null,
+  onCompareStart: jest.fn(),
+  onCompareEnd: jest.fn(),
 };
 
 describe('ChapterNavBar', () => {

--- a/app/src/components/ChapterNavBar.tsx
+++ b/app/src/components/ChapterNavBar.tsx
@@ -4,15 +4,18 @@
  * Layout:
  *   ← NIV ▾       ‹ Genesis 2 ›          🔊 ⓘ
  *   (back/trans)    (prev/qnav/next)    (TTS/intro)
+ *
+ * When compare mode is active, the translation pill shows "KJV | ASV"
+ * and the dropdown footer shows "Exit Compare" instead of "Compare +".
  */
 
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { View, Text, TouchableOpacity, Modal, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ArrowLeft, ChevronLeft, ChevronRight, Info, Volume2 } from 'lucide-react-native';
+import { ArrowLeft, ChevronLeft, ChevronRight, Info, Volume2, Check } from 'lucide-react-native';
 import { CompactDropdown, type DropdownOption } from './CompactDropdown';
-import { lightImpact } from '../utils/haptics';
-import { base, useTheme, spacing, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import { lightImpact, selectionFeedback } from '../utils/haptics';
+import { base, useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
 import { TRANSLATIONS } from '../db/translationRegistry';
 
 const TRANSLATION_OPTIONS: DropdownOption[] = TRANSLATIONS.map((t) => ({
@@ -34,14 +37,54 @@ interface Props {
   ttsActive?: boolean;
   translation: string;
   onTranslationChange: (t: string) => void;
+  comparisonTranslation: string | null;
+  onCompareStart: (t: string) => void;
+  onCompareEnd: () => void;
 }
 
 export function ChapterNavBar({
   bookName, chapterNum, hasPrev, hasNext,
   onPrev, onNext, onQnav, onBack, onIntroPress, onTTSPress, ttsActive,
   translation, onTranslationChange,
+  comparisonTranslation, onCompareStart, onCompareEnd,
 }: Props) {
   const { base } = useTheme();
+  const [comparePicker, setComparePicker] = useState(false);
+
+  const compLabel = comparisonTranslation
+    ? (TRANSLATIONS.find(t => t.id === comparisonTranslation)?.label ?? comparisonTranslation.toUpperCase())
+    : undefined;
+
+  const handleCompareFooter = useCallback((close: () => void) => {
+    if (comparisonTranslation) {
+      return (
+        <TouchableOpacity
+          onPress={() => { onCompareEnd(); close(); }}
+          style={styles.compareFooterBtn}
+          accessibilityLabel="Exit translation comparison"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.compareFooterText, { color: base.danger ?? base.textMuted }]}>Exit Compare</Text>
+        </TouchableOpacity>
+      );
+    }
+    return (
+      <TouchableOpacity
+        onPress={() => { close(); setComparePicker(true); }}
+        style={styles.compareFooterBtn}
+        accessibilityLabel="Compare with another translation"
+        accessibilityRole="button"
+      >
+        <Text style={[styles.compareFooterText, { color: base.gold }]}>Compare +</Text>
+      </TouchableOpacity>
+    );
+  }, [comparisonTranslation, onCompareEnd, base]);
+
+  const handleCompareSelect = useCallback((key: string) => {
+    selectionFeedback();
+    onCompareStart(key);
+    setComparePicker(false);
+  }, [onCompareStart]);
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: base.bg }]}>
@@ -60,8 +103,10 @@ export function ChapterNavBar({
           ) : null}
           <CompactDropdown
             value={translation}
+            secondaryLabel={compLabel}
             options={TRANSLATION_OPTIONS}
             onSelect={onTranslationChange}
+            renderFooter={handleCompareFooter}
           />
         </View>
 
@@ -122,6 +167,31 @@ export function ChapterNavBar({
           ) : null}
         </View>
       </View>
+
+      {/* Comparison translation picker modal */}
+      <Modal visible={comparePicker} transparent animationType="fade">
+        <TouchableWithoutFeedback onPress={() => setComparePicker(false)}>
+          <View style={styles.pickerBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={[styles.pickerMenu, { backgroundColor: base.bgElevated, borderColor: base.border }]}>
+                <Text style={[styles.pickerTitle, { color: base.text }]}>Compare with:</Text>
+                {TRANSLATION_OPTIONS.filter(o => o.key !== translation).map((opt) => (
+                  <TouchableOpacity
+                    key={opt.key}
+                    onPress={() => handleCompareSelect(opt.key)}
+                    style={styles.pickerItem}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Compare with ${opt.label}`}
+                  >
+                    <Text style={[styles.pickerLabel, { color: base.text }]}>{opt.label}</Text>
+                    {opt.key === comparisonTranslation && <Check size={14} color={base.gold} />}
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -138,7 +208,7 @@ const styles = StyleSheet.create({
   sideSection: {
     flexDirection: 'row',
     alignItems: 'center',
-    width: 90,
+    width: 100,
     gap: 2,
   },
   sideSectionRight: {
@@ -171,5 +241,50 @@ const styles = StyleSheet.create({
     minHeight: MIN_TOUCH_TARGET,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  compareFooterBtn: {
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+  },
+  compareFooterText: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+  },
+  pickerBackdrop: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  pickerMenu: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    minWidth: 200,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  pickerTitle: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.xs,
+  },
+  pickerItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: MIN_TOUCH_TARGET,
+    paddingHorizontal: spacing.md,
+  },
+  pickerLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
   },
 });

--- a/app/src/components/CompactDropdown.tsx
+++ b/app/src/components/CompactDropdown.tsx
@@ -24,18 +24,23 @@ export interface DropdownOption {
 
 interface Props {
   value: string;
+  /** Optional secondary label shown after a pipe in the pill (e.g. "KJV | ASV"). */
+  secondaryLabel?: string;
   options: DropdownOption[];
   onSelect: (key: string) => void;
   direction?: 'down' | 'up';
+  /** Render slot below the options list (e.g. Compare + button). Receives close callback. */
+  renderFooter?: (close: () => void) => React.ReactNode;
 }
 
-export function CompactDropdown({ value, options, onSelect, direction = 'down' }: Props) {
+export function CompactDropdown({ value, secondaryLabel, options, onSelect, direction = 'down', renderFooter }: Props) {
   const { base } = useTheme();
   const [open, setOpen] = useState(false);
   const [pillLayout, setPillLayout] = useState<LayoutRectangle | null>(null);
   const pillRef = useRef<View>(null);
 
-  const activeLabel = options.find((o) => o.key === value)?.label ?? value.toUpperCase();
+  const primaryLabel = options.find((o) => o.key === value)?.label ?? value.toUpperCase();
+  const activeLabel = secondaryLabel ? `${primaryLabel} | ${secondaryLabel}` : primaryLabel;
 
   const handleOpen = useCallback(() => {
     pillRef.current?.measureInWindow((x, y, width, height) => {
@@ -103,6 +108,12 @@ export function CompactDropdown({ value, options, onSelect, direction = 'down' }
                     </TouchableOpacity>
                   );
                 })}
+                {renderFooter && (
+                  <>
+                    <View style={[styles.footerDivider, { backgroundColor: base.border }]} />
+                    {renderFooter(() => setOpen(false))}
+                  </>
+                )}
               </View>
             </TouchableWithoutFeedback>
           </View>
@@ -149,5 +160,9 @@ const styles = StyleSheet.create({
   menuLabel: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 14,
+  },
+  footerDivider: {
+    height: 1,
+    marginHorizontal: spacing.sm,
   },
 });

--- a/app/src/components/CompareBar.tsx
+++ b/app/src/components/CompareBar.tsx
@@ -1,0 +1,54 @@
+/**
+ * CompareBar — Thin gold indicator bar: "Comparing KJV and ASV  ✕"
+ * Shown below the nav bar when parallel translation mode is active.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { X } from 'lucide-react-native';
+import { useTheme, spacing, fontFamily } from '../theme';
+
+interface Props {
+  primaryLabel: string;
+  comparisonLabel: string;
+  onDismiss: () => void;
+}
+
+export function CompareBar({ primaryLabel, comparisonLabel, onDismiss }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.bar, { backgroundColor: base.gold + '08', borderBottomColor: base.gold + '20' }]}
+      accessibilityRole="toolbar"
+      accessibilityLabel={`Comparing ${primaryLabel} and ${comparisonLabel}. Tap X to exit.`}
+    >
+      <Text style={[styles.text, { color: base.gold }]}>
+        Comparing {primaryLabel} and {comparisonLabel}
+      </Text>
+      <TouchableOpacity
+        onPress={onDismiss}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityLabel="Exit translation comparison"
+        accessibilityRole="button"
+      >
+        <X size={14} color={base.textMuted} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    height: 28,
+    paddingHorizontal: spacing.md,
+    borderBottomWidth: 1,
+  },
+  text: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+});

--- a/app/src/components/ComparisonVerse.tsx
+++ b/app/src/components/ComparisonVerse.tsx
@@ -1,0 +1,54 @@
+/**
+ * ComparisonVerse — Renders the comparison translation text below a primary verse.
+ * Display-only: no VHL, no highlights, no interlinear, no long-press.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, spacing } from '../theme';
+
+interface Props {
+  text: string | null;
+  translationLabel: string;
+}
+
+export function ComparisonVerse({ text, translationLabel }: Props) {
+  const { base } = useTheme();
+
+  if (text === null) {
+    return (
+      <View style={styles.container}>
+        <Text style={[styles.missing, { color: base.textMuted + '40' }]}>—</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.compText, { color: base.textMuted }]}>{text}</Text>
+      <Text style={[styles.label, { color: base.textMuted + '80' }]}>{translationLabel}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+    paddingLeft: 32,
+  },
+  compText: {
+    fontFamily: fontFamily.body,
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    alignSelf: 'flex-end',
+    marginTop: 2,
+  },
+  missing: {
+    fontStyle: 'italic',
+    fontSize: 13,
+  },
+});

--- a/app/src/components/SectionBlock.tsx
+++ b/app/src/components/SectionBlock.tsx
@@ -36,6 +36,10 @@ interface Props {
   depthExplored?: number;
   depthTotal?: number;
   onDepthRecord?: (sectionId: string, panelType: string) => void;
+  /** Comparison verses for parallel translation view. */
+  comparisonVerses?: Verse[];
+  comparisonLabel?: string;
+  primaryLabel?: string;
 }
 
 export function SectionBlock({
@@ -44,11 +48,17 @@ export function SectionBlock({
   onPanelToggle, onNotePress, onRefPress, onVerseLongPress, onVerseNumPress, activeVerseNum,
   renderButtonRow, renderPanel,
   depthExplored, depthTotal, onDepthRecord,
+  comparisonVerses, comparisonLabel, primaryLabel,
 }: Props) {
   const { base } = useTheme();
 
   // Filter verses for this section
   const sectionVerses = verses.filter(
+    (v) => v.verse_num >= section.verse_start && v.verse_num <= section.verse_end
+  );
+
+  // Filter comparison verses for this section
+  const sectionCompVerses = comparisonVerses?.filter(
     (v) => v.verse_num >= section.verse_start && v.verse_num <= section.verse_end
   );
 
@@ -87,6 +97,9 @@ export function SectionBlock({
         onVerseLongPress={onVerseLongPress}
         onVerseNumPress={onVerseNumPress}
         activeVerseNum={activeVerseNum}
+        comparisonVerses={sectionCompVerses}
+        comparisonLabel={comparisonLabel}
+        primaryLabel={primaryLabel}
       />
 
       {/* Panel button row after verses */}

--- a/app/src/components/VerseBlock.tsx
+++ b/app/src/components/VerseBlock.tsx
@@ -1,12 +1,13 @@
 /**
- * VerseBlock — Renders verse text for a section with VHL highlighting
- * and per-verse note indicators.
+ * VerseBlock — Renders verse text for a section with VHL highlighting,
+ * per-verse note indicators, and optional comparison translation.
  */
 
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { HighlightedText } from './HighlightedText';
 import { NoteIndicator } from './NoteIndicator';
+import { ComparisonVerse } from './ComparisonVerse';
 import { base, useTheme, spacing, fontFamily } from '../theme';
 import type { Verse, VHLGroup } from '../types';
 
@@ -22,62 +23,96 @@ interface Props {
   onVerseLongPress?: (verseNum: number, text: string) => void;
   onVerseNumPress?: (verseNum: number) => void;
   activeVerseNum?: number;
+  /** Comparison verses for parallel translation view. */
+  comparisonVerses?: Verse[];
+  /** Label for the comparison translation (e.g. "ASV"). */
+  comparisonLabel?: string;
+  /** Label for the primary translation (e.g. "KJV"). Shown only when comparing. */
+  primaryLabel?: string;
 }
 
 export const VerseBlock = React.memo(function VerseBlock({
   verses, vhlGroups, activeVhlGroups, notedVerses, sectionId,
   fontSize = 16, onVhlWordPress, onNotePress, onVerseLongPress, onVerseNumPress, activeVerseNum,
+  comparisonVerses, comparisonLabel, primaryLabel,
 }: Props) {
   const { base } = useTheme();
   if (!verses.length) return null;
 
   const lineHeight = fontSize * 1.6;
   const numSize = Math.max(11, fontSize * 0.65);
+  const isComparing = !!comparisonVerses && comparisonVerses.length > 0;
 
   return (
     <View style={styles.container}>
-      {verses.map((verse) => (
-        <TouchableOpacity
-          key={verse.verse_num}
-          style={[styles.verseRow, activeVerseNum === verse.verse_num && { backgroundColor: base.gold + '15', borderRadius: 4, marginHorizontal: -4, paddingHorizontal: 4 }]}
-          onLongPress={onVerseLongPress ? () => onVerseLongPress(verse.verse_num, verse.text) : undefined}
-          activeOpacity={onVerseLongPress ? 0.7 : 1}
-          delayLongPress={400}
-          accessibilityRole="button"
-          accessibilityLabel={`Verse ${verse.verse_num}. Long press for options`}
-          accessibilityHint="Long press to copy, share, or add a note"
-        >
-          {/* Verse number (tap for interlinear) */}
-          <Text
-            style={[styles.verseNum, { fontSize: numSize, lineHeight, color: base.verseNum }]}
-            accessibilityLabel={`Verse ${verse.verse_num}`}
-            onPress={onVerseNumPress ? () => onVerseNumPress(verse.verse_num) : undefined}
-          >
-            {verse.verse_num}
-          </Text>
+      {verses.map((verse, idx) => {
+        const comp = isComparing
+          ? comparisonVerses!.find(cv => cv.verse_num === verse.verse_num)
+          : null;
 
-          {/* Verse text with VHL */}
-          <View style={styles.textWrap}>
-            <HighlightedText
-              text={verse.text}
-              groups={vhlGroups}
-              activeGroups={activeVhlGroups}
-              sectionId={sectionId}
-              onVhlWordPress={onVhlWordPress}
-              style={{ fontSize, lineHeight }}
-            />
+        return (
+          <View key={verse.verse_num}>
+            <TouchableOpacity
+              style={[styles.verseRow, activeVerseNum === verse.verse_num && { backgroundColor: base.gold + '15', borderRadius: 4, marginHorizontal: -4, paddingHorizontal: 4 }]}
+              onLongPress={onVerseLongPress ? () => onVerseLongPress(verse.verse_num, verse.text) : undefined}
+              activeOpacity={onVerseLongPress ? 0.7 : 1}
+              delayLongPress={400}
+              accessibilityRole="button"
+              accessibilityLabel={`Verse ${verse.verse_num}. Long press for options`}
+              accessibilityHint="Long press to copy, share, or add a note"
+            >
+              {/* Verse number (tap for interlinear) */}
+              <Text
+                style={[styles.verseNum, { fontSize: numSize, lineHeight, color: base.verseNum }]}
+                accessibilityLabel={`Verse ${verse.verse_num}`}
+                onPress={onVerseNumPress ? () => onVerseNumPress(verse.verse_num) : undefined}
+              >
+                {verse.verse_num}
+              </Text>
+
+              {/* Verse text with VHL */}
+              <View style={styles.textWrap}>
+                <HighlightedText
+                  text={verse.text}
+                  groups={vhlGroups}
+                  activeGroups={activeVhlGroups}
+                  sectionId={sectionId}
+                  onVhlWordPress={onVhlWordPress}
+                  style={{ fontSize, lineHeight }}
+                />
+                {/* Primary translation label (only in compare mode) */}
+                {isComparing && primaryLabel && (
+                  <Text style={[styles.translationLabel, { color: base.textMuted + '80' }]}>
+                    {primaryLabel}
+                  </Text>
+                )}
+              </View>
+
+              {/* Note indicator */}
+              {onNotePress && (
+                <NoteIndicator
+                  verseNum={verse.verse_num}
+                  hasNote={notedVerses.has(verse.verse_num)}
+                  onPress={onNotePress}
+                />
+              )}
+            </TouchableOpacity>
+
+            {/* Comparison verse (display only — no VHL, no interaction) */}
+            {isComparing && (
+              <ComparisonVerse
+                text={comp?.text ?? null}
+                translationLabel={comparisonLabel ?? ''}
+              />
+            )}
+
+            {/* Divider between verse pairs in compare mode */}
+            {isComparing && idx < verses.length - 1 && (
+              <View style={[styles.compareDivider, { borderBottomColor: base.border }]} />
+            )}
           </View>
-
-          {/* Note indicator */}
-          {onNotePress && (
-            <NoteIndicator
-              verseNum={verse.verse_num}
-              hasNote={notedVerses.has(verse.verse_num)}
-              onPress={onNotePress}
-            />
-          )}
-        </TouchableOpacity>
-      ))}
+        );
+      })}
     </View>
   );
 });
@@ -99,5 +134,17 @@ const styles = StyleSheet.create({
   },
   textWrap: {
     flex: 1,
+  },
+  translationLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    alignSelf: 'flex-end',
+    marginTop: 2,
+  },
+  compareDivider: {
+    borderBottomWidth: 1,
+    borderStyle: 'dashed',
+    marginVertical: 8,
+    marginHorizontal: spacing.md,
   },
 });

--- a/app/src/hooks/useChapterData.ts
+++ b/app/src/hooks/useChapterData.ts
@@ -1,5 +1,8 @@
 /**
  * hooks/useChapterData.ts — Load ALL data for a chapter in one call.
+ *
+ * When comparisonTranslation is set, also loads comparison verses
+ * for parallel translation view.
  */
 
 import { useState, useEffect, useMemo } from 'react';
@@ -19,6 +22,7 @@ interface ChapterData {
   chapter: Chapter | null;
   sections: SectionData[];
   verses: Verse[];
+  comparisonVerses: Verse[];
   vhlGroups: VHLGroup[];
   chapterPanels: ChapterPanel[];
   noteCount: number;
@@ -27,9 +31,11 @@ interface ChapterData {
 
 export function useChapterData(bookId: string | null, chapterNum: number): ChapterData {
   const translation = useSettingsStore((s) => s.translation);
+  const comparisonTranslation = useSettingsStore((s) => s.comparisonTranslation);
   const [chapter, setChapter] = useState<Chapter | null>(null);
   const [sections, setSections] = useState<SectionData[]>([]);
   const [verses, setVerses] = useState<Verse[]>([]);
+  const [comparisonVerses, setComparisonVerses] = useState<Verse[]>([]);
   const [vhlGroups, setVhlGroups] = useState<VHLGroup[]>([]);
   const [chapterPanels, setChapterPanels] = useState<ChapterPanel[]>([]);
   const [noteCount, setNoteCount] = useState(0);
@@ -50,9 +56,12 @@ export function useChapterData(bookId: string | null, chapterNum: number): Chapt
         return;
       }
 
-      const [secs, vv, vhl, cp, nc] = await Promise.all([
+      const [secs, vv, compVv, vhl, cp, nc] = await Promise.all([
         getSections(ch.id),
         getVerses(bookId!, chapterNum, translation),
+        comparisonTranslation
+          ? getVerses(bookId!, chapterNum, comparisonTranslation)
+          : Promise.resolve([]),
         getVHLGroups(ch.id),
         getChapterPanels(ch.id),
         getNoteCount(bookId!, chapterNum),
@@ -72,6 +81,7 @@ export function useChapterData(bookId: string | null, chapterNum: number): Chapt
 
       setSections(secsWithPanels);
       setVerses(vv);
+      setComparisonVerses(compVv);
       setVhlGroups(vhl);
       setChapterPanels(cp);
       setNoteCount(nc);
@@ -80,7 +90,7 @@ export function useChapterData(bookId: string | null, chapterNum: number): Chapt
 
     load();
     return () => { cancelled = true; };
-  }, [bookId, chapterNum, translation]);
+  }, [bookId, chapterNum, translation, comparisonTranslation]);
 
-  return { chapter, sections, verses, vhlGroups, chapterPanels, noteCount, isLoading };
+  return { chapter, sections, verses, comparisonVerses, vhlGroups, chapterPanels, noteCount, isLoading };
 }

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -28,6 +28,7 @@ import { updateLastActive, cancelReengagement } from '../services/reengagement';
 import { getBook } from '../db/content';
 
 import { ChapterNavBar } from '../components/ChapterNavBar';
+import { CompareBar } from '../components/CompareBar';
 import { ChapterHeader } from '../components/ChapterHeader';
 import { SectionBlock } from '../components/SectionBlock';
 import { ButtonRow } from '../components/ButtonRow';
@@ -43,6 +44,7 @@ import { InterlinearSheet } from '../components/InterlinearSheet';
 import { TTSControls } from '../components/TTSControls';
 import { useTTS } from '../hooks/useTTS';
 
+import { TRANSLATION_MAP } from '../db/translationRegistry';
 import { base, useTheme, spacing, radii, fontFamily } from '../theme';
 
 // Enable LayoutAnimation on Android
@@ -58,6 +60,8 @@ export default function ChapterScreen() {
 
   const fontSize = useSettingsStore((s) => s.fontSize);
   const translation = useSettingsStore((s) => s.translation);
+  const comparisonTranslation = useSettingsStore((s) => s.comparisonTranslation);
+  const setComparisonTranslation = useSettingsStore((s) => s.setComparisonTranslation);
   const { switchTranslation } = useTranslationSwitch();
   const { checkAndPrompt } = useStoreReview();
   const studyCoachEnabled = useSettingsStore((s) => s.studyCoachEnabled);
@@ -75,7 +79,7 @@ export default function ChapterScreen() {
   const [highlights, setHighlights] = useState<VerseHighlight[]>([]);
 
   const {
-    chapter, sections, verses, vhlGroups,
+    chapter, sections, verses, comparisonVerses, vhlGroups,
     chapterPanels, noteCount, isLoading,
   } = useChapterData(bookId, chapterNum);
 
@@ -310,6 +314,9 @@ export default function ChapterScreen() {
         ttsActive={ttsActive}
         translation={translation}
         onTranslationChange={switchTranslation}
+        comparisonTranslation={comparisonTranslation}
+        onCompareStart={setComparisonTranslation}
+        onCompareEnd={() => setComparisonTranslation(null)}
       />
 
       {/* Breadcrumb pill — visible when navigated from Content Library */}
@@ -321,6 +328,15 @@ export default function ChapterScreen() {
         >
           <Text style={[styles.breadcrumbText, { color: base.gold }]}>← Content Library</Text>
         </TouchableOpacity>
+      )}
+
+      {/* Compare bar — shown when parallel translation is active */}
+      {comparisonTranslation && (
+        <CompareBar
+          primaryLabel={TRANSLATION_MAP.get(translation)?.label ?? translation.toUpperCase()}
+          comparisonLabel={TRANSLATION_MAP.get(comparisonTranslation)?.label ?? comparisonTranslation.toUpperCase()}
+          onDismiss={() => setComparisonTranslation(null)}
+        />
       )}
 
       {/* Reading progress bar */}
@@ -386,6 +402,9 @@ export default function ChapterScreen() {
               depthExplored={depthMap.get(sec.id)?.explored}
               depthTotal={depthMap.get(sec.id)?.total}
               onDepthRecord={recordOpen}
+              comparisonVerses={comparisonTranslation ? comparisonVerses : undefined}
+              comparisonLabel={comparisonTranslation ? (TRANSLATION_MAP.get(comparisonTranslation)?.label ?? comparisonTranslation.toUpperCase()) : undefined}
+              primaryLabel={comparisonTranslation ? (TRANSLATION_MAP.get(translation)?.label ?? translation.toUpperCase()) : undefined}
               renderButtonRow={(panels, sectionId) => (
                 <View onLayout={(e) => {
                   const sectionY = sectionYMap.current[sectionId] ?? 0;

--- a/app/src/stores/settingsStore.ts
+++ b/app/src/stores/settingsStore.ts
@@ -29,6 +29,7 @@ interface SettingsState {
   studyCoachEnabled: boolean;
   theme: ThemePreference;
   ttsVoice: string;
+  comparisonTranslation: string | null;
   isHydrated: boolean;
 
   setTranslation: (t: string) => void;
@@ -38,6 +39,7 @@ interface SettingsState {
   setStudyCoachEnabled: (v: boolean) => void;
   setTheme: (t: ThemePreference) => void;
   setTtsVoice: (v: string) => void;
+  setComparisonTranslation: (t: string | null) => void;
   hydrate: () => Promise<void>;
 }
 
@@ -49,6 +51,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   studyCoachEnabled: true,
   theme: 'dark' as ThemePreference,
   ttsVoice: '',
+  comparisonTranslation: null,
   isHydrated: false,
 
   setTranslation: async (t) => {
@@ -87,6 +90,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     await setPreference('ttsVoice', v);
   },
 
+  setComparisonTranslation: async (t) => {
+    set({ comparisonTranslation: t });
+    await setPreference('comparisonTranslation', t ?? '');
+  },
+
   hydrate: async () => {
     try {
       const t = await getPreference('translation');
@@ -96,6 +104,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       const sc = await getPreference('studyCoachEnabled');
       const th = await getPreference('theme');
       const voice = await getPreference('ttsVoice');
+      const comp = await getPreference('comparisonTranslation');
 
       set({
         translation: (t && TRANSLATION_MAP.has(t) ? t : 'kjv'),
@@ -105,6 +114,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
         studyCoachEnabled: sc !== '0',
         theme: (VALID_THEMES.includes(th as ThemePreference) ? th : 'dark') as ThemePreference,
         ttsVoice: voice ?? '',
+        comparisonTranslation: (comp && TRANSLATION_MAP.has(comp)) ? comp : null,
         isHydrated: true,
       });
     } catch (err) {

--- a/app/src/utils/verseMatch.ts
+++ b/app/src/utils/verseMatch.ts
@@ -1,0 +1,18 @@
+/**
+ * utils/verseMatch.ts — Pairs primary and comparison verses by verse_num.
+ */
+
+import type { Verse } from '../types';
+
+export interface VersePair {
+  primary: Verse;
+  comparison: Verse | null;
+}
+
+export function matchVerses(primary: Verse[], comparison: Verse[]): VersePair[] {
+  const compMap = new Map(comparison.map(v => [v.verse_num, v]));
+  return primary.map(v => ({
+    primary: v,
+    comparison: compMap.get(v.verse_num) ?? null,
+  }));
+}


### PR DESCRIPTION
New feature: inline parallel translation reading. When active, each verse displays the comparison translation directly below the primary text — no separate screen or bottom sheet needed.

Entry point: "Compare +" footer in the translation dropdown opens a picker for the comparison translation. When active, the pill shows "KJV | ASV" and a gold CompareBar appears below the nav bar with a dismiss button.

New files:
- utils/verseMatch.ts: matchVerses() pairs primary + comparison by verse_num
- components/ComparisonVerse.tsx: renders comparison text (display-only, no VHL/highlights/interaction) or "—" for missing verses
- components/CompareBar.tsx: thin gold indicator bar with dismiss button

Modified files:
- settingsStore.ts: comparisonTranslation state + persistence
- useChapterData.ts: fetches comparison verses in parallel when active
- CompactDropdown.tsx: secondaryLabel prop for dual pill display, renderFooter slot for Compare+/Exit Compare button
- ChapterNavBar.tsx: compare props, comparison picker modal, footer rendering in dropdown
- VerseBlock.tsx: renders ComparisonVerse below each primary verse, shows translation labels, dashed dividers between verse pairs
- SectionBlock.tsx: threads comparison props to VerseBlock
- ChapterScreen.tsx: reads comparison state, passes to nav/sections, renders CompareBar

Design:
- Primary verse: full styling (VHL, highlights, notes, interlinear)
- Comparison verse: base.textMuted color, no interactivity
- Translation labels (9px, right-aligned) on both when comparing
- TTS reads primary only, long-press fires on primary only
- Compare persists across chapter navigation and app restart

https://claude.ai/code/session_01A4HcModKHZYEAerBS28rzr