### PR TITLE
Fix duplicate React key errors in parallel passages screen

### DIFF
--- a/app/src/components/GospelDots.tsx
+++ b/app/src/components/GospelDots.tsx
@@ -35,8 +35,8 @@ export function GospelDots({ books, isOT }: Props) {
   if (isOT) {
     return (
       <View style={styles.row}>
-        {books.map((b) => (
-          <View key={b} style={[styles.dot, { backgroundColor: base.gold + '20' }]}>
+        {books.map((b, idx) => (
+          <View key={`${b}-${idx}`} style={[styles.dot, { backgroundColor: base.gold + '20' }]}>
             <Text style={[styles.dotText, { color: base.gold }]}>
               {OT_ABBREV[b] ?? b.slice(0, 3)}
             </Text>

--- a/app/src/screens/ParallelDetailScreen.tsx
+++ b/app/src/screens/ParallelDetailScreen.tsx
@@ -108,7 +108,7 @@ export default function ParallelDetailScreen() {
 
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
         {/* Gospel passage cards */}
-        {passages.map((p) => {
+        {passages.map((p, idx) => {
           const cfg = GOSPEL_CONFIG[p.book];
           const gospelName = cfg?.name ?? p.book.charAt(0).toUpperCase() + p.book.slice(1);
           const color = cfg?.color ?? base.gold;
@@ -116,7 +116,7 @@ export default function ParallelDetailScreen() {
 
           return (
             <GospelPassageCard
-              key={p.book}
+              key={`${p.book}-${idx}`}
               gospelName={gospelName}
               ref={p.ref}
               verses={passageTexts[p.book] ?? []}


### PR DESCRIPTION
OT parallel passages can reference the same book multiple times (e.g., 2 Samuel 2:4 and 2 Samuel 5:3). Using book name alone as the React key caused duplicate key warnings. Use book-index composite keys instead.

https://claude.ai/code/session_01FcVaKeyytARWxv8KtpSbop