### PR TITLE
fix: Add error handling to useDebateTopics to prevent infinite spinner

### DIFF
--- a/app/src/hooks/useDebateTopics.ts
+++ b/app/src/hooks/useDebateTopics.ts
@@ -8,6 +8,7 @@ import {
   searchDebateTopics, getDebateTopicScholars,
 } from '../db/content';
 import type { DebateTopicSummary, DebateTopic, Scholar } from '../types';
+import { logger } from '../utils/logger';
 
 // ── Category constants ────────────────────────────────────────
 
@@ -43,10 +44,15 @@ export function useDebateTopics(): UseDebateTopicsResult {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
-    getDebateTopics().then((t) => {
-      setAllTopics(t);
-      setLoading(false);
-    });
+    getDebateTopics()
+      .then((t) => {
+        setAllTopics(t);
+        setLoading(false);
+      })
+      .catch((err) => {
+        logger.error('useDebateTopics', 'Failed to load debate topics', err);
+        setLoading(false);
+      });
   }, []);
 
   // Debounced search


### PR DESCRIPTION
The hook's getDebateTopics() call had no .catch() handler, so if the query fails (e.g. stale DB without debate_topics table), the promise rejects silently and loading stays true forever — showing an infinite spinner. Now logs the error and transitions to the empty state.

https://claude.ai/code/session_01P2aZVhcyq5mRrUmp2LUMPo