### PR TITLE
fix: Resolve CI failures — add PlanDetail to Home stack and mock Acti…

### DIFF
--- a/app/__tests__/screens/HomeScreen.test.tsx
+++ b/app/__tests__/screens/HomeScreen.test.tsx
@@ -85,6 +85,10 @@ jest.mock('@/utils/shareVerse', () => ({
   shareVerse: jest.fn(),
 }));
 
+jest.mock('@/components/ActivePlanCard', () => ({
+  ActivePlanCard: () => null,
+}));
+
 // ── Tests ─────────────────────────────────────────────────────────
 
 describe('HomeScreen', () => {

--- a/app/src/navigation/HomeStack.tsx
+++ b/app/src/navigation/HomeStack.tsx
@@ -12,6 +12,7 @@ import TopicBrowseScreen from '../screens/TopicBrowseScreen';
 import TopicDetailScreen from '../screens/TopicDetailScreen';
 import DictionaryBrowseScreen from '../screens/DictionaryBrowseScreen';
 import DictionaryDetailScreen from '../screens/DictionaryDetailScreen';
+import PlanDetailScreen from '../screens/PlanDetailScreen';
 import { useTheme } from '../theme';
 import type { HomeStackParamList } from './types';
 
@@ -35,6 +36,7 @@ export function HomeStack() {
       <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
       <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
       <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
+      <Stack.Screen name="PlanDetail" component={PlanDetailScreen} />
     </Stack.Navigator>
   );
 }

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -47,6 +47,7 @@ export type HomeStackParamList = {
   TopicDetail: { topicId: string };
   DictionaryBrowse: undefined;
   DictionaryDetail: { entryId: string };
+  PlanDetail: { planId: string };
 };
 
 export type ExploreStackParamList = {


### PR DESCRIPTION
…vePlanCard in tests

ActivePlanCard navigated to PlanDetail which wasn't in HomeStackParamList, causing a TS error. HomeScreen tests failed because ActivePlanCard called getUserDb() without a mock. Added PlanDetail screen to the Home stack navigator and types, and mocked ActivePlanCard in the test file.

https://claude.ai/code/session_01JgT45hqTfFjAFyVYwRCF5U