### PR TITLE
chore(ci): Add debate-topics.json validation to schema_validator + CI meta coverage

### DIFF
--- a/_tools/ci_content_check.py
+++ b/_tools/ci_content_check.py
@@ -83,6 +83,26 @@ def parse_changed_files(file_paths: list[str]) -> dict:
     return dict(chapters)
 
 
+def parse_changed_meta_files(file_paths: list[str]) -> list[str]:
+    """Parse changed file paths to find modified meta files.
+
+    Args:
+        file_paths: List of paths like "content/meta/debate-topics.json"
+
+    Returns:
+        List of meta filenames that changed (e.g. ["debate-topics.json"])
+    """
+    meta_files = []
+    for fp in file_paths:
+        fp = fp.strip()
+        if not fp:
+            continue
+        parts = Path(fp).parts
+        if len(parts) >= 3 and parts[0] == "content" and parts[1] == "meta":
+            meta_files.append(parts[2])
+    return meta_files
+
+
 # ─── Quality Check ──────────────────────────────────────────────────
 
 def run_quality_check(book_dir: str, chapter_nums: list[int]) -> list[dict]:
@@ -193,6 +213,91 @@ def run_accuracy_check(book_dir: str, chapter_nums: list[int],
         claim_details.append({
             "id": claim.id,
             "chapter_id": claim.chapter_id,
+            "panel_type": claim.panel_type,
+            "claim_type": claim.claim_type,
+            "claim_text": claim.claim_text[:300],
+            "source_attribution": claim.source_attribution,
+            "status": result.status,
+            "confidence": result.confidence,
+            "notes": result.notes,
+            "fix_suggestion": result.fix_suggestion,
+            "tier": result.tier,
+        })
+
+    return {
+        "claims": claim_details,
+        "stats": dict(status_counts),
+        "total": len(all_claims),
+        "tier2_calls": t2_calls,
+        "tier2_cost": round(t2_cost, 2),
+    }
+
+
+# ─── Meta Accuracy Check ──────────────────────────────────────────
+
+# Map meta filenames to the MetaClaimExtractor methods that handle them
+META_FILE_EXTRACTORS = {
+    "debate-topics.json": "extract_debate_topics",
+    "difficult-passages.json": "extract_difficult_passages",
+    "prophecy-chains.json": "extract_prophecy_chains",
+    "concepts.json": "extract_concepts",
+    "people.json": "extract_people",
+}
+
+
+def run_meta_accuracy_check(meta_files: list[str],
+                            max_tier: int = 2) -> dict:
+    """Run accuracy auditing on changed meta files.
+
+    Uses MetaClaimExtractor to extract claims from the specified meta files,
+    then verifies them through the standard accuracy pipeline.
+
+    Returns same shape as run_accuracy_check().
+    """
+    try:
+        from accuracy_meta_extractors import MetaClaimExtractor
+    except ImportError:
+        return {
+            "claims": [], "stats": {}, "total": 0,
+            "tier2_calls": 0, "tier2_cost": 0,
+            "meta_note": "accuracy_meta_extractors import failed",
+        }
+
+    extractor = MetaClaimExtractor()
+    verifier = AccuracyVerifier(max_tier=max_tier)
+    all_claims = []
+
+    for meta_file in meta_files:
+        method_name = META_FILE_EXTRACTORS.get(meta_file)
+        if not method_name:
+            continue
+        method = getattr(extractor, method_name, None)
+        if not method:
+            continue
+        try:
+            claims = method()
+            all_claims.extend(claims)
+        except Exception as e:
+            print(f"  Meta extractor error ({meta_file}): {e}", file=sys.stderr)
+
+    if not all_claims:
+        return {
+            "claims": [], "stats": {}, "total": 0,
+            "tier2_calls": 0, "tier2_cost": 0,
+        }
+
+    # Verify extracted claims
+    all_results = verifier.verify_claims(all_claims, "ot")
+
+    status_counts = Counter(r.status for r in all_results)
+    t2_calls = verifier.tier2.call_count if verifier.tier2 else 0
+    t2_cost = t2_calls * 0.005
+
+    claim_details = []
+    for claim, result in zip(all_claims, all_results):
+        claim_details.append({
+            "id": claim.id,
+            "chapter_id": f"meta/{claim.chapter_id}",
             "panel_type": claim.panel_type,
             "claim_type": claim.claim_type,
             "claim_text": claim.claim_text[:300],
@@ -523,8 +628,9 @@ def main():
 
     # Parse into book/chapter pairs
     changed = parse_changed_files(file_paths)
+    changed_meta = parse_changed_meta_files(file_paths)
 
-    if not changed:
+    if not changed and not changed_meta:
         result = {
             "status": "skip",
             "message": "No chapter content changes detected",
@@ -541,6 +647,8 @@ def main():
           f"{len(changed)} book(s)", file=sys.stderr)
     for book, chapters in sorted(changed.items()):
         print(f"  {book}: chapters {sorted(chapters)}", file=sys.stderr)
+    if changed_meta:
+        print(f"Meta files changed: {changed_meta}", file=sys.stderr)
 
     if args.dry_run:
         print(json.dumps({"changed": {k: sorted(v) for k, v in changed.items()},
@@ -579,6 +687,22 @@ def main():
                     hard_errors.append(
                         f"REFUTED: {claim['id']} — {claim['notes'][:150]}"
                     )
+
+        # Meta accuracy checks (when meta files changed)
+        routable_meta = [f for f in changed_meta if f in META_FILE_EXTRACTORS]
+        if routable_meta:
+            print(f"Running meta accuracy checks for: {routable_meta}",
+                  file=sys.stderr)
+            meta_ar = run_meta_accuracy_check(
+                routable_meta, max_tier=args.tier
+            )
+            if meta_ar["total"] > 0:
+                accuracy_results["_meta"] = meta_ar
+                for claim in meta_ar["claims"]:
+                    if claim["status"] == STATUS_REFUTED:
+                        hard_errors.append(
+                            f"META REFUTED: {claim['id']} — {claim['notes'][:150]}"
+                        )
 
         # Baseline comparison
         all_claims = []

--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -10,7 +10,7 @@ Validation sections:
   2. CROSS-REFERENCES  — Scholar scopes → valid books, people parent refs → valid IDs
   3. COMPLETENESS      — 66 live books, correct chapter counts
   4. PANEL DISTRIBUTION — Section/chapter panel type frequency counts
-  5. FEATURE META      — Prophecy chains, concepts, difficult passages schema
+  5. FEATURE META      — Prophecy chains, concepts, difficult passages, debate topics schema
 
 Exit codes:
   0 = all checks passed
@@ -265,6 +265,104 @@ def main():
                         check(f"passage {p.get('id','?')} response [{j}] has '{rk}'",
                               rk in r, f"missing '{rk}'")
         print(f"  difficult passages: {len(dp_data)}")
+
+    # ── Debate Topics ──
+    dt_path = META / 'debate-topics.json'
+    if dt_path.exists():
+        print("\n--- DEBATE TOPICS ---")
+        dt_data = json.loads(dt_path.read_text())
+        check("debate-topics.json is list", isinstance(dt_data, list))
+
+        all_book_ids = {b['id'] for b in books}
+        valid_categories = {'ethical', 'historical', 'interpretive', 'textual', 'theological'}
+        tag_re = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+        seen_topic_ids = set()
+        enriched_count = 0
+        unenriched_ids = []
+        tag_format_warnings = 0
+
+        for i, t in enumerate(dt_data):
+            tid = t.get('id', f'index_{i}')
+
+            # ── Structural: required skeleton fields ──
+            for key in ('id', 'title', 'category', 'book_id', 'chapters', 'passage', 'question'):
+                check(f"debate topic {tid} has '{key}'", key in t,
+                      f"missing '{key}'")
+
+            # Unique ID
+            if 'id' in t:
+                check(f"debate topic {tid} unique ID",
+                      t['id'] not in seen_topic_ids,
+                      f"duplicate ID: {t['id']}")
+                seen_topic_ids.add(t['id'])
+
+            # book_id referential integrity
+            book_id = t.get('book_id')
+            if book_id:
+                check(f"debate topic {tid} book_id valid",
+                      book_id in all_book_ids,
+                      f"'{book_id}' not in books.json")
+
+            # category membership
+            cat = t.get('category')
+            if cat:
+                check(f"debate topic {tid} category valid",
+                      cat in valid_categories,
+                      f"'{cat}' not in {sorted(valid_categories)}")
+
+            # positions non-empty list
+            positions = t.get('positions', [])
+            check(f"debate topic {tid} has positions",
+                  isinstance(positions, list) and len(positions) >= 1,
+                  f"got {len(positions) if isinstance(positions, list) else type(positions).__name__}")
+
+            # Position structural validation
+            for j, pos in enumerate(positions):
+                for pk in ('id', 'label', 'tradition_family', 'argument'):
+                    check(f"debate topic {tid} position [{j}] has '{pk}'",
+                          pk in pos,
+                          f"missing '{pk}'")
+
+                # scholar_ids referential integrity (if present)
+                for sid in pos.get('scholar_ids', []):
+                    check(f"debate topic {tid} pos [{j}] scholar '{sid}' valid",
+                          sid in scholar_ids,
+                          f"'{sid}' not in scholars.json")
+
+            # ── Enrichment completeness ──
+            has_context = bool(t.get('context'))
+            has_synthesis = bool(t.get('synthesis'))
+            has_related = isinstance(t.get('related_passages'), list) and len(t.get('related_passages', [])) > 0
+            has_tags = isinstance(t.get('tags'), list) and len(t.get('tags', [])) >= 3
+
+            # Check position-level enrichment
+            positions_enriched = True
+            for pos in positions:
+                if not (pos.get('strengths') and pos.get('weaknesses')):
+                    positions_enriched = False
+                if not (isinstance(pos.get('key_verses'), list) and len(pos.get('key_verses', [])) >= 2):
+                    positions_enriched = False
+
+            fully_enriched = all([has_context, has_synthesis, has_related, has_tags, positions_enriched])
+
+            if fully_enriched:
+                enriched_count += 1
+
+                # Tag format check (warning only — existing data has non-conforming tags)
+                for tag in t.get('tags', []):
+                    if not tag_re.match(tag):
+                        tag_format_warnings += 1
+            else:
+                unenriched_ids.append(tid)
+
+        # Summary stats
+        print(f"  Total topics: {len(dt_data)}")
+        print(f"  Fully enriched: {enriched_count}")
+        print(f"  Unenriched: {len(unenriched_ids)}")
+        if tag_format_warnings > 0:
+            print(f"  [WARN] {tag_format_warnings} tags have non-lowercase-hyphenated format (cleanup needed)")
+        if unenriched_ids and len(unenriched_ids) <= 20:
+            print(f"  Unenriched IDs: {unenriched_ids}")
 
     # ── 6. Life Topics ──
     life_topics_dir = CONTENT / 'life_topics'


### PR DESCRIPTION
Closes #320

## Changes

### schema_validator.py
- New **DEBATE TOPICS** validation section (after difficult passages, before life topics)
- **Structural checks** (hard fail): required skeleton fields, unique IDs, book_id → books.json, category enum, non-empty positions, position sub-fields, scholar_ids → scholars.json
- **Enrichment tracking** (informational): context, synthesis, related_passages, tags (3+), per-position strengths/weaknesses/key_verses (2+)
- Tag format regex checked as **warning only** — 139 existing tags need normalization (separate cleanup task)
- Summary stats: 303 total, 115 fully enriched, 188 unenriched

### ci_content_check.py
- New `parse_changed_meta_files()` — detects which `content/meta/*.json` files changed
- New `META_FILE_EXTRACTORS` routing map — connects meta filenames to `MetaClaimExtractor` methods
- New `run_meta_accuracy_check()` — runs accuracy pipeline on meta claims
- `main()` updated — no longer silently skips meta-only changesets

## Validation
- `schema_validator.py` passes: **118,895 passed, 0 failed**
- All 303 debate topics pass structural checks
- 115/303 topics pass enrichment completeness checks