### PR TITLE
fix(content): Remove evt_ prefix from 40 Psalms timeline links

### DIFF
--- a/content/psalms/101.json
+++ b/content/psalms/101.json
@@ -6,7 +6,7 @@
   "title": "Psalms 101",
   "subtitle": "I Will Walk with a Blameless Heart",
   "timeline_link": {
-    "event_id": "evt_david-jerusalem",
+    "event_id": "david-jerusalem",
     "text": "See on Timeline — David Captures Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/102.json
+++ b/content/psalms/102.json
@@ -6,7 +6,7 @@
   "title": "Psalms 102",
   "subtitle": "A Prayer of the Afflicted",
   "timeline_link": {
-    "event_id": "evt_first-temple-destroyed",
+    "event_id": "first-temple-destroyed",
     "text": "See on Timeline — Temple Destroyed"
   },
   "map_story_link": null,

--- a/content/psalms/105.json
+++ b/content/psalms/105.json
@@ -6,7 +6,7 @@
   "title": "Psalms 105",
   "subtitle": "He Remembers His Covenant Forever",
   "timeline_link": {
-    "event_id": "evt_covenant-abram",
+    "event_id": "covenant-abram",
     "text": "See on Timeline — Abrahamic Covenant"
   },
   "map_story_link": null,

--- a/content/psalms/106.json
+++ b/content/psalms/106.json
@@ -6,7 +6,7 @@
   "title": "Psalms 106",
   "subtitle": "Give Thanks to the LORD, for He Is Good",
   "timeline_link": {
-    "event_id": "evt_exodus",
+    "event_id": "exodus",
     "text": "See on Timeline — The Exodus"
   },
   "map_story_link": null,

--- a/content/psalms/110.json
+++ b/content/psalms/110.json
@@ -6,7 +6,7 @@
   "title": "Psalms 110",
   "subtitle": "The LORD Says to My Lord: Sit at My Right Hand",
   "timeline_link": {
-    "event_id": "evt_davidic-covenant",
+    "event_id": "davidic-covenant",
     "text": "See on Timeline — Davidic Covenant"
   },
   "map_story_link": null,

--- a/content/psalms/114.json
+++ b/content/psalms/114.json
@@ -6,7 +6,7 @@
   "title": "Psalms 114",
   "subtitle": "When Israel Came Out of Egypt",
   "timeline_link": {
-    "event_id": "evt_exodus",
+    "event_id": "exodus",
     "text": "See on Timeline — The Exodus"
   },
   "map_story_link": null,

--- a/content/psalms/118.json
+++ b/content/psalms/118.json
@@ -6,7 +6,7 @@
   "title": "Psalms 118",
   "subtitle": "The Stone the Builders Rejected",
   "timeline_link": {
-    "event_id": "evt_triumphal-entry",
+    "event_id": "triumphal-entry",
     "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": null,

--- a/content/psalms/122.json
+++ b/content/psalms/122.json
@@ -6,7 +6,7 @@
   "title": "Psalms 122",
   "subtitle": "I Rejoiced When They Said, “Let Us Go to the House of the LORD”",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/126.json
+++ b/content/psalms/126.json
@@ -6,7 +6,7 @@
   "title": "Psalms 126",
   "subtitle": "When the LORD Restored the Fortunes of Zion",
   "timeline_link": {
-    "event_id": "evt_ezra-return",
+    "event_id": "ezra-return",
     "text": "See on Timeline — Ezra Returns to Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/132.json
+++ b/content/psalms/132.json
@@ -6,7 +6,7 @@
   "title": "Psalms 132",
   "subtitle": "LORD, Remember David",
   "timeline_link": {
-    "event_id": "evt_ark-to-jerusalem",
+    "event_id": "ark-to-jerusalem",
     "text": "See on Timeline — Ark Brought to Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/134.json
+++ b/content/psalms/134.json
@@ -6,7 +6,7 @@
   "title": "Psalms 134",
   "subtitle": "Praise the LORD, All You Servants of the LORD",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/136.json
+++ b/content/psalms/136.json
@@ -6,7 +6,7 @@
   "title": "Psalms 136",
   "subtitle": "His Love Endures Forever",
   "timeline_link": {
-    "event_id": "evt_creation",
+    "event_id": "creation",
     "text": "See on Timeline — Creation"
   },
   "map_story_link": null,

--- a/content/psalms/142.json
+++ b/content/psalms/142.json
@@ -6,7 +6,7 @@
   "title": "Psalms 142",
   "subtitle": "I Cry Aloud to the LORD",
   "timeline_link": {
-    "event_id": "evt_david-anointed",
+    "event_id": "david-anointed",
     "text": "See on Timeline — David Anointed"
   },
   "map_story_link": null,

--- a/content/psalms/144.json
+++ b/content/psalms/144.json
@@ -6,7 +6,7 @@
   "title": "Psalms 144",
   "subtitle": "Praise Be to the LORD My Rock",
   "timeline_link": {
-    "event_id": "evt_david-goliath",
+    "event_id": "david-goliath",
     "text": "See on Timeline — David Defeats Goliath"
   },
   "map_story_link": null,

--- a/content/psalms/147.json
+++ b/content/psalms/147.json
@@ -6,7 +6,7 @@
   "title": "Psalms 147",
   "subtitle": "How Good It Is to Sing Praises",
   "timeline_link": {
-    "event_id": "evt_nehemiah-wall-completed",
+    "event_id": "nehemiah-wall-completed",
     "text": "See on Timeline — Walls Rebuilt"
   },
   "map_story_link": null,

--- a/content/psalms/149.json
+++ b/content/psalms/149.json
@@ -6,7 +6,7 @@
   "title": "Psalms 149",
   "subtitle": "Sing to the LORD a New Song",
   "timeline_link": {
-    "event_id": "evt_second-temple-completed",
+    "event_id": "second-temple-completed",
     "text": "See on Timeline — Second Temple"
   },
   "map_story_link": null,

--- a/content/psalms/15.json
+++ b/content/psalms/15.json
@@ -6,7 +6,7 @@
   "title": "Psalms 15",
   "subtitle": "Who May Dwell in Your Sanctuary?",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/2.json
+++ b/content/psalms/2.json
@@ -6,7 +6,7 @@
   "title": "Psalms 2",
   "subtitle": "The LORD’s Anointed",
   "timeline_link": {
-    "event_id": "evt_davidic-covenant",
+    "event_id": "davidic-covenant",
     "text": "See on Timeline — Davidic Covenant"
   },
   "map_story_link": null,

--- a/content/psalms/20.json
+++ b/content/psalms/20.json
@@ -6,7 +6,7 @@
   "title": "Psalms 20",
   "subtitle": "May the LORD Answer You",
   "timeline_link": {
-    "event_id": "evt_david-anointed",
+    "event_id": "david-anointed",
     "text": "See on Timeline — David Anointed"
   },
   "map_story_link": null,

--- a/content/psalms/21.json
+++ b/content/psalms/21.json
@@ -6,7 +6,7 @@
   "title": "Psalms 21",
   "subtitle": "The King Rejoices in God’s Strength",
   "timeline_link": {
-    "event_id": "evt_david-anointed",
+    "event_id": "david-anointed",
     "text": "See on Timeline — David Anointed"
   },
   "map_story_link": null,

--- a/content/psalms/22.json
+++ b/content/psalms/22.json
@@ -6,7 +6,7 @@
   "title": "Psalms 22",
   "subtitle": "My God, My God, Why Have You Forsaken Me?",
   "timeline_link": {
-    "event_id": "evt_crucifixion",
+    "event_id": "crucifixion",
     "text": "See on Timeline — Crucifixion"
   },
   "map_story_link": null,

--- a/content/psalms/24.json
+++ b/content/psalms/24.json
@@ -6,7 +6,7 @@
   "title": "Psalms 24",
   "subtitle": "The King of Glory",
   "timeline_link": {
-    "event_id": "evt_ark-to-jerusalem",
+    "event_id": "ark-to-jerusalem",
     "text": "See on Timeline — Ark Brought to Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/45.json
+++ b/content/psalms/45.json
@@ -6,7 +6,7 @@
   "title": "Psalms 45",
   "subtitle": "A Royal Wedding Song",
   "timeline_link": {
-    "event_id": "evt_solomon-wisdom",
+    "event_id": "solomon-wisdom",
     "text": "See on Timeline — Solomon's Wisdom"
   },
   "map_story_link": null,

--- a/content/psalms/46.json
+++ b/content/psalms/46.json
@@ -6,7 +6,7 @@
   "title": "Psalms 46",
   "subtitle": "God Is Our Refuge and Strength",
   "timeline_link": {
-    "event_id": "evt_hezekiah-assyria",
+    "event_id": "hezekiah-assyria",
     "text": "See on Timeline — Assyrian Siege"
   },
   "map_story_link": null,

--- a/content/psalms/48.json
+++ b/content/psalms/48.json
@@ -6,7 +6,7 @@
   "title": "Psalms 48",
   "subtitle": "Great Is the LORD in the City of Our God",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/68.json
+++ b/content/psalms/68.json
@@ -6,7 +6,7 @@
   "title": "Psalms 68",
   "subtitle": "May God Arise, Let His Enemies Be Scattered",
   "timeline_link": {
-    "event_id": "evt_ark-to-jerusalem",
+    "event_id": "ark-to-jerusalem",
     "text": "See on Timeline — Ark Brought to Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/69.json
+++ b/content/psalms/69.json
@@ -6,7 +6,7 @@
   "title": "Psalms 69",
   "subtitle": "Save Me, O God, for the Waters Have Come Up to My Neck",
   "timeline_link": {
-    "event_id": "evt_crucifixion",
+    "event_id": "crucifixion",
     "text": "See on Timeline — Crucifixion"
   },
   "map_story_link": null,

--- a/content/psalms/7.json
+++ b/content/psalms/7.json
@@ -6,7 +6,7 @@
   "title": "Psalms 7",
   "subtitle": "A Plea for Justice",
   "timeline_link": {
-    "event_id": "evt_david-anointed",
+    "event_id": "david-anointed",
     "text": "See on Timeline — David Anointed"
   },
   "map_story_link": null,

--- a/content/psalms/74.json
+++ b/content/psalms/74.json
@@ -6,7 +6,7 @@
   "title": "Psalms 74",
   "subtitle": "Why Have You Rejected Us Forever?",
   "timeline_link": {
-    "event_id": "evt_first-temple-destroyed",
+    "event_id": "first-temple-destroyed",
     "text": "See on Timeline — Temple Destroyed"
   },
   "map_story_link": null,

--- a/content/psalms/76.json
+++ b/content/psalms/76.json
@@ -6,7 +6,7 @@
   "title": "Psalms 76",
   "subtitle": "In Judah God Is Known",
   "timeline_link": {
-    "event_id": "evt_hezekiah-assyria",
+    "event_id": "hezekiah-assyria",
     "text": "See on Timeline — Assyrian Siege"
   },
   "map_story_link": null,

--- a/content/psalms/78.json
+++ b/content/psalms/78.json
@@ -6,7 +6,7 @@
   "title": "Psalms 78",
   "subtitle": "Give Ear, O My People, to My Teaching",
   "timeline_link": {
-    "event_id": "evt_exodus",
+    "event_id": "exodus",
     "text": "See on Timeline — The Exodus"
   },
   "map_story_link": null,

--- a/content/psalms/79.json
+++ b/content/psalms/79.json
@@ -6,7 +6,7 @@
   "title": "Psalms 79",
   "subtitle": "The Nations Have Invaded Your Inheritance",
   "timeline_link": {
-    "event_id": "evt_fall_jerusalem",
+    "event_id": "fall_jerusalem",
     "text": "See on Timeline — Fall of Jerusalem"
   },
   "map_story_link": null,

--- a/content/psalms/80.json
+++ b/content/psalms/80.json
@@ -6,7 +6,7 @@
   "title": "Psalms 80",
   "subtitle": "Hear Us, Shepherd of Israel",
   "timeline_link": {
-    "event_id": "evt_fall-north",
+    "event_id": "fall-north",
     "text": "See on Timeline — Fall of Northern Kingdom"
   },
   "map_story_link": null,

--- a/content/psalms/83.json
+++ b/content/psalms/83.json
@@ -6,7 +6,7 @@
   "title": "Psalms 83",
   "subtitle": "Do Not Keep Silent, O God",
   "timeline_link": {
-    "event_id": "evt_judges-deborah",
+    "event_id": "judges-deborah",
     "text": "See on Timeline — Deborah and Barak"
   },
   "map_story_link": null,

--- a/content/psalms/84.json
+++ b/content/psalms/84.json
@@ -6,7 +6,7 @@
   "title": "Psalms 84",
   "subtitle": "How Lovely Is Your Dwelling Place",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/85.json
+++ b/content/psalms/85.json
@@ -6,7 +6,7 @@
   "title": "Psalms 85",
   "subtitle": "Will You Not Revive Us Again?",
   "timeline_link": {
-    "event_id": "evt_cyrus-decree",
+    "event_id": "cyrus-decree",
     "text": "See on Timeline — Return Permitted"
   },
   "map_story_link": null,

--- a/content/psalms/87.json
+++ b/content/psalms/87.json
@@ -6,7 +6,7 @@
   "title": "Psalms 87",
   "subtitle": "Glorious Things Are Said of You, City of God",
   "timeline_link": {
-    "event_id": "evt_solomon-temple",
+    "event_id": "solomon-temple",
     "text": "See on Timeline — Temple Completed"
   },
   "map_story_link": null,

--- a/content/psalms/89.json
+++ b/content/psalms/89.json
@@ -6,7 +6,7 @@
   "title": "Psalms 89",
   "subtitle": "I Will Sing of the LORD’s Great Love Forever",
   "timeline_link": {
-    "event_id": "evt_davidic-covenant",
+    "event_id": "davidic-covenant",
     "text": "See on Timeline — Davidic Covenant"
   },
   "map_story_link": null,

--- a/content/psalms/95.json
+++ b/content/psalms/95.json
@@ -6,7 +6,7 @@
   "title": "Psalms 95",
   "subtitle": "Come, Let Us Sing for Joy to the LORD",
   "timeline_link": {
-    "event_id": "evt_wilderness-wandering",
+    "event_id": "wilderness-wandering",
     "text": "See on Timeline — Wilderness Wandering"
   },
   "map_story_link": null,

--- a/content/psalms/99.json
+++ b/content/psalms/99.json
@@ -6,7 +6,7 @@
   "title": "Psalms 99",
   "subtitle": "The LORD Reigns; Let the Nations Tremble",
   "timeline_link": {
-    "event_id": "evt_sinai-covenant",
+    "event_id": "sinai-covenant",
     "text": "See on Timeline — The Sinai Covenant"
   },
   "map_story_link": null,


### PR DESCRIPTION
## Summary

Fixes #329

All 40 broken `timeline_link.event_id` values used an `evt_` prefix that doesn't exist in `timelines.json`. The correct IDs are the same without the prefix.

## Changes

| Before | After |
|--------|-------|
| `evt_exodus` | `exodus` |
| `evt_david-anointed` | `david-anointed` |
| `evt_solomon-temple` | `solomon-temple` |
| ... (40 total) | ... |

## Validation

- ✅ Schema validator: 118,972 passed, 0 failed
- ✅ Timeline links: 1,072 valid, 0 broken

## Part of Epic #327