### PR TITLE
fix(content): Remove 2,823 duplicate scholar notes

### DIFF
--- a/content/1_samuel/1.json
+++ b/content/1_samuel/1.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:9",
-              "note": "MacArthur: The passage on \"I was pouring out my soul to the LORD\"; the vow of a Nazirite son reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "1:10",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "1:11",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "1:12",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:9",
-              "note": "Calvin: On \"I was pouring out my soul to the LORD\"; the vow of a Nazirite son: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "1:10",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:9",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "1:10",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:9",
-              "note": "Bergen: On \"I was pouring out my soul to the LORD\"; the vow of a Nazirite son: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "1:11",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:9",
-              "note": "Tsumura: On \"I was pouring out my soul to the LORD\"; the vow of a Nazirite son: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "1:10",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"I was pouring out my soul to the LORD\"; the vow of a Nazirite son. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "MacArthur: The passage on God remembers Hannah; the child dedicated to lifelong service at Shiloh reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "1:20",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "1:21",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "1:22",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Calvin: On God remembers Hannah; the child dedicated to lifelong service at Shiloh: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "1:20",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "1:20",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Bergen: On God remembers Hannah; the child dedicated to lifelong service at Shiloh: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "1:21",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Tsumura: On God remembers Hannah; the child dedicated to lifelong service at Shiloh: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "1:20",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses God remembers Hannah; the child dedicated to lifelong service at Shiloh. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/10.json
+++ b/content/1_samuel/10.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:14",
-              "note": "MacArthur: The passage on sacred lot; \"he had hidden himself among the supplies\"; some despise him reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "10:15",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "10:16",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "10:17",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:14",
-              "note": "Calvin: On sacred lot; \"he had hidden himself among the supplies\"; some despise him: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "10:15",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:14",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "10:15",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:14",
-              "note": "Bergen: On sacred lot; \"he had hidden himself among the supplies\"; some despise him: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "10:16",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:14",
-              "note": "Tsumura: On sacred lot; \"he had hidden himself among the supplies\"; some despise him: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "10:15",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses sacred lot; \"he had hidden himself among the supplies\"; some despise him. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/11.json
+++ b/content/1_samuel/11.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "MacArthur: The passage on \"shall Saul reign?\"; mercy for opponents; renewal of the kingdom reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "11:13",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "11:14",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "11:15",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Calvin: On \"shall Saul reign?\"; mercy for opponents; renewal of the kingdom: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "11:13",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "11:13",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Bergen: On \"shall Saul reign?\"; mercy for opponents; renewal of the kingdom: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "11:14",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Tsumura: On \"shall Saul reign?\"; mercy for opponents; renewal of the kingdom: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "11:13",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"shall Saul reign?\"; mercy for opponents; renewal of the kingdom. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/12.json
+++ b/content/1_samuel/12.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:6",
-              "note": "MacArthur: The passage on from Egypt to monarchy; wheat-harvest thunder; \"do not turn aside to useless idols\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "12:7",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "12:8",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "12:9",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:6",
-              "note": "Calvin: On from Egypt to monarchy; wheat-harvest thunder; \"do not turn aside to useless idols\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "12:7",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:6",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "12:7",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:6",
-              "note": "Bergen: On from Egypt to monarchy; wheat-harvest thunder; \"do not turn aside to useless idols\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "12:8",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:6",
-              "note": "Tsumura: On from Egypt to monarchy; wheat-harvest thunder; \"do not turn aside to useless idols\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "12:7",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses from Egypt to monarchy; wheat-harvest thunder; \"do not turn aside to useless idols\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/13.json
+++ b/content/1_samuel/13.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "MacArthur: The passage on seven days; \"you have done foolishly\"; \"your kingdom will not endure\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "13:9",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "13:10",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "13:11",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "Calvin: On seven days; \"you have done foolishly\"; \"your kingdom will not endure\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "13:9",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "13:9",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "Bergen: On seven days; \"you have done foolishly\"; \"your kingdom will not endure\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "13:10",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "Tsumura: On seven days; \"you have done foolishly\"; \"your kingdom will not endure\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "13:9",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses seven days; \"you have done foolishly\"; \"your kingdom will not endure\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:16",
-              "note": "MacArthur: The passage on only Saul and Jonathan have swords; Philistine technological dominance reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "13:17",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "13:18",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "13:19",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:16",
-              "note": "Calvin: On only Saul and Jonathan have swords; Philistine technological dominance: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "13:17",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:16",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "13:17",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:16",
-              "note": "Bergen: On only Saul and Jonathan have swords; Philistine technological dominance: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "13:18",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:16",
-              "note": "Tsumura: On only Saul and Jonathan have swords; Philistine technological dominance: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "13:17",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses only Saul and Jonathan have swords; Philistine technological dominance. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/14.json
+++ b/content/1_samuel/14.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:16",
-              "note": "MacArthur: The passage on \"cursed be anyone who eats\"; Jonathan eats honey unknowingly; the people rescue him reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "14:17",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "14:18",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "14:19",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:16",
-              "note": "Calvin: On \"cursed be anyone who eats\"; Jonathan eats honey unknowingly; the people rescue him: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "14:17",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:16",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "14:17",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:16",
-              "note": "Bergen: On \"cursed be anyone who eats\"; Jonathan eats honey unknowingly; the people rescue him: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "14:18",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:16",
-              "note": "Tsumura: On \"cursed be anyone who eats\"; Jonathan eats honey unknowingly; the people rescue him: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "14:17",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"cursed be anyone who eats\"; Jonathan eats honey unknowingly; the people rescue him. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:47",
-              "note": "MacArthur: The passage on victories on every side; Saul's family; continuous Philistine warfare reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "14:48",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "14:49",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "14:50",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:47",
-              "note": "Calvin: On victories on every side; Saul's family; continuous Philistine warfare: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "14:48",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:47",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "14:48",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:47",
-              "note": "Bergen: On victories on every side; Saul's family; continuous Philistine warfare: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "14:49",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:47",
-              "note": "Tsumura: On victories on every side; Saul's family; continuous Philistine warfare: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "14:48",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses victories on every side; Saul's family; continuous Philistine warfare. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/15.json
+++ b/content/1_samuel/15.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:10",
-              "note": "MacArthur: The passage on Samuel confronts Saul; \"I have sinned\"; the kingdom torn away; Agag executed reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "15:11",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "15:12",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "15:13",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:10",
-              "note": "Calvin: On Samuel confronts Saul; \"I have sinned\"; the kingdom torn away; Agag executed: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "15:11",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:10",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "15:11",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:10",
-              "note": "Bergen: On Samuel confronts Saul; \"I have sinned\"; the kingdom torn away; Agag executed: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "15:12",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:10",
-              "note": "Tsumura: On Samuel confronts Saul; \"I have sinned\"; the kingdom torn away; Agag executed: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "15:11",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Samuel confronts Saul; \"I have sinned\"; the kingdom torn away; Agag executed. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:32",
-              "note": "MacArthur: The passage on \"as your sword has made women childless\"; the LORD was grieved he had made Saul king reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "15:33",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "15:34",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "15:35",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:32",
-              "note": "Calvin: On \"as your sword has made women childless\"; the LORD was grieved he had made Saul king: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "15:33",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:32",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "15:33",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:32",
-              "note": "Bergen: On \"as your sword has made women childless\"; the LORD was grieved he had made Saul king: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "15:34",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:32",
-              "note": "Tsumura: On \"as your sword has made women childless\"; the LORD was grieved he had made Saul king: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "15:33",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"as your sword has made women childless\"; the LORD was grieved he had made Saul king. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/16.json
+++ b/content/1_samuel/16.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:14",
-              "note": "MacArthur: The passage on an evil spirit torments Saul; David's harp brings relief; Saul loves David reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "16:15",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "16:16",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "16:17",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:14",
-              "note": "Calvin: On an evil spirit torments Saul; David's harp brings relief; Saul loves David: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "16:15",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:14",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "16:15",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:14",
-              "note": "Bergen: On an evil spirit torments Saul; David's harp brings relief; Saul loves David: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "16:16",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:14",
-              "note": "Tsumura: On an evil spirit torments Saul; David's harp brings relief; Saul loves David: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "16:15",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses an evil spirit torments Saul; David's harp brings relief; Saul loves David. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/17.json
+++ b/content/1_samuel/17.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:31",
-              "note": "MacArthur: The passage on rejected armour; \"I come in the name of the LORD\"; sling, stone, sword; Goliath falls reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "17:32",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "17:33",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "17:34",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:31",
-              "note": "Calvin: On rejected armour; \"I come in the name of the LORD\"; sling, stone, sword; Goliath falls: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "17:32",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:31",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "17:32",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:31",
-              "note": "Bergen: On rejected armour; \"I come in the name of the LORD\"; sling, stone, sword; Goliath falls: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "17:33",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:31",
-              "note": "Tsumura: On rejected armour; \"I come in the name of the LORD\"; sling, stone, sword; Goliath falls: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "17:32",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses rejected armour; \"I come in the name of the LORD\"; sling, stone, sword; Goliath falls. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:55",
-              "note": "MacArthur: The passage on \"whose son is this youth?\" — Saul's question foreshadows the dynastic rivalry reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "17:56",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "17:57",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "17:58",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:55",
-              "note": "Calvin: On \"whose son is this youth?\" — Saul's question foreshadows the dynastic rivalry: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "17:56",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:55",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "17:56",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:55",
-              "note": "Bergen: On \"whose son is this youth?\" — Saul's question foreshadows the dynastic rivalry: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "17:57",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:55",
-              "note": "Tsumura: On \"whose son is this youth?\" — Saul's question foreshadows the dynastic rivalry: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "17:56",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"whose son is this youth?\" — Saul's question foreshadows the dynastic rivalry. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/18.json
+++ b/content/1_samuel/18.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:17",
-              "note": "MacArthur: The passage on Merab, then Michal; the bride-price of Philistine foreskins; \"David had success in all he did\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "18:18",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "18:19",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "18:20",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:17",
-              "note": "Calvin: On Merab, then Michal; the bride-price of Philistine foreskins; \"David had success in all he did\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "18:18",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:17",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "18:18",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:17",
-              "note": "Bergen: On Merab, then Michal; the bride-price of Philistine foreskins; \"David had success in all he did\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "18:19",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:17",
-              "note": "Tsumura: On Merab, then Michal; the bride-price of Philistine foreskins; \"David had success in all he did\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "18:18",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Merab, then Michal; the bride-price of Philistine foreskins; \"David had success in all he did\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/19.json
+++ b/content/1_samuel/19.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "MacArthur: The passage on Michal's deception with the idol; Saul's men and then Saul himself prophesy at Naioth reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "19:12",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "19:13",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "19:14",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "Calvin: On Michal's deception with the idol; Saul's men and then Saul himself prophesy at Naioth: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "19:12",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "19:12",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "Bergen: On Michal's deception with the idol; Saul's men and then Saul himself prophesy at Naioth: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "19:13",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "Tsumura: On Michal's deception with the idol; Saul's men and then Saul himself prophesy at Naioth: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "19:12",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Michal's deception with the idol; Saul's men and then Saul himself prophesy at Naioth. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/2.json
+++ b/content/1_samuel/2.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "MacArthur: The passage on contempt for offerings; sexual immorality; Samuel grows in favour reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "2:13",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "2:14",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "2:15",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Calvin: On contempt for offerings; sexual immorality; Samuel grows in favour: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "2:13",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "2:13",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Bergen: On contempt for offerings; sexual immorality; Samuel grows in favour: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "2:14",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Tsumura: On contempt for offerings; sexual immorality; Samuel grows in favour: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "2:13",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses contempt for offerings; sexual immorality; Samuel grows in favour. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:27",
-              "note": "MacArthur: The passage on judgment announced; a faithful priest will arise reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "2:28",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "2:29",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "2:30",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:27",
-              "note": "Calvin: On judgment announced; a faithful priest will arise: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "2:28",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:27",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "2:28",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:27",
-              "note": "Bergen: On judgment announced; a faithful priest will arise: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "2:29",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:27",
-              "note": "Tsumura: On judgment announced; a faithful priest will arise: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "2:28",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses judgment announced; a faithful priest will arise. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/20.json
+++ b/content/1_samuel/20.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:24",
-              "note": "MacArthur: The passage on new moon feast; Saul hurls spear at Jonathan; the field, the arrows, the tears reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "20:25",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "20:26",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "20:27",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:24",
-              "note": "Calvin: On new moon feast; Saul hurls spear at Jonathan; the field, the arrows, the tears: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "20:25",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:24",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "20:25",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:24",
-              "note": "Bergen: On new moon feast; Saul hurls spear at Jonathan; the field, the arrows, the tears: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "20:26",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:24",
-              "note": "Tsumura: On new moon feast; Saul hurls spear at Jonathan; the field, the arrows, the tears: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "20:25",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses new moon feast; Saul hurls spear at Jonathan; the field, the arrows, the tears. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/21.json
+++ b/content/1_samuel/21.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:10",
-              "note": "MacArthur: The passage on recognised as \"king of the land\"; scratching on doors; drool in his beard reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "21:11",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "21:12",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "21:13",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:10",
-              "note": "Calvin: On recognised as \"king of the land\"; scratching on doors; drool in his beard: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "21:11",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:10",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "21:11",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:10",
-              "note": "Bergen: On recognised as \"king of the land\"; scratching on doors; drool in his beard: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "21:12",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:10",
-              "note": "Tsumura: On recognised as \"king of the land\"; scratching on doors; drool in his beard: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "21:11",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses recognised as \"king of the land\"; scratching on doors; drool in his beard. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/22.json
+++ b/content/1_samuel/22.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:6",
-              "note": "MacArthur: The passage on Saul accuses his servants; Doeg the Edomite obeys; Abiathar escapes to David reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "22:7",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "22:8",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "22:9",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:6",
-              "note": "Calvin: On Saul accuses his servants; Doeg the Edomite obeys; Abiathar escapes to David: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "22:7",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:6",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "22:7",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:6",
-              "note": "Bergen: On Saul accuses his servants; Doeg the Edomite obeys; Abiathar escapes to David: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "22:8",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:6",
-              "note": "Tsumura: On Saul accuses his servants; Doeg the Edomite obeys; Abiathar escapes to David: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "22:7",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Saul accuses his servants; Doeg the Edomite obeys; Abiathar escapes to David. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/23.json
+++ b/content/1_samuel/23.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "MacArthur: The passage on \"do not be afraid\"; Jonathan strengthens David; the Ziphites betray David; Philistine raid saves him reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "23:16",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "23:17",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "23:18",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "Calvin: On \"do not be afraid\"; Jonathan strengthens David; the Ziphites betray David; Philistine raid saves him: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "23:16",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "23:16",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "Bergen: On \"do not be afraid\"; Jonathan strengthens David; the Ziphites betray David; Philistine raid saves him: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "23:17",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "Tsumura: On \"do not be afraid\"; Jonathan strengthens David; the Ziphites betray David; Philistine raid saves him: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "23:16",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"do not be afraid\"; Jonathan strengthens David; the Ziphites betray David; Philistine raid saves him. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/24.json
+++ b/content/1_samuel/24.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:8",
-              "note": "MacArthur: The passage on \"may the LORD judge between us\"; Saul acknowledges David will be king; temporary peace reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "24:9",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "24:10",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "24:11",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:8",
-              "note": "Calvin: On \"may the LORD judge between us\"; Saul acknowledges David will be king; temporary peace: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "24:9",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:8",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "24:9",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:8",
-              "note": "Bergen: On \"may the LORD judge between us\"; Saul acknowledges David will be king; temporary peace: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "24:10",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:8",
-              "note": "Tsumura: On \"may the LORD judge between us\"; Saul acknowledges David will be king; temporary peace: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "24:9",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"may the LORD judge between us\"; Saul acknowledges David will be king; temporary peace. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/25.json
+++ b/content/1_samuel/25.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:18",
-              "note": "MacArthur: The passage on Abigail intercedes; \"the LORD will make a lasting dynasty\"; Nabal struck by God; David marries Abigail reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "25:19",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "25:20",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "25:21",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:18",
-              "note": "Calvin: On Abigail intercedes; \"the LORD will make a lasting dynasty\"; Nabal struck by God; David marries Abigail: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "25:19",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "25:18",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "25:19",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "25:18",
-              "note": "Bergen: On Abigail intercedes; \"the LORD will make a lasting dynasty\"; Nabal struck by God; David marries Abigail: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "25:20",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "25:18",
-              "note": "Tsumura: On Abigail intercedes; \"the LORD will make a lasting dynasty\"; Nabal struck by God; David marries Abigail: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "25:19",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Abigail intercedes; \"the LORD will make a lasting dynasty\"; Nabal struck by God; David marries Abigail. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/26.json
+++ b/content/1_samuel/26.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:13",
-              "note": "MacArthur: The passage on \"why does my lord pursue?\"; Saul confesses again; \"you will do great things\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "26:14",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "26:15",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "26:16",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:13",
-              "note": "Calvin: On \"why does my lord pursue?\"; Saul confesses again; \"you will do great things\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "26:14",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "26:13",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "26:14",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "26:13",
-              "note": "Bergen: On \"why does my lord pursue?\"; Saul confesses again; \"you will do great things\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "26:15",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "26:13",
-              "note": "Tsumura: On \"why does my lord pursue?\"; Saul confesses again; \"you will do great things\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "26:14",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"why does my lord pursue?\"; Saul confesses again; \"you will do great things\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/27.json
+++ b/content/1_samuel/27.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:8",
-              "note": "MacArthur: The passage on Geshurites, Girzites, Amalekites; \"against the Negev of Judah\" — Achish trusts David reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "27:9",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "27:10",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "27:11",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:8",
-              "note": "Calvin: On Geshurites, Girzites, Amalekites; \"against the Negev of Judah\" — Achish trusts David: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "27:9",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "27:8",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "27:9",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "27:8",
-              "note": "Bergen: On Geshurites, Girzites, Amalekites; \"against the Negev of Judah\" — Achish trusts David: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "27:10",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "27:8",
-              "note": "Tsumura: On Geshurites, Girzites, Amalekites; \"against the Negev of Judah\" — Achish trusts David: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "27:9",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Geshurites, Girzites, Amalekites; \"against the Negev of Judah\" — Achish trusts David. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/28.json
+++ b/content/1_samuel/28.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "28:7",
-              "note": "MacArthur: The passage on the medium at Endor; Samuel appears; \"the LORD has torn the kingdom from you\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "28:8",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "28:9",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "28:10",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "28:7",
-              "note": "Calvin: On the medium at Endor; Samuel appears; \"the LORD has torn the kingdom from you\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "28:8",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "28:7",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "28:8",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "28:7",
-              "note": "Bergen: On the medium at Endor; Samuel appears; \"the LORD has torn the kingdom from you\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "28:9",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "28:7",
-              "note": "Tsumura: On the medium at Endor; Samuel appears; \"the LORD has torn the kingdom from you\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "28:8",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the medium at Endor; Samuel appears; \"the LORD has torn the kingdom from you\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/29.json
+++ b/content/1_samuel/29.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "29:6",
-              "note": "MacArthur: The passage on \"you are upright in my eyes, but the lords do not approve\"; providential extraction reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "29:7",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "29:8",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "29:9",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "29:6",
-              "note": "Calvin: On \"you are upright in my eyes, but the lords do not approve\"; providential extraction: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "29:7",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "29:6",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "29:7",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "29:6",
-              "note": "Bergen: On \"you are upright in my eyes, but the lords do not approve\"; providential extraction: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "29:8",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "29:6",
-              "note": "Tsumura: On \"you are upright in my eyes, but the lords do not approve\"; providential extraction: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "29:7",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"you are upright in my eyes, but the lords do not approve\"; providential extraction. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/3.json
+++ b/content/1_samuel/3.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:11",
-              "note": "MacArthur: The passage on \"I am about to do something that will make the ears tingle\"; Samuel established as prophet reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "3:12",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "3:13",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "3:14",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:11",
-              "note": "Calvin: On \"I am about to do something that will make the ears tingle\"; Samuel established as prophet: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "3:12",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:11",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "3:12",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:11",
-              "note": "Bergen: On \"I am about to do something that will make the ears tingle\"; Samuel established as prophet: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "3:13",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:11",
-              "note": "Tsumura: On \"I am about to do something that will make the ears tingle\"; Samuel established as prophet: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "3:12",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"I am about to do something that will make the ears tingle\"; Samuel established as prophet. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/30.json
+++ b/content/1_samuel/30.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "30:7",
-              "note": "MacArthur: The passage on ephod inquiry; Egyptian slave guide; total recovery; \"the share of those who stay is equal\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "30:8",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "30:9",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "30:10",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "30:7",
-              "note": "Calvin: On ephod inquiry; Egyptian slave guide; total recovery; \"the share of those who stay is equal\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "30:8",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "30:7",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "30:8",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "30:7",
-              "note": "Bergen: On ephod inquiry; Egyptian slave guide; total recovery; \"the share of those who stay is equal\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "30:9",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "30:7",
-              "note": "Tsumura: On ephod inquiry; Egyptian slave guide; total recovery; \"the share of those who stay is equal\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "30:8",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses ephod inquiry; Egyptian slave guide; total recovery; \"the share of those who stay is equal\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/31.json
+++ b/content/1_samuel/31.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "31:8",
-              "note": "MacArthur: The passage on body hung on Beth Shan wall; men of Jabesh retrieve the bodies; burned and buried reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "31:9",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "31:10",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "31:11",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "31:8",
-              "note": "Calvin: On body hung on Beth Shan wall; men of Jabesh retrieve the bodies; burned and buried: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "31:9",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "31:8",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "31:9",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "31:8",
-              "note": "Bergen: On body hung on Beth Shan wall; men of Jabesh retrieve the bodies; burned and buried: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "31:10",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "31:8",
-              "note": "Tsumura: On body hung on Beth Shan wall; men of Jabesh retrieve the bodies; burned and buried: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "31:9",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses body hung on Beth Shan wall; men of Jabesh retrieve the bodies; burned and buried. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/4.json
+++ b/content/1_samuel/4.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:12",
-              "note": "MacArthur: The passage on the news kills Eli; Phinehas's wife names her son \"Where is the glory?\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "4:13",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "4:14",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "4:15",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:12",
-              "note": "Calvin: On the news kills Eli; Phinehas's wife names her son \"Where is the glory?\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "4:13",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:12",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "4:13",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:12",
-              "note": "Bergen: On the news kills Eli; Phinehas's wife names her son \"Where is the glory?\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "4:14",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:12",
-              "note": "Tsumura: On the news kills Eli; Phinehas's wife names her son \"Where is the glory?\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "4:13",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the news kills Eli; Phinehas's wife names her son \"Where is the glory?\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/5.json
+++ b/content/1_samuel/5.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "MacArthur: The passage on tumours and mice; the Philistines pass the ark from city to city reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "5:7",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "5:8",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "5:9",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Calvin: On tumours and mice; the Philistines pass the ark from city to city: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "5:7",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "5:7",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Bergen: On tumours and mice; the Philistines pass the ark from city to city: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "5:8",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Tsumura: On tumours and mice; the Philistines pass the ark from city to city: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "5:7",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses tumours and mice; the Philistines pass the ark from city to city. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/6.json
+++ b/content/1_samuel/6.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "MacArthur: The passage on Levites receive the ark; 70 struck dead for looking inside; \"who can stand before the LORD?\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "6:14",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "6:15",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "6:16",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "Calvin: On Levites receive the ark; 70 struck dead for looking inside; \"who can stand before the LORD?\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "6:14",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "6:14",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "Bergen: On Levites receive the ark; 70 struck dead for looking inside; \"who can stand before the LORD?\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "6:15",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "Tsumura: On Levites receive the ark; 70 struck dead for looking inside; \"who can stand before the LORD?\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "6:14",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Levites receive the ark; 70 struck dead for looking inside; \"who can stand before the LORD?\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/7.json
+++ b/content/1_samuel/7.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "MacArthur: The passage on fasting and sacrifice; \"thus far the LORD has helped us\"; Samuel judges Israel reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "7:8",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "7:9",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "7:10",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "Calvin: On fasting and sacrifice; \"thus far the LORD has helped us\"; Samuel judges Israel: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "7:8",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "7:8",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "Bergen: On fasting and sacrifice; \"thus far the LORD has helped us\"; Samuel judges Israel: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "7:9",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "Tsumura: On fasting and sacrifice; \"thus far the LORD has helped us\"; Samuel judges Israel: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "7:8",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses fasting and sacrifice; \"thus far the LORD has helped us\"; Samuel judges Israel. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/8.json
+++ b/content/1_samuel/8.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "MacArthur: The passage on Samuel warns; the people refuse to listen; God grants the request reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "8:11",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "8:12",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "8:13",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "Calvin: On Samuel warns; the people refuse to listen; God grants the request: God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "8:11",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "8:11",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "Bergen: On Samuel warns; the people refuse to listen; God grants the request: the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "8:12",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "Tsumura: On Samuel warns; the people refuse to listen; God grants the request: the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "8:11",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Samuel warns; the people refuse to listen; God grants the request. The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/1_samuel/9.json
+++ b/content/1_samuel/9.json
@@ -151,76 +151,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:15",
-              "note": "MacArthur: The passage on \"the LORD revealed to Samuel\"; the feast; the rooftop conversation; \"all Israel's desire\" reveals the heart of 1 Samuel's theology: God is building a kingdom, and the question is not whether Israel will have a king, but what kind of king God will provide. Human selection fails; divine selection endures."
-            },
-            {
-              "ref": "9:16",
-              "note": "MacArthur: The contrast between outward appearance and inward reality runs through the entire book. Saul looks like a king but lacks a king's heart. David looks like a shepherd boy but possesses the heart God seeks. \"The LORD looks at the heart\" (16:7) is the book's interpretive key."
-            },
-            {
-              "ref": "9:17",
-              "note": "MacArthur: Every episode in 1 Samuel contributes to the messianic trajectory — the anointed king whom God himself chooses, who rules with a shepherd's heart, who defeats the enemies of God's people. David is the type; Christ is the antitype."
-            },
-            {
-              "ref": "9:18",
-              "note": "MacArthur: The practical lesson: faithfulness in small things precedes authority over great things. David tends sheep before he leads armies. God's training program for leaders always begins in obscurity, not in palaces."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:15",
-              "note": "Calvin: On \"the LORD revealed to Samuel\"; the feast; the rooftop conversation; \"all Israel's desire\": God's providence operates through the full range of human experience — ambition, grief, jealousy, courage, and prayer. Nothing in the Samuel narrative happens outside divine sovereignty, yet human responsibility is never diminished."
-            },
-            {
-              "ref": "9:16",
-              "note": "Calvin: The application for the church: God's purposes are never thwarted by human failure. Saul's disobedience does not derail God's plan; it reveals it. David's anointing was always the destination; Saul's reign was the painful journey to it."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:15",
-              "note": "NET Note: The Hebrew syntax employs thewayyiqtolnarrative chain with strategically placedwĕqatalforms that signal shifts in perspective or background information. The narrator's technique is sophisticated and deliberate."
-            },
-            {
-              "ref": "9:16",
-              "note": "NET Note: Key terms in this section carry institutional weight:māšîaḥ(\"anointed one\"),nāgîd(\"designated ruler\"), andmelek(\"king\") are not synonyms but reflect distinct stages of legitimation in Israel's evolving monarchy."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:15",
-              "note": "Bergen: On \"the LORD revealed to Samuel\"; the feast; the rooftop conversation; \"all Israel's desire\": the narrative advances 1 Samuel's central theological argument — the transition from theocratic judges to anointed monarchy. God remains sovereign over the process, using human ambition, failure, and faith to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "9:17",
-              "note": "Bergen: The literary artistry here is characteristic of the Samuel narrative's sophistication — irony, foreshadowing, and character development serve the theological point that God's choice of king reflects his own priorities, not Israel's."
-            }
-          ]
+          "notes": []
         },
         "tsumura": {
           "source": "David T. Tsumura, The First Book of Samuel, NICOT (2007) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:15",
-              "note": "Tsumura: On \"the LORD revealed to Samuel\"; the feast; the rooftop conversation; \"all Israel's desire\": the Hebrew syntax and vocabulary in this section exhibit features characteristic of early monarchic prose narrative. Key terms carry specific institutional and covenantal connotations that anchor the passage in the broader Deuteronomistic framework."
-            },
-            {
-              "ref": "9:16",
-              "note": "Tsumura: The philological analysis reveals wordplay and sound patterns that reinforce the narrative's theological message. The narrator employs subtle linguistic devices to guide the reader's evaluation of characters and events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"the LORD revealed to Samuel\"; the feast; the rooftop conversation; \"all Israel's desire\". The narrative advances 1 Samuel's central question: what kind of king does Israel need? Every episode contributes to the answer — not the one who looks the part, but the one whose heart is aligned with God's purposes."

--- a/content/2_chronicles/15.json
+++ b/content/2_chronicles/15.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:(9, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:(9, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Asa gathers all Judah and Benjamin “and the people from Ephraim, Manasseh, and Simeon who had settled among them” — northerners who defected to Judah. They enter a covenant to seek the LORD with all their heart. Anyone who does not seek the LORD is to be put to death. They seek God eagerly, and “he was found by them.” Asa even deposes his grandmother Maakah for making an Asherah pole. “Asa’s heart was fully committed to the LORD all his life.”"

--- a/content/2_chronicles/16.json
+++ b/content/2_chronicles/16.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:(7, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:(7, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The seer Hanani confronts Asa: “Because you relied on the king of Aram and not on the LORD your God, the army of the king of Aram has escaped from your hand.” He reminds Asa of the Cushite victory: “The eyes of the LORD range throughout the earth to strengthen those whose hearts are fully committed to him.” Asa rages, imprisons Hanani, and brutalises some people. He develops a foot disease and “even in his illness he did not seek the LORD but only the physicians.” He dies. The man who once sought God with his whole heart ends by seeking only doctors."

--- a/content/2_chronicles/17.json
+++ b/content/2_chronicles/17.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:(10, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:(10, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Jehoshaphat receives tribute from Philistines and Arabs. His army totals over a million men across five divisions. The commanders “willingly offered themselves for service.” The Chronicler’s formula: seeking God → divine blessing → military strength → international recognition. Jehoshaphat embodies the pattern."

--- a/content/2_chronicles/18.json
+++ b/content/2_chronicles/18.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:(18, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:(18, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Micaiah reveals a vision: a lying spirit in the mouths of Ahab’s prophets. Ahab disguises himself; a random arrow kills him. Jehoshaphat escapes — “the LORD helped him, and God drew them away from him.” The Chronicler adds this theological note absent from Kings: Jehoshaphat cried out and God intervened. Even in the consequences of a bad alliance, the seeker of God receives protection."

--- a/content/2_chronicles/19.json
+++ b/content/2_chronicles/19.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:(4, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:(4, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Jehoshaphat appoints judges throughout Judah with a charge unique to Chronicles: “Consider carefully what you do, because you are not judging for mere mortals but for the LORD, who is with you whenever you give a verdict. Judge carefully, for with the LORD our God there is no injustice or partiality or bribery.” He establishes a central court in Jerusalem with Levites, priests, and clan leaders. Justice is both local and centralised, both divine and institutional."

--- a/content/2_chronicles/20.json
+++ b/content/2_chronicles/20.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:(14, '')",
-              "note": "The principle demonstrated here applies universally: God’s governance is consistent, and human choices produce proportional divine responses."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:(14, '')",
-              "note": "The Chronicler’s characteristic vocabulary and theological framework shape the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Spirit comes on Jahaziel the Levite: “Do not be afraid. The battle is not yours but God’s. You will not have to fight.” Jehoshaphat appoints singers to march ahead of the army: “Give thanks to the LORD, for his love endures forever.” As they sing, the LORD sets ambushes among the enemies, who destroy each other. Judah arrives to find only corpses and plunder. They spend three days collecting it. The Valley of Berakah (“blessing”) is named. The Chronicler’s most spectacular illustration of the worship-wins-battles principle."

--- a/content/2_chronicles/21.json
+++ b/content/2_chronicles/21.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:(12, '')",
-              "note": "The principle demonstrated here — that God’s governance is consistent and consequential — applies to every generation."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:(12, '')",
-              "note": "The Chronicler’s distinctive vocabulary shapes the presentation, connecting this section to his broader theological framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "A letter arrives from Elijah the prophet (unique to Chronicles — extraordinary, since Elijah operated in the northern kingdom): “You have not walked in the ways of your father Jehoshaphat... you will be struck with a lingering disease of the bowels.” Philistines and Arabs raid Judah, carry off his sons and wives, leaving only Jehoahaz (Ahaziah). The bowel disease strikes. “He died, to no one’s regret.” The harshest epitaph in Chronicles."

--- a/content/2_chronicles/22.json
+++ b/content/2_chronicles/22.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:(10, '')",
-              "note": "The principle demonstrated here — that God’s governance is consistent and consequential — applies to every generation."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:(10, '')",
-              "note": "The Chronicler’s distinctive vocabulary shapes the presentation, connecting this section to his broader theological framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Athaliah destroys the entire royal family and seizes the throne — the only non-Davidic ruler of Judah. But Jehoshabeath (Jehoiada’s wife) hides baby Joash in the temple for six years. The Davidic line hangs by a thread. The Chronicler’s version is compressed but preserves the essential drama: one baby, hidden in God’s house, preserves the eternal covenant."

--- a/content/2_chronicles/23.json
+++ b/content/2_chronicles/23.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:(12, '')",
-              "note": "The principle demonstrated here — that God’s governance is consistent and consequential — applies to every generation."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:(12, '')",
-              "note": "The Chronicler’s distinctive vocabulary shapes the presentation, connecting this section to his broader theological framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Athaliah hears the commotion, sees the king by the pillar, and screams “Treason!” She is executed outside the temple. Jehoiada makes a covenant between the LORD, the king, and the people. The Baal temple is destroyed, its priest Mattan killed. “All the people of the land rejoiced, and the city was calm.” Order restored through legitimate worship and legitimate kingship."

--- a/content/2_chronicles/24.json
+++ b/content/2_chronicles/24.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:(15, '')",
-              "note": "The principle demonstrated here — that God’s governance is consistent and consequential — applies to every generation."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:(15, '')",
-              "note": "The Chronicler’s distinctive vocabulary shapes the presentation, connecting this section to his broader theological framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "After Jehoiada’s death, the officials lead Joash astray. Prophets are sent but ignored. Zechariah son of Jehoiada prophesies against them; Joash has him stoned in the temple courtyard. Zechariah’s dying words: “May the LORD see this and call you to account.” Within a year, Aram invades with a small force and defeats Judah’s large army “because Judah had forsaken the LORD.” Joash is assassinated in bed. “He was not buried in the tombs of the kings.” The man the temple saved becomes the man who desecrates it."

--- a/content/2_chronicles/25.json
+++ b/content/2_chronicles/25.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:(14, '')",
-              "note": "The principle demonstrated here — that God’s governance is consistent and consequential — applies to every generation."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "25:(14, '')",
-              "note": "The Chronicler’s distinctive vocabulary shapes the presentation, connecting this section to his broader theological framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "After defeating Edom, Amaziah brings back their gods and worships them. A prophet confronts him: “Why do you consult this people’s gods, which could not save their own people from your hand?” Amaziah silences the prophet. Then he challenges Israel’s Jehoash — receives the thistle-and-cedar parable — and is defeated. Jerusalem’s wall is breached. He is eventually assassinated. “From the time that Amaziah turned away from following the LORD, they conspired against him.” The turning point is precise: apostasy triggers assassination."

--- a/content/2_chronicles/26.json
+++ b/content/2_chronicles/26.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:(16, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "26:(16, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "“But after Uzziah became powerful, his pride led to his downfall.” He enters the temple to burn incense — a priestly prerogative. Eighty priests confront him: “It is not right for you, Uzziah, to burn incense.” He rages. Leprosy erupts on his forehead while he holds the censer. He rushes out; the LORD has struck him. He lives in quarantine until death, excluded from the temple. “Isaiah 6:1 — “In the year that King Uzziah died, I saw the Lord.” Isaiah’s call comes when the leprous king dies."

--- a/content/2_chronicles/27.json
+++ b/content/2_chronicles/27.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:(5, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "27:(5, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "“Jotham grew powerful because he walked steadfastly before the LORD his God.” The Chronicler’s thesis in one sentence: steady faithfulness produces power. The brevity of the account is itself a commentary — a faithful, undramatic reign doesn’t need many words. He dies and is buried in the City of David. “Ahaz his son succeeded him.”"

--- a/content/2_chronicles/28.json
+++ b/content/2_chronicles/28.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "28:(16, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "28:(16, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Edomites and Philistines attack. Ahaz appeals to Tiglath-Pileser: “I am your servant.” He strips the temple to pay tribute. Then he closes the temple doors, sets up altars on every street corner, and worships the gods of Damascus. “They were his downfall and the downfall of all Israel.” He dies and is NOT buried in the tombs of the kings. The Chronicler’s Ahaz is the mirror-image of Hezekiah: total forsaking vs. total seeking."

--- a/content/2_chronicles/29.json
+++ b/content/2_chronicles/29.json
@@ -72,21 +72,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "29:(20, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "29:(20, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Hezekiah and the city leaders bring seven bulls, rams, lambs, and goats as sin offerings “for the kingdom, for the sanctuary, and for Judah.” The Levites stand with David’s instruments; the priests with trumpets. “The song of the LORD began also, with the trumpets and the instruments of David.” When the singing stops, the assembly bows. “Hezekiah and all the people rejoiced at what God had brought about for his people, because it was done so quickly.” The speed of reform astonishes even the reformers."

--- a/content/2_chronicles/30.json
+++ b/content/2_chronicles/30.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "30:(13, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "30:(13, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "A great assembly gathers. Many eat the Passover without being ceremonially clean. Hezekiah prays: “May the LORD, who is good, pardon everyone who sets their heart on seeking God — even if they are not clean.” God hears and heals the people. The celebration is so joyful they extend it seven more days. “There was great joy in Jerusalem, for since the days of Solomon there had been nothing like this.” The Chronicler places Hezekiah’s Passover second only to Solomon’s dedication."

--- a/content/2_chronicles/31.json
+++ b/content/2_chronicles/31.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "31:(11, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "31:(11, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Hezekiah orders storerooms prepared in the temple. Officials are appointed to manage the contributions. The Chronicler lists administrators by name. The chapter closes with the comprehensive verdict: “In everything that he undertook in the service of God’s temple and in obedience to the law and the commands, he sought his God and worked wholeheartedly. And so he prospered.” The seek/prosper formula at its purest."

--- a/content/2_chronicles/32.json
+++ b/content/2_chronicles/32.json
@@ -80,21 +80,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "32:(20, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "32:(20, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "“King Hezekiah and the prophet Isaiah cried out in prayer to heaven about this.” The LORD sends an angel who annihilates the Assyrian army. Sennacherib returns to Nineveh and is killed by his sons. The Chronicler adds: “So the LORD saved Hezekiah and the people of Jerusalem.” Hezekiah’s illness, Merodach-Baladan’s embassy, and the treasury-showing are compressed into a few verses. “Hezekiah’s heart was proud” but he repents, and wrath is deferred. He dies honoured: “All Judah and the people of Jerusalem honoured him when he died.”"

--- a/content/2_chronicles/33.json
+++ b/content/2_chronicles/33.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "33:(11, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "33:(11, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Assyrians capture Manasseh with hooks, bind him, and take him to Babylon. “In his distress he sought the favour of the LORD his God and humbled himself greatly.” God is moved by his entreaty and brings him back to Jerusalem. Manasseh then removes the foreign gods, rebuilds the altar, and restores worship. This entire episode is ABSENT from Kings. The Chronicler’s Manasseh repents — the worst king experiences the seek/find pattern. If even Manasseh can be restored through repentance, no one is beyond redemption. This is the Chronicler’s most radical theological statement."

--- a/content/2_chronicles/34.json
+++ b/content/2_chronicles/34.json
@@ -76,21 +76,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "34:(14, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "34:(14, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "During temple repairs, Hilkiah finds the Book of the Law. Josiah tears his robes. Huldah the prophetess delivers the oracle: judgment is coming, but Josiah will be gathered to his ancestors in peace. Josiah reads the book publicly and renews the covenant. “As long as he lived, they did not fail to follow the LORD.” The qualification “as long as he lived” is ominous — after his death, the fall is swift."

--- a/content/2_chronicles/35.json
+++ b/content/2_chronicles/35.json
@@ -80,21 +80,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "35:(20, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "35:(20, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Pharaoh Necho marches north. Josiah intercepts him at Megiddo. Necho sends messengers: “God has told me to hurry. Stop opposing God, who is with me, or he will destroy you.” The Chronicler adds this detail absent from Kings: Necho claims divine authority, and Josiah ignores it. “Josiah would not turn away from him, but disguised himself.” He is fatally wounded by archers. “Jeremiah composed laments for Josiah.” The greatest reformer dies because he refused to listen to God’s word — even when it came through a pagan king."

--- a/content/2_chronicles/36.json
+++ b/content/2_chronicles/36.json
@@ -80,21 +80,11 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "36:(15, '')",
-              "note": "The principle here applies universally: God’s governance is consistent and his responses are proportional to human faithfulness."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "36:(15, '')",
-              "note": "The Chronicler’s distinctive theological vocabulary shapes the presentation of these events."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Nebuchadnezzar burns the temple, breaks down the walls, and deports the survivors to Babylon. “The land enjoyed its sabbath rests; all the time of its desolation it rested, until the seventy years were completed, in fulfilment of the word of the LORD spoken by Jeremiah.” But the book does not end with destruction. Its final verses are Cyrus’s decree: “The LORD, the God of heaven, has given me all the kingdoms of the earth and he has appointed me to build a temple for him at Jerusalem. Any of his people among you may go up.” The same words open the book of Ezra. Chronicles ends mid-sentence, pointing forward to restoration. The last word is not exile but “let him go up.”"

--- a/content/2_samuel/1.json
+++ b/content/2_samuel/1.json
@@ -147,72 +147,24 @@
             {
               "ref": "1:17",
               "note": "MacArthur: The passage on David's elegy; Jonathan's love; Saul's honour in death reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "1:18",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "1:19",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "1:20",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:17",
-              "note": "Calvin: On David's elegy; Jonathan's love; Saul's honour in death: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "1:18",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:17",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "1:18",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:17",
-              "note": "Bergen: On David's elegy; Jonathan's love; Saul's honour in death: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "1:19",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:17",
-              "note": "Anderson: On David's elegy; Jonathan's love; Saul's honour in death: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "1:18",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses David's elegy; Jonathan's love; Saul's honour in death. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/10.json
+++ b/content/2_samuel/10.json
@@ -147,72 +147,24 @@
             {
               "ref": "10:6",
               "note": "MacArthur: The passage on two-front battle; Joab's trust in God; Aramean coalition crushed reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "10:7",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "10:8",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "10:9",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Calvin: On two-front battle; Joab's trust in God; Aramean coalition crushed: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "10:7",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "10:7",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Bergen: On two-front battle; Joab's trust in God; Aramean coalition crushed: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "10:8",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Anderson: On two-front battle; Joab's trust in God; Aramean coalition crushed: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "10:7",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses two-front battle; Joab's trust in God; Aramean coalition crushed. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/11.json
+++ b/content/2_samuel/11.json
@@ -147,72 +147,24 @@
             {
               "ref": "11:6",
               "note": "MacArthur: The passage on Uriah recalled; refuses to go home; \"the ark and Israel and Judah are staying in tents\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "11:7",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "11:8",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "11:9",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:6",
-              "note": "Calvin: On Uriah recalled; refuses to go home; \"the ark and Israel and Judah are staying in tents\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "11:7",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:6",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "11:7",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:6",
-              "note": "Bergen: On Uriah recalled; refuses to go home; \"the ark and Israel and Judah are staying in tents\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "11:8",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:6",
-              "note": "Anderson: On Uriah recalled; refuses to go home; \"the ark and Israel and Judah are staying in tents\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "11:7",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Uriah recalled; refuses to go home; \"the ark and Israel and Judah are staying in tents\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."
@@ -251,72 +203,24 @@
             {
               "ref": "11:14",
               "note": "MacArthur: The passage on Uriah carries his own death warrant; Joab arranges the killing; \"the sword devours one as well as another\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "11:15",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "11:16",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "11:17",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:14",
-              "note": "Calvin: On Uriah carries his own death warrant; Joab arranges the killing; \"the sword devours one as well as another\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "11:15",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:14",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "11:15",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:14",
-              "note": "Bergen: On Uriah carries his own death warrant; Joab arranges the killing; \"the sword devours one as well as another\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "11:16",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:14",
-              "note": "Anderson: On Uriah carries his own death warrant; Joab arranges the killing; \"the sword devours one as well as another\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "11:15",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Uriah carries his own death warrant; Joab arranges the killing; \"the sword devours one as well as another\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/12.json
+++ b/content/2_samuel/12.json
@@ -147,72 +147,24 @@
             {
               "ref": "12:15",
               "note": "MacArthur: The passage on David fasts and prays; \"can I bring him back?\"; Bathsheba bears Solomon; \"the LORD loved him\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "12:16",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "12:17",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "12:18",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:15",
-              "note": "Calvin: On David fasts and prays; \"can I bring him back?\"; Bathsheba bears Solomon; \"the LORD loved him\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "12:16",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:15",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "12:16",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:15",
-              "note": "Bergen: On David fasts and prays; \"can I bring him back?\"; Bathsheba bears Solomon; \"the LORD loved him\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "12:17",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:15",
-              "note": "Anderson: On David fasts and prays; \"can I bring him back?\"; Bathsheba bears Solomon; \"the LORD loved him\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "12:16",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses David fasts and prays; \"can I bring him back?\"; Bathsheba bears Solomon; \"the LORD loved him\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."
@@ -251,72 +203,24 @@
             {
               "ref": "12:26",
               "note": "MacArthur: The passage on Joab saves the honour for David; the Ammonite crown; forced labour reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "12:27",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "12:28",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "12:29",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:26",
-              "note": "Calvin: On Joab saves the honour for David; the Ammonite crown; forced labour: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "12:27",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:26",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "12:27",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:26",
-              "note": "Bergen: On Joab saves the honour for David; the Ammonite crown; forced labour: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "12:28",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:26",
-              "note": "Anderson: On Joab saves the honour for David; the Ammonite crown; forced labour: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "12:27",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Joab saves the honour for David; the Ammonite crown; forced labour. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/13.json
+++ b/content/2_samuel/13.json
@@ -147,72 +147,24 @@
             {
               "ref": "13:23",
               "note": "MacArthur: The passage on two years of waiting; the sheep-shearing feast; Absalom's calculated revenge; three years in exile reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "13:24",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "13:25",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "13:26",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:23",
-              "note": "Calvin: On two years of waiting; the sheep-shearing feast; Absalom's calculated revenge; three years in exile: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "13:24",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:23",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "13:24",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:23",
-              "note": "Bergen: On two years of waiting; the sheep-shearing feast; Absalom's calculated revenge; three years in exile: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "13:25",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:23",
-              "note": "Anderson: On two years of waiting; the sheep-shearing feast; Absalom's calculated revenge; three years in exile: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "13:24",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses two years of waiting; the sheep-shearing feast; Absalom's calculated revenge; three years in exile. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/14.json
+++ b/content/2_samuel/14.json
@@ -147,72 +147,24 @@
             {
               "ref": "14:21",
               "note": "MacArthur: The passage on two years in Jerusalem without seeing David's face; Absalom forces Joab's hand; the kiss of reconciliation reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "14:22",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "14:23",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "14:24",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:21",
-              "note": "Calvin: On two years in Jerusalem without seeing David's face; Absalom forces Joab's hand; the kiss of reconciliation: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "14:22",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:21",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "14:22",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:21",
-              "note": "Bergen: On two years in Jerusalem without seeing David's face; Absalom forces Joab's hand; the kiss of reconciliation: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "14:23",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:21",
-              "note": "Anderson: On two years in Jerusalem without seeing David's face; Absalom forces Joab's hand; the kiss of reconciliation: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "14:22",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses two years in Jerusalem without seeing David's face; Absalom forces Joab's hand; the kiss of reconciliation. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/15.json
+++ b/content/2_samuel/15.json
@@ -147,72 +147,24 @@
             {
               "ref": "15:13",
               "note": "MacArthur: The passage on barefoot on the Mount of Olives; Ittai's loyalty; the ark sent back; Hushai as double agent reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "15:14",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "15:15",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "15:16",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "Calvin: On barefoot on the Mount of Olives; Ittai's loyalty; the ark sent back; Hushai as double agent: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "15:14",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "15:14",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "Bergen: On barefoot on the Mount of Olives; Ittai's loyalty; the ark sent back; Hushai as double agent: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "15:15",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "Anderson: On barefoot on the Mount of Olives; Ittai's loyalty; the ark sent back; Hushai as double agent: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "15:14",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses barefoot on the Mount of Olives; Ittai's loyalty; the ark sent back; Hushai as double agent. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/16.json
+++ b/content/2_samuel/16.json
@@ -147,72 +147,24 @@
             {
               "ref": "16:15",
               "note": "MacArthur: The passage on Hushai's deception begins; Ahithophel advises taking David's concubines; the tent on the roof reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "16:16",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "16:17",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "16:18",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:15",
-              "note": "Calvin: On Hushai's deception begins; Ahithophel advises taking David's concubines; the tent on the roof: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "16:16",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:15",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "16:16",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:15",
-              "note": "Bergen: On Hushai's deception begins; Ahithophel advises taking David's concubines; the tent on the roof: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "16:17",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:15",
-              "note": "Anderson: On Hushai's deception begins; Ahithophel advises taking David's concubines; the tent on the roof: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "16:16",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Hushai's deception begins; Ahithophel advises taking David's concubines; the tent on the roof. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/17.json
+++ b/content/2_samuel/17.json
@@ -147,72 +147,24 @@
             {
               "ref": "17:15",
               "note": "MacArthur: The passage on Ahithophel hangs himself; David reaches Mahanaim; supplies from loyal allies reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "17:16",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "17:17",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "17:18",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:15",
-              "note": "Calvin: On Ahithophel hangs himself; David reaches Mahanaim; supplies from loyal allies: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "17:16",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:15",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "17:16",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:15",
-              "note": "Bergen: On Ahithophel hangs himself; David reaches Mahanaim; supplies from loyal allies: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "17:17",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:15",
-              "note": "Anderson: On Ahithophel hangs himself; David reaches Mahanaim; supplies from loyal allies: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "17:16",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Ahithophel hangs himself; David reaches Mahanaim; supplies from loyal allies. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/18.json
+++ b/content/2_samuel/18.json
@@ -147,72 +147,24 @@
             {
               "ref": "18:19",
               "note": "MacArthur: The passage on the Cushite and Ahimaaz bring news; \"the king was shaken... O my son, my son Absalom! If only I had died instead of you\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "18:20",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "18:21",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "18:22",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:19",
-              "note": "Calvin: On the Cushite and Ahimaaz bring news; \"the king was shaken... O my son, my son Absalom! If only I had died instead of you\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "18:20",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:19",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "18:20",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:19",
-              "note": "Bergen: On the Cushite and Ahimaaz bring news; \"the king was shaken... O my son, my son Absalom! If only I had died instead of you\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "18:21",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:19",
-              "note": "Anderson: On the Cushite and Ahimaaz bring news; \"the king was shaken... O my son, my son Absalom! If only I had died instead of you\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "18:20",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the Cushite and Ahimaaz bring news; \"the king was shaken... O my son, my son Absalom! If only I had died instead of you\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/19.json
+++ b/content/2_samuel/19.json
@@ -147,72 +147,24 @@
             {
               "ref": "19:9",
               "note": "MacArthur: The passage on crossing the Jordan again; forgiveness and grudges; tribal rivalry over the king reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "19:10",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "19:11",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "19:12",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "Calvin: On crossing the Jordan again; forgiveness and grudges; tribal rivalry over the king: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "19:10",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "19:10",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "Bergen: On crossing the Jordan again; forgiveness and grudges; tribal rivalry over the king: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "19:11",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "Anderson: On crossing the Jordan again; forgiveness and grudges; tribal rivalry over the king: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "19:10",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses crossing the Jordan again; forgiveness and grudges; tribal rivalry over the king. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/2.json
+++ b/content/2_samuel/2.json
@@ -147,72 +147,24 @@
             {
               "ref": "2:12",
               "note": "MacArthur: The passage on contest by the pool; Abner kills Asahel; Joab's grudge begins reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "2:13",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "2:14",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "2:15",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Calvin: On contest by the pool; Abner kills Asahel; Joab's grudge begins: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "2:13",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "2:13",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Bergen: On contest by the pool; Abner kills Asahel; Joab's grudge begins: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "2:14",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:12",
-              "note": "Anderson: On contest by the pool; Abner kills Asahel; Joab's grudge begins: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "2:13",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses contest by the pool; Abner kills Asahel; Joab's grudge begins. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/20.json
+++ b/content/2_samuel/20.json
@@ -147,72 +147,24 @@
             {
               "ref": "20:14",
               "note": "MacArthur: The passage on Sheba beheaded; the city saved; David's administration listed again reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "20:15",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "20:16",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "20:17",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:14",
-              "note": "Calvin: On Sheba beheaded; the city saved; David's administration listed again: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "20:15",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:14",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "20:15",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:14",
-              "note": "Bergen: On Sheba beheaded; the city saved; David's administration listed again: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "20:16",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:14",
-              "note": "Anderson: On Sheba beheaded; the city saved; David's administration listed again: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "20:15",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Sheba beheaded; the city saved; David's administration listed again. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/21.json
+++ b/content/2_samuel/21.json
@@ -147,72 +147,24 @@
             {
               "ref": "21:15",
               "note": "MacArthur: The passage on David nearly killed; \"you shall not go out with us to battle\"; four giants slain reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "21:16",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "21:17",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "21:18",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "Calvin: On David nearly killed; \"you shall not go out with us to battle\"; four giants slain: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "21:16",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "21:16",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "Bergen: On David nearly killed; \"you shall not go out with us to battle\"; four giants slain: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "21:17",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "Anderson: On David nearly killed; \"you shall not go out with us to battle\"; four giants slain: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "21:16",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses David nearly killed; \"you shall not go out with us to battle\"; four giants slain. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/22.json
+++ b/content/2_samuel/22.json
@@ -147,72 +147,24 @@
             {
               "ref": "22:26",
               "note": "MacArthur: The passage on the lamp of Israel; pursuing enemies; \"to David and his descendants forever\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "22:27",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "22:28",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "22:29",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:26",
-              "note": "Calvin: On the lamp of Israel; pursuing enemies; \"to David and his descendants forever\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "22:27",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:26",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "22:27",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:26",
-              "note": "Bergen: On the lamp of Israel; pursuing enemies; \"to David and his descendants forever\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "22:28",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:26",
-              "note": "Anderson: On the lamp of Israel; pursuing enemies; \"to David and his descendants forever\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "22:27",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the lamp of Israel; pursuing enemies; \"to David and his descendants forever\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/23.json
+++ b/content/2_samuel/23.json
@@ -147,72 +147,24 @@
             {
               "ref": "23:8",
               "note": "MacArthur: The passage on Josheb-Basshebeth, Eleazar, Shammah; the Three and the Thirty; Uriah the Hittite listed last reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "23:9",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "23:10",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "23:11",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:8",
-              "note": "Calvin: On Josheb-Basshebeth, Eleazar, Shammah; the Three and the Thirty; Uriah the Hittite listed last: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "23:9",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:8",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "23:9",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:8",
-              "note": "Bergen: On Josheb-Basshebeth, Eleazar, Shammah; the Three and the Thirty; Uriah the Hittite listed last: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "23:10",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:8",
-              "note": "Anderson: On Josheb-Basshebeth, Eleazar, Shammah; the Three and the Thirty; Uriah the Hittite listed last: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "23:9",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Josheb-Basshebeth, Eleazar, Shammah; the Three and the Thirty; Uriah the Hittite listed last. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/24.json
+++ b/content/2_samuel/24.json
@@ -147,72 +147,24 @@
             {
               "ref": "24:10",
               "note": "MacArthur: The passage on \"I have sinned greatly\"; three choices; pestilence; the angel at Araunah's threshing floor reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "24:11",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "24:12",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "24:13",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:10",
-              "note": "Calvin: On \"I have sinned greatly\"; three choices; pestilence; the angel at Araunah's threshing floor: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "24:11",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:10",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "24:11",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:10",
-              "note": "Bergen: On \"I have sinned greatly\"; three choices; pestilence; the angel at Araunah's threshing floor: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "24:12",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:10",
-              "note": "Anderson: On \"I have sinned greatly\"; three choices; pestilence; the angel at Araunah's threshing floor: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "24:11",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"I have sinned greatly\"; three choices; pestilence; the angel at Araunah's threshing floor. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."
@@ -251,72 +203,24 @@
             {
               "ref": "24:18",
               "note": "MacArthur: The passage on \"I will not offer burnt offerings that cost me nothing\"; the site of the future temple reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "24:19",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "24:20",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "24:21",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:18",
-              "note": "Calvin: On \"I will not offer burnt offerings that cost me nothing\"; the site of the future temple: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "24:19",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:18",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "24:19",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:18",
-              "note": "Bergen: On \"I will not offer burnt offerings that cost me nothing\"; the site of the future temple: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "24:20",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:18",
-              "note": "Anderson: On \"I will not offer burnt offerings that cost me nothing\"; the site of the future temple: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "24:19",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"I will not offer burnt offerings that cost me nothing\"; the site of the future temple. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/3.json
+++ b/content/2_samuel/3.json
@@ -147,72 +147,24 @@
             {
               "ref": "3:22",
               "note": "MacArthur: The passage on Joab stabs Abner at the gate; David's public mourning; \"I am weak today, though anointed king\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "3:23",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "3:24",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "3:25",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:22",
-              "note": "Calvin: On Joab stabs Abner at the gate; David's public mourning; \"I am weak today, though anointed king\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "3:23",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:22",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "3:23",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:22",
-              "note": "Bergen: On Joab stabs Abner at the gate; David's public mourning; \"I am weak today, though anointed king\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "3:24",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:22",
-              "note": "Anderson: On Joab stabs Abner at the gate; David's public mourning; \"I am weak today, though anointed king\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "3:23",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Joab stabs Abner at the gate; David's public mourning; \"I am weak today, though anointed king\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/4.json
+++ b/content/2_samuel/4.json
@@ -147,72 +147,24 @@
             {
               "ref": "4:9",
               "note": "MacArthur: The passage on \"how much more when wicked men have killed a righteous man\"; hands and feet cut off reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "4:10",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "4:11",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "4:12",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:9",
-              "note": "Calvin: On \"how much more when wicked men have killed a righteous man\"; hands and feet cut off: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "4:10",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:9",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "4:10",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:9",
-              "note": "Bergen: On \"how much more when wicked men have killed a righteous man\"; hands and feet cut off: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "4:11",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:9",
-              "note": "Anderson: On \"how much more when wicked men have killed a righteous man\"; hands and feet cut off: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "4:10",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"how much more when wicked men have killed a righteous man\"; hands and feet cut off. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/5.json
+++ b/content/2_samuel/5.json
@@ -147,72 +147,24 @@
             {
               "ref": "5:6",
               "note": "MacArthur: The passage on Jebusite stronghold; the water shaft; Hiram builds David's palace reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "5:7",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "5:8",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "5:9",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Calvin: On Jebusite stronghold; the water shaft; Hiram builds David's palace: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "5:7",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "5:7",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Bergen: On Jebusite stronghold; the water shaft; Hiram builds David's palace: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "5:8",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Anderson: On Jebusite stronghold; the water shaft; Hiram builds David's palace: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "5:7",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Jebusite stronghold; the water shaft; Hiram builds David's palace. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."
@@ -251,72 +203,24 @@
             {
               "ref": "5:17",
               "note": "MacArthur: The passage on the Valley of Rephaim; \"the sound of marching in the balsam trees\" reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "5:18",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "5:19",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "5:20",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:17",
-              "note": "Calvin: On the Valley of Rephaim; \"the sound of marching in the balsam trees\": God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "5:18",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:17",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "5:18",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:17",
-              "note": "Bergen: On the Valley of Rephaim; \"the sound of marching in the balsam trees\": the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "5:19",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:17",
-              "note": "Anderson: On the Valley of Rephaim; \"the sound of marching in the balsam trees\": the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "5:18",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the Valley of Rephaim; \"the sound of marching in the balsam trees\". The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/6.json
+++ b/content/2_samuel/6.json
@@ -147,72 +147,24 @@
             {
               "ref": "6:12",
               "note": "MacArthur: The passage on sacrifice every six steps; David dances in a linen ephod; Michal's contempt; barrenness reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "6:13",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "6:14",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "6:15",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:12",
-              "note": "Calvin: On sacrifice every six steps; David dances in a linen ephod; Michal's contempt; barrenness: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "6:13",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:12",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "6:13",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:12",
-              "note": "Bergen: On sacrifice every six steps; David dances in a linen ephod; Michal's contempt; barrenness: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "6:14",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:12",
-              "note": "Anderson: On sacrifice every six steps; David dances in a linen ephod; Michal's contempt; barrenness: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "6:13",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses sacrifice every six steps; David dances in a linen ephod; Michal's contempt; barrenness. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/7.json
+++ b/content/2_samuel/7.json
@@ -147,72 +147,24 @@
             {
               "ref": "7:18",
               "note": "MacArthur: The passage on humility, gratitude, and faith; \"do as you promised\" — the model prayer of the anointed king reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "7:19",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "7:20",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "7:21",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:18",
-              "note": "Calvin: On humility, gratitude, and faith; \"do as you promised\" — the model prayer of the anointed king: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "7:19",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:18",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "7:19",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:18",
-              "note": "Bergen: On humility, gratitude, and faith; \"do as you promised\" — the model prayer of the anointed king: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "7:20",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:18",
-              "note": "Anderson: On humility, gratitude, and faith; \"do as you promised\" — the model prayer of the anointed king: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "7:19",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses humility, gratitude, and faith; \"do as you promised\" — the model prayer of the anointed king. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/8.json
+++ b/content/2_samuel/8.json
@@ -147,72 +147,24 @@
             {
               "ref": "8:15",
               "note": "MacArthur: The passage on justice for all the people; Joab, Jehoshaphat, Zadok, Abiathar, Seraiah, Benaiah reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "8:16",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "8:17",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "8:18",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:15",
-              "note": "Calvin: On justice for all the people; Joab, Jehoshaphat, Zadok, Abiathar, Seraiah, Benaiah: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "8:16",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:15",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "8:16",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:15",
-              "note": "Bergen: On justice for all the people; Joab, Jehoshaphat, Zadok, Abiathar, Seraiah, Benaiah: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "8:17",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:15",
-              "note": "Anderson: On justice for all the people; Joab, Jehoshaphat, Zadok, Abiathar, Seraiah, Benaiah: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "8:16",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses justice for all the people; Joab, Jehoshaphat, Zadok, Abiathar, Seraiah, Benaiah. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/2_samuel/9.json
+++ b/content/2_samuel/9.json
@@ -147,72 +147,24 @@
             {
               "ref": "9:9",
               "note": "MacArthur: The passage on Ziba appointed steward; the crippled grandson of Saul dines with the king; covenant ḥesed reveals God's sovereign management of David's kingdom — blessings and judgments alike serve the covenant purpose. The Davidic covenant (ch 7) is the theological backbone of the entire book; every episode is read in its light."
-            },
-            {
-              "ref": "9:10",
-              "note": "MacArthur: David is the Bible's most fully developed human character — warrior, poet, lover, sinner, penitent, king. His complexity is not a literary weakness but a theological asset: God works through flawed people, not around them."
-            },
-            {
-              "ref": "9:11",
-              "note": "MacArthur: The messianic trajectory runs through every chapter of 2 Samuel. David's throne, David's seed, David's city — all are types of Christ's eternal kingdom. \"The LORD declares to you that the LORD himself will establish a house for you\" (7:11)."
-            },
-            {
-              "ref": "9:12",
-              "note": "MacArthur: The practical application is both comforting and sobering: God's promises are unbreakable, but his discipline is real. David kept his throne but lost his peace. Grace does not eliminate consequences; it sustains the sinner through them."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:9",
-              "note": "Calvin: On Ziba appointed steward; the crippled grandson of Saul dines with the king; covenant ḥesed: God's providence governs every detail of David's reign — victories, sins, and consequences alike serve the divine purpose. David is simultaneously the anointed king and a broken sinner, and God uses both dimensions to accomplish his will."
-            },
-            {
-              "ref": "9:10",
-              "note": "Calvin: The church must learn from David that no height of spiritual privilege exempts one from the consequences of sin. The sword that never departed from David's house (12:10) is a warning to every generation that presumes upon grace."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:9",
-              "note": "NET Note: The Hebrew syntax here employs thewayyiqtolnarrative chain with strategically placed disjunctive clauses that provide background information and shift perspective. Key institutional terms —melek,nāgîd,māšîaḥ— carry distinct political and theological connotations."
-            },
-            {
-              "ref": "9:10",
-              "note": "NET Note: Textual variants between MT and 4QSamᵃ/LXX in this section affect the narrative's details though not its theological direction. The NET translation notes indicate where critical decisions between readings were necessary."
-            }
-          ]
+          "notes": []
         },
         "bergen": {
           "source": "Robert D. Bergen, 1, 2 Samuel, New American Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:9",
-              "note": "Bergen: On Ziba appointed steward; the crippled grandson of Saul dines with the king; covenant ḥesed: the narrative advances 2 Samuel's central theological argument — God's covenant with David (ch 7) is both unconditional in its promise and consequential in its outworking. David's sins do not void the covenant but unleash its disciplinary clauses."
-            },
-            {
-              "ref": "9:11",
-              "note": "Bergen: The narrator's literary skill is on full display — irony, foreshadowing, and the interplay between public kingship and private failure create the most psychologically complex character portrait in the OT."
-            }
-          ]
+          "notes": []
         },
         "anderson": {
           "source": "A.A. Anderson, 2 Samuel, Word Biblical Commentary (1989) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:9",
-              "note": "Anderson: On Ziba appointed steward; the crippled grandson of Saul dines with the king; covenant ḥesed: the text-critical evidence for this passage reveals occasional divergences between MT, LXX, and 4QSamᵃ. The philological analysis illuminates the narrator's craft and the institutional vocabulary of the early monarchy."
-            },
-            {
-              "ref": "9:10",
-              "note": "Anderson: The Hebrew syntax and vocabulary here are characteristic of the Succession Narrative's prose style — psychologically realistic, politically nuanced, and theologically restrained. The narrator shows rather than tells, leaving moral evaluation largely to the reader."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Ziba appointed steward; the crippled grandson of Saul dines with the king; covenant ḥesed. The narrative advances 2 Samuel's central tension: the Davidic covenant is unconditional in its promise but consequential in its outworking. David's victories, sins, and sufferings all serve the larger story of God building a kingdom through a flawed but chosen king."

--- a/content/acts/13.json
+++ b/content/acts/13.json
@@ -4,51 +4,51 @@
   "book_dir": "acts",
   "chapter_num": 13,
   "title": "Acts 13",
-  "subtitle": "First Missionary Journey \u2014 Cyprus and Pisidian Antioch",
+  "subtitle": "First Missionary Journey — Cyprus and Pisidian Antioch",
   "timeline_link": {
     "event_id": "pauls-missionary-journeys",
-    "text": "See on Timeline \u2014 First Missionary Journey"
+    "text": "See on Timeline — First Missionary Journey"
   },
   "map_story_link": {
     "story_id": "paul-journey1",
-    "text": "See on Map \u2014 Paul's 1st Journey"
+    "text": "See on Map — Paul's 1st Journey"
   },
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201425 \u2014 Commissioned from Antioch; Cyprus; Pisidian Antioch",
+      "header": "Verses 1—25 — Commissioned from Antioch; Cyprus; Pisidian Antioch",
       "verse_start": 1,
       "verse_end": 25,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03c6\u03bf\u03c1\u03af\u03c3\u03b1\u03c4\u03b5",
+            "word": "ἀφορίσατε",
             "transliteration": "aphorisate",
             "gloss": "set apart",
-            "paragraph": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment \u2014 God had set him apart before birth; the church now formally recognizes and releases that calling."
+            "paragraph": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment — God had set him apart before birth; the church now formally recognizes and releases that calling."
           },
           {
-            "word": "\u03a0\u03b1\u1fe6\u03bb\u03bf\u03c2",
+            "word": "Παῦλος",
             "transliteration": "Paulos",
             "gloss": "Paul",
-            "paragraph": "verse 9 marks the transition from 'Saul' to 'Paul' \u2014 the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
+            "paragraph": "verse 9 marks the transition from 'Saul' to 'Paul' — the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
           }
         ],
         "places": [
           {
             "name": "Antioch on the Orontes",
-            "coords": "36.2021\u00b0 N, 36.1603\u00b0 E",
+            "coords": "36.2021° N, 36.1603° E",
             "text": "The launching base for all three Pauline missionary journeys. A diverse, cosmopolitan city with a large Jewish community and a thriving Gentile population. The church's diversity (v.1: Barnabas from Cyprus, Simeon from Africa, Lucius from Cyrene, Manaen from Herod's court, Saul from Tarsus) mirrors the world it is about to reach."
           },
           {
             "name": "Pisidian Antioch",
-            "coords": "38.3167\u00b0 N, 31.2000\u00b0 E",
-            "text": "A Roman colony in the Phrygian highlands (not the Syrian Antioch of v.1 but a different city \u2014 named for the same Seleucid founder). A significant Roman administrative centre with a large Jewish community. Paul's sermon here is the most detailed account of synagogue preaching in Acts."
+            "coords": "38.3167° N, 31.2000° E",
+            "text": "A Roman colony in the Phrygian highlands (not the Syrian Antioch of v.1 but a different city — named for the same Seleucid founder). A significant Roman administrative centre with a large Jewish community. Paul's sermon here is the most detailed account of synagogue preaching in Acts."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 46\u201348",
+            "date": "c. AD 46–48",
             "name": "First Missionary Journey Begins",
             "text": "Paul and Barnabas are commissioned by the Antioch church and the Holy Spirit, launching the first deliberate apostolic mission to the Gentile world. The journey will take them through Cyprus, Pamphylia, and Galatia.",
             "current": true
@@ -60,7 +60,7 @@
             "current": false
           },
           {
-            "date": "c. AD 48\u201349",
+            "date": "c. AD 48–49",
             "name": "Jerusalem Council",
             "text": "",
             "current": false
@@ -70,50 +70,50 @@
           "refs": [
             {
               "ref": "Acts 9:15",
-              "note": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" \u2014 the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately."
+              "note": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" — the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately."
             },
             {
-              "ref": "Galatians 1:15\u201316",
+              "ref": "Galatians 1:15–16",
               "note": "\"God set me apart from my mother's womb... to reveal his Son in me so that I might preach him among the Gentiles.\" Paul's autobiographical account matches the Acts commissioning narrative."
             },
             {
               "ref": "Isaiah 49:6",
-              "note": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" \u2014 cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission."
+              "note": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" — cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "13:2\u20133",
-              "note": "MacArthur on the commissioning process: worship and fasting precede the Spirit's direction; prayer and laying on of hands follow it. The sequence is: waiting on God \u2192 receiving direction \u2192 confirming response. MacArthur uses this as the NT model for missionary commissioning \u2014 Spirit-initiated, church-confirmed, prayer-surrounded."
+              "ref": "13:2–3",
+              "note": "MacArthur on the commissioning process: worship and fasting precede the Spirit's direction; prayer and laying on of hands follow it. The sequence is: waiting on God → receiving direction → confirming response. MacArthur uses this as the NT model for missionary commissioning — Spirit-initiated, church-confirmed, prayer-surrounded."
             },
             {
-              "ref": "13:10\u201311",
-              "note": "MacArthur on Paul's confrontation with Elymas: Paul does not debate or negotiate but pronounces prophetic judgment. The blindness inflicted on Elymas mirrors Paul's own blindness at Damascus \u2014 a mercy that might lead to sight. MacArthur notes the pattern: God's judgments are often invitations to the very experience that opens eyes."
+              "ref": "13:10–11",
+              "note": "MacArthur on Paul's confrontation with Elymas: Paul does not debate or negotiate but pronounces prophetic judgment. The blindness inflicted on Elymas mirrors Paul's own blindness at Damascus — a mercy that might lead to sight. MacArthur notes the pattern: God's judgments are often invitations to the very experience that opens eyes."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:2",
-              "note": "Calvin on 'While they were worshiping the Lord and fasting': the Spirit speaks through the gathered, attentive community. Calvin uses this to argue that extraordinary callings (missionary commissioning) come through ordinary means (corporate worship) \u2014 not through private visions alone. The community's recognition is part of the calling's confirmation."
+              "note": "Calvin on 'While they were worshiping the Lord and fasting': the Spirit speaks through the gathered, attentive community. Calvin uses this to argue that extraordinary callings (missionary commissioning) come through ordinary means (corporate worship) — not through private visions alone. The community's recognition is part of the calling's confirmation."
             },
             {
               "ref": "13:9",
-              "note": "Calvin on Paul filled with the Holy Spirit before confronting Elymas: the filling is not for eloquence or confidence alone but for supernatural discernment. Calvin notes that Paul 'looked straight at him' (atenisas) \u2014 the same word used of Stephen's gaze at the Sanhedrin (6:15) and Peter's gaze at the lame man (3:4). The penetrating look precedes the prophetic word."
+              "note": "Calvin on Paul filled with the Holy Spirit before confronting Elymas: the filling is not for eloquence or confidence alone but for supernatural discernment. Calvin notes that Paul 'looked straight at him' (atenisas) — the same word used of Stephen's gaze at the Sanhedrin (6:15) and Peter's gaze at the lame man (3:4). The penetrating look precedes the prophetic word."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:1",
-              "note": "The NET notes the significance of Manaen's description as syntrophos (literally 'one brought up with') Herod the tetrarch \u2014 a term for a childhood companion raised in the royal household. Manaen's presence in the Antioch church leadership represents the Gospel's penetration of the highest social levels of Jewish society."
+              "note": "The NET notes the significance of Manaen's description as syntrophos (literally 'one brought up with') Herod the tetrarch — a term for a childhood companion raised in the royal household. Manaen's presence in the Antioch church leadership represents the Gospel's penetration of the highest social levels of Jewish society."
             },
             {
               "ref": "13:20",
@@ -122,24 +122,24 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "13:2",
-              "note": "\"The Holy Spirit said, Set apart for me Barnabas and Saul\" \u2014 Robertson notes the Spirit speaking directly through prophets during corporate worship. The commissioning is initiated by God through the gathered community, not by human administrative decision. The Spirit is the senior partner in every genuine missionary enterprise."
+              "note": "\"The Holy Spirit said, Set apart for me Barnabas and Saul\" — Robertson notes the Spirit speaking directly through prophets during corporate worship. The commissioning is initiated by God through the gathered community, not by human administrative decision. The Spirit is the senior partner in every genuine missionary enterprise."
             },
             {
               "ref": "13:9",
-              "note": "The first appearance of \"Paul\" replacing \"Saul\" \u2014 Robertson notes this is Luke's way of signalling the shift from Jewish to Gentile mission territory. Paulos was Paul's actual Roman name used in Roman contexts; its adoption here is culturally strategic as well as personally natural."
+              "note": "The first appearance of \"Paul\" replacing \"Saul\" — Robertson notes this is Luke's way of signalling the shift from Jewish to Gentile mission territory. Paulos was Paul's actual Roman name used in Roman contexts; its adoption here is culturally strategic as well as personally natural."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "13:1",
-              "note": "Keener notes the remarkable diversity of the Antioch church's leadership: Barnabas (Levite from Cyprus), Simeon Niger (probably African, 'Niger' meaning 'black'), Lucius of Cyrene (North African), Manaen (raised in Herod Antipas's household \u2014 connected to the ruling elite), and Saul (diaspora Jew from Tarsus). This team embodies the multicultural community they are about to evangelise."
+              "note": "Keener notes the remarkable diversity of the Antioch church's leadership: Barnabas (Levite from Cyprus), Simeon Niger (probably African, 'Niger' meaning 'black'), Lucius of Cyrene (North African), Manaen (raised in Herod Antipas's household — connected to the ruling elite), and Saul (diaspora Jew from Tarsus). This team embodies the multicultural community they are about to evangelise."
             },
             {
               "ref": "13:7",
@@ -148,51 +148,51 @@
           ]
         },
         "hist": {
-          "context": "The commissioning of vv.1\u20133 is one of the most significant structural moments in Acts: the Spirit speaks through corporate worship and fasting, names specific individuals, and the community responds with prayer and laying on of hands. This is not apostolic appointment from Jerusalem but Spirit-directed commissioning from Antioch \u2014 the grass-roots mission structure that will carry the Gospel to the ends of the earth. Paul's sermon (vv.16\u201341) is modelled on Stephen's speech (ch.7) \u2014 a survey of salvation history building to a Christological climax \u2014 but applied now to a Diaspora synagogue audience."
+          "context": "The commissioning of vv.1–3 is one of the most significant structural moments in Acts: the Spirit speaks through corporate worship and fasting, names specific individuals, and the community responds with prayer and laying on of hands. This is not apostolic appointment from Jerusalem but Spirit-directed commissioning from Antioch — the grass-roots mission structure that will carry the Gospel to the ends of the earth. Paul's sermon (vv.16–41) is modelled on Stephen's speech (ch.7) — a survey of salvation history building to a Christological climax — but applied now to a Diaspora synagogue audience."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 26\u201441 \u2014 Paul\u2019s Sermon: Through Jesus Forgiveness Is Proclaimed",
+      "header": "Verses 26—41 — Paul’s Sermon: Through Jesus Forgiveness Is Proclaimed",
       "verse_start": 26,
       "verse_end": 41,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03b9\u03ba\u03b1\u03b9\u03c9\u03b8\u1fc6\u03bd\u03b1\u03b9",
-            "transliteration": "dikai\u014dth\u0113nai",
+            "word": "δικαιωθῆναι",
+            "transliteration": "dikaiōthēnai",
             "gloss": "justified / set free",
             "paragraph": "v.39 is Paul's earliest recorded statement of justification by faith: 'everyone who believes is set free (justified) from every sin, a justification you were not able to obtain under the law of Moses.' This is the theological thesis of Galatians and Romans, stated in embryonic form in Paul's first synagogue sermon."
           },
           {
-            "word": "\u1f61\u03c1\u03b9\u03c3\u03bc\u03ad\u03bd\u03bf\u03b9 \u03b5\u1f30\u03c2 \u03b6\u03c9\u1f74\u03bd \u03b1\u1f30\u03ce\u03bd\u03b9\u03bf\u03bd",
-            "transliteration": "h\u014drismenoi eis z\u014d\u0113n ai\u014dnion",
+            "word": "ὡρισμένοι εἰς ζωὴν αἰώνιον",
+            "transliteration": "hōrismenoi eis zōēn aiōnion",
             "gloss": "appointed for eternal life",
-            "paragraph": "v.48 \u2014 a crucial phrase. The passive participle 'appointed' (h\u014drismenoi) indicates divine action: those who believed were those whom God had previously appointed. Luke presents the correlation between divine appointment and human faith without explaining their relationship \u2014 the mystery Luke preserves intact."
+            "paragraph": "v.48 — a crucial phrase. The passive participle 'appointed' (hōrismenoi) indicates divine action: those who believed were those whom God had previously appointed. Luke presents the correlation between divine appointment and human faith without explaining their relationship — the mystery Luke preserves intact."
           }
         ],
         "places": [
           {
-            "name": "Pisidian Antioch \u2014 Synagogue",
-            "coords": "38.3167\u00b0 N, 31.2000\u00b0 E",
+            "name": "Pisidian Antioch — Synagogue",
+            "coords": "38.3167° N, 31.2000° E",
             "text": "The synagogue invitation (v.15) gives Paul his first major preaching platform: 'if you have a word of exhortation for the people, please speak.' The formal synagogue service has just included Torah and Prophets readings; Paul builds on them. The sermon structure mirrors the service's own movement from history to contemporary application."
           },
           {
             "name": "Iconium",
-            "coords": "37.8740\u00b0 N, 32.4846\u00b0 E",
-            "text": "Modern Konya in central Turkey \u2014 Paul and Barnabas's next stop after expulsion from Pisidian Antioch. A major city on the road network connecting western and eastern Asia Minor. The pattern of synagogue preaching \u2192 Jewish opposition \u2192 turning to Gentiles \u2192 expulsion \u2192 moving on will repeat at each city."
+            "coords": "37.8740° N, 32.4846° E",
+            "text": "Modern Konya in central Turkey — Paul and Barnabas's next stop after expulsion from Pisidian Antioch. A major city on the road network connecting western and eastern Asia Minor. The pattern of synagogue preaching → Jewish opposition → turning to Gentiles → expulsion → moving on will repeat at each city."
           }
         ],
         "tl": [
           {
             "date": "c. AD 47",
-            "name": "Pisidian Antioch \u2014 First Major Sermon",
-            "text": "Paul's synagogue sermon in Pisidian Antioch establishes the pattern for his entire Gentile mission: synagogue first \u2192 Israel's rejection \u2192 turning to Gentiles \u2192 persecution \u2192 moving on. This pattern will repeat in every city.",
+            "name": "Pisidian Antioch — First Major Sermon",
+            "text": "Paul's synagogue sermon in Pisidian Antioch establishes the pattern for his entire Gentile mission: synagogue first → Israel's rejection → turning to Gentiles → persecution → moving on. This pattern will repeat in every city.",
             "current": true
           },
           {
-            "date": "c. AD 47\u201348",
+            "date": "c. AD 47–48",
             "name": "Iconium, Lystra, Derbe",
             "text": "",
             "current": false
@@ -208,68 +208,68 @@
           "refs": [
             {
               "ref": "Isaiah 49:6",
-              "note": "\"I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth\" \u2014 cited in v.47 as the scriptural mandate for turning to the Gentiles. This verse will be cited again in Acts 26:23 and Luke 2:32."
+              "note": "\"I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth\" — cited in v.47 as the scriptural mandate for turning to the Gentiles. This verse will be cited again in Acts 26:23 and Luke 2:32."
             },
             {
               "ref": "Psalm 2:7",
-              "note": "\"You are my son; today I have become your father\" \u2014 cited in v.33 as fulfilled in the resurrection. Paul reads the Psalm as a coronation announcement fulfilled at Christ's resurrection-exaltation."
+              "note": "\"You are my son; today I have become your father\" — cited in v.33 as fulfilled in the resurrection. Paul reads the Psalm as a coronation announcement fulfilled at Christ's resurrection-exaltation."
             },
             {
               "ref": "Habakkuk 1:5",
-              "note": "\"Look, you scoffers, wonder and perish... something you would never believe\" \u2014 cited in v.41 as a warning to those who reject the Gospel. Paul applies the prophet's warning about Babylon to those who reject Christ."
+              "note": "\"Look, you scoffers, wonder and perish... something you would never believe\" — cited in v.41 as a warning to those who reject the Gospel. Paul applies the prophet's warning about Babylon to those who reject Christ."
             }
           ],
           "echoes": [
             {
               "source_ref": "Isaiah 55:3 / Psalm 16:10",
-              "target_ref": "Acts 13:34\u201335",
+              "target_ref": "Acts 13:34–35",
               "type": "direct_quote",
-              "source_context": "Isaiah promised the sure mercies given to David \u2014 faithful covenant love that endures. The psalmist trusted that God would not abandon him to the grave or let his Holy One see decay.",
-              "connection": "Paul argues in Pisidian Antioch: David himself died and saw decay, so he was not speaking of himself. The non-decay promise requires resurrection \u2014 and finds fulfillment in Jesus alone.",
+              "source_context": "Isaiah promised the sure mercies given to David — faithful covenant love that endures. The psalmist trusted that God would not abandon him to the grave or let his Holy One see decay.",
+              "connection": "Paul argues in Pisidian Antioch: David himself died and saw decay, so he was not speaking of himself. The non-decay promise requires resurrection — and finds fulfillment in Jesus alone.",
               "significance": "Paul's synagogue sermons read the Psalms christologically: David wrote as prophet about his greater Son. The resurrection is the hermeneutical key that unlocks these texts."
             },
             {
               "source_ref": "Habakkuk 1:5",
               "target_ref": "Acts 13:41",
               "type": "direct_quote",
-              "source_context": "Habakkuk warned that God was doing a work in Israel's day that they would not believe even if told. The unbelievable work was judgment through the Babylonians \u2014 judgment on the complacent.",
+              "source_context": "Habakkuk warned that God was doing a work in Israel's day that they would not believe even if told. The unbelievable work was judgment through the Babylonians — judgment on the complacent.",
               "connection": "Paul applies this to his Jewish audience: 'Beware, lest what is said in the prophets come upon you.' The pattern of unbelief leading to judgment remains active. Rejection of Jesus has consequences.",
-              "significance": "Paul's warning echoes the prophetic tradition: God's saving acts can become judgment when rejected. The 'work' now is resurrection and Gentile inclusion \u2014 equally unbelievable to scoffers."
+              "significance": "Paul's warning echoes the prophetic tradition: God's saving acts can become judgment when rejected. The 'work' now is resurrection and Gentile inclusion — equally unbelievable to scoffers."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "13:38\u201339",
-              "note": "MacArthur on Paul's justification statement: this is the earliest recorded Pauline articulation of what will become the theological core of Galatians and Romans. \"Through him everyone who believes is set free (justified) from every sin\" \u2014 justification is by faith, not by law-keeping, and it covers sins the Mosaic law's sacrificial system could not permanently address."
+              "ref": "13:38–39",
+              "note": "MacArthur on Paul's justification statement: this is the earliest recorded Pauline articulation of what will become the theological core of Galatians and Romans. \"Through him everyone who believes is set free (justified) from every sin\" — justification is by faith, not by law-keeping, and it covers sins the Mosaic law's sacrificial system could not permanently address."
             },
             {
               "ref": "13:48",
-              "note": "MacArthur on divine appointment and human faith: both are present and neither cancels the other. Those who were appointed believed; those who believed were appointed. MacArthur uses this to argue that divine sovereignty and human responsibility are not in contradiction but in mysterious cooperation \u2014 the Bible asserts both without resolving the tension philosophically."
+              "note": "MacArthur on divine appointment and human faith: both are present and neither cancels the other. Those who were appointed believed; those who believed were appointed. MacArthur uses this to argue that divine sovereignty and human responsibility are not in contradiction but in mysterious cooperation — the Bible asserts both without resolving the tension philosophically."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:46",
-              "note": "Calvin on 'we now turn to the Gentiles': Paul does not abandon the Jewish mission but announces the consequence of deliberate rejection. Calvin notes that 'since you reject it' is the key \u2014 the turning to Gentiles is not Plan B but the logically necessitated consequence of Israel's deliberate self-exclusion. The promise remains for Israel; it is they who have set it aside."
+              "note": "Calvin on 'we now turn to the Gentiles': Paul does not abandon the Jewish mission but announces the consequence of deliberate rejection. Calvin notes that 'since you reject it' is the key — the turning to Gentiles is not Plan B but the logically necessitated consequence of Israel's deliberate self-exclusion. The promise remains for Israel; it is they who have set it aside."
             },
             {
               "ref": "13:48",
-              "note": "Calvin on divine appointment and faith: this is one of Calvin's key Acts texts for the doctrine of election. 'As many as were appointed for eternal life believed' \u2014 the believing is real and human; the appointment is prior and divine. Calvin reads this as Luke's confirmation that the doctrine of election is not a Pauline speciality but embedded in the narrative of Acts."
+              "note": "Calvin on divine appointment and faith: this is one of Calvin's key Acts texts for the doctrine of election. 'As many as were appointed for eternal life believed' — the believing is real and human; the appointment is prior and divine. Calvin reads this as Luke's confirmation that the doctrine of election is not a Pauline speciality but embedded in the narrative of Acts."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:39",
-              "note": "The NET notes that the verb 'justified' (dikai\u014dth\u0113nai) is used only here in Acts in its full Pauline sense. Luke uses justification language sparingly, but this occurrence confirms that Paul's synagogue preaching already contained the theological core of his later epistles \u2014 Acts and the letters are consistent."
+              "note": "The NET notes that the verb 'justified' (dikaiōthēnai) is used only here in Acts in its full Pauline sense. Luke uses justification language sparingly, but this occurrence confirms that Paul's synagogue preaching already contained the theological core of his later epistles — Acts and the letters are consistent."
             },
             {
               "ref": "13:48",
@@ -278,71 +278,71 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "13:39",
-              "note": "Robertson on \"justification you were not able to obtain under the law of Moses\" \u2014 the first explicit statement of justification by faith in Acts, matching Paul's later Galatians and Romans argument. Robertson notes that Paul states the principle without the full theological elaboration of his letters \u2014 the synagogue sermon form requires conciseness, not comprehensive doctrinal treatment."
+              "note": "Robertson on \"justification you were not able to obtain under the law of Moses\" — the first explicit statement of justification by faith in Acts, matching Paul's later Galatians and Romans argument. Robertson notes that Paul states the principle without the full theological elaboration of his letters — the synagogue sermon form requires conciseness, not comprehensive doctrinal treatment."
             },
             {
               "ref": "13:48",
-              "note": "Robertson on \"all who were appointed for eternal life believed\" \u2014 the passive participle tetagmenoi (from tass\u014d \u2014 to appoint, to ordain) indicates prior divine action. Robertson notes that this does not eliminate the human faith response (they believed) but grounds it in divine appointment. The two are correlated in Luke's account without philosophical resolution."
+              "note": "Robertson on \"all who were appointed for eternal life believed\" — the passive participle tetagmenoi (from tassō — to appoint, to ordain) indicates prior divine action. Robertson notes that this does not eliminate the human faith response (they believed) but grounds it in divine appointment. The two are correlated in Luke's account without philosophical resolution."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "13:46",
-              "note": "\"We had to speak the word of God to you first. Since you reject it... we now turn to the Gentiles\" \u2014 Keener notes this is not a permanent abandonment of the Jewish mission (Paul will enter the synagogue again at the next city) but a principle: priority does not mean exclusivity. The Jewish community has the first hearing; rejection opens the door to the Gentile community."
+              "note": "\"We had to speak the word of God to you first. Since you reject it... we now turn to the Gentiles\" — Keener notes this is not a permanent abandonment of the Jewish mission (Paul will enter the synagogue again at the next city) but a principle: priority does not mean exclusivity. The Jewish community has the first hearing; rejection opens the door to the Gentile community."
             },
             {
               "ref": "13:48",
-              "note": "Keener notes that \"appointed for eternal life\" (tetagmenoi eis z\u014d\u0113n ai\u014dnion) reflects Luke's consistent divine-passive for salvation. The same construction appears in Acts 2:47 (\"the Lord added to their number\") and 11:18 (\"God has granted repentance\"). Salvation throughout Acts is consistently presented as God's initiative and gift."
+              "note": "Keener notes that \"appointed for eternal life\" (tetagmenoi eis zōēn aiōnion) reflects Luke's consistent divine-passive for salvation. The same construction appears in Acts 2:47 (\"the Lord added to their number\") and 11:18 (\"God has granted repentance\"). Salvation throughout Acts is consistently presented as God's initiative and gift."
             }
           ]
         },
         "hist": {
-          "context": "Paul's Pisidian Antioch sermon is the fullest account of his synagogue preaching in Acts. It moves through four stages: salvation history survey (vv.17\u201325) \u2192 death and resurrection testimony (vv.26\u201331) \u2192 scriptural proof from Psalms 2, 16, and Isaiah 55 (vv.32\u201337) \u2192 invitation and warning (vv.38\u201341). The Isaiah 49:6 quotation in v.47 is the programmatic declaration of the Gentile mission: 'I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth.' Paul applies to himself the calling of the Servant of the Lord \u2014 the mission given to Israel is now carried by Israel's Messiah through his apostle."
+          "context": "Paul's Pisidian Antioch sermon is the fullest account of his synagogue preaching in Acts. It moves through four stages: salvation history survey (vv.17–25) → death and resurrection testimony (vv.26–31) → scriptural proof from Psalms 2, 16, and Isaiah 55 (vv.32–37) → invitation and warning (vv.38–41). The Isaiah 49:6 quotation in v.47 is the programmatic declaration of the Gentile mission: 'I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth.' Paul applies to himself the calling of the Servant of the Lord — the mission given to Israel is now carried by Israel's Messiah through his apostle."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 42\u201452 \u2014 Jews Reject; Gentiles Rejoice; Paul and Barnabas Expelled",
+      "header": "Verses 42—52 — Jews Reject; Gentiles Rejoice; Paul and Barnabas Expelled",
       "verse_start": 42,
       "verse_end": 52,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03c6\u03bf\u03c1\u03af\u03c3\u03b1\u03c4\u03b5",
+            "word": "ἀφορίσατε",
             "transliteration": "aphorisate",
             "gloss": "set apart",
-            "paragraph": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment \u2014 God had set him apart before birth; the church now formally recognizes and releases that calling."
+            "paragraph": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment — God had set him apart before birth; the church now formally recognizes and releases that calling."
           },
           {
-            "word": "\u03a0\u03b1\u1fe6\u03bb\u03bf\u03c2",
+            "word": "Παῦλος",
             "transliteration": "Paulos",
             "gloss": "Paul",
-            "paragraph": "verse 9 marks the transition from 'Saul' to 'Paul' \u2014 the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
+            "paragraph": "verse 9 marks the transition from 'Saul' to 'Paul' — the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
           }
         ],
         "places": [
           {
             "name": "Antioch on the Orontes",
-            "coords": "36.2021\u00b0 N, 36.1603\u00b0 E",
+            "coords": "36.2021° N, 36.1603° E",
             "text": "The launching base for all three Pauline missionary journeys. A diverse, cosmopolitan city with a large Jewish community and a thriving Gentile population. The church's diversity (v.1: Barnabas from Cyprus, Simeon from Africa, Lucius from Cyrene, Manaen from Herod's court, Saul from Tarsus) mirrors the world it is about to reach."
           },
           {
             "name": "Pisidian Antioch",
-            "coords": "38.3167\u00b0 N, 31.2000\u00b0 E",
-            "text": "A Roman colony in the Phrygian highlands (not the Syrian Antioch of v.1 but a different city \u2014 named for the same Seleucid founder). A significant Roman administrative centre with a large Jewish community. Paul's sermon here is the most detailed account of synagogue preaching in Acts."
+            "coords": "38.3167° N, 31.2000° E",
+            "text": "A Roman colony in the Phrygian highlands (not the Syrian Antioch of v.1 but a different city — named for the same Seleucid founder). A significant Roman administrative centre with a large Jewish community. Paul's sermon here is the most detailed account of synagogue preaching in Acts."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 46\u201348",
+            "date": "c. AD 46–48",
             "name": "First Missionary Journey Begins",
             "text": "Paul and Barnabas are commissioned by the Antioch church and the Holy Spirit, launching the first deliberate apostolic mission to the Gentile world. The journey will take them through Cyprus, Pamphylia, and Galatia.",
             "current": true
@@ -354,7 +354,7 @@
             "current": false
           },
           {
-            "date": "c. AD 48\u201349",
+            "date": "c. AD 48–49",
             "name": "Jerusalem Council",
             "text": "",
             "current": false
@@ -364,15 +364,15 @@
           "refs": [
             {
               "ref": "Acts 9:15",
-              "note": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" \u2014 the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately."
+              "note": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" — the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately."
             },
             {
-              "ref": "Galatians 1:15\u201316",
+              "ref": "Galatians 1:15–16",
               "note": "\"God set me apart from my mother's womb... to reveal his Son in me so that I might preach him among the Gentiles.\" Paul's autobiographical account matches the Acts commissioning narrative."
             },
             {
               "ref": "Isaiah 49:6",
-              "note": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" \u2014 cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission."
+              "note": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" — cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission."
             }
           ],
           "echoes": [
@@ -387,72 +387,27 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:2\u20133",
-              "note": "MacArthur on the commissioning process: worship and fasting precede the Spirit's direction; prayer and laying on of hands follow it. The sequence is: waiting on God \u2192 receiving direction \u2192 confirming response. MacArthur uses this as the NT model for missionary commissioning \u2014 Spirit-initiated, church-confirmed, prayer-surrounded."
-            },
-            {
-              "ref": "13:10\u201311",
-              "note": "MacArthur on Paul's confrontation with Elymas: Paul does not debate or negotiate but pronounces prophetic judgment. The blindness inflicted on Elymas mirrors Paul's own blindness at Damascus \u2014 a mercy that might lead to sight. MacArthur notes the pattern: God's judgments are often invitations to the very experience that opens eyes."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:2",
-              "note": "Calvin on 'While they were worshiping the Lord and fasting': the Spirit speaks through the gathered, attentive community. Calvin uses this to argue that extraordinary callings (missionary commissioning) come through ordinary means (corporate worship) \u2014 not through private visions alone. The community's recognition is part of the calling's confirmation."
-            },
-            {
-              "ref": "13:9",
-              "note": "Calvin on Paul filled with the Holy Spirit before confronting Elymas: the filling is not for eloquence or confidence alone but for supernatural discernment. Calvin notes that Paul 'looked straight at him' (atenisas) \u2014 the same word used of Stephen's gaze at the Sanhedrin (6:15) and Peter's gaze at the lame man (3:4). The penetrating look precedes the prophetic word."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:1",
-              "note": "The NET notes the significance of Manaen's description as syntrophos (literally 'one brought up with') Herod the tetrarch \u2014 a term for a childhood companion raised in the royal household. Manaen's presence in the Antioch church leadership represents the Gospel's penetration of the highest social levels of Jewish society."
-            },
-            {
-              "ref": "13:20",
-              "note": "The NET notes the textual variant in v.20: the 450 years can refer to the period from the patriarchs' entry into Egypt to the division of Canaan, or to the period of the judges. The NET prefers the reading that places the 450 years as the period from the Exodus to the judges, following the Western text tradition."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "13:2",
-              "note": "\"The Holy Spirit said, Set apart for me Barnabas and Saul\" \u2014 Robertson notes the Spirit speaking directly through prophets during corporate worship. The commissioning is initiated by God through the gathered community, not by human administrative decision. The Spirit is the senior partner in every genuine missionary enterprise."
-            },
-            {
-              "ref": "13:9",
-              "note": "The first appearance of \"Paul\" replacing \"Saul\" \u2014 Robertson notes this is Luke's way of signalling the shift from Jewish to Gentile mission territory. Paulos was Paul's actual Roman name used in Roman contexts; its adoption here is culturally strategic as well as personally natural."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:1",
-              "note": "Keener notes the remarkable diversity of the Antioch church's leadership: Barnabas (Levite from Cyprus), Simeon Niger (probably African, 'Niger' meaning 'black'), Lucius of Cyrene (North African), Manaen (raised in Herod Antipas's household \u2014 connected to the ruling elite), and Saul (diaspora Jew from Tarsus). This team embodies the multicultural community they are about to evangelise."
-            },
-            {
-              "ref": "13:7",
-              "note": "Keener notes that Sergius Paulus as proconsul of Cyprus is corroborated by inscriptions. A Latin inscription from Rome and a Greek inscription from Cyprus both mention a Sergius Paulus as a senior official of the period. This is one of Acts' many historically verifiable details."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "The commissioning of vv.1\u20133 is one of the most significant structural moments in Acts: the Spirit speaks through corporate worship and fasting, names specific individuals, and the community responds with prayer and laying on of hands. This is not apostolic appointment from Jerusalem but Spirit-directed commissioning from Antioch \u2014 the grass-roots mission structure that will carry the Gospel to the ends of the earth. Paul's sermon (vv.16\u201341) is modelled on Stephen's speech (ch.7) \u2014 a survey of salvation history building to a Christological climax \u2014 but applied now to a Diaspora synagogue audience."
+          "context": "The commissioning of vv.1–3 is one of the most significant structural moments in Acts: the Spirit speaks through corporate worship and fasting, names specific individuals, and the community responds with prayer and laying on of hands. This is not apostolic appointment from Jerusalem but Spirit-directed commissioning from Antioch — the grass-roots mission structure that will carry the Gospel to the ends of the earth. Paul's sermon (vv.16–41) is modelled on Stephen's speech (ch.7) — a survey of salvation history building to a Christological climax — but applied now to a Diaspora synagogue audience."
         }
       }
     }
@@ -460,54 +415,54 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Paul\u2197 People",
+        "name": "Paul↗ People",
         "role": "Apostle to the Gentiles; author of thirteen NT letters",
-        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen\u2019s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13\u201328 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts\u2019 theological climax: the gospel reaching the empire\u2019s capital, \"boldly and without hindrance\" (Acts 28:31)."
+        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen’s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13–28 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts’ theological climax: the gospel reaching the empire’s capital, \"boldly and without hindrance\" (Acts 28:31)."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>While they were worshiping the Lord and fasting, the Holy Spirit said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>While they were worshiping the Lord and fasting, the Holy Spirit said, \u201cSet apart for me Barnabas and Saul for the work to which I have called them.\u201d</td></tr><tr><td class=\"t-label\">NIV</td><td>who was an attendant of the proconsul, Sergius Paulus. The proconsul, an intelligent man, sent for Barnabas and Saul because he wanted to hear the word of God.</td></tr><tr><td class=\"t-label\">ESV</td><td>He was with the proconsul, Sergius Paulus, a man of intelligence, who summoned Barnabas and Saul and sought to hear the word of God.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>While they were worshiping the Lord and fasting, the Holy Spirit said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>While they were worshiping the Lord and fasting, the Holy Spirit said, “Set apart for me Barnabas and Saul for the work to which I have called them.”</td></tr><tr><td class=\"t-label\">NIV</td><td>who was an attendant of the proconsul, Sergius Paulus. The proconsul, an intelligent man, sent for Barnabas and Saul because he wanted to hear the word of God.</td></tr><tr><td class=\"t-label\">ESV</td><td>He was with the proconsul, Sergius Paulus, a man of intelligence, who summoned Barnabas and Saul and sought to hear the word of God.</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"MacArthur on the commissioning process: worship and fasting precede the Spirit's direction; prayer and laying on of hands follow it. The sequence is: waiting on God \u2192 receiving direction \u2192 confirming \""
+        "text": "\"MacArthur on the commissioning process: worship and fasting precede the Spirit's direction; prayer and laying on of hands follow it. The sequence is: waiting on God → receiving direction → confirming \""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201425 \u2014 Commissioned from Antioch; Cyprus; Pisidian Antioch",
-          "text": "Context  The commissioning of vv.1\u20133 is one of the most significant structural moments in Acts: the Spirit speaks throug\u2026",
+          "label": "Verses 1—25 — Commissioned from Antioch; Cyprus; Pisidian Antioch",
+          "text": "Context  The commissioning of vv.1–3 is one of the most significant structural moments in Acts: the Spirit speaks throug…",
           "is_key": false
         },
         {
-          "label": "Verses 26\u201441 \u2014 Paul\u2019s Sermon: Through Jesus Forgiveness Is Proclaimed",
-          "text": "Context  Paul's Pisidian Antioch sermon is the fullest account of his synagogue preaching in Acts. It moves through four\u2026",
+          "label": "Verses 26—41 — Paul’s Sermon: Through Jesus Forgiveness Is Proclaimed",
+          "text": "Context  Paul's Pisidian Antioch sermon is the fullest account of his synagogue preaching in Acts. It moves through four…",
           "is_key": false
         },
         {
-          "label": "Verses 42\u201452 \u2014 Jews Reject; Gentiles Rejoice; Paul and Barnabas Expelled",
-          "text": "Context  The commissioning of vv.1\u20133 is one of the most significant structural moments in Acts: the Spirit speaks throug\u2026",
+          "label": "Verses 42—52 — Jews Reject; Gentiles Rejoice; Paul and Barnabas Expelled",
+          "text": "Context  The commissioning of vv.1–3 is one of the most significant structural moments in Acts: the Spirit speaks throug…",
           "is_key": false
         }
       ],
@@ -515,40 +470,40 @@
     },
     "hebtext": [
       {
-        "word": "\u1f00\u03c6\u03bf\u03c1\u03af\u03c3\u03b1\u03c4\u03b5",
+        "word": "ἀφορίσατε",
         "tlit": "aphorisate",
         "gloss": "set apart",
-        "note": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment \u2014 God had set him apart before birth; the church now formally recognizes and releases that calling."
+        "note": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment — God had set him apart before birth; the church now formally recognizes and releases that calling."
       },
       {
-        "word": "\u03a0\u03b1\u1fe6\u03bb\u03bf\u03c2",
+        "word": "Παῦλος",
         "tlit": "Paulos",
         "gloss": "Paul",
-        "note": "verse 9 marks the transition from 'Saul' to 'Paul' \u2014 the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
+        "note": "verse 9 marks the transition from 'Saul' to 'Paul' — the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
       },
       {
-        "word": "\u03b4\u03b9\u03ba\u03b1\u03b9\u03c9\u03b8\u1fc6\u03bd\u03b1\u03b9",
-        "tlit": "dikai\u014dth\u0113nai",
+        "word": "δικαιωθῆναι",
+        "tlit": "dikaiōthēnai",
         "gloss": "justified / set free",
         "note": "v.39 is Paul's earliest recorded statement of justification by faith: 'everyone who believes is set free (justified) from every sin, a justification you were not able to obtain under the law of Moses.' This is the theological thesis of Galatians and Romans, stated in embryonic form in Paul's first synagogue sermon."
       },
       {
-        "word": "\u1f61\u03c1\u03b9\u03c3\u03bc\u03ad\u03bd\u03bf\u03b9 \u03b5\u1f30\u03c2 \u03b6\u03c9\u1f74\u03bd \u03b1\u1f30\u03ce\u03bd\u03b9\u03bf\u03bd",
-        "tlit": "h\u014drismenoi eis z\u014d\u0113n ai\u014dnion",
+        "word": "ὡρισμένοι εἰς ζωὴν αἰώνιον",
+        "tlit": "hōrismenoi eis zōēn aiōnion",
         "gloss": "appointed for eternal life",
-        "note": "v.48 \u2014 a crucial phrase. The passive participle 'appointed' (h\u014drismenoi) indicates divine action: those who believed were those whom God had previously appointed. Luke presents the correlation between divine appointment and human faith without explaining their relationship \u2014 the mystery Luke preserves intact."
+        "note": "v.48 — a crucial phrase. The passive participle 'appointed' (hōrismenoi) indicates divine action: those who believed were those whom God had previously appointed. Luke presents the correlation between divine appointment and human faith without explaining their relationship — the mystery Luke preserves intact."
       },
       {
-        "word": "\u1f00\u03c6\u03bf\u03c1\u03af\u03c3\u03b1\u03c4\u03b5",
+        "word": "ἀφορίσατε",
         "tlit": "aphorisate",
         "gloss": "set apart",
-        "note": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment \u2014 God had set him apart before birth; the church now formally recognizes and releases that calling."
+        "note": "the divine commission in v.2 uses the same verb Paul uses of himself in Gal 1:15 ('set apart from my mother's womb'). The Antioch commissioning is not the origin of Paul's call but its public deployment — God had set him apart before birth; the church now formally recognizes and releases that calling."
       },
       {
-        "word": "\u03a0\u03b1\u1fe6\u03bb\u03bf\u03c2",
+        "word": "Παῦλος",
         "tlit": "Paulos",
         "gloss": "Paul",
-        "note": "verse 9 marks the transition from 'Saul' to 'Paul' \u2014 the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
+        "note": "verse 9 marks the transition from 'Saul' to 'Paul' — the Roman name he will use throughout his Gentile mission. This is not a conversion name change but the practical adoption of his Roman cognomen for a Roman world. The shift also marks the narrative transition: from here Paul leads; Barnabas follows."
       }
     ],
     "thread": [
@@ -556,12 +511,12 @@
         "anchor": "Scripture Walkthrough",
         "target": "Acts 9:15",
         "type": "Connection",
-        "text": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" \u2014 the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately.",
+        "text": "\"This man is my chosen instrument to proclaim my name to the Gentiles and their kings\" — the Damascus road commission is now publicly deployed. The Antioch commissioning is the church's formal release of what God had prepared privately.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Galatians 1:15\u201316",
+        "target": "Galatians 1:15–16",
         "type": "Connection",
         "text": "\"God set me apart from my mother's womb... to reveal his Son in me so that I might preach him among the Gentiles.\" Paul's autobiographical account matches the Acts commissioning narrative.",
         "direction": "backward"
@@ -570,28 +525,28 @@
         "anchor": "Scripture Walkthrough",
         "target": "Isaiah 49:6",
         "type": "Connection",
-        "text": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" \u2014 cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission.",
+        "text": "\"I will make you a light for the Gentiles, that my salvation may reach to the ends of the earth\" — cited in Acts 13:47 as Paul's scriptural mandate for the Gentile mission.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isaiah 49:6",
         "type": "Connection",
-        "text": "\"I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth\" \u2014 cited in v.47 as the scriptural mandate for turning to the Gentiles. This verse will be cited again in Acts 26:23 and Luke 2:32.",
+        "text": "\"I have made you a light for the Gentiles, that you may bring salvation to the ends of the earth\" — cited in v.47 as the scriptural mandate for turning to the Gentiles. This verse will be cited again in Acts 26:23 and Luke 2:32.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Psalm 2:7",
         "type": "Fulfilment",
-        "text": "\"You are my son; today I have become your father\" \u2014 cited in v.33 as fulfilled in the resurrection. Paul reads the Psalm as a coronation announcement fulfilled at Christ's resurrection-exaltation.",
+        "text": "\"You are my son; today I have become your father\" — cited in v.33 as fulfilled in the resurrection. Paul reads the Psalm as a coronation announcement fulfilled at Christ's resurrection-exaltation.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Habakkuk 1:5",
         "type": "Connection",
-        "text": "\"Look, you scoffers, wonder and perish... something you would never believe\" \u2014 cited in v.41 as a warning to those who reject the Gospel. Paul applies the prophet's warning about Babylon to those who reject Christ.",
+        "text": "\"Look, you scoffers, wonder and perish... something you would never believe\" — cited in v.41 as a warning to those who reject the Gospel. Paul applies the prophet's warning about Babylon to those who reject Christ.",
         "direction": "backward"
       }
     ],
@@ -599,14 +554,14 @@
       {
         "ref": "Acts 13",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 13 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -616,12 +571,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -786,7 +741,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Set apart for me Barnabas and Saul for the work to which I have called them' (v. 2). The Spirit initiates mission; the church confirms. Fasting, praying, sending\u2014Antioch releases its best for the world.",
+      "tip": "'Set apart for me Barnabas and Saul for the work to which I have called them' (v. 2). The Spirit initiates mission; the church confirms. Fasting, praying, sending—Antioch releases its best for the world.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/acts/15.json
+++ b/content/acts/15.json
@@ -7,40 +7,40 @@
   "subtitle": "The Jerusalem Council",
   "timeline_link": {
     "event_id": "jerusalem-council",
-    "text": "See on Timeline \u2014 Jerusalem Council"
+    "text": "See on Timeline — Jerusalem Council"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201421 \u2014 The Jerusalem Council: Peter\u2019s Testimony; James\u2019 Ruling",
+      "header": "Verses 1—21 — The Jerusalem Council: Peter’s Testimony; James’ Ruling",
       "verse_start": 1,
       "verse_end": 21,
       "panels": {
         "heb": [
           {
-            "word": "\u03b6\u03ae\u03c4\u03b7\u03bc\u03b1",
-            "transliteration": "z\u0113t\u0113ma",
+            "word": "ζήτημα",
+            "transliteration": "zētēma",
             "gloss": "question/dispute",
-            "paragraph": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation \u2014 the first church council in history."
+            "paragraph": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation — the first church council in history."
           },
           {
-            "word": "\u1f10\u03c0\u03ad\u03c3\u03c4\u03c1\u03b5\u03c8\u03b5\u03bd",
+            "word": "ἐπέστρεψεν",
             "transliteration": "epestrepsen",
             "gloss": "intervened / turned",
-            "paragraph": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action \u2014 God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
+            "paragraph": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action — God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
           }
         ],
         "places": [
           {
-            "name": "Jerusalem \u2014 Council Setting",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "The Jerusalem church is the theological centre of gravity for the entire early church. The apostles and elders \u2014 including Peter, James, John (the 'pillars', Gal 2:9), and Paul and Barnabas \u2014 constitute the first formal ecumenical gathering. Jerusalem is the appropriate venue: the Gospel went out from here; the question about the Gospel's requirements returns here for resolution."
+            "name": "Jerusalem — Council Setting",
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "The Jerusalem church is the theological centre of gravity for the entire early church. The apostles and elders — including Peter, James, John (the 'pillars', Gal 2:9), and Paul and Barnabas — constitute the first formal ecumenical gathering. Jerusalem is the appropriate venue: the Gospel went out from here; the question about the Gospel's requirements returns here for resolution."
           },
           {
-            "name": "Antioch \u2014 The Controversy Origin",
-            "coords": "36.2021\u00b0 N, 36.1603\u00b0 E",
-            "text": "The controversy begins in Antioch when Judean teachers arrive and require circumcision for salvation. Antioch \u2014 the Gentile mission's base \u2014 is the logical flashpoint: here is where the practical consequences of the theological question are most acute. The mixed Jewish-Gentile community cannot survive the Judaizers' requirement without fracturing."
+            "name": "Antioch — The Controversy Origin",
+            "coords": "36.2021° N, 36.1603° E",
+            "text": "The controversy begins in Antioch when Judean teachers arrive and require circumcision for salvation. Antioch — the Gentile mission's base — is the logical flashpoint: here is where the practical consequences of the theological question are most acute. The mixed Jewish-Gentile community cannot survive the Judaizers' requirement without fracturing."
           }
         ],
         "tl": [
@@ -51,13 +51,13 @@
             "current": true
           },
           {
-            "date": "c. AD 48\u201349",
+            "date": "c. AD 48–49",
             "name": "Galatian Controversy Background",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 49\u201351",
+            "date": "c. AD 49–51",
             "name": "Second Missionary Journey",
             "text": "",
             "current": false
@@ -66,129 +66,129 @@
         "cross": {
           "refs": [
             {
-              "ref": "Galatians 2:1\u201310",
-              "note": "Paul's account of the Jerusalem Council \u2014 confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission."
+              "ref": "Galatians 2:1–10",
+              "note": "Paul's account of the Jerusalem Council — confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission."
             },
             {
-              "ref": "Amos 9:11\u201312",
-              "note": "Cited in James's speech (vv.16\u201317) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew reads 'possess' \u2014 James uses the LXX version."
+              "ref": "Amos 9:11–12",
+              "note": "Cited in James's speech (vv.16–17) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew reads 'possess' — James uses the LXX version."
             },
             {
-              "ref": "Acts 10:44\u201348",
-              "note": "The Cornelius episode \u2014 Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision."
+              "ref": "Acts 10:44–48",
+              "note": "The Cornelius episode — Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision."
             }
           ],
           "echoes": [
             {
-              "source_ref": "Amos 9:11\u201312",
-              "target_ref": "Acts 15:16\u201317",
+              "source_ref": "Amos 9:11–12",
+              "target_ref": "Acts 15:16–17",
               "type": "direct_quote",
-              "source_context": "Amos prophesied that God would rebuild David's fallen tent so that the remnant of humanity \u2014 including Gentiles who bear his name \u2014 might seek the Lord.",
+              "source_context": "Amos prophesied that God would rebuild David's fallen tent so that the remnant of humanity — including Gentiles who bear his name — might seek the Lord.",
               "connection": "James quotes this at the Jerusalem Council to justify Gentile inclusion without full Torah observance. The rebuilt booth is the restored Davidic kingdom; Gentile seekers are the fulfillment.",
               "significance": "This citation settles the Jew-Gentile debate in Acts: Gentile inclusion is not aberration but prophetic fulfillment. Scripture itself authorizes the church's inclusive practice."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "15:10\u201311",
-              "note": "MacArthur on Peter's \"yoke\" argument and grace statement: v.11 (\"we believe it is through the grace of our Lord Jesus Christ that we are saved, just as they are\") is one of the clearest statements of salvation by grace alone in Acts. Peter has been transformed by the Cornelius experience \u2014 the man who told Jesus \"never, Lord\" about Gentile inclusion now argues most forcefully for their equal standing before God."
+              "ref": "15:10–11",
+              "note": "MacArthur on Peter's \"yoke\" argument and grace statement: v.11 (\"we believe it is through the grace of our Lord Jesus Christ that we are saved, just as they are\") is one of the clearest statements of salvation by grace alone in Acts. Peter has been transformed by the Cornelius experience — the man who told Jesus \"never, Lord\" about Gentile inclusion now argues most forcefully for their equal standing before God."
             },
             {
-              "ref": "15:13\u201318",
-              "note": "MacArthur on James's Amos citation: James uses Scripture as the decisive argument. Peter's argument was from experience (Cornelius); Barnabas and Paul's was from miracles (signs and wonders); James's is from Scripture. MacArthur notes that James places the scriptural argument last and calls it decisive \u2014 experience and miracles are confirmatory, but Scripture is authoritative."
+              "ref": "15:13–18",
+              "note": "MacArthur on James's Amos citation: James uses Scripture as the decisive argument. Peter's argument was from experience (Cornelius); Barnabas and Paul's was from miracles (signs and wonders); James's is from Scripture. MacArthur notes that James places the scriptural argument last and calls it decisive — experience and miracles are confirmatory, but Scripture is authoritative."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:9",
-              "note": "Calvin on 'purified their hearts by faith': this verse is, for Calvin, the clearest statement in Acts of the doctrine of faith. The heart is purified not by circumcision, ritual, or law-observance but by faith \u2014 God's work through the instrument of trust in Christ. Calvin uses this as his summary of what the Council established: the Reformation's sola fide is embedded in the apostolic council's deliberations."
+              "note": "Calvin on 'purified their hearts by faith': this verse is, for Calvin, the clearest statement in Acts of the doctrine of faith. The heart is purified not by circumcision, ritual, or law-observance but by faith — God's work through the instrument of trust in Christ. Calvin uses this as his summary of what the Council established: the Reformation's sola fide is embedded in the apostolic council's deliberations."
             },
             {
               "ref": "15:10",
-              "note": "Calvin on the 'yoke' argument: Peter is making an argument from Israel's own history of covenant failure. If circumcised Israel could not bear the law's full weight, requiring it of Gentiles is a strategy for their condemnation, not their salvation. Calvin notes that the law is not bad (it is holy, Rom 7:12) but no one can bear it as a means of justification \u2014 precisely because all fall short."
+              "note": "Calvin on the 'yoke' argument: Peter is making an argument from Israel's own history of covenant failure. If circumcised Israel could not bear the law's full weight, requiring it of Gentiles is a strategy for their condemnation, not their salvation. Calvin notes that the law is not bad (it is holy, Rom 7:12) but no one can bear it as a means of justification — precisely because all fall short."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
-              "ref": "15:16\u201317",
-              "note": "The NET notes the LXX/MT discrepancy in the Amos quotation. The MT reads \"so that they may possess the remnant of Edom\" \u2014 a prophecy about Israelite territorial expansion. The LXX reads \"so that the rest of humanity may seek the Lord\" \u2014 a prophecy of universal seeking. James uses the LXX because it directly supports his argument about Gentile inclusion. This is not text manipulation but the legitimate use of an authoritative translation."
+              "ref": "15:16–17",
+              "note": "The NET notes the LXX/MT discrepancy in the Amos quotation. The MT reads \"so that they may possess the remnant of Edom\" — a prophecy about Israelite territorial expansion. The LXX reads \"so that the rest of humanity may seek the Lord\" — a prophecy of universal seeking. James uses the LXX because it directly supports his argument about Gentile inclusion. This is not text manipulation but the legitimate use of an authoritative translation."
             },
             {
               "ref": "15:20",
-              "note": "The NET notes that the four abstentions (food polluted by idols, sexual immorality, strangled animals, blood) probably reflect the Noachide commandments \u2014 the minimal ethical requirements that Jewish tradition held applicable to all humanity (cf. Gen 9:1\u20137). James frames the Gentile requirements in terms of the minimal standards Judaism expected of righteous Gentiles."
+              "note": "The NET notes that the four abstentions (food polluted by idols, sexual immorality, strangled animals, blood) probably reflect the Noachide commandments — the minimal ethical requirements that Jewish tradition held applicable to all humanity (cf. Gen 9:1–7). James frames the Gentile requirements in terms of the minimal standards Judaism expected of righteous Gentiles."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:9",
-              "note": "\"He did not discriminate between us and them, for he purified their hearts by faith\" \u2014 Robertson notes the aorist \"purified\" (katharisas): a completed divine action. God cleansed the Gentiles' hearts by faith \u2014 the same cleansing the Jews had received. Robertson uses this to argue that the Jerusalem Council's decision was not a concession to Pauline pressure but a recognition of what God had already done."
+              "note": "\"He did not discriminate between us and them, for he purified their hearts by faith\" — Robertson notes the aorist \"purified\" (katharisas): a completed divine action. God cleansed the Gentiles' hearts by faith — the same cleansing the Jews had received. Robertson uses this to argue that the Jerusalem Council's decision was not a concession to Pauline pressure but a recognition of what God had already done."
             },
             {
               "ref": "15:10",
-              "note": "\"A yoke that neither we nor our ancestors have been able to bear\" \u2014 Robertson on Peter's remarkable admission: the Torah's requirements are not being met by Jews themselves. The demand to impose them on Gentiles is therefore not only unnecessary but hypocritical. Robertson notes the pastoral courage of this admission in a Jerusalem context."
+              "note": "\"A yoke that neither we nor our ancestors have been able to bear\" — Robertson on Peter's remarkable admission: the Torah's requirements are not being met by Jews themselves. The demand to impose them on Gentiles is therefore not only unnecessary but hypocritical. Robertson notes the pastoral courage of this admission in a Jerusalem context."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "15:1\u20132",
-              "note": "Keener provides background on the 'Judaizers' \u2014 Jewish Christians who believed Gentile converts must be circumcised and observe Torah to be fully saved. This position was not unreasonable from a traditional Jewish perspective: proselytes to Judaism were required to be circumcised and observe Torah. The Judaizers were simply applying the standard proselyte requirement to Christian Gentiles."
+              "ref": "15:1–2",
+              "note": "Keener provides background on the 'Judaizers' — Jewish Christians who believed Gentile converts must be circumcised and observe Torah to be fully saved. This position was not unreasonable from a traditional Jewish perspective: proselytes to Judaism were required to be circumcised and observe Torah. The Judaizers were simply applying the standard proselyte requirement to Christian Gentiles."
             },
             {
-              "ref": "15:16\u201317",
-              "note": "Keener notes the significance of James's use of the LXX version of Amos 9:11\u201312. The MT Amos reads \"so that they may possess\" (the remnant of Edom); the LXX reads \"so that the rest of humanity may seek the Lord.\" James uses the LXX version because it makes the Gentile inclusion point most clearly. This is standard Jewish hermeneutical practice \u2014 using the textual tradition that best supports the argument."
+              "ref": "15:16–17",
+              "note": "Keener notes the significance of James's use of the LXX version of Amos 9:11–12. The MT Amos reads \"so that they may possess\" (the remnant of Edom); the LXX reads \"so that the rest of humanity may seek the Lord.\" James uses the LXX version because it makes the Gentile inclusion point most clearly. This is standard Jewish hermeneutical practice — using the textual tradition that best supports the argument."
             }
           ]
         },
         "hist": {
-          "context": "The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The question was not about Jewish Christian observance (Jewish believers could continue circumcision and Torah observance) but about whether Gentile converts must become Jews to be saved. Peter's argument (vv.7\u201311) is from divine precedent: God accepted the Gentiles without circumcision (Cornelius episode). James's argument (vv.13\u201318) is from Scripture: Amos 9:11\u201312 prophesied Gentile inclusion in the restored David's tent. Together they establish the principle that salvation is by grace through faith alone \u2014 the theological foundation of the entire Gentile mission."
+          "context": "The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The question was not about Jewish Christian observance (Jewish believers could continue circumcision and Torah observance) but about whether Gentile converts must become Jews to be saved. Peter's argument (vv.7–11) is from divine precedent: God accepted the Gentiles without circumcision (Cornelius episode). James's argument (vv.13–18) is from Scripture: Amos 9:11–12 prophesied Gentile inclusion in the restored David's tent. Together they establish the principle that salvation is by grace through faith alone — the theological foundation of the entire Gentile mission."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 22\u201435 \u2014 The Council\u2019s Letter; Judas and Silas Sent",
+      "header": "Verses 22—35 — The Council’s Letter; Judas and Silas Sent",
       "verse_start": 22,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "\u1f14\u03b4\u03bf\u03be\u03b5\u03bd \u03b3\u1f70\u03c1 \u03c4\u1ff7 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03b9 \u03c4\u1ff7 \u1f01\u03b3\u03af\u1ff3 \u03ba\u03b1\u1f76 \u1f21\u03bc\u1fd6\u03bd",
-            "transliteration": "edoxen gar t\u014d pneumati t\u014d hagi\u014d kai h\u0113min",
+            "word": "ἔδοξεν γὰρ τῷ πνεύματι τῷ ἁγίῳ καὶ ἡμῖν",
+            "transliteration": "edoxen gar tō pneumati tō hagiō kai hēmin",
             "gloss": "it seemed good to the Holy Spirit and to us",
-            "paragraph": "the Council's formula in v.28 \u2014 one of the most significant phrases in Acts. The Spirit and the human deliberators are coordinated: the Council does not claim to act independently ('the Spirit told us') but jointly ('the Spirit and we'). This is the model for Spirit-directed church decision-making: attentive to heaven, deliberate on earth."
+            "paragraph": "the Council's formula in v.28 — one of the most significant phrases in Acts. The Spirit and the human deliberators are coordinated: the Council does not claim to act independently ('the Spirit told us') but jointly ('the Spirit and we'). This is the model for Spirit-directed church decision-making: attentive to heaven, deliberate on earth."
           },
           {
-            "word": "\u03c0\u03b1\u03c1\u03bf\u03be\u03c5\u03c3\u03bc\u03cc\u03c2",
+            "word": "παροξυσμός",
             "transliteration": "paroxysmos",
             "gloss": "sharp disagreement",
-            "paragraph": "from paroxyn\u014d \u2014 to sharpen, to provoke. The disagreement between Paul and Barnabas is described with a medical/physical term for a sharp pain or spasm. Luke does not soften the conflict: two Spirit-filled, proven missionaries have an irreconcilable dispute. The honesty is itself instructive \u2014 the Bible's heroes are fully human."
+            "paragraph": "from paroxynō — to sharpen, to provoke. The disagreement between Paul and Barnabas is described with a medical/physical term for a sharp pain or spasm. Luke does not soften the conflict: two Spirit-filled, proven missionaries have an irreconcilable dispute. The honesty is itself instructive — the Bible's heroes are fully human."
           }
         ],
         "places": [
           {
-            "name": "Cyprus \u2014 Barnabas and Mark",
-            "coords": "35.1264\u00b0 N, 33.4299\u00b0 E",
-            "text": "Barnabas takes John Mark back to Cyprus \u2014 his homeland (4:36). The rift with Paul opens a second front in the mission: Cyprus receives renewed attention under Barnabas and Mark. What appears to be failure (the split) actually multiplies the mission's reach. God works even through conflict."
+            "name": "Cyprus — Barnabas and Mark",
+            "coords": "35.1264° N, 33.4299° E",
+            "text": "Barnabas takes John Mark back to Cyprus — his homeland (4:36). The rift with Paul opens a second front in the mission: Cyprus receives renewed attention under Barnabas and Mark. What appears to be failure (the split) actually multiplies the mission's reach. God works even through conflict."
           },
           {
             "name": "Syria and Cilicia",
-            "coords": "36.8000\u00b0 N, 36.1500\u00b0 E",
-            "text": "Paul takes Silas through Syria and Cilicia (v.41) \u2014 the region he had evangelised during the hidden years after his Damascus conversion (Gal 1:21). He is revisiting and strengthening churches he had founded years earlier, before the Antioch-based mission began."
+            "coords": "36.8000° N, 36.1500° E",
+            "text": "Paul takes Silas through Syria and Cilicia (v.41) — the region he had evangelised during the hidden years after his Damascus conversion (Gal 1:21). He is revisiting and strengthening churches he had founded years earlier, before the Antioch-based mission began."
           }
         ],
         "tl": [
@@ -205,7 +205,7 @@
             "current": false
           },
           {
-            "date": "c. AD 49\u201351",
+            "date": "c. AD 49–51",
             "name": "Second Missionary Journey Begins",
             "text": "",
             "current": false
@@ -215,24 +215,24 @@
           "refs": [
             {
               "ref": "Colossians 4:10",
-              "note": "\"Mark, the cousin of Barnabas... if he comes to you, welcome him\" \u2014 Paul's later commendation of Mark shows the relationship was eventually restored."
+              "note": "\"Mark, the cousin of Barnabas... if he comes to you, welcome him\" — Paul's later commendation of Mark shows the relationship was eventually restored."
             },
             {
               "ref": "2 Timothy 4:11",
-              "note": "\"Get Mark and bring him with you, because he is helpful to me in my ministry\" \u2014 Paul's final letter shows complete reconciliation. Barnabas was right about Mark; Paul came to agree."
+              "note": "\"Get Mark and bring him with you, because he is helpful to me in my ministry\" — Paul's final letter shows complete reconciliation. Barnabas was right about Mark; Paul came to agree."
             },
             {
-              "ref": "Philippians 1:15\u201318",
+              "ref": "Philippians 1:15–18",
               "note": "\"Some preach Christ out of envy and rivalry... but what does it matter? The important thing is that in every way, whether from false motives or true, Christ is preached.\" Paul's mature theology of mission: even imperfect motives and divided teams serve the Gospel's advance."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:28",
-              "note": "MacArthur on \"it seemed good to the Holy Spirit and to us\" \u2014 this is, for MacArthur, the constitutional principle of all Spirit-directed church governance. The Spirit does not bypass human deliberation; he guides it. The church is neither a democracy (where majority rules regardless of Spirit) nor a theocracy (where claimed divine voices bypass human accountability) but a Spirit-led community of deliberate discernment."
+              "note": "MacArthur on \"it seemed good to the Holy Spirit and to us\" — this is, for MacArthur, the constitutional principle of all Spirit-directed church governance. The Spirit does not bypass human deliberation; he guides it. The church is neither a democracy (where majority rules regardless of Spirit) nor a theocracy (where claimed divine voices bypass human accountability) but a Spirit-led community of deliberate discernment."
             },
             {
               "ref": "15:39",
@@ -241,24 +241,24 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:28",
-              "note": "Calvin on 'it seemed good to the Holy Spirit and to us' \u2014 this is Calvin's primary NT text for the authority of church councils. Councils derive their authority not from the bishops assembled but from the Spirit who guides them. However, Calvin is careful: the Council's authority is derivative and conditional \u2014 it holds only when its decisions are consistent with Scripture. A council that contradicts Scripture is not speaking for the Holy Spirit."
+              "note": "Calvin on 'it seemed good to the Holy Spirit and to us' — this is Calvin's primary NT text for the authority of church councils. Councils derive their authority not from the bishops assembled but from the Spirit who guides them. However, Calvin is careful: the Council's authority is derivative and conditional — it holds only when its decisions are consistent with Scripture. A council that contradicts Scripture is not speaking for the Holy Spirit."
             },
             {
               "ref": "15:39",
-              "note": "Calvin on the Paul-Barnabas dispute: Calvin does not excuse Paul's severity but does defend his judgment. The mission required accountability; Mark had proven unreliable in the critical moment. Calvin uses this to argue for both grace (Barnabas's patient restoration) and discipline (Paul's principled refusal) as legitimate pastoral postures \u2014 neither cancels the other; the church needs both."
+              "note": "Calvin on the Paul-Barnabas dispute: Calvin does not excuse Paul's severity but does defend his judgment. The mission required accountability; Mark had proven unreliable in the critical moment. Calvin uses this to argue for both grace (Barnabas's patient restoration) and discipline (Paul's principled refusal) as legitimate pastoral postures — neither cancels the other; the church needs both."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "15:29",
-              "note": "The NET notes that the four abstentions (food sacrificed to idols, blood, strangled animals, sexual immorality) correspond to the Noachide commandments \u2014 the minimal ethical requirements Jewish tradition held applicable to righteous Gentiles. The Council is not requiring Torah observance but the minimal standards already expected of God-fearers."
+              "note": "The NET notes that the four abstentions (food sacrificed to idols, blood, strangled animals, sexual immorality) correspond to the Noachide commandments — the minimal ethical requirements Jewish tradition held applicable to righteous Gentiles. The Council is not requiring Torah observance but the minimal standards already expected of God-fearers."
             },
             {
               "ref": "15:34",
@@ -267,66 +267,66 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:28",
-              "note": "\"It seemed good to the Holy Spirit and to us\" \u2014 Robertson notes the remarkable coordination of divine and human deliberation in a single phrase. The Council is not claiming direct divine dictation but Spirit-guided human discernment. Robertson uses this as the model for church councils in every age: attentive to the Spirit, responsible in deliberation, humble in formulation."
+              "note": "\"It seemed good to the Holy Spirit and to us\" — Robertson notes the remarkable coordination of divine and human deliberation in a single phrase. The Council is not claiming direct divine dictation but Spirit-guided human discernment. Robertson uses this as the model for church councils in every age: attentive to the Spirit, responsible in deliberation, humble in formulation."
             },
             {
               "ref": "15:39",
-              "note": "Robertson on the \"sharp disagreement\" (paroxysmos): Robertson notes this is the Greek medical term for a sharp crisis or convulsion of an illness. Luke uses it without editorial comment. Robertson observes that later references (Col 4:10; 2 Tim 4:11) confirm that both Barnabas and Paul were ultimately vindicated \u2014 Barnabas in his faith in Mark, Paul in his mission discipline."
+              "note": "Robertson on the \"sharp disagreement\" (paroxysmos): Robertson notes this is the Greek medical term for a sharp crisis or convulsion of an illness. Luke uses it without editorial comment. Robertson observes that later references (Col 4:10; 2 Tim 4:11) confirm that both Barnabas and Paul were ultimately vindicated — Barnabas in his faith in Mark, Paul in his mission discipline."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "15:28",
               "note": "Keener notes that \"it seemed good to the Holy Spirit and to us\" is the most explicit statement of Spirit-guided corporate discernment in Acts. The Council deliberated (\"after much discussion,\" v.7; \"the whole assembly became silent,\" v.12; \"James spoke up,\" v.13) and then formulated its conclusion as jointly Spirit-human. This is the biblical model for church governance: neither autocratic authority nor mere democratic consensus, but Spirit-attentive deliberation."
             },
             {
-              "ref": "15:36\u201339",
-              "note": "Keener provides context for the Paul-Barnabas dispute. John Mark's departure at Perga (13:13) may have been for legitimate reasons \u2014 illness, family, or theological concerns about the Gentile mission's direction. Paul's refusal to take him reflected a mission discipline standard; Barnabas's willingness to give him another chance reflected pastoral patience. Neither was wrong in the abstract; they were incompatible in this specific team."
+              "ref": "15:36–39",
+              "note": "Keener provides context for the Paul-Barnabas dispute. John Mark's departure at Perga (13:13) may have been for legitimate reasons — illness, family, or theological concerns about the Gentile mission's direction. Paul's refusal to take him reflected a mission discipline standard; Barnabas's willingness to give him another chance reflected pastoral patience. Neither was wrong in the abstract; they were incompatible in this specific team."
             }
           ]
         },
         "hist": {
-          "context": "The Paul-Barnabas split (vv.36\u201341) is one of Acts' most humanly honest passages. Two proven missionaries, full of the Holy Spirit, cannot agree about a third person's fitness for ministry. Luke offers no verdict: Barnabas proved right (Col 4:10 and 2 Tim 4:11 show Mark's eventual full restoration), and Paul proved right (Silas was an excellent choice, and the mission needed an accountable team member). The split doubles the mission's reach: two teams instead of one. God's sovereignty works even through human disagreement."
+          "context": "The Paul-Barnabas split (vv.36–41) is one of Acts' most humanly honest passages. Two proven missionaries, full of the Holy Spirit, cannot agree about a third person's fitness for ministry. Luke offers no verdict: Barnabas proved right (Col 4:10 and 2 Tim 4:11 show Mark's eventual full restoration), and Paul proved right (Silas was an excellent choice, and the mission needed an accountable team member). The split doubles the mission's reach: two teams instead of one. God's sovereignty works even through human disagreement."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 36\u201441 \u2014 Paul and Barnabas Part Ways; Silas Chosen",
+      "header": "Verses 36—41 — Paul and Barnabas Part Ways; Silas Chosen",
       "verse_start": 36,
       "verse_end": 41,
       "panels": {
         "heb": [
           {
-            "word": "\u03b6\u03ae\u03c4\u03b7\u03bc\u03b1",
-            "transliteration": "z\u0113t\u0113ma",
+            "word": "ζήτημα",
+            "transliteration": "zētēma",
             "gloss": "question/dispute",
-            "paragraph": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation \u2014 the first church council in history."
+            "paragraph": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation — the first church council in history."
           },
           {
-            "word": "\u1f10\u03c0\u03ad\u03c3\u03c4\u03c1\u03b5\u03c8\u03b5\u03bd",
+            "word": "ἐπέστρεψεν",
             "transliteration": "epestrepsen",
             "gloss": "intervened / turned",
-            "paragraph": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action \u2014 God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
+            "paragraph": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action — God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
           }
         ],
         "places": [
           {
-            "name": "Jerusalem \u2014 Council Setting",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "The Jerusalem church is the theological centre of gravity for the entire early church. The apostles and elders \u2014 including Peter, James, John (the 'pillars', Gal 2:9), and Paul and Barnabas \u2014 constitute the first formal ecumenical gathering. Jerusalem is the appropriate venue: the Gospel went out from here; the question about the Gospel's requirements returns here for resolution."
+            "name": "Jerusalem — Council Setting",
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "The Jerusalem church is the theological centre of gravity for the entire early church. The apostles and elders — including Peter, James, John (the 'pillars', Gal 2:9), and Paul and Barnabas — constitute the first formal ecumenical gathering. Jerusalem is the appropriate venue: the Gospel went out from here; the question about the Gospel's requirements returns here for resolution."
           },
           {
-            "name": "Antioch \u2014 The Controversy Origin",
-            "coords": "36.2021\u00b0 N, 36.1603\u00b0 E",
-            "text": "The controversy begins in Antioch when Judean teachers arrive and require circumcision for salvation. Antioch \u2014 the Gentile mission's base \u2014 is the logical flashpoint: here is where the practical consequences of the theological question are most acute. The mixed Jewish-Gentile community cannot survive the Judaizers' requirement without fracturing."
+            "name": "Antioch — The Controversy Origin",
+            "coords": "36.2021° N, 36.1603° E",
+            "text": "The controversy begins in Antioch when Judean teachers arrive and require circumcision for salvation. Antioch — the Gentile mission's base — is the logical flashpoint: here is where the practical consequences of the theological question are most acute. The mixed Jewish-Gentile community cannot survive the Judaizers' requirement without fracturing."
           }
         ],
         "tl": [
@@ -337,13 +337,13 @@
             "current": true
           },
           {
-            "date": "c. AD 48\u201349",
+            "date": "c. AD 48–49",
             "name": "Galatian Controversy Background",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 49\u201351",
+            "date": "c. AD 49–51",
             "name": "Second Missionary Journey",
             "text": "",
             "current": false
@@ -352,86 +352,41 @@
         "cross": {
           "refs": [
             {
-              "ref": "Galatians 2:1\u201310",
-              "note": "Paul's account of the Jerusalem Council \u2014 confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission."
+              "ref": "Galatians 2:1–10",
+              "note": "Paul's account of the Jerusalem Council — confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission."
             },
             {
-              "ref": "Amos 9:11\u201312",
-              "note": "Cited in James's speech (vv.16\u201317) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew reads 'possess' \u2014 James uses the LXX version."
+              "ref": "Amos 9:11–12",
+              "note": "Cited in James's speech (vv.16–17) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew reads 'possess' — James uses the LXX version."
             },
             {
-              "ref": "Acts 10:44\u201348",
-              "note": "The Cornelius episode \u2014 Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision."
+              "ref": "Acts 10:44–48",
+              "note": "The Cornelius episode — Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:10\u201311",
-              "note": "MacArthur on Peter's \"yoke\" argument and grace statement: v.11 (\"we believe it is through the grace of our Lord Jesus Christ that we are saved, just as they are\") is one of the clearest statements of salvation by grace alone in Acts. Peter has been transformed by the Cornelius experience \u2014 the man who told Jesus \"never, Lord\" about Gentile inclusion now argues most forcefully for their equal standing before God."
-            },
-            {
-              "ref": "15:13\u201318",
-              "note": "MacArthur on James's Amos citation: James uses Scripture as the decisive argument. Peter's argument was from experience (Cornelius); Barnabas and Paul's was from miracles (signs and wonders); James's is from Scripture. MacArthur notes that James places the scriptural argument last and calls it decisive \u2014 experience and miracles are confirmatory, but Scripture is authoritative."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "Calvin on 'purified their hearts by faith': this verse is, for Calvin, the clearest statement in Acts of the doctrine of faith. The heart is purified not by circumcision, ritual, or law-observance but by faith \u2014 God's work through the instrument of trust in Christ. Calvin uses this as his summary of what the Council established: the Reformation's sola fide is embedded in the apostolic council's deliberations."
-            },
-            {
-              "ref": "15:10",
-              "note": "Calvin on the 'yoke' argument: Peter is making an argument from Israel's own history of covenant failure. If circumcised Israel could not bear the law's full weight, requiring it of Gentiles is a strategy for their condemnation, not their salvation. Calvin notes that the law is not bad (it is holy, Rom 7:12) but no one can bear it as a means of justification \u2014 precisely because all fall short."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:16\u201317",
-              "note": "The NET notes the LXX/MT discrepancy in the Amos quotation. The MT reads \"so that they may possess the remnant of Edom\" \u2014 a prophecy about Israelite territorial expansion. The LXX reads \"so that the rest of humanity may seek the Lord\" \u2014 a prophecy of universal seeking. James uses the LXX because it directly supports his argument about Gentile inclusion. This is not text manipulation but the legitimate use of an authoritative translation."
-            },
-            {
-              "ref": "15:20",
-              "note": "The NET notes that the four abstentions (food polluted by idols, sexual immorality, strangled animals, blood) probably reflect the Noachide commandments \u2014 the minimal ethical requirements that Jewish tradition held applicable to all humanity (cf. Gen 9:1\u20137). James frames the Gentile requirements in terms of the minimal standards Judaism expected of righteous Gentiles."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "\"He did not discriminate between us and them, for he purified their hearts by faith\" \u2014 Robertson notes the aorist \"purified\" (katharisas): a completed divine action. God cleansed the Gentiles' hearts by faith \u2014 the same cleansing the Jews had received. Robertson uses this to argue that the Jerusalem Council's decision was not a concession to Pauline pressure but a recognition of what God had already done."
-            },
-            {
-              "ref": "15:10",
-              "note": "\"A yoke that neither we nor our ancestors have been able to bear\" \u2014 Robertson on Peter's remarkable admission: the Torah's requirements are not being met by Jews themselves. The demand to impose them on Gentiles is therefore not only unnecessary but hypocritical. Robertson notes the pastoral courage of this admission in a Jerusalem context."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:1\u20132",
-              "note": "Keener provides background on the 'Judaizers' \u2014 Jewish Christians who believed Gentile converts must be circumcised and observe Torah to be fully saved. This position was not unreasonable from a traditional Jewish perspective: proselytes to Judaism were required to be circumcised and observe Torah. The Judaizers were simply applying the standard proselyte requirement to Christian Gentiles."
-            },
-            {
-              "ref": "15:16\u201317",
-              "note": "Keener notes the significance of James's use of the LXX version of Amos 9:11\u201312. The MT Amos reads \"so that they may possess\" (the remnant of Edom); the LXX reads \"so that the rest of humanity may seek the Lord.\" James uses the LXX version because it makes the Gentile inclusion point most clearly. This is standard Jewish hermeneutical practice \u2014 using the textual tradition that best supports the argument."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The question was not about Jewish Christian observance (Jewish believers could continue circumcision and Torah observance) but about whether Gentile converts must become Jews to be saved. Peter's argument (vv.7\u201311) is from divine precedent: God accepted the Gentiles without circumcision (Cornelius episode). James's argument (vv.13\u201318) is from Scripture: Amos 9:11\u201312 prophesied Gentile inclusion in the restored David's tent. Together they establish the principle that salvation is by grace through faith alone \u2014 the theological foundation of the entire Gentile mission."
+          "context": "The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The question was not about Jewish Christian observance (Jewish believers could continue circumcision and Torah observance) but about whether Gentile converts must become Jews to be saved. Peter's argument (vv.7–11) is from divine precedent: God accepted the Gentiles without circumcision (Cornelius episode). James's argument (vv.13–18) is from Scripture: Amos 9:11–12 prophesied Gentile inclusion in the restored David's tent. Together they establish the principle that salvation is by grace through faith alone — the theological foundation of the entire Gentile mission."
         }
       }
     }
@@ -439,58 +394,58 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Paul\u2197 People",
+        "name": "Paul↗ People",
         "role": "Apostle to the Gentiles; author of thirteen NT letters",
-        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen\u2019s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13\u201328 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts\u2019 theological climax: the gospel reaching the empire\u2019s capital, \"boldly and without hindrance\" (Acts 28:31)."
+        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen’s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13–28 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts’ theological climax: the gospel reaching the empire’s capital, \"boldly and without hindrance\" (Acts 28:31)."
       },
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       },
       {
-        "name": "Barnabas\u2197 People",
-        "role": "Paul\u2019s first missionary partner; 'Son of Encouragement'",
-        "text": "Barnabas (Joseph of Cyprus) is introduced as a generous land-seller in Acts 4:36\u201337 and is the one who vouches for the newly converted Paul to the suspicious Jerusalem church (Acts 9:27). He leads the Antioch church (Acts 11:22\u201324) and takes Paul as his partner for the first missionary journey (Acts 13\u201314). Their sharp disagreement over Mark (Acts 15:36\u201340) ends their partnership but doubles the missionary coverage."
+        "name": "Barnabas↗ People",
+        "role": "Paul’s first missionary partner; 'Son of Encouragement'",
+        "text": "Barnabas (Joseph of Cyprus) is introduced as a generous land-seller in Acts 4:36–37 and is the one who vouches for the newly converted Paul to the suspicious Jerusalem church (Acts 9:27). He leads the Antioch church (Acts 11:22–24) and takes Paul as his partner for the first missionary journey (Acts 13–14). Their sharp disagreement over Mark (Acts 15:36–40) ends their partnership but doubles the missionary coverage."
       },
       {
-        "name": "James\u2197 People",
+        "name": "James↗ People",
         "role": "Brother of Jesus; leader of the Jerusalem church",
-        "text": "James the brother of Jesus (not the apostle James son of Zebedee) emerges in Acts as the dominant figure of the Jerusalem church. He is not mentioned in Acts 1\u20139 but appears decisively in Acts 12:17 (Peter reports to him after his prison release), acts as president at the Jerusalem Council (Acts 15:13\u201321), and receives Paul\u2019s final Jerusalem report (Acts 21:18). Paul calls him a \"pillar\" of the church (Gal 2:9). He authored the letter of James."
+        "text": "James the brother of Jesus (not the apostle James son of Zebedee) emerges in Acts as the dominant figure of the Jerusalem church. He is not mentioned in Acts 1–9 but appears decisively in Acts 12:17 (Peter reports to him after his prison release), acts as president at the Jerusalem Council (Acts 15:13–21), and receives Paul’s final Jerusalem report (Acts 21:18). Paul calls him a \"pillar\" of the church (Gal 2:9). He authored the letter of James."
       },
       {
-        "name": "Silas\u2197 People",
-        "role": "Prophet and Paul\u2019s companion on the second missionary journey",
-        "text": "Silas (Silvanus) is a leading figure in the Jerusalem church and a prophet (Acts 15:32) chosen by Paul to replace Barnabas after their split. He accompanies Paul through Macedonia, Philippi (imprisoned together, Acts 16:25\u201334), Thessalonica, Berea, and Corinth. His Roman citizenship alongside Paul\u2019s creates the legal dynamic at Philippi. He is co-author of both Thessalonian letters."
+        "name": "Silas↗ People",
+        "role": "Prophet and Paul’s companion on the second missionary journey",
+        "text": "Silas (Silvanus) is a leading figure in the Jerusalem church and a prophet (Acts 15:32) chosen by Paul to replace Barnabas after their split. He accompanies Paul through Macedonia, Philippi (imprisoned together, Acts 16:25–34), Thessalonica, Berea, and Corinth. His Roman citizenship alongside Paul’s creates the legal dynamic at Philippi. He is co-author of both Thessalonian letters."
       },
       {
-        "name": "Cornelius\u2197 People",
+        "name": "Cornelius↗ People",
         "role": "Roman centurion; first Gentile convert; pivot of Acts 10",
-        "text": "Cornelius is a God-fearing Roman centurion at Caesarea \u2014 devout, generous, and prayerful but uncircumcised. His angel-directed encounter with Peter (Acts 10) is the theological turning point of Acts: the Spirit falls on Gentiles before baptism, demonstrating that God shows no partiality. Peter\u2019s report to Jerusalem (Acts 11) establishes the principle that will be formalized at the Jerusalem Council (Acts 15)."
+        "text": "Cornelius is a God-fearing Roman centurion at Caesarea — devout, generous, and prayerful but uncircumcised. His angel-directed encounter with Peter (Acts 10) is the theological turning point of Acts: the Spirit falls on Gentiles before baptism, demonstrating that God shows no partiality. Peter’s report to Jerusalem (Acts 11) establishes the principle that will be formalized at the Jerusalem Council (Acts 15)."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>After much discussion, Peter got up and addressed them: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And after there had been much debate, Peter stood up and said to them, \u201cBrothers, you know that in the early days God made a choice among you, that by my mouth the Gentiles should hear the word of the gospel and believe.</td></tr><tr><td class=\"t-label\">NIV</td><td>Then some of the believers who belonged to the party of the Pharisees stood up and said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But some believers who belonged to the party of the Pharisees rose up and said, \u201cIt is necessary to circumcise them and to order them to keep the law of Moses.\u201d</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>After much discussion, Peter got up and addressed them: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And after there had been much debate, Peter stood up and said to them, “Brothers, you know that in the early days God made a choice among you, that by my mouth the Gentiles should hear the word of the gospel and believe.</td></tr><tr><td class=\"t-label\">NIV</td><td>Then some of the believers who belonged to the party of the Pharisees stood up and said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But some believers who belonged to the party of the Pharisees rose up and said, “It is necessary to circumcise them and to order them to keep the law of Moses.”</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
@@ -500,18 +455,18 @@
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201421 \u2014 The Jerusalem Council: Peter\u2019s Testimony; James\u2019 Ruling",
-          "text": "Context  The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The\u2026",
+          "label": "Verses 1—21 — The Jerusalem Council: Peter’s Testimony; James’ Ruling",
+          "text": "Context  The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The…",
           "is_key": false
         },
         {
-          "label": "Verses 22\u201435 \u2014 The Council\u2019s Letter; Judas and Silas Sent",
-          "text": "Context  The Paul-Barnabas split (vv.36\u201341) is one of Acts' most humanly honest passages. Two proven missionaries, full\u2026",
+          "label": "Verses 22—35 — The Council’s Letter; Judas and Silas Sent",
+          "text": "Context  The Paul-Barnabas split (vv.36–41) is one of Acts' most humanly honest passages. Two proven missionaries, full…",
           "is_key": false
         },
         {
-          "label": "Verses 36\u201441 \u2014 Paul and Barnabas Part Ways; Silas Chosen",
-          "text": "Context  The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The\u2026",
+          "label": "Verses 36—41 — Paul and Barnabas Part Ways; Silas Chosen",
+          "text": "Context  The Jerusalem Council (c. AD 49) is the most important theological deliberation in the NT church's history. The…",
           "is_key": false
         }
       ],
@@ -519,83 +474,83 @@
     },
     "hebtext": [
       {
-        "word": "\u03b6\u03ae\u03c4\u03b7\u03bc\u03b1",
-        "tlit": "z\u0113t\u0113ma",
+        "word": "ζήτημα",
+        "tlit": "zētēma",
         "gloss": "question/dispute",
-        "note": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation \u2014 the first church council in history."
+        "note": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation — the first church council in history."
       },
       {
-        "word": "\u1f10\u03c0\u03ad\u03c3\u03c4\u03c1\u03b5\u03c8\u03b5\u03bd",
+        "word": "ἐπέστρεψεν",
         "tlit": "epestrepsen",
         "gloss": "intervened / turned",
-        "note": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action \u2014 God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
+        "note": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action — God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
       },
       {
-        "word": "\u1f14\u03b4\u03bf\u03be\u03b5\u03bd \u03b3\u1f70\u03c1 \u03c4\u1ff7 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03b9 \u03c4\u1ff7 \u1f01\u03b3\u03af\u1ff3 \u03ba\u03b1\u1f76 \u1f21\u03bc\u1fd6\u03bd",
-        "tlit": "edoxen gar t\u014d pneumati t\u014d hagi\u014d kai h\u0113min",
+        "word": "ἔδοξεν γὰρ τῷ πνεύματι τῷ ἁγίῳ καὶ ἡμῖν",
+        "tlit": "edoxen gar tō pneumati tō hagiō kai hēmin",
         "gloss": "it seemed good to the Holy Spirit and to us",
-        "note": "the Council's formula in v.28 \u2014 one of the most significant phrases in Acts. The Spirit and the human deliberators are coordinated: the Council does not claim to act independently ('the Spirit told us') but jointly ('the Spirit and we'). This is the model for Spirit-directed church decision-making: attentive to heaven, deliberate on earth."
+        "note": "the Council's formula in v.28 — one of the most significant phrases in Acts. The Spirit and the human deliberators are coordinated: the Council does not claim to act independently ('the Spirit told us') but jointly ('the Spirit and we'). This is the model for Spirit-directed church decision-making: attentive to heaven, deliberate on earth."
       },
       {
-        "word": "\u03c0\u03b1\u03c1\u03bf\u03be\u03c5\u03c3\u03bc\u03cc\u03c2",
+        "word": "παροξυσμός",
         "tlit": "paroxysmos",
         "gloss": "sharp disagreement",
-        "note": "from paroxyn\u014d \u2014 to sharpen, to provoke. The disagreement between Paul and Barnabas is described with a medical/physical term for a sharp pain or spasm. Luke does not soften the conflict: two Spirit-filled, proven missionaries have an irreconcilable dispute. The honesty is itself instructive \u2014 the Bible's heroes are fully human."
+        "note": "from paroxynō — to sharpen, to provoke. The disagreement between Paul and Barnabas is described with a medical/physical term for a sharp pain or spasm. Luke does not soften the conflict: two Spirit-filled, proven missionaries have an irreconcilable dispute. The honesty is itself instructive — the Bible's heroes are fully human."
       },
       {
-        "word": "\u03b6\u03ae\u03c4\u03b7\u03bc\u03b1",
-        "tlit": "z\u0113t\u0113ma",
+        "word": "ζήτημα",
+        "tlit": "zētēma",
         "gloss": "question/dispute",
-        "note": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation \u2014 the first church council in history."
+        "note": "the word in v.2 for the controversy is not simply a 'disagreement' but a formal theological question requiring authoritative resolution (also used in 18:15; 23:29; 25:19; 26:3). The Jerusalem Council is not an informal discussion but a formal theological deliberation — the first church council in history."
       },
       {
-        "word": "\u1f10\u03c0\u03ad\u03c3\u03c4\u03c1\u03b5\u03c8\u03b5\u03bd",
+        "word": "ἐπέστρεψεν",
         "tlit": "epestrepsen",
         "gloss": "intervened / turned",
-        "note": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action \u2014 God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
+        "note": "James uses a significant word in v.14: God 'epestrepsen' (turned his attention, visited, intervened) to take a people from the Gentiles. The verb is used of divine eschatological action — God's decisive turning toward the Gentiles is not a historical accident but a purposeful divine intervention."
       }
     ],
     "thread": [
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Galatians 2:1\u201310",
+        "target": "Galatians 2:1–10",
         "type": "Connection",
-        "text": "Paul's account of the Jerusalem Council \u2014 confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission.",
+        "text": "Paul's account of the Jerusalem Council — confirmed the agreement: Paul and Barnabas were given the right hand of fellowship to continue the Gentile mission, while Peter, James, and John would focus on the Jewish mission.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Amos 9:11\u201312",
+        "target": "Amos 9:11–12",
         "type": "Connection",
-        "text": "Cited in James's speech (vv.16\u201317) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew read\u2026",
+        "text": "Cited in James's speech (vv.16–17) as the OT prophecy of Gentile inclusion: 'I will rebuild David's fallen shelter... so that the rest of humanity may seek the Lord, even all the Gentiles who bear my name.' LXX Amos reads 'seek' where the Hebrew read…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 10:44\u201348",
+        "target": "Acts 10:44–48",
         "type": "Connection",
-        "text": "The Cornelius episode \u2014 Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision.",
+        "text": "The Cornelius episode — Peter's decisive evidence: 'God, who knows the heart, showed that he accepted them by giving the Holy Spirit to them, just as he did to us' (v.8). The Gentile Pentecost is the theological foundation for the Council's decision.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Colossians 4:10",
         "type": "Connection",
-        "text": "\"Mark, the cousin of Barnabas... if he comes to you, welcome him\" \u2014 Paul's later commendation of Mark shows the relationship was eventually restored.",
+        "text": "\"Mark, the cousin of Barnabas... if he comes to you, welcome him\" — Paul's later commendation of Mark shows the relationship was eventually restored.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "2 Timothy 4:11",
         "type": "Connection",
-        "text": "\"Get Mark and bring him with you, because he is helpful to me in my ministry\" \u2014 Paul's final letter shows complete reconciliation. Barnabas was right about Mark; Paul came to agree.",
+        "text": "\"Get Mark and bring him with you, because he is helpful to me in my ministry\" — Paul's final letter shows complete reconciliation. Barnabas was right about Mark; Paul came to agree.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Philippians 1:15\u201318",
+        "target": "Philippians 1:15–18",
         "type": "Connection",
-        "text": "\"Some preach Christ out of envy and rivalry... but what does it matter? The important thing is that in every way, whether from false motives or true, Christ is preached.\" Paul's mature theology of mission: even imperfect motives and divided teams ser\u2026",
+        "text": "\"Some preach Christ out of envy and rivalry... but what does it matter? The important thing is that in every way, whether from false motives or true, Christ is preached.\" Paul's mature theology of mission: even imperfect motives and divided teams ser…",
         "direction": "backward"
       }
     ],
@@ -603,14 +558,14 @@
       {
         "ref": "Acts 15",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 15 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -620,12 +575,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }

--- a/content/acts/16.json
+++ b/content/acts/16.json
@@ -4,63 +4,63 @@
   "book_dir": "acts",
   "chapter_num": 16,
   "title": "Acts 16",
-  "subtitle": "The Second Missionary Journey \u2014 Philippi",
+  "subtitle": "The Second Missionary Journey — Philippi",
   "timeline_link": {
     "event_id": "pauls-missionary-journeys",
-    "text": "See on Timeline \u2014 First Missionary Journey"
+    "text": "See on Timeline — First Missionary Journey"
   },
   "map_story_link": {
     "story_id": "paul-journey2",
-    "text": "See on Map \u2014 Paul's 2nd Journey"
+    "text": "See on Map — Paul's 2nd Journey"
   },
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201410 \u2014 Timothy Joins; The Macedonian Vision; Lydia Converted",
+      "header": "Verses 1—10 — Timothy Joins; The Macedonian Vision; Lydia Converted",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
         "heb": [
           {
-            "word": "\u03bf\u1f50\u03ba \u03b5\u1f34\u03b1\u03c3\u03b5\u03bd \u03b1\u1f50\u03c4\u03bf\u1f7a\u03c2 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u1f38\u03b7\u03c3\u03bf\u1fe6",
-            "transliteration": "ouk eiasen autous to pneuma I\u0113sou",
+            "word": "οὐκ εἴασεν αὐτοὺς τὸ πνεῦμα Ἰησοῦ",
+            "transliteration": "ouk eiasen autous to pneuma Iēsou",
             "gloss": "the Spirit of Jesus would not allow them",
-            "paragraph": "v.7 \u2014 one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission \u2014 blocking Asia and Bithynia, opening Macedonia \u2014 demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
+            "paragraph": "v.7 — one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission — blocking Asia and Bithynia, opening Macedonia — demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
           },
           {
-            "word": "\u1f24\u03bd\u03bf\u03b9\u03be\u03b5\u03bd \u03c4\u1f74\u03bd \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03bd",
-            "transliteration": "\u0113noixen t\u0113n kardian",
+            "word": "ἤνοιξεν τὴν καρδίαν",
+            "transliteration": "ēnoixen tēn kardian",
             "gloss": "opened her heart",
-            "paragraph": "the Lord opened Lydia's heart (v.14) \u2014 a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (di\u0113noigen) implies a sealed container being unsealed \u2014 Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
+            "paragraph": "the Lord opened Lydia's heart (v.14) — a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (diēnoigen) implies a sealed container being unsealed — Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
           }
         ],
         "places": [
           {
             "name": "Troas",
-            "coords": "39.7500\u00b0 N, 26.1333\u00b0 E",
-            "text": "The port city of Alexandria Troas on the Aegean coast of Asia Minor \u2014 the point where Paul crosses from Asia to Europe. The Macedonian vision (v.9) comes here; the 'we' sections begin here (v.10), indicating Luke joined the party. Troas is the hinge between the Asian and European missions."
+            "coords": "39.7500° N, 26.1333° E",
+            "text": "The port city of Alexandria Troas on the Aegean coast of Asia Minor — the point where Paul crosses from Asia to Europe. The Macedonian vision (v.9) comes here; the 'we' sections begin here (v.10), indicating Luke joined the party. Troas is the hinge between the Asian and European missions."
           },
           {
             "name": "Philippi",
-            "coords": "41.0167\u00b0 N, 24.2833\u00b0 E",
-            "text": "A Roman colony in Macedonia (northern Greece), founded in 42 BC by Octavian and Antony after the Battle of Philippi. As a Roman colony, it had Roman law, Roman magistrates (strat\u0113goi), and a Latin-speaking upper class. The church Paul plants here will be the recipient of his most affectionate letter (Philippians)."
+            "coords": "41.0167° N, 24.2833° E",
+            "text": "A Roman colony in Macedonia (northern Greece), founded in 42 BC by Octavian and Antony after the Battle of Philippi. As a Roman colony, it had Roman law, Roman magistrates (stratēgoi), and a Latin-speaking upper class. The church Paul plants here will be the recipient of his most affectionate letter (Philippians)."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 49\u201350",
-            "name": "Macedonian Call \u2014 Europe Opens",
-            "text": "The Spirit blocks Asia and Bithynia and directs Paul to Troas. The Macedonian vision confirms the call westward. Paul crosses into Europe \u2014 the Gospel reaches Greece for the first time.",
+            "date": "c. AD 49–50",
+            "name": "Macedonian Call — Europe Opens",
+            "text": "The Spirit blocks Asia and Bithynia and directs Paul to Troas. The Macedonian vision confirms the call westward. Paul crosses into Europe — the Gospel reaches Greece for the first time.",
             "current": true
           },
           {
             "date": "c. AD 50",
-            "name": "Philippi \u2014 First European Church",
+            "name": "Philippi — First European Church",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 50\u201351",
+            "date": "c. AD 50–51",
             "name": "Thessalonica, Athens, Corinth",
             "text": "",
             "current": false
@@ -69,38 +69,38 @@
         "cross": {
           "refs": [
             {
-              "ref": "Philippians 1:3\u20135",
-              "note": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" \u2014 Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in its founding (Lydia's house) becomes his most trusted partner."
+              "ref": "Philippians 1:3–5",
+              "note": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" — Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in its founding (Lydia's house) becomes his most trusted partner."
             },
             {
               "ref": "Acts 16:10",
-              "note": "The first \"we\" passage \u2014 Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony."
+              "note": "The first \"we\" passage — Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony."
             },
             {
               "ref": "2 Corinthians 11:25",
-              "note": "\"Three times I was beaten with rods\" \u2014 Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings."
+              "note": "\"Three times I was beaten with rods\" — Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "16:6\u20137",
+              "ref": "16:6–7",
               "note": "MacArthur on the Spirit's redirection: the mission's geography is determined not by human strategic planning but by the Spirit's active guidance. MacArthur uses this to argue against both the paralysis of waiting for clear divine direction and the presumptuousness of acting without it. Paul moved forward until the Spirit blocked; then he paused and received new direction. This is the model for Spirit-led mission."
             },
             {
               "ref": "16:14",
-              "note": "MacArthur on Lydia's conversion: 'the Lord opened her heart' \u2014 MacArthur emphasises that this is not a synergistic co-operation between God and Lydia but a divine act that enabled her response. God opened; she responded. MacArthur uses this as his key Acts text for irresistible grace: God's opening of the heart makes the subsequent believing certain, not merely possible."
+              "note": "MacArthur on Lydia's conversion: 'the Lord opened her heart' — MacArthur emphasises that this is not a synergistic co-operation between God and Lydia but a divine act that enabled her response. God opened; she responded. MacArthur uses this as his key Acts text for irresistible grace: God's opening of the heart makes the subsequent believing certain, not merely possible."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:9",
-              "note": "Calvin on the Macedonian vision: the vision is not sought but given \u2014 Paul does not manufacture guidance by extended prayer or method, but receives it in the night. Calvin uses this to argue against both the mysticism that seeks visions and the rationalism that dismisses them. God guides as and when he chooses; the servant's role is attentive readiness."
+              "note": "Calvin on the Macedonian vision: the vision is not sought but given — Paul does not manufacture guidance by extended prayer or method, but receives it in the night. Calvin uses this to argue against both the mysticism that seeks visions and the rationalism that dismisses them. God guides as and when he chooses; the servant's role is attentive readiness."
             },
             {
               "ref": "16:14",
@@ -109,86 +109,86 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:12",
-              "note": "The NET notes a textual variant in the description of Philippi: 'a leading city (pr\u014dt\u0113) of the district' vs. 'a city of the first district (pr\u014dt\u0113s meridos)' of Macedonia. Either reading confirms Philippi's prominence. The NET prefers 'a leading city' as the most natural reading."
+              "note": "The NET notes a textual variant in the description of Philippi: 'a leading city (prōtē) of the district' vs. 'a city of the first district (prōtēs meridos)' of Macedonia. Either reading confirms Philippi's prominence. The NET prefers 'a leading city' as the most natural reading."
             },
             {
               "ref": "16:16",
-              "note": "The NET notes that the slave girl had a \"python spirit\" (pneuma pyth\u014dna) \u2014 the Python was the mythological serpent at Delphi, associated with prophetic powers. Her owners were exploiting a genuine supernatural ability (accurate prediction) for profit. Paul's exorcism destroyed their economic asset, which is the direct cause of his arrest \u2014 the Gospel's conflict with exploitative economics is the real issue."
+              "note": "The NET notes that the slave girl had a \"python spirit\" (pneuma pythōna) — the Python was the mythological serpent at Delphi, associated with prophetic powers. Her owners were exploiting a genuine supernatural ability (accurate prediction) for profit. Paul's exorcism destroyed their economic asset, which is the direct cause of his arrest — the Gospel's conflict with exploitative economics is the real issue."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
-              "ref": "16:6\u20137",
-              "note": "Robertson on the Spirit's double blocking: the Spirit of the Lord prevents entry into Asia (v.6) and the Spirit of Jesus prevents entry into Bithynia (v.7). Robertson notes that Luke uses two slightly different phrases for the same Spirit \u2014 both \"Holy Spirit\" and \"Spirit of Jesus\" are used interchangeably, confirming the full Trinitarian identity of the Spirit with Jesus."
+              "ref": "16:6–7",
+              "note": "Robertson on the Spirit's double blocking: the Spirit of the Lord prevents entry into Asia (v.6) and the Spirit of Jesus prevents entry into Bithynia (v.7). Robertson notes that Luke uses two slightly different phrases for the same Spirit — both \"Holy Spirit\" and \"Spirit of Jesus\" are used interchangeably, confirming the full Trinitarian identity of the Spirit with Jesus."
             },
             {
               "ref": "16:14",
-              "note": "Robertson on \"the Lord opened her heart to respond to Paul's message\" \u2014 Robertson notes the divine passive with the Lord as agent. Paul preached; God opened. Robertson uses this to argue for both the necessity of proclamation (Paul's role) and the necessity of divine action (the Lord's role) in conversion \u2014 neither alone is sufficient."
+              "note": "Robertson on \"the Lord opened her heart to respond to Paul's message\" — Robertson notes the divine passive with the Lord as agent. Paul preached; God opened. Robertson uses this to argue for both the necessity of proclamation (Paul's role) and the necessity of divine action (the Lord's role) in conversion — neither alone is sufficient."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "16:12",
-              "note": "Keener notes Philippi's status as a Roman colony (colonia). Roman colonies were formally Roman soil, populated by Roman veterans and citizens, governed by Roman law. The magistrates (strat\u0113goi, the Roman equivalent of duoviri) Paul faces are Roman officials. The charge against Paul and Silas (v.20\u201321) \u2014 advocating unlawful customs for Romans \u2014 makes sense only in this Roman colonial context."
+              "note": "Keener notes Philippi's status as a Roman colony (colonia). Roman colonies were formally Roman soil, populated by Roman veterans and citizens, governed by Roman law. The magistrates (stratēgoi, the Roman equivalent of duoviri) Paul faces are Roman officials. The charge against Paul and Silas (v.20–21) — advocating unlawful customs for Romans — makes sense only in this Roman colonial context."
             },
             {
               "ref": "16:14",
-              "note": "Keener provides background on Lydia. Purple cloth (porphyrop\u014dlis \u2014 dealer in purple goods) was an extremely lucrative trade \u2014 purple dye from the murex shellfish or the madder plant was the most expensive textile colourant in the ancient world. Lydia was a wealthy, independent businesswoman from Thyatira (in Lydia, Asia Minor). Her household baptism and hospitality establish her as the first Christian in Europe."
+              "note": "Keener provides background on Lydia. Purple cloth (porphyropōlis — dealer in purple goods) was an extremely lucrative trade — purple dye from the murex shellfish or the madder plant was the most expensive textile colourant in the ancient world. Lydia was a wealthy, independent businesswoman from Thyatira (in Lydia, Asia Minor). Her household baptism and hospitality establish her as the first Christian in Europe."
             }
           ]
         },
         "hist": {
-          "context": "Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels the mission westward toward Macedonia \u2014 and the Macedonian vision confirms the direction. The 'we' sections begin at v.10, indicating Luke is now a firsthand witness. Philippi provides three conversion vignettes that represent three social strata: Lydia (wealthy merchant, high-status woman), the slave girl (lowest social status), and the jailer (Roman official, mid-level authority) \u2014 the Gospel's reach spans the entire social spectrum."
+          "context": "Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels the mission westward toward Macedonia — and the Macedonian vision confirms the direction. The 'we' sections begin at v.10, indicating Luke is now a firsthand witness. Philippi provides three conversion vignettes that represent three social strata: Lydia (wealthy merchant, high-status woman), the slave girl (lowest social status), and the jailer (Roman official, mid-level authority) — the Gospel's reach spans the entire social spectrum."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201424 \u2014 Philippi: The Slave Girl; Paul and Silas Imprisoned",
+      "header": "Verses 11—24 — Philippi: The Slave Girl; Paul and Silas Imprisoned",
       "verse_start": 11,
       "verse_end": 24,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03ce\u03b6\u03bf\u03bc\u03b1\u03b9",
-            "transliteration": "s\u014dzomai",
+            "word": "σώζομαι",
+            "transliteration": "sōzomai",
             "gloss": "to be saved",
-            "paragraph": "the jailer's question 'What must I do to be saved?' (v.30) uses the most comprehensive Greek word for salvation \u2014 s\u014dz\u014d covers physical rescue, healing, and eternal deliverance. In context he may initially mean 'rescue from my predicament,' but Paul's answer ('Believe in the Lord Jesus') addresses the ultimate dimension. The question is answered at its deepest level."
+            "paragraph": "the jailer's question 'What must I do to be saved?' (v.30) uses the most comprehensive Greek word for salvation — sōzō covers physical rescue, healing, and eternal deliverance. In context he may initially mean 'rescue from my predicament,' but Paul's answer ('Believe in the Lord Jesus') addresses the ultimate dimension. The question is answered at its deepest level."
           },
           {
-            "word": "\u1fec\u03c9\u03bc\u03b1\u1fd6\u03bf\u03af",
-            "transliteration": "Rh\u014dmaioi",
+            "word": "Ῥωμαῖοί",
+            "transliteration": "Rhōmaioi",
             "gloss": "Roman citizens",
-            "paragraph": "v.37 \u2014 Paul's assertion of Roman citizenship is not a contradiction of his willingness to suffer but a strategic use of legal rights for the church's protection. As Roman citizens, Paul and Silas were entitled to a proper trial before punishment \u2014 their beating without trial (v.37: akatakritous) was illegal. Paul insists on public exoneration to protect the Philippi church from accusations of harbouring criminals."
+            "paragraph": "v.37 — Paul's assertion of Roman citizenship is not a contradiction of his willingness to suffer but a strategic use of legal rights for the church's protection. As Roman citizens, Paul and Silas were entitled to a proper trial before punishment — their beating without trial (v.37: akatakritous) was illegal. Paul insists on public exoneration to protect the Philippi church from accusations of harbouring criminals."
           }
         ],
         "places": [
           {
             "name": "The Philippian Prison",
-            "coords": "41.0167\u00b0 N, 24.2833\u00b0 E",
-            "text": "The inner cell and stocks (v.24) represent maximum security \u2014 the same pattern as Peter's prison in Jerusalem (Acts 12:4). The earthquake that opens all doors and loosens all chains mirrors the angelic deliverance of Acts 5 and 12, establishing the pattern: God delivers from maximum-security imprisonment when it serves his purposes."
+            "coords": "41.0167° N, 24.2833° E",
+            "text": "The inner cell and stocks (v.24) represent maximum security — the same pattern as Peter's prison in Jerusalem (Acts 12:4). The earthquake that opens all doors and loosens all chains mirrors the angelic deliverance of Acts 5 and 12, establishing the pattern: God delivers from maximum-security imprisonment when it serves his purposes."
           },
           {
             "name": "Lydia's House",
-            "coords": "41.0167\u00b0 N, 24.2833\u00b0 E",
-            "text": "The church in Philippi gathers in Lydia's house (v.40) \u2014 the first Christian meeting place in Europe. That the church is rooted in the home of a wealthy businesswoman reflects the social diversity of the early church: economic resources put at the community's service without hierarchy."
+            "coords": "41.0167° N, 24.2833° E",
+            "text": "The church in Philippi gathers in Lydia's house (v.40) — the first Christian meeting place in Europe. That the church is rooted in the home of a wealthy businesswoman reflects the social diversity of the early church: economic resources put at the community's service without hierarchy."
           }
         ],
         "tl": [
           {
             "date": "c. AD 50",
-            "name": "The Philippian Jailer \u2014 Midnight Salvation",
-            "text": "Paul and Silas, flogged and imprisoned, sing hymns at midnight. An earthquake opens all doors. The jailer, about to kill himself, is stopped by Paul and asks the most important question in Acts: 'What must I do to be saved?' Paul's answer \u2014 'Believe in the Lord Jesus' \u2014 is the Gospel in six words.",
+            "name": "The Philippian Jailer — Midnight Salvation",
+            "text": "Paul and Silas, flogged and imprisoned, sing hymns at midnight. An earthquake opens all doors. The jailer, about to kill himself, is stopped by Paul and asks the most important question in Acts: 'What must I do to be saved?' Paul's answer — 'Believe in the Lord Jesus' — is the Gospel in six words.",
             "current": true
           },
           {
@@ -208,24 +208,24 @@
           "refs": [
             {
               "ref": "Acts 5:19",
-              "note": "The angelic prison escape of Acts 5 \u2014 the earthquake in Acts 16 follows the same providential pattern: God delivers his servants from maximum-security imprisonment."
+              "note": "The angelic prison escape of Acts 5 — the earthquake in Acts 16 follows the same providential pattern: God delivers his servants from maximum-security imprisonment."
             },
             {
               "ref": "Philippians 4:4",
-              "note": "\"Rejoice in the Lord always. I will say it again: Rejoice!\" \u2014 Paul writes this from prison. The midnight singing at Philippi (Acts 16:25) is the biographical foundation of Paul's theology of joy-in-suffering."
+              "note": "\"Rejoice in the Lord always. I will say it again: Rejoice!\" — Paul writes this from prison. The midnight singing at Philippi (Acts 16:25) is the biographical foundation of Paul's theology of joy-in-suffering."
             },
             {
-              "ref": "Romans 13:1\u20137",
-              "note": "Paul's later teaching on submission to governing authorities is not contradicted by his claim of rights in v.37 \u2014 he uses legal channels, not rebellion, to defend the church's position."
+              "ref": "Romans 13:1–7",
+              "note": "Paul's later teaching on submission to governing authorities is not contradicted by his claim of rights in v.37 — he uses legal channels, not rebellion, to defend the church's position."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:31",
-              "note": "\"Believe in the Lord Jesus, and you will be saved \u2014 you and your household\" \u2014 MacArthur notes the simplicity and comprehensiveness of the Gospel statement. No preliminary requirements, no list of conditions, no cultural demands \u2014 just faith in the Lord Jesus. MacArthur uses this as the model for Gospel proclamation: clear, direct, complete."
+              "note": "\"Believe in the Lord Jesus, and you will be saved — you and your household\" — MacArthur notes the simplicity and comprehensiveness of the Gospel statement. No preliminary requirements, no list of conditions, no cultural demands — just faith in the Lord Jesus. MacArthur uses this as the model for Gospel proclamation: clear, direct, complete."
             },
             {
               "ref": "16:37",
@@ -234,109 +234,109 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:25",
-              "note": "Calvin on the midnight singing: 'Paul and Silas were not merely resigned to their suffering \u2014 they were actively rejoicing. Calvin notes that joy under suffering is not natural but supernatural \u2014 the evidence of the Spirit's work overcoming the flesh's inclination to despair. The singing was also a form of witness: the other prisoners heard God being praised in the midst of unjust imprisonment."
+              "note": "Calvin on the midnight singing: 'Paul and Silas were not merely resigned to their suffering — they were actively rejoicing. Calvin notes that joy under suffering is not natural but supernatural — the evidence of the Spirit's work overcoming the flesh's inclination to despair. The singing was also a form of witness: the other prisoners heard God being praised in the midst of unjust imprisonment."
             },
             {
               "ref": "16:31",
-              "note": "Calvin on 'you and your household': Calvin notes that the promise extends to the jailer's household not as automatic salvation of all family members but as the covenant promise \u2014 God's grace typically follows family lines. The household's faith response (v.32\u201334) confirms that the promise requires individual believing, not merely familial connection."
+              "note": "Calvin on 'you and your household': Calvin notes that the promise extends to the jailer's household not as automatic salvation of all family members but as the covenant promise — God's grace typically follows family lines. The household's faith response (v.32–34) confirms that the promise requires individual believing, not merely familial connection."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:30",
-              "note": "The NET notes that the question \"what must I do to be saved?\" (ti me dei poiein hina s\u014dth\u014d) is the central evangelistic question of Acts. The verb dei (must) implies an urgency and certainty \u2014 the jailer is not asking hypothetically but desperately. Paul's answer is equally unambiguous: \"believe in the Lord Jesus.\""
+              "note": "The NET notes that the question \"what must I do to be saved?\" (ti me dei poiein hina sōthō) is the central evangelistic question of Acts. The verb dei (must) implies an urgency and certainty — the jailer is not asking hypothetically but desperately. Paul's answer is equally unambiguous: \"believe in the Lord Jesus.\""
             },
             {
               "ref": "16:37",
-              "note": "The NET notes the legal term akatakritous (without a trial, uncondemned) \u2014 a technical Roman legal term. Paul is using precise legal vocabulary to establish the magistrates' liability. The official public escort from prison (v.39) is the legally required acknowledgment of wrongdoing \u2014 a public exoneration of Paul and Silas and, by extension, of the Philippian church they leave behind."
+              "note": "The NET notes the legal term akatakritous (without a trial, uncondemned) — a technical Roman legal term. Paul is using precise legal vocabulary to establish the magistrates' liability. The official public escort from prison (v.39) is the legally required acknowledgment of wrongdoing — a public exoneration of Paul and Silas and, by extension, of the Philippian church they leave behind."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "16:25",
-              "note": "\"Praying and singing hymns to God, and the other prisoners were listening to them\" \u2014 Robertson notes the imperfect tense (ep\u0113kroonto \u2014 were listening, continuously). The other prisoners did not go back to sleep; they kept listening throughout. The midnight worship service had an audience Paul and Silas did not know about \u2014 a reminder that faithful behaviour under suffering witnesses to observers we cannot see."
+              "note": "\"Praying and singing hymns to God, and the other prisoners were listening to them\" — Robertson notes the imperfect tense (epēkroonto — were listening, continuously). The other prisoners did not go back to sleep; they kept listening throughout. The midnight worship service had an audience Paul and Silas did not know about — a reminder that faithful behaviour under suffering witnesses to observers we cannot see."
             },
             {
               "ref": "16:30",
-              "note": "\"Sirs, what must I do to be saved?\" \u2014 Robertson notes the aorist subjunctive (s\u014dth\u014d \u2014 that I may be saved): the question is urgent and specific. Robertson observes that the jailer has just witnessed the miraculous earthquake and the apostles' refusal to escape \u2014 he knows he is in the presence of the holy."
+              "note": "\"Sirs, what must I do to be saved?\" — Robertson notes the aorist subjunctive (sōthō — that I may be saved): the question is urgent and specific. Robertson observes that the jailer has just witnessed the miraculous earthquake and the apostles' refusal to escape — he knows he is in the presence of the holy."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "16:25\u201326",
-              "note": "Keener notes the literary parallel with Acts 12:6\u201310 (Peter sleeping in prison; earthquake/angel deliverance). Both accounts involve maximum security, miraculous release, and the guards' bewilderment. But the Philippi account has a crucial addition: Paul and Silas stay, and this enables the jailer's conversion. The miracle serves evangelism, not escape."
+              "ref": "16:25–26",
+              "note": "Keener notes the literary parallel with Acts 12:6–10 (Peter sleeping in prison; earthquake/angel deliverance). Both accounts involve maximum security, miraculous release, and the guards' bewilderment. But the Philippi account has a crucial addition: Paul and Silas stay, and this enables the jailer's conversion. The miracle serves evangelism, not escape."
             },
             {
               "ref": "16:37",
-              "note": "Keener provides background on the legal significance of Paul's Roman citizenship claim. The Lex Porcia and Lex Sempronia (Roman laws dating to the 2nd century BC) prohibited flogging Roman citizens before trial. The magistrates' alarm (v.38: ephob\u0113th\u0113san) is genuine: they had committed a serious illegal act. Paul's insistence on public acknowledgment is both principled and strategic."
+              "note": "Keener provides background on the legal significance of Paul's Roman citizenship claim. The Lex Porcia and Lex Sempronia (Roman laws dating to the 2nd century BC) prohibited flogging Roman citizens before trial. The magistrates' alarm (v.38: ephobēthēsan) is genuine: they had committed a serious illegal act. Paul's insistence on public acknowledgment is both principled and strategic."
             }
           ]
         },
         "hist": {
-          "context": "The midnight worship of Paul and Silas (v.25) is one of the most remarkable scenes in Acts: flogged, feet in stocks, they pray and sing hymns. The earthquake is God's response \u2014 but the most significant part of the scene is that they do not escape when the doors open. Their staying enables the jailer's conversion. Paul's insistence on public exoneration (vv.37\u201339) is strategic rather than self-interested: the Philippi church needs legal protection, and the magistrates' public acknowledgment of wrongdoing provides it. The Roman citizenship card is played for the church's benefit, not Paul's pride."
+          "context": "The midnight worship of Paul and Silas (v.25) is one of the most remarkable scenes in Acts: flogged, feet in stocks, they pray and sing hymns. The earthquake is God's response — but the most significant part of the scene is that they do not escape when the doors open. Their staying enables the jailer's conversion. Paul's insistence on public exoneration (vv.37–39) is strategic rather than self-interested: the Philippi church needs legal protection, and the magistrates' public acknowledgment of wrongdoing provides it. The Roman citizenship card is played for the church's benefit, not Paul's pride."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 25\u201440 \u2014 The Philippian Jailer: What Must I Do to Be Saved?",
+      "header": "Verses 25—40 — The Philippian Jailer: What Must I Do to Be Saved?",
       "verse_start": 25,
       "verse_end": 40,
       "panels": {
         "heb": [
           {
-            "word": "\u03bf\u1f50\u03ba \u03b5\u1f34\u03b1\u03c3\u03b5\u03bd \u03b1\u1f50\u03c4\u03bf\u1f7a\u03c2 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u1f38\u03b7\u03c3\u03bf\u1fe6",
-            "transliteration": "ouk eiasen autous to pneuma I\u0113sou",
+            "word": "οὐκ εἴασεν αὐτοὺς τὸ πνεῦμα Ἰησοῦ",
+            "transliteration": "ouk eiasen autous to pneuma Iēsou",
             "gloss": "the Spirit of Jesus would not allow them",
-            "paragraph": "v.7 \u2014 one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission \u2014 blocking Asia and Bithynia, opening Macedonia \u2014 demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
+            "paragraph": "v.7 — one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission — blocking Asia and Bithynia, opening Macedonia — demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
           },
           {
-            "word": "\u1f24\u03bd\u03bf\u03b9\u03be\u03b5\u03bd \u03c4\u1f74\u03bd \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03bd",
-            "transliteration": "\u0113noixen t\u0113n kardian",
+            "word": "ἤνοιξεν τὴν καρδίαν",
+            "transliteration": "ēnoixen tēn kardian",
             "gloss": "opened her heart",
-            "paragraph": "the Lord opened Lydia's heart (v.14) \u2014 a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (di\u0113noigen) implies a sealed container being unsealed \u2014 Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
+            "paragraph": "the Lord opened Lydia's heart (v.14) — a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (diēnoigen) implies a sealed container being unsealed — Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
           }
         ],
         "places": [
           {
             "name": "Troas",
-            "coords": "39.7500\u00b0 N, 26.1333\u00b0 E",
-            "text": "The port city of Alexandria Troas on the Aegean coast of Asia Minor \u2014 the point where Paul crosses from Asia to Europe. The Macedonian vision (v.9) comes here; the 'we' sections begin here (v.10), indicating Luke joined the party. Troas is the hinge between the Asian and European missions."
+            "coords": "39.7500° N, 26.1333° E",
+            "text": "The port city of Alexandria Troas on the Aegean coast of Asia Minor — the point where Paul crosses from Asia to Europe. The Macedonian vision (v.9) comes here; the 'we' sections begin here (v.10), indicating Luke joined the party. Troas is the hinge between the Asian and European missions."
           },
           {
             "name": "Philippi",
-            "coords": "41.0167\u00b0 N, 24.2833\u00b0 E",
-            "text": "A Roman colony in Macedonia (northern Greece), founded in 42 BC by Octavian and Antony after the Battle of Philippi. As a Roman colony, it had Roman law, Roman magistrates (strat\u0113goi), and a Latin-speaking upper class. The church Paul plants here will be the recipient of his most affectionate letter (Philippians)."
+            "coords": "41.0167° N, 24.2833° E",
+            "text": "A Roman colony in Macedonia (northern Greece), founded in 42 BC by Octavian and Antony after the Battle of Philippi. As a Roman colony, it had Roman law, Roman magistrates (stratēgoi), and a Latin-speaking upper class. The church Paul plants here will be the recipient of his most affectionate letter (Philippians)."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 49\u201350",
-            "name": "Macedonian Call \u2014 Europe Opens",
-            "text": "The Spirit blocks Asia and Bithynia and directs Paul to Troas. The Macedonian vision confirms the call westward. Paul crosses into Europe \u2014 the Gospel reaches Greece for the first time.",
+            "date": "c. AD 49–50",
+            "name": "Macedonian Call — Europe Opens",
+            "text": "The Spirit blocks Asia and Bithynia and directs Paul to Troas. The Macedonian vision confirms the call westward. Paul crosses into Europe — the Gospel reaches Greece for the first time.",
             "current": true
           },
           {
             "date": "c. AD 50",
-            "name": "Philippi \u2014 First European Church",
+            "name": "Philippi — First European Church",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 50\u201351",
+            "date": "c. AD 50–51",
             "name": "Thessalonica, Athens, Corinth",
             "text": "",
             "current": false
@@ -345,86 +345,41 @@
         "cross": {
           "refs": [
             {
-              "ref": "Philippians 1:3\u20135",
-              "note": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" \u2014 Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in its founding (Lydia's house) becomes his most trusted partner."
+              "ref": "Philippians 1:3–5",
+              "note": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" — Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in its founding (Lydia's house) becomes his most trusted partner."
             },
             {
               "ref": "Acts 16:10",
-              "note": "The first \"we\" passage \u2014 Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony."
+              "note": "The first \"we\" passage — Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony."
             },
             {
               "ref": "2 Corinthians 11:25",
-              "note": "\"Three times I was beaten with rods\" \u2014 Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings."
+              "note": "\"Three times I was beaten with rods\" — Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:6\u20137",
-              "note": "MacArthur on the Spirit's redirection: the mission's geography is determined not by human strategic planning but by the Spirit's active guidance. MacArthur uses this to argue against both the paralysis of waiting for clear divine direction and the presumptuousness of acting without it. Paul moved forward until the Spirit blocked; then he paused and received new direction. This is the model for Spirit-led mission."
-            },
-            {
-              "ref": "16:14",
-              "note": "MacArthur on Lydia's conversion: 'the Lord opened her heart' \u2014 MacArthur emphasises that this is not a synergistic co-operation between God and Lydia but a divine act that enabled her response. God opened; she responded. MacArthur uses this as his key Acts text for irresistible grace: God's opening of the heart makes the subsequent believing certain, not merely possible."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:9",
-              "note": "Calvin on the Macedonian vision: the vision is not sought but given \u2014 Paul does not manufacture guidance by extended prayer or method, but receives it in the night. Calvin uses this to argue against both the mysticism that seeks visions and the rationalism that dismisses them. God guides as and when he chooses; the servant's role is attentive readiness."
-            },
-            {
-              "ref": "16:14",
-              "note": "Calvin on 'the Lord opened her heart to respond': this is Calvin's proof text for the doctrine of effectual calling. God does not merely offer the Gospel and wait; he opens hearts. The opening is not compulsion (Lydia responds freely) but regeneration (she could not have responded without the opening). Calvin's ordo salutis is embedded in this single verse."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:12",
-              "note": "The NET notes a textual variant in the description of Philippi: 'a leading city (pr\u014dt\u0113) of the district' vs. 'a city of the first district (pr\u014dt\u0113s meridos)' of Macedonia. Either reading confirms Philippi's prominence. The NET prefers 'a leading city' as the most natural reading."
-            },
-            {
-              "ref": "16:16",
-              "note": "The NET notes that the slave girl had a \"python spirit\" (pneuma pyth\u014dna) \u2014 the Python was the mythological serpent at Delphi, associated with prophetic powers. Her owners were exploiting a genuine supernatural ability (accurate prediction) for profit. Paul's exorcism destroyed their economic asset, which is the direct cause of his arrest \u2014 the Gospel's conflict with exploitative economics is the real issue."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "16:6\u20137",
-              "note": "Robertson on the Spirit's double blocking: the Spirit of the Lord prevents entry into Asia (v.6) and the Spirit of Jesus prevents entry into Bithynia (v.7). Robertson notes that Luke uses two slightly different phrases for the same Spirit \u2014 both \"Holy Spirit\" and \"Spirit of Jesus\" are used interchangeably, confirming the full Trinitarian identity of the Spirit with Jesus."
-            },
-            {
-              "ref": "16:14",
-              "note": "Robertson on \"the Lord opened her heart to respond to Paul's message\" \u2014 Robertson notes the divine passive with the Lord as agent. Paul preached; God opened. Robertson uses this to argue for both the necessity of proclamation (Paul's role) and the necessity of divine action (the Lord's role) in conversion \u2014 neither alone is sufficient."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:12",
-              "note": "Keener notes Philippi's status as a Roman colony (colonia). Roman colonies were formally Roman soil, populated by Roman veterans and citizens, governed by Roman law. The magistrates (strat\u0113goi, the Roman equivalent of duoviri) Paul faces are Roman officials. The charge against Paul and Silas (v.20\u201321) \u2014 advocating unlawful customs for Romans \u2014 makes sense only in this Roman colonial context."
-            },
-            {
-              "ref": "16:14",
-              "note": "Keener provides background on Lydia. Purple cloth (porphyrop\u014dlis \u2014 dealer in purple goods) was an extremely lucrative trade \u2014 purple dye from the murex shellfish or the madder plant was the most expensive textile colourant in the ancient world. Lydia was a wealthy, independent businesswoman from Thyatira (in Lydia, Asia Minor). Her household baptism and hospitality establish her as the first Christian in Europe."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels the mission westward toward Macedonia \u2014 and the Macedonian vision confirms the direction. The 'we' sections begin at v.10, indicating Luke is now a firsthand witness. Philippi provides three conversion vignettes that represent three social strata: Lydia (wealthy merchant, high-status woman), the slave girl (lowest social status), and the jailer (Roman official, mid-level authority) \u2014 the Gospel's reach spans the entire social spectrum."
+          "context": "Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels the mission westward toward Macedonia — and the Macedonian vision confirms the direction. The 'we' sections begin at v.10, indicating Luke is now a firsthand witness. Philippi provides three conversion vignettes that represent three social strata: Lydia (wealthy merchant, high-status woman), the slave girl (lowest social status), and the jailer (Roman official, mid-level authority) — the Gospel's reach spans the entire social spectrum."
         }
       }
     }
@@ -432,43 +387,43 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Paul\u2197 People",
+        "name": "Paul↗ People",
         "role": "Apostle to the Gentiles; author of thirteen NT letters",
-        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen\u2019s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13\u201328 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts\u2019 theological climax: the gospel reaching the empire\u2019s capital, \"boldly and without hindrance\" (Acts 28:31)."
+        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen’s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13–28 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts’ theological climax: the gospel reaching the empire’s capital, \"boldly and without hindrance\" (Acts 28:31)."
       },
       {
-        "name": "Philip\u2197 People",
+        "name": "Philip↗ People",
         "role": "Evangelist; deacon who brought the gospel to Samaria and Ethiopia",
-        "text": "Philip the evangelist (distinct from Philip the apostle) is one of the seven deacons of Acts 6. Scattered by Stephen\u2019s persecution, he preaches in Samaria with signs and wonders (Acts 8:4\u201313), then is directed by an angel to the Ethiopian eunuch on the Gaza road (Acts 8:26\u201340), baptising him and inaugurating the gospel\u2019s African reach. He later hosts Paul at Caesarea (Acts 21:8)."
+        "text": "Philip the evangelist (distinct from Philip the apostle) is one of the seven deacons of Acts 6. Scattered by Stephen’s persecution, he preaches in Samaria with signs and wonders (Acts 8:4–13), then is directed by an angel to the Ethiopian eunuch on the Gaza road (Acts 8:26–40), baptising him and inaugurating the gospel’s African reach. He later hosts Paul at Caesarea (Acts 21:8)."
       },
       {
-        "name": "Silas\u2197 People",
-        "role": "Prophet and Paul\u2019s companion on the second missionary journey",
-        "text": "Silas (Silvanus) is a leading figure in the Jerusalem church and a prophet (Acts 15:32) chosen by Paul to replace Barnabas after their split. He accompanies Paul through Macedonia, Philippi (imprisoned together, Acts 16:25\u201334), Thessalonica, Berea, and Corinth. His Roman citizenship alongside Paul\u2019s creates the legal dynamic at Philippi. He is co-author of both Thessalonian letters."
+        "name": "Silas↗ People",
+        "role": "Prophet and Paul’s companion on the second missionary journey",
+        "text": "Silas (Silvanus) is a leading figure in the Jerusalem church and a prophet (Acts 15:32) chosen by Paul to replace Barnabas after their split. He accompanies Paul through Macedonia, Philippi (imprisoned together, Acts 16:25–34), Thessalonica, Berea, and Corinth. His Roman citizenship alongside Paul’s creates the legal dynamic at Philippi. He is co-author of both Thessalonian letters."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>During the night Paul had a vision of a man of Macedonia standing and begging him, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And a vision appeared to Paul in the night: a man of Macedonia was standing there, urging him and saying, \u201cCome over to Macedonia and help us.\u201d</td></tr><tr><td class=\"t-label\">NIV</td><td>Paul and his companions traveled throughout the region of Phrygia and Galatia, having been kept by the Holy Spirit from preaching the word in the province of Asia.</td></tr><tr><td class=\"t-label\">ESV</td><td>And they went through the region of Phrygia and Galatia, having been forbidden by the Holy Spirit to speak the word in Asia.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>During the night Paul had a vision of a man of Macedonia standing and begging him, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And a vision appeared to Paul in the night: a man of Macedonia was standing there, urging him and saying, “Come over to Macedonia and help us.”</td></tr><tr><td class=\"t-label\">NIV</td><td>Paul and his companions traveled throughout the region of Phrygia and Galatia, having been kept by the Holy Spirit from preaching the word in the province of Asia.</td></tr><tr><td class=\"t-label\">ESV</td><td>And they went through the region of Phrygia and Galatia, having been forbidden by the Holy Spirit to speak the word in Asia.</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
@@ -478,18 +433,18 @@
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201410 \u2014 Timothy Joins; The Macedonian Vision; Lydia Converted",
-          "text": "Context  Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels th\u2026",
+          "label": "Verses 1—10 — Timothy Joins; The Macedonian Vision; Lydia Converted",
+          "text": "Context  Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels th…",
           "is_key": false
         },
         {
-          "label": "Verses 11\u201424 \u2014 Philippi: The Slave Girl; Paul and Silas Imprisoned",
-          "text": "Context  The midnight worship of Paul and Silas (v.25) is one of the most remarkable scenes in Acts: flogged, feet in st\u2026",
+          "label": "Verses 11—24 — Philippi: The Slave Girl; Paul and Silas Imprisoned",
+          "text": "Context  The midnight worship of Paul and Silas (v.25) is one of the most remarkable scenes in Acts: flogged, feet in st…",
           "is_key": false
         },
         {
-          "label": "Verses 25\u201440 \u2014 The Philippian Jailer: What Must I Do to Be Saved?",
-          "text": "Context  Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels th\u2026",
+          "label": "Verses 25—40 — The Philippian Jailer: What Must I Do to Be Saved?",
+          "text": "Context  Acts 16 is the pivot into Europe. The Spirit's double-blocking (Asia prevented, Bithynia prevented) channels th…",
           "is_key": false
         }
       ],
@@ -497,83 +452,83 @@
     },
     "hebtext": [
       {
-        "word": "\u03bf\u1f50\u03ba \u03b5\u1f34\u03b1\u03c3\u03b5\u03bd \u03b1\u1f50\u03c4\u03bf\u1f7a\u03c2 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u1f38\u03b7\u03c3\u03bf\u1fe6",
-        "tlit": "ouk eiasen autous to pneuma I\u0113sou",
+        "word": "οὐκ εἴασεν αὐτοὺς τὸ πνεῦμα Ἰησοῦ",
+        "tlit": "ouk eiasen autous to pneuma Iēsou",
         "gloss": "the Spirit of Jesus would not allow them",
-        "note": "v.7 \u2014 one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission \u2014 blocking Asia and Bithynia, opening Macedonia \u2014 demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
+        "note": "v.7 — one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission — blocking Asia and Bithynia, opening Macedonia — demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
       },
       {
-        "word": "\u1f24\u03bd\u03bf\u03b9\u03be\u03b5\u03bd \u03c4\u1f74\u03bd \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03bd",
-        "tlit": "\u0113noixen t\u0113n kardian",
+        "word": "ἤνοιξεν τὴν καρδίαν",
+        "tlit": "ēnoixen tēn kardian",
         "gloss": "opened her heart",
-        "note": "the Lord opened Lydia's heart (v.14) \u2014 a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (di\u0113noigen) implies a sealed container being unsealed \u2014 Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
+        "note": "the Lord opened Lydia's heart (v.14) — a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (diēnoigen) implies a sealed container being unsealed — Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
       },
       {
-        "word": "\u03c3\u03ce\u03b6\u03bf\u03bc\u03b1\u03b9",
-        "tlit": "s\u014dzomai",
+        "word": "σώζομαι",
+        "tlit": "sōzomai",
         "gloss": "to be saved",
-        "note": "the jailer's question 'What must I do to be saved?' (v.30) uses the most comprehensive Greek word for salvation \u2014 s\u014dz\u014d covers physical rescue, healing, and eternal deliverance. In context he may initially mean 'rescue from my predicament,' but Paul's answer ('Believe in the Lord Jesus') addresses the ultimate dimension. The question is answered at its deepest level."
+        "note": "the jailer's question 'What must I do to be saved?' (v.30) uses the most comprehensive Greek word for salvation — sōzō covers physical rescue, healing, and eternal deliverance. In context he may initially mean 'rescue from my predicament,' but Paul's answer ('Believe in the Lord Jesus') addresses the ultimate dimension. The question is answered at its deepest level."
       },
       {
-        "word": "\u1fec\u03c9\u03bc\u03b1\u1fd6\u03bf\u03af",
-        "tlit": "Rh\u014dmaioi",
+        "word": "Ῥωμαῖοί",
+        "tlit": "Rhōmaioi",
         "gloss": "Roman citizens",
-        "note": "v.37 \u2014 Paul's assertion of Roman citizenship is not a contradiction of his willingness to suffer but a strategic use of legal rights for the church's protection. As Roman citizens, Paul and Silas were entitled to a proper trial before punishment \u2014 their beating without trial (v.37: akatakritous) was illegal. Paul insists on public exoneration to protect the Philippi church from accusations of harbouring criminals."
+        "note": "v.37 — Paul's assertion of Roman citizenship is not a contradiction of his willingness to suffer but a strategic use of legal rights for the church's protection. As Roman citizens, Paul and Silas were entitled to a proper trial before punishment — their beating without trial (v.37: akatakritous) was illegal. Paul insists on public exoneration to protect the Philippi church from accusations of harbouring criminals."
       },
       {
-        "word": "\u03bf\u1f50\u03ba \u03b5\u1f34\u03b1\u03c3\u03b5\u03bd \u03b1\u1f50\u03c4\u03bf\u1f7a\u03c2 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u1f38\u03b7\u03c3\u03bf\u1fe6",
-        "tlit": "ouk eiasen autous to pneuma I\u0113sou",
+        "word": "οὐκ εἴασεν αὐτοὺς τὸ πνεῦμα Ἰησοῦ",
+        "tlit": "ouk eiasen autous to pneuma Iēsou",
         "gloss": "the Spirit of Jesus would not allow them",
-        "note": "v.7 \u2014 one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission \u2014 blocking Asia and Bithynia, opening Macedonia \u2014 demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
+        "note": "v.7 — one of only two NT uses of 'Spirit of Jesus' (also Phil 1:19). The Spirit's active redirection of the mission — blocking Asia and Bithynia, opening Macedonia — demonstrates that the Holy Spirit is not merely a power empowering human initiative but a personal agent directing the mission according to his own purposes."
       },
       {
-        "word": "\u1f24\u03bd\u03bf\u03b9\u03be\u03b5\u03bd \u03c4\u1f74\u03bd \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03bd",
-        "tlit": "\u0113noixen t\u0113n kardian",
+        "word": "ἤνοιξεν τὴν καρδίαν",
+        "tlit": "ēnoixen tēn kardian",
         "gloss": "opened her heart",
-        "note": "the Lord opened Lydia's heart (v.14) \u2014 a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (di\u0113noigen) implies a sealed container being unsealed \u2014 Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
+        "note": "the Lord opened Lydia's heart (v.14) — a divine-passive construction: God is the agent of her conversion, not merely the occasion for it. 'Opened' (diēnoigen) implies a sealed container being unsealed — Lydia's heart was closed to this message until God opened it. This is Luke's most explicit statement of divine action in individual conversion."
       }
     ],
     "thread": [
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Philippians 1:3\u20135",
+        "target": "Philippians 1:3–5",
         "type": "Connection",
-        "text": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" \u2014 Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in i\u2026",
+        "text": "\"In all my prayers for all of you, I always pray with joy because of your partnership in the gospel from the first day until now\" — Paul's letter to the Philippian church is the direct fruit of the Acts 16 mission. The church that sheltered Paul in i…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Acts 16:10",
         "type": "Connection",
-        "text": "The first \"we\" passage \u2014 Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony.",
+        "text": "The first \"we\" passage — Luke joins the party at Troas. The eyewitness perspective that \"we got ready at once to leave for Macedonia\" anchors the European mission in direct personal testimony.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "2 Corinthians 11:25",
         "type": "Connection",
-        "text": "\"Three times I was beaten with rods\" \u2014 Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings.",
+        "text": "\"Three times I was beaten with rods\" — Paul's reference confirms the Philippi flogging of Acts 16:22 as one of multiple such beatings.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Acts 5:19",
         "type": "Connection",
-        "text": "The angelic prison escape of Acts 5 \u2014 the earthquake in Acts 16 follows the same providential pattern: God delivers his servants from maximum-security imprisonment.",
+        "text": "The angelic prison escape of Acts 5 — the earthquake in Acts 16 follows the same providential pattern: God delivers his servants from maximum-security imprisonment.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Philippians 4:4",
         "type": "Connection",
-        "text": "\"Rejoice in the Lord always. I will say it again: Rejoice!\" \u2014 Paul writes this from prison. The midnight singing at Philippi (Acts 16:25) is the biographical foundation of Paul's theology of joy-in-suffering.",
+        "text": "\"Rejoice in the Lord always. I will say it again: Rejoice!\" — Paul writes this from prison. The midnight singing at Philippi (Acts 16:25) is the biographical foundation of Paul's theology of joy-in-suffering.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Romans 13:1\u20137",
+        "target": "Romans 13:1–7",
         "type": "Connection",
-        "text": "Paul's later teaching on submission to governing authorities is not contradicted by his claim of rights in v.37 \u2014 he uses legal channels, not rebellion, to defend the church's position.",
+        "text": "Paul's later teaching on submission to governing authorities is not contradicted by his claim of rights in v.37 — he uses legal channels, not rebellion, to defend the church's position.",
         "direction": "backward"
       }
     ],
@@ -581,14 +536,14 @@
       {
         "ref": "Acts 16",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 16 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -598,12 +553,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -768,12 +723,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Come over to Macedonia and help us' (v. 9). Paul's vision redirects the mission westward\u2014into Europe. Providence closes Asian doors to open European ones. A jailer's conversion follows a midnight earthquake.",
+      "tip": "'Come over to Macedonia and help us' (v. 9). Paul's vision redirects the mission westward—into Europe. Providence closes Asian doors to open European ones. A jailer's conversion follows a midnight earthquake.",
       "genre_tag": "structure_guide"
     },
     {
       "after_section": 2,
-      "tip": "'Believe in the Lord Jesus, and you will be saved\u2014you and your household' (v. 31). The Philippian jailer asks the essential question; Paul gives the essential answer. Household conversion\u2014family faith.",
+      "tip": "'Believe in the Lord Jesus, and you will be saved—you and your household' (v. 31). The Philippian jailer asks the essential question; Paul gives the essential answer. Household conversion—family faith.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/acts/2.json
+++ b/content/acts/2.json
@@ -4,60 +4,60 @@
   "book_dir": "acts",
   "chapter_num": 2,
   "title": "Acts 2",
-  "subtitle": "Pentecost \u2014 The Spirit Poured Out",
+  "subtitle": "Pentecost — The Spirit Poured Out",
   "timeline_link": {
     "event_id": "pentecost",
-    "text": "See on Timeline \u2014 Pentecost"
+    "text": "See on Timeline — Pentecost"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201413 \u2014 The Day of Pentecost: Filled with the Holy Spirit",
+      "header": "Verses 1—13 — The Day of Pentecost: Filled with the Holy Spirit",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c5\u03bc\u03c0\u03bb\u03b7\u03c1\u03bf\u1fe6\u03c3\u03b8\u03b1\u03b9",
-            "transliteration": "sympl\u0113rousthai",
+            "word": "συμπληροῦσθαι",
+            "transliteration": "symplērousthai",
             "gloss": "was being fulfilled",
-            "paragraph": "imperfect passive of sympl\u0113ro\u014d \u2014 Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
+            "paragraph": "imperfect passive of symplēroō — Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
           },
           {
-            "word": "\u1f10\u03ba\u03c0\u03bb\u03b7\u03c1\u03cc\u03c9 / \u1f41\u03bc\u03bf\u1fe6",
+            "word": "ἐκπληρόω / ὁμοῦ",
             "transliteration": "homou",
             "gloss": "together in one place",
-            "paragraph": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") \u2014 either way, corporate oneness precedes corporate blessing."
+            "paragraph": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") — either way, corporate oneness precedes corporate blessing."
           }
         ],
         "places": [
           {
-            "name": "Jerusalem \u2014 Upper City",
-            "coords": "31.7705\u00b0 N, 35.2294\u00b0 E",
-            "text": "The house (oikos, v2) was likely in the upper city residential district, possibly the same upper room of 1:13. The sound \"filled the whole house\" \u2014 a private dwelling, not the Temple, which had not yet opened for the day."
+            "name": "Jerusalem — Upper City",
+            "coords": "31.7705° N, 35.2294° E",
+            "text": "The house (oikos, v2) was likely in the upper city residential district, possibly the same upper room of 1:13. The sound \"filled the whole house\" — a private dwelling, not the Temple, which had not yet opened for the day."
           },
           {
-            "name": "The Nations of v9\u201311",
-            "coords": "0\u00b0 N, 0\u00b0 E",
-            "text": "The geographic sweep of the Diaspora crowd \u2014 from Parthia (east) to Rome (west) to Libya and Crete (south) \u2014 represents the inhabited world. Luke's list is the reverse of Babel: languages scattered at judgment, language barriers crossed at Pentecost."
+            "name": "The Nations of v9–11",
+            "coords": "0° N, 0° E",
+            "text": "The geographic sweep of the Diaspora crowd — from Parthia (east) to Rome (west) to Libya and Crete (south) — represents the inhabited world. Luke's list is the reverse of Babel: languages scattered at judgment, language barriers crossed at Pentecost."
           }
         ],
         "tl": [
           {
             "date": "c. 1446 BC",
-            "name": "Sinai \u2014 Torah Given",
+            "name": "Sinai — Torah Given",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Pentecost \u2014 Spirit Poured Out",
+            "name": "Pentecost — Spirit Poured Out",
             "text": "Fifty days after the resurrection-Passover, the Spirit descends on 120 gathered disciples in Jerusalem. Three thousand are baptized. The church is born as the new covenant community.",
             "current": true
           },
           {
-            "date": "c. AD 30\u2013100",
+            "date": "c. AD 30–100",
             "name": "Global Spread",
             "text": "",
             "current": false
@@ -66,130 +66,130 @@
         "cross": {
           "refs": [
             {
-              "ref": "Joel 2:28\u201332",
-              "note": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" \u2014 the Spirit poured on all flesh, marking the dawn of the messianic age."
+              "ref": "Joel 2:28–32",
+              "note": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" — the Spirit poured on all flesh, marking the dawn of the messianic age."
             },
             {
-              "ref": "Ezekiel 36:26\u201327",
-              "note": "The promised new heart and Spirit within Israel \u2014 the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality)."
+              "ref": "Ezekiel 36:26–27",
+              "note": "The promised new heart and Spirit within Israel — the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality)."
             },
             {
-              "ref": "Genesis 11:1\u20139",
+              "ref": "Genesis 11:1–9",
               "note": "The reversal of Babel is the implicit theological background: languages scattered at judgment; language barriers crossed at Pentecost."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "2:1\u20134",
-              "note": "Pentecost was a one-time, non-repeatable event \u2014 the inauguration of the new covenant age. Just as Calvary was once-for-all, so was Pentecost. The sign of tongues served an evangelistic purpose for Diaspora Jews, not a devotional template for all subsequent believers."
+              "ref": "2:1–4",
+              "note": "Pentecost was a one-time, non-repeatable event — the inauguration of the new covenant age. Just as Calvary was once-for-all, so was Pentecost. The sign of tongues served an evangelistic purpose for Diaspora Jews, not a devotional template for all subsequent believers."
             },
             {
               "ref": "2:17",
-              "note": "Peter adds \"in the last days\" to Joel's \"after these things\" \u2014 a significant interpretive move identifying the present moment as the inauguration of the messianic last days. Pentecost is the beginning of the end, not the end itself."
+              "note": "Peter adds \"in the last days\" to Joel's \"after these things\" — a significant interpretive move identifying the present moment as the inauguration of the messianic last days. Pentecost is the beginning of the end, not the end itself."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:4",
               "note": "The Spirit filling \"all of them\" fulfils the democratic vision of Numbers 11:29 where Moses wished all the Lord's people were prophets. The new covenant reality is universal access to the Spirit, not confined to leaders or specialists."
             },
             {
-              "ref": "2:17\u201318",
-              "note": "Calvin notes the prophetic scope: \"your sons and daughters will prophesy\" \u2014 the Spirit's gifts in the new age are not restricted by gender or age. The new covenant community is constituted by the Spirit's work in all its members."
+              "ref": "2:17–18",
+              "note": "Calvin notes the prophetic scope: \"your sons and daughters will prophesy\" — the Spirit's gifts in the new age are not restricted by gender or age. The new covenant community is constituted by the Spirit's work in all its members."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:17",
               "note": "Peter's quotation of Joel 2:28 adds \"in the last days\" to Joel's \"after these things,\" interpreting the temporal marker as eschatological. Peter identifies the present moment as the dawn of the messianic age."
             },
             {
-              "ref": "2:19\u201320",
-              "note": "The cosmic signs of blood, fire, smoke, sun darkened, and moon to blood have not yet been literally fulfilled. Luke preserves the full Joel quotation including the unfulfilled portion \u2014 Pentecost is the inaugurated beginning, not the consummation, of the \"last days.\""
+              "ref": "2:19–20",
+              "note": "The cosmic signs of blood, fire, smoke, sun darkened, and moon to blood have not yet been literally fulfilled. Luke preserves the full Joel quotation including the unfulfilled portion — Pentecost is the inaugurated beginning, not the consummation, of the \"last days.\""
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
-              "ref": "2:2\u20134",
-              "note": "The sound was like wind (\u0113chos biaias pno\u0113s) but the tongues were like fire (h\u014dsei pyros) \u2014 Luke uses similes, not identity. This is not literal wind or literal flame but phenomena resembling them, echoing the Baptist's prediction that the Messiah would baptize \"with the Holy Spirit and fire\" (Luke 3:16)."
+              "ref": "2:2–4",
+              "note": "The sound was like wind (ēchos biaias pnoēs) but the tongues were like fire (hōsei pyros) — Luke uses similes, not identity. This is not literal wind or literal flame but phenomena resembling them, echoing the Baptist's prediction that the Messiah would baptize \"with the Holy Spirit and fire\" (Luke 3:16)."
             },
             {
               "ref": "2:4",
-              "note": "\"Other tongues\" (heterais gl\u014dssais) \u2014 Robertson defends these as genuine human languages (xenoglossy), not ecstatic utterance, on the grounds that the crowd immediately identifies their native languages (v8). The miracle is one of speaking, confirmed by miracles of hearing."
+              "note": "\"Other tongues\" (heterais glōssais) — Robertson defends these as genuine human languages (xenoglossy), not ecstatic utterance, on the grounds that the crowd immediately identifies their native languages (v8). The miracle is one of speaking, confirmed by miracles of hearing."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "2:1\u20134",
-              "note": "By the first century many Jews associated Shavuot with the Sinai covenant (Jubilees; the Damascus Document from Qumran treated it as a covenant-renewal festival). Luke's audience familiar with these associations would hear in Pentecost a new covenant inauguration \u2014 the Spirit replacing the stone tablets."
+              "ref": "2:1–4",
+              "note": "By the first century many Jews associated Shavuot with the Sinai covenant (Jubilees; the Damascus Document from Qumran treated it as a covenant-renewal festival). Luke's audience familiar with these associations would hear in Pentecost a new covenant inauguration — the Spirit replacing the stone tablets."
             },
             {
-              "ref": "2:9\u201311",
+              "ref": "2:9–11",
               "note": "The list of nations follows a roughly geographic sweep from east to west, consistent with ancient geographic conventions. The presence of \"visitors from Rome\" (v10) foreshadows the book's destination: Rome is already represented at the church's birth."
             }
           ]
         },
         "hist": {
-          "context": "Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first century it had also acquired associations with the giving of the Torah at Sinai. Luke's timing is not accidental: the Spirit comes at the festival that celebrated God's covenant word, now replacing the law of stone with the law written on hearts (Jer 31:33; Ezek 36:27). The list of nations in vv.9\u201311 is a reverse-Babel: at Babel the nations were scattered by language confusion; at Pentecost they are gathered by a unified message heard in every language."
+          "context": "Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first century it had also acquired associations with the giving of the Torah at Sinai. Luke's timing is not accidental: the Spirit comes at the festival that celebrated God's covenant word, now replacing the law of stone with the law written on hearts (Jer 31:33; Ezek 36:27). The list of nations in vv.9–11 is a reverse-Babel: at Babel the nations were scattered by language confusion; at Pentecost they are gathered by a unified message heard in every language."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201436 \u2014 Peter\u2019s Sermon: This Is What Was Spoken by the Prophet Joel",
+      "header": "Verses 14—36 — Peter’s Sermon: This Is What Was Spoken by the Prophet Joel",
       "verse_start": 14,
       "verse_end": 36,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03b1\u03c4\u03b5\u03bd\u03cd\u03b3\u03b7\u03c3\u03b1\u03bd",
+            "word": "κατενύγησαν",
             "transliteration": "katenygesan",
             "gloss": "were cut to the heart",
-            "paragraph": "a hapax legomenon in the NT \u2014 from nyss\u014d (to pierce, to sting). The crowd's hearing of the crucified Messiah produces a sharp, painful recognition of guilt. This is not mere sentiment but the beginning of genuine repentance."
+            "paragraph": "a hapax legomenon in the NT — from nyssō (to pierce, to sting). The crowd's hearing of the crucified Messiah produces a sharp, painful recognition of guilt. This is not mere sentiment but the beginning of genuine repentance."
           },
           {
-            "word": "\u03bc\u03b5\u03c4\u03b1\u03bd\u03bf\u03ae\u03c3\u03b1\u03c4\u03b5",
-            "transliteration": "metano\u0113sate",
+            "word": "μετανοήσατε",
+            "transliteration": "metanoēsate",
             "gloss": "repent",
-            "paragraph": "aorist imperative \u2014 urgent, decisive. Not emotional remorse alone but a fundamental reorientation of mind and life toward God. Peter's use echoes Jesus's own inaugural proclamation (Mark 1:15)."
+            "paragraph": "aorist imperative — urgent, decisive. Not emotional remorse alone but a fundamental reorientation of mind and life toward God. Peter's use echoes Jesus's own inaugural proclamation (Mark 1:15)."
           }
         ],
         "places": [
           {
             "name": "Solomon's Colonnade",
-            "coords": "31.7767\u00b0 N, 35.2354\u00b0 E",
-            "text": "The covered eastern portico of the Temple Mount \u2014 the early church's regular public gathering place (2:46; 3:11; 5:12). A sheltered, visible space where teaching could reach the entire Jerusalem population."
+            "coords": "31.7767° N, 35.2354° E",
+            "text": "The covered eastern portico of the Temple Mount — the early church's regular public gathering place (2:46; 3:11; 5:12). A sheltered, visible space where teaching could reach the entire Jerusalem population."
           },
           {
             "name": "House to House",
-            "coords": "31.7705\u00b0 N, 35.2294\u00b0 E",
-            "text": "The breaking of bread \"home by home\" (kat' oikon, v46) indicates a network of household communities, not one central meeting place. The earliest church structure was the household \u2014 intimate community alongside public proclamation."
+            "coords": "31.7705° N, 35.2294° E",
+            "text": "The breaking of bread \"home by home\" (kat' oikon, v46) indicates a network of household communities, not one central meeting place. The earliest church structure was the household — intimate community alongside public proclamation."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
             "name": "Three Thousand Baptized",
-            "text": "On the day of Pentecost, Peter's sermon leads to the baptism of about three thousand people. The Jerusalem church begins with this large, Diaspora-connected community \u2014 the seed of the global church.",
+            "text": "On the day of Pentecost, Peter's sermon leads to the baptism of about three thousand people. The Jerusalem church begins with this large, Diaspora-connected community — the seed of the global church.",
             "current": true
           },
           {
-            "date": "c. AD 30\u201335",
+            "date": "c. AD 30–35",
             "name": "Jerusalem Community",
             "text": "",
             "current": false
@@ -204,166 +204,166 @@
         "cross": {
           "refs": [
             {
-              "ref": "Psalm 16:8\u201311",
-              "note": "Cited in vv.25\u201328 \u2014 \"you will not abandon me to the realm of the dead.\" Peter argues David could not have written this about himself (he died and his tomb remains) but prophetically of the Messiah's resurrection."
+              "ref": "Psalm 16:8–11",
+              "note": "Cited in vv.25–28 — \"you will not abandon me to the realm of the dead.\" Peter argues David could not have written this about himself (he died and his tomb remains) but prophetically of the Messiah's resurrection."
             },
             {
               "ref": "Psalm 110:1",
-              "note": "\"The Lord said to my Lord: Sit at my right hand\" \u2014 cited in vv.34\u201335. Jesus's session at the right hand is the ground of the Spirit's outpouring (v33: \"exalted to the right hand... he has poured out what you now see and hear\")."
+              "note": "\"The Lord said to my Lord: Sit at my right hand\" — cited in vv.34–35. Jesus's session at the right hand is the ground of the Spirit's outpouring (v33: \"exalted to the right hand... he has poured out what you now see and hear\")."
             },
             {
               "ref": "Exodus 32:28",
-              "note": "Three thousand killed at Sinai after the golden calf \u2014 the implicit contrast with three thousand given life at Pentecost."
+              "note": "Three thousand killed at Sinai after the golden calf — the implicit contrast with three thousand given life at Pentecost."
             }
           ],
           "echoes": [
             {
               "source_ref": "Psalm 110:1",
-              "target_ref": "Acts 2:34\u201335",
+              "target_ref": "Acts 2:34–35",
               "type": "direct_quote",
               "source_context": "The LORD invites David's lord to sit at his right hand in heavenly enthronement. This is royal installation language applied to a figure greater than David.",
               "connection": "Peter argues: David did not ascend to heaven, so he was not speaking about himself. Jesus, raised and exalted, now sits at God's right hand. The psalm finds its fulfillment.",
               "significance": "The right-hand session becomes central to NT christology: Jesus reigns now, at the Father's right hand, until all enemies are subdued. Present lordship, future consummation."
             },
             {
-              "source_ref": "Joel 2:28\u201332",
-              "target_ref": "Acts 2:17\u201321",
+              "source_ref": "Joel 2:28–32",
+              "target_ref": "Acts 2:17–21",
               "type": "direct_quote",
-              "source_context": "Joel prophesied that in the last days God would pour out his Spirit on all flesh \u2014 sons and daughters, old and young, servants and slaves would prophesy. Before the great day of the Lord, cosmic signs would appear.",
+              "source_context": "Joel prophesied that in the last days God would pour out his Spirit on all flesh — sons and daughters, old and young, servants and slaves would prophesy. Before the great day of the Lord, cosmic signs would appear.",
               "connection": "Peter's Pentecost sermon begins: 'This is what was spoken by the prophet Joel.' The Spirit's outpouring on the multilingual crowd fulfills the 'all flesh' promise. The last days have begun.",
-              "significance": "Pentecost is not novelty but prophecy fulfilled. The Spirit's democratization \u2014 no longer limited to prophets, priests, and kings \u2014 signals the new age Joel announced."
+              "significance": "Pentecost is not novelty but prophecy fulfilled. The Spirit's democratization — no longer limited to prophets, priests, and kings — signals the new age Joel announced."
             },
             {
-              "source_ref": "2 Samuel 7:12\u201313",
-              "target_ref": "Acts 2:30\u201331",
+              "source_ref": "2 Samuel 7:12–13",
+              "target_ref": "Acts 2:30–31",
               "type": "allusion",
-              "source_context": "God promised David that his offspring would sit on his throne forever. The Davidic covenant established an eternal dynasty \u2014 but how can any merely human king reign forever?",
-              "connection": "Peter argues David was a prophet who knew his descendant would be raised from the dead to sit on his throne. The resurrection is how the eternal-throne promise is kept \u2014 through a king who cannot die.",
+              "source_context": "God promised David that his offspring would sit on his throne forever. The Davidic covenant established an eternal dynasty — but how can any merely human king reign forever?",
+              "connection": "Peter argues David was a prophet who knew his descendant would be raised from the dead to sit on his throne. The resurrection is how the eternal-throne promise is kept — through a king who cannot die.",
               "significance": "Resurrection becomes the interpretive key to the Davidic covenant. The promise was always about more than a human dynasty; it required a Son of David who conquers death itself."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:38",
-              "note": "MacArthur's careful exegesis: the preposition eis (\"for\") can indicate result or basis. He argues it means \"because of\" or \"in light of\" forgiveness already granted by repentance and faith \u2014 not that baptism causes forgiveness. Acts 3:19 (repent and turn, for forgiveness \u2014 no baptism mentioned) supports this reading."
+              "note": "MacArthur's careful exegesis: the preposition eis (\"for\") can indicate result or basis. He argues it means \"because of\" or \"in light of\" forgiveness already granted by repentance and faith — not that baptism causes forgiveness. Acts 3:19 (repent and turn, for forgiveness — no baptism mentioned) supports this reading."
             },
             {
               "ref": "2:42",
-              "note": "The four marks of the early church \u2014 apostolic teaching, fellowship, breaking of bread, prayer \u2014 are the irreducible minimum of authentic church life. They are not four programs but four dimensions of a single organic life centred on Christ."
+              "note": "The four marks of the early church — apostolic teaching, fellowship, breaking of bread, prayer — are the irreducible minimum of authentic church life. They are not four programs but four dimensions of a single organic life centred on Christ."
             },
             {
-              "ref": "2:46\u201347",
-              "note": "The pattern of \"temple courts plus homes\" models NT church structure: large gathered worship in a public space, intimate community in households. Both dimensions are necessary \u2014 public proclamation reaches the city; household fellowship forms disciples."
+              "ref": "2:46–47",
+              "note": "The pattern of \"temple courts plus homes\" models NT church structure: large gathered worship in a public space, intimate community in households. Both dimensions are necessary — public proclamation reaches the city; household fellowship forms disciples."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:42",
-              "note": "Calvin reads the four marks not as a description of the primitive church alone but as the permanent marks of the church in every age. Where these four are present \u2014 true doctrine, true fellowship, true sacraments, true prayer \u2014 there is the church."
+              "note": "Calvin reads the four marks not as a description of the primitive church alone but as the permanent marks of the church in every age. Where these four are present — true doctrine, true fellowship, true sacraments, true prayer — there is the church."
             },
             {
-              "ref": "2:44\u201345",
-              "note": "Calvin is careful not to establish a permanent communism from this passage. This was a temporary, Jerusalem-specific response to urgent need, not a universal economic model. The underlying principle \u2014 generous sharing with those in need \u2014 is permanent; the specific arrangement was circumstantial."
+              "ref": "2:44–45",
+              "note": "Calvin is careful not to establish a permanent communism from this passage. This was a temporary, Jerusalem-specific response to urgent need, not a universal economic model. The underlying principle — generous sharing with those in need — is permanent; the specific arrangement was circumstantial."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:46",
-              "note": "The NET notes that \"breaking bread\" (kl\u014dntes arton) without the article may refer to ordinary shared meals, while \"the breaking of bread\" with the article in v42 may refer to the Lord's Supper. Luke may be describing both the eucharistic practice and communal table fellowship as expressions of a single community reality."
+              "note": "The NET notes that \"breaking bread\" (klōntes arton) without the article may refer to ordinary shared meals, while \"the breaking of bread\" with the article in v42 may refer to the Lord's Supper. Luke may be describing both the eucharistic practice and communal table fellowship as expressions of a single community reality."
             },
             {
               "ref": "2:47",
-              "note": "\"The Lord added to their number daily those who were being saved\" \u2014 the passive \"were being saved\" (es\u014dzomenous) indicates that salvation is God's act. Luke's consistent use of the divine passive for salvation guards against a purely human-decision model of conversion."
+              "note": "\"The Lord added to their number daily those who were being saved\" — the passive \"were being saved\" (esōzomenous) indicates that salvation is God's act. Luke's consistent use of the divine passive for salvation guards against a purely human-decision model of conversion."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "2:38",
-              "note": "Robertson gives careful attention to eis aphesin hamarti\u014dn (\"for/unto the forgiveness of sins\"). He notes eis with the accusative can indicate aim or basis. The parallel in Matt 12:41 (repented at/eis the preaching of Jonah) shows the word does not require causation. The verse does not require baptismal regeneration."
+              "note": "Robertson gives careful attention to eis aphesin hamartiōn (\"for/unto the forgiveness of sins\"). He notes eis with the accusative can indicate aim or basis. The parallel in Matt 12:41 (repented at/eis the preaching of Jonah) shows the word does not require causation. The verse does not require baptismal regeneration."
             },
             {
               "ref": "2:42",
-              "note": "\"Breaking of bread\" (klasis tou artou) \u2014 used in Luke 24:35 for the Emmaus meal in which Christ was recognised. This likely refers to the Lord's Supper in its early informal, meal-context form \u2014 remembrance of Christ's death within a shared meal."
+              "note": "\"Breaking of bread\" (klasis tou artou) — used in Luke 24:35 for the Emmaus meal in which Christ was recognised. This likely refers to the Lord's Supper in its early informal, meal-context form — remembrance of Christ's death within a shared meal."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "2:41",
               "note": "Jerusalem had over forty ritual immersion pools (miqva'oth) excavated near the southern entrance to the Temple Mount, used for purification before entering the Temple. These would have provided ample facilities for the mass baptism of three thousand on a single day."
             },
             {
-              "ref": "2:44\u201345",
-              "note": "The communal sharing of the Jerusalem church differs from Qumran: Jerusalem sharing is voluntary and family-based, not an entrance requirement. Acts 5:4 confirms the voluntary nature \u2014 Ananias's sin was lying, not keeping property."
+              "ref": "2:44–45",
+              "note": "The communal sharing of the Jerusalem church differs from Qumran: Jerusalem sharing is voluntary and family-based, not an entrance requirement. Acts 5:4 confirms the voluntary nature — Ananias's sin was lying, not keeping property."
             }
           ]
         },
         "hist": {
-          "context": "Peter's sermon (vv.14\u201336) is organized around three OT proof-texts (Joel 2, Psalm 16, Psalm 110) building to the climactic declaration of v36: 'God has made this Jesus... both Lord and Messiah.' Each text answers a question: What is happening now? (Joel) What was the resurrection? (Psalm 16) What is his present status? (Psalm 110). The three-thousand baptisms are the Sinai reversal: at the golden calf, three thousand were killed (Exod 32:28); at Pentecost, three thousand receive life \u2014 the contrast between law that kills and Spirit that gives life (2 Cor 3:6)."
+          "context": "Peter's sermon (vv.14–36) is organized around three OT proof-texts (Joel 2, Psalm 16, Psalm 110) building to the climactic declaration of v36: 'God has made this Jesus... both Lord and Messiah.' Each text answers a question: What is happening now? (Joel) What was the resurrection? (Psalm 16) What is his present status? (Psalm 110). The three-thousand baptisms are the Sinai reversal: at the golden calf, three thousand were killed (Exod 32:28); at Pentecost, three thousand receive life — the contrast between law that kills and Spirit that gives life (2 Cor 3:6)."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 37\u201447 \u2014 Three Thousand Baptised; The Community of Believers",
+      "header": "Verses 37—47 — Three Thousand Baptised; The Community of Believers",
       "verse_start": 37,
       "verse_end": 47,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c5\u03bc\u03c0\u03bb\u03b7\u03c1\u03bf\u1fe6\u03c3\u03b8\u03b1\u03b9",
-            "transliteration": "sympl\u0113rousthai",
+            "word": "συμπληροῦσθαι",
+            "transliteration": "symplērousthai",
             "gloss": "was being fulfilled",
-            "paragraph": "imperfect passive of sympl\u0113ro\u014d \u2014 Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
+            "paragraph": "imperfect passive of symplēroō — Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
           },
           {
-            "word": "\u1f10\u03ba\u03c0\u03bb\u03b7\u03c1\u03cc\u03c9 / \u1f41\u03bc\u03bf\u1fe6",
+            "word": "ἐκπληρόω / ὁμοῦ",
             "transliteration": "homou",
             "gloss": "together in one place",
-            "paragraph": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") \u2014 either way, corporate oneness precedes corporate blessing."
+            "paragraph": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") — either way, corporate oneness precedes corporate blessing."
           }
         ],
         "places": [
           {
-            "name": "Jerusalem \u2014 Upper City",
-            "coords": "31.7705\u00b0 N, 35.2294\u00b0 E",
-            "text": "The house (oikos, v2) was likely in the upper city residential district, possibly the same upper room of 1:13. The sound \"filled the whole house\" \u2014 a private dwelling, not the Temple, which had not yet opened for the day."
+            "name": "Jerusalem — Upper City",
+            "coords": "31.7705° N, 35.2294° E",
+            "text": "The house (oikos, v2) was likely in the upper city residential district, possibly the same upper room of 1:13. The sound \"filled the whole house\" — a private dwelling, not the Temple, which had not yet opened for the day."
           },
           {
-            "name": "The Nations of v9\u201311",
-            "coords": "0\u00b0 N, 0\u00b0 E",
-            "text": "The geographic sweep of the Diaspora crowd \u2014 from Parthia (east) to Rome (west) to Libya and Crete (south) \u2014 represents the inhabited world. Luke's list is the reverse of Babel: languages scattered at judgment, language barriers crossed at Pentecost."
+            "name": "The Nations of v9–11",
+            "coords": "0° N, 0° E",
+            "text": "The geographic sweep of the Diaspora crowd — from Parthia (east) to Rome (west) to Libya and Crete (south) — represents the inhabited world. Luke's list is the reverse of Babel: languages scattered at judgment, language barriers crossed at Pentecost."
           }
         ],
         "tl": [
           {
             "date": "c. 1446 BC",
-            "name": "Sinai \u2014 Torah Given",
+            "name": "Sinai — Torah Given",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Pentecost \u2014 Spirit Poured Out",
+            "name": "Pentecost — Spirit Poured Out",
             "text": "Fifty days after the resurrection-Passover, the Spirit descends on 120 gathered disciples in Jerusalem. Three thousand are baptized. The church is born as the new covenant community.",
             "current": true
           },
           {
-            "date": "c. AD 30\u2013100",
+            "date": "c. AD 30–100",
             "name": "Global Spread",
             "text": "",
             "current": false
@@ -372,86 +372,41 @@
         "cross": {
           "refs": [
             {
-              "ref": "Joel 2:28\u201332",
-              "note": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" \u2014 the Spirit poured on all flesh, marking the dawn of the messianic age."
+              "ref": "Joel 2:28–32",
+              "note": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" — the Spirit poured on all flesh, marking the dawn of the messianic age."
             },
             {
-              "ref": "Ezekiel 36:26\u201327",
-              "note": "The promised new heart and Spirit within Israel \u2014 the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality)."
+              "ref": "Ezekiel 36:26–27",
+              "note": "The promised new heart and Spirit within Israel — the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality)."
             },
             {
-              "ref": "Genesis 11:1\u20139",
+              "ref": "Genesis 11:1–9",
               "note": "The reversal of Babel is the implicit theological background: languages scattered at judgment; language barriers crossed at Pentecost."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:1\u20134",
-              "note": "Pentecost was a one-time, non-repeatable event \u2014 the inauguration of the new covenant age. Just as Calvary was once-for-all, so was Pentecost. The sign of tongues served an evangelistic purpose for Diaspora Jews, not a devotional template for all subsequent believers."
-            },
-            {
-              "ref": "2:17",
-              "note": "Peter adds \"in the last days\" to Joel's \"after these things\" \u2014 a significant interpretive move identifying the present moment as the inauguration of the messianic last days. Pentecost is the beginning of the end, not the end itself."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:4",
-              "note": "The Spirit filling \"all of them\" fulfils the democratic vision of Numbers 11:29 where Moses wished all the Lord's people were prophets. The new covenant reality is universal access to the Spirit, not confined to leaders or specialists."
-            },
-            {
-              "ref": "2:17\u201318",
-              "note": "Calvin notes the prophetic scope: \"your sons and daughters will prophesy\" \u2014 the Spirit's gifts in the new age are not restricted by gender or age. The new covenant community is constituted by the Spirit's work in all its members."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:17",
-              "note": "Peter's quotation of Joel 2:28 adds \"in the last days\" to Joel's \"after these things,\" interpreting the temporal marker as eschatological. Peter identifies the present moment as the dawn of the messianic age."
-            },
-            {
-              "ref": "2:19\u201320",
-              "note": "The cosmic signs of blood, fire, smoke, sun darkened, and moon to blood have not yet been literally fulfilled. Luke preserves the full Joel quotation including the unfulfilled portion \u2014 Pentecost is the inaugurated beginning, not the consummation, of the \"last days.\""
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "2:2\u20134",
-              "note": "The sound was like wind (\u0113chos biaias pno\u0113s) but the tongues were like fire (h\u014dsei pyros) \u2014 Luke uses similes, not identity. This is not literal wind or literal flame but phenomena resembling them, echoing the Baptist's prediction that the Messiah would baptize \"with the Holy Spirit and fire\" (Luke 3:16)."
-            },
-            {
-              "ref": "2:4",
-              "note": "\"Other tongues\" (heterais gl\u014dssais) \u2014 Robertson defends these as genuine human languages (xenoglossy), not ecstatic utterance, on the grounds that the crowd immediately identifies their native languages (v8). The miracle is one of speaking, confirmed by miracles of hearing."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:1\u20134",
-              "note": "By the first century many Jews associated Shavuot with the Sinai covenant (Jubilees; the Damascus Document from Qumran treated it as a covenant-renewal festival). Luke's audience familiar with these associations would hear in Pentecost a new covenant inauguration \u2014 the Spirit replacing the stone tablets."
-            },
-            {
-              "ref": "2:9\u201311",
-              "note": "The list of nations follows a roughly geographic sweep from east to west, consistent with ancient geographic conventions. The presence of \"visitors from Rome\" (v10) foreshadows the book's destination: Rome is already represented at the church's birth."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first century it had also acquired associations with the giving of the Torah at Sinai. Luke's timing is not accidental: the Spirit comes at the festival that celebrated God's covenant word, now replacing the law of stone with the law written on hearts (Jer 31:33; Ezek 36:27). The list of nations in vv.9\u201311 is a reverse-Babel: at Babel the nations were scattered by language confusion; at Pentecost they are gathered by a unified message heard in every language."
+          "context": "Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first century it had also acquired associations with the giving of the Torah at Sinai. Luke's timing is not accidental: the Spirit comes at the festival that celebrated God's covenant word, now replacing the law of stone with the law written on hearts (Jer 31:33; Ezek 36:27). The list of nations in vv.9–11 is a reverse-Babel: at Babel the nations were scattered by language confusion; at Pentecost they are gathered by a unified message heard in every language."
         }
       }
     }
@@ -459,54 +414,54 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Utterly amazed, they asked: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And they were amazed and astonished, saying, \u201cAre not all these who are speaking Galileans?</td></tr><tr><td class=\"t-label\">NIV</td><td>They saw what seemed to be tongues of fire that separated and came to rest on each of them.</td></tr><tr><td class=\"t-label\">ESV</td><td>And divided tongues as of fire appeared to them and rested on each one of them.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Utterly amazed, they asked: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And they were amazed and astonished, saying, “Are not all these who are speaking Galileans?</td></tr><tr><td class=\"t-label\">NIV</td><td>They saw what seemed to be tongues of fire that separated and came to rest on each of them.</td></tr><tr><td class=\"t-label\">ESV</td><td>And divided tongues as of fire appeared to them and rested on each one of them.</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"Pentecost was a one-time, non-repeatable event \u2014 the inauguration of the new covenant age. Just as Calvary was once-for-all, so was Pentecost. The sign of tongues served an evangelistic purpose for Di\""
+        "text": "\"Pentecost was a one-time, non-repeatable event — the inauguration of the new covenant age. Just as Calvary was once-for-all, so was Pentecost. The sign of tongues served an evangelistic purpose for Di\""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201413 \u2014 The Day of Pentecost: Filled with the Holy Spirit",
-          "text": "Context  Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first cen\u2026",
+          "label": "Verses 1—13 — The Day of Pentecost: Filled with the Holy Spirit",
+          "text": "Context  Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first cen…",
           "is_key": false
         },
         {
-          "label": "Verses 14\u201436 \u2014 Peter\u2019s Sermon: This Is What Was Spoken by the Prophet Joel",
-          "text": "Context  Peter's sermon (vv.14\u201336) is organized around three OT proof-texts (Joel 2, Psalm 16, Psalm 110) building to th\u2026",
+          "label": "Verses 14—36 — Peter’s Sermon: This Is What Was Spoken by the Prophet Joel",
+          "text": "Context  Peter's sermon (vv.14–36) is organized around three OT proof-texts (Joel 2, Psalm 16, Psalm 110) building to th…",
           "is_key": false
         },
         {
-          "label": "Verses 37\u201447 \u2014 Three Thousand Baptised; The Community of Believers",
-          "text": "Context  Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first cen\u2026",
+          "label": "Verses 37—47 — Three Thousand Baptised; The Community of Believers",
+          "text": "Context  Shavuot (Pentecost, 'fiftieth day') was the Jewish harvest festival fifty days after Passover. By the first cen…",
           "is_key": false
         }
       ],
@@ -514,83 +469,83 @@
     },
     "hebtext": [
       {
-        "word": "\u03c3\u03c5\u03bc\u03c0\u03bb\u03b7\u03c1\u03bf\u1fe6\u03c3\u03b8\u03b1\u03b9",
-        "tlit": "sympl\u0113rousthai",
+        "word": "συμπληροῦσθαι",
+        "tlit": "symplērousthai",
         "gloss": "was being fulfilled",
-        "note": "imperfect passive of sympl\u0113ro\u014d \u2014 Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
+        "note": "imperfect passive of symplēroō — Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
       },
       {
-        "word": "\u1f10\u03ba\u03c0\u03bb\u03b7\u03c1\u03cc\u03c9 / \u1f41\u03bc\u03bf\u1fe6",
+        "word": "ἐκπληρόω / ὁμοῦ",
         "tlit": "homou",
         "gloss": "together in one place",
-        "note": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") \u2014 either way, corporate oneness precedes corporate blessing."
+        "note": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") — either way, corporate oneness precedes corporate blessing."
       },
       {
-        "word": "\u03ba\u03b1\u03c4\u03b5\u03bd\u03cd\u03b3\u03b7\u03c3\u03b1\u03bd",
+        "word": "κατενύγησαν",
         "tlit": "katenygesan",
         "gloss": "were cut to the heart",
-        "note": "a hapax legomenon in the NT \u2014 from nyss\u014d (to pierce, to sting). The crowd's hearing of the crucified Messiah produces a sharp, painful recognition of guilt. This is not mere sentiment but the beginning of genuine repentance."
+        "note": "a hapax legomenon in the NT — from nyssō (to pierce, to sting). The crowd's hearing of the crucified Messiah produces a sharp, painful recognition of guilt. This is not mere sentiment but the beginning of genuine repentance."
       },
       {
-        "word": "\u03bc\u03b5\u03c4\u03b1\u03bd\u03bf\u03ae\u03c3\u03b1\u03c4\u03b5",
-        "tlit": "metano\u0113sate",
+        "word": "μετανοήσατε",
+        "tlit": "metanoēsate",
         "gloss": "repent",
-        "note": "aorist imperative \u2014 urgent, decisive. Not emotional remorse alone but a fundamental reorientation of mind and life toward God. Peter's use echoes Jesus's own inaugural proclamation (Mark 1:15)."
+        "note": "aorist imperative — urgent, decisive. Not emotional remorse alone but a fundamental reorientation of mind and life toward God. Peter's use echoes Jesus's own inaugural proclamation (Mark 1:15)."
       },
       {
-        "word": "\u03c3\u03c5\u03bc\u03c0\u03bb\u03b7\u03c1\u03bf\u1fe6\u03c3\u03b8\u03b1\u03b9",
-        "tlit": "sympl\u0113rousthai",
+        "word": "συμπληροῦσθαι",
+        "tlit": "symplērousthai",
         "gloss": "was being fulfilled",
-        "note": "imperfect passive of sympl\u0113ro\u014d \u2014 Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
+        "note": "imperfect passive of symplēroō — Pentecost was not just arriving but being \"fulfilled.\" Luke uses a word that implies the feast day was itself a type now meeting its antitype. Shavuot becomes the occasion for what it always pointed toward."
       },
       {
-        "word": "\u1f10\u03ba\u03c0\u03bb\u03b7\u03c1\u03cc\u03c9 / \u1f41\u03bc\u03bf\u1fe6",
+        "word": "ἐκπληρόω / ὁμοῦ",
         "tlit": "homou",
         "gloss": "together in one place",
-        "note": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") \u2014 either way, corporate oneness precedes corporate blessing."
+        "note": "Luke emphasises the community's gathered unity as the vessel for the outpouring. Some manuscripts read homothymadon (\"with one accord\") — either way, corporate oneness precedes corporate blessing."
       }
     ],
     "thread": [
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Joel 2:28\u201332",
+        "target": "Joel 2:28–32",
         "type": "Connection",
-        "text": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" \u2014 the Spirit poured on all flesh, marking the dawn of the messianic age.",
+        "text": "Peter's extended quotation interprets Pentecost as the beginning of Joel's \"last days\" — the Spirit poured on all flesh, marking the dawn of the messianic age.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Ezekiel 36:26\u201327",
+        "target": "Ezekiel 36:26–27",
         "type": "Connection",
-        "text": "The promised new heart and Spirit within Israel \u2014 the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality).",
+        "text": "The promised new heart and Spirit within Israel — the OT background to Acts 2. The Spirit is not merely upon believers (OT pattern) but within them (new covenant reality).",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Genesis 11:1\u20139",
+        "target": "Genesis 11:1–9",
         "type": "Connection",
         "text": "The reversal of Babel is the implicit theological background: languages scattered at judgment; language barriers crossed at Pentecost.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Psalm 16:8\u201311",
+        "target": "Psalm 16:8–11",
         "type": "Connection",
-        "text": "Cited in vv.25\u201328 \u2014 \"you will not abandon me to the realm of the dead.\" Peter argues David could not have written this about himself (he died and his tomb remains) but prophetically of the Messiah's resurrection.",
+        "text": "Cited in vv.25–28 — \"you will not abandon me to the realm of the dead.\" Peter argues David could not have written this about himself (he died and his tomb remains) but prophetically of the Messiah's resurrection.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Psalm 110:1",
         "type": "Connection",
-        "text": "\"The Lord said to my Lord: Sit at my right hand\" \u2014 cited in vv.34\u201335. Jesus's session at the right hand is the ground of the Spirit's outpouring (v33: \"exalted to the right hand... he has poured out what you now see and hear\").",
+        "text": "\"The Lord said to my Lord: Sit at my right hand\" — cited in vv.34–35. Jesus's session at the right hand is the ground of the Spirit's outpouring (v33: \"exalted to the right hand... he has poured out what you now see and hear\").",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Exodus 32:28",
         "type": "Connection",
-        "text": "Three thousand killed at Sinai after the golden calf \u2014 the implicit contrast with three thousand given life at Pentecost.",
+        "text": "Three thousand killed at Sinai after the golden calf — the implicit contrast with three thousand given life at Pentecost.",
         "direction": "backward"
       }
     ],
@@ -598,14 +553,14 @@
       {
         "ref": "Acts 2",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 2 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -615,12 +570,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -785,7 +740,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Tongues of fire... each of them' (vv. 3-4). Pentecost reverses Babel: scattered languages reunited in comprehension. Parthians, Medes, Elamites\u2014all hear in their own tongue. The Spirit creates understanding across division.",
+      "tip": "'Tongues of fire... each of them' (vv. 3-4). Pentecost reverses Babel: scattered languages reunited in comprehension. Parthians, Medes, Elamites—all hear in their own tongue. The Spirit creates understanding across division.",
       "genre_tag": "canonical_thread"
     },
     {

--- a/content/acts/21.json
+++ b/content/acts/21.json
@@ -4,29 +4,29 @@
   "book_dir": "acts",
   "chapter_num": 21,
   "title": "Acts 21",
-  "subtitle": "Paul Arrives in Jerusalem \u2014 Arrested in the Temple",
+  "subtitle": "Paul Arrives in Jerusalem — Arrested in the Temple",
   "timeline_link": {
     "event_id": "pauls-letters",
-    "text": "See on Timeline \u2014 Paul's Letters"
+    "text": "See on Timeline — Paul's Letters"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201416 \u2014 Journey to Jerusalem; Agabus\u2019 Prophecy; Philip\u2019s House",
+      "header": "Verses 1—16 — Journey to Jerusalem; Agabus’ Prophecy; Philip’s House",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03b9\u1f70 \u03c4\u03bf\u1fe6 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03bf\u03c2",
+            "word": "διὰ τοῦ πνεύματος",
             "transliteration": "dia tou pneumatos",
             "gloss": "through the Spirit",
             "paragraph": "the warnings at Tyre (v.4) and Agabus's prophecy (v.11) both come 'through the Spirit.' This raises a question: if the Spirit warned Paul not to go, why does he go? The answer most commentators give is that the Spirit conveyed the fact of coming suffering; the interpretation 'therefore don't go' came from the community, not from the Spirit. Paul accepts the prediction but refuses the conclusion."
           },
           {
-            "word": "\u03b3\u03b5\u03bd\u03b7\u03b8\u03ae\u03c4\u03c9 \u03c4\u1f78 \u03b8\u03ad\u03bb\u03b7\u03bc\u03b1 \u03c4\u03bf\u1fe6 \u03ba\u03c5\u03c1\u03af\u03bf\u03c5",
-            "transliteration": "gen\u0113th\u0113t\u014d to thel\u0113ma tou kyriou",
+            "word": "γενηθήτω τὸ θέλημα τοῦ κυρίου",
+            "transliteration": "genēthētō to thelēma tou kyriou",
             "gloss": "The Lord's will be done",
             "paragraph": "the community's surrender in v.14 echoes Gethsemane (Luke 22:42: 'not my will, but yours be done'). The phrase marks the moment of acceptance: when Paul cannot be dissuaded, they commit the situation to God's will. This is the model for accepting what cannot be changed."
           }
@@ -34,19 +34,19 @@
         "places": [
           {
             "name": "Caesarea",
-            "coords": "32.5000\u00b0 N, 34.9000\u00b0 E",
-            "text": "Philip the evangelist's home \u2014 where Paul stays several days and receives Agabus's acted prophecy. The same Caesarea where Cornelius was converted (Acts 10); where Paul will be imprisoned for two years (Acts 24:27). The city is the hinge between Paul's free ministry and his coming custody."
+            "coords": "32.5000° N, 34.9000° E",
+            "text": "Philip the evangelist's home — where Paul stays several days and receives Agabus's acted prophecy. The same Caesarea where Cornelius was converted (Acts 10); where Paul will be imprisoned for two years (Acts 24:27). The city is the hinge between Paul's free ministry and his coming custody."
           },
           {
             "name": "Jerusalem",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "Paul's goal \u2014 and his prison. He arrives warmly received by James and the elders (v.17), makes his report, and follows the purification advice. Despite his compliance, the riot will happen (v.27). Jerusalem is the city where both the Gospel originated and where Paul's imprisonment begins."
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "Paul's goal — and his prison. He arrives warmly received by James and the elders (v.17), makes his report, and follows the purification advice. Despite his compliance, the riot will happen (v.27). Jerusalem is the city where both the Gospel originated and where Paul's imprisonment begins."
           }
         ],
         "tl": [
           {
             "date": "c. AD 57",
-            "name": "Journey to Jerusalem \u2014 Final Warnings",
+            "name": "Journey to Jerusalem — Final Warnings",
             "text": "Paul's journey to Jerusalem is marked by prophetic warnings at every stop. He arrives knowing what awaits. The community's weeping and the Gethsemane-echo of 'the Lord's will be done' frame the journey as a deliberate walk into suffering.",
             "current": true
           },
@@ -67,24 +67,24 @@
           "refs": [
             {
               "ref": "Luke 9:51",
-              "note": "\"Jesus resolutely set out for Jerusalem\" \u2014 Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes."
+              "note": "\"Jesus resolutely set out for Jerusalem\" — Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes."
             },
             {
-              "ref": "Acts 20:22\u201323",
-              "note": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" \u2014 Paul anticipated the warnings at the Miletus speech."
+              "ref": "Acts 20:22–23",
+              "note": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" — Paul anticipated the warnings at the Miletus speech."
             },
             {
-              "ref": "Romans 15:25\u201328",
-              "note": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" \u2014 Paul's letter written shortly before this journey explains the theological motivation."
+              "ref": "Romans 15:25–28",
+              "note": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" — Paul's letter written shortly before this journey explains the theological motivation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:13",
-              "note": "MacArthur on Paul's response to the community's weeping: 'Why are you weeping and breaking my heart?' \u2014 MacArthur notes that sometimes the most loving thing those who care for us can do is accept our decision rather than continue pleading. The community's eventual 'the Lord's will be done' is itself an act of faith and love."
+              "note": "MacArthur on Paul's response to the community's weeping: 'Why are you weeping and breaking my heart?' — MacArthur notes that sometimes the most loving thing those who care for us can do is accept our decision rather than continue pleading. The community's eventual 'the Lord's will be done' is itself an act of faith and love."
             },
             {
               "ref": "21:24",
@@ -93,7 +93,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:4",
@@ -101,101 +101,101 @@
             },
             {
               "ref": "21:14",
-              "note": "Calvin on 'the Lord's will be done' \u2014 this is, for Calvin, the supreme expression of Christian submission. When all persuasion has failed and the servant of God is determined, the community's role is to commit the situation to God rather than continue to struggle. Calvin uses this as the model for accepting the vocational decisions of others: counsel, then release."
+              "note": "Calvin on 'the Lord's will be done' — this is, for Calvin, the supreme expression of Christian submission. When all persuasion has failed and the servant of God is determined, the community's role is to commit the situation to God rather than continue to struggle. Calvin uses this as the model for accepting the vocational decisions of others: counsel, then release."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:4",
               "note": "The NET notes the ambiguity of \"through the Spirit they urged Paul not to go.\" The most natural reading is that the Spirit warned them of what would happen; their urging Paul not to go was their response to that warning, not a direct Spirit command. This distinguishes the Spirit's revelation (suffering awaits) from the community's application (therefore don't go)."
             },
             {
-              "ref": "21:23\u201324",
+              "ref": "21:23–24",
               "note": "The NET notes that Paul's participation in the Nazirite rite was consistent with his letter to the Corinthians (1 Cor 9:20) and not inconsistent with his Galatian argument. He never required Gentiles to observe Torah; he voluntarily observed Jewish customs when it served the mission and did not compromise justification by faith."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:11",
-              "note": "Robertson on Agabus's acted prophecy: the binding of hands and feet with Paul's belt is in the tradition of OT prophetic sign-acts (Isaiah 20:2\u20134; Jeremiah 27:2). Robertson notes that Agabus did not say \"do not go\" \u2014 he said \"this is what will happen.\" The interpretation \"therefore don't go\" came from the community, not from the prophet. Paul accepted the prediction but rejected the inference."
+              "note": "Robertson on Agabus's acted prophecy: the binding of hands and feet with Paul's belt is in the tradition of OT prophetic sign-acts (Isaiah 20:2–4; Jeremiah 27:2). Robertson notes that Agabus did not say \"do not go\" — he said \"this is what will happen.\" The interpretation \"therefore don't go\" came from the community, not from the prophet. Paul accepted the prediction but rejected the inference."
             },
             {
               "ref": "21:13",
-              "note": "\"I am ready not only to be bound, but also to die in Jerusalem\" \u2014 Robertson notes the deliberate Gethsemane echo. Paul's willingness to die for the name of the Lord Jesus is the apostolic expression of discipleship's ultimate cost (Luke 9:23: \"take up his cross daily and follow me\")."
+              "note": "\"I am ready not only to be bound, but also to die in Jerusalem\" — Robertson notes the deliberate Gethsemane echo. Paul's willingness to die for the name of the Lord Jesus is the apostolic expression of discipleship's ultimate cost (Luke 9:23: \"take up his cross daily and follow me\")."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "21:8\u20139",
-              "note": "Keener notes the significance of Philip the evangelist's household. Philip is 'one of the Seven' (Acts 6:5) and 'the evangelist' \u2014 a title that distinguishes his role from apostle or elder. His four daughters who prophesied are the fulfilment of Joel 2:28/Acts 2:17: 'your sons and daughters will prophesy.' The household represents the continuity of prophetic ministry from Pentecost forward."
+              "ref": "21:8–9",
+              "note": "Keener notes the significance of Philip the evangelist's household. Philip is 'one of the Seven' (Acts 6:5) and 'the evangelist' — a title that distinguishes his role from apostle or elder. His four daughters who prophesied are the fulfilment of Joel 2:28/Acts 2:17: 'your sons and daughters will prophesy.' The household represents the continuity of prophetic ministry from Pentecost forward."
             },
             {
-              "ref": "21:20\u201324",
-              "note": "Keener notes the historical plausibility of James's concern. Jerusalem had large numbers of Torah-observant Jewish Christians ('thousands... all of them zealous for the law') who had heard distorted reports about Paul's teaching. Paul's willingness to participate in the Nazirite vow purification was genuine \u2014 not hypocrisy but cultural flexibility (1 Cor 9:20: 'to the Jews I became like a Jew')."
+              "ref": "21:20–24",
+              "note": "Keener notes the historical plausibility of James's concern. Jerusalem had large numbers of Torah-observant Jewish Christians ('thousands... all of them zealous for the law') who had heard distorted reports about Paul's teaching. Paul's willingness to participate in the Nazirite vow purification was genuine — not hypocrisy but cultural flexibility (1 Cor 9:20: 'to the Jews I became like a Jew')."
             }
           ]
         },
         "hist": {
-          "context": "The journey to Jerusalem is punctuated by prophetic warnings at every stop \u2014 Tyre (v.4), Agabus at Caesarea (vv.10\u201311), the community's pleading (v.12). Paul's response (v.13: 'I am ready not only to be bound, but also to die in Jerusalem') is a deliberate echo of Jesus's own journey to Jerusalem, where he 'set his face toward Jerusalem' (Luke 9:51) knowing what awaited. Luke constructs a parallel passion narrative: Paul walks the same road as his Lord, and the community cannot dissuade him."
+          "context": "The journey to Jerusalem is punctuated by prophetic warnings at every stop — Tyre (v.4), Agabus at Caesarea (vv.10–11), the community's pleading (v.12). Paul's response (v.13: 'I am ready not only to be bound, but also to die in Jerusalem') is a deliberate echo of Jesus's own journey to Jerusalem, where he 'set his face toward Jerusalem' (Luke 9:51) knowing what awaited. Luke constructs a parallel passion narrative: Paul walks the same road as his Lord, and the community cannot dissuade him."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201436 \u2014 Arrival in Jerusalem; Arrested in the Temple",
+      "header": "Verses 17—36 — Arrival in Jerusalem; Arrested in the Temple",
       "verse_start": 17,
       "verse_end": 36,
       "panels": {
         "heb": [
           {
-            "word": "\u1f38\u03bf\u03c5\u03b4\u03b1\u1fd6\u03bf\u03b9 \u1f00\u03c0\u1f78 \u03c4\u1fc6\u03c2 \u1f08\u03c3\u03af\u03b1\u03c2",
-            "transliteration": "Ioudaioi apo t\u0113s Asias",
+            "word": "Ἰουδαῖοι ἀπὸ τῆς Ἀσίας",
+            "transliteration": "Ioudaioi apo tēs Asias",
             "gloss": "Jews from the province of Asia",
-            "paragraph": "the accusers in v.27 are not Jerusalem Jews but Diaspora Jews from Asia \u2014 likely from Ephesus, where Paul had spent three years. The irony is bitter: those most exposed to Paul's ministry are the ones who arrest him. The charge of bringing Greeks into the temple (v.28) was false (v.29 \u2014 a case of mistaken identity) but it triggered the riot."
+            "paragraph": "the accusers in v.27 are not Jerusalem Jews but Diaspora Jews from Asia — likely from Ephesus, where Paul had spent three years. The irony is bitter: those most exposed to Paul's ministry are the ones who arrest him. The charge of bringing Greeks into the temple (v.28) was false (v.29 — a case of mistaken identity) but it triggered the riot."
           },
           {
-            "word": "\u03c7\u03b9\u03bb\u03af\u03b1\u03c1\u03c7\u03bf\u03c2",
+            "word": "χιλίαρχος",
             "transliteration": "chiliarchos",
             "gloss": "commander of the Roman troops",
-            "paragraph": "the chiliarchos (literally 'commander of a thousand' \u2014 a tribune) of the Antonia fortress. Claudius Lysias (named in 23:26) will be Paul's unwitting protector throughout the Jerusalem period \u2014 a Roman officer whose self-interest repeatedly serves Paul's survival."
+            "paragraph": "the chiliarchos (literally 'commander of a thousand' — a tribune) of the Antonia fortress. Claudius Lysias (named in 23:26) will be Paul's unwitting protector throughout the Jerusalem period — a Roman officer whose self-interest repeatedly serves Paul's survival."
           }
         ],
         "places": [
           {
             "name": "The Temple Courts",
-            "coords": "31.7779\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Temple's outer courts were accessible to Gentiles up to the Court of the Gentiles; the inner courts were forbidden to non-Jews on pain of death. The charge that Paul brought Trophimus into the forbidden area (v.28\u201329) was false \u2014 but the misidentification triggered one of the most violent scenes in Acts."
+            "coords": "31.7779° N, 35.2354° E",
+            "text": "The Temple's outer courts were accessible to Gentiles up to the Court of the Gentiles; the inner courts were forbidden to non-Jews on pain of death. The charge that Paul brought Trophimus into the forbidden area (v.28–29) was false — but the misidentification triggered one of the most violent scenes in Acts."
           },
           {
             "name": "The Antonia Fortress",
-            "coords": "31.7820\u00b0 N, 35.2344\u00b0 E",
-            "text": "The Roman military headquarters adjacent to the Temple Mount \u2014 from which soldiers could see into the Temple courts and respond immediately to disorder (v.31\u201332). The stairs connecting the fortress to the Temple courts are where Paul stands to address the crowd (v.40). Paul is literally rescued from the mob by Rome."
+            "coords": "31.7820° N, 35.2344° E",
+            "text": "The Roman military headquarters adjacent to the Temple Mount — from which soldiers could see into the Temple courts and respond immediately to disorder (v.31–32). The stairs connecting the fortress to the Temple courts are where Paul stands to address the crowd (v.40). Paul is literally rescued from the mob by Rome."
           }
         ],
         "tl": [
           {
             "date": "c. AD 57",
             "name": "Arrest in the Temple",
-            "text": "Paul is seized by Diaspora Jews in the Temple courts on a false charge, beaten by the mob, and rescued by Roman soldiers from the Antonia fortress. He is bound with two chains \u2014 the fulfilment of Agabus's prophecy. Paul's free ministry ends; his captivity witness begins.",
+            "text": "Paul is seized by Diaspora Jews in the Temple courts on a false charge, beaten by the mob, and rescued by Roman soldiers from the Antonia fortress. He is bound with two chains — the fulfilment of Agabus's prophecy. Paul's free ministry ends; his captivity witness begins.",
             "current": true
           },
           {
-            "date": "c. AD 57\u201359",
+            "date": "c. AD 57–59",
             "name": "Caesarean Imprisonment",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 60\u201362",
+            "date": "c. AD 60–62",
             "name": "Roman Imprisonment",
             "text": "",
             "current": false
@@ -205,37 +205,37 @@
           "refs": [
             {
               "ref": "Acts 21:11",
-              "note": "Agabus's prophecy: 'In this way the Jewish leaders in Jerusalem will bind the owner of this belt and will hand him over to the Gentiles' \u2014 fulfilled precisely in vv.30\u201333."
+              "note": "Agabus's prophecy: 'In this way the Jewish leaders in Jerusalem will bind the owner of this belt and will hand him over to the Gentiles' — fulfilled precisely in vv.30–33."
             },
             {
               "ref": "Luke 21:12",
-              "note": "\"They will seize you and persecute you. They will hand you over to synagogues and put you in prison, and you will be brought before kings and governors, and all on account of my name\" \u2014 Jesus's prediction to the disciples, now being fulfilled in Paul."
+              "note": "\"They will seize you and persecute you. They will hand you over to synagogues and put you in prison, and you will be brought before kings and governors, and all on account of my name\" — Jesus's prediction to the disciples, now being fulfilled in Paul."
             },
             {
               "ref": "Acts 28:17",
-              "note": "\"I have done nothing wrong against the Jewish people or against the customs of our ancestors\" \u2014 Paul's summary of his defence, which the entire captivity narrative (chs 21\u201328) substantiates."
+              "note": "\"I have done nothing wrong against the Jewish people or against the customs of our ancestors\" — Paul's summary of his defence, which the entire captivity narrative (chs 21–28) substantiates."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:30",
-              "note": "MacArthur notes the tragic irony: Paul came to Jerusalem to demonstrate solidarity with Jewish Christians by delivering the Gentile churches' offering, and he is nearly killed by Diaspora Jews on a false charge. The love that brought him to Jerusalem becomes the occasion for the arrest that will send him to Rome. MacArthur sees God's providential hand: the false charge achieves what Paul himself had planned \u2014 he will reach Rome (19:21)."
+              "note": "MacArthur notes the tragic irony: Paul came to Jerusalem to demonstrate solidarity with Jewish Christians by delivering the Gentile churches' offering, and he is nearly killed by Diaspora Jews on a false charge. The love that brought him to Jerusalem becomes the occasion for the arrest that will send him to Rome. MacArthur sees God's providential hand: the false charge achieves what Paul himself had planned — he will reach Rome (19:21)."
             },
             {
-              "ref": "21:37\u201339",
+              "ref": "21:37–39",
               "note": "MacArthur on Paul asking to speak: even as he is being carried up the steps, beaten and bound, Paul is thinking missionally. The crowd of thousands that pursued him becomes, from the steps of the Antonia, the largest audience he has had in Jerusalem. MacArthur uses this as the model of the missionary mind: every situation, including arrest, is an opportunity for proclamation."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "21:27\u201330",
-              "note": "Calvin on the riot: the false accusation triggers a genuine mob response because it touched the most sensitive nerve in Jewish identity \u2014 the holiness of the Temple. Calvin notes that the most dangerous lies are those that contain a kernel of truth: Paul did oppose certain uses of the law, and he did travel with Gentiles. The distortion was in the application, not in the premise."
+              "ref": "21:27–30",
+              "note": "Calvin on the riot: the false accusation triggers a genuine mob response because it touched the most sensitive nerve in Jewish identity — the holiness of the Temple. Calvin notes that the most dangerous lies are those that contain a kernel of truth: Paul did oppose certain uses of the law, and he did travel with Gentiles. The distortion was in the application, not in the premise."
             },
             {
               "ref": "21:40",
@@ -244,36 +244,36 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:29",
-              "note": "The NET notes the significant phrase \"they had previously seen\" (\u0113san... proewrakotes) \u2014 the accusation was based on a prior sighting of Trophimus with Paul in the city, not in the Temple. The crowd assumed Paul had brought him into the restricted area. The charge was based on assumption, not observation \u2014 a false accusation that triggers genuine consequences."
+              "note": "The NET notes the significant phrase \"they had previously seen\" (ēsan... proewrakotes) — the accusation was based on a prior sighting of Trophimus with Paul in the city, not in the Temple. The crowd assumed Paul had brought him into the restricted area. The charge was based on assumption, not observation — a false accusation that triggers genuine consequences."
             },
             {
               "ref": "21:38",
-              "note": "The NET notes the Greek Aigyption (the Egyptian) \u2014 the definite article suggests this was a known figure, not an unknown. Josephus's accounts (Jewish War 2.261\u2013263; Antiquities 20.169\u2013172) describe the same person, confirming Luke's historical accuracy and providing context for the tribune's immediate recognition of the reference."
+              "note": "The NET notes the Greek Aigyption (the Egyptian) — the definite article suggests this was a known figure, not an unknown. Josephus's accounts (Jewish War 2.261–263; Antiquities 20.169–172) describe the same person, confirming Luke's historical accuracy and providing context for the tribune's immediate recognition of the reference."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:28",
-              "note": "\"This is the man who teaches everyone everywhere against our people and our law and this place\" \u2014 Robertson notes the triple accusation mirrors Stephen's charges (6:13\u201314): against the people, the law, and the Temple. Paul is being charged with what Stephen was charged with, in the same place. The parallel passion narrative continues."
+              "note": "\"This is the man who teaches everyone everywhere against our people and our law and this place\" — Robertson notes the triple accusation mirrors Stephen's charges (6:13–14): against the people, the law, and the Temple. Paul is being charged with what Stephen was charged with, in the same place. The parallel passion narrative continues."
             },
             {
               "ref": "21:39",
-              "note": "\"I am a Jew, from Tarsus in Cilicia, a citizen of no ordinary city\" \u2014 Robertson on Paul's self-identification: he claims both his Jewish identity (Ioudaios eimai) and his Tarsian civic standing (ast\u0113 ouk as\u0113mou). He uses both identities strategically: Jewish for the crowd, Tarsian for the tribune."
+              "note": "\"I am a Jew, from Tarsus in Cilicia, a citizen of no ordinary city\" — Robertson on Paul's self-identification: he claims both his Jewish identity (Ioudaios eimai) and his Tarsian civic standing (astē ouk asēmou). He uses both identities strategically: Jewish for the crowd, Tarsian for the tribune."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "21:28\u201329",
+              "ref": "21:28–29",
               "note": "Keener notes the significance of the charge about bringing Trophimus into the Temple. The dividing wall between the Court of the Gentiles and the inner courts had explicit warnings in Greek and Latin threatening death to any Gentile who crossed it. Two such inscriptions have been found archaeologically. The charge, though false, was taken with deadly seriousness."
             },
             {
@@ -283,26 +283,26 @@
           ]
         },
         "hist": {
-          "context": "The Temple arrest is the pivot of Acts \u2014 from here Paul is never a free man again. The charge is false (Trophimus was not brought into the forbidden area) but the riot is real. The Roman commander's immediate response from the Antonia fortress saves Paul's life. The pattern now established will govern chs 21\u201328: Paul is in Roman custody, being moved through a series of legal hearings. Luke's extended narration of Paul's captivity is not an anticlimax but his sustained argument that the Gospel is innocent before Roman law."
+          "context": "The Temple arrest is the pivot of Acts — from here Paul is never a free man again. The charge is false (Trophimus was not brought into the forbidden area) but the riot is real. The Roman commander's immediate response from the Antonia fortress saves Paul's life. The pattern now established will govern chs 21–28: Paul is in Roman custody, being moved through a series of legal hearings. Luke's extended narration of Paul's captivity is not an anticlimax but his sustained argument that the Gospel is innocent before Roman law."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 37\u201440 \u2014 Paul Addresses the Commander; Permission to Speak",
+      "header": "Verses 37—40 — Paul Addresses the Commander; Permission to Speak",
       "verse_start": 37,
       "verse_end": 40,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03b9\u1f70 \u03c4\u03bf\u1fe6 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03bf\u03c2",
+            "word": "διὰ τοῦ πνεύματος",
             "transliteration": "dia tou pneumatos",
             "gloss": "through the Spirit",
             "paragraph": "the warnings at Tyre (v.4) and Agabus's prophecy (v.11) both come 'through the Spirit.' This raises a question: if the Spirit warned Paul not to go, why does he go? The answer most commentators give is that the Spirit conveyed the fact of coming suffering; the interpretation 'therefore don't go' came from the community, not from the Spirit. Paul accepts the prediction but refuses the conclusion."
           },
           {
-            "word": "\u03b3\u03b5\u03bd\u03b7\u03b8\u03ae\u03c4\u03c9 \u03c4\u1f78 \u03b8\u03ad\u03bb\u03b7\u03bc\u03b1 \u03c4\u03bf\u1fe6 \u03ba\u03c5\u03c1\u03af\u03bf\u03c5",
-            "transliteration": "gen\u0113th\u0113t\u014d to thel\u0113ma tou kyriou",
+            "word": "γενηθήτω τὸ θέλημα τοῦ κυρίου",
+            "transliteration": "genēthētō to thelēma tou kyriou",
             "gloss": "The Lord's will be done",
             "paragraph": "the community's surrender in v.14 echoes Gethsemane (Luke 22:42: 'not my will, but yours be done'). The phrase marks the moment of acceptance: when Paul cannot be dissuaded, they commit the situation to God's will. This is the model for accepting what cannot be changed."
           }
@@ -310,19 +310,19 @@
         "places": [
           {
             "name": "Caesarea",
-            "coords": "32.5000\u00b0 N, 34.9000\u00b0 E",
-            "text": "Philip the evangelist's home \u2014 where Paul stays several days and receives Agabus's acted prophecy. The same Caesarea where Cornelius was converted (Acts 10); where Paul will be imprisoned for two years (Acts 24:27). The city is the hinge between Paul's free ministry and his coming custody."
+            "coords": "32.5000° N, 34.9000° E",
+            "text": "Philip the evangelist's home — where Paul stays several days and receives Agabus's acted prophecy. The same Caesarea where Cornelius was converted (Acts 10); where Paul will be imprisoned for two years (Acts 24:27). The city is the hinge between Paul's free ministry and his coming custody."
           },
           {
             "name": "Jerusalem",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "Paul's goal \u2014 and his prison. He arrives warmly received by James and the elders (v.17), makes his report, and follows the purification advice. Despite his compliance, the riot will happen (v.27). Jerusalem is the city where both the Gospel originated and where Paul's imprisonment begins."
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "Paul's goal — and his prison. He arrives warmly received by James and the elders (v.17), makes his report, and follows the purification advice. Despite his compliance, the riot will happen (v.27). Jerusalem is the city where both the Gospel originated and where Paul's imprisonment begins."
           }
         ],
         "tl": [
           {
             "date": "c. AD 57",
-            "name": "Journey to Jerusalem \u2014 Final Warnings",
+            "name": "Journey to Jerusalem — Final Warnings",
             "text": "Paul's journey to Jerusalem is marked by prophetic warnings at every stop. He arrives knowing what awaits. The community's weeping and the Gethsemane-echo of 'the Lord's will be done' frame the journey as a deliberate walk into suffering.",
             "current": true
           },
@@ -343,85 +343,40 @@
           "refs": [
             {
               "ref": "Luke 9:51",
-              "note": "\"Jesus resolutely set out for Jerusalem\" \u2014 Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes."
+              "note": "\"Jesus resolutely set out for Jerusalem\" — Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes."
             },
             {
-              "ref": "Acts 20:22\u201323",
-              "note": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" \u2014 Paul anticipated the warnings at the Miletus speech."
+              "ref": "Acts 20:22–23",
+              "note": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" — Paul anticipated the warnings at the Miletus speech."
             },
             {
-              "ref": "Romans 15:25\u201328",
-              "note": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" \u2014 Paul's letter written shortly before this journey explains the theological motivation."
+              "ref": "Romans 15:25–28",
+              "note": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" — Paul's letter written shortly before this journey explains the theological motivation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:13",
-              "note": "MacArthur on Paul's response to the community's weeping: 'Why are you weeping and breaking my heart?' \u2014 MacArthur notes that sometimes the most loving thing those who care for us can do is accept our decision rather than continue pleading. The community's eventual 'the Lord's will be done' is itself an act of faith and love."
-            },
-            {
-              "ref": "21:24",
-              "note": "MacArthur on Paul's compliance with the purification vow: this is not inconsistency with his doctrine of justification by faith (the law cannot save) but the application of his principle of cultural flexibility (1 Cor 9:20). MacArthur notes the important distinction: Paul never required Gentiles to be circumcised or observe Torah; he himself voluntarily observed Jewish customs when it served mission purposes without compromising the Gospel."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:4",
-              "note": "Calvin on the Tyre disciples urging Paul not to go 'through the Spirit': Calvin argues these disciples correctly received the Spirit's warning about what would happen but incorrectly inferred what Paul should do. The Spirit informed; they concluded. Their love and the Spirit's warning were both genuine; their conclusion that Paul should therefore not go was their own addition to the prophecy."
-            },
-            {
-              "ref": "21:14",
-              "note": "Calvin on 'the Lord's will be done' \u2014 this is, for Calvin, the supreme expression of Christian submission. When all persuasion has failed and the servant of God is determined, the community's role is to commit the situation to God rather than continue to struggle. Calvin uses this as the model for accepting the vocational decisions of others: counsel, then release."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:4",
-              "note": "The NET notes the ambiguity of \"through the Spirit they urged Paul not to go.\" The most natural reading is that the Spirit warned them of what would happen; their urging Paul not to go was their response to that warning, not a direct Spirit command. This distinguishes the Spirit's revelation (suffering awaits) from the community's application (therefore don't go)."
-            },
-            {
-              "ref": "21:23\u201324",
-              "note": "The NET notes that Paul's participation in the Nazirite rite was consistent with his letter to the Corinthians (1 Cor 9:20) and not inconsistent with his Galatian argument. He never required Gentiles to observe Torah; he voluntarily observed Jewish customs when it served the mission and did not compromise justification by faith."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "21:11",
-              "note": "Robertson on Agabus's acted prophecy: the binding of hands and feet with Paul's belt is in the tradition of OT prophetic sign-acts (Isaiah 20:2\u20134; Jeremiah 27:2). Robertson notes that Agabus did not say \"do not go\" \u2014 he said \"this is what will happen.\" The interpretation \"therefore don't go\" came from the community, not from the prophet. Paul accepted the prediction but rejected the inference."
-            },
-            {
-              "ref": "21:13",
-              "note": "\"I am ready not only to be bound, but also to die in Jerusalem\" \u2014 Robertson notes the deliberate Gethsemane echo. Paul's willingness to die for the name of the Lord Jesus is the apostolic expression of discipleship's ultimate cost (Luke 9:23: \"take up his cross daily and follow me\")."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:8\u20139",
-              "note": "Keener notes the significance of Philip the evangelist's household. Philip is 'one of the Seven' (Acts 6:5) and 'the evangelist' \u2014 a title that distinguishes his role from apostle or elder. His four daughters who prophesied are the fulfilment of Joel 2:28/Acts 2:17: 'your sons and daughters will prophesy.' The household represents the continuity of prophetic ministry from Pentecost forward."
-            },
-            {
-              "ref": "21:20\u201324",
-              "note": "Keener notes the historical plausibility of James's concern. Jerusalem had large numbers of Torah-observant Jewish Christians ('thousands... all of them zealous for the law') who had heard distorted reports about Paul's teaching. Paul's willingness to participate in the Nazirite vow purification was genuine \u2014 not hypocrisy but cultural flexibility (1 Cor 9:20: 'to the Jews I became like a Jew')."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "The journey to Jerusalem is punctuated by prophetic warnings at every stop \u2014 Tyre (v.4), Agabus at Caesarea (vv.10\u201311), the community's pleading (v.12). Paul's response (v.13: 'I am ready not only to be bound, but also to die in Jerusalem') is a deliberate echo of Jesus's own journey to Jerusalem, where he 'set his face toward Jerusalem' (Luke 9:51) knowing what awaited. Luke constructs a parallel passion narrative: Paul walks the same road as his Lord, and the community cannot dissuade him."
+          "context": "The journey to Jerusalem is punctuated by prophetic warnings at every stop — Tyre (v.4), Agabus at Caesarea (vv.10–11), the community's pleading (v.12). Paul's response (v.13: 'I am ready not only to be bound, but also to die in Jerusalem') is a deliberate echo of Jesus's own journey to Jerusalem, where he 'set his face toward Jerusalem' (Luke 9:51) knowing what awaited. Luke constructs a parallel passion narrative: Paul walks the same road as his Lord, and the community cannot dissuade him."
         }
       }
     }
@@ -429,54 +384,54 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Paul\u2197 People",
+        "name": "Paul↗ People",
         "role": "Apostle to the Gentiles; author of thirteen NT letters",
-        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen\u2019s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13\u201328 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts\u2019 theological climax: the gospel reaching the empire\u2019s capital, \"boldly and without hindrance\" (Acts 28:31)."
+        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen’s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13–28 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts’ theological climax: the gospel reaching the empire’s capital, \"boldly and without hindrance\" (Acts 28:31)."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Leaving the next day, we reached Caesarea and stayed at the house of Philip the evangelist, one of the Seven.</td></tr><tr><td class=\"t-label\">ESV</td><td>On the next day we departed and came to Caesarea, and we entered the house of Philip the evangelist, who was one of the seven, and stayed with him.</td></tr><tr><td class=\"t-label\">NIV</td><td>We sought out the disciples there and stayed with them seven days. Through the Spirit they urged Paul not to go on to Jerusalem.</td></tr><tr><td class=\"t-label\">ESV</td><td>And having sought out the disciples, we stayed there for seven days. And through the Spirit they were telling Paul not to go on to Jerusalem.</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"MacArthur on Paul's response to the community's weeping: 'Why are you weeping and breaking my heart?' \u2014 MacArthur notes that sometimes the most loving thing those who care for us can do is accept our \""
+        "text": "\"MacArthur on Paul's response to the community's weeping: 'Why are you weeping and breaking my heart?' — MacArthur notes that sometimes the most loving thing those who care for us can do is accept our \""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201416 \u2014 Journey to Jerusalem; Agabus\u2019 Prophecy; Philip\u2019s House",
-          "text": "Context  The journey to Jerusalem is punctuated by prophetic warnings at every stop \u2014 Tyre (v.4), Agabus at Caesarea (vv\u2026",
+          "label": "Verses 1—16 — Journey to Jerusalem; Agabus’ Prophecy; Philip’s House",
+          "text": "Context  The journey to Jerusalem is punctuated by prophetic warnings at every stop — Tyre (v.4), Agabus at Caesarea (vv…",
           "is_key": false
         },
         {
-          "label": "Verses 17\u201436 \u2014 Arrival in Jerusalem; Arrested in the Temple",
-          "text": "Context  The Temple arrest is the pivot of Acts \u2014 from here Paul is never a free man again. The charge is false (Trophim\u2026",
+          "label": "Verses 17—36 — Arrival in Jerusalem; Arrested in the Temple",
+          "text": "Context  The Temple arrest is the pivot of Acts — from here Paul is never a free man again. The charge is false (Trophim…",
           "is_key": false
         },
         {
-          "label": "Verses 37\u201440 \u2014 Paul Addresses the Commander; Permission to Speak",
-          "text": "Context  The journey to Jerusalem is punctuated by prophetic warnings at every stop \u2014 Tyre (v.4), Agabus at Caesarea (vv\u2026",
+          "label": "Verses 37—40 — Paul Addresses the Commander; Permission to Speak",
+          "text": "Context  The journey to Jerusalem is punctuated by prophetic warnings at every stop — Tyre (v.4), Agabus at Caesarea (vv…",
           "is_key": false
         }
       ],
@@ -484,38 +439,38 @@
     },
     "hebtext": [
       {
-        "word": "\u03b4\u03b9\u1f70 \u03c4\u03bf\u1fe6 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03bf\u03c2",
+        "word": "διὰ τοῦ πνεύματος",
         "tlit": "dia tou pneumatos",
         "gloss": "through the Spirit",
         "note": "the warnings at Tyre (v.4) and Agabus's prophecy (v.11) both come 'through the Spirit.' This raises a question: if the Spirit warned Paul not to go, why does he go? The answer most commentators give is that the Spirit conveyed the fact of coming suffering; the interpretation 'therefore don't go' came from the community, not from the Spirit. Paul accepts the prediction but refuses the conclusion."
       },
       {
-        "word": "\u03b3\u03b5\u03bd\u03b7\u03b8\u03ae\u03c4\u03c9 \u03c4\u1f78 \u03b8\u03ad\u03bb\u03b7\u03bc\u03b1 \u03c4\u03bf\u1fe6 \u03ba\u03c5\u03c1\u03af\u03bf\u03c5",
-        "tlit": "gen\u0113th\u0113t\u014d to thel\u0113ma tou kyriou",
+        "word": "γενηθήτω τὸ θέλημα τοῦ κυρίου",
+        "tlit": "genēthētō to thelēma tou kyriou",
         "gloss": "The Lord's will be done",
         "note": "the community's surrender in v.14 echoes Gethsemane (Luke 22:42: 'not my will, but yours be done'). The phrase marks the moment of acceptance: when Paul cannot be dissuaded, they commit the situation to God's will. This is the model for accepting what cannot be changed."
       },
       {
-        "word": "\u1f38\u03bf\u03c5\u03b4\u03b1\u1fd6\u03bf\u03b9 \u1f00\u03c0\u1f78 \u03c4\u1fc6\u03c2 \u1f08\u03c3\u03af\u03b1\u03c2",
-        "tlit": "Ioudaioi apo t\u0113s Asias",
+        "word": "Ἰουδαῖοι ἀπὸ τῆς Ἀσίας",
+        "tlit": "Ioudaioi apo tēs Asias",
         "gloss": "Jews from the province of Asia",
-        "note": "the accusers in v.27 are not Jerusalem Jews but Diaspora Jews from Asia \u2014 likely from Ephesus, where Paul had spent three years. The irony is bitter: those most exposed to Paul's ministry are the ones who arrest him. The charge of bringing Greeks into the temple (v.28) was false (v.29 \u2014 a case of mistaken identity) but it triggered the riot."
+        "note": "the accusers in v.27 are not Jerusalem Jews but Diaspora Jews from Asia — likely from Ephesus, where Paul had spent three years. The irony is bitter: those most exposed to Paul's ministry are the ones who arrest him. The charge of bringing Greeks into the temple (v.28) was false (v.29 — a case of mistaken identity) but it triggered the riot."
       },
       {
-        "word": "\u03c7\u03b9\u03bb\u03af\u03b1\u03c1\u03c7\u03bf\u03c2",
+        "word": "χιλίαρχος",
         "tlit": "chiliarchos",
         "gloss": "commander of the Roman troops",
-        "note": "the chiliarchos (literally 'commander of a thousand' \u2014 a tribune) of the Antonia fortress. Claudius Lysias (named in 23:26) will be Paul's unwitting protector throughout the Jerusalem period \u2014 a Roman officer whose self-interest repeatedly serves Paul's survival."
+        "note": "the chiliarchos (literally 'commander of a thousand' — a tribune) of the Antonia fortress. Claudius Lysias (named in 23:26) will be Paul's unwitting protector throughout the Jerusalem period — a Roman officer whose self-interest repeatedly serves Paul's survival."
       },
       {
-        "word": "\u03b4\u03b9\u1f70 \u03c4\u03bf\u1fe6 \u03c0\u03bd\u03b5\u03cd\u03bc\u03b1\u03c4\u03bf\u03c2",
+        "word": "διὰ τοῦ πνεύματος",
         "tlit": "dia tou pneumatos",
         "gloss": "through the Spirit",
         "note": "the warnings at Tyre (v.4) and Agabus's prophecy (v.11) both come 'through the Spirit.' This raises a question: if the Spirit warned Paul not to go, why does he go? The answer most commentators give is that the Spirit conveyed the fact of coming suffering; the interpretation 'therefore don't go' came from the community, not from the Spirit. Paul accepts the prediction but refuses the conclusion."
       },
       {
-        "word": "\u03b3\u03b5\u03bd\u03b7\u03b8\u03ae\u03c4\u03c9 \u03c4\u1f78 \u03b8\u03ad\u03bb\u03b7\u03bc\u03b1 \u03c4\u03bf\u1fe6 \u03ba\u03c5\u03c1\u03af\u03bf\u03c5",
-        "tlit": "gen\u0113th\u0113t\u014d to thel\u0113ma tou kyriou",
+        "word": "γενηθήτω τὸ θέλημα τοῦ κυρίου",
+        "tlit": "genēthētō to thelēma tou kyriou",
         "gloss": "The Lord's will be done",
         "note": "the community's surrender in v.14 echoes Gethsemane (Luke 22:42: 'not my will, but yours be done'). The phrase marks the moment of acceptance: when Paul cannot be dissuaded, they commit the situation to God's will. This is the model for accepting what cannot be changed."
       }
@@ -525,42 +480,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Luke 9:51",
         "type": "Echo",
-        "text": "\"Jesus resolutely set out for Jerusalem\" \u2014 Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes.",
+        "text": "\"Jesus resolutely set out for Jerusalem\" — Paul's determination mirrors Jesus's own. Luke constructs a parallel passion narrative across both volumes.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 20:22\u201323",
-        "type": "Type\u2192Antitype",
-        "text": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" \u2014 Paul anticipated the warnings at the Miletus speech.",
+        "target": "Acts 20:22–23",
+        "type": "Type→Antitype",
+        "text": "\"Compelled by the Spirit, I am going to Jerusalem, not knowing what will happen to me there. I only know that prison and hardships are facing me\" — Paul anticipated the warnings at the Miletus speech.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Romans 15:25\u201328",
+        "target": "Romans 15:25–28",
         "type": "Connection",
-        "text": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" \u2014 Paul's letter written shortly before this journey explains the theological motivation.",
+        "text": "\"Now, however, I am on my way to Jerusalem in the service of the Lord's people there\" — Paul's letter written shortly before this journey explains the theological motivation.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Acts 21:11",
         "type": "Fulfilment",
-        "text": "Agabus's prophecy: 'In this way the Jewish leaders in Jerusalem will bind the owner of this belt and will hand him over to the Gentiles' \u2014 fulfilled precisely in vv.30\u201333.",
+        "text": "Agabus's prophecy: 'In this way the Jewish leaders in Jerusalem will bind the owner of this belt and will hand him over to the Gentiles' — fulfilled precisely in vv.30–33.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Luke 21:12",
         "type": "Fulfilment",
-        "text": "\"They will seize you and persecute you. They will hand you over to synagogues and put you in prison, and you will be brought before kings and governors, and all on account of my name\" \u2014 Jesus's prediction to the disciples, now being fulfilled in Paul\u2026",
+        "text": "\"They will seize you and persecute you. They will hand you over to synagogues and put you in prison, and you will be brought before kings and governors, and all on account of my name\" — Jesus's prediction to the disciples, now being fulfilled in Paul…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Acts 28:17",
         "type": "Connection",
-        "text": "\"I have done nothing wrong against the Jewish people or against the customs of our ancestors\" \u2014 Paul's summary of his defence, which the entire captivity narrative (chs 21\u201328) substantiates.",
+        "text": "\"I have done nothing wrong against the Jewish people or against the customs of our ancestors\" — Paul's summary of his defence, which the entire captivity narrative (chs 21–28) substantiates.",
         "direction": "backward"
       }
     ],
@@ -568,14 +523,14 @@
       {
         "ref": "Acts 21",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 21 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -585,12 +540,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }

--- a/content/acts/5.json
+++ b/content/acts/5.json
@@ -7,57 +7,57 @@
   "subtitle": "Ananias and Sapphira; Apostles Imprisoned Again",
   "timeline_link": {
     "event_id": "pentecost",
-    "text": "See on Timeline \u2014 Pentecost"
+    "text": "See on Timeline — Pentecost"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201416 \u2014 Ananias and Sapphira; The Apostles Heal Many",
+      "header": "Verses 1—16 — Ananias and Sapphira; The Apostles Heal Many",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bd\u03bf\u03c3\u03c6\u03af\u03c3\u03b1\u03c4\u03bf",
+            "word": "ἐνοσφίσατο",
             "transliteration": "enosphisato",
             "gloss": "kept back",
-            "paragraph": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft \u2014 deliberate concealment of what was owed to God."
+            "paragraph": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft — deliberate concealment of what was owed to God."
           },
           {
-            "word": "\u03c8\u03b5\u03cd\u03c3\u03b1\u03c3\u03b8\u03b1\u03af \u03c3\u03b5 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u03c4\u1f78 \u1f05\u03b3\u03b9\u03bf\u03bd",
+            "word": "ψεύσασθαί σε τὸ πνεῦμα τὸ ἅγιον",
             "transliteration": "pseusasthai se to pneuma to hagion",
             "gloss": "you have lied to the Holy Spirit",
-            "paragraph": "the accusation identifies the Spirit as a person who can be lied to \u2014 establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
+            "paragraph": "the accusation identifies the Spirit as a person who can be lied to — establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
           }
         ],
         "places": [
           {
             "name": "Solomon's Colonnade",
-            "coords": "31.7767\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Eastern Portico \u2014 the church's regular public gathering place (v12). \"No one else dared join them\" (v13) likely refers to uncommitted observers who respected the community's distinctiveness. The space combines public visibility with the community's evident holiness."
+            "coords": "31.7767° N, 35.2354° E",
+            "text": "The Eastern Portico — the church's regular public gathering place (v12). \"No one else dared join them\" (v13) likely refers to uncommitted observers who respected the community's distinctiveness. The space combines public visibility with the community's evident holiness."
           },
           {
             "name": "Jerusalem Streets",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "Peter's shadow healing the sick (v15) places the apostolic ministry in Jerusalem's public streets. The city's streets become mission territory \u2014 the church is not confined to private spaces but present in the city's daily life."
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "Peter's shadow healing the sick (v15) places the apostolic ministry in Jerusalem's public streets. The city's streets become mission territory — the church is not confined to private spaces but present in the city's daily life."
           }
         ],
         "tl": [
           {
             "date": "c. 1406 BC",
-            "name": "Achan's Sin \u2014 Jericho",
+            "name": "Achan's Sin — Jericho",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
             "name": "Ananias and Sapphira",
-            "text": "The sudden deaths establish the seriousness of the Spirit's presence. Their sin was not insufficient generosity but the lie \u2014 the attempt to appear more committed than they were. This is the founding-moment judgment of the new covenant community.",
+            "text": "The sudden deaths establish the seriousness of the Spirit's presence. Their sin was not insufficient generosity but the lie — the attempt to appear more committed than they were. This is the founding-moment judgment of the new covenant community.",
             "current": true
           },
           {
-            "date": "c. AD 30\u201335",
+            "date": "c. AD 30–35",
             "name": "Jerusalem Church Growth",
             "text": "",
             "current": false
@@ -67,67 +67,67 @@
           "refs": [
             {
               "ref": "Joshua 7:1",
-              "note": "Achan's keeping back of devoted things \u2014 the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation."
+              "note": "Achan's keeping back of devoted things — the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation."
             },
             {
-              "ref": "Leviticus 10:1\u20132",
-              "note": "Nadab and Abihu's unauthorised fire brought immediate death \u2014 the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community."
+              "ref": "Leviticus 10:1–2",
+              "note": "Nadab and Abihu's unauthorised fire brought immediate death — the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community."
             },
             {
-              "ref": "Acts 4:36\u201337",
-              "note": "Barnabas sold a field and brought all the proceeds \u2014 the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate."
+              "ref": "Acts 4:36–37",
+              "note": "Barnabas sold a field and brought all the proceeds — the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "5:3\u20134",
-              "note": "The implicit Trinitarian argument: v3 says they lied to the Holy Spirit; v4 says they lied to God. The equation is direct \u2014 the Holy Spirit is God. MacArthur uses this to establish the Spirit's full deity from narrative evidence rather than doctrinal formulation."
+              "ref": "5:3–4",
+              "note": "The implicit Trinitarian argument: v3 says they lied to the Holy Spirit; v4 says they lied to God. The equation is direct — the Holy Spirit is God. MacArthur uses this to establish the Spirit's full deity from narrative evidence rather than doctrinal formulation."
             },
             {
               "ref": "5:11",
-              "note": "This is the first use of \"church\" (ekkl\u0113sia) in Acts \u2014 placed at the moment of the first internal discipline. The community of grace is simultaneously the community of holiness; God's love and holiness are expressed together, not in tension."
+              "note": "This is the first use of \"church\" (ekklēsia) in Acts — placed at the moment of the first internal discipline. The community of grace is simultaneously the community of holiness; God's love and holiness are expressed together, not in tension."
             },
             {
-              "ref": "5:15\u201316",
-              "note": "The shadow healings are evidence that God can work through any means he chooses without establishing those means as normative. The shadow was a sovereign expression of apostolic authority at a specific founding moment \u2014 not a technique to be repeated."
+              "ref": "5:15–16",
+              "note": "The shadow healings are evidence that God can work through any means he chooses without establishing those means as normative. The shadow was a sovereign expression of apostolic authority at a specific founding moment — not a technique to be repeated."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "5:3\u20134",
+              "ref": "5:3–4",
               "note": "Calvin: the Spirit is not a lesser divine energy but fully God, fully personal, and therefore capable of being sinned against in a way that constitutes direct offense against the Trinity. This is one of the clearest NT proofs of the Spirit's divine personhood."
             },
             {
               "ref": "5:5",
-              "note": "God chose this founding moment to establish that his church is not a human institution but a covenant community under his immediate governance. Just as the first sin in Eden brought death, the first hypocrisy in the new covenant community brings death \u2014 to establish the seriousness of what has begun."
+              "note": "God chose this founding moment to establish that his church is not a human institution but a covenant community under his immediate governance. Just as the first sin in Eden brought death, the first hypocrisy in the new covenant community brings death — to establish the seriousness of what has begun."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:2",
-              "note": "The NET notes that \"kept back\" (enosphisato) is the same verb as Josh 7:1 LXX for Achan's sin. The verbal echo is almost certainly intentional \u2014 the Ananias episode is the Acts equivalent of the Achan story: a covenant violation at the founding moment of God's people's new beginning."
+              "note": "The NET notes that \"kept back\" (enosphisato) is the same verb as Josh 7:1 LXX for Achan's sin. The verbal echo is almost certainly intentional — the Ananias episode is the Acts equivalent of the Achan story: a covenant violation at the founding moment of God's people's new beginning."
             },
             {
               "ref": "5:9",
-              "note": "\"Test the Spirit of the Lord\" (peirasai to pneuma Kyriou) echoes Israel's testing of God at Massah (Exod 17:7; Ps 95:8\u20139). The community's hypocritical pretense is framed as a repetition of Israel's wilderness sin."
+              "note": "\"Test the Spirit of the Lord\" (peirasai to pneuma Kyriou) echoes Israel's testing of God at Massah (Exod 17:7; Ps 95:8–9). The community's hypocritical pretense is framed as a repetition of Israel's wilderness sin."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "5:3",
-              "note": "Robertson notes that \"filled your heart\" (epl\u0113r\u014dsen t\u0113n kardian sou) uses the same construction as \"filled with the Holy Spirit\" \u2014 but here Satan is the filler. Every heart is filled by one master or another. There is no neutral ground."
+              "note": "Robertson notes that \"filled your heart\" (eplērōsen tēn kardian sou) uses the same construction as \"filled with the Holy Spirit\" — but here Satan is the filler. Every heart is filled by one master or another. There is no neutral ground."
             },
             {
               "ref": "5:5",
@@ -136,70 +136,70 @@
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "5:1\u20134",
-              "note": "Keener notes that the sin of Ananias is not in keeping part of the proceeds (v4 explicitly states the money was his to keep) but in the deliberate staging of the gift as total. In the community context of 4:32\u201335, to pretend full surrender while keeping back part was a direct claim on apostolic affirmation he had not earned."
+              "ref": "5:1–4",
+              "note": "Keener notes that the sin of Ananias is not in keeping part of the proceeds (v4 explicitly states the money was his to keep) but in the deliberate staging of the gift as total. In the community context of 4:32–35, to pretend full surrender while keeping back part was a direct claim on apostolic affirmation he had not earned."
             },
             {
-              "ref": "5:12\u201316",
-              "note": "Luke presents Peter's shadow (v15) without theological endorsement or condemnation. The people's faith, however imperfectly formed, is met with healing \u2014 consistent with Luke's pattern: God works graciously even through imperfect understanding of his ways."
+              "ref": "5:12–16",
+              "note": "Luke presents Peter's shadow (v15) without theological endorsement or condemnation. The people's faith, however imperfectly formed, is met with healing — consistent with Luke's pattern: God works graciously even through imperfect understanding of his ways."
             }
           ]
         },
         "hist": {
-          "context": "The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was voluntary (4:34\u201337) but once a commitment was staged publicly, breaking it was a direct challenge to God's presence. The severity mirrors Nadab and Abihu (Lev 10:1\u20132) \u2014 founding-moment judgments that define the seriousness of what has begun. The 'great fear' (v11) that follows is formative: it defines the community's awareness of God's holiness. The first use of the word 'church' (ekkl\u0113sia) in Acts appears in v11 \u2014 a telling placement: the church is named at the moment of its first internal discipline."
+          "context": "The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was voluntary (4:34–37) but once a commitment was staged publicly, breaking it was a direct challenge to God's presence. The severity mirrors Nadab and Abihu (Lev 10:1–2) — founding-moment judgments that define the seriousness of what has begun. The 'great fear' (v11) that follows is formative: it defines the community's awareness of God's holiness. The first use of the word 'church' (ekklēsia) in Acts appears in v11 — a telling placement: the church is named at the moment of its first internal discipline."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201432 \u2014 Arrested Again; The Angel Opens the Prison",
+      "header": "Verses 17—32 — Arrested Again; The Angel Opens the Prison",
       "verse_start": 17,
       "verse_end": 32,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b5\u03b9\u03b8\u03b1\u03c1\u03c7\u03b5\u1fd6\u03bd \u03b4\u03b5\u1fd6 \u03b8\u03b5\u1ff7",
-            "transliteration": "peitharchein dei the\u014d",
+            "word": "πειθαρχεῖν δεῖ θεῷ",
+            "transliteration": "peitharchein dei theō",
             "gloss": "We must obey God",
-            "paragraph": "the most memorable line of Acts 5. Peitharche\u014d means to be subject to authority \u2014 obedience not just as action but as recognized lordship. The \"must\" (dei) is the same theological necessity word used throughout Luke-Acts for what God's plan requires."
+            "paragraph": "the most memorable line of Acts 5. Peitharcheō means to be subject to authority — obedience not just as action but as recognized lordship. The \"must\" (dei) is the same theological necessity word used throughout Luke-Acts for what God's plan requires."
           },
           {
-            "word": "\u03ba\u03b1\u03c4\u03b7\u03be\u03b9\u03ce\u03b8\u03b7\u03c3\u03b1\u03bd",
-            "transliteration": "kat\u0113xi\u014dth\u0113san",
+            "word": "κατηξιώθησαν",
+            "transliteration": "katēxiōthēsan",
             "gloss": "were counted worthy",
-            "paragraph": "the aorist passive implies divine action \u2014 God counted them worthy, not they themselves. The joy is therefore not stoicism but theological gratitude: the Lord himself has honoured them by calling them to share his pattern of suffering."
+            "paragraph": "the aorist passive implies divine action — God counted them worthy, not they themselves. The joy is therefore not stoicism but theological gratitude: the Lord himself has honoured them by calling them to share his pattern of suffering."
           }
         ],
         "places": [
           {
-            "name": "The Public Jail \u2014 Jerusalem",
-            "coords": "31.7705\u00b0 N, 35.2294\u00b0 E",
-            "text": "The public jail (t\u0113r\u0113sis d\u0113mosia, v18) was officially designated, not a private holding. The apostles' miraculous escape \u2014 guards present, doors locked \u2014 was therefore publicly verifiable and undeniable."
+            "name": "The Public Jail — Jerusalem",
+            "coords": "31.7705° N, 35.2294° E",
+            "text": "The public jail (tērēsis dēmosia, v18) was officially designated, not a private holding. The apostles' miraculous escape — guards present, doors locked — was therefore publicly verifiable and undeniable."
           },
           {
             "name": "House to House",
-            "coords": "31.7705\u00b0 N, 35.2294\u00b0 E",
+            "coords": "31.7705° N, 35.2294° E",
             "text": "The closing summary (v42) reiterates the dual-venue pattern of 2:46: temple courts (public proclamation) and house to house (community formation). The Jerusalem church's model combines bold public presence with intimate discipleship."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Second Arrest \u2014 Flogged and Released",
-            "text": "The apostles are imprisoned, freed by an angel, re-arrested in the Temple, flogged, and released \u2014 all in one episode. They respond with joy and continued teaching (5:40\u201342). The escalation of opposition is matched by escalating boldness.",
+            "name": "Second Arrest — Flogged and Released",
+            "text": "The apostles are imprisoned, freed by an angel, re-arrested in the Temple, flogged, and released — all in one episode. They respond with joy and continued teaching (5:40–42). The escalation of opposition is matched by escalating boldness.",
             "current": true
           },
           {
-            "date": "c. AD 5\u201310",
-            "name": "Gamaliel \u2014 Teacher of Paul",
+            "date": "c. AD 5–10",
+            "name": "Gamaliel — Teacher of Paul",
             "text": "",
             "current": false
           },
           {
-            "date": "c. AD 6\u201346",
+            "date": "c. AD 6–46",
             "name": "Theudas and Judas the Galilean",
             "text": "",
             "current": false
@@ -208,136 +208,136 @@
         "cross": {
           "refs": [
             {
-              "ref": "Acts 4:19\u201320",
-              "note": "Peter's first statement of the principle \u2014 \"We must obey God rather than human beings\" \u2014 first stated at release (4:19\u201320), now repeated after flogging (5:29). The repetition reinforces total commitment."
+              "ref": "Acts 4:19–20",
+              "note": "Peter's first statement of the principle — \"We must obey God rather than human beings\" — first stated at release (4:19–20), now repeated after flogging (5:29). The repetition reinforces total commitment."
             },
             {
-              "ref": "Daniel 3:16\u201318",
-              "note": "Shadrach, Meshach, and Abednego's \"we will not serve your gods\" before Nebuchadnezzar \u2014 the OT parallel for faithful witness before earthly authority claiming total obedience."
+              "ref": "Daniel 3:16–18",
+              "note": "Shadrach, Meshach, and Abednego's \"we will not serve your gods\" before Nebuchadnezzar — the OT parallel for faithful witness before earthly authority claiming total obedience."
             },
             {
               "ref": "1 Peter 4:13",
-              "note": "\"Rejoice inasmuch as you participate in the sufferings of Christ\" \u2014 the theology Peter will write later is the theology he lives in Acts 5:41."
+              "note": "\"Rejoice inasmuch as you participate in the sufferings of Christ\" — the theology Peter will write later is the theology he lives in Acts 5:41."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:29",
               "note": "MacArthur applies the principle carefully: civil disobedience applies only when human authority commands what God forbids, or forbids what God commands. It is not a general license to disobey inconvenient authorities. The apostles did not attack the Sanhedrin; they kept preaching."
             },
             {
-              "ref": "5:38\u201339",
-              "note": "MacArthur notes Gamaliel's argument, while providentially useful, is theologically insufficient. Many false religions have not self-destructed. The test of endurance cannot distinguish true from false movements \u2014 only the content of the claim (resurrection of the Messiah, attested by witnesses) can do that."
+              "ref": "5:38–39",
+              "note": "MacArthur notes Gamaliel's argument, while providentially useful, is theologically insufficient. Many false religions have not self-destructed. The test of endurance cannot distinguish true from false movements — only the content of the claim (resurrection of the Messiah, attested by witnesses) can do that."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:29",
-              "note": "Calvin uses this verse as a cornerstone of his doctrine of resistance to tyranny. When magistrates command what God forbids, the Christian's duty is clear. But resistance takes the form of non-compliance and prayer \u2014 not revolution or personal vengeance."
+              "note": "Calvin uses this verse as a cornerstone of his doctrine of resistance to tyranny. When magistrates command what God forbids, the Christian's duty is clear. But resistance takes the form of non-compliance and prayer — not revolution or personal vengeance."
             },
             {
               "ref": "5:41",
-              "note": "Calvin on rejoicing in suffering: the apostles' joy is not natural courage or Stoic equanimity but the fruit of the Holy Spirit. They are not indifferent to pain but transformed in their response \u2014 Spirit-given gladness in participation with Christ's pattern."
+              "note": "Calvin on rejoicing in suffering: the apostles' joy is not natural courage or Stoic equanimity but the fruit of the Holy Spirit. They are not indifferent to pain but transformed in their response — Spirit-given gladness in participation with Christ's pattern."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:30",
-              "note": "\"Hanging him on a tree\" (kremasantes epi xylou) \u2014 a reference to Deut 21:22\u201323: hanging on a tree marks someone as cursed by God. Peter directly confronts the theological objection: yes, Jesus died accursed \u2014 but that is how he bore the curse for others (Gal 3:13)."
+              "note": "\"Hanging him on a tree\" (kremasantes epi xylou) — a reference to Deut 21:22–23: hanging on a tree marks someone as cursed by God. Peter directly confronts the theological objection: yes, Jesus died accursed — but that is how he bore the curse for others (Gal 3:13)."
             },
             {
               "ref": "5:42",
-              "note": "The verse summarises with two infinitives: \"teaching\" (didaskein) and \"proclaiming the good news\" (euangelizesthai). Both systematic instruction of believers and evangelistic proclamation to outsiders are part of the apostolic mission \u2014 neither alone is sufficient."
+              "note": "The verse summarises with two infinitives: \"teaching\" (didaskein) and \"proclaiming the good news\" (euangelizesthai). Both systematic instruction of believers and evangelistic proclamation to outsiders are part of the apostolic mission — neither alone is sufficient."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "5:29",
-              "note": "Robertson notes the absolute priority expressed in \"We must obey God rather than human beings\" \u2014 the comparative construction (mallon \u0113) is categorical, not grudging. This does not mean Christians never obey government; it means when genuine conflict exists between divine and human command, there is no question which takes precedence."
+              "note": "Robertson notes the absolute priority expressed in \"We must obey God rather than human beings\" — the comparative construction (mallon ē) is categorical, not grudging. This does not mean Christians never obey government; it means when genuine conflict exists between divine and human command, there is no question which takes precedence."
             },
             {
               "ref": "5:41",
-              "note": "\"Counted worthy of suffering disgrace\" (kat\u0113xi\u014dth\u0113san atimasth\u0113nai) \u2014 Robertson savours the paradox: \"they were honoured to be dishonoured.\" The passive implies divine action: God counted them worthy. The joy is therefore theological gratitude, not Stoic resignation."
+              "note": "\"Counted worthy of suffering disgrace\" (katēxiōthēsan atimasthēnai) — Robertson savours the paradox: \"they were honoured to be dishonoured.\" The passive implies divine action: God counted them worthy. The joy is therefore theological gratitude, not Stoic resignation."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "5:34\u201339",
-              "note": "Keener provides historical context for Gamaliel's examples. Josephus mentions a Theudas who led a revolt around AD 44\u201346 \u2014 later than this speech's implied date. Some scholars see a historical problem; Keener suggests either Luke's Theudas is an earlier, different figure, or Josephus's dating is approximate."
+              "ref": "5:34–39",
+              "note": "Keener provides historical context for Gamaliel's examples. Josephus mentions a Theudas who led a revolt around AD 44–46 — later than this speech's implied date. Some scholars see a historical problem; Keener suggests either Luke's Theudas is an earlier, different figure, or Josephus's dating is approximate."
             },
             {
               "ref": "5:41",
-              "note": "Keener notes the cultural significance: public flogging (thirty-nine lashes) was designed to humiliate and destroy public reputation in the honour-shame culture of the first-century Mediterranean. The apostles' joy inverts this completely \u2014 they treat the honour-stripping as honour-conferring. This is one of early Christianity's most distinctive social inversions."
+              "note": "Keener notes the cultural significance: public flogging (thirty-nine lashes) was designed to humiliate and destroy public reputation in the honour-shame culture of the first-century Mediterranean. The apostles' joy inverts this completely — they treat the honour-stripping as honour-conferring. This is one of early Christianity's most distinctive social inversions."
             }
           ]
         },
         "hist": {
-          "context": "Gamaliel's speech (vv.34\u201339) is one of the most debated passages in Acts. His argument \u2014 if it's human it will fail; if divine you cannot stop it \u2014 sounds like wisdom but is actually pragmatic rather than principled. He does not commit to the truth of the resurrection; he simply counsels caution. Luke presents it as providentially useful without endorsing Gamaliel's theological epistemology. The apostles' rejoicing in suffering (v41) is the first record of Christians celebrating persecution \u2014 a pattern that recurs throughout Acts and the Epistles. The logic is the theology of the cross: suffering for Christ is participation in his pattern, not a curse."
+          "context": "Gamaliel's speech (vv.34–39) is one of the most debated passages in Acts. His argument — if it's human it will fail; if divine you cannot stop it — sounds like wisdom but is actually pragmatic rather than principled. He does not commit to the truth of the resurrection; he simply counsels caution. Luke presents it as providentially useful without endorsing Gamaliel's theological epistemology. The apostles' rejoicing in suffering (v41) is the first record of Christians celebrating persecution — a pattern that recurs throughout Acts and the Epistles. The logic is the theology of the cross: suffering for Christ is participation in his pattern, not a curse."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 33\u201442 \u2014 Gamaliel\u2019s Counsel; The Apostles Flogged and Released",
+      "header": "Verses 33—42 — Gamaliel’s Counsel; The Apostles Flogged and Released",
       "verse_start": 33,
       "verse_end": 42,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bd\u03bf\u03c3\u03c6\u03af\u03c3\u03b1\u03c4\u03bf",
+            "word": "ἐνοσφίσατο",
             "transliteration": "enosphisato",
             "gloss": "kept back",
-            "paragraph": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft \u2014 deliberate concealment of what was owed to God."
+            "paragraph": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft — deliberate concealment of what was owed to God."
           },
           {
-            "word": "\u03c8\u03b5\u03cd\u03c3\u03b1\u03c3\u03b8\u03b1\u03af \u03c3\u03b5 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u03c4\u1f78 \u1f05\u03b3\u03b9\u03bf\u03bd",
+            "word": "ψεύσασθαί σε τὸ πνεῦμα τὸ ἅγιον",
             "transliteration": "pseusasthai se to pneuma to hagion",
             "gloss": "you have lied to the Holy Spirit",
-            "paragraph": "the accusation identifies the Spirit as a person who can be lied to \u2014 establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
+            "paragraph": "the accusation identifies the Spirit as a person who can be lied to — establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
           }
         ],
         "places": [
           {
             "name": "Solomon's Colonnade",
-            "coords": "31.7767\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Eastern Portico \u2014 the church's regular public gathering place (v12). \"No one else dared join them\" (v13) likely refers to uncommitted observers who respected the community's distinctiveness. The space combines public visibility with the community's evident holiness."
+            "coords": "31.7767° N, 35.2354° E",
+            "text": "The Eastern Portico — the church's regular public gathering place (v12). \"No one else dared join them\" (v13) likely refers to uncommitted observers who respected the community's distinctiveness. The space combines public visibility with the community's evident holiness."
           },
           {
             "name": "Jerusalem Streets",
-            "coords": "31.7683\u00b0 N, 35.2137\u00b0 E",
-            "text": "Peter's shadow healing the sick (v15) places the apostolic ministry in Jerusalem's public streets. The city's streets become mission territory \u2014 the church is not confined to private spaces but present in the city's daily life."
+            "coords": "31.7683° N, 35.2137° E",
+            "text": "Peter's shadow healing the sick (v15) places the apostolic ministry in Jerusalem's public streets. The city's streets become mission territory — the church is not confined to private spaces but present in the city's daily life."
           }
         ],
         "tl": [
           {
             "date": "c. 1406 BC",
-            "name": "Achan's Sin \u2014 Jericho",
+            "name": "Achan's Sin — Jericho",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
             "name": "Ananias and Sapphira",
-            "text": "The sudden deaths establish the seriousness of the Spirit's presence. Their sin was not insufficient generosity but the lie \u2014 the attempt to appear more committed than they were. This is the founding-moment judgment of the new covenant community.",
+            "text": "The sudden deaths establish the seriousness of the Spirit's presence. Their sin was not insufficient generosity but the lie — the attempt to appear more committed than they were. This is the founding-moment judgment of the new covenant community.",
             "current": true
           },
           {
-            "date": "c. AD 30\u201335",
+            "date": "c. AD 30–35",
             "name": "Jerusalem Church Growth",
             "text": "",
             "current": false
@@ -347,89 +347,40 @@
           "refs": [
             {
               "ref": "Joshua 7:1",
-              "note": "Achan's keeping back of devoted things \u2014 the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation."
+              "note": "Achan's keeping back of devoted things — the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation."
             },
             {
-              "ref": "Leviticus 10:1\u20132",
-              "note": "Nadab and Abihu's unauthorised fire brought immediate death \u2014 the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community."
+              "ref": "Leviticus 10:1–2",
+              "note": "Nadab and Abihu's unauthorised fire brought immediate death — the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community."
             },
             {
-              "ref": "Acts 4:36\u201337",
-              "note": "Barnabas sold a field and brought all the proceeds \u2014 the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate."
+              "ref": "Acts 4:36–37",
+              "note": "Barnabas sold a field and brought all the proceeds — the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:3\u20134",
-              "note": "The implicit Trinitarian argument: v3 says they lied to the Holy Spirit; v4 says they lied to God. The equation is direct \u2014 the Holy Spirit is God. MacArthur uses this to establish the Spirit's full deity from narrative evidence rather than doctrinal formulation."
-            },
-            {
-              "ref": "5:11",
-              "note": "This is the first use of \"church\" (ekkl\u0113sia) in Acts \u2014 placed at the moment of the first internal discipline. The community of grace is simultaneously the community of holiness; God's love and holiness are expressed together, not in tension."
-            },
-            {
-              "ref": "5:15\u201316",
-              "note": "The shadow healings are evidence that God can work through any means he chooses without establishing those means as normative. The shadow was a sovereign expression of apostolic authority at a specific founding moment \u2014 not a technique to be repeated."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:3\u20134",
-              "note": "Calvin: the Spirit is not a lesser divine energy but fully God, fully personal, and therefore capable of being sinned against in a way that constitutes direct offense against the Trinity. This is one of the clearest NT proofs of the Spirit's divine personhood."
-            },
-            {
-              "ref": "5:5",
-              "note": "God chose this founding moment to establish that his church is not a human institution but a covenant community under his immediate governance. Just as the first sin in Eden brought death, the first hypocrisy in the new covenant community brings death \u2014 to establish the seriousness of what has begun."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:2",
-              "note": "The NET notes that \"kept back\" (enosphisato) is the same verb as Josh 7:1 LXX for Achan's sin. The verbal echo is almost certainly intentional \u2014 the Ananias episode is the Acts equivalent of the Achan story: a covenant violation at the founding moment of God's people's new beginning."
-            },
-            {
-              "ref": "5:9",
-              "note": "\"Test the Spirit of the Lord\" (peirasai to pneuma Kyriou) echoes Israel's testing of God at Massah (Exod 17:7; Ps 95:8\u20139). The community's hypocritical pretense is framed as a repetition of Israel's wilderness sin."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "5:3",
-              "note": "Robertson notes that \"filled your heart\" (epl\u0113r\u014dsen t\u0113n kardian sou) uses the same construction as \"filled with the Holy Spirit\" \u2014 but here Satan is the filler. Every heart is filled by one master or another. There is no neutral ground."
-            },
-            {
-              "ref": "5:5",
-              "note": "The immediate death is not presented by Luke as Peter's act but as God's judgment. Luke does not say Peter killed Ananias; he reports the sequence without causal attribution to Peter. The judgment is sovereign and direct."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:1\u20134",
-              "note": "Keener notes that the sin of Ananias is not in keeping part of the proceeds (v4 explicitly states the money was his to keep) but in the deliberate staging of the gift as total. In the community context of 4:32\u201335, to pretend full surrender while keeping back part was a direct claim on apostolic affirmation he had not earned."
-            },
-            {
-              "ref": "5:12\u201316",
-              "note": "Luke presents Peter's shadow (v15) without theological endorsement or condemnation. The people's faith, however imperfectly formed, is met with healing \u2014 consistent with Luke's pattern: God works graciously even through imperfect understanding of his ways."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was voluntary (4:34\u201337) but once a commitment was staged publicly, breaking it was a direct challenge to God's presence. The severity mirrors Nadab and Abihu (Lev 10:1\u20132) \u2014 founding-moment judgments that define the seriousness of what has begun. The 'great fear' (v11) that follows is formative: it defines the community's awareness of God's holiness. The first use of the word 'church' (ekkl\u0113sia) in Acts appears in v11 \u2014 a telling placement: the church is named at the moment of its first internal discipline."
+          "context": "The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was voluntary (4:34–37) but once a commitment was staged publicly, breaking it was a direct challenge to God's presence. The severity mirrors Nadab and Abihu (Lev 10:1–2) — founding-moment judgments that define the seriousness of what has begun. The 'great fear' (v11) that follows is formative: it defines the community's awareness of God's holiness. The first use of the word 'church' (ekklēsia) in Acts appears in v11 — a telling placement: the church is named at the moment of its first internal discipline."
         }
       }
     }
@@ -439,52 +390,52 @@
       {
         "name": "Ananias",
         "role": "Key biblical figure",
-        "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community\u2026"
+        "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Peter said to her, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But Peter said to her, \u201cHow is it that you have agreed together to test the Spirit of the Lord? Behold, the feet of those who have buried your husband are at the door, and they will carry you out.\u201d</td></tr><tr><td class=\"t-label\">NIV</td><td>Then Peter said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But Peter said, \u201cAnanias, why has Satan filled your heart to lie to the Holy Spirit and to keep back for yourself part of the proceeds of the land?</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Peter said to her, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But Peter said to her, “How is it that you have agreed together to test the Spirit of the Lord? Behold, the feet of those who have buried your husband are at the door, and they will carry you out.”</td></tr><tr><td class=\"t-label\">NIV</td><td>Then Peter said, \\</td></tr><tr><td class=\"t-label\">ESV</td><td>But Peter said, “Ananias, why has Satan filled your heart to lie to the Holy Spirit and to keep back for yourself part of the proceeds of the land?</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"The implicit Trinitarian argument: v3 says they lied to the Holy Spirit; v4 says they lied to God. The equation is direct \u2014 the Holy Spirit is God. MacArthur uses this to establish the Spirit's full d\""
+        "text": "\"The implicit Trinitarian argument: v3 says they lied to the Holy Spirit; v4 says they lied to God. The equation is direct — the Holy Spirit is God. MacArthur uses this to establish the Spirit's full d\""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201416 \u2014 Ananias and Sapphira; The Apostles Heal Many",
-          "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was volu\u2026",
+          "label": "Verses 1—16 — Ananias and Sapphira; The Apostles Heal Many",
+          "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was volu…",
           "is_key": false
         },
         {
-          "label": "Verses 17\u201432 \u2014 Arrested Again; The Angel Opens the Prison",
-          "text": "Context  Gamaliel's speech (vv.34\u201339) is one of the most debated passages in Acts. His argument \u2014 if it's human it will\u2026",
+          "label": "Verses 17—32 — Arrested Again; The Angel Opens the Prison",
+          "text": "Context  Gamaliel's speech (vv.34–39) is one of the most debated passages in Acts. His argument — if it's human it will…",
           "is_key": false
         },
         {
-          "label": "Verses 33\u201442 \u2014 Gamaliel\u2019s Counsel; The Apostles Flogged and Released",
-          "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was volu\u2026",
+          "label": "Verses 33—42 — Gamaliel’s Counsel; The Apostles Flogged and Released",
+          "text": "Context  The Ananias and Sapphira episode establishes the covenant boundaries of the new community. The sharing was volu…",
           "is_key": false
         }
       ],
@@ -492,40 +443,40 @@
     },
     "hebtext": [
       {
-        "word": "\u1f10\u03bd\u03bf\u03c3\u03c6\u03af\u03c3\u03b1\u03c4\u03bf",
+        "word": "ἐνοσφίσατο",
         "tlit": "enosphisato",
         "gloss": "kept back",
-        "note": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft \u2014 deliberate concealment of what was owed to God."
+        "note": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft — deliberate concealment of what was owed to God."
       },
       {
-        "word": "\u03c8\u03b5\u03cd\u03c3\u03b1\u03c3\u03b8\u03b1\u03af \u03c3\u03b5 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u03c4\u1f78 \u1f05\u03b3\u03b9\u03bf\u03bd",
+        "word": "ψεύσασθαί σε τὸ πνεῦμα τὸ ἅγιον",
         "tlit": "pseusasthai se to pneuma to hagion",
         "gloss": "you have lied to the Holy Spirit",
-        "note": "the accusation identifies the Spirit as a person who can be lied to \u2014 establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
+        "note": "the accusation identifies the Spirit as a person who can be lied to — establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
       },
       {
-        "word": "\u03c0\u03b5\u03b9\u03b8\u03b1\u03c1\u03c7\u03b5\u1fd6\u03bd \u03b4\u03b5\u1fd6 \u03b8\u03b5\u1ff7",
-        "tlit": "peitharchein dei the\u014d",
+        "word": "πειθαρχεῖν δεῖ θεῷ",
+        "tlit": "peitharchein dei theō",
         "gloss": "We must obey God",
-        "note": "the most memorable line of Acts 5. Peitharche\u014d means to be subject to authority \u2014 obedience not just as action but as recognized lordship. The \"must\" (dei) is the same theological necessity word used throughout Luke-Acts for what God's plan requires."
+        "note": "the most memorable line of Acts 5. Peitharcheō means to be subject to authority — obedience not just as action but as recognized lordship. The \"must\" (dei) is the same theological necessity word used throughout Luke-Acts for what God's plan requires."
       },
       {
-        "word": "\u03ba\u03b1\u03c4\u03b7\u03be\u03b9\u03ce\u03b8\u03b7\u03c3\u03b1\u03bd",
-        "tlit": "kat\u0113xi\u014dth\u0113san",
+        "word": "κατηξιώθησαν",
+        "tlit": "katēxiōthēsan",
         "gloss": "were counted worthy",
-        "note": "the aorist passive implies divine action \u2014 God counted them worthy, not they themselves. The joy is therefore not stoicism but theological gratitude: the Lord himself has honoured them by calling them to share his pattern of suffering."
+        "note": "the aorist passive implies divine action — God counted them worthy, not they themselves. The joy is therefore not stoicism but theological gratitude: the Lord himself has honoured them by calling them to share his pattern of suffering."
       },
       {
-        "word": "\u1f10\u03bd\u03bf\u03c3\u03c6\u03af\u03c3\u03b1\u03c4\u03bf",
+        "word": "ἐνοσφίσατο",
         "tlit": "enosphisato",
         "gloss": "kept back",
-        "note": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft \u2014 deliberate concealment of what was owed to God."
+        "note": "the same rare verb used in the LXX for Achan's sin at Jericho (Josh 7:1). Luke's word choice connects Ananias to Israel's most notorious act of covenant theft — deliberate concealment of what was owed to God."
       },
       {
-        "word": "\u03c8\u03b5\u03cd\u03c3\u03b1\u03c3\u03b8\u03b1\u03af \u03c3\u03b5 \u03c4\u1f78 \u03c0\u03bd\u03b5\u1fe6\u03bc\u03b1 \u03c4\u1f78 \u1f05\u03b3\u03b9\u03bf\u03bd",
+        "word": "ψεύσασθαί σε τὸ πνεῦμα τὸ ἅγιον",
         "tlit": "pseusasthai se to pneuma to hagion",
         "gloss": "you have lied to the Holy Spirit",
-        "note": "the accusation identifies the Spirit as a person who can be lied to \u2014 establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
+        "note": "the accusation identifies the Spirit as a person who can be lied to — establishing the Spirit's full personhood and, implicitly, his full deity (v4 equates lying to the Spirit with lying to God)."
       }
     ],
     "thread": [
@@ -533,42 +484,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Joshua 7:1",
         "type": "Connection",
-        "text": "Achan's keeping back of devoted things \u2014 the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation.",
+        "text": "Achan's keeping back of devoted things — the same LXX verb (nosphizomai) as v2. The covenant community's integrity depends on full surrender; partial obedience is covenant violation.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Leviticus 10:1\u20132",
+        "target": "Leviticus 10:1–2",
         "type": "Connection",
-        "text": "Nadab and Abihu's unauthorised fire brought immediate death \u2014 the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community.",
+        "text": "Nadab and Abihu's unauthorised fire brought immediate death — the OT precedent for divine judgment protecting the holiness of a newly inaugurated covenant community.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 4:36\u201337",
+        "target": "Acts 4:36–37",
         "type": "Connection",
-        "text": "Barnabas sold a field and brought all the proceeds \u2014 the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate.",
+        "text": "Barnabas sold a field and brought all the proceeds — the positive model immediately preceding this negative counter-example. Luke's literary pairing is deliberate.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 4:19\u201320",
+        "target": "Acts 4:19–20",
         "type": "Connection",
-        "text": "Peter's first statement of the principle \u2014 \"We must obey God rather than human beings\" \u2014 first stated at release (4:19\u201320), now repeated after flogging (5:29). The repetition reinforces total commitment.",
+        "text": "Peter's first statement of the principle — \"We must obey God rather than human beings\" — first stated at release (4:19–20), now repeated after flogging (5:29). The repetition reinforces total commitment.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Daniel 3:16\u201318",
+        "target": "Daniel 3:16–18",
         "type": "Echo",
-        "text": "Shadrach, Meshach, and Abednego's \"we will not serve your gods\" before Nebuchadnezzar \u2014 the OT parallel for faithful witness before earthly authority claiming total obedience.",
+        "text": "Shadrach, Meshach, and Abednego's \"we will not serve your gods\" before Nebuchadnezzar — the OT parallel for faithful witness before earthly authority claiming total obedience.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 Peter 4:13",
         "type": "Connection",
-        "text": "\"Rejoice inasmuch as you participate in the sufferings of Christ\" \u2014 the theology Peter will write later is the theology he lives in Acts 5:41.",
+        "text": "\"Rejoice inasmuch as you participate in the sufferings of Christ\" — the theology Peter will write later is the theology he lives in Acts 5:41.",
         "direction": "backward"
       }
     ],
@@ -576,14 +527,14 @@
       {
         "ref": "Acts 5",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 5 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -593,12 +544,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -763,7 +714,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'You have not lied just to human beings but to God' (v. 4). Ananias and Sapphira's sin wasn't withholding money\u2014it was deception. The Spirit is a person to whom one can lie. Consequences are immediate: holy fear spreads.",
+      "tip": "'You have not lied just to human beings but to God' (v. 4). Ananias and Sapphira's sin wasn't withholding money—it was deception. The Spirit is a person to whom one can lie. Consequences are immediate: holy fear spreads.",
       "genre_tag": "theological_insight"
     },
     {

--- a/content/acts/7.json
+++ b/content/acts/7.json
@@ -7,46 +7,46 @@
   "subtitle": "Stephen's Defence and Martyrdom",
   "timeline_link": {
     "event_id": "stephen-martyred",
-    "text": "See on Timeline \u2014 Stephen's Martyrdom"
+    "text": "See on Timeline — Stephen's Martyrdom"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201429 \u2014 Stephen\u2019s Speech: Abraham, Joseph, and Moses",
+      "header": "Verses 1—29 — Stephen’s Speech: Abraham, Joseph, and Moses",
       "verse_start": 1,
       "verse_end": 29,
       "panels": {
         "heb": [
           {
-            "word": "\u1f41 \u03b8\u03b5\u1f78\u03c2 \u03c4\u1fc6\u03c2 \u03b4\u03cc\u03be\u03b7\u03c2",
-            "transliteration": "ho theos t\u0113s dox\u0113s",
+            "word": "ὁ θεὸς τῆς δόξης",
+            "transliteration": "ho theos tēs doxēs",
             "gloss": "The God of glory",
             "paragraph": "appears here and in Psalm 29:3 (LXX). The opening title frames the entire speech: God's glory is not temple-bound. The same glory that appeared to Abraham in Mesopotamia (before any temple, any land, any law) will appear to Stephen in heaven at the speech's end (7:55). Glory bookends the argument."
           },
           {
-            "word": "\u03ba\u03b1\u03c4\u03bf\u03b9\u03ba\u03b5\u1fd6\u03bd",
+            "word": "κατοικεῖν",
             "transliteration": "katoikein",
             "gloss": "to dwell/settle",
-            "paragraph": "Stephen traces Abraham's journey through multiple geographies \u2014 Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
+            "paragraph": "Stephen traces Abraham's journey through multiple geographies — Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
           }
         ],
         "places": [
           {
             "name": "Mesopotamia (Ur)",
-            "coords": "30.9626\u00b0 N, 46.1025\u00b0 E",
-            "text": "Abraham's origin \u2014 modern southern Iraq. God appeared to Abraham here, before he left for Harran (Gen 11:31\u201312:1). The first divine appearance in Israel's covenant history occurs entirely outside the promised land \u2014 Stephen's geographic opening argument."
+            "coords": "30.9626° N, 46.1025° E",
+            "text": "Abraham's origin — modern southern Iraq. God appeared to Abraham here, before he left for Harran (Gen 11:31–12:1). The first divine appearance in Israel's covenant history occurs entirely outside the promised land — Stephen's geographic opening argument."
           },
           {
             "name": "Harran",
-            "coords": "36.8631\u00b0 N, 39.0283\u00b0 E",
+            "coords": "36.8631° N, 39.0283° E",
             "text": "The city in northern Mesopotamia where Terah settled with Abraham and family. God's call to leave was given in Mesopotamia; Abraham completes the departure after Terah's death. Stephen tracks the movement precisely to show God's initiative operating across multiple geographies."
           }
         ],
         "tl": [
           {
             "date": "c. 2100 BC",
-            "name": "Abraham \u2014 Called in Mesopotamia",
+            "name": "Abraham — Called in Mesopotamia",
             "text": "God appears to Abraham in Ur of the Chaldeans, outside the promised land, before any temple. Stephen's point: divine initiative precedes every institution. The covenant is older than the land, the law, and the Temple.",
             "current": false
           },
@@ -57,56 +57,56 @@
             "current": false
           },
           {
-            "date": "c. AD 33\u201334",
+            "date": "c. AD 33–34",
             "name": "Stephen's Defence",
-            "text": "Stephen's comprehensive survey of salvation history is the most theologically ambitious speech in Acts \u2014 and the most confrontational. He argues that Israel has always resisted the Holy Spirit.",
+            "text": "Stephen's comprehensive survey of salvation history is the most theologically ambitious speech in Acts — and the most confrontational. He argues that Israel has always resisted the Holy Spirit.",
             "current": true
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Genesis 12:1\u20133",
-              "note": "God's call of Abraham in Mesopotamia \u2014 the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography."
+              "ref": "Genesis 12:1–3",
+              "note": "God's call of Abraham in Mesopotamia — the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography."
             },
             {
               "ref": "Deuteronomy 18:15",
-              "note": "The prophet-like-Moses prophecy \u2014 cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected."
+              "note": "The prophet-like-Moses prophecy — cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected."
             },
             {
-              "ref": "Amos 5:25\u201327",
-              "note": "Cited in vv.42\u201343 \u2014 Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly."
+              "ref": "Amos 5:25–27",
+              "note": "Cited in vv.42–43 — Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:2",
-              "note": "MacArthur notes that Stephen's opening \u2014 \"the God of glory appeared to our father Abraham while he was still in Mesopotamia\" \u2014 directly refutes the temple charges. If God appeared to Abraham before the Temple existed, the Temple cannot be the prerequisite for God's presence. The Temple is the response to the covenant, not its foundation."
+              "note": "MacArthur notes that Stephen's opening — \"the God of glory appeared to our father Abraham while he was still in Mesopotamia\" — directly refutes the temple charges. If God appeared to Abraham before the Temple existed, the Temple cannot be the prerequisite for God's presence. The Temple is the response to the covenant, not its foundation."
             },
             {
-              "ref": "7:9\u201310",
-              "note": "\"God was with him\" in Egypt \u2014 the presence of God with Joseph in slavery and prison is the guarantee that God's covenant faithfulness is not geography-dependent. The same principle applies to the scattered, persecuted Jerusalem church."
+              "ref": "7:9–10",
+              "note": "\"God was with him\" in Egypt — the presence of God with Joseph in slavery and prison is the guarantee that God's covenant faithfulness is not geography-dependent. The same principle applies to the scattered, persecuted Jerusalem church."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "7:2\u20133",
-              "note": "Calvin notes that Stephen begins with the word \"glory\" to establish his thesis: the God of Israel is the God of majesty who cannot be confined. Every institution God establishes \u2014 law, tabernacle, temple \u2014 is a condescension to human weakness, not a limitation on divine freedom."
+              "ref": "7:2–3",
+              "note": "Calvin notes that Stephen begins with the word \"glory\" to establish his thesis: the God of Israel is the God of majesty who cannot be confined. Every institution God establishes — law, tabernacle, temple — is a condescension to human weakness, not a limitation on divine freedom."
             },
             {
               "ref": "7:5",
-              "note": "Calvin on \"no inheritance, not even ground to set his foot on\": the physical possession of Canaan was never the substance of the Abrahamic covenant but only its pledge. The patriarchs lived as strangers because they understood the true inheritance was spiritual and eschatological (Heb 11:9\u201316)."
+              "note": "Calvin on \"no inheritance, not even ground to set his foot on\": the physical possession of Canaan was never the substance of the Abrahamic covenant but only its pledge. The patriarchs lived as strangers because they understood the true inheritance was spiritual and eschatological (Heb 11:9–16)."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:4",
@@ -114,70 +114,70 @@
             },
             {
               "ref": "7:14",
-              "note": "\"Seventy-five in all\" \u2014 follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently throughout Acts."
+              "note": "\"Seventy-five in all\" — follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently throughout Acts."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "7:2",
-              "note": "\"The God of glory\" \u2014 Robertson notes this unusual title frames the entire speech: God's glory is not temple-bound. The theophanic glory that appeared to Abraham in Mesopotamia is the same glory Stephen sees in heaven at the speech's end (7:55). Glory bookends the argument."
+              "note": "\"The God of glory\" — Robertson notes this unusual title frames the entire speech: God's glory is not temple-bound. The theophanic glory that appeared to Abraham in Mesopotamia is the same glory Stephen sees in heaven at the speech's end (7:55). Glory bookends the argument."
             },
             {
               "ref": "7:5",
-              "note": "\"No inheritance here, not even enough ground to set his foot on\" \u2014 Robertson notes the pointed irony: the father of the Jewish nation did not own the land he lived in. The covenant was about promise and relationship, not real estate."
+              "note": "\"No inheritance here, not even enough ground to set his foot on\" — Robertson notes the pointed irony: the father of the Jewish nation did not own the land he lived in. The covenant was about promise and relationship, not real estate."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "7:2\u20138",
-              "note": "Keener situates Stephen's speech in the tradition of Hellenistic Jewish apologetics \u2014 Philo and Josephus both retell patriarchal history emphasising the universality of God's working. Stephen uses the same tradition but arrives at a radical conclusion: the institutions of Jewish worship were always provisional, pointing beyond themselves."
+              "ref": "7:2–8",
+              "note": "Keener situates Stephen's speech in the tradition of Hellenistic Jewish apologetics — Philo and Josephus both retell patriarchal history emphasising the universality of God's working. Stephen uses the same tradition but arrives at a radical conclusion: the institutions of Jewish worship were always provisional, pointing beyond themselves."
             },
             {
               "ref": "7:14",
-              "note": "\"Seventy-five in all\" \u2014 the NET notes this follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently, as do most NT authors when citing the OT."
+              "note": "\"Seventy-five in all\" — the NET notes this follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently, as do most NT authors when citing the OT."
             }
           ]
         },
         "hist": {
-          "context": "Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured in three movements: (1) Patriarchs \u2014 God works outside the land (vv.2\u201316); (2) Moses \u2014 Israel repeatedly rejects their deliverer (vv.17\u201343); (3) Tabernacle/Temple \u2014 God never needed the building (vv.44\u201350); climaxing in direct indictment (vv.51\u201353). The recurring pattern: God sends a deliverer \u2192 the people reject him \u2192 God's purpose advances anyway. Joseph rejected \u2192 becomes ruler. Moses rejected (twice) \u2192 becomes deliverer. The pattern builds relentlessly toward: you rejected the Righteous One (v52)."
+          "context": "Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured in three movements: (1) Patriarchs — God works outside the land (vv.2–16); (2) Moses — Israel repeatedly rejects their deliverer (vv.17–43); (3) Tabernacle/Temple — God never needed the building (vv.44–50); climaxing in direct indictment (vv.51–53). The recurring pattern: God sends a deliverer → the people reject him → God's purpose advances anyway. Joseph rejected → becomes ruler. Moses rejected (twice) → becomes deliverer. The pattern builds relentlessly toward: you rejected the Righteous One (v52)."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 30\u201450 \u2014 Moses Continued; The Tabernacle; Solomon\u2019s Temple",
+      "header": "Verses 30—50 — Moses Continued; The Tabernacle; Solomon’s Temple",
       "verse_start": 30,
       "verse_end": 50,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03ba\u03bb\u03b7\u03c1\u03bf\u03c4\u03c1\u03ac\u03c7\u03b7\u03bb\u03bf\u03b9",
-            "transliteration": "skl\u0113rotracheloi",
+            "word": "σκληροτράχηλοι",
+            "transliteration": "sklērotracheloi",
             "gloss": "stiff-necked",
-            "paragraph": "literally \"hard-necked\" \u2014 the LXX term for Israel's stubbornness (Exod 33:3, 5; Deut 9:6, 13). Stephen uses the very words God used to Israel in the wilderness and applies them directly to the Sanhedrin. The accusation is devastating because it uses their own scriptures against them."
+            "paragraph": "literally \"hard-necked\" — the LXX term for Israel's stubbornness (Exod 33:3, 5; Deut 9:6, 13). Stephen uses the very words God used to Israel in the wilderness and applies them directly to the Sanhedrin. The accusation is devastating because it uses their own scriptures against them."
           },
           {
-            "word": "\u1f00\u03c0\u03b5\u03c1\u03af\u03c4\u03bc\u03b7\u03c4\u03bf\u03b9 \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03b9\u03c2 \u03ba\u03b1\u1f76 \u03c4\u03bf\u1fd6\u03c2 \u1f60\u03c3\u03af\u03bd",
-            "transliteration": "aperitm\u0113toi kardiais kai tois \u014dsin",
+            "word": "ἀπερίτμητοι καρδίαις καὶ τοῖς ὠσίν",
+            "transliteration": "aperitmētoi kardiais kai tois ōsin",
             "gloss": "uncircumcised in hearts and ears",
-            "paragraph": "Circumcision of the heart is the Deuteronomic ideal (Deut 10:16; 30:6; Jer 4:4). Stephen accuses the circumcised defenders of the law of being uncircumcised where it actually matters \u2014 in heart and ear."
+            "paragraph": "Circumcision of the heart is the Deuteronomic ideal (Deut 10:16; 30:6; Jer 4:4). Stephen accuses the circumcised defenders of the law of being uncircumcised where it actually matters — in heart and ear."
           }
         ],
         "places": [
           {
-            "name": "Outside the City \u2014 Stoning Site",
-            "coords": "31.7820\u00b0 N, 35.2354\u00b0 E",
-            "text": "Stoning required taking the condemned outside the city walls (Lev 24:14; cf. Heb 13:12). Stephen was dragged \"out of the city\" (v58). The witnesses laid their coats at Saul's feet \u2014 witnesses were required to throw the first stones, divesting themselves of outer garments for ease of movement."
+            "name": "Outside the City — Stoning Site",
+            "coords": "31.7820° N, 35.2354° E",
+            "text": "Stoning required taking the condemned outside the city walls (Lev 24:14; cf. Heb 13:12). Stephen was dragged \"out of the city\" (v58). The witnesses laid their coats at Saul's feet — witnesses were required to throw the first stones, divesting themselves of outer garments for ease of movement."
           },
           {
             "name": "Heaven Open",
-            "coords": "0\u00b0 N, 0\u00b0 E",
+            "coords": "0° N, 0° E",
             "text": "\"I see heaven open and the Son of Man standing at the right hand of God\" (v56). Stephen's vision is the most explicit post-resurrection appearance of Jesus in Acts. The \"standing\" rather than sitting is often noted: the risen Lord stands in honour of his first martyr."
           }
         ],
@@ -189,7 +189,7 @@
             "current": false
           },
           {
-            "date": "c. AD 33\u201334",
+            "date": "c. AD 33–34",
             "name": "Stephen Stoned",
             "text": "Stephen becomes the first Christian martyr, stoned outside Jerusalem's walls. His death triggers the first general persecution and the scattering that fulfils the 1:8 commission. Paul (Saul) is present as a consenting witness (8:1).",
             "current": true
@@ -204,38 +204,38 @@
         "cross": {
           "refs": [
             {
-              "ref": "Isaiah 66:1\u20132",
-              "note": "The direct Temple quotation (vv.49\u201350) \u2014 \"Heaven is my throne, earth my footstool. What kind of house will you build for me?\" The prophetic undermining of Temple theology from within Israel's own prophetic tradition."
+              "ref": "Isaiah 66:1–2",
+              "note": "The direct Temple quotation (vv.49–50) — \"Heaven is my throne, earth my footstool. What kind of house will you build for me?\" The prophetic undermining of Temple theology from within Israel's own prophetic tradition."
             },
             {
               "ref": "Luke 23:34, 46",
-              "note": "\"Father, forgive them\" and \"Into your hands I commit my spirit\" \u2014 Stephen's two dying prayers (vv.59\u201360) deliberately mirror these two cross-words, establishing the martyrdom pattern for all subsequent Christian suffering."
+              "note": "\"Father, forgive them\" and \"Into your hands I commit my spirit\" — Stephen's two dying prayers (vv.59–60) deliberately mirror these two cross-words, establishing the martyrdom pattern for all subsequent Christian suffering."
             },
             {
               "ref": "Psalm 110:1",
-              "note": "\"Sit at my right hand\" \u2014 Jesus is seen standing (v55), not sitting, in honour of his first martyr. The session at the right hand is established; the standing signals the moment's solemnity."
+              "note": "\"Sit at my right hand\" — Jesus is seen standing (v55), not sitting, in honour of his first martyr. The session at the right hand is established; the standing signals the moment's solemnity."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "7:55\u201356",
-              "note": "MacArthur treats Stephen's vision as an actual physical sight of the glorified Christ \u2014 not a metaphor. This is one of the few post-Pentecost appearances of the risen Jesus recorded in Acts (alongside the Damascus road). The vision grounds Stephen's boldness: he is not facing death alone."
+              "ref": "7:55–56",
+              "note": "MacArthur treats Stephen's vision as an actual physical sight of the glorified Christ — not a metaphor. This is one of the few post-Pentecost appearances of the risen Jesus recorded in Acts (alongside the Damascus road). The vision grounds Stephen's boldness: he is not facing death alone."
             },
             {
               "ref": "7:60",
-              "note": "Stephen's prayer for his killers \u2014 \"Lord, do not hold this sin against them\" \u2014 is the most dramatic expression of the forgiveness ethic in the NT outside the cross itself. It comes from a dying man with every reason for resentment."
+              "note": "Stephen's prayer for his killers — \"Lord, do not hold this sin against them\" — is the most dramatic expression of the forgiveness ethic in the NT outside the cross itself. It comes from a dying man with every reason for resentment."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "7:48\u201350",
-              "note": "Calvin on the Temple critique: Stephen is not abolishing worship but reforming its theology. The error of the Sanhedrin was not in valuing the Temple but in failing to understand what it was for \u2014 to point beyond itself to the living God who inhabits eternity."
+              "ref": "7:48–50",
+              "note": "Calvin on the Temple critique: Stephen is not abolishing worship but reforming its theology. The error of the Sanhedrin was not in valuing the Temple but in failing to understand what it was for — to point beyond itself to the living God who inhabits eternity."
             },
             {
               "ref": "7:60",
@@ -244,85 +244,85 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:55",
-              "note": "The NET notes that \"full of the Holy Spirit\" (pl\u0113r\u0113s pneumatos hagiou) uses the adjective pl\u0113r\u0113s \u2014 describing a stable, ongoing state of being Spirit-filled, not a fresh infilling for this moment but the culmination of the Spirit-filled life described throughout chs 6\u20137."
+              "note": "The NET notes that \"full of the Holy Spirit\" (plērēs pneumatos hagiou) uses the adjective plērēs — describing a stable, ongoing state of being Spirit-filled, not a fresh infilling for this moment but the culmination of the Spirit-filled life described throughout chs 6–7."
             },
             {
               "ref": "7:60",
-              "note": "\"Fell asleep\" (ekoimet\u0113) \u2014 Luke's euphemism for a believer's death that became standard in the NT (1 Cor 15:6, 18, 20; 1 Thess 4:13\u201315). The metaphor carries resurrection hope: sleep ends in waking."
+              "note": "\"Fell asleep\" (ekoimetē) — Luke's euphemism for a believer's death that became standard in the NT (1 Cor 15:6, 18, 20; 1 Thess 4:13–15). The metaphor carries resurrection hope: sleep ends in waking."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
-              "ref": "7:48\u201350",
-              "note": "Robertson notes that Stephen quotes Isaiah 66:1\u20132 to establish that the Temple was never God's ultimate dwelling \u2014 even Solomon's prayer at its dedication acknowledged this (1 Kings 8:27). Stephen is not rejecting worship but exposing the idolatry of treating the institution as an end rather than a means."
+              "ref": "7:48–50",
+              "note": "Robertson notes that Stephen quotes Isaiah 66:1–2 to establish that the Temple was never God's ultimate dwelling — even Solomon's prayer at its dedication acknowledged this (1 Kings 8:27). Stephen is not rejecting worship but exposing the idolatry of treating the institution as an end rather than a means."
             },
             {
-              "ref": "7:55\u201356",
-              "note": "\"Jesus standing at the right hand of God\" \u2014 the only other NT text using this precise language is Hebrews 12:2 (seated). The standing here may indicate that Jesus has risen from his throne in honour of his servant."
+              "ref": "7:55–56",
+              "note": "\"Jesus standing at the right hand of God\" — the only other NT text using this precise language is Hebrews 12:2 (seated). The standing here may indicate that Jesus has risen from his throne in honour of his servant."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "7:51\u201353",
-              "note": "Keener notes the rhetorical shift in vv.51\u201353: after fifty verses of historical narration, Stephen shifts to direct denunciation. This reversal is deliberate \u2014 he has been building to this accusation throughout. The Sanhedrin expected to judge him; he turns the court and judges them."
+              "ref": "7:51–53",
+              "note": "Keener notes the rhetorical shift in vv.51–53: after fifty verses of historical narration, Stephen shifts to direct denunciation. This reversal is deliberate — he has been building to this accusation throughout. The Sanhedrin expected to judge him; he turns the court and judges them."
             },
             {
               "ref": "7:58",
-              "note": "Saul holding the coats is not a minor detail. Ancient stoning procedure required witnesses to divest themselves of outer garments to throw the first stones. Saul's function as coat-keeper indicates a semi-official supervisory role \u2014 a young man of standing, not a mere bystander."
+              "note": "Saul holding the coats is not a minor detail. Ancient stoning procedure required witnesses to divest themselves of outer garments to throw the first stones. Saul's function as coat-keeper indicates a semi-official supervisory role — a young man of standing, not a mere bystander."
             }
           ]
         },
         "hist": {
-          "context": "Stephen's direct accusation (vv.51\u201353) is the speech's thesis: 'You always resist the Holy Spirit.' After fifty verses of historical narration (building the case), he shifts suddenly to direct denunciation \u2014 reversing the roles. The Sanhedrin expected to judge him; he turns the court and judges them from their own history. His two dying prayers deliberately echo Jesus's two cross-words from Luke 23: 'Lord Jesus, receive my spirit' (Luke 23:46: 'into your hands I commit my spirit') and 'Lord, do not hold this sin against them' (Luke 23:34: 'Father, forgive them'). The first martyr walks the same road as the first and only perfect martyr."
+          "context": "Stephen's direct accusation (vv.51–53) is the speech's thesis: 'You always resist the Holy Spirit.' After fifty verses of historical narration (building the case), he shifts suddenly to direct denunciation — reversing the roles. The Sanhedrin expected to judge him; he turns the court and judges them from their own history. His two dying prayers deliberately echo Jesus's two cross-words from Luke 23: 'Lord Jesus, receive my spirit' (Luke 23:46: 'into your hands I commit my spirit') and 'Lord, do not hold this sin against them' (Luke 23:34: 'Father, forgive them'). The first martyr walks the same road as the first and only perfect martyr."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 51\u201460 \u2014 You Always Resist the Holy Spirit; Stephen Stoned",
+      "header": "Verses 51—60 — You Always Resist the Holy Spirit; Stephen Stoned",
       "verse_start": 51,
       "verse_end": 60,
       "panels": {
         "heb": [
           {
-            "word": "\u1f41 \u03b8\u03b5\u1f78\u03c2 \u03c4\u1fc6\u03c2 \u03b4\u03cc\u03be\u03b7\u03c2",
-            "transliteration": "ho theos t\u0113s dox\u0113s",
+            "word": "ὁ θεὸς τῆς δόξης",
+            "transliteration": "ho theos tēs doxēs",
             "gloss": "The God of glory",
             "paragraph": "appears here and in Psalm 29:3 (LXX). The opening title frames the entire speech: God's glory is not temple-bound. The same glory that appeared to Abraham in Mesopotamia (before any temple, any land, any law) will appear to Stephen in heaven at the speech's end (7:55). Glory bookends the argument."
           },
           {
-            "word": "\u03ba\u03b1\u03c4\u03bf\u03b9\u03ba\u03b5\u1fd6\u03bd",
+            "word": "κατοικεῖν",
             "transliteration": "katoikein",
             "gloss": "to dwell/settle",
-            "paragraph": "Stephen traces Abraham's journey through multiple geographies \u2014 Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
+            "paragraph": "Stephen traces Abraham's journey through multiple geographies — Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
           }
         ],
         "places": [
           {
             "name": "Mesopotamia (Ur)",
-            "coords": "30.9626\u00b0 N, 46.1025\u00b0 E",
-            "text": "Abraham's origin \u2014 modern southern Iraq. God appeared to Abraham here, before he left for Harran (Gen 11:31\u201312:1). The first divine appearance in Israel's covenant history occurs entirely outside the promised land \u2014 Stephen's geographic opening argument."
+            "coords": "30.9626° N, 46.1025° E",
+            "text": "Abraham's origin — modern southern Iraq. God appeared to Abraham here, before he left for Harran (Gen 11:31–12:1). The first divine appearance in Israel's covenant history occurs entirely outside the promised land — Stephen's geographic opening argument."
           },
           {
             "name": "Harran",
-            "coords": "36.8631\u00b0 N, 39.0283\u00b0 E",
+            "coords": "36.8631° N, 39.0283° E",
             "text": "The city in northern Mesopotamia where Terah settled with Abraham and family. God's call to leave was given in Mesopotamia; Abraham completes the departure after Terah's death. Stephen tracks the movement precisely to show God's initiative operating across multiple geographies."
           }
         ],
         "tl": [
           {
             "date": "c. 2100 BC",
-            "name": "Abraham \u2014 Called in Mesopotamia",
+            "name": "Abraham — Called in Mesopotamia",
             "text": "God appears to Abraham in Ur of the Chaldeans, outside the promised land, before any temple. Stephen's point: divine initiative precedes every institution. The covenant is older than the land, the law, and the Temple.",
             "current": false
           },
@@ -333,95 +333,50 @@
             "current": false
           },
           {
-            "date": "c. AD 33\u201334",
+            "date": "c. AD 33–34",
             "name": "Stephen's Defence",
-            "text": "Stephen's comprehensive survey of salvation history is the most theologically ambitious speech in Acts \u2014 and the most confrontational. He argues that Israel has always resisted the Holy Spirit.",
+            "text": "Stephen's comprehensive survey of salvation history is the most theologically ambitious speech in Acts — and the most confrontational. He argues that Israel has always resisted the Holy Spirit.",
             "current": true
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Genesis 12:1\u20133",
-              "note": "God's call of Abraham in Mesopotamia \u2014 the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography."
+              "ref": "Genesis 12:1–3",
+              "note": "God's call of Abraham in Mesopotamia — the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography."
             },
             {
               "ref": "Deuteronomy 18:15",
-              "note": "The prophet-like-Moses prophecy \u2014 cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected."
+              "note": "The prophet-like-Moses prophecy — cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected."
             },
             {
-              "ref": "Amos 5:25\u201327",
-              "note": "Cited in vv.42\u201343 \u2014 Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly."
+              "ref": "Amos 5:25–27",
+              "note": "Cited in vv.42–43 — Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:2",
-              "note": "MacArthur notes that Stephen's opening \u2014 \"the God of glory appeared to our father Abraham while he was still in Mesopotamia\" \u2014 directly refutes the temple charges. If God appeared to Abraham before the Temple existed, the Temple cannot be the prerequisite for God's presence. The Temple is the response to the covenant, not its foundation."
-            },
-            {
-              "ref": "7:9\u201310",
-              "note": "\"God was with him\" in Egypt \u2014 the presence of God with Joseph in slavery and prison is the guarantee that God's covenant faithfulness is not geography-dependent. The same principle applies to the scattered, persecuted Jerusalem church."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:2\u20133",
-              "note": "Calvin notes that Stephen begins with the word \"glory\" to establish his thesis: the God of Israel is the God of majesty who cannot be confined. Every institution God establishes \u2014 law, tabernacle, temple \u2014 is a condescension to human weakness, not a limitation on divine freedom."
-            },
-            {
-              "ref": "7:5",
-              "note": "Calvin on \"no inheritance, not even ground to set his foot on\": the physical possession of Canaan was never the substance of the Abrahamic covenant but only its pledge. The patriarchs lived as strangers because they understood the true inheritance was spiritual and eschatological (Heb 11:9\u201316)."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:4",
-              "note": "The NET notes a textual issue: Gen 11:26 says Terah was 70 when he fathered Abraham; Acts 7:4 says Abraham left after his father's death. The Samaritan Pentateuch reads Terah's death at 145, resolving the chronology. Luke may follow a textual tradition different from the Masoretic Text."
-            },
-            {
-              "ref": "7:14",
-              "note": "\"Seventy-five in all\" \u2014 follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently throughout Acts."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "7:2",
-              "note": "\"The God of glory\" \u2014 Robertson notes this unusual title frames the entire speech: God's glory is not temple-bound. The theophanic glory that appeared to Abraham in Mesopotamia is the same glory Stephen sees in heaven at the speech's end (7:55). Glory bookends the argument."
-            },
-            {
-              "ref": "7:5",
-              "note": "\"No inheritance here, not even enough ground to set his foot on\" \u2014 Robertson notes the pointed irony: the father of the Jewish nation did not own the land he lived in. The covenant was about promise and relationship, not real estate."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:2\u20138",
-              "note": "Keener situates Stephen's speech in the tradition of Hellenistic Jewish apologetics \u2014 Philo and Josephus both retell patriarchal history emphasising the universality of God's working. Stephen uses the same tradition but arrives at a radical conclusion: the institutions of Jewish worship were always provisional, pointing beyond themselves."
-            },
-            {
-              "ref": "7:14",
-              "note": "\"Seventy-five in all\" \u2014 the NET notes this follows the LXX (Gen 46:27; Exod 1:5 LXX) rather than the Hebrew text (seventy). Luke uses the LXX consistently, as do most NT authors when citing the OT."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured in three movements: (1) Patriarchs \u2014 God works outside the land (vv.2\u201316); (2) Moses \u2014 Israel repeatedly rejects their deliverer (vv.17\u201343); (3) Tabernacle/Temple \u2014 God never needed the building (vv.44\u201350); climaxing in direct indictment (vv.51\u201353). The recurring pattern: God sends a deliverer \u2192 the people reject him \u2192 God's purpose advances anyway. Joseph rejected \u2192 becomes ruler. Moses rejected (twice) \u2192 becomes deliverer. The pattern builds relentlessly toward: you rejected the Righteous One (v52)."
+          "context": "Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured in three movements: (1) Patriarchs — God works outside the land (vv.2–16); (2) Moses — Israel repeatedly rejects their deliverer (vv.17–43); (3) Tabernacle/Temple — God never needed the building (vv.44–50); climaxing in direct indictment (vv.51–53). The recurring pattern: God sends a deliverer → the people reject him → God's purpose advances anyway. Joseph rejected → becomes ruler. Moses rejected (twice) → becomes deliverer. The pattern builds relentlessly toward: you rejected the Righteous One (v52)."
         }
       }
     }
@@ -429,54 +384,54 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Stephen\u2197 People",
+        "name": "Stephen↗ People",
         "role": "First martyr; deacon whose speech reframed salvation history",
-        "text": "Stephen is appointed as one of the seven deacons in Acts 6 to serve the Hellenistic widows. His speech before the Sanhedrin (Acts 7) is the longest speech in Acts and a sweeping reinterpretation of Israel\u2019s history as a pattern of rejecting God\u2019s messengers. He is stoned while seeing the Son of Man standing at God\u2019s right hand. His death scatters the Jerusalem church and launches the Gentile mission (Acts 8:1\u20134)."
+        "text": "Stephen is appointed as one of the seven deacons in Acts 6 to serve the Hellenistic widows. His speech before the Sanhedrin (Acts 7) is the longest speech in Acts and a sweeping reinterpretation of Israel’s history as a pattern of rejecting God’s messengers. He is stoned while seeing the Son of Man standing at God’s right hand. His death scatters the Jerusalem church and launches the Gentile mission (Acts 8:1–4)."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>To this he replied: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And Stephen said: \u201cBrothers and fathers, hear me. The God of glory appeared to our father Abraham when he was in Mesopotamia, before he lived in Haran,</td></tr><tr><td class=\"t-label\">NIV</td><td>God spoke to him in this way: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And God spoke to this effect\u2014that his offspring would be sojourners in a land belonging to others, who would enslave them and afflict them four hundred years.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>To this he replied: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And Stephen said: “Brothers and fathers, hear me. The God of glory appeared to our father Abraham when he was in Mesopotamia, before he lived in Haran,</td></tr><tr><td class=\"t-label\">NIV</td><td>God spoke to him in this way: \\</td></tr><tr><td class=\"t-label\">ESV</td><td>And God spoke to this effect—that his offspring would be sojourners in a land belonging to others, who would enslave them and afflict them four hundred years.</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"MacArthur notes that Stephen's opening \u2014 \"the God of glory appeared to our father Abraham while he was still in Mesopotamia\" \u2014 directly refutes the temple charges. If God appeared to Abraham before th\""
+        "text": "\"MacArthur notes that Stephen's opening — \"the God of glory appeared to our father Abraham while he was still in Mesopotamia\" — directly refutes the temple charges. If God appeared to Abraham before th\""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201429 \u2014 Stephen\u2019s Speech: Abraham, Joseph, and Moses",
-          "text": "Context  Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured i\u2026",
+          "label": "Verses 1—29 — Stephen’s Speech: Abraham, Joseph, and Moses",
+          "text": "Context  Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured i…",
           "is_key": false
         },
         {
-          "label": "Verses 30\u201450 \u2014 Moses Continued; The Tabernacle; Solomon\u2019s Temple",
-          "text": "Context  Stephen's direct accusation (vv.51\u201353) is the speech's thesis: 'You always resist the Holy Spirit.' After fifty\u2026",
+          "label": "Verses 30—50 — Moses Continued; The Tabernacle; Solomon’s Temple",
+          "text": "Context  Stephen's direct accusation (vv.51–53) is the speech's thesis: 'You always resist the Holy Spirit.' After fifty…",
           "is_key": false
         },
         {
-          "label": "Verses 51\u201460 \u2014 You Always Resist the Holy Spirit; Stephen Stoned",
-          "text": "Context  Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured i\u2026",
+          "label": "Verses 51—60 — You Always Resist the Holy Spirit; Stephen Stoned",
+          "text": "Context  Acts 7 is the longest speech in Acts (60 verses) and the most confrontational. Stephen's survey is structured i…",
           "is_key": false
         }
       ],
@@ -484,83 +439,83 @@
     },
     "hebtext": [
       {
-        "word": "\u1f41 \u03b8\u03b5\u1f78\u03c2 \u03c4\u1fc6\u03c2 \u03b4\u03cc\u03be\u03b7\u03c2",
-        "tlit": "ho theos t\u0113s dox\u0113s",
+        "word": "ὁ θεὸς τῆς δόξης",
+        "tlit": "ho theos tēs doxēs",
         "gloss": "The God of glory",
         "note": "appears here and in Psalm 29:3 (LXX). The opening title frames the entire speech: God's glory is not temple-bound. The same glory that appeared to Abraham in Mesopotamia (before any temple, any land, any law) will appear to Stephen in heaven at the speech's end (7:55). Glory bookends the argument."
       },
       {
-        "word": "\u03ba\u03b1\u03c4\u03bf\u03b9\u03ba\u03b5\u1fd6\u03bd",
+        "word": "κατοικεῖν",
         "tlit": "katoikein",
         "gloss": "to dwell/settle",
-        "note": "Stephen traces Abraham's journey through multiple geographies \u2014 Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
+        "note": "Stephen traces Abraham's journey through multiple geographies — Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
       },
       {
-        "word": "\u03c3\u03ba\u03bb\u03b7\u03c1\u03bf\u03c4\u03c1\u03ac\u03c7\u03b7\u03bb\u03bf\u03b9",
-        "tlit": "skl\u0113rotracheloi",
+        "word": "σκληροτράχηλοι",
+        "tlit": "sklērotracheloi",
         "gloss": "stiff-necked",
-        "note": "literally \"hard-necked\" \u2014 the LXX term for Israel's stubbornness (Exod 33:3, 5; Deut 9:6, 13). Stephen uses the very words God used to Israel in the wilderness and applies them directly to the Sanhedrin. The accusation is devastating because it uses their own scriptures against them."
+        "note": "literally \"hard-necked\" — the LXX term for Israel's stubbornness (Exod 33:3, 5; Deut 9:6, 13). Stephen uses the very words God used to Israel in the wilderness and applies them directly to the Sanhedrin. The accusation is devastating because it uses their own scriptures against them."
       },
       {
-        "word": "\u1f00\u03c0\u03b5\u03c1\u03af\u03c4\u03bc\u03b7\u03c4\u03bf\u03b9 \u03ba\u03b1\u03c1\u03b4\u03af\u03b1\u03b9\u03c2 \u03ba\u03b1\u1f76 \u03c4\u03bf\u1fd6\u03c2 \u1f60\u03c3\u03af\u03bd",
-        "tlit": "aperitm\u0113toi kardiais kai tois \u014dsin",
+        "word": "ἀπερίτμητοι καρδίαις καὶ τοῖς ὠσίν",
+        "tlit": "aperitmētoi kardiais kai tois ōsin",
         "gloss": "uncircumcised in hearts and ears",
-        "note": "Circumcision of the heart is the Deuteronomic ideal (Deut 10:16; 30:6; Jer 4:4). Stephen accuses the circumcised defenders of the law of being uncircumcised where it actually matters \u2014 in heart and ear."
+        "note": "Circumcision of the heart is the Deuteronomic ideal (Deut 10:16; 30:6; Jer 4:4). Stephen accuses the circumcised defenders of the law of being uncircumcised where it actually matters — in heart and ear."
       },
       {
-        "word": "\u1f41 \u03b8\u03b5\u1f78\u03c2 \u03c4\u1fc6\u03c2 \u03b4\u03cc\u03be\u03b7\u03c2",
-        "tlit": "ho theos t\u0113s dox\u0113s",
+        "word": "ὁ θεὸς τῆς δόξης",
+        "tlit": "ho theos tēs doxēs",
         "gloss": "The God of glory",
         "note": "appears here and in Psalm 29:3 (LXX). The opening title frames the entire speech: God's glory is not temple-bound. The same glory that appeared to Abraham in Mesopotamia (before any temple, any land, any law) will appear to Stephen in heaven at the speech's end (7:55). Glory bookends the argument."
       },
       {
-        "word": "\u03ba\u03b1\u03c4\u03bf\u03b9\u03ba\u03b5\u1fd6\u03bd",
+        "word": "κατοικεῖν",
         "tlit": "katoikein",
         "gloss": "to dwell/settle",
-        "note": "Stephen traces Abraham's journey through multiple geographies \u2014 Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
+        "note": "Stephen traces Abraham's journey through multiple geographies — Mesopotamia, Harran, Canaan. At each stage God is present and active. The God of the Bible is the God of the journey before he is the God of any destination."
       }
     ],
     "thread": [
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Genesis 12:1\u20133",
+        "target": "Genesis 12:1–3",
         "type": "Connection",
-        "text": "God's call of Abraham in Mesopotamia \u2014 the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography.",
+        "text": "God's call of Abraham in Mesopotamia — the foundation of Stephen's argument. The covenant begins outside Canaan, with a God not confined to any geography.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Deuteronomy 18:15",
         "type": "Fulfilment",
-        "text": "The prophet-like-Moses prophecy \u2014 cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected.",
+        "text": "The prophet-like-Moses prophecy — cited in v37 as fulfilled in Jesus. Stephen's survey culminates in this claim: the whole of Israel's history pointed to Jesus, whom they rejected.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Amos 5:25\u201327",
+        "target": "Amos 5:25–27",
         "type": "Connection",
-        "text": "Cited in vv.42\u201343 \u2014 Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly.",
+        "text": "Cited in vv.42–43 — Israel's wilderness idolatry and the resulting exile. Stephen uses the prophets to confirm the pattern: Israel's rejection of God's agents is not a recent anomaly.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Isaiah 66:1\u20132",
+        "target": "Isaiah 66:1–2",
         "type": "Connection",
-        "text": "The direct Temple quotation (vv.49\u201350) \u2014 \"Heaven is my throne, earth my footstool. What kind of house will you build for me?\" The prophetic undermining of Temple theology from within Israel's own prophetic tradition.",
+        "text": "The direct Temple quotation (vv.49–50) — \"Heaven is my throne, earth my footstool. What kind of house will you build for me?\" The prophetic undermining of Temple theology from within Israel's own prophetic tradition.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Luke 23:34, 46",
         "type": "Connection",
-        "text": "\"Father, forgive them\" and \"Into your hands I commit my spirit\" \u2014 Stephen's two dying prayers (vv.59\u201360) deliberately mirror these two cross-words, establishing the martyrdom pattern for all subsequent Christian suffering.",
+        "text": "\"Father, forgive them\" and \"Into your hands I commit my spirit\" — Stephen's two dying prayers (vv.59–60) deliberately mirror these two cross-words, establishing the martyrdom pattern for all subsequent Christian suffering.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Psalm 110:1",
         "type": "Connection",
-        "text": "\"Sit at my right hand\" \u2014 Jesus is seen standing (v55), not sitting, in honour of his first martyr. The session at the right hand is established; the standing signals the moment's solemnity.",
+        "text": "\"Sit at my right hand\" — Jesus is seen standing (v55), not sitting, in honour of his first martyr. The session at the right hand is established; the standing signals the moment's solemnity.",
         "direction": "backward"
       }
     ],
@@ -568,14 +523,14 @@
       {
         "ref": "Acts 7",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 7 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -585,12 +540,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -760,7 +715,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'Look, I see heaven open and the Son of Man standing at the right hand of God' (v. 56). Jesus stands\u2014to welcome? To vindicate? Stephen dies praying for his killers. 'Saul approved of their killing him' (8:1). A seed planted.",
+      "tip": "'Look, I see heaven open and the Son of Man standing at the right hand of God' (v. 56). Jesus stands—to welcome? To vindicate? Stephen dies praying for his killers. 'Saul approved of their killing him' (8:1). A seed planted.",
       "genre_tag": "canonical_thread"
     }
   ]

--- a/content/acts/9.json
+++ b/content/acts/9.json
@@ -7,51 +7,51 @@
   "subtitle": "Saul's Conversion and Early Ministry",
   "timeline_link": {
     "event_id": "paul-conversion",
-    "text": "See on Timeline \u2014 Paul Conversion"
+    "text": "See on Timeline — Paul Conversion"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201419 \u2014 Saul\u2019s Conversion on the Road to Damascus",
+      "header": "Verses 1—19 — Saul’s Conversion on the Road to Damascus",
       "verse_start": 1,
       "verse_end": 19,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bc\u03c0\u03bd\u03ad\u03c9\u03bd \u1f00\u03c0\u03b5\u03b9\u03bb\u1fc6\u03c2",
-            "transliteration": "empne\u014dn apeil\u0113s",
+            "word": "ἐμπνέων ἀπειλῆς",
+            "transliteration": "empneōn apeilēs",
             "gloss": "breathing out murderous threats",
-            "paragraph": "a vivid compound \u2014 Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
+            "paragraph": "a vivid compound — Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
           },
           {
-            "word": "\u03c4\u1fc6\u03c2 \u1f41\u03b4\u03bf\u1fe6",
-            "transliteration": "t\u0113s hodou",
+            "word": "τῆς ὁδοῦ",
+            "transliteration": "tēs hodou",
             "gloss": "the Way",
-            "paragraph": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) \u2014 Christianity is a whole orientation of life, not merely a belief system."
+            "paragraph": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) — Christianity is a whole orientation of life, not merely a belief system."
           }
         ],
         "places": [
           {
             "name": "Damascus",
-            "coords": "33.5138\u00b0 N, 36.2765\u00b0 E",
-            "text": "Capital of Syria, c.240 km north of Jerusalem \u2014 one of the oldest continuously inhabited cities in the world. A large Jewish community made it a natural extension of Jerusalem's religious authority. Paul's encounter with Christ happens on this public road, not in private \u2014 a verifiable, historical event."
+            "coords": "33.5138° N, 36.2765° E",
+            "text": "Capital of Syria, c.240 km north of Jerusalem — one of the oldest continuously inhabited cities in the world. A large Jewish community made it a natural extension of Jerusalem's religious authority. Paul's encounter with Christ happens on this public road, not in private — a verifiable, historical event."
           },
           {
-            "name": "Straight Street \u2014 Damascus",
-            "coords": "33.5100\u00b0 N, 36.3070\u00b0 E",
-            "text": "The main east-west thoroughfare of Damascus (v11, still identifiable today as the Via Recta). The house of Judas where Saul stayed was on this specific street \u2014 a verifiable address that Luke records with the precision of reliable history."
+            "name": "Straight Street — Damascus",
+            "coords": "33.5100° N, 36.3070° E",
+            "text": "The main east-west thoroughfare of Damascus (v11, still identifiable today as the Via Recta). The house of Judas where Saul stayed was on this specific street — a verifiable address that Luke records with the precision of reliable history."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 33\u201335",
-            "name": "Paul's Conversion \u2014 Damascus Road",
-            "text": "Saul of Tarsus encounters the risen Jesus on the road to Damascus. Blinded for three days, healed by Ananias, baptized, and immediately begins preaching. The most dramatic reversal in Acts \u2014 the persecutor becomes the preacher.",
+            "date": "c. AD 33–35",
+            "name": "Paul's Conversion — Damascus Road",
+            "text": "Saul of Tarsus encounters the risen Jesus on the road to Damascus. Blinded for three days, healed by Ananias, baptized, and immediately begins preaching. The most dramatic reversal in Acts — the persecutor becomes the preacher.",
             "current": true
           },
           {
-            "date": "c. AD 35\u201337",
+            "date": "c. AD 35–37",
             "name": "Paul in Arabia and Return",
             "text": "",
             "current": false
@@ -66,130 +66,130 @@
         "cross": {
           "refs": [
             {
-              "ref": "1 Corinthians 15:8\u20139",
+              "ref": "1 Corinthians 15:8–9",
               "note": "\"Last of all he appeared to me also, as to one abnormally born. For I am the least of the apostles... because I persecuted the church of God.\" Paul's own testimony confirms the Acts account."
             },
             {
-              "ref": "Galatians 1:13\u201316",
+              "ref": "Galatians 1:13–16",
               "note": "Paul's autobiographical account: \"God, who set me apart from my mother's womb... was pleased to reveal his Son in me so that I might preach him among the Gentiles.\""
             },
             {
-              "ref": "Philippians 3:4\u20136",
-              "note": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" \u2014 the man God chose as his instrument."
+              "ref": "Philippians 3:4–6",
+              "note": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" — the man God chose as his instrument."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:5",
-              "note": "\"I am Jesus, whom you are persecuting\" \u2014 the identification of Christ with his people is the foundation of NT ecclesiology. Saul thought he was opposing a human movement; he was attacking the living Lord. Those who treat the church as merely human institution misunderstand its nature as radically as Saul did."
+              "note": "\"I am Jesus, whom you are persecuting\" — the identification of Christ with his people is the foundation of NT ecclesiology. Saul thought he was opposing a human movement; he was attacking the living Lord. Those who treat the church as merely human institution misunderstand its nature as radically as Saul did."
             },
             {
-              "ref": "9:15\u201316",
-              "note": "The sovereign language of election frames Paul's entire apostolic career. He did not choose his calling; he was chosen for it before he understood what it meant. Paul's conversion was not persuasion but revelation \u2014 a direct, sovereign act of God."
+              "ref": "9:15–16",
+              "note": "The sovereign language of election frames Paul's entire apostolic career. He did not choose his calling; he was chosen for it before he understood what it meant. Paul's conversion was not persuasion but revelation — a direct, sovereign act of God."
             },
             {
               "ref": "9:20",
-              "note": "\"At once he began to preach\" \u2014 MacArthur notes the immediacy: no retreat for preparation, no extended discipleship programme before witness. The encounter with the risen Christ was itself the commissioning. The same pattern characterises every genuine conversion: the response is immediate and public."
+              "note": "\"At once he began to preach\" — MacArthur notes the immediacy: no retreat for preparation, no extended discipleship programme before witness. The encounter with the risen Christ was itself the commissioning. The same pattern characterises every genuine conversion: the response is immediate and public."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "9:4\u20135",
-              "note": "Calvin on the divine address: \"Why do you persecute me?\" is the revelation of the mystical union \u2014 Christ and his church are one. Paul will develop this doctrine in his letters; he first learns it in the moment of his conversion, discovering the union in the very act of violating it."
+              "ref": "9:4–5",
+              "note": "Calvin on the divine address: \"Why do you persecute me?\" is the revelation of the mystical union — Christ and his church are one. Paul will develop this doctrine in his letters; he first learns it in the moment of his conversion, discovering the union in the very act of violating it."
             },
             {
               "ref": "9:15",
-              "note": "Calvin on divine election in Paul's conversion: God does not wait for Saul to stop persecuting before choosing him \u2014 he is chosen as a persecutor, in the act of persecution. This is the purest possible demonstration of unconditional election: no merit, no preparation, no openness \u2014 only sovereign grace acting against all human probability."
+              "note": "Calvin on divine election in Paul's conversion: God does not wait for Saul to stop persecuting before choosing him — he is chosen as a persecutor, in the act of persecution. This is the purest possible demonstration of unconditional election: no merit, no preparation, no openness — only sovereign grace acting against all human probability."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:7",
-              "note": "\"They heard the sound but did not see anyone\" \u2014 the NET notes the apparent tension with 22:9: \"My companions saw the light, but they did not hear the voice.\" The NET harmonises: they heard a sound (general noise) but not intelligible speech, while they saw light but not the person. The accounts are complementary, not contradictory."
+              "note": "\"They heard the sound but did not see anyone\" — the NET notes the apparent tension with 22:9: \"My companions saw the light, but they did not hear the voice.\" The NET harmonises: they heard a sound (general noise) but not intelligible speech, while they saw light but not the person. The accounts are complementary, not contradictory."
             },
             {
               "ref": "9:15",
-              "note": "\"Chosen instrument\" (skeuos eklog\u0113s) \u2014 literally \"a vessel of choice/election.\" The metaphor recurs in Paul's letters (2 Cor 4:7: \"treasure in jars of clay\") \u2014 the container serves the content; Paul's life is shaped by what he carries."
+              "note": "\"Chosen instrument\" (skeuos eklogēs) — literally \"a vessel of choice/election.\" The metaphor recurs in Paul's letters (2 Cor 4:7: \"treasure in jars of clay\") — the container serves the content; Paul's life is shaped by what he carries."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "9:4",
-              "note": "\"Saul, Saul, why do you persecute me?\" \u2014 Robertson notes the double vocative as a mark of urgency and personal address, used in OT divine calls (Gen 22:11: \"Abraham, Abraham\"; Exod 3:4: \"Moses, Moses\"). The risen Christ addresses the persecutor with the same intimate directness as God's call to the patriarchs."
+              "note": "\"Saul, Saul, why do you persecute me?\" — Robertson notes the double vocative as a mark of urgency and personal address, used in OT divine calls (Gen 22:11: \"Abraham, Abraham\"; Exod 3:4: \"Moses, Moses\"). The risen Christ addresses the persecutor with the same intimate directness as God's call to the patriarchs."
             },
             {
               "ref": "9:15",
-              "note": "\"This man is my chosen instrument\" \u2014 Robertson on skeuos eklog\u0113s (vessel of election): Paul is not self-chosen but divinely selected for a specific purpose. The passive construction governs everything that follows: Paul's ministry is grounded in divine initiative, not human qualification."
+              "note": "\"This man is my chosen instrument\" — Robertson on skeuos eklogēs (vessel of election): Paul is not self-chosen but divinely selected for a specific purpose. The passive construction governs everything that follows: Paul's ministry is grounded in divine initiative, not human qualification."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "9:1\u20132",
-              "note": "Keener provides historical context: the high priest had religious jurisdiction over Diaspora synagogues. The request for extradition of members of \"the Way\" reflects legal procedure \u2014 bringing charges before the proper religious authority. Saul is acting through official channels, not as a rogue vigilante."
+              "ref": "9:1–2",
+              "note": "Keener provides historical context: the high priest had religious jurisdiction over Diaspora synagogues. The request for extradition of members of \"the Way\" reflects legal procedure — bringing charges before the proper religious authority. Saul is acting through official channels, not as a rogue vigilante."
             },
             {
-              "ref": "9:15\u201316",
-              "note": "Keener notes the two-part commission: proclaim to Gentiles and kings AND people of Israel. The suffering element (\"I will show him how much he must suffer\") is equally programmatic \u2014 Paul's missionary career is a theology of the cross in biographical form."
+              "ref": "9:15–16",
+              "note": "Keener notes the two-part commission: proclaim to Gentiles and kings AND people of Israel. The suffering element (\"I will show him how much he must suffer\") is equally programmatic — Paul's missionary career is a theology of the cross in biographical form."
             }
           ]
         },
         "hist": {
-          "context": "The Damascus road account is told three times in Acts (9:1\u201319; 22:6\u201316; 26:12\u201318) \u2014 the only event so repeated. Each retelling adds details appropriate to its audience. The repetition signals that Paul's conversion is not private experience but public, court-level testimony: he has seen the risen Jesus, which qualifies him as an apostle (1 Cor 9:1; 15:8\u20139). The risen Jesus's question 'Why do you persecute me?' identifies himself with those Saul is persecuting \u2014 the theological foundation of Paul's later 'body of Christ' ecclesiology: attacking the church is attacking Christ himself (1 Cor 12:12\u201327)."
+          "context": "The Damascus road account is told three times in Acts (9:1–19; 22:6–16; 26:12–18) — the only event so repeated. Each retelling adds details appropriate to its audience. The repetition signals that Paul's conversion is not private experience but public, court-level testimony: he has seen the risen Jesus, which qualifies him as an apostle (1 Cor 9:1; 15:8–9). The risen Jesus's question 'Why do you persecute me?' identifies himself with those Saul is persecuting — the theological foundation of Paul's later 'body of Christ' ecclesiology: attacking the church is attacking Christ himself (1 Cor 12:12–27)."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 20\u201431 \u2014 Saul Preaches in Damascus and Jerusalem; The Church Has Peace",
+      "header": "Verses 20—31 — Saul Preaches in Damascus and Jerusalem; The Church Has Peace",
       "verse_start": 20,
       "verse_end": 31,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c0\u03c5\u03c1\u03af\u03b4\u03b9",
+            "word": "σπυρίδι",
             "transliteration": "spuridi",
             "gloss": "basket",
-            "paragraph": "the same word Paul uses in 2 Cor 11:33, independently confirming the event. The basket (a large wicker container) lowered through a gap in the city wall is a detail both Luke and Paul record \u2014 mutual attestation of an undeniable historical memory."
+            "paragraph": "the same word Paul uses in 2 Cor 11:33, independently confirming the event. The basket (a large wicker container) lowered through a gap in the city wall is a detail both Luke and Paul record — mutual attestation of an undeniable historical memory."
           },
           {
-            "word": "\u03bc\u03b1\u03b8\u03ae\u03c4\u03c1\u03b9\u03b1",
-            "transliteration": "math\u0113tria",
+            "word": "μαθήτρια",
+            "transliteration": "mathētria",
             "gloss": "disciple (feminine)",
-            "paragraph": "the only occurrence of the feminine form of math\u0113t\u0113s (disciple) in the NT. Tabitha is unambiguously presented as a full disciple, not merely a supporting character \u2014 Luke's vocabulary makes her standing explicit."
+            "paragraph": "the only occurrence of the feminine form of mathētēs (disciple) in the NT. Tabitha is unambiguously presented as a full disciple, not merely a supporting character — Luke's vocabulary makes her standing explicit."
           }
         ],
         "places": [
           {
             "name": "Lydda (Lod)",
-            "coords": "31.9531\u00b0 N, 34.8951\u00b0 E",
-            "text": "A town on the main road from Jerusalem to Joppa, in the fertile Shephelah. Modern Lod, near Tel Aviv's airport. Peter's healing of Aeneas made the Gospel known throughout the Plain of Sharon \u2014 the entire coastal corridor."
+            "coords": "31.9531° N, 34.8951° E",
+            "text": "A town on the main road from Jerusalem to Joppa, in the fertile Shephelah. Modern Lod, near Tel Aviv's airport. Peter's healing of Aeneas made the Gospel known throughout the Plain of Sharon — the entire coastal corridor."
           },
           {
             "name": "Joppa (Yafo)",
-            "coords": "32.0543\u00b0 N, 34.7510\u00b0 E",
-            "text": "The ancient Mediterranean port city \u2014 where Jonah tried to flee (Jon 1:3) and where cedar for Solomon's Temple was shipped (2 Chr 2:16). Modern Yafo, now part of Tel Aviv. Peter's lodging with a tanner (ritually marginal occupation) already anticipates the boundary-crossing of ch.10."
+            "coords": "32.0543° N, 34.7510° E",
+            "text": "The ancient Mediterranean port city — where Jonah tried to flee (Jon 1:3) and where cedar for Solomon's Temple was shipped (2 Chr 2:16). Modern Yafo, now part of Tel Aviv. Peter's lodging with a tanner (ritually marginal occupation) already anticipates the boundary-crossing of ch.10."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 35\u201338",
+            "date": "c. AD 35–38",
             "name": "Paul's Early Ministry",
-            "text": "After Damascus, Paul visits Jerusalem briefly (Gal 1:18 \u2014 fifteen days with Peter), then disappears to Tarsus for several years (Acts 9:30; Gal 1:21). Barnabas will retrieve him for Antioch (Acts 11:25\u201326) \u2014 possibly 8\u201310 years after his conversion.",
+            "text": "After Damascus, Paul visits Jerusalem briefly (Gal 1:18 — fifteen days with Peter), then disappears to Tarsus for several years (Acts 9:30; Gal 1:21). Barnabas will retrieve him for Antioch (Acts 11:25–26) — possibly 8–10 years after his conversion.",
             "current": true
           },
           {
@@ -199,8 +199,8 @@
             "current": false
           },
           {
-            "date": "c. AD 37\u201340",
-            "name": "Cornelius \u2014 Gentile Mission Opens",
+            "date": "c. AD 37–40",
+            "name": "Cornelius — Gentile Mission Opens",
             "text": "",
             "current": false
           }
@@ -208,34 +208,34 @@
         "cross": {
           "refs": [
             {
-              "ref": "2 Corinthians 11:32\u201333",
+              "ref": "2 Corinthians 11:32–33",
               "note": "Paul's own account of the Damascus escape: 'In Damascus the governor under King Aretas guarded the city... But I was lowered in a basket from a window in the wall and slipped through his hands.' Independent confirmation of Acts 9:25."
             },
             {
-              "ref": "1 Kings 17:17\u201324",
-              "note": "Elijah's raising of the widow's son \u2014 the OT precedent for Peter's raising of Tabitha. Both involve an upstairs room, bereaved women, a prophet who prays and commands."
+              "ref": "1 Kings 17:17–24",
+              "note": "Elijah's raising of the widow's son — the OT precedent for Peter's raising of Tabitha. Both involve an upstairs room, bereaved women, a prophet who prays and commands."
             },
             {
-              "ref": "Acts 4:36\u201337",
+              "ref": "Acts 4:36–37",
               "note": "Barnabas's previous generosity established his character. His advocacy for Saul is the pastoral counterpart: he built the community financially; now he restores it relationally."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:31",
-              "note": "MacArthur on the period of peace: the church grows qualitatively as well as numerically \u2014 \"strengthened, living in the fear of the Lord, encouraged by the Holy Spirit.\" Both numerical growth and spiritual depth are marks of health. Neither alone constitutes a fully healthy church."
+              "note": "MacArthur on the period of peace: the church grows qualitatively as well as numerically — \"strengthened, living in the fear of the Lord, encouraged by the Holy Spirit.\" Both numerical growth and spiritual depth are marks of health. Neither alone constitutes a fully healthy church."
             },
             {
-              "ref": "9:40\u201341",
-              "note": "MacArthur on the raising of Tabitha: the command \"Tabitha, get up\" (Tabitha, an\u00e1st\u0113thi) echoes Jesus's \"Talitha, koum\" (Mark 5:41 \u2014 \"Little girl, get up\") so closely that Luke may be drawing the parallel intentionally. Peter acts in the name and pattern of Jesus."
+              "ref": "9:40–41",
+              "note": "MacArthur on the raising of Tabitha: the command \"Tabitha, get up\" (Tabitha, anástēthi) echoes Jesus's \"Talitha, koum\" (Mark 5:41 — \"Little girl, get up\") so closely that Luke may be drawing the parallel intentionally. Peter acts in the name and pattern of Jesus."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:27",
@@ -248,33 +248,33 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:36",
-              "note": "The NET notes that Tabitha is described as a math\u0113tria \u2014 the feminine form of math\u0113t\u0113s (disciple). This is the only occurrence of the feminine form in the NT, which does not mean women were not disciples but that Luke used the grammatically precise form in this case."
+              "note": "The NET notes that Tabitha is described as a mathētria — the feminine form of mathētēs (disciple). This is the only occurrence of the feminine form in the NT, which does not mean women were not disciples but that Luke used the grammatically precise form in this case."
             },
             {
               "ref": "9:43",
-              "note": "The NET notes Simon the tanner's social status. Tanners were associated with ritual impurity in Jewish tradition (Mishnah Ketubot 7:10 \u2014 a husband who becomes a tanner has grounds for his wife to seek a divorce). Peter's willingness to stay with Simon anticipates the Cornelius episode immediately following."
+              "note": "The NET notes Simon the tanner's social status. Tanners were associated with ritual impurity in Jewish tradition (Mishnah Ketubot 7:10 — a husband who becomes a tanner has grounds for his wife to seek a divorce). Peter's willingness to stay with Simon anticipates the Cornelius episode immediately following."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "9:27",
-              "note": "Robertson on Barnabas as apostolic advocate: the Greek di\u0113g\u0113sato (he related/described) is used for authoritative eyewitness testimony. Barnabas presents a case \u2014 here is what happened on the Damascus road, here is what Saul has done since. This is the first recorded character reference for apostolic credentials."
+              "note": "Robertson on Barnabas as apostolic advocate: the Greek diēgēsato (he related/described) is used for authoritative eyewitness testimony. Barnabas presents a case — here is what happened on the Damascus road, here is what Saul has done since. This is the first recorded character reference for apostolic credentials."
             },
             {
               "ref": "9:40",
-              "note": "\"Peter sent them all out of the room; then he got down on his knees and prayed\" \u2014 Robertson notes the parallel with 2 Kings 4:33 (Elisha) and 1 Kings 17:19 (Elijah). The isolation is prayerful: Peter is about to ask God for something extraordinary and needs uninterrupted communion."
+              "note": "\"Peter sent them all out of the room; then he got down on his knees and prayed\" — Robertson notes the parallel with 2 Kings 4:33 (Elisha) and 1 Kings 17:19 (Elijah). The isolation is prayerful: Peter is about to ask God for something extraordinary and needs uninterrupted communion."
             }
           ]
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "9:36",
@@ -287,51 +287,51 @@
           ]
         },
         "hist": {
-          "context": "Barnabas's vouching for Saul (v27) is one of the most consequential acts of pastoral courage in Acts. Without it, Paul might have remained permanently isolated from the Jerusalem church. The man who sold a field to support the poor now risks his own standing to restore an enemy. Peter's coastal ministry (vv.32\u201343) geographically prepares the region for the Cornelius mission of ch.10 \u2014 Lydda and Joppa flank Caesarea to the south. Luke's geography is theological: the locations are never accidental."
+          "context": "Barnabas's vouching for Saul (v27) is one of the most consequential acts of pastoral courage in Acts. Without it, Paul might have remained permanently isolated from the Jerusalem church. The man who sold a field to support the poor now risks his own standing to restore an enemy. Peter's coastal ministry (vv.32–43) geographically prepares the region for the Cornelius mission of ch.10 — Lydda and Joppa flank Caesarea to the south. Luke's geography is theological: the locations are never accidental."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 32\u201443 \u2014 Aeneas Healed; Dorcas Raised from the Dead",
+      "header": "Verses 32—43 — Aeneas Healed; Dorcas Raised from the Dead",
       "verse_start": 32,
       "verse_end": 43,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bc\u03c0\u03bd\u03ad\u03c9\u03bd \u1f00\u03c0\u03b5\u03b9\u03bb\u1fc6\u03c2",
-            "transliteration": "empne\u014dn apeil\u0113s",
+            "word": "ἐμπνέων ἀπειλῆς",
+            "transliteration": "empneōn apeilēs",
             "gloss": "breathing out murderous threats",
-            "paragraph": "a vivid compound \u2014 Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
+            "paragraph": "a vivid compound — Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
           },
           {
-            "word": "\u03c4\u1fc6\u03c2 \u1f41\u03b4\u03bf\u1fe6",
-            "transliteration": "t\u0113s hodou",
+            "word": "τῆς ὁδοῦ",
+            "transliteration": "tēs hodou",
             "gloss": "the Way",
-            "paragraph": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) \u2014 Christianity is a whole orientation of life, not merely a belief system."
+            "paragraph": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) — Christianity is a whole orientation of life, not merely a belief system."
           }
         ],
         "places": [
           {
             "name": "Damascus",
-            "coords": "33.5138\u00b0 N, 36.2765\u00b0 E",
-            "text": "Capital of Syria, c.240 km north of Jerusalem \u2014 one of the oldest continuously inhabited cities in the world. A large Jewish community made it a natural extension of Jerusalem's religious authority. Paul's encounter with Christ happens on this public road, not in private \u2014 a verifiable, historical event."
+            "coords": "33.5138° N, 36.2765° E",
+            "text": "Capital of Syria, c.240 km north of Jerusalem — one of the oldest continuously inhabited cities in the world. A large Jewish community made it a natural extension of Jerusalem's religious authority. Paul's encounter with Christ happens on this public road, not in private — a verifiable, historical event."
           },
           {
-            "name": "Straight Street \u2014 Damascus",
-            "coords": "33.5100\u00b0 N, 36.3070\u00b0 E",
-            "text": "The main east-west thoroughfare of Damascus (v11, still identifiable today as the Via Recta). The house of Judas where Saul stayed was on this specific street \u2014 a verifiable address that Luke records with the precision of reliable history."
+            "name": "Straight Street — Damascus",
+            "coords": "33.5100° N, 36.3070° E",
+            "text": "The main east-west thoroughfare of Damascus (v11, still identifiable today as the Via Recta). The house of Judas where Saul stayed was on this specific street — a verifiable address that Luke records with the precision of reliable history."
           }
         ],
         "tl": [
           {
-            "date": "c. AD 33\u201335",
-            "name": "Paul's Conversion \u2014 Damascus Road",
-            "text": "Saul of Tarsus encounters the risen Jesus on the road to Damascus. Blinded for three days, healed by Ananias, baptized, and immediately begins preaching. The most dramatic reversal in Acts \u2014 the persecutor becomes the preacher.",
+            "date": "c. AD 33–35",
+            "name": "Paul's Conversion — Damascus Road",
+            "text": "Saul of Tarsus encounters the risen Jesus on the road to Damascus. Blinded for three days, healed by Ananias, baptized, and immediately begins preaching. The most dramatic reversal in Acts — the persecutor becomes the preacher.",
             "current": true
           },
           {
-            "date": "c. AD 35\u201337",
+            "date": "c. AD 35–37",
             "name": "Paul in Arabia and Return",
             "text": "",
             "current": false
@@ -346,90 +346,41 @@
         "cross": {
           "refs": [
             {
-              "ref": "1 Corinthians 15:8\u20139",
+              "ref": "1 Corinthians 15:8–9",
               "note": "\"Last of all he appeared to me also, as to one abnormally born. For I am the least of the apostles... because I persecuted the church of God.\" Paul's own testimony confirms the Acts account."
             },
             {
-              "ref": "Galatians 1:13\u201316",
+              "ref": "Galatians 1:13–16",
               "note": "Paul's autobiographical account: \"God, who set me apart from my mother's womb... was pleased to reveal his Son in me so that I might preach him among the Gentiles.\""
             },
             {
-              "ref": "Philippians 3:4\u20136",
-              "note": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" \u2014 the man God chose as his instrument."
+              "ref": "Philippians 3:4–6",
+              "note": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" — the man God chose as his instrument."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:5",
-              "note": "\"I am Jesus, whom you are persecuting\" \u2014 the identification of Christ with his people is the foundation of NT ecclesiology. Saul thought he was opposing a human movement; he was attacking the living Lord. Those who treat the church as merely human institution misunderstand its nature as radically as Saul did."
-            },
-            {
-              "ref": "9:15\u201316",
-              "note": "The sovereign language of election frames Paul's entire apostolic career. He did not choose his calling; he was chosen for it before he understood what it meant. Paul's conversion was not persuasion but revelation \u2014 a direct, sovereign act of God."
-            },
-            {
-              "ref": "9:20",
-              "note": "\"At once he began to preach\" \u2014 MacArthur notes the immediacy: no retreat for preparation, no extended discipleship programme before witness. The encounter with the risen Christ was itself the commissioning. The same pattern characterises every genuine conversion: the response is immediate and public."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:4\u20135",
-              "note": "Calvin on the divine address: \"Why do you persecute me?\" is the revelation of the mystical union \u2014 Christ and his church are one. Paul will develop this doctrine in his letters; he first learns it in the moment of his conversion, discovering the union in the very act of violating it."
-            },
-            {
-              "ref": "9:15",
-              "note": "Calvin on divine election in Paul's conversion: God does not wait for Saul to stop persecuting before choosing him \u2014 he is chosen as a persecutor, in the act of persecution. This is the purest possible demonstration of unconditional election: no merit, no preparation, no openness \u2014 only sovereign grace acting against all human probability."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:7",
-              "note": "\"They heard the sound but did not see anyone\" \u2014 the NET notes the apparent tension with 22:9: \"My companions saw the light, but they did not hear the voice.\" The NET harmonises: they heard a sound (general noise) but not intelligible speech, while they saw light but not the person. The accounts are complementary, not contradictory."
-            },
-            {
-              "ref": "9:15",
-              "note": "\"Chosen instrument\" (skeuos eklog\u0113s) \u2014 literally \"a vessel of choice/election.\" The metaphor recurs in Paul's letters (2 Cor 4:7: \"treasure in jars of clay\") \u2014 the container serves the content; Paul's life is shaped by what he carries."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "9:4",
-              "note": "\"Saul, Saul, why do you persecute me?\" \u2014 Robertson notes the double vocative as a mark of urgency and personal address, used in OT divine calls (Gen 22:11: \"Abraham, Abraham\"; Exod 3:4: \"Moses, Moses\"). The risen Christ addresses the persecutor with the same intimate directness as God's call to the patriarchs."
-            },
-            {
-              "ref": "9:15",
-              "note": "\"This man is my chosen instrument\" \u2014 Robertson on skeuos eklog\u0113s (vessel of election): Paul is not self-chosen but divinely selected for a specific purpose. The passive construction governs everything that follows: Paul's ministry is grounded in divine initiative, not human qualification."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "keener": {
-          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012\u20132015) \u2014 Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:1\u20132",
-              "note": "Keener provides historical context: the high priest had religious jurisdiction over Diaspora synagogues. The request for extradition of members of \"the Way\" reflects legal procedure \u2014 bringing charges before the proper religious authority. Saul is acting through official channels, not as a rogue vigilante."
-            },
-            {
-              "ref": "9:15\u201316",
-              "note": "Keener notes the two-part commission: proclaim to Gentiles and kings AND people of Israel. The suffering element (\"I will show him how much he must suffer\") is equally programmatic \u2014 Paul's missionary career is a theology of the cross in biographical form."
-            }
-          ]
+          "source": "Craig S. Keener, Acts: An Exegetical Commentary (4 vols., 2012–2015) — Scholarly Paraphrase",
+          "notes": []
         },
         "hist": {
-          "context": "The Damascus road account is told three times in Acts (9:1\u201319; 22:6\u201316; 26:12\u201318) \u2014 the only event so repeated. Each retelling adds details appropriate to its audience. The repetition signals that Paul's conversion is not private experience but public, court-level testimony: he has seen the risen Jesus, which qualifies him as an apostle (1 Cor 9:1; 15:8\u20139). The risen Jesus's question 'Why do you persecute me?' identifies himself with those Saul is persecuting \u2014 the theological foundation of Paul's later 'body of Christ' ecclesiology: attacking the church is attacking Christ himself (1 Cor 12:12\u201327)."
+          "context": "The Damascus road account is told three times in Acts (9:1–19; 22:6–16; 26:12–18) — the only event so repeated. Each retelling adds details appropriate to its audience. The repetition signals that Paul's conversion is not private experience but public, court-level testimony: he has seen the risen Jesus, which qualifies him as an apostle (1 Cor 9:1; 15:8–9). The risen Jesus's question 'Why do you persecute me?' identifies himself with those Saul is persecuting — the theological foundation of Paul's later 'body of Christ' ecclesiology: attacking the church is attacking Christ himself (1 Cor 12:12–27)."
         }
       }
     }
@@ -437,69 +388,69 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Paul\u2197 People",
+        "name": "Paul↗ People",
         "role": "Apostle to the Gentiles; author of thirteen NT letters",
-        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen\u2019s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13\u201328 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts\u2019 theological climax: the gospel reaching the empire\u2019s capital, \"boldly and without hindrance\" (Acts 28:31)."
+        "text": "Paul (Saul of Tarsus) is introduced as a persecutor at Stephen’s stoning (Acts 7:58) and is dramatically converted on the Damascus road (Acts 9). He dominates Acts 13–28 across three missionary journeys, planting churches from Cyprus to Greece to Rome. His final journey to Rome as a prisoner frames Acts’ theological climax: the gospel reaching the empire’s capital, \"boldly and without hindrance\" (Acts 28:31)."
       },
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       },
       {
-        "name": "Barnabas\u2197 People",
-        "role": "Paul\u2019s first missionary partner; 'Son of Encouragement'",
-        "text": "Barnabas (Joseph of Cyprus) is introduced as a generous land-seller in Acts 4:36\u201337 and is the one who vouches for the newly converted Paul to the suspicious Jerusalem church (Acts 9:27). He leads the Antioch church (Acts 11:22\u201324) and takes Paul as his partner for the first missionary journey (Acts 13\u201314). Their sharp disagreement over Mark (Acts 15:36\u201340) ends their partnership but doubles the missionary coverage."
+        "name": "Barnabas↗ People",
+        "role": "Paul’s first missionary partner; 'Son of Encouragement'",
+        "text": "Barnabas (Joseph of Cyprus) is introduced as a generous land-seller in Acts 4:36–37 and is the one who vouches for the newly converted Paul to the suspicious Jerusalem church (Acts 9:27). He leads the Antioch church (Acts 11:22–24) and takes Paul as his partner for the first missionary journey (Acts 13–14). Their sharp disagreement over Mark (Acts 15:36–40) ends their partnership but doubles the missionary coverage."
       },
       {
-        "name": "Cornelius\u2197 People",
+        "name": "Cornelius↗ People",
         "role": "Roman centurion; first Gentile convert; pivot of Acts 10",
-        "text": "Cornelius is a God-fearing Roman centurion at Caesarea \u2014 devout, generous, and prayerful but uncircumcised. His angel-directed encounter with Peter (Acts 10) is the theological turning point of Acts: the Spirit falls on Gentiles before baptism, demonstrating that God shows no partiality. Peter\u2019s report to Jerusalem (Acts 11) establishes the principle that will be formalized at the Jerusalem Council (Acts 15)."
+        "text": "Cornelius is a God-fearing Roman centurion at Caesarea — devout, generous, and prayerful but uncircumcised. His angel-directed encounter with Peter (Acts 10) is the theological turning point of Acts: the Spirit falls on Gentiles before baptism, demonstrating that God shows no partiality. Peter’s report to Jerusalem (Acts 11) establishes the principle that will be formalized at the Jerusalem Council (Acts 15)."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\\</td></tr><tr><td class=\"t-label\">ESV</td><td>And he said, \u201cWho are you, Lord?\u201d And he said, \u201cI am Jesus, whom you are persecuting.</td></tr><tr><td class=\"t-label\">NIV</td><td>\\</td></tr><tr><td class=\"t-label\">ESV</td><td>But rise and enter the city, and you will be told what you are to do.\u201d</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\\</td></tr><tr><td class=\"t-label\">ESV</td><td>And he said, “Who are you, Lord?” And he said, “I am Jesus, whom you are persecuting.</td></tr><tr><td class=\"t-label\">NIV</td><td>\\</td></tr><tr><td class=\"t-label\">ESV</td><td>But rise and enter the city, and you will be told what you are to do.”</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities of the Jews (c.93 AD)",
-        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts \u2014 the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
-        "note": "Acts\u2019 historical details consistently align with Josephus\u2019s independent account of the same period, supporting the narrative\u2019s historical credibility."
+        "quote": "Josephus provides extensive first-century background for the political, religious, and social conditions described in Acts — the Herodian family, Pharisees and Sadducees, Roman provincial governance.",
+        "note": "Acts’ historical details consistently align with Josephus’s independent account of the same period, supporting the narrative’s historical credibility."
       },
       {
         "title": "Dead Sea Scrolls (1QS, 1QM)",
-        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged \u2014 their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
-        "note": "The Scrolls demonstrate that the early church\u2019s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
+        "quote": "The Qumran community texts illuminate the diversity of Second Temple Judaism from which Christianity emerged — their eschatological expectations, community rules, and temple criticism parallel aspects of the early church.",
+        "note": "The Scrolls demonstrate that the early church’s practices (community meals, shared goods, eschatological expectation) were not unprecedented within Jewish renewal movements."
       },
       {
         "title": "Greco-Roman Travel Literature and Epistolary Conventions",
-        "quote": "Acts\u2019 travel narrative (ch.13\u201328) conforms to the conventions of ancient Greek travel literature, and Paul\u2019s speeches follow rhetorical models documented in Greco-Roman oratory.",
-        "note": "The Hellenistic literary conventions confirm Acts\u2019 composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
+        "quote": "Acts’ travel narrative (ch.13–28) conforms to the conventions of ancient Greek travel literature, and Paul’s speeches follow rhetorical models documented in Greco-Roman oratory.",
+        "note": "The Hellenistic literary conventions confirm Acts’ composition for a sophisticated Greco-Roman audience and support its historical reliability as ancient historiography."
       }
     ],
     "rec": [
       {
         "who": "John Chrysostom, Homilies on Acts (c.400 AD)",
-        "text": "\"Chrysostom\u2019s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit\u2019s active role and the apostles\u2019 moral example for the church.\""
+        "text": "\"Chrysostom’s 55 homilies on Acts are the most thorough patristic commentary, emphasising the Spirit’s active role and the apostles’ moral example for the church.\""
       },
       {
         "who": "John MacArthur",
-        "text": "\"\"I am Jesus, whom you are persecuting\" \u2014 the identification of Christ with his people is the foundation of NT ecclesiology. Saul thought he was opposing a human movement; he was attacking the living L\""
+        "text": "\"\"I am Jesus, whom you are persecuting\" — the identification of Christ with his people is the foundation of NT ecclesiology. Saul thought he was opposing a human movement; he was attacking the living L\""
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Verses 1\u201419 \u2014 Saul\u2019s Conversion on the Road to Damascus",
-          "text": "Context  The Damascus road account is told three times in Acts (9:1\u201319; 22:6\u201316; 26:12\u201318) \u2014 the only event so repeated.\u2026",
+          "label": "Verses 1—19 — Saul’s Conversion on the Road to Damascus",
+          "text": "Context  The Damascus road account is told three times in Acts (9:1–19; 22:6–16; 26:12–18) — the only event so repeated.…",
           "is_key": false
         },
         {
-          "label": "Verses 20\u201431 \u2014 Saul Preaches in Damascus and Jerusalem; The Church Has Peace",
-          "text": "Context  Barnabas's vouching for Saul (v27) is one of the most consequential acts of pastoral courage in Acts. Without i\u2026",
+          "label": "Verses 20—31 — Saul Preaches in Damascus and Jerusalem; The Church Has Peace",
+          "text": "Context  Barnabas's vouching for Saul (v27) is one of the most consequential acts of pastoral courage in Acts. Without i…",
           "is_key": false
         },
         {
-          "label": "Verses 32\u201443 \u2014 Aeneas Healed; Dorcas Raised from the Dead",
-          "text": "Context  The Damascus road account is told three times in Acts (9:1\u201319; 22:6\u201316; 26:12\u201318) \u2014 the only event so repeated.\u2026",
+          "label": "Verses 32—43 — Aeneas Healed; Dorcas Raised from the Dead",
+          "text": "Context  The Damascus road account is told three times in Acts (9:1–19; 22:6–16; 26:12–18) — the only event so repeated.…",
           "is_key": false
         }
       ],
@@ -507,81 +458,81 @@
     },
     "hebtext": [
       {
-        "word": "\u1f10\u03bc\u03c0\u03bd\u03ad\u03c9\u03bd \u1f00\u03c0\u03b5\u03b9\u03bb\u1fc6\u03c2",
-        "tlit": "empne\u014dn apeil\u0113s",
+        "word": "ἐμπνέων ἀπειλῆς",
+        "tlit": "empneōn apeilēs",
         "gloss": "breathing out murderous threats",
-        "note": "a vivid compound \u2014 Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
+        "note": "a vivid compound — Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
       },
       {
-        "word": "\u03c4\u1fc6\u03c2 \u1f41\u03b4\u03bf\u1fe6",
-        "tlit": "t\u0113s hodou",
+        "word": "τῆς ὁδοῦ",
+        "tlit": "tēs hodou",
         "gloss": "the Way",
-        "note": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) \u2014 Christianity is a whole orientation of life, not merely a belief system."
+        "note": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) — Christianity is a whole orientation of life, not merely a belief system."
       },
       {
-        "word": "\u03c3\u03c0\u03c5\u03c1\u03af\u03b4\u03b9",
+        "word": "σπυρίδι",
         "tlit": "spuridi",
         "gloss": "basket",
-        "note": "the same word Paul uses in 2 Cor 11:33, independently confirming the event. The basket (a large wicker container) lowered through a gap in the city wall is a detail both Luke and Paul record \u2014 mutual attestation of an undeniable historical memory."
+        "note": "the same word Paul uses in 2 Cor 11:33, independently confirming the event. The basket (a large wicker container) lowered through a gap in the city wall is a detail both Luke and Paul record — mutual attestation of an undeniable historical memory."
       },
       {
-        "word": "\u03bc\u03b1\u03b8\u03ae\u03c4\u03c1\u03b9\u03b1",
-        "tlit": "math\u0113tria",
+        "word": "μαθήτρια",
+        "tlit": "mathētria",
         "gloss": "disciple (feminine)",
-        "note": "the only occurrence of the feminine form of math\u0113t\u0113s (disciple) in the NT. Tabitha is unambiguously presented as a full disciple, not merely a supporting character \u2014 Luke's vocabulary makes her standing explicit."
+        "note": "the only occurrence of the feminine form of mathētēs (disciple) in the NT. Tabitha is unambiguously presented as a full disciple, not merely a supporting character — Luke's vocabulary makes her standing explicit."
       },
       {
-        "word": "\u1f10\u03bc\u03c0\u03bd\u03ad\u03c9\u03bd \u1f00\u03c0\u03b5\u03b9\u03bb\u1fc6\u03c2",
-        "tlit": "empne\u014dn apeil\u0113s",
+        "word": "ἐμπνέων ἀπειλῆς",
+        "tlit": "empneōn apeilēs",
         "gloss": "breathing out murderous threats",
-        "note": "a vivid compound \u2014 Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
+        "note": "a vivid compound — Saul's persecution is so total that threatening speech is like his breath. The image will be completely reversed: the man who breathes threats will soon be breathless on the Damascus road."
       },
       {
-        "word": "\u03c4\u1fc6\u03c2 \u1f41\u03b4\u03bf\u1fe6",
-        "tlit": "t\u0113s hodou",
+        "word": "τῆς ὁδοῦ",
+        "tlit": "tēs hodou",
         "gloss": "the Way",
-        "note": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) \u2014 Christianity is a whole orientation of life, not merely a belief system."
+        "note": "one of the earliest self-designations of the Christian movement (Acts 19:9, 23; 22:4; 24:14, 22). Reflecting the Deuteronomic 'two ways' tradition and Jesus's 'I am the way' (John 14:6) — Christianity is a whole orientation of life, not merely a belief system."
       }
     ],
     "thread": [
       {
         "anchor": "Scripture Walkthrough",
-        "target": "1 Corinthians 15:8\u20139",
+        "target": "1 Corinthians 15:8–9",
         "type": "Connection",
         "text": "\"Last of all he appeared to me also, as to one abnormally born. For I am the least of the apostles... because I persecuted the church of God.\" Paul's own testimony confirms the Acts account.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Galatians 1:13\u201316",
+        "target": "Galatians 1:13–16",
         "type": "Connection",
         "text": "Paul's autobiographical account: \"God, who set me apart from my mother's womb... was pleased to reveal his Son in me so that I might preach him among the Gentiles.\"",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Philippians 3:4\u20136",
+        "target": "Philippians 3:4–6",
         "type": "Connection",
-        "text": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" \u2014 the man God chose as his instrument.",
+        "text": "Paul's credentials as persecutor: \"as for zeal, persecuting the church; as for righteousness based on the law, faultless\" — the man God chose as his instrument.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "2 Corinthians 11:32\u201333",
+        "target": "2 Corinthians 11:32–33",
         "type": "Connection",
         "text": "Paul's own account of the Damascus escape: 'In Damascus the governor under King Aretas guarded the city... But I was lowered in a basket from a window in the wall and slipped through his hands.' Independent confirmation of Acts 9:25.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "1 Kings 17:17\u201324",
+        "target": "1 Kings 17:17–24",
         "type": "Connection",
-        "text": "Elijah's raising of the widow's son \u2014 the OT precedent for Peter's raising of Tabitha. Both involve an upstairs room, bereaved women, a prophet who prays and commands.",
+        "text": "Elijah's raising of the widow's son — the OT precedent for Peter's raising of Tabitha. Both involve an upstairs room, bereaved women, a prophet who prays and commands.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 4:36\u201337",
+        "target": "Acts 4:36–37",
         "type": "Connection",
         "text": "Barnabas's previous generosity established his character. His advocacy for Saul is the pastoral counterpart: he built the community financially; now he restores it relationally.",
         "direction": "backward"
@@ -591,14 +542,14 @@
       {
         "ref": "Acts 9",
         "title": "Western text (Codex Bezae D) vs Alexandrian text",
-        "content": "Alexandrian(P45, P74, \u05d0, B) is the primary scholarly text.Western(Codex Bezae D) is 10\u201315% longer, with additions that appear to expand and harmonise.",
+        "content": "Alexandrian(P45, P74, א, B) is the primary scholarly text.Western(Codex Bezae D) is 10–15% longer, with additions that appear to expand and harmonise.",
         "note": "Acts has the most significant NT textual variation. The Western text of Acts is not simply corrupt but may preserve early oral expansions. Most scholars follow the shorter Alexandrian text as more original."
       },
       {
         "ref": "Acts 9 (general)",
         "title": "P45 and early papyrus witnesses",
         "content": "The Chester Beatty Papyrus (P45, c.250 AD) is the earliest substantial Acts manuscript, generally supporting the Alexandrian text with some unique readings.",
-        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text\u2019s substantial additions remain a subject of scholarly investigation."
+        "note": "The papyrus evidence has largely confirmed the Alexandrian tradition as the best text of Acts, though the Western text’s substantial additions remain a subject of scholarly investigation."
       }
     ],
     "debate": [
@@ -608,12 +559,12 @@
           {
             "name": "Traditional Lukan authorship (Hengel, Keener, classical scholarship)",
             "proponents": "Attributes Acts to Luke the physician (Col 4:14), a companion of Paul, on the basis of the \"we\" passages, historical accuracy, and early church tradition.",
-            "argument": "Luke\u2019s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
+            "argument": "Luke’s medical vocabulary (noted by Hobart) and the detailed geographical and political accuracy of Acts support the traditional attribution."
           },
           {
             "name": "Anonymous/secondary authorship (Haenchen, Conzelmann)",
-            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts\u2019 Paul and the Pauline letters, suggesting a later author using Lukan sources.",
-            "argument": "This view notes that Acts does not always match Paul\u2019s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
+            "proponents": "Questions Lukan authorship on the basis of discrepancies between Acts’ Paul and the Pauline letters, suggesting a later author using Lukan sources.",
+            "argument": "This view notes that Acts does not always match Paul’s letters precisely, and argues the \"we\" passages may be a literary device rather than eyewitness markers."
           }
         ]
       }
@@ -783,7 +734,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'He is my chosen instrument to proclaim my name to the Gentiles and their kings' (v. 15). Ananias hesitates\u2014Saul's reputation precedes him. But God's purpose overrides reputation. The persecutor becomes the apostle.",
+      "tip": "'He is my chosen instrument to proclaim my name to the Gentiles and their kings' (v. 15). Ananias hesitates—Saul's reputation precedes him. But God's purpose overrides reputation. The persecutor becomes the apostle.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/deuteronomy/1.json
+++ b/content/deuteronomy/1.json
@@ -209,10 +209,6 @@
             {
               "ref": "1:19",
               "note": "Craigie: The literary structure of this passage within Deuteronomy's larger address follows the standard ANE treaty pattern, moving from historical precedent to specific obligation. The rhetorical force depends on the audience reco1:19Tigay: The JPS commentary highlights that this section's legislation has parallels in other ANE legal collections but is distinctively reframed within the Deuteronomic theology of covenant love and centralised worship.gnising the covenantal framework."
-            },
-            {
-              "ref": "1:19",
-              "note": "Tigay: The JPS commentary highlights that this section's legislation has parallels in other ANE legal collections but is distinctively reframed within the Deuteronomic theology of covenant love and centralised worship."
             }
           ]
         },

--- a/content/deuteronomy/10.json
+++ b/content/deuteronomy/10.json
@@ -176,55 +176,19 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:12",
-              "note": "Tigay: On fear, love, serve: the great summary: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "10:13",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:12",
-              "note": "Craigie: On fear, love, serve: the great summary: the structure here follows the pattern of ANE treaty stipulations — specific obligations laid on the vassal by the suzerain. The parallels with Hittite treaty forms confirm that Deuteronomy's legal material is presented in a recognised international diplomatic format."
-            },
-            {
-              "ref": "10:14",
-              "note": "Craigie: The literary placement of this section within the larger address serves a rhetorical function — Moses builds from general principles to specific applications, a technique well attested in ancient Near Eastern legal and wisdom literature."
-            }
-          ]
+          "notes": []
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:12",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "10:13",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:12",
-              "note": "Calvin: On fear, love, serve: the great summary: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "10:14",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Verses 12–22 are one of Deuteronomy's great theological summaries. Moses asks: what does God require of you? Five-fold: fear, walk, love, serve, observe (v.12). Then he grounds these demands in God's character: God is the God of gods, Lord of lords — yet he loves the alien, provides for the orphan and widow, executes justice for the oppressed. The demands flow from the character: love the alien because God loves the alien; fear God because he is incomparable."

--- a/content/deuteronomy/11.json
+++ b/content/deuteronomy/11.json
@@ -162,16 +162,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:26",
-              "note": "Tigay: On blessing and curse; Ebal and Gerizim: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "11:27",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -188,29 +179,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:26",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "11:27",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:26",
-              "note": "Calvin: On blessing and curse; Ebal and Gerizim: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "11:28",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The first discourse closes with a preview of the covenant ceremony that will take place after crossing the Jordan (detailed in ch.27): the blessings pronounced from Mount Gerizim, the curses from Mount Ebal. The two mountains facing each other across the valley of Shechem become the physical embodiment of the covenant's binary character. The whole land is arranged around this choice: blessing on one side, curse on the other, Israel standing between — called to choose."

--- a/content/deuteronomy/12.json
+++ b/content/deuteronomy/12.json
@@ -196,29 +196,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:29",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "12:30",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:29",
-              "note": "Calvin: On no curiosity about Canaanite religion: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "12:31",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The final verses anticipate the temptation of religious imitation: after the Canaanites are driven out, Israel might adopt their worship practices for the LORD. This is explicitly forbidden. The Canaanites even burned their children to their gods (v.31), the ultimate expression of Canaanite religion's corruption and the most urgent warning about where religious syncretism ultimately leads."

--- a/content/deuteronomy/13.json
+++ b/content/deuteronomy/13.json
@@ -175,42 +175,15 @@
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:12",
-              "note": "Craigie: On the apostate city destroyed: the structure here follows the pattern of ANE treaty stipulations — specific obligations laid on the vassal by the suzerain. The parallels with Hittite treaty forms confirm that Deuteronomy's legal material is presented in a recognised international diplomatic format."
-            },
-            {
-              "ref": "13:14",
-              "note": "Craigie: The literary placement of this section within the larger address serves a rhetorical function — Moses builds from general principles to specific applications, a technique well attested in ancient Near Eastern legal and wisdom literature."
-            }
-          ]
+          "notes": []
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:12",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "13:13",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:12",
-              "note": "Calvin: On the apostate city destroyed: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "13:14",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "If an entire Israelite city is led into idolatry, it receives the same herem treatment as Canaanite cities: complete destruction, burning to ash, never rebuilt. The logic is consistent: apostasy within the covenant community is more dangerous than apostasy outside it. An Israelite city worshipping false gods is a cancer in the covenant body. The chapter ends with the covenant promise: if you execute this judgment, God will be merciful to you and multiply you."

--- a/content/deuteronomy/14.json
+++ b/content/deuteronomy/14.json
@@ -158,55 +158,19 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:22",
-              "note": "Tigay: On the annual and third-year tithes: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "14:23",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:22",
-              "note": "Craigie: On the annual and third-year tithes: the structure here follows the pattern of ANE treaty stipulations — specific obligations laid on the vassal by the suzerain. The parallels with Hittite treaty forms confirm that Deuteronomy's legal material is presented in a recognised international diplomatic format."
-            },
-            {
-              "ref": "14:24",
-              "note": "Craigie: The literary placement of this section within the larger address serves a rhetorical function — Moses builds from general principles to specific applications, a technique well attested in ancient Near Eastern legal and wisdom literature."
-            }
-          ]
+          "notes": []
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:22",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "14:23",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:22",
-              "note": "Calvin: On the annual and third-year tithes: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "14:24",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Deuteronomy distinguishes two tithe cycles: the annual tithe for the pilgrimage feasts (vv.22–26), and the third-year tithe for the Levites, foreigners, orphans, and widows (vv.27–29). The annual tithe is consumed \"in the presence of the LORD\" at the chosen sanctuary — a festive meal of rejoicing before God. If the journey is too long to bring produce, it may be converted to money. The third-year tithe stays locally for the poor. Together they form a comprehensive social welfare system embedded in the agricultural calendar."

--- a/content/deuteronomy/15.json
+++ b/content/deuteronomy/15.json
@@ -166,16 +166,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:19",
-              "note": "Tigay: On the firstborn animal reserved for God: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "15:20",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -192,29 +183,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:19",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "15:20",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:19",
-              "note": "Calvin: On the firstborn animal reserved for God: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "15:21",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The firstborn animal law concludes chapter 15: male firstborn cattle, sheep, and goats belong to the LORD and may not be put to work or used for shearing. They are eaten at the annual feasts. The pattern of Deuteronomy's economic legislation is now visible: the seventh-year release, the tithes, the firstborn laws — all are structured acknowledgments of divine ownership."

--- a/content/deuteronomy/16.json
+++ b/content/deuteronomy/16.json
@@ -172,55 +172,19 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:18",
-              "note": "Tigay: On appoint judges; do not pervert justice: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "16:19",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:18",
-              "note": "Craigie: On appoint judges; do not pervert justice: the structure here follows the pattern of ANE treaty stipulations — specific obligations laid on the vassal by the suzerain. The parallels with Hittite treaty forms confirm that Deuteronomy's legal material is presented in a recognised international diplomatic format."
-            },
-            {
-              "ref": "16:20",
-              "note": "Craigie: The literary placement of this section within the larger address serves a rhetorical function — Moses builds from general principles to specific applications, a technique well attested in ancient Near Eastern legal and wisdom literature."
-            }
-          ]
+          "notes": []
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:18",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "16:19",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:18",
-              "note": "Calvin: On appoint judges; do not pervert justice: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "16:20",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The festival laws transition immediately to judicial laws — the connection is deliberate. A community that celebrates God's justice must embody justice in its courts. Judges are to be appointed in every town; they must judge impartially, take no bribes, not pervert justice. The Asherah pole and sacred stone — symbols of Canaanite fertility religion — must not be set up near the altar: not even in the village square may Canaanite religious symbols stand alongside the altar of the LORD."

--- a/content/deuteronomy/17.json
+++ b/content/deuteronomy/17.json
@@ -168,16 +168,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:14",
-              "note": "Tigay: On the law of the king: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "17:15",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -194,29 +185,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:14",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "17:15",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:14",
-              "note": "Calvin: On the law of the king: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "17:16",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The law of the king (vv.14–20) fundamentally redefines kingship. The Israelite king is to be chosen by God (not the people), be from among the Israelites, not multiply horses/wives/wealth, and read the Torah daily so that his heart is not lifted above his brothers. The king is a brother, not a lord. The Deuteronomic ideal — the king as the Torah's primary student and servant — is the measure against which all of Israel's kings will be evaluated in the Deuteronomistic History."

--- a/content/deuteronomy/18.json
+++ b/content/deuteronomy/18.json
@@ -206,29 +206,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:9",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "18:10",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:9",
-              "note": "Calvin: On forbidden practices; the Prophet like Moses: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "18:11",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Having established the Levitical priesthood's material support, Moses turns to Israel's spiritual infrastructure: the prohibition of all occult access to divine knowledge (vv.9–14) and the promise of the true prophet (vv.15–22). The contrast is complete: Israel has authorised channels of divine communication (priest and prophet); it must not resort to illegitimate ones. The ten forbidden practices are followed by the one authorised alternative: a prophet like Moses, whose words come directly from God."

--- a/content/deuteronomy/19.json
+++ b/content/deuteronomy/19.json
@@ -172,16 +172,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:15",
-              "note": "Tigay: On two witnesses; false testimony punished: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "19:16",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -198,29 +189,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:15",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "19:16",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:15",
-              "note": "Calvin: On two witnesses; false testimony punished: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "19:17",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The law of witnesses (vv.15-21) establishes two foundational principles: the two-witness requirement for conviction, and the talion principle for false witnesses. False witnesses receive the punishment they sought to inflict on the accused -- a powerful disincentive. The \"eye for eye, tooth for tooth\" (v.21) principle is not vindictiveness but proportionality: punishment may not exceed the crime. This actually limits revenge rather than enabling it."

--- a/content/deuteronomy/2.json
+++ b/content/deuteronomy/2.json
@@ -180,10 +180,6 @@
             {
               "ref": "2:30",
               "note": "Craigie: The hardening of Sihon's heart is structurally parallel to the Exodus hardening of Pharaoh and serves the same theological function: demonstrating that no human will can thwart God's redemptive purposes. The mighty are brought low to show God's greatness, not Israel's military skill."
-            },
-            {
-              "ref": "2:26",
-              "note": "Craigie: The literary structure of this passage within Deuteronomy's larger address follows the standard ANE treaty pattern, moving from historical precedent to specific obligation. The rhetorical force depends on the audience recognising the covenantal framework."
             }
           ]
         },

--- a/content/deuteronomy/20.json
+++ b/content/deuteronomy/20.json
@@ -164,16 +164,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:10",
-              "note": "Tigay: On treatment of cities; fruit trees preserved: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "20:11",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -190,29 +181,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:10",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "20:11",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:10",
-              "note": "Calvin: On treatment of cities; fruit trees preserved: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "20:12",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The rules of engagement distinguish between distant cities (offer peace first; if refused, besiege and enslave; if they fight, kill the men and take the rest) and Canaanite cities (herem -- total destruction). Even in the most severe military action, fruit trees around besieged cities must not be cut down -- they serve life and must not be destroyed in the service of death. The distinction between people who may be killed and trees that must be preserved shows that the warfare rules have a consistent ecological-humanitarian framework."

--- a/content/deuteronomy/21.json
+++ b/content/deuteronomy/21.json
@@ -164,16 +164,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "Tigay: On firstborn rights; rebellious sons; the hanged man: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "21:16",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -190,29 +181,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "21:16",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:15",
-              "note": "Calvin: On firstborn rights; rebellious sons; the hanged man: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "21:17",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter continues with: (3) the rights of the firstborn in a polygamous household -- the firstborn of the unloved wife receives the double portion regardless of paternal preference (vv.15-17); (4) the rebellious son -- if incorrigible, he is to be brought before the elders for community judgment (vv.18-21); (5) the hanging-on-a-tree legislation -- a body must be buried before nightfall, for a hanged man is under God's curse (vv.22-23). Paul applies v.23 directly to the crucifixion in Galatians 3:13."

--- a/content/deuteronomy/22.json
+++ b/content/deuteronomy/22.json
@@ -166,55 +166,19 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:13",
-              "note": "Tigay: On sexual integrity laws: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "22:14",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:13",
-              "note": "Craigie: On sexual integrity laws: the structure here follows the pattern of ANE treaty stipulations — specific obligations laid on the vassal by the suzerain. The parallels with Hittite treaty forms confirm that Deuteronomy's legal material is presented in a recognised international diplomatic format."
-            },
-            {
-              "ref": "22:15",
-              "note": "Craigie: The literary placement of this section within the larger address serves a rhetorical function — Moses builds from general principles to specific applications, a technique well attested in ancient Near Eastern legal and wisdom literature."
-            }
-          ]
+          "notes": []
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:13",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "22:14",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:13",
-              "note": "Calvin: On sexual integrity laws: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "22:15",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The sexual laws address: a husband's false accusation of his wife (vv.13-21), adultery (v.22), sexual assault in city and field (vv.23-27), rape of an unmarried woman (vv.28-29), and sex with a father's wife (v.30). The laws consistently protect women's dignity and sexual integrity while imposing severe penalties on violators. The distinction between city assault (presumed complicit) and field assault (presumed non-complicit) reflects a presumption of innocence for the party who could not have been heard if she cried out."

--- a/content/deuteronomy/23.json
+++ b/content/deuteronomy/23.json
@@ -168,16 +168,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "Tigay: On escaped slaves; interest; vows: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "23:16",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -194,29 +185,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "23:16",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:15",
-              "note": "Calvin: On escaped slaves; interest; vows: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "23:17",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter concludes with: protection of escaped slaves (vv.15-16), prohibition of sacred prostitution (vv.17-18), interest laws (vv.19-20), vow obligations (vv.21-23), and the gleaning law (vv.24-25). The gleaning law -- you may eat your neighbour's grapes or grain when passing through, but you may not take any away -- is a practical mechanism for providing for the hungry through dignity-preserving access, not charity handouts."

--- a/content/deuteronomy/24.json
+++ b/content/deuteronomy/24.json
@@ -168,16 +168,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "Tigay: On wages; gleaning for the vulnerable: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "24:15",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -194,29 +185,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "24:15",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "Calvin: On wages; gleaning for the vulnerable: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "24:16",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter concludes with: same-day wage payment for poor workers (vv.14-15), individual culpability (v.16), justice for the alien, orphan, and widow (v.17), and gleaning laws (vv.19-22). The gleaning laws -- leave some of your harvest for the foreigner, orphan, and widow -- are the OT's most practical anti-poverty provision. Unlike charity, gleaning preserves the dignity of the poor: they work for what they receive."

--- a/content/deuteronomy/25.json
+++ b/content/deuteronomy/25.json
@@ -164,16 +164,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "25:13",
-              "note": "Tigay: On honest weights; remember Amalek: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "25:14",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -190,29 +181,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "25:13",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "25:14",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:13",
-              "note": "Calvin: On honest weights; remember Amalek: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "25:15",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter closes with honest weights and measures (vv.13-16) and the command to blot out Amalek's memory (vv.17-19). Both are covenant integrity laws: honest commerce reflects covenant integrity in daily life; the war against Amalek reflects covenant integrity in history. God, whose patience is demonstrated in the wilderness, will ultimately judge the predatory and the deceptive. The chapter ends with one of Deuteronomy's most urgent commands: do not forget."

--- a/content/deuteronomy/26.json
+++ b/content/deuteronomy/26.json
@@ -184,29 +184,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "26:16",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "26:17",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:16",
-              "note": "Calvin: On the bilateral covenant affirmation: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "26:18",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The covenant bilateral declaration is the climax of Deuteronomy's central law section. Israel declares: \"The LORD is our God; we will walk in obedience to him.\" The LORD declares: \"You are my treasured possession... a holy people.\" Both declarations are in the declarative, not the conditional: not \"if you obey\" but \"I have declared.\" The covenant relationship is established by mutual acknowledgment -- gracious declaration calls forth responsive declaration."

--- a/content/deuteronomy/27.json
+++ b/content/deuteronomy/27.json
@@ -172,16 +172,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "27:11",
-              "note": "Tigay: On the twelve curses: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "27:12",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -198,29 +189,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "27:11",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "27:12",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:11",
-              "note": "Calvin: On the twelve curses: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "27:13",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The twelve curses (vv.15-26) are deliberately targeted at secret sins -- violations hidden from human observers. Idolatry, dishonoring parents, boundary moving, misleading the blind, perverting justice, sexual violations, murder, and accepting a bribe: these are the sins most likely to go unpunished by human courts. The covenant curses address the judicial blind spots. The final curse (v.26) is comprehensive: \"Cursed is anyone who does not uphold the words of this law by carrying them out.\" Paul quotes this in Gal 3:10."

--- a/content/deuteronomy/28.json
+++ b/content/deuteronomy/28.json
@@ -198,29 +198,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "28:45",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "28:46",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "28:45",
-              "note": "Calvin: On the great curses: siege and exile: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "28:47",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The second half of the curse section intensifies dramatically: disease, defeat, madness, exile, siege so severe parents eat their children, return to Egypt as slaves with no buyers. Many scholars note that the curse section closely parallels the Vassal Treaties of Esarhaddon (672 BC) -- either as shared ANE treaty formula or as evidence of a specific relationship. The curses are not designed to be fulfilled but to be avoided -- yet the historical narrative of Joshua through Kings shows them progressively fulfilled."

--- a/content/deuteronomy/29.json
+++ b/content/deuteronomy/29.json
@@ -158,16 +158,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "29:22",
-              "note": "Tigay: On future desolation; hidden and revealed things: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "29:23",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -184,29 +175,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "29:22",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "29:23",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "29:22",
-              "note": "Calvin: On future desolation; hidden and revealed things: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "29:24",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter closes with a prospective description of the land's desolation when Israel apostatises -- foreign nations will ask why the land is ruined. The answer: because they forsook the covenant of the LORD. Then the most-quoted verse of chapter 29: \"The secret things belong to the LORD our God, but the things revealed belong to us and to our children forever, that we may follow all the words of this law.\" The hidden/revealed distinction is the foundational principle of biblical epistemology: act on what God has given, trust him with what he has withheld."

--- a/content/deuteronomy/30.json
+++ b/content/deuteronomy/30.json
@@ -194,29 +194,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "30:11",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "30:12",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "30:11",
-              "note": "Calvin: On the word is near; choose life: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "30:13",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter's conclusion is Deuteronomy's most famous passage: the accessibility of the covenant word (vv.11-14) and the great binary choice (vv.15-20). Moses sets before Israel the two ways: life and prosperity, or death and destruction. Love the LORD, walk in his ways, keep his commands and you will live and increase. Turn away and you will perish. Heaven and earth are called as witnesses. Then the most direct command in the book: \"Choose life, so that you and your children may live.\""

--- a/content/deuteronomy/31.json
+++ b/content/deuteronomy/31.json
@@ -162,16 +162,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "31:23",
-              "note": "Tigay: On the song commanded; Torah deposited: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "31:24",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -188,29 +179,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "31:23",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "31:24",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "31:23",
-              "note": "Calvin: On the song commanded; Torah deposited: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "31:25",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter closes with Joshua's direct commissioning before the LORD at the tent of meeting (v.23) -- a more solemn version of the public commissioning before Israel (vv.7-8). God then commands Moses to write the song of ch.32 as a witness -- because \"I know how rebellious and stiff-necked you are. If you have been rebellious against the LORD while I am still alive and with you, how much more will you rebel after I die!\" (v.27). The Torah scroll is deposited beside the ark as a witness against Israel. Two witnesses: the song (in their mouths) and the Torah (beside the ark)."

--- a/content/deuteronomy/32.json
+++ b/content/deuteronomy/32.json
@@ -180,16 +180,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "32:26",
-              "note": "Tigay: On divine vindication; Moses commanded to die: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "32:27",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -206,29 +197,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "32:26",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "32:27",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "32:26",
-              "note": "Calvin: On divine vindication; Moses commanded to die: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "32:28",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The song's conclusion (vv.26-43) is God's vindication: he will not completely destroy Israel because his enemies would misattribute the destruction to their own power (v.27). God's honour is paradoxically Israel's protection. The song closes with the most universal invitation in Deuteronomy: \"Rejoice, you nations, with his people, for he will avenge the blood of his servants\" (v.43). After the song is delivered, Moses is commanded to ascend Mount Nebo to view the land and die there."

--- a/content/deuteronomy/33.json
+++ b/content/deuteronomy/33.json
@@ -168,16 +168,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "33:18",
-              "note": "Tigay: On remaining blessings; the great doxology: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "33:19",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -194,29 +185,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "33:18",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "33:19",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "33:18",
-              "note": "Calvin: On remaining blessings; the great doxology: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "33:20",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The remaining tribal blessings (Zebulun, Issachar, Gad, Dan, Naphtali, Asher) are followed by the magnificent doxological close (vv.26-29): \"There is no one like the God of Jeshurun, who rides across the heavens to help you and on the clouds in his majesty... The eternal God is your refuge, and underneath are the everlasting arms.\" The chapter closes: \"Blessed are you, Israel! Who is like you, a people saved by the LORD?\" The question echoes the Exodus victory song (Exod 15:11: \"Who among the gods is like you, LORD?\") -- Israel's uniqueness is a reflection of its God's uniqueness."

--- a/content/deuteronomy/34.json
+++ b/content/deuteronomy/34.json
@@ -190,29 +190,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "34:9",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "34:10",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "34:9",
-              "note": "Calvin: On Joshua's commission; the verdict on Moses: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "34:11",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The final verses describe the transition: Joshua, full of the spirit of wisdom because Moses had laid hands on him, assumes leadership. The Israelites listen to Joshua and do what the LORD commanded Moses. And then the final word: no prophet has since arisen in Israel like Moses, whom the LORD knew face to face. The OT ends with an unfilled expectation -- Moses is unequalled, but a prophet like Moses was promised (18:15). The gap waits for its answer in the Word made flesh."

--- a/content/deuteronomy/4.json
+++ b/content/deuteronomy/4.json
@@ -217,16 +217,7 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:41",
-              "note": "Calvin: On cities of refuge east of Jordan: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "4:43",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Moses designates three cities of refuge east of the Jordan: Bezer in the plateau wilderness (for Reuben), Ramoth in Gilead (for Gad), and Golan in Bashan (for Manasseh). The legal principle is that the unintentional killer must not be executed before a proper hearing. Three more cities will be designated west of the Jordan after the conquest (19:1–9). The passage ends by re-establishing the setting for Moses' second and longest address."

--- a/content/deuteronomy/5.json
+++ b/content/deuteronomy/5.json
@@ -192,29 +192,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:22",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "5:23",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:22",
-              "note": "Calvin: On the mediator's role; life through obedience: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "5:24",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "After the Decalogue, Moses recounts the people's terrified response: let Moses mediate, for if we hear God directly we will die. God affirms this response: \"They are right in what they have said\" (v.28). The fear was appropriate — the holy God's direct voice is death to sinful humanity. The mediator pattern is established as theological necessity. Moses is then commissioned to receive all the commandments and teach the people — the structure of Deuteronomy's entire second address."

--- a/content/deuteronomy/6.json
+++ b/content/deuteronomy/6.json
@@ -192,29 +192,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:20",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "6:21",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:20",
-              "note": "Calvin: On teaching the next generation: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "6:22",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The chapter closes with the Deuteronomic catechism: when your child asks \"why these laws?\" you answer with the Exodus narrative. The answer to religious formation's \"why\" is always historical: because God acted, because we were slaves and God freed us. Law is not arbitrary command but the shape of a redeemed life. This catechetical framework — child asks, parent tells the Exodus story — becomes the structural principle of Passover pedagogy."

--- a/content/deuteronomy/7.json
+++ b/content/deuteronomy/7.json
@@ -162,16 +162,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:17",
-              "note": "Tigay: On do not fear; God will drive them out: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "7:18",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -188,29 +179,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:17",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "7:18",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:17",
-              "note": "Calvin: On do not fear; God will drive them out: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "7:19",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Moses anticipates the objection: what if the nations are too numerous? The answer: remember what God did to Pharaoh and Egypt. He will drive out the nations \"little by little\" (v.22) — not all at once, because the land needs time to be inhabited and wild animals would multiply in empty territory. The gradualness is providential wisdom, not delay. The chapter closes with instructions on destroying idols — even the silver and gold of their images must not be kept."

--- a/content/deuteronomy/8.json
+++ b/content/deuteronomy/8.json
@@ -176,16 +176,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:11",
-              "note": "Tigay: On the prosperity trap; do not forget: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "8:12",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -202,29 +193,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:11",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "8:12",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:11",
-              "note": "Calvin: On the prosperity trap; do not forget: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "8:13",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The prosperity warning is urgent: when you have built fine houses, when your herds have grown, when your silver and gold have increased — then your heart will become proud and you will forget the LORD. Moses anticipates the exact psychological mechanism of covenant forgetting: prosperity produces pride, pride produces self-sufficiency, self-sufficiency produces amnesia about God. The corrective is attribution — \"remember the LORD your God, for it is he who gives you the ability to produce wealth\" (v.18)."

--- a/content/deuteronomy/9.json
+++ b/content/deuteronomy/9.json
@@ -172,16 +172,7 @@
         },
         "tigay": {
           "source": "Jeffrey H. Tigay, Deuteronomy, JPS Torah Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:13",
-              "note": "Tigay: On the golden calf; Moses' intercession: the JPS commentary observes that this legislation reflects the distinctive Deuteronomic concern for centralisation and humanitarian ethics. Where earlier law codes state the rule, Deuteronomy adds motivation clauses that ground the law in Israel's experience of God."
-            },
-            {
-              "ref": "9:14",
-              "note": "Tigay: Comparative ANE evidence illuminates the background — similar provisions appear in the Code of Hammurabi and the Middle Assyrian Laws, but Deuteronomy's theological framing is unique: the law serves the covenant relationship, not merely social order."
-            }
-          ]
+          "notes": []
         },
         "craigie": {
           "source": "Peter C. Craigie, The Book of Deuteronomy, NICOT (1976) — Scholarly Paraphrase",
@@ -198,29 +189,11 @@
         },
         "netbible": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:13",
-              "note": "NET Note: The Hebrew syntax in this section reflects the characteristic Deuteronomic style — parenetic (exhortatory) prose with long conditional clauses linking obedience to blessing. The grammatical structure reinforces the theological point: covenant loyalty produces tangible outcomes."
-            },
-            {
-              "ref": "9:14",
-              "note": "NET Note: Several terms in this passage carry technical covenant vocabulary. The repeated use ofšāmar(\"to keep, guard\") frames obedience as vigilant custody of God's commands, not passive acquiescence."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:13",
-              "note": "Calvin: On the golden calf; Moses' intercession: the law here is not mere legislation but divine pedagogy — God shapes his people's character through specific commands that address the conditions they will face in Canaan. Every statute reflects both God's holiness and his care for human wellbeing."
-            },
-            {
-              "ref": "9:15",
-              "note": "Calvin: The application extends to the church in every age. What Moses commands Israel in historical particularity, the Spirit applies to believers in principle. The form changes; the underlying demand for covenant faithfulness does not."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Moses recounts the golden calf incident: God's anger, the tablets smashed, the intercession lasting forty days and nights. The intercession is the theological centre. Moses does not argue Israel's righteousness. He argues three things: (1) Your reputation is at stake — Egypt will mock you; (2) Your promises are at stake — you swore to Abraham; (3) This is your people and your inheritance. The intercession works — Israel is not destroyed. Moses here is at his most Christlike: standing between a guilty people and a righteous God."

--- a/content/exodus/3.json
+++ b/content/exodus/3.json
@@ -7,39 +7,39 @@
   "subtitle": "The Burning Bush; God Reveals Himself; The Commission",
   "timeline_link": {
     "event_id": "burning-bush",
-    "text": "See on Timeline \u2014 Burning Bush"
+    "text": "See on Timeline — Burning Bush"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20139 \u2014 The Burning Bush; God Reveals Himself",
+      "header": "Verses 1–9 — The Burning Bush; God Reveals Himself",
       "verse_start": 1,
       "verse_end": 9,
       "panels": {
         "heb": [
           {
-            "word": "\u05e1\u05b0\u05e0\u05b6\u05d4",
+            "word": "סְנֶה",
             "transliteration": "seneh",
             "gloss": "bush / thornbush",
-            "paragraph": "V.2: The burning bush is a thornbush (not a noble tree) that burns without being consumed. The choice of plant is pointed: the thornbush is the most common, least impressive shrub of the Sinai wilderness. God reveals himself not in grandeur but in the ordinary. The fire that does not consume is the central image: the divine presence is real and intense but does not destroy what it inhabits \u2014 the paradigm of all divine indwelling."
+            "paragraph": "V.2: The burning bush is a thornbush (not a noble tree) that burns without being consumed. The choice of plant is pointed: the thornbush is the most common, least impressive shrub of the Sinai wilderness. God reveals himself not in grandeur but in the ordinary. The fire that does not consume is the central image: the divine presence is real and intense but does not destroy what it inhabits — the paradigm of all divine indwelling."
           },
           {
-            "word": "\u05e7\u05b0\u05d3\u05b9\u05e9\u05c1",
+            "word": "קְדֹשׁ",
             "transliteration": "qadosh",
             "gloss": "holy",
-            "paragraph": "V.5: \"The ground on which you are standing is holy ground.\" The holiness is not intrinsic to the ground; it is relational \u2014 the ground is holy because God is there. The command to remove sandals acknowledges the asymmetry between the divine and human, the sacred and the common. This is the first use of \"holy\" in Exodus, and it frames the entire book: Israel will be called to be a holy nation (19:6) in the presence of a holy God."
+            "paragraph": "V.5: \"The ground on which you are standing is holy ground.\" The holiness is not intrinsic to the ground; it is relational — the ground is holy because God is there. The command to remove sandals acknowledges the asymmetry between the divine and human, the sacred and the common. This is the first use of \"holy\" in Exodus, and it frames the entire book: Israel will be called to be a holy nation (19:6) in the presence of a holy God."
           },
           {
-            "word": "\u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05d0\u05b2\u05e9\u05b6\u05c1\u05e8 \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4",
+            "word": "אֶהְיֶה אֲשֶׁר אֶהְיֶה",
             "transliteration": "ehyeh asher ehyeh",
             "gloss": "I AM WHO I AM",
             "paragraph": "V.14: The most theologically loaded phrase in the Torah. The divine name YHWH is derived from the verb hayah (to be). The phrase may mean: \"I AM WHO I AM\" (ontological, emphasising God's absolute self-existence); \"I WILL BE WHAT I WILL BE\" (relational, emphasising God's promise to be present); or \"I am the One who causes to be\" (causative). All three dimensions are present and none can be reduced to the others."
           }
         ],
         "hist": {
-          "historical": "Horeb (= Sinai) is the theological mountain of the entire Pentateuch \u2014 the site of the law-giving (Exod 19), Elijah's flight (1 Kgs 19), and now Moses's commissioning. Its location is debated (traditional identification: Jebel Musa in the Sinai Peninsula; alternative: Jebel al-Lawz in Arabia). The forty years in Midian would place Moses in the region of the Hejaz/Sinai peninsula \u2014 consistent with either location.",
-          "context": "Moses at the bush is at the lowest point of his trajectory: eighty years old, tending sheep in the wilderness for forty years, having failed in his first attempt at deliverance. The bush burns and is not consumed \u2014 the image of Israel under oppression: afflicted but not destroyed. God's appearance here reverses every human expectation: the deliverer is not found in a palace but in a desert; not in his strength but in his weakness; not when he seeks God but when he notices something unusual in his ordinary work."
+          "historical": "Horeb (= Sinai) is the theological mountain of the entire Pentateuch — the site of the law-giving (Exod 19), Elijah's flight (1 Kgs 19), and now Moses's commissioning. Its location is debated (traditional identification: Jebel Musa in the Sinai Peninsula; alternative: Jebel al-Lawz in Arabia). The forty years in Midian would place Moses in the region of the Hejaz/Sinai peninsula — consistent with either location.",
+          "context": "Moses at the bush is at the lowest point of his trajectory: eighty years old, tending sheep in the wilderness for forty years, having failed in his first attempt at deliverance. The bush burns and is not consumed — the image of Israel under oppression: afflicted but not destroyed. God's appearance here reverses every human expectation: the deliverer is not found in a palace but in a desert; not in his strength but in his weakness; not when he seeks God but when he notices something unusual in his ordinary work."
         },
         "cross": {
           "refs": [
@@ -48,12 +48,12 @@
               "note": "Jesus: \"Before Abraham was, I AM.\" The divine name of Exodus 3:14 is applied to Christ, the most explicit self-identification in the Gospel of John."
             },
             {
-              "ref": "Acts 7:30\u201334",
+              "ref": "Acts 7:30–34",
               "note": "Stephen: \"Now when forty years had passed, an angel appeared to him in the wilderness of Mount Sinai, in a flame of fire in a bush.\""
             },
             {
               "ref": "Rev 1:4",
-              "note": "\"From him who is and who was and who is to come\" \u2014 the Revelation unpacks the Exodus name YHWH as the three tenses of divine existence."
+              "note": "\"From him who is and who was and who is to come\" — the Revelation unpacks the Exodus name YHWH as the three tenses of divine existence."
             }
           ]
         },
@@ -66,7 +66,7 @@
           {
             "name": "Near side of the wilderness / Sinai",
             "coords": "Western Sinai",
-            "text": "\"The far side of the wilderness\" \u2014 Moses has taken Jethro's flocks deep into the Sinai. The remoteness of the location dramatises that the call comes not in a city or temple but in the empty wilderness, at the mountain's edge."
+            "text": "\"The far side of the wilderness\" — Moses has taken Jethro's flocks deep into the Sinai. The remoteness of the location dramatises that the call comes not in a city or temple but in the empty wilderness, at the mountain's edge."
           }
         ],
         "tl": [
@@ -90,7 +90,7 @@
           },
           {
             "date": "c. 1447 BC",
-            "name": "Burning bush \u2014 this passage (Moses age 79)",
+            "name": "Burning bush — this passage (Moses age 79)",
             "text": "Moses has been in Midian 40 years when God appears at Horeb. The 40-year formation in Midian parallels Israel's 40-year formation in the wilderness. The burning bush appears in Moses's 79th year; he will die at 120.",
             "current": true
           },
@@ -108,7 +108,7 @@
           }
         ],
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:2",
@@ -116,63 +116,63 @@
             },
             {
               "ref": "3:6",
-              "note": "God introduces himself not by his power but by his relationships: \"the God of Abraham, the God of Isaac, and the God of Jacob.\" He is not first \"the Creator\" or \"the Almighty\" but the covenant-keeper \u2014 defined by his faithfulness to specific people across generations. Jesus will later use this exact verse to prove the resurrection (Matt 22:32): if God is their God, they must be alive, for God is not the God of the dead. The burning bush carries the resurrection inside it."
+              "note": "God introduces himself not by his power but by his relationships: \"the God of Abraham, the God of Isaac, and the God of Jacob.\" He is not first \"the Creator\" or \"the Almighty\" but the covenant-keeper — defined by his faithfulness to specific people across generations. Jesus will later use this exact verse to prove the resurrection (Matt 22:32): if God is their God, they must be alive, for God is not the God of the dead. The burning bush carries the resurrection inside it."
             },
             {
               "ref": "3:1",
-              "note": "Moses at \"Horeb, the mountain of God\" \u2014 Sarna notes the identification of Horeb with Sinai (cf. 19:1) and the significance of the site. The place is called \"the mountain of God\" proleptically \u2014 it is not yet so famous; the title anticipates the Sinai revelation to come. That the most important revelation in Israel's history begins with a shepherd tending flocks on an ordinary day is itself a theological statement: God breaks into the ordinary, not just the extraordinary."
+              "note": "Moses at \"Horeb, the mountain of God\" — Sarna notes the identification of Horeb with Sinai (cf. 19:1) and the significance of the site. The place is called \"the mountain of God\" proleptically — it is not yet so famous; the title anticipates the Sinai revelation to come. That the most important revelation in Israel's history begins with a shepherd tending flocks on an ordinary day is itself a theological statement: God breaks into the ordinary, not just the extraordinary."
             },
             {
-              "ref": "3:2\u20134",
-              "note": "The burning bush (\u05d4\u05b7\u05e1\u05b0\u05bc\u05e0\u05b6\u05d4 \u05d1\u05b9\u05bc\u05e2\u05b5\u05e8, hasseneh b\u014d\u02bf\u0113r) is the central image of the chapter. Sarna notes the word seneh (bush, specifically briar or thornbush) appears only in Exod 3 and Deut 33:16 in the entire OT, and that Sinai may derive from the same root. The bush burns but is not consumed: fire in the OT is a regular theophanic element (Gen 15:17; Exod 13:21; Ezek 1), but the non-consumption is the novel detail \u2014 the divine presence does not destroy what it inhabits. This becomes the paradigm for Israel's survival in the wilderness."
+              "ref": "3:2–4",
+              "note": "The burning bush (הַסְּנֶה בֹּעֵר, hasseneh bōʿēr) is the central image of the chapter. Sarna notes the word seneh (bush, specifically briar or thornbush) appears only in Exod 3 and Deut 33:16 in the entire OT, and that Sinai may derive from the same root. The bush burns but is not consumed: fire in the OT is a regular theophanic element (Gen 15:17; Exod 13:21; Ezek 1), but the non-consumption is the novel detail — the divine presence does not destroy what it inhabits. This becomes the paradigm for Israel's survival in the wilderness."
             },
             {
               "ref": "3:8",
-              "note": "\"A land flowing with milk and honey\" \u2014 Sarna identifies this as a formulaic description of Canaan's agricultural richness, occurring 21 times in the OT. Egyptian literary sources describe Canaan similarly. Milk represents pastoral abundance (livestock); honey likely refers to date honey (dibs) or grape syrup, the natural sweeteners of the region. The phrase is covenant geography \u2014 the land promised to the patriarchs is now being named as the destination of the Exodus."
+              "note": "\"A land flowing with milk and honey\" — Sarna identifies this as a formulaic description of Canaan's agricultural richness, occurring 21 times in the OT. Egyptian literary sources describe Canaan similarly. Milk represents pastoral abundance (livestock); honey likely refers to date honey (dibs) or grape syrup, the natural sweeteners of the region. The phrase is covenant geography — the land promised to the patriarchs is now being named as the destination of the Exodus."
             },
             {
-              "ref": "3:2\u20133",
-              "note": "Alter on the bush: \"The angel of the LORD appears in a flame of fire out of a bush, and the bush is burning yet is not consumed. Moses says, 'I will turn aside to see this great sight.'\" Alter notes the two-step revelation: first the sight arrests Moses, then God speaks. The delay is significant \u2014 Moses must turn aside, must choose to engage. The divine call requires the human turn. The burning bush is not a compulsion but an invitation; Moses' response is the first act of his vocation."
+              "ref": "3:2–3",
+              "note": "Alter on the bush: \"The angel of the LORD appears in a flame of fire out of a bush, and the bush is burning yet is not consumed. Moses says, 'I will turn aside to see this great sight.'\" Alter notes the two-step revelation: first the sight arrests Moses, then God speaks. The delay is significant — Moses must turn aside, must choose to engage. The divine call requires the human turn. The burning bush is not a compulsion but an invitation; Moses' response is the first act of his vocation."
             },
             {
               "ref": "3:6",
-              "note": "\"And Moses hid his face, for he was afraid to look at God.\" Alter notes the progression from curiosity (v.3: \"I will turn aside to see\") to awe (v.6: he hides his face). The same man who had to look at injustice (2:11) now cannot look at holiness. This paradox \u2014 the justice-seeker overwhelmed by the holy \u2014 defines prophetic identity. Moses must learn that the God he will represent is not merely just but holy: a fire that illuminates without consuming, but that demands one remove one's sandals."
+              "note": "\"And Moses hid his face, for he was afraid to look at God.\" Alter notes the progression from curiosity (v.3: \"I will turn aside to see\") to awe (v.6: he hides his face). The same man who had to look at injustice (2:11) now cannot look at holiness. This paradox — the justice-seeker overwhelmed by the holy — defines prophetic identity. Moses must learn that the God he will represent is not merely just but holy: a fire that illuminates without consuming, but that demands one remove one's sandals."
             },
             {
               "ref": "3:2",
-              "note": "Calvin on the angel and the divine presence: \"The angel of the Lord was himself God, since the appearance was of divine majesty.\" Calvin identifies the Angel of the LORD in the OT theophanies as the pre-incarnate Christ (the second person of the Trinity), following Augustine and the majority patristic tradition. \"God in his glory does not appear to men unless through his Word or Son, who is the image of his person.\" The burning bush is a Christophany \u2014 the same divine Word who will become flesh appears in fire."
+              "note": "Calvin on the angel and the divine presence: \"The angel of the Lord was himself God, since the appearance was of divine majesty.\" Calvin identifies the Angel of the LORD in the OT theophanies as the pre-incarnate Christ (the second person of the Trinity), following Augustine and the majority patristic tradition. \"God in his glory does not appear to men unless through his Word or Son, who is the image of his person.\" The burning bush is a Christophany — the same divine Word who will become flesh appears in fire."
             },
             {
               "ref": "3:5",
-              "note": "\"The place where you are standing is holy ground\" \u2014 Calvin: \"The sanctity of the place was a sort of preface to render Moses more attentive.\" The removal of sandals is an act of self-humbling before the Holy One. Calvin connects this to the NT principle that before God we stand on nothing our own \u2014 all our coverings must be removed. \"We cannot draw near to God unless we cast away all vain confidence, and present ourselves before him naked and empty.\""
+              "note": "\"The place where you are standing is holy ground\" — Calvin: \"The sanctity of the place was a sort of preface to render Moses more attentive.\" The removal of sandals is an act of self-humbling before the Holy One. Calvin connects this to the NT principle that before God we stand on nothing our own — all our coverings must be removed. \"We cannot draw near to God unless we cast away all vain confidence, and present ourselves before him naked and empty.\""
             },
             {
               "ref": "3:2",
-              "note": "The NET note on \u05de\u05b7\u05dc\u05b0\u05d0\u05b7\u05da\u05b0 \u05d9\u05b0\u05d4\u05d5\u05b8\u05d4 (mal\u02beak YHWH, \"the angel of the LORD\") discusses whether this designates a distinct being (a created messenger) or YHWH himself in theophanic form. The text transitions immediately from \"the angel\" (v.2) to \"God called to him\" (v.4) to \"I am the God of your father\" (v.6), suggesting the angel functions as YHWH's personal presence. The NET translators note this is the standard pattern of the \"angel of the LORD\" \u2014 initial appearance as a distinct figure, then identification with YHWH himself."
+              "note": "The NET note on מַלְאַךְ יְהוָה (malʾak YHWH, \"the angel of the LORD\") discusses whether this designates a distinct being (a created messenger) or YHWH himself in theophanic form. The text transitions immediately from \"the angel\" (v.2) to \"God called to him\" (v.4) to \"I am the God of your father\" (v.6), suggesting the angel functions as YHWH's personal presence. The NET translators note this is the standard pattern of the \"angel of the LORD\" — initial appearance as a distinct figure, then identification with YHWH himself."
             },
             {
               "ref": "3:8",
-              "note": "The NET note on \"milk and honey\" identifies the six peoples listed (Canaanites, Hittites, Amorites, Perizzites, Hivites, Jebusites) as a stock formula for Canaan's pre-Israelite inhabitants appearing throughout the Pentateuch. The \"flowing\" of milk and honey (\u05d6\u05b8\u05d1\u05b7\u05ea \u05d7\u05b8\u05dc\u05b8\u05d1 \u05d5\u05bc\u05d3\u05b0\u05d1\u05b7\u05e9\u05c1, z\u0101bat \u1e25\u0101l\u0101b \u00fbd\u0115b\u0101\u0161) uses an unusual verb meaning \"to flow, to gush\" \u2014 agricultural hyperbole standard in ancient Near Eastern descriptions of fertile lands. Similar language appears in Egyptian texts describing Canaan."
+              "note": "The NET note on \"milk and honey\" identifies the six peoples listed (Canaanites, Hittites, Amorites, Perizzites, Hivites, Jebusites) as a stock formula for Canaan's pre-Israelite inhabitants appearing throughout the Pentateuch. The \"flowing\" of milk and honey (זָבַת חָלָב וּדְבַשׁ, zābat ḥālāb ûdĕbāš) uses an unusual verb meaning \"to flow, to gush\" — agricultural hyperbole standard in ancient Near Eastern descriptions of fertile lands. Similar language appears in Egyptian texts describing Canaan."
             },
             {
               "ref": "3:1",
-              "note": "\"Moses was keeping the flock of his father-in-law Jethro... and led the flock to the west side of the wilderness and came to Horeb, the mountain of God.\" The ordinariness of the beginning is the point. Moses is doing what he has done for forty years \u2014 shepherding. He is not seeking a vision; he is doing his job. The burning bush finds him in the middle of the ordinary. God initiates; Moses is not pursuing."
+              "note": "\"Moses was keeping the flock of his father-in-law Jethro... and led the flock to the west side of the wilderness and came to Horeb, the mountain of God.\" The ordinariness of the beginning is the point. Moses is doing what he has done for forty years — shepherding. He is not seeking a vision; he is doing his job. The burning bush finds him in the middle of the ordinary. God initiates; Moses is not pursuing."
             },
             {
-              "ref": "3:2\u20133",
-              "note": "The burning bush that is not consumed presents two simultaneous facts: fire (divine presence, consuming holiness) and preservation (the bush is not destroyed). The tension between these two facts is the tension of all encounters with God \u2014 his holiness should consume what is unholy; his grace preserves what his holiness would destroy. Moses \"turns aside\" \u2014 a small act of curiosity that becomes the pivot of world history."
+              "ref": "3:2–3",
+              "note": "The burning bush that is not consumed presents two simultaneous facts: fire (divine presence, consuming holiness) and preservation (the bush is not destroyed). The tension between these two facts is the tension of all encounters with God — his holiness should consume what is unholy; his grace preserves what his holiness would destroy. Moses \"turns aside\" — a small act of curiosity that becomes the pivot of world history."
             },
             {
               "ref": "3:4",
-              "note": "\"When the LORD saw that he turned aside to look, God called to him.\" God waits for Moses to respond. The initiative is divine (the burning bush), but the response is required (Moses turns aside). God calls him by name: \"Moses, Moses!\" \u2014 the double vocative used throughout Scripture for urgent divine address (Abraham, Abraham, Gen 22:11; Samuel, Samuel, 1 Sam 3:10; Martha, Martha, Luke 10:41). The name spoken twice signals both intimacy and urgency."
+              "note": "\"When the LORD saw that he turned aside to look, God called to him.\" God waits for Moses to respond. The initiative is divine (the burning bush), but the response is required (Moses turns aside). God calls him by name: \"Moses, Moses!\" — the double vocative used throughout Scripture for urgent divine address (Abraham, Abraham, Gen 22:11; Samuel, Samuel, 1 Sam 3:10; Martha, Martha, Luke 10:41). The name spoken twice signals both intimacy and urgency."
             },
             {
               "ref": "3:5",
-              "note": "The command to remove sandals before holy ground is the paradigmatic gesture of creaturely humility before the divine presence. Sandals separate the foot from the ground; their removal is the acknowledgment of direct contact with a reality that cannot be approached on ordinary terms. The command does not say \"this ground is always holy\" but \"the ground where you are standing\" \u2014 holiness attaches to the divine presence, not to geography. The burning bush can be anywhere."
+              "note": "The command to remove sandals before holy ground is the paradigmatic gesture of creaturely humility before the divine presence. Sandals separate the foot from the ground; their removal is the acknowledgment of direct contact with a reality that cannot be approached on ordinary terms. The command does not say \"this ground is always holy\" but \"the ground where you are standing\" — holiness attaches to the divine presence, not to geography. The burning bush can be anywhere."
             },
             {
               "ref": "3:6",
-              "note": "\"I am the God of your father, the God of Abraham, the God of Isaac, and the God of Jacob.\" The self-identification grounds the encounter in covenant history. This is not a new God introducing himself; this is the God of the covenant fathers appearing to the one they have been waiting for. Jesus will use this verse to prove the resurrection (Matt 22:32): \"he is not the God of the dead but of the living.\" The God who identifies himself this way is still in relationship with Abraham, Isaac, and Jacob \u2014 they live."
+              "note": "\"I am the God of your father, the God of Abraham, the God of Isaac, and the God of Jacob.\" The self-identification grounds the encounter in covenant history. This is not a new God introducing himself; this is the God of the covenant fathers appearing to the one they have been waiting for. Jesus will use this verse to prove the resurrection (Matt 22:32): \"he is not the God of the dead but of the living.\" The God who identifies himself this way is still in relationship with Abraham, Isaac, and Jacob — they live."
             },
             {
               "ref": "3:1",
@@ -184,19 +184,19 @@
             },
             {
               "ref": "3:5",
-              "note": "The command to remove sandals is paralleled in Josh 5:15 (Joshua before Jericho, on \"holy ground\"). Sarna notes that sandal removal in the ancient world was associated with servitude (cf. John 1:27) and with sacred space entry. Both associations are present here: Moses is entering the sphere of divine service and the sphere of divine presence. The gesture is both submission and preparation \u2014 Moses is being fitted for service."
+              "note": "The command to remove sandals is paralleled in Josh 5:15 (Joshua before Jericho, on \"holy ground\"). Sarna notes that sandal removal in the ancient world was associated with servitude (cf. John 1:27) and with sacred space entry. Both associations are present here: Moses is entering the sphere of divine service and the sphere of divine presence. The gesture is both submission and preparation — Moses is being fitted for service."
             },
             {
-              "ref": "3:2\u20133",
-              "note": "\"And he looked, and behold, the bush was burning, yet it was not consumed.\" The \"behold\" (hinneh) is the Hebrew particle of direct perception \u2014 the narrator uses it to put the reader in Moses' visual position. We see what he sees. Alter notes the scene is constructed around the paradox: fire is by nature consuming; this fire does not consume. The paradox is what arrests Moses' attention and what arrests the reader's. The inexplicable is the invitation to approach."
+              "ref": "3:2–3",
+              "note": "\"And he looked, and behold, the bush was burning, yet it was not consumed.\" The \"behold\" (hinneh) is the Hebrew particle of direct perception — the narrator uses it to put the reader in Moses' visual position. We see what he sees. Alter notes the scene is constructed around the paradox: fire is by nature consuming; this fire does not consume. The paradox is what arrests Moses' attention and what arrests the reader's. The inexplicable is the invitation to approach."
             },
             {
               "ref": "3:4",
-              "note": "The double call \u2014 \"Moses, Moses!\" \u2014 is one of the Bible's most intimate moments of divine-human contact. Alter notes the repetition of name in divine address always signals a moment of particular urgency or intimacy: Abraham (Gen 22:11), Jacob (Gen 46:2), Samuel (1 Sam 3:10). The structure of the response is also formulaic: \"Here I am\" (hineni) \u2014 the word of full, unconditional availability. Before Moses knows what is being asked, he has already said yes."
+              "note": "The double call — \"Moses, Moses!\" — is one of the Bible's most intimate moments of divine-human contact. Alter notes the repetition of name in divine address always signals a moment of particular urgency or intimacy: Abraham (Gen 22:11), Jacob (Gen 46:2), Samuel (1 Sam 3:10). The structure of the response is also formulaic: \"Here I am\" (hineni) — the word of full, unconditional availability. Before Moses knows what is being asked, he has already said yes."
             },
             {
               "ref": "3:6",
-              "note": "God's self-introduction through the patriarchs is a narrative connection of remarkable depth. Alter notes the phrase \"God of your father\" (singular) before the triple formula (\"God of Abraham, God of Isaac, God of Jacob\") is unusual \u2014 the singular \"your father\" anchors the introduction personally before expanding it covenantally. This God is both Moses' ancestral God and the God of the great covenant narrative. The personal and the historical are unified in the introduction."
+              "note": "God's self-introduction through the patriarchs is a narrative connection of remarkable depth. Alter notes the phrase \"God of your father\" (singular) before the triple formula (\"God of Abraham, God of Isaac, God of Jacob\") is unusual — the singular \"your father\" anchors the introduction personally before expanding it covenantally. This God is both Moses' ancestral God and the God of the great covenant narrative. The personal and the historical are unified in the introduction."
             },
             {
               "ref": "3:2",
@@ -216,96 +216,12 @@
             },
             {
               "ref": "3:5",
-              "note": "The NET note on \"holy ground\" explains that the Hebrew term qadosh (holy, set apart) means separated from the ordinary for divine use. The note discusses the parallel with Josh 5:15 and notes that the removal of sandals \u2014 leather from dead animals \u2014 may also be connected to purity regulations: the dead were excluded from the sacred sphere, and sandals made of dead animal hide were therefore inappropriate in the holy presence. Both the humility and the purity interpretations may be simultaneously operative."
-            },
-            {
-              "ref": "3:1",
-              "note": "\"Moses was keeping the flock of his father-in-law Jethro... and led the flock to the west side of the wilderness and came to Horeb, the mountain of God.\" The ordinariness of the beginning is the point. Moses is doing what he has done for forty years \u2014 shepherding. He is not seeking a vision; he is doing his job. The burning bush finds him in the middle of the ordinary. God initiates; Moses is not pursuing."
-            },
-            {
-              "ref": "3:2\u20133",
-              "note": "The burning bush that is not consumed presents two simultaneous facts: fire (divine presence, consuming holiness) and preservation (the bush is not destroyed). The tension between these two facts is the tension of all encounters with God \u2014 his holiness should consume what is unholy; his grace preserves what his holiness would destroy. Moses \"turns aside\" \u2014 a small act of curiosity that becomes the pivot of world history."
-            },
-            {
-              "ref": "3:4",
-              "note": "\"When the LORD saw that he turned aside to look, God called to him.\" God waits for Moses to respond. The initiative is divine (the burning bush), but the response is required (Moses turns aside). God calls him by name: \"Moses, Moses!\" \u2014 the double vocative used throughout Scripture for urgent divine address (Abraham, Abraham, Gen 22:11; Samuel, Samuel, 1 Sam 3:10; Martha, Martha, Luke 10:41). The name spoken twice signals both intimacy and urgency."
-            },
-            {
-              "ref": "3:5",
-              "note": "The command to remove sandals before holy ground is the paradigmatic gesture of creaturely humility before the divine presence. Sandals separate the foot from the ground; their removal is the acknowledgment of direct contact with a reality that cannot be approached on ordinary terms. The command does not say \"this ground is always holy\" but \"the ground where you are standing\" \u2014 holiness attaches to the divine presence, not to geography. The burning bush can be anywhere."
-            },
-            {
-              "ref": "3:6",
-              "note": "\"I am the God of your father, the God of Abraham, the God of Isaac, and the God of Jacob.\" The self-identification grounds the encounter in covenant history. This is not a new God introducing himself; this is the God of the covenant fathers appearing to the one they have been waiting for. Jesus will use this verse to prove the resurrection (Matt 22:32): \"he is not the God of the dead but of the living.\" The God who identifies himself this way is still in relationship with Abraham, Isaac, and Jacob \u2014 they live."
-            },
-            {
-              "ref": "3:1",
-              "note": "Sarna notes the geography of chapter 3 is carefully specified: Horeb, \"the mountain of God.\" This name for the sacred mountain (used in the Deuteronomic tradition; \"Sinai\" is used in J and P) indicates that the mountain was already known as a sacred site before Moses arrived. The divine designation in the toponym (\"the mountain of God\") is not a narrative convention but a recognition that this mountain is already set apart in the geography of the story."
-            },
-            {
-              "ref": "3:2",
-              "note": "The malach YHWH (\"angel of the LORD\") who appears in the flame is a theological phenomenon throughout the OT: a theophanic representative who is distinguished from God yet identified with him (vv.4-6 shift smoothly from \"angel\" to \"God\" to \"the LORD\"). Sarna notes this is not confusion but a deliberate representation of divine transcendence (God does not appear directly) and immanence (God truly is present and speaking). The \"angel\" is the mediating form of the divine presence."
-            },
-            {
-              "ref": "3:5",
-              "note": "The command to remove sandals is paralleled in Josh 5:15 (Joshua before Jericho, on \"holy ground\"). Sarna notes that sandal removal in the ancient world was associated with servitude (cf. John 1:27) and with sacred space entry. Both associations are present here: Moses is entering the sphere of divine service and the sphere of divine presence. The gesture is both submission and preparation \u2014 Moses is being fitted for service."
-            },
-            {
-              "ref": "3:2\u20133",
-              "note": "\"And he looked, and behold, the bush was burning, yet it was not consumed.\" The \"behold\" (hinneh) is the Hebrew particle of direct perception \u2014 the narrator uses it to put the reader in Moses' visual position. We see what he sees. Alter notes the scene is constructed around the paradox: fire is by nature consuming; this fire does not consume. The paradox is what arrests Moses' attention and what arrests the reader's. The inexplicable is the invitation to approach."
-            },
-            {
-              "ref": "3:4",
-              "note": "The double call \u2014 \"Moses, Moses!\" \u2014 is one of the Bible's most intimate moments of divine-human contact. Alter notes the repetition of name in divine address always signals a moment of particular urgency or intimacy: Abraham (Gen 22:11), Jacob (Gen 46:2), Samuel (1 Sam 3:10). The structure of the response is also formulaic: \"Here I am\" (hineni) \u2014 the word of full, unconditional availability. Before Moses knows what is being asked, he has already said yes."
-            },
-            {
-              "ref": "3:6",
-              "note": "God's self-introduction through the patriarchs is a narrative connection of remarkable depth. Alter notes the phrase \"God of your father\" (singular) before the triple formula (\"God of Abraham, God of Isaac, God of Jacob\") is unusual \u2014 the singular \"your father\" anchors the introduction personally before expanding it covenantally. This God is both Moses' ancestral God and the God of the great covenant narrative. The personal and the historical are unified in the introduction."
-            },
-            {
-              "ref": "3:2",
-              "note": "Calvin on the burning bush: \"God wished to give an extraordinary specimen of his power, that Moses might be filled with wonder and attention.\" The extraordinary sight is God's way of arresting the attention of the man he is about to commission. Calvin also reads the non-consuming fire typologically: \"This was a symbol of the Church, which is often hard pressed by the flames of adversity but is not consumed.\" The image of preservation through fire runs through all of Scripture."
-            },
-            {
-              "ref": "3:5",
-              "note": "The holy ground is Calvin's occasion to teach about divine majesty: \"Wherever God manifests his presence, the place acquires a sanctity which should inspire us with fear and reverence.\" The application is explicitly liturgical: \"hence we gather that when we are admitted to the presence of God, whether in prayer or in the public assemblies, we must lay aside all earthly feelings, and put away the filth of our lusts.\" The burning bush is the model for all worship."
-            },
-            {
-              "ref": "3:6",
-              "note": "\"I am the God of thy father, the God of Abraham, the God of Isaac, and the God of Jacob.\" Calvin: \"He enumerates these three, that Moses might know that the covenant did not perish with its authors, but that it was still firm and perpetual.\" The covenant God is not a God of past relationships but of present, living ones. The promise made to Abraham is as alive in this moment as when it was made. This is the theological ground of Moses' commission: God is still bound by what he promised."
-            },
-            {
-              "ref": "3:2",
-              "note": "The NET note on the \"angel of the LORD\" explains the Hebrew malach YHWH is used throughout the OT for a theophanic presence distinct from yet identified with YHWH (Gen 16:7-13; 22:11-18; Judg 6:11-23). The notes discuss two main interpretive positions: (1) a created angelic being representing God; (2) a pre-incarnate manifestation of the Son of God (the \"Angel-Christology\" of the Fathers). The narrative itself oscillates between identifying the figure as \"angel\" and as \"God/LORD,\" indicating a deliberate theological complexity."
-            },
-            {
-              "ref": "3:5",
-              "note": "The NET note on \"holy ground\" explains that the Hebrew term qadosh (holy, set apart) means separated from the ordinary for divine use. The note discusses the parallel with Josh 5:15 and notes that the removal of sandals \u2014 leather from dead animals \u2014 may also be connected to purity regulations: the dead were excluded from the sacred sphere, and sandals made of dead animal hide were therefore inappropriate in the holy presence. Both the humility and the purity interpretations may be simultaneously operative."
-            },
-            {
-              "ref": "3:1",
-              "note": "\"Moses was keeping the flock of his father-in-law Jethro... and led the flock to the west side of the wilderness and came to Horeb, the mountain of God.\" The ordinariness of the beginning is the point. Moses is doing what he has done for forty years \u2014 shepherding. He is not seeking a vision; he is doing his job. The burning bush finds him in the middle of the ordinary. God initiates; Moses is not pursuing."
-            },
-            {
-              "ref": "3:2\u20133",
-              "note": "The burning bush that is not consumed presents two simultaneous facts: fire (divine presence, consuming holiness) and preservation (the bush is not destroyed). The tension between these two facts is the tension of all encounters with God \u2014 his holiness should consume what is unholy; his grace preserves what his holiness would destroy. Moses \"turns aside\" \u2014 a small act of curiosity that becomes the pivot of world history."
-            },
-            {
-              "ref": "3:4",
-              "note": "\"When the LORD saw that he turned aside to look, God called to him.\" God waits for Moses to respond. The initiative is divine (the burning bush), but the response is required (Moses turns aside). God calls him by name: \"Moses, Moses!\" \u2014 the double vocative used throughout Scripture for urgent divine address (Abraham, Abraham, Gen 22:11; Samuel, Samuel, 1 Sam 3:10; Martha, Martha, Luke 10:41). The name spoken twice signals both intimacy and urgency."
-            },
-            {
-              "ref": "3:5",
-              "note": "The command to remove sandals before holy ground is the paradigmatic gesture of creaturely humility before the divine presence. Sandals separate the foot from the ground; their removal is the acknowledgment of direct contact with a reality that cannot be approached on ordinary terms. The command does not say \"this ground is always holy\" but \"the ground where you are standing\" \u2014 holiness attaches to the divine presence, not to geography. The burning bush can be anywhere."
-            },
-            {
-              "ref": "3:6",
-              "note": "\"I am the God of your father, the God of Abraham, the God of Isaac, and the God of Jacob.\" The self-identification grounds the encounter in covenant history. This is not a new God introducing himself; this is the God of the covenant fathers appearing to the one they have been waiting for. Jesus will use this verse to prove the resurrection (Matt 22:32): \"he is not the God of the dead but of the living.\" The God who identifies himself this way is still in relationship with Abraham, Isaac, and Jacob \u2014 they live."
+              "note": "The NET note on \"holy ground\" explains that the Hebrew term qadosh (holy, set apart) means separated from the ordinary for divine use. The note discusses the parallel with Josh 5:15 and notes that the removal of sandals — leather from dead animals — may also be connected to purity regulations: the dead were excluded from the sacred sphere, and sandals made of dead animal hide were therefore inappropriate in the holy presence. Both the humility and the purity interpretations may be simultaneously operative."
             }
           ]
         },
         "sarna": {
-          "source": "Nahum Sarna, JPS Torah Commentary \u2014 Scholarly Paraphrase",
+          "source": "Nahum Sarna, JPS Torah Commentary — Scholarly Paraphrase",
           "notes": [
             {
               "ref": "3:1",
@@ -317,29 +233,29 @@
             },
             {
               "ref": "3:5",
-              "note": "The command to remove sandals is paralleled in Josh 5:15 (Joshua before Jericho, on \"holy ground\"). Sarna notes that sandal removal in the ancient world was associated with servitude (cf. John 1:27) and with sacred space entry. Both associations are present here: Moses is entering the sphere of divine service and the sphere of divine presence. The gesture is both submission and preparation \u2014 Moses is being fitted for service."
+              "note": "The command to remove sandals is paralleled in Josh 5:15 (Joshua before Jericho, on \"holy ground\"). Sarna notes that sandal removal in the ancient world was associated with servitude (cf. John 1:27) and with sacred space entry. Both associations are present here: Moses is entering the sphere of divine service and the sphere of divine presence. The gesture is both submission and preparation — Moses is being fitted for service."
             }
           ]
         },
         "alter": {
-          "source": "Robert Alter, The Hebrew Bible: A Translation with Commentary \u2014 Scholarly Paraphrase",
+          "source": "Robert Alter, The Hebrew Bible: A Translation with Commentary — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "3:2\u20133",
-              "note": "\"And he looked, and behold, the bush was burning, yet it was not consumed.\" The \"behold\" (hinneh) is the Hebrew particle of direct perception \u2014 the narrator uses it to put the reader in Moses' visual position. We see what he sees. Alter notes the scene is constructed around the paradox: fire is by nature consuming; this fire does not consume. The paradox is what arrests Moses' attention and what arrests the reader's. The inexplicable is the invitation to approach."
+              "ref": "3:2–3",
+              "note": "\"And he looked, and behold, the bush was burning, yet it was not consumed.\" The \"behold\" (hinneh) is the Hebrew particle of direct perception — the narrator uses it to put the reader in Moses' visual position. We see what he sees. Alter notes the scene is constructed around the paradox: fire is by nature consuming; this fire does not consume. The paradox is what arrests Moses' attention and what arrests the reader's. The inexplicable is the invitation to approach."
             },
             {
               "ref": "3:4",
-              "note": "The double call \u2014 \"Moses, Moses!\" \u2014 is one of the Bible's most intimate moments of divine-human contact. Alter notes the repetition of name in divine address always signals a moment of particular urgency or intimacy: Abraham (Gen 22:11), Jacob (Gen 46:2), Samuel (1 Sam 3:10). The structure of the response is also formulaic: \"Here I am\" (hineni) \u2014 the word of full, unconditional availability. Before Moses knows what is being asked, he has already said yes."
+              "note": "The double call — \"Moses, Moses!\" — is one of the Bible's most intimate moments of divine-human contact. Alter notes the repetition of name in divine address always signals a moment of particular urgency or intimacy: Abraham (Gen 22:11), Jacob (Gen 46:2), Samuel (1 Sam 3:10). The structure of the response is also formulaic: \"Here I am\" (hineni) — the word of full, unconditional availability. Before Moses knows what is being asked, he has already said yes."
             },
             {
               "ref": "3:6",
-              "note": "God's self-introduction through the patriarchs is a narrative connection of remarkable depth. Alter notes the phrase \"God of your father\" (singular) before the triple formula (\"God of Abraham, God of Isaac, God of Jacob\") is unusual \u2014 the singular \"your father\" anchors the introduction personally before expanding it covenantally. This God is both Moses' ancestral God and the God of the great covenant narrative. The personal and the historical are unified in the introduction."
+              "note": "God's self-introduction through the patriarchs is a narrative connection of remarkable depth. Alter notes the phrase \"God of your father\" (singular) before the triple formula (\"God of Abraham, God of Isaac, God of Jacob\") is unusual — the singular \"your father\" anchors the introduction personally before expanding it covenantally. This God is both Moses' ancestral God and the God of the great covenant narrative. The personal and the historical are unified in the introduction."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:2",
@@ -356,7 +272,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:2",
@@ -364,7 +280,7 @@
             },
             {
               "ref": "3:5",
-              "note": "The NET note on \"holy ground\" explains that the Hebrew term qadosh (holy, set apart) means separated from the ordinary for divine use. The note discusses the parallel with Josh 5:15 and notes that the removal of sandals \u2014 leather from dead animals \u2014 may also be connected to purity regulations: the dead were excluded from the sacred sphere, and sandals made of dead animal hide were therefore inappropriate in the holy presence. Both the humility and the purity interpretations may be simultaneously operative."
+              "note": "The NET note on \"holy ground\" explains that the Hebrew term qadosh (holy, set apart) means separated from the ordinary for divine use. The note discusses the parallel with Josh 5:15 and notes that the removal of sandals — leather from dead animals — may also be connected to purity regulations: the dead were excluded from the sacred sphere, and sandals made of dead animal hide were therefore inappropriate in the holy presence. Both the humility and the purity interpretations may be simultaneously operative."
             }
           ]
         }
@@ -372,152 +288,152 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 10\u201322 \u2014 The Commission; the Name I AM",
+      "header": "Verses 10–22 — The Commission; the Name I AM",
       "verse_start": 10,
       "verse_end": 22,
       "panels": {
         "heb": [
           {
-            "word": "\u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05e2\u05b4\u05de\u05b8\u05bc\u05da\u05b0",
+            "word": "אֶהְיֶה עִמָּךְ",
             "transliteration": "ehyeh immak",
             "gloss": "I will be with you",
-            "paragraph": "V.12: Before Moses hears the name of God (v.14), he hears the promise of God's presence. \"I will be with you\" is the first response to Moses' objection \u2014 \"who am I?\" The answer is not \"you are Moses, son of Amram, educated in Pharaoh's court\" but \"I will be with you.\" Adequacy is not required; presence is promised. This is the structure of every divine commission in Scripture."
+            "paragraph": "V.12: Before Moses hears the name of God (v.14), he hears the promise of God's presence. \"I will be with you\" is the first response to Moses' objection — \"who am I?\" The answer is not \"you are Moses, son of Amram, educated in Pharaoh's court\" but \"I will be with you.\" Adequacy is not required; presence is promised. This is the structure of every divine commission in Scripture."
           },
           {
-            "word": "\u05d9\u05b0\u05d4\u05d5\u05b8\u05d4",
+            "word": "יְהוָה",
             "transliteration": "YHWH",
             "gloss": "the LORD (the divine name)",
-            "paragraph": "V.15: The four-consonant divine name (the Tetragrammaton) is here declared the permanent name of God \u2014 \"this is my name forever, and thus I am to be remembered throughout all generations.\" The name connects to ehyeh (I AM, v.14) through the root hayah (to be). YHWH is the third-person form of the same verb \u2014 \"he is\" or \"he causes to be.\" The name that God calls himself (I AM) and the name by which others call him (He Is / YHWH) encode the divine self-existence."
+            "paragraph": "V.15: The four-consonant divine name (the Tetragrammaton) is here declared the permanent name of God — \"this is my name forever, and thus I am to be remembered throughout all generations.\" The name connects to ehyeh (I AM, v.14) through the root hayah (to be). YHWH is the third-person form of the same verb — \"he is\" or \"he causes to be.\" The name that God calls himself (I AM) and the name by which others call him (He Is / YHWH) encode the divine self-existence."
           },
           {
-            "word": "\u05d6\u05b8\u05e7\u05b5\u05df",
+            "word": "זָקֵן",
             "transliteration": "zaqen",
             "gloss": "elders",
-            "paragraph": "V.16: \"Gather the elders of Israel\" \u2014 the first instruction for community leadership in the Exodus narrative. The elders (zequenim) are the tribal leadership structure that survived the Egyptian bondage. Moses is not to lead alone; he is to work through the existing leadership structure of the people. The congregation model is established before the journey begins: God works through community, not merely through the solitary prophet."
+            "paragraph": "V.16: \"Gather the elders of Israel\" — the first instruction for community leadership in the Exodus narrative. The elders (zequenim) are the tribal leadership structure that survived the Egyptian bondage. Moses is not to lead alone; he is to work through the existing leadership structure of the people. The congregation model is established before the journey begins: God works through community, not merely through the solitary prophet."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "John 8:58",
-              "note": "\"Before Abraham was, I AM\" \u2014 Jesus applies the divine name of Exod 3:14 to himself, the most unambiguous divine self-claim in the Gospels."
+              "note": "\"Before Abraham was, I AM\" — Jesus applies the divine name of Exod 3:14 to himself, the most unambiguous divine self-claim in the Gospels."
             },
             {
               "ref": "John 4:26",
-              "note": "To the Samaritan woman: \"I who speak to you am he\" \u2014 ego eimi, \"I AM\" \u2014 the same self-identification structure as Exod 3:14."
+              "note": "To the Samaritan woman: \"I who speak to you am he\" — ego eimi, \"I AM\" — the same self-identification structure as Exod 3:14."
             },
             {
-              "ref": "Exod 6:2\u20133",
+              "ref": "Exod 6:2–3",
               "note": "God tells Moses: \"I appeared to Abraham, to Isaac, and to Jacob as God Almighty (El Shaddai), but by my name the LORD (YHWH) I did not make myself known to them.\" The full disclosure of the Tetragrammaton is given here and expanded in ch.6."
             }
           ]
         },
         "poi": [
           {
-            "name": "Egypt \u2014 land of promise contrast",
+            "name": "Egypt — land of promise contrast",
             "coords": "Nile Valley vs Canaan",
-            "text": "\"I have come down to rescue them from the hand of the Egyptians and to bring them up out of that land into a good and spacious land.\" Egypt and Canaan are set in direct geographical contrast: the land of oppression vs the land of promise. The topographic language \u2014 \"come down\" to Egypt, \"bring up\" to Canaan \u2014 is consistent with the actual elevation change."
+            "text": "\"I have come down to rescue them from the hand of the Egyptians and to bring them up out of that land into a good and spacious land.\" Egypt and Canaan are set in direct geographical contrast: the land of oppression vs the land of promise. The topographic language — \"come down\" to Egypt, \"bring up\" to Canaan — is consistent with the actual elevation change."
           },
           {
             "name": "Land of milk and honey",
             "coords": "Canaan; the Promised Land",
-            "text": "The promised land is first described here as \"a land flowing with milk and honey.\" This pastoral description \u2014 abundant pasture and wildflowers \u2014 evokes the terrain of the Negev and central hill country in spring. It will become the standard Exodus formula for Canaan."
+            "text": "The promised land is first described here as \"a land flowing with milk and honey.\" This pastoral description — abundant pasture and wildflowers — evokes the terrain of the Negev and central hill country in spring. It will become the standard Exodus formula for Canaan."
           }
         ],
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:14",
-              "note": "\"I AM WHO I AM.\" This is the most important self-disclosure in all of Scripture before the Incarnation. The name YHWH is not a classification but a category-breaking assertion: I am self-existent, self-defining, self-grounding. I am not subject to Israel's categories or Pharaoh's categories or Moses's categories. I simply am \u2014 and I am present with you. Every subsequent act of God in Exodus is an unpacking of this name: what does it mean that I AM is with Israel? It means Egypt's gods cannot stop him, Pharaoh's army cannot catch him, the desert cannot kill his people. I AM covers everything."
+              "note": "\"I AM WHO I AM.\" This is the most important self-disclosure in all of Scripture before the Incarnation. The name YHWH is not a classification but a category-breaking assertion: I am self-existent, self-defining, self-grounding. I am not subject to Israel's categories or Pharaoh's categories or Moses's categories. I simply am — and I am present with you. Every subsequent act of God in Exodus is an unpacking of this name: what does it mean that I AM is with Israel? It means Egypt's gods cannot stop him, Pharaoh's army cannot catch him, the desert cannot kill his people. I AM covers everything."
             },
             {
               "ref": "3:15",
-              "note": "\"This is my name forever, and thus I am to be remembered throughout all generations.\" The name YHWH is not a secret or a temporary self-disclosure \u2014 it is the permanent identity by which God will be known. The Westminster Catechism asks: \"What is God?\" The burning bush has already answered: I AM WHO I AM. The question behind every human heart \u2014 is there a God? \u2014 is answered not with a philosophical argument but with a burning bush, a covenant promise, and a name that means: I am here, I have always been here, and I always will be."
+              "note": "\"This is my name forever, and thus I am to be remembered throughout all generations.\" The name YHWH is not a secret or a temporary self-disclosure — it is the permanent identity by which God will be known. The Westminster Catechism asks: \"What is God?\" The burning bush has already answered: I AM WHO I AM. The question behind every human heart — is there a God? — is answered not with a philosophical argument but with a burning bush, a covenant promise, and a name that means: I am here, I have always been here, and I always will be."
             },
             {
-              "ref": "3:11\u201312",
-              "note": "Moses' first objection \u2014 \"Who am I?\" \u2014 is met with the paradigmatic divine response to all genuine calls: \"I will be with you.\" Sarna notes this shifts the question from Moses' qualification to God's presence. The question \"who am I?\" never receives a direct answer in the text; the answer is always \"who God is.\" This pattern (objection \u2014 divine reassurance of presence) structures the entire call narrative through 4:17."
+              "ref": "3:11–12",
+              "note": "Moses' first objection — \"Who am I?\" — is met with the paradigmatic divine response to all genuine calls: \"I will be with you.\" Sarna notes this shifts the question from Moses' qualification to God's presence. The question \"who am I?\" never receives a direct answer in the text; the answer is always \"who God is.\" This pattern (objection — divine reassurance of presence) structures the entire call narrative through 4:17."
             },
             {
               "ref": "3:14",
-              "note": "The divine name \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05d0\u05b2\u05e9\u05b6\u05c1\u05e8 \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 (\u02beehyeh \u02be\u0103\u0161er \u02beehyeh) \u2014 \"I AM WHO I AM\" or \"I WILL BE WHAT I WILL BE\" \u2014 is the theological summit of Exodus 3. Sarna argues the name should be understood dynamically rather than statically: not \"I am the eternal being\" (philosophical) but \"I will be actively present as I will be present\" (relational). The name guarantees not a metaphysical definition of God but a commitment to accompany and act. YHWH is the God who is always-being-present in the history of his people."
+              "note": "The divine name אֶהְיֶה אֲשֶׁר אֶהְיֶה (ʾehyeh ʾăšer ʾehyeh) — \"I AM WHO I AM\" or \"I WILL BE WHAT I WILL BE\" — is the theological summit of Exodus 3. Sarna argues the name should be understood dynamically rather than statically: not \"I am the eternal being\" (philosophical) but \"I will be actively present as I will be present\" (relational). The name guarantees not a metaphysical definition of God but a commitment to accompany and act. YHWH is the God who is always-being-present in the history of his people."
             },
             {
               "ref": "3:11",
-              "note": "Alter reads the objections dialogue as a literary pattern common to prophetic call narratives (cf. Gideon in Judg 6, Jeremiah in Jer 1). The structure is: call \u2192 objection \u2192 divine rebuttal \u2192 sign. Moses' \"who am I?\" is not false modesty but genuine incapacity. He has been forty years in the wilderness, a failed would-be deliverer. The divine answer does not flatter Moses' abilities \u2014 \"I will be with you\" redirects all qualification away from Moses entirely. The call narrative is simultaneously a theology of grace."
+              "note": "Alter reads the objections dialogue as a literary pattern common to prophetic call narratives (cf. Gideon in Judg 6, Jeremiah in Jer 1). The structure is: call → objection → divine rebuttal → sign. Moses' \"who am I?\" is not false modesty but genuine incapacity. He has been forty years in the wilderness, a failed would-be deliverer. The divine answer does not flatter Moses' abilities — \"I will be with you\" redirects all qualification away from Moses entirely. The call narrative is simultaneously a theology of grace."
             },
             {
               "ref": "3:14",
-              "note": "Alter on \"I AM WHO I AM\": \"The elaborated name involves a play on the Hebrew verb 'to be' in the first person. The name YHWH... sounds like the third-person form 'he is' or perhaps 'he causes to be.'\" Alter reads it as \"an assertion of a dynamic, even paradoxical self-definition: God is what he will be, undetermined by any category of human understanding.\" The name refuses to be pinned down by human conceptuality while simultaneously insisting on divine relatedness \u2014 God will be present, but on his own terms."
+              "note": "Alter on \"I AM WHO I AM\": \"The elaborated name involves a play on the Hebrew verb 'to be' in the first person. The name YHWH... sounds like the third-person form 'he is' or perhaps 'he causes to be.'\" Alter reads it as \"an assertion of a dynamic, even paradoxical self-definition: God is what he will be, undetermined by any category of human understanding.\" The name refuses to be pinned down by human conceptuality while simultaneously insisting on divine relatedness — God will be present, but on his own terms."
             },
             {
               "ref": "3:14",
-              "note": "Calvin's interpretation of \"I AM WHO I AM\" is strongly ontological: \"God attributes to himself alone divine glory, because he alone exists of himself, and draws from himself all that exists.\" This is the aseity of God \u2014 self-existence. Calvin: \"The name of Jehovah is derived from the Hebrew verb 'to be', not only to express that he is eternal, but that he alone gives to all things their subsistence.\" The name is the ground of all theology: the being of God is the foundation on which all else rests."
+              "note": "Calvin's interpretation of \"I AM WHO I AM\" is strongly ontological: \"God attributes to himself alone divine glory, because he alone exists of himself, and draws from himself all that exists.\" This is the aseity of God — self-existence. Calvin: \"The name of Jehovah is derived from the Hebrew verb 'to be', not only to express that he is eternal, but that he alone gives to all things their subsistence.\" The name is the ground of all theology: the being of God is the foundation on which all else rests."
             },
             {
               "ref": "3:18",
-              "note": "\"The elders of Israel will listen to you\" \u2014 Calvin on the promise: \"God does not promise that Pharaoh will listen, but that the elders will. This shows us what we must expect: obedience within the covenant community; resistance from the world.\" Calvin anticipates the pattern of the entire plague narrative: Israel believes; Pharaoh hardens. The asymmetry is built into the structure of the divine promise from the start. God does not guarantee universal reception; he guarantees the faithfulness of his own."
+              "note": "\"The elders of Israel will listen to you\" — Calvin on the promise: \"God does not promise that Pharaoh will listen, but that the elders will. This shows us what we must expect: obedience within the covenant community; resistance from the world.\" Calvin anticipates the pattern of the entire plague narrative: Israel believes; Pharaoh hardens. The asymmetry is built into the structure of the divine promise from the start. God does not guarantee universal reception; he guarantees the faithfulness of his own."
             },
             {
               "ref": "3:14",
-              "note": "The NET note gives extensive treatment to \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05d0\u05b2\u05e9\u05b6\u05c1\u05e8 \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4. Three main interpretations: (1) pure being / aseity \u2014 \"I am the one who is\" (Aquila, LXX \u1f10\u03b3\u03ce \u03b5\u1f30\u03bc\u03b9 \u1f41 \u1f64\u03bd, John 8:58); (2) dynamic presence \u2014 \"I will be what I will be / I will be there as I will be there\" (Buber, Sarna); (3) causative interpretation \u2014 \"I cause to be what I cause to be\" (Albright), understanding the Hiphil stem. The NET translators follow the dynamic interpretation but note all three are grammatically viable. The context of a call narrative favours the relational/presence reading."
+              "note": "The NET note gives extensive treatment to אֶהְיֶה אֲשֶׁר אֶהְיֶה. Three main interpretations: (1) pure being / aseity — \"I am the one who is\" (Aquila, LXX ἐγώ εἰμι ὁ ὤν, John 8:58); (2) dynamic presence — \"I will be what I will be / I will be there as I will be there\" (Buber, Sarna); (3) causative interpretation — \"I cause to be what I cause to be\" (Albright), understanding the Hiphil stem. The NET translators follow the dynamic interpretation but note all three are grammatically viable. The context of a call narrative favours the relational/presence reading."
             },
             {
               "ref": "3:22",
-              "note": "The NET note on \"plunder the Egyptians\" (\u05d5\u05b0\u05e0\u05b4\u05e6\u05b7\u05bc\u05dc\u05b0\u05ea\u05b6\u05bc\u05dd, w\u0115ni\u1e63\u1e63altem \u2014 \"and you will plunder/strip\") addresses the ethical question raised by patristic interpreters. Origen spiritualised it as taking \"Egyptian gold\" (pagan learning) for the service of God. The NET translators note the verb is the same used in Ezek 14:14 for rescue/salvation \u2014 the word carries the sense of taking back what was owed. The Israelites had laboured without pay; taking silver, gold, and clothing is back-wages, not theft."
+              "note": "The NET note on \"plunder the Egyptians\" (וְנִצַּלְתֶּם, wĕniṣṣaltem — \"and you will plunder/strip\") addresses the ethical question raised by patristic interpreters. Origen spiritualised it as taking \"Egyptian gold\" (pagan learning) for the service of God. The NET translators note the verb is the same used in Ezek 14:14 for rescue/salvation — the word carries the sense of taking back what was owed. The Israelites had laboured without pay; taking silver, gold, and clothing is back-wages, not theft."
             },
             {
-              "ref": "3:10\u201312",
-              "note": "The structure of Moses' call is: commission (v.10), objection (v.11), reassurance (v.12). This \"call-narrative form\" recurs throughout prophetic literature (Jeremiah 1:4-10; Isaiah 6). Moses' first objection \u2014 \"who am I?\" \u2014 is the right question. It is not false modesty but accurate self-assessment: he is a fugitive shepherd, eighty years old, with no standing in Egypt and no credibility with Israel. God's answer bypasses the self-assessment entirely: \"I will be with you.\" The commission rests on the Caller, not the called."
+              "ref": "3:10–12",
+              "note": "The structure of Moses' call is: commission (v.10), objection (v.11), reassurance (v.12). This \"call-narrative form\" recurs throughout prophetic literature (Jeremiah 1:4-10; Isaiah 6). Moses' first objection — \"who am I?\" — is the right question. It is not false modesty but accurate self-assessment: he is a fugitive shepherd, eighty years old, with no standing in Egypt and no credibility with Israel. God's answer bypasses the self-assessment entirely: \"I will be with you.\" The commission rests on the Caller, not the called."
             },
             {
-              "ref": "3:13\u201314",
-              "note": "\"What is his name? What shall I say to them?\" Moses anticipates the question Israel will ask. The answer is extraordinary: \"I AM WHO I AM.\" God's name is not a proper name in the conventional sense \u2014 it is a statement of his being. He is the self-existent One, the One whose existence is not contingent on anything outside himself. Every other being exists because something caused it to exist; God simply is. The name is a description of his ontology, his nature \u2014 the foundational fact of all reality."
+              "ref": "3:13–14",
+              "note": "\"What is his name? What shall I say to them?\" Moses anticipates the question Israel will ask. The answer is extraordinary: \"I AM WHO I AM.\" God's name is not a proper name in the conventional sense — it is a statement of his being. He is the self-existent One, the One whose existence is not contingent on anything outside himself. Every other being exists because something caused it to exist; God simply is. The name is a description of his ontology, his nature — the foundational fact of all reality."
             },
             {
               "ref": "3:15",
               "note": "\"The LORD, the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, has sent me to you. This is my name forever, and thus I am to be remembered throughout all generations.\" The covenant names are united: the great I AM is the God of the patriarchs. The transcendent name (YHWH) and the relational names (God of Abraham, Isaac, Jacob) are one. The God of absolute being is also the God of specific covenant promises. These two truths hold together."
             },
             {
-              "ref": "3:16\u201317",
-              "note": "The specific promise \u2014 \"I will bring you up out of the affliction of Egypt to the land of the Canaanites... a land flowing with milk and honey\" \u2014 is the Abrahamic inheritance now given specific geographical content. \"Milk and honey\" is not merely a positive description of agricultural fertility; it is a covenant formula signifying the full blessing of the promised land. Moses is commissioned to bring Israel to the fulfilment of what Abraham was shown from afar."
+              "ref": "3:16–17",
+              "note": "The specific promise — \"I will bring you up out of the affliction of Egypt to the land of the Canaanites... a land flowing with milk and honey\" — is the Abrahamic inheritance now given specific geographical content. \"Milk and honey\" is not merely a positive description of agricultural fertility; it is a covenant formula signifying the full blessing of the promised land. Moses is commissioned to bring Israel to the fulfilment of what Abraham was shown from afar."
             },
             {
-              "ref": "3:19\u201320",
-              "note": "God tells Moses in advance that Pharaoh will refuse: \"I know that the king of Egypt will not let you go.\" The foreknowledge is not fatalism \u2014 it is the ground of Moses' confidence. He does not need to be surprised by Pharaoh's refusal or wonder if God's plan has failed. The refusals are part of the plan. They are the occasions for the \"wonders\" (niflaot) by which God will stretch out his hand. Pharaoh's hardness is not a setback; it is the canvas on which God paints his power."
+              "ref": "3:19–20",
+              "note": "God tells Moses in advance that Pharaoh will refuse: \"I know that the king of Egypt will not let you go.\" The foreknowledge is not fatalism — it is the ground of Moses' confidence. He does not need to be surprised by Pharaoh's refusal or wonder if God's plan has failed. The refusals are part of the plan. They are the occasions for the \"wonders\" (niflaot) by which God will stretch out his hand. Pharaoh's hardness is not a setback; it is the canvas on which God paints his power."
             },
             {
-              "ref": "3:13\u201314",
-              "note": "The question \"what is his name?\" reflects the ancient conception that a name encodes the essential nature of its bearer. To know a god's name was to know his character and to have access to his power. Moses anticipates that Israel will ask for the divine name not as an abstract theological question but as a practical one: who exactly has sent you? What is the divine name that grounds this commission? Sarna notes that YHWH was likely not entirely unknown before this moment (cf. Gen 4:26) \u2014 the revelation here is not the name itself but its full theological content: the God whose name means \"I AM\" is now showing what that means through the Exodus."
+              "ref": "3:13–14",
+              "note": "The question \"what is his name?\" reflects the ancient conception that a name encodes the essential nature of its bearer. To know a god's name was to know his character and to have access to his power. Moses anticipates that Israel will ask for the divine name not as an abstract theological question but as a practical one: who exactly has sent you? What is the divine name that grounds this commission? Sarna notes that YHWH was likely not entirely unknown before this moment (cf. Gen 4:26) — the revelation here is not the name itself but its full theological content: the God whose name means \"I AM\" is now showing what that means through the Exodus."
             },
             {
               "ref": "3:14",
-              "note": "\"Ehyeh asher ehyeh\" \u2014 the three main interpretations: (1) ontological: I am the absolutely self-existent Being (the dominant philosophical tradition, from the Septuagint's \"I am the One who is\" through Aquinas); (2) relational/promissory: I will be what I will be \u2014 my character will be revealed in my acts (Buber, Childs); (3) causative: I cause to be \u2014 I am the creator, the source of all existence (Albright). Sarna favours a combination of (1) and (2): the name asserts both absolute being and active, relational self-revelation."
+              "note": "\"Ehyeh asher ehyeh\" — the three main interpretations: (1) ontological: I am the absolutely self-existent Being (the dominant philosophical tradition, from the Septuagint's \"I am the One who is\" through Aquinas); (2) relational/promissory: I will be what I will be — my character will be revealed in my acts (Buber, Childs); (3) causative: I cause to be — I am the creator, the source of all existence (Albright). Sarna favours a combination of (1) and (2): the name asserts both absolute being and active, relational self-revelation."
             },
             {
-              "ref": "3:16\u201317",
+              "ref": "3:16–17",
               "note": "Sarna notes \"a land flowing with milk and honey\" (eretz zavat chalav udevash) is a formulaic expression appearing twenty times in the Pentateuch. The image is of abundant pastoral and agricultural productivity: milk from the flocks, honey from wild bees or date palms. But Sarna points to the covenantal resonance: this is the land God swore to Abraham (Gen 15:18-21); naming it now connects Moses' commission to the original promise. The Exodus is not a new event; it is the fulfilment of an ancient commitment."
             },
             {
-              "ref": "3:11\u201312",
+              "ref": "3:11–12",
               "note": "Moses' \"who am I?\" is a formulaic self-deprecation that appears in call narratives throughout the Bible (Gideon: Judg 6:15; Jeremiah: Jer 1:6; Paul: 1 Cor 15:9). Alter notes the structural function: the objection makes space for the divine reassurance, which is the theological content the narrative actually wants to communicate. Moses' inadequacy is the frame for God's adequacy. The dialogue is not merely psychological; it is theological argument, each exchange advancing a claim about who is ultimately responsible for the commission."
             },
             {
-              "ref": "3:13\u201314",
-              "note": "\"Ehyeh asher ehyeh\" is perhaps the most discussed sentence in the Pentateuch. Alter notes the grammatical peculiarity: asher (\"who\" or \"that\") introduces a clause of definition or explanation, but the explanation is circular \u2014 \"I AM the one who I AM.\" The circularity is not evasion but ontological claim: God's being cannot be defined by reference to anything outside himself. He is self-defining. The name is simultaneously the most specific answer to Moses' question and the least containable: you cannot reduce this God to a category."
+              "ref": "3:13–14",
+              "note": "\"Ehyeh asher ehyeh\" is perhaps the most discussed sentence in the Pentateuch. Alter notes the grammatical peculiarity: asher (\"who\" or \"that\") introduces a clause of definition or explanation, but the explanation is circular — \"I AM the one who I AM.\" The circularity is not evasion but ontological claim: God's being cannot be defined by reference to anything outside himself. He is self-defining. The name is simultaneously the most specific answer to Moses' question and the least containable: you cannot reduce this God to a category."
             },
             {
               "ref": "3:12",
-              "note": "\"I will be with you\" \u2014 Calvin: \"It is not the excellence of man, but the power of God alone, which gives success to holy undertakings.\" The entire structure of Moses' objection and God's answer is Calvin's paradigm for all Christian service. The question is never \"am I adequate?\" \u2014 no one is. The question is \"has God called?\" If so, his presence is the guarantee of the outcome. Moses is the model of the servant who learns that God's \"I will be with you\" is the only qualification that matters."
+              "note": "\"I will be with you\" — Calvin: \"It is not the excellence of man, but the power of God alone, which gives success to holy undertakings.\" The entire structure of Moses' objection and God's answer is Calvin's paradigm for all Christian service. The question is never \"am I adequate?\" — no one is. The question is \"has God called?\" If so, his presence is the guarantee of the outcome. Moses is the model of the servant who learns that God's \"I will be with you\" is the only qualification that matters."
             },
             {
               "ref": "3:14",
-              "note": "\"I AM THAT I AM\" \u2014 Calvin: \"God here alludes to his own eternity, to distinguish himself from all created beings... He alone truly exists, because he alone exists of himself.\" This is Calvin's most concentrated statement of divine aseity (self-existence) in his Exodus commentary. God is not derived; he is the source. All other things exist contingently; God exists necessarily. The name is the philosophical foundation of everything Calvin will say about God's sovereignty."
+              "note": "\"I AM THAT I AM\" — Calvin: \"God here alludes to his own eternity, to distinguish himself from all created beings... He alone truly exists, because he alone exists of himself.\" This is Calvin's most concentrated statement of divine aseity (self-existence) in his Exodus commentary. God is not derived; he is the source. All other things exist contingently; God exists necessarily. The name is the philosophical foundation of everything Calvin will say about God's sovereignty."
             },
             {
-              "ref": "3:15\u201316",
-              "note": "Calvin on the connection of the divine name to the patriarchal covenant: \"God designed to remind Moses of the covenant which he had made with the fathers, lest he should think that this was a new God, different from the one whom Abraham had worshipped.\" The God of the burning bush is the God of Genesis. The same covenant, the same promise, the same faithfulness \u2014 now moving toward fulfilment. The names of Abraham, Isaac, and Jacob are not merely historical references; they are the content of the covenant God is about to keep."
+              "ref": "3:15–16",
+              "note": "Calvin on the connection of the divine name to the patriarchal covenant: \"God designed to remind Moses of the covenant which he had made with the fathers, lest he should think that this was a new God, different from the one whom Abraham had worshipped.\" The God of the burning bush is the God of Genesis. The same covenant, the same promise, the same faithfulness — now moving toward fulfilment. The names of Abraham, Isaac, and Jacob are not merely historical references; they are the content of the covenant God is about to keep."
             },
             {
               "ref": "3:14",
@@ -526,138 +442,58 @@
             {
               "ref": "3:15",
               "note": "The NET note on \"this is my name forever\" explains the Hebrew le'olam (forever, for all time) and adds that the divine name YHWH (the LORD) appears approximately 6,828 times in the Old Testament, making it by far the most common divine designation. The note discusses the Jewish tradition of not pronouncing the divine name (using Adonai or HaShem as substitutes) as a later development not reflected in the original text, where the name was clearly intended for regular use in worship and speech."
-            },
-            {
-              "ref": "3:10\u201312",
-              "note": "The structure of Moses' call is: commission (v.10), objection (v.11), reassurance (v.12). This \"call-narrative form\" recurs throughout prophetic literature (Jeremiah 1:4-10; Isaiah 6). Moses' first objection \u2014 \"who am I?\" \u2014 is the right question. It is not false modesty but accurate self-assessment: he is a fugitive shepherd, eighty years old, with no standing in Egypt and no credibility with Israel. God's answer bypasses the self-assessment entirely: \"I will be with you.\" The commission rests on the Caller, not the called."
-            },
-            {
-              "ref": "3:13\u201314",
-              "note": "\"What is his name? What shall I say to them?\" Moses anticipates the question Israel will ask. The answer is extraordinary: \"I AM WHO I AM.\" God's name is not a proper name in the conventional sense \u2014 it is a statement of his being. He is the self-existent One, the One whose existence is not contingent on anything outside himself. Every other being exists because something caused it to exist; God simply is. The name is a description of his ontology, his nature \u2014 the foundational fact of all reality."
-            },
-            {
-              "ref": "3:15",
-              "note": "\"The LORD, the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, has sent me to you. This is my name forever, and thus I am to be remembered throughout all generations.\" The covenant names are united: the great I AM is the God of the patriarchs. The transcendent name (YHWH) and the relational names (God of Abraham, Isaac, Jacob) are one. The God of absolute being is also the God of specific covenant promises. These two truths hold together."
-            },
-            {
-              "ref": "3:16\u201317",
-              "note": "The specific promise \u2014 \"I will bring you up out of the affliction of Egypt to the land of the Canaanites... a land flowing with milk and honey\" \u2014 is the Abrahamic inheritance now given specific geographical content. \"Milk and honey\" is not merely a positive description of agricultural fertility; it is a covenant formula signifying the full blessing of the promised land. Moses is commissioned to bring Israel to the fulfilment of what Abraham was shown from afar."
-            },
-            {
-              "ref": "3:19\u201320",
-              "note": "God tells Moses in advance that Pharaoh will refuse: \"I know that the king of Egypt will not let you go.\" The foreknowledge is not fatalism \u2014 it is the ground of Moses' confidence. He does not need to be surprised by Pharaoh's refusal or wonder if God's plan has failed. The refusals are part of the plan. They are the occasions for the \"wonders\" (niflaot) by which God will stretch out his hand. Pharaoh's hardness is not a setback; it is the canvas on which God paints his power."
-            },
-            {
-              "ref": "3:13\u201314",
-              "note": "The question \"what is his name?\" reflects the ancient conception that a name encodes the essential nature of its bearer. To know a god's name was to know his character and to have access to his power. Moses anticipates that Israel will ask for the divine name not as an abstract theological question but as a practical one: who exactly has sent you? What is the divine name that grounds this commission? Sarna notes that YHWH was likely not entirely unknown before this moment (cf. Gen 4:26) \u2014 the revelation here is not the name itself but its full theological content: the God whose name means \"I AM\" is now showing what that means through the Exodus."
-            },
-            {
-              "ref": "3:14",
-              "note": "\"Ehyeh asher ehyeh\" \u2014 the three main interpretations: (1) ontological: I am the absolutely self-existent Being (the dominant philosophical tradition, from the Septuagint's \"I am the One who is\" through Aquinas); (2) relational/promissory: I will be what I will be \u2014 my character will be revealed in my acts (Buber, Childs); (3) causative: I cause to be \u2014 I am the creator, the source of all existence (Albright). Sarna favours a combination of (1) and (2): the name asserts both absolute being and active, relational self-revelation."
-            },
-            {
-              "ref": "3:16\u201317",
-              "note": "Sarna notes \"a land flowing with milk and honey\" (eretz zavat chalav udevash) is a formulaic expression appearing twenty times in the Pentateuch. The image is of abundant pastoral and agricultural productivity: milk from the flocks, honey from wild bees or date palms. But Sarna points to the covenantal resonance: this is the land God swore to Abraham (Gen 15:18-21); naming it now connects Moses' commission to the original promise. The Exodus is not a new event; it is the fulfilment of an ancient commitment."
-            },
-            {
-              "ref": "3:11\u201312",
-              "note": "Moses' \"who am I?\" is a formulaic self-deprecation that appears in call narratives throughout the Bible (Gideon: Judg 6:15; Jeremiah: Jer 1:6; Paul: 1 Cor 15:9). Alter notes the structural function: the objection makes space for the divine reassurance, which is the theological content the narrative actually wants to communicate. Moses' inadequacy is the frame for God's adequacy. The dialogue is not merely psychological; it is theological argument, each exchange advancing a claim about who is ultimately responsible for the commission."
-            },
-            {
-              "ref": "3:13\u201314",
-              "note": "\"Ehyeh asher ehyeh\" is perhaps the most discussed sentence in the Pentateuch. Alter notes the grammatical peculiarity: asher (\"who\" or \"that\") introduces a clause of definition or explanation, but the explanation is circular \u2014 \"I AM the one who I AM.\" The circularity is not evasion but ontological claim: God's being cannot be defined by reference to anything outside himself. He is self-defining. The name is simultaneously the most specific answer to Moses' question and the least containable: you cannot reduce this God to a category."
-            },
-            {
-              "ref": "3:12",
-              "note": "\"I will be with you\" \u2014 Calvin: \"It is not the excellence of man, but the power of God alone, which gives success to holy undertakings.\" The entire structure of Moses' objection and God's answer is Calvin's paradigm for all Christian service. The question is never \"am I adequate?\" \u2014 no one is. The question is \"has God called?\" If so, his presence is the guarantee of the outcome. Moses is the model of the servant who learns that God's \"I will be with you\" is the only qualification that matters."
-            },
-            {
-              "ref": "3:14",
-              "note": "\"I AM THAT I AM\" \u2014 Calvin: \"God here alludes to his own eternity, to distinguish himself from all created beings... He alone truly exists, because he alone exists of himself.\" This is Calvin's most concentrated statement of divine aseity (self-existence) in his Exodus commentary. God is not derived; he is the source. All other things exist contingently; God exists necessarily. The name is the philosophical foundation of everything Calvin will say about God's sovereignty."
-            },
-            {
-              "ref": "3:15\u201316",
-              "note": "Calvin on the connection of the divine name to the patriarchal covenant: \"God designed to remind Moses of the covenant which he had made with the fathers, lest he should think that this was a new God, different from the one whom Abraham had worshipped.\" The God of the burning bush is the God of Genesis. The same covenant, the same promise, the same faithfulness \u2014 now moving toward fulfilment. The names of Abraham, Isaac, and Jacob are not merely historical references; they are the content of the covenant God is about to keep."
-            },
-            {
-              "ref": "3:14",
-              "note": "The NET note on \"I AM WHO I AM\" presents the three main grammatical analyses: (1) first-person Qal imperfect of hayah: \"I will be/exist\"; (2) Hiphil causative: \"I cause to be\"; (3) a deliberate play on both. The note discusses the Septuagint's translation (ego eimi ho on, \"I am the one who is\") as influential in shaping the philosophical interpretation. The note concludes: \"The name may be intentionally enigmatic, emphasising that God's full nature cannot be captured in a name, while affirming his active, present, and relational nature.\""
-            },
-            {
-              "ref": "3:15",
-              "note": "The NET note on \"this is my name forever\" explains the Hebrew le'olam (forever, for all time) and adds that the divine name YHWH (the LORD) appears approximately 6,828 times in the Old Testament, making it by far the most common divine designation. The note discusses the Jewish tradition of not pronouncing the divine name (using Adonai or HaShem as substitutes) as a later development not reflected in the original text, where the name was clearly intended for regular use in worship and speech."
-            },
-            {
-              "ref": "3:10\u201312",
-              "note": "The structure of Moses' call is: commission (v.10), objection (v.11), reassurance (v.12). This \"call-narrative form\" recurs throughout prophetic literature (Jeremiah 1:4-10; Isaiah 6). Moses' first objection \u2014 \"who am I?\" \u2014 is the right question. It is not false modesty but accurate self-assessment: he is a fugitive shepherd, eighty years old, with no standing in Egypt and no credibility with Israel. God's answer bypasses the self-assessment entirely: \"I will be with you.\" The commission rests on the Caller, not the called."
-            },
-            {
-              "ref": "3:13\u201314",
-              "note": "\"What is his name? What shall I say to them?\" Moses anticipates the question Israel will ask. The answer is extraordinary: \"I AM WHO I AM.\" God's name is not a proper name in the conventional sense \u2014 it is a statement of his being. He is the self-existent One, the One whose existence is not contingent on anything outside himself. Every other being exists because something caused it to exist; God simply is. The name is a description of his ontology, his nature \u2014 the foundational fact of all reality."
-            },
-            {
-              "ref": "3:15",
-              "note": "\"The LORD, the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, has sent me to you. This is my name forever, and thus I am to be remembered throughout all generations.\" The covenant names are united: the great I AM is the God of the patriarchs. The transcendent name (YHWH) and the relational names (God of Abraham, Isaac, Jacob) are one. The God of absolute being is also the God of specific covenant promises. These two truths hold together."
-            },
-            {
-              "ref": "3:16\u201317",
-              "note": "The specific promise \u2014 \"I will bring you up out of the affliction of Egypt to the land of the Canaanites... a land flowing with milk and honey\" \u2014 is the Abrahamic inheritance now given specific geographical content. \"Milk and honey\" is not merely a positive description of agricultural fertility; it is a covenant formula signifying the full blessing of the promised land. Moses is commissioned to bring Israel to the fulfilment of what Abraham was shown from afar."
-            },
-            {
-              "ref": "3:19\u201320",
-              "note": "God tells Moses in advance that Pharaoh will refuse: \"I know that the king of Egypt will not let you go.\" The foreknowledge is not fatalism \u2014 it is the ground of Moses' confidence. He does not need to be surprised by Pharaoh's refusal or wonder if God's plan has failed. The refusals are part of the plan. They are the occasions for the \"wonders\" (niflaot) by which God will stretch out his hand. Pharaoh's hardness is not a setback; it is the canvas on which God paints his power."
             }
           ]
         },
         "sarna": {
-          "source": "Nahum Sarna, JPS Torah Commentary \u2014 Scholarly Paraphrase",
+          "source": "Nahum Sarna, JPS Torah Commentary — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "3:13\u201314",
-              "note": "The question \"what is his name?\" reflects the ancient conception that a name encodes the essential nature of its bearer. To know a god's name was to know his character and to have access to his power. Moses anticipates that Israel will ask for the divine name not as an abstract theological question but as a practical one: who exactly has sent you? What is the divine name that grounds this commission? Sarna notes that YHWH was likely not entirely unknown before this moment (cf. Gen 4:26) \u2014 the revelation here is not the name itself but its full theological content: the God whose name means \"I AM\" is now showing what that means through the Exodus."
+              "ref": "3:13–14",
+              "note": "The question \"what is his name?\" reflects the ancient conception that a name encodes the essential nature of its bearer. To know a god's name was to know his character and to have access to his power. Moses anticipates that Israel will ask for the divine name not as an abstract theological question but as a practical one: who exactly has sent you? What is the divine name that grounds this commission? Sarna notes that YHWH was likely not entirely unknown before this moment (cf. Gen 4:26) — the revelation here is not the name itself but its full theological content: the God whose name means \"I AM\" is now showing what that means through the Exodus."
             },
             {
               "ref": "3:14",
-              "note": "\"Ehyeh asher ehyeh\" \u2014 the three main interpretations: (1) ontological: I am the absolutely self-existent Being (the dominant philosophical tradition, from the Septuagint's \"I am the One who is\" through Aquinas); (2) relational/promissory: I will be what I will be \u2014 my character will be revealed in my acts (Buber, Childs); (3) causative: I cause to be \u2014 I am the creator, the source of all existence (Albright). Sarna favours a combination of (1) and (2): the name asserts both absolute being and active, relational self-revelation."
+              "note": "\"Ehyeh asher ehyeh\" — the three main interpretations: (1) ontological: I am the absolutely self-existent Being (the dominant philosophical tradition, from the Septuagint's \"I am the One who is\" through Aquinas); (2) relational/promissory: I will be what I will be — my character will be revealed in my acts (Buber, Childs); (3) causative: I cause to be — I am the creator, the source of all existence (Albright). Sarna favours a combination of (1) and (2): the name asserts both absolute being and active, relational self-revelation."
             },
             {
-              "ref": "3:16\u201317",
+              "ref": "3:16–17",
               "note": "Sarna notes \"a land flowing with milk and honey\" (eretz zavat chalav udevash) is a formulaic expression appearing twenty times in the Pentateuch. The image is of abundant pastoral and agricultural productivity: milk from the flocks, honey from wild bees or date palms. But Sarna points to the covenantal resonance: this is the land God swore to Abraham (Gen 15:18-21); naming it now connects Moses' commission to the original promise. The Exodus is not a new event; it is the fulfilment of an ancient commitment."
             }
           ]
         },
         "alter": {
-          "source": "Robert Alter, The Hebrew Bible: A Translation with Commentary \u2014 Scholarly Paraphrase",
+          "source": "Robert Alter, The Hebrew Bible: A Translation with Commentary — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "3:11\u201312",
+              "ref": "3:11–12",
               "note": "Moses' \"who am I?\" is a formulaic self-deprecation that appears in call narratives throughout the Bible (Gideon: Judg 6:15; Jeremiah: Jer 1:6; Paul: 1 Cor 15:9). Alter notes the structural function: the objection makes space for the divine reassurance, which is the theological content the narrative actually wants to communicate. Moses' inadequacy is the frame for God's adequacy. The dialogue is not merely psychological; it is theological argument, each exchange advancing a claim about who is ultimately responsible for the commission."
             },
             {
-              "ref": "3:13\u201314",
-              "note": "\"Ehyeh asher ehyeh\" is perhaps the most discussed sentence in the Pentateuch. Alter notes the grammatical peculiarity: asher (\"who\" or \"that\") introduces a clause of definition or explanation, but the explanation is circular \u2014 \"I AM the one who I AM.\" The circularity is not evasion but ontological claim: God's being cannot be defined by reference to anything outside himself. He is self-defining. The name is simultaneously the most specific answer to Moses' question and the least containable: you cannot reduce this God to a category."
+              "ref": "3:13–14",
+              "note": "\"Ehyeh asher ehyeh\" is perhaps the most discussed sentence in the Pentateuch. Alter notes the grammatical peculiarity: asher (\"who\" or \"that\") introduces a clause of definition or explanation, but the explanation is circular — \"I AM the one who I AM.\" The circularity is not evasion but ontological claim: God's being cannot be defined by reference to anything outside himself. He is self-defining. The name is simultaneously the most specific answer to Moses' question and the least containable: you cannot reduce this God to a category."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:12",
-              "note": "\"I will be with you\" \u2014 Calvin: \"It is not the excellence of man, but the power of God alone, which gives success to holy undertakings.\" The entire structure of Moses' objection and God's answer is Calvin's paradigm for all Christian service. The question is never \"am I adequate?\" \u2014 no one is. The question is \"has God called?\" If so, his presence is the guarantee of the outcome. Moses is the model of the servant who learns that God's \"I will be with you\" is the only qualification that matters."
+              "note": "\"I will be with you\" — Calvin: \"It is not the excellence of man, but the power of God alone, which gives success to holy undertakings.\" The entire structure of Moses' objection and God's answer is Calvin's paradigm for all Christian service. The question is never \"am I adequate?\" — no one is. The question is \"has God called?\" If so, his presence is the guarantee of the outcome. Moses is the model of the servant who learns that God's \"I will be with you\" is the only qualification that matters."
             },
             {
               "ref": "3:14",
-              "note": "\"I AM THAT I AM\" \u2014 Calvin: \"God here alludes to his own eternity, to distinguish himself from all created beings... He alone truly exists, because he alone exists of himself.\" This is Calvin's most concentrated statement of divine aseity (self-existence) in his Exodus commentary. God is not derived; he is the source. All other things exist contingently; God exists necessarily. The name is the philosophical foundation of everything Calvin will say about God's sovereignty."
+              "note": "\"I AM THAT I AM\" — Calvin: \"God here alludes to his own eternity, to distinguish himself from all created beings... He alone truly exists, because he alone exists of himself.\" This is Calvin's most concentrated statement of divine aseity (self-existence) in his Exodus commentary. God is not derived; he is the source. All other things exist contingently; God exists necessarily. The name is the philosophical foundation of everything Calvin will say about God's sovereignty."
             },
             {
-              "ref": "3:15\u201316",
-              "note": "Calvin on the connection of the divine name to the patriarchal covenant: \"God designed to remind Moses of the covenant which he had made with the fathers, lest he should think that this was a new God, different from the one whom Abraham had worshipped.\" The God of the burning bush is the God of Genesis. The same covenant, the same promise, the same faithfulness \u2014 now moving toward fulfilment. The names of Abraham, Isaac, and Jacob are not merely historical references; they are the content of the covenant God is about to keep."
+              "ref": "3:15–16",
+              "note": "Calvin on the connection of the divine name to the patriarchal covenant: \"God designed to remind Moses of the covenant which he had made with the fathers, lest he should think that this was a new God, different from the one whom Abraham had worshipped.\" The God of the burning bush is the God of Genesis. The same covenant, the same promise, the same faithfulness — now moving toward fulfilment. The names of Abraham, Isaac, and Jacob are not merely historical references; they are the content of the covenant God is about to keep."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:14",
@@ -670,7 +506,7 @@
           ]
         },
         "hist": {
-          "context": "Moses's question \"what is his name?\" is not ignorance of a name but a request for the character, authority, and reliability behind the name. In the ancient world, knowing a god's name was knowing their nature and the basis of relationship with them. YHWH's answer \u2014 I AM WHO I AM \u2014 refuses domestication while asserting radical, self-grounding presence. The name is a promise: I will be with you (v.12: \"I will be with you,\" \u02beehyeh \u02bfimmak \u2014 the same \u02beehyeh root) as I have always been."
+          "context": "Moses's question \"what is his name?\" is not ignorance of a name but a request for the character, authority, and reliability behind the name. In the ancient world, knowing a god's name was knowing their nature and the basis of relationship with them. YHWH's answer — I AM WHO I AM — refuses domestication while asserting radical, self-grounding presence. The name is a promise: I will be with you (v.12: \"I will be with you,\" ʾehyeh ʿimmak — the same ʾehyeh root) as I have always been."
         }
       }
     }
@@ -678,37 +514,37 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "Moses\u2197 People",
+        "name": "Moses↗ People",
         "role": "Prophet, lawgiver, and covenant mediator",
-        "text": "Moses stands at the centre of the Pentateuch\u2019s narrative \u2014 the one man who spoke with God face to face (Exod 33:11; Num 12:8) and mediated the Sinai covenant to Israel. In Leviticus he receives the priestly legislation; in Numbers he leads, intercedes, and ultimately fails at Meribah (Num 20). The writer of Hebrews calls him \"faithful in all God\u2019s house\" (Heb 3:5) while distinguishing him from Christ, the Son over the house."
+        "text": "Moses stands at the centre of the Pentateuch’s narrative — the one man who spoke with God face to face (Exod 33:11; Num 12:8) and mediated the Sinai covenant to Israel. In Leviticus he receives the priestly legislation; in Numbers he leads, intercedes, and ultimately fails at Meribah (Num 20). The writer of Hebrews calls him \"faithful in all God’s house\" (Heb 3:5) while distinguishing him from Christ, the Son over the house."
       },
       {
         "name": "Israel",
         "role": "Key biblical figure",
-        "text": "The bush burns and is not consumed \u2014 the image of Israel under oppression: afflicted but not destroyed\u2026"
+        "text": "The bush burns and is not consumed — the image of Israel under oppression: afflicted but not destroyed…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ESV</td><td>\"God said to Moses, 'I AM WHO I AM.' And he said, 'Say this to the people of Israel: I AM has sent me to you.'\"</td></tr><tr><td class=\"t-label\">NIV</td><td>\"God said to Moses, 'I AM WHO I AM. This is what you are to say to the Israelites: I AM has sent me to you.'\"</td></tr><tr><td class=\"t-label\">LXX (Greek)</td><td>Ego eimi ho \u014dn \u2014 \"I am the one who is\" \u2014 emphasising ontological self-existence.</td></tr><tr><td class=\"t-label\">KJV</td><td>\"And God said unto Moses, I AM THAT I AM: and he said, Thus shalt thou say unto the children of Israel, I AM hath sent me unto you.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ESV</td><td>\"God said to Moses, 'I AM WHO I AM.' And he said, 'Say this to the people of Israel: I AM has sent me to you.'\"</td></tr><tr><td class=\"t-label\">NIV</td><td>\"God said to Moses, 'I AM WHO I AM. This is what you are to say to the Israelites: I AM has sent me to you.'\"</td></tr><tr><td class=\"t-label\">LXX (Greek)</td><td>Ego eimi ho ōn — \"I am the one who is\" — emphasising ontological self-existence.</td></tr><tr><td class=\"t-label\">KJV</td><td>\"And God said unto Moses, I AM THAT I AM: and he said, Thus shalt thou say unto the children of Israel, I AM hath sent me unto you.\"</td></tr>",
     "src": [
       {
         "title": "Ugaritic El texts",
-        "quote": "Canaanite texts use similar \"I am\" formulas for El (the high god) in covenant contexts \u2014 showing the formula is recognisable in the ancient Semitic world while being filled with unique content by Israel's God.",
+        "quote": "Canaanite texts use similar \"I am\" formulas for El (the high god) in covenant contexts — showing the formula is recognisable in the ancient Semitic world while being filled with unique content by Israel's God.",
         "note": "The divine-name formula has ANE context while being theologically unprecedented."
       },
       {
         "title": "LXX Exod 3:14",
-        "quote": "The LXX rendering (ego eimi ho \u014dn, \"I am the one who is\") shaped Greek philosophical theology of divine being \u2014 Philo of Alexandria built his entire theology of God on this rendering.",
+        "quote": "The LXX rendering (ego eimi ho ōn, \"I am the one who is\") shaped Greek philosophical theology of divine being — Philo of Alexandria built his entire theology of God on this rendering.",
         "note": "The name YHWH became the axis of both Jewish and Christian philosophical theology."
       }
     ],
     "rec": [
       {
         "who": "John 8:58",
-        "text": "Jesus's \"before Abraham was, I am\" is the most explicit NT claim to the divine name of Exod 3:14 \u2014 and the moment the Jewish leaders take up stones."
+        "text": "Jesus's \"before Abraham was, I am\" is the most explicit NT claim to the divine name of Exod 3:14 — and the moment the Jewish leaders take up stones."
       },
       {
         "who": "Aquinas, Summa Theologica I.13",
-        "text": "Thomas Aquinas argues that \"He Who Is\" (Qui Est) is the most proper name of God \u2014 building directly on the LXX rendering of Exod 3:14. The burning bush became the foundation of medieval philosophical theology."
+        "text": "Thomas Aquinas argues that \"He Who Is\" (Qui Est) is the most proper name of God — building directly on the LXX rendering of Exod 3:14. The burning bush became the foundation of medieval philosophical theology."
       }
     ],
     "lit": {
@@ -728,40 +564,40 @@
     },
     "hebtext": [
       {
-        "word": "\u05e1\u05b0\u05e0\u05b6\u05d4",
+        "word": "סְנֶה",
         "tlit": "seneh",
         "gloss": "bush / thornbush",
-        "note": "V.2: The burning bush is a thornbush (not a noble tree) that burns without being consumed. The choice of plant is pointed: the thornbush is the most common, least impressive shrub of the Sinai wilderness. God reveals himself not in grandeur but in the ordinary. The fire that does not consume is the central image: the divine presence is real and intense but does not destroy what it inhabits \u2014 the paradigm of all divine indwelling."
+        "note": "V.2: The burning bush is a thornbush (not a noble tree) that burns without being consumed. The choice of plant is pointed: the thornbush is the most common, least impressive shrub of the Sinai wilderness. God reveals himself not in grandeur but in the ordinary. The fire that does not consume is the central image: the divine presence is real and intense but does not destroy what it inhabits — the paradigm of all divine indwelling."
       },
       {
-        "word": "\u05e7\u05b0\u05d3\u05b9\u05e9\u05c1",
+        "word": "קְדֹשׁ",
         "tlit": "qadosh",
         "gloss": "holy",
-        "note": "V.5: \"The ground on which you are standing is holy ground.\" The holiness is not intrinsic to the ground; it is relational \u2014 the ground is holy because God is there. The command to remove sandals acknowledges the asymmetry between the divine and human, the sacred and the common. This is the first use of \"holy\" in Exodus, and it frames the entire book: Israel will be called to be a holy nation (19:6) in the presence of a holy God."
+        "note": "V.5: \"The ground on which you are standing is holy ground.\" The holiness is not intrinsic to the ground; it is relational — the ground is holy because God is there. The command to remove sandals acknowledges the asymmetry between the divine and human, the sacred and the common. This is the first use of \"holy\" in Exodus, and it frames the entire book: Israel will be called to be a holy nation (19:6) in the presence of a holy God."
       },
       {
-        "word": "\u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05d0\u05b2\u05e9\u05b6\u05c1\u05e8 \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4",
+        "word": "אֶהְיֶה אֲשֶׁר אֶהְיֶה",
         "tlit": "ehyeh asher ehyeh",
         "gloss": "I AM WHO I AM",
         "note": "V.14: The most theologically loaded phrase in the Torah. The divine name YHWH is derived from the verb hayah (to be). The phrase may mean: \"I AM WHO I AM\" (ontological, emphasising God's absolute self-existence); \"I WILL BE WHAT I WILL BE\" (relational, emphasising God's promise to be present); or \"I am the One who causes to be\" (causative). All three dimensions are present and none can be reduced to the others."
       },
       {
-        "word": "\u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05e2\u05b4\u05de\u05b8\u05bc\u05da\u05b0",
+        "word": "אֶהְיֶה עִמָּךְ",
         "tlit": "ehyeh immak",
         "gloss": "I will be with you",
-        "note": "V.12: Before Moses hears the name of God (v.14), he hears the promise of God's presence. \"I will be with you\" is the first response to Moses' objection \u2014 \"who am I?\" The answer is not \"you are Moses, son of Amram, educated in Pharaoh's court\" but \"I will be with you.\" Adequacy is not required; presence is promised. This is the structure of every divine commission in Scripture."
+        "note": "V.12: Before Moses hears the name of God (v.14), he hears the promise of God's presence. \"I will be with you\" is the first response to Moses' objection — \"who am I?\" The answer is not \"you are Moses, son of Amram, educated in Pharaoh's court\" but \"I will be with you.\" Adequacy is not required; presence is promised. This is the structure of every divine commission in Scripture."
       },
       {
-        "word": "\u05d9\u05b0\u05d4\u05d5\u05b8\u05d4",
+        "word": "יְהוָה",
         "tlit": "YHWH",
         "gloss": "the LORD (the divine name)",
-        "note": "V.15: The four-consonant divine name (the Tetragrammaton) is here declared the permanent name of God \u2014 \"this is my name forever, and thus I am to be remembered throughout all generations.\" The name connects to ehyeh (I AM, v.14) through the root hayah (to be). YHWH is the third-person form of the same verb \u2014 \"he is\" or \"he causes to be.\" The name that God calls himself (I AM) and the name by which others call him (He Is / YHWH) encode the divine self-existence."
+        "note": "V.15: The four-consonant divine name (the Tetragrammaton) is here declared the permanent name of God — \"this is my name forever, and thus I am to be remembered throughout all generations.\" The name connects to ehyeh (I AM, v.14) through the root hayah (to be). YHWH is the third-person form of the same verb — \"he is\" or \"he causes to be.\" The name that God calls himself (I AM) and the name by which others call him (He Is / YHWH) encode the divine self-existence."
       },
       {
-        "word": "\u05d6\u05b8\u05e7\u05b5\u05df",
+        "word": "זָקֵן",
         "tlit": "zaqen",
         "gloss": "elders",
-        "note": "V.16: \"Gather the elders of Israel\" \u2014 the first instruction for community leadership in the Exodus narrative. The elders (zequenim) are the tribal leadership structure that survived the Egyptian bondage. Moses is not to lead alone; he is to work through the existing leadership structure of the people. The congregation model is established before the journey begins: God works through community, not merely through the solitary prophet."
+        "note": "V.16: \"Gather the elders of Israel\" — the first instruction for community leadership in the Exodus narrative. The elders (zequenim) are the tribal leadership structure that survived the Egyptian bondage. Moses is not to lead alone; he is to work through the existing leadership structure of the people. The congregation model is established before the journey begins: God works through community, not merely through the solitary prophet."
       }
     ],
     "thread": [
@@ -774,7 +610,7 @@
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Acts 7:30\u201334",
+        "target": "Acts 7:30–34",
         "type": "Connection",
         "text": "Stephen: \"Now when forty years had passed, an angel appeared to him in the wilderness of Mount Sinai, in a flame of fire in a bush.\"",
         "direction": "backward"
@@ -783,26 +619,26 @@
         "anchor": "Scripture Walkthrough",
         "target": "Rev 1:4",
         "type": "Connection",
-        "text": "\"From him who is and who was and who is to come\" \u2014 the Revelation unpacks the Exodus name YHWH as the three tenses of divine existence.",
+        "text": "\"From him who is and who was and who is to come\" — the Revelation unpacks the Exodus name YHWH as the three tenses of divine existence.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 8:58",
         "type": "Connection",
-        "text": "\"Before Abraham was, I AM\" \u2014 Jesus applies the divine name of Exod 3:14 to himself, the most unambiguous divine self-claim in the Gospels.",
+        "text": "\"Before Abraham was, I AM\" — Jesus applies the divine name of Exod 3:14 to himself, the most unambiguous divine self-claim in the Gospels.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 4:26",
         "type": "Connection",
-        "text": "To the Samaritan woman: \"I who speak to you am he\" \u2014 ego eimi, \"I AM\" \u2014 the same self-identification structure as Exod 3:14.",
+        "text": "To the Samaritan woman: \"I who speak to you am he\" — ego eimi, \"I AM\" — the same self-identification structure as Exod 3:14.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
-        "target": "Exod 6:2\u20133",
+        "target": "Exod 6:2–3",
         "type": "Connection",
         "text": "God tells Moses: \"I appeared to Abraham, to Isaac, and to Jacob as God Almighty (El Shaddai), but by my name the LORD (YHWH) I did not make myself known to them.\" The full disclosure of the Tetragrammaton is given here and expanded in ch.6.",
         "direction": "backward"
@@ -813,13 +649,13 @@
         "ref": "3:1",
         "title": "Horeb or Sinai?",
         "content": "Chapter 3 uses \"Horeb, the mountain of God.\" Exodus 19 uses \"Sinai.\" The two names appear throughout the Pentateuch in what source critics identify as separate literary traditions (Horeb = Deuteronomic/Elohistic; Sinai = Jahwistic/Priestly). The Samaritan Pentateuch and LXX do not systematically harmonise these.",
-        "note": "Most scholars accept that Horeb and Sinai refer to the same geographical location \u2014 the sacred mountain of the south. The two names may reflect different tribal/regional traditions for the same peak, or different aspects (Sinai = the mountain; Horeb = the desert region). The theological content is identical in both traditions: this is the mountain of divine encounter."
+        "note": "Most scholars accept that Horeb and Sinai refer to the same geographical location — the sacred mountain of the south. The two names may reflect different tribal/regional traditions for the same peak, or different aspects (Sinai = the mountain; Horeb = the desert region). The theological content is identical in both traditions: this is the mountain of divine encounter."
       },
       {
         "ref": "3:14",
         "title": "Translations of Ehyeh Asher Ehyeh",
-        "content": "LXX: ego eimi ho on (\"I am the one who is\" \u2014 ontological emphasis). Vulgate: Ego sum qui sum (same). KJV/ESV/NIV: \"I AM WHO I AM.\" NRSV: \"I AM WHO I AM.\" Some modern scholars (Buber, Rosenzweig): \"I will be there as I will be there\" (relational/promissory emphasis). NEB: \"I am what I am.\"",
-        "note": "The translation choice encodes a theological position. Ontological translations (LXX, traditional) emphasise divine self-existence; relational translations (Buber) emphasise divine presence and promise. The Hebrew imperfect tense (ehyeh) can carry both present and future meaning \u2014 \"I am\" and \"I will be\" are both grammatically valid. The richest interpretation holds both: God is ontologically self-existent AND relationally present-in-promise."
+        "content": "LXX: ego eimi ho on (\"I am the one who is\" — ontological emphasis). Vulgate: Ego sum qui sum (same). KJV/ESV/NIV: \"I AM WHO I AM.\" NRSV: \"I AM WHO I AM.\" Some modern scholars (Buber, Rosenzweig): \"I will be there as I will be there\" (relational/promissory emphasis). NEB: \"I am what I am.\"",
+        "note": "The translation choice encodes a theological position. Ontological translations (LXX, traditional) emphasise divine self-existence; relational translations (Buber) emphasise divine presence and promise. The Hebrew imperfect tense (ehyeh) can carry both present and future meaning — \"I am\" and \"I will be\" are both grammatically valid. The richest interpretation holds both: God is ontologically self-existent AND relationally present-in-promise."
       }
     ],
     "debate": [
@@ -834,7 +670,7 @@
           {
             "name": "Previously Known, Now Fully Disclosed",
             "proponents": "Conservative scholars (Kitchen, Sarna, MacArthur)",
-            "argument": "Gen 4:26 (\"at that time people began to call upon the name of the LORD\") shows YHWH was known earlier. Gen 15:7 has God identify himself as YHWH to Abraham. Exod 6:3 means not \"never heard the name\" but \"never experienced the full covenant significance of the name\" \u2014 Abraham knew the name but not the full redemptive programme it encodes. The disclosure at the burning bush is qualitative, not merely nominal."
+            "argument": "Gen 4:26 (\"at that time people began to call upon the name of the LORD\") shows YHWH was known earlier. Gen 15:7 has God identify himself as YHWH to Abraham. Exod 6:3 means not \"never heard the name\" but \"never experienced the full covenant significance of the name\" — Abraham knew the name but not the full redemptive programme it encodes. The disclosure at the burning bush is qualitative, not merely nominal."
           }
         ]
       },
@@ -844,12 +680,12 @@
           {
             "name": "Ontological: Self-Existent Being",
             "proponents": "LXX translators, Augustine, Aquinas, Calvin",
-            "argument": "God's name encodes his aseity \u2014 self-existence, the ground of all being. \"I AM\" means God exists necessarily, not contingently. This philosophical reading became dominant in Christian theology through the Septuagint's ego eimi ho on and shaped the entire tradition of classical theism."
+            "argument": "God's name encodes his aseity — self-existence, the ground of all being. \"I AM\" means God exists necessarily, not contingently. This philosophical reading became dominant in Christian theology through the Septuagint's ego eimi ho on and shaped the entire tradition of classical theism."
           },
           {
             "name": "Relational/Covenantal: Active Presence",
             "proponents": "Buber, Childs, Brueggemann",
-            "argument": "The imperfect tense of ehyeh points to future action: \"I will be who I will be.\" The name is a covenant promise, not a philosophical statement \u2014 God will prove who he is by what he does. The Exodus is the definition of the name, not a deduction from it."
+            "argument": "The imperfect tense of ehyeh points to future action: \"I will be who I will be.\" The name is a covenant promise, not a philosophical statement — God will prove who he is by what he does. The Exodus is the definition of the name, not a deduction from it."
           },
           {
             "name": "Causative: Creator",
@@ -882,7 +718,7 @@
           "score": 8
         }
       ],
-      "note": "Exodus 3 is the theological centre of the book: the God who has heard, remembered, seen, and known (2:23-25) now speaks, names himself, and commissions his servant. The burning bush gives Exodus its central symbol \u2014 the divine presence that is real, intense, and inexhaustible \u2014 and the divine name gives the book its central theological claim: the God who acts in the Exodus is the self-existent, covenant-keeping God whose name is \"I AM.\""
+      "note": "Exodus 3 is the theological centre of the book: the God who has heard, remembered, seen, and known (2:23-25) now speaks, names himself, and commissions his servant. The burning bush gives Exodus its central symbol — the divine presence that is real, intense, and inexhaustible — and the divine name gives the book its central theological claim: the God who acts in the Exodus is the self-existent, covenant-keeping God whose name is \"I AM.\""
     }
   },
   "vhl_groups": [
@@ -990,12 +826,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'I AM WHO I AM' (v. 14)\u2014the divine name revealed. Hebrew \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 \u05d0\u05b2\u05e9\u05b6\u05c1\u05e8 \u05d0\u05b6\u05d4\u05b0\u05d9\u05b6\u05d4 resists translation: 'I will be what I will be,' or 'I am the one who is.' God names himself with a verb, not a noun. Presence, not definition.",
+      "tip": "'I AM WHO I AM' (v. 14)—the divine name revealed. Hebrew אֶהְיֶה אֲשֶׁר אֶהְיֶה resists translation: 'I will be what I will be,' or 'I am the one who is.' God names himself with a verb, not a noun. Presence, not definition.",
       "genre_tag": "theological_insight"
     },
     {
       "after_section": 2,
-      "tip": "'Take off your sandals, for the place where you are standing is holy ground' (v. 5). Holiness isn't the bush\u2014it's God's presence. Any ground becomes sacred when God shows up. Moses learns: approach matters before assignment.",
+      "tip": "'Take off your sandals, for the place where you are standing is holy ground' (v. 5). Holiness isn't the bush—it's God's presence. Any ground becomes sacred when God shows up. Moses learns: approach matters before assignment.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/exodus/34.json
+++ b/content/exodus/34.json
@@ -269,10 +269,6 @@
           "source": "Robert Alter, The Hebrew Bible: A Translation with Commentary — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "34:29–35",
-              "note": "Moses' veil is worn outside the encounter (speaking to the people) but removed inside it (speaking to God). Mediated relationship requires veiling; immediate relationship requires unveiling."
-            },
-            {
               "ref": "34:29-32",
               "note": "Moses' radiant face after his forty-day encounter is the physical evidence that he has been in the divine presence. Alter notes the community's fear at the radiance — they cannot approach until Aaron reassures them — establishes the mediating function of Moses: the glory that would overwhelm the community is borne by their representative."
             }

--- a/content/exodus/36.json
+++ b/content/exodus/36.json
@@ -216,16 +216,7 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "36:5-7",
-              "note": "MacArthur: The people were bringing more than enough for the work. Moses gave an order to stop the offering. The only divinely-commanded halt to religious giving in Scripture. The superabundance of the offering is the measure of the covenant community's gratitude."
-            },
-            {
-              "ref": "36:8",
-              "note": "MacArthur: The verbal echo of God's instructions in the construction report establishes the criterion of success: did the workers do exactly what God commanded? Faithful correspondence to divine specification is the tabernacle's standard of success."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/job/17.json
+++ b/content/job/17.json
@@ -158,21 +158,11 @@
         },
         "clines": {
           "source": "David J.A. Clines, Job, WBC (3 vols., 1989–2011) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:14–16",
-              "note": "Clines: the corruption-as-family imagery is the chapter’s most disturbing move. The grave replaces community. Worms replace relatives. Darkness replaces home."
-            }
-          ]
+          "notes": []
         },
         "habel": {
           "source": "Norman C. Habel, The Book of Job, OTL (1985) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:10–16",
-              "note": "Habel: Job’s despair is the low point of the legal case. The plaintiff has exhausted his arguments. Hope descends with him to the dust."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Job describes the grave as his new family: corruption is his father, the worm is his mother and sister (v.14). Every human relationship has been replaced by decay. Hope descends with him to the dust (v.16)."

--- a/content/job/18.json
+++ b/content/job/18.json
@@ -170,10 +170,6 @@
           "source": "David J.A. Clines, Job, WBC (3 vols., 1989–2011) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "18:5–21",
-              "note": "Clines: Bildad’s speech is notable for what it lacks: argument. There is no theology, no reasoning, no appeal to evidence. It is pure assertion — a verbal avalanche aimed at burying Job."
-            },
-            {
               "ref": "18:21",
               "note": "Clines: “the place of one who does not know God” is Bildad’s final verdict. He has moved from “does God pervert justice?” (8:3) to an outright accusation that Job does not know God."
             }

--- a/content/john/1.json
+++ b/content/john/1.json
@@ -285,63 +285,19 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:1",
-              "note": "\"The Word was God\" — the predicate nominative (theos) without the article in Greek is anarthrous but not indefinite. The grammar establishes quality: the Word partakes fully of the divine nature. This is not \"the Word was a god\" (Jehovah's Witnesses) or \"the Word was divine\" (Arianism) but the Word shares the very essence of deity. All three trinitarian persons are simultaneously affirmed: the Word was with God (distinguishing persons) and the Word was God (asserting shared essence)."
-            },
-            {
-              "ref": "1:14",
-              "note": "\"The Word became flesh\" — sarx (flesh) is the most emphatic possible expression of genuine humanity. John does not say the Word appeared in a body or took on human form — he says the Word became flesh, asserting the full reality of the Incarnation against the docetism that would plague the church within a generation. \"Made his dwelling\" (eskēnōsen) — the Tabernacle image: God dwelling in the midst of his people, his glory now visible in a human face."
-            },
-            {
-              "ref": "1:12-13",
-              "note": "\"To all who received him... he gave the right to become children of God.\" The gift of sonship is not natural but supernatural — \"born not of natural descent... but born of God.\" This is John's first statement of what ch 3 will develop as the new birth: regeneration as the precondition for receiving the Word."
-            },
-            {
-              "ref": "1:17-18",
-              "note": "\"Grace and truth came through Jesus Christ\" — the same attributes (hesed and emet) that characterised God's self-revelation to Moses at Sinai (Exod 34:6). Jesus is the personal, embodied, visible manifestation of what Moses was only allowed to see from behind. \"The one and only Son\" (monogenēs) — not merely unique in character but uniquely born of God."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:1",
-              "note": "Calvin insists on the eternal pre-existence of the Word against all attempts to read \"in the beginning\" as referring to the beginning of Jesus's earthly ministry. The Word's being \"with God\" (pros ton theon) establishes a personal distinction within the Godhead before creation; the Word's being God establishes the essential unity. The prologue is thus the clearest scriptural foundation for the doctrine of the Trinity."
-            },
-            {
-              "ref": "1:14",
-              "note": "The Word becoming flesh is the single most important event in human history. Calvin stresses that John does not say the Word was clothed with flesh or appeared in flesh but that the Word became flesh — the two natures are united in one person without confusion or conversion. This is the miracle of the Incarnation: the infinite condescending to the finite without ceasing to be infinite."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:1",
-              "note": "The Greek word order is significant: \"and God was the Word\" (kai theos ēn ho logos). The anarthrous (article-less) predicate nominative theos asserts that the Word partakes of divine nature/essence. Colwell's rule in Greek grammar confirms that this construction asserts quality, not identity with the entire Godhead. Jehovah's Witnesses' rendering \"a god\" violates Greek grammar."
-            },
-            {
-              "ref": "1:14",
-              "note": "Eskēnōsen (tabernacled) is a unique occurrence in the NT. The connection to the Tabernacle (skēnē in the LXX) is almost certainly deliberate. The statement that \"we have seen his glory\" echoes Moses's request to see God's glory (Exod 33:18) and the cloud filling the Tabernacle (Exod 40:34). In Jesus, what Moses saw only partially and obliquely has been seen directly."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "1:1",
-              "note": "Augustine: \"In the beginning was the Word — you heard the thunder, now hear the instruction. The Word was with God and the Word was God. How was it with God? As the Son with the Father. How was the Word God? In such a way that he is not the Father, yet is of the same substance as the Father.\""
-            },
-            {
-              "ref": "1:14",
-              "note": "Chrysostom: \"He became flesh — not changed into flesh, for the divine nature cannot be changed; but he assumed flesh while remaining what he was. The sun is not diminished when it shines on mud, nor was the Word polluted when it clothed itself in flesh. He assumed our nature to raise our nature to his own level.\""
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Prologue and Genesis 1\nJohn opens with \"In the beginning\" (en archē) — the exact opening of the LXX's Genesis 1:1. The correspondence is deliberate: John is presenting the Incarnation as a new creation event. As the first creation came through the spoken Word of God (Gen 1:3, \"Let there be light\"), so the new creation comes through the incarnate Word. The light/darkness contrast of 1:4-5 maps directly onto the first day of creation.\n\nThe Prologue and Wisdom Literature\nJewish wisdom tradition (Prov 8:22-31; Sir 24; Wis 7:22-8:1) had long personified divine Wisdom as a figure present at creation, dwelling with Israel, and mediating between God and humanity. John draws on this tradition but makes a decisive move: he identifies the personified Word/Wisdom not with Torah (as Sirach does) but with the person of Jesus Christ (v.17). The prologue is a deliberate christological reinterpretation of Jewish wisdom theology."
@@ -386,63 +342,19 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:29",
-              "note": "\"Look, the Lamb of God, who takes away the sin of the world!\" — ho airōn tēn hamartian tou kosmou, literally \"the one taking up / carrying away the sin of the world.\" The present participle implies ongoing action: Jesus perpetually carries the world's sin. The singular \"sin\" (hamartian, not \"sins\") points to the root condition of human alienation from God, not merely individual transgressions."
-            },
-            {
-              "ref": "1:42",
-              "note": "\"You will be called Cephas (Peter)\" — Jesus gives Simon a new name before he has done anything to deserve it. The name \"rock\" describes not who Simon is but who he will become through Christ's transformation. Naming in Scripture is an act of divine sovereignty: God renamed Abram, Jacob, and Saul; now the Son of God renames Simon."
-            },
-            {
-              "ref": "1:51",
-              "note": "The Jacob's ladder allusion is staggering: Jesus identifies himself as the stairway connecting heaven and earth. Jacob's ladder was a one-night vision; Jesus is the permanent, personal locus where the divine and human realms meet. He is not merely a pathway to God — he is the pathway (cf. 14:6)."
-            },
-            {
-              "ref": "1:47",
-              "note": "\"An Israelite in whom there is no deceit\" — the contrast with Jacob (whose name means \"deceiver\") is deliberate. Nathanael is the authentic Israel that Jacob aspired to become. Jesus's supernatural knowledge of Nathanael under the fig tree is the first hint of the divine omniscience that John will develop throughout the Gospel."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:29",
-              "note": "Calvin notes that the Baptist's declaration, coming before any of Jesus's miracles or teaching, establishes that the Incarnation's purpose is atoning sacrifice. The title \"Lamb of God\" is not a gentle pastoral metaphor but a precise sacrificial category: Jesus is the one on whom God's judgment falls on behalf of sinners."
-            },
-            {
-              "ref": "1:51",
-              "note": "Calvin takes the Jacob's ladder as the foundational image for mediatorial Christology: there is no direct unmediated access between the holy God and sinful humanity. Christ as the ladder is the sole point of contact between heaven and earth. The \"ascending and descending\" of angels indicates that all divine communication with humanity now passes through the incarnate Son."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:34",
-              "note": "\"God's Chosen One\" (NIV) vs. \"Son of God\" (most other versions). The textual tradition is divided: important manuscripts (including p106 and Sinaiticus) read \"Chosen One\" (ho eklektos); others read \"Son of God\" (ho huios). NA28 adopts \"Chosen One\" as the harder reading, likely original; scribes may have harmonised toward \"Son of God\" which appears frequently in John."
-            },
-            {
-              "ref": "1:51",
-              "note": "\"Very truly I tell you\" — the double \"Amen\" (amēn amēn legō hymin) is a construction unique to John, occurring 25 times. It signals solemn authoritative declaration. Jesus speaks with his own authority, unlike the OT prophets who said \"Thus says the Lord.\" This formula is itself a Christological claim."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "1:29",
-              "note": "Augustine: \"Behold the Lamb of God who takes away the sin of the world. He did not say the sins of Jews only, or of Romans only, or even of believers only — but of the world. So immense is the grace of Christ: he takes away the sin not of one nation but of all nations, not of the past only but of all time.\""
-            },
-            {
-              "ref": "1:14",
-              "note": "Cyril of Alexandria: \"The Word became flesh — that is, became a complete human being, body and rational soul together. He put on human nature in its entirety in order to heal it in its entirety. What is not assumed is not healed; but what is united to God is saved.\""
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Baptist's Testimony\nJohn structures the Baptist's witness as a series of \"next day\" scenes (vv.29, 35, 43) — a week of escalating testimony building toward Jesus's first sign at Cana (ch.2). The Baptist's triple denial (\"I am not the Messiah / Elijah / the Prophet\") mirrors the triple denial that will characterise Peter later — but in an ironic positive direction: the Baptist's denials all serve to magnify Jesus. His self-description (\"voice of one calling in the wilderness\") deliberately positions him as the fulfilment of Isaiah 40:3.\n\n\"Come and See\"\nThe phrase \"come and see\" (vv.39, 46) is John's characteristic invitation throughout the Gospel — an experiential epistemology: discipleship begins not with arguments but with encounter. Jesus's first words in John's Gospel are a question: \"What do you want?\" (v.38). The disciples answer with a question: \"Where are you staying?\" Jesus's response sets the tone for the entire Gospel: \"Come and see.\""

--- a/content/john/11.json
+++ b/content/john/11.json
@@ -7,76 +7,76 @@
   "subtitle": "The Resurrection of Lazarus",
   "timeline_link": {
     "event_id": "lazarus-raised",
-    "text": "See on Timeline \u2014 Lazarus Raised"
+    "text": "See on Timeline — Lazarus Raised"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201316 \u2014 Lazarus Is Ill; I Am the Resurrection and the Life",
+      "header": "Verses 1–16 — Lazarus Is Ill; I Am the Resurrection and the Life",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi h\u0113 anastasis kai h\u0113 z\u014d\u0113",
-            "transliteration": "e-GO ei-MI h\u0113 a-NAS-ta-sis kai h\u0113 ZO-\u0113",
+            "word": "egō eimi hē anastasis kai hē zōē",
+            "transliteration": "e-GO ei-MI hē a-NAS-ta-sis kai hē ZO-ē",
             "gloss": "I am the resurrection and the life",
-            "paragraph": "The fifth I am saying with predicate \u2014 and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense \u2014 the resurrection is present, not merely future, because it is a person, not merely an event."
+            "paragraph": "The fifth I am saying with predicate — and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense — the resurrection is present, not merely future, because it is a person, not merely an event."
           },
           {
             "word": "edakrysen",
             "transliteration": "e-DAK-ry-sen",
             "gloss": "Jesus wept",
-            "paragraph": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakry\u014d \u2014 to weep quietly, to shed tears \u2014 rather than klai\u014d (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
+            "paragraph": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakryō — to weep quietly, to shed tears — rather than klaiō (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
-            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus \u2014 Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
+            "coords": "31.7742° N, 35.2659° E",
+            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus — Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ezek 37:12-13",
-              "note": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" \u2014 the valley of dry bones as background for Lazarus's resurrection."
+              "note": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" — the valley of dry bones as background for Lazarus's resurrection."
             },
             {
               "ref": "1 Kgs 17:17-24",
-              "note": "Elijah raising the widow's son \u2014 the OT parallel that frames raising the dead as a prophetic act establishing divine credentials."
+              "note": "Elijah raising the widow's son — the OT parallel that frames raising the dead as a prophetic act establishing divine credentials."
             },
             {
               "ref": "Rom 8:11",
-              "note": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" \u2014 Paul's application of the resurrection principle to believers."
+              "note": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" — Paul's application of the resurrection principle to believers."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:4",
-              "note": "\"This sickness will not end in death. No, it is for God's glory so that God's Son may be glorified through it\" \u2014 the same theodicy principle as John 9:3. Jesus sees the illness not as a tragedy to be prevented but as the occasion for a revelation of divine glory. His two-day delay (v.6) is not negligence but purposive waiting: he is waiting until the death is unambiguous so the glory will be unmistakable."
+              "note": "\"This sickness will not end in death. No, it is for God's glory so that God's Son may be glorified through it\" — the same theodicy principle as John 9:3. Jesus sees the illness not as a tragedy to be prevented but as the occasion for a revelation of divine glory. His two-day delay (v.6) is not negligence but purposive waiting: he is waiting until the death is unambiguous so the glory will be unmistakable."
             },
             {
               "ref": "11:25-26",
-              "note": "\"I am the resurrection and the life\" \u2014 the saying has two parts: (1) \"The one who believes in me will live, even though they die\" \u2014 physical death does not end the life of the believer; (2) \"Whoever lives by believing in me will never die\" \u2014 the spiritual life in Christ has no terminus. The first addresses the believer who has died (like Lazarus); the second addresses the living believer. Together they cover the whole range of Christian mortality."
+              "note": "\"I am the resurrection and the life\" — the saying has two parts: (1) \"The one who believes in me will live, even though they die\" — physical death does not end the life of the believer; (2) \"Whoever lives by believing in me will never die\" — the spiritual life in Christ has no terminus. The first addresses the believer who has died (like Lazarus); the second addresses the living believer. Together they cover the whole range of Christian mortality."
             },
             {
               "ref": "11:35",
-              "note": "\"Jesus wept\" \u2014 the theological weight of this shortest verse is enormous. The omniscient Son of God, who knows he is about to raise Lazarus, weeps over his friend's death. Why? Not because death has surprised him or because he fears it cannot be reversed \u2014 but because death is genuinely grievous. God weeps over death even as he overcomes it. The tears are not performance but the expression of genuine solidarity with human suffering."
+              "note": "\"Jesus wept\" — the theological weight of this shortest verse is enormous. The omniscient Son of God, who knows he is about to raise Lazarus, weeps over his friend's death. Why? Not because death has surprised him or because he fears it cannot be reversed — but because death is genuinely grievous. God weeps over death even as he overcomes it. The tears are not performance but the expression of genuine solidarity with human suffering."
             },
             {
               "ref": "11:43-44",
-              "note": "\"Lazarus, come forth!\" \u2014 the bare command, the response of a dead man. The graveclothes-bound figure emerging from the cave is one of the most visually powerful moments in the Gospels. Jesus then gives the command that will define the church's ongoing ministry: \"Loose him, and let him go.\" The raising is Jesus's work; the loosing is the community's work."
+              "note": "\"Lazarus, come forth!\" — the bare command, the response of a dead man. The graveclothes-bound figure emerging from the cave is one of the most visually powerful moments in the Gospels. Jesus then gives the command that will define the church's ongoing ministry: \"Loose him, and let him go.\" The raising is Jesus's work; the loosing is the community's work."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:4",
@@ -84,44 +84,44 @@
             },
             {
               "ref": "11:25-27",
-              "note": "Martha's confession (\"I believe that you are the Messiah, the Son of God, who is to come into the world\") is, for Calvin, the most complete confession in John before Thomas's post-resurrection \"My Lord and my God!\" (20:28). It encompasses messiahship, divine Sonship, and incarnation. It is spoken in the context of grief and unanswered prayer \u2014 making it more remarkable, not less."
+              "note": "Martha's confession (\"I believe that you are the Messiah, the Son of God, who is to come into the world\") is, for Calvin, the most complete confession in John before Thomas's post-resurrection \"My Lord and my God!\" (20:28). It encompasses messiahship, divine Sonship, and incarnation. It is spoken in the context of grief and unanswered prayer — making it more remarkable, not less."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "11:33",
-              "note": "The two Greek verbs \u2014 embrimaomai (\"groaned/was deeply moved\") and tarasso (\"was troubled\") \u2014 are both strong emotional terms. The most natural reading is genuine emotional distress at the sight of Mary and the mourners weeping. Some scholars have argued Jesus was troubled by the unbelief he saw (v.37's critical question); others by the prospect of his own coming death (triggered by this anticipatory raising). The text does not specify the object of the groaning."
+              "note": "The two Greek verbs — embrimaomai (\"groaned/was deeply moved\") and tarasso (\"was troubled\") — are both strong emotional terms. The most natural reading is genuine emotional distress at the sight of Mary and the mourners weeping. Some scholars have argued Jesus was troubled by the unbelief he saw (v.37's critical question); others by the prospect of his own coming death (triggered by this anticipatory raising). The text does not specify the object of the groaning."
             },
             {
               "ref": "11:44",
-              "note": "\"Loose him, and let him go\" \u2014 the Greek lysate auton kai aphete auton hupagein has been read theologically as a command to the church: the resurrection is Christ's work; the loosing of the graveclothes is the community's ministry \u2014 freeing those whom Christ has raised from the bindings of their former life."
+              "note": "\"Loose him, and let him go\" — the Greek lysate auton kai aphete auton hupagein has been read theologically as a command to the church: the resurrection is Christ's work; the loosing of the graveclothes is the community's ministry — freeing those whom Christ has raised from the bindings of their former life."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "11:25",
-              "note": "Augustine: \"I am the resurrection \u2014 not merely 'I give resurrection' but 'I am the resurrection.' He himself is what he gives. He himself is what he promises. To have him is to have life. To lose him is to die. If you believe in me, even though you die, you will live \u2014 because I am the life.\""
+              "note": "Augustine: \"I am the resurrection — not merely 'I give resurrection' but 'I am the resurrection.' He himself is what he gives. He himself is what he promises. To have him is to have life. To lose him is to die. If you believe in me, even though you die, you will live — because I am the life.\""
             },
             {
               "ref": "11:35",
-              "note": "Chrysostom: \"Jesus wept. He wept not as one ignorant of what would happen, nor as doubting his own power, but to show that he was truly human, to show that he felt real grief at real death. He wept to comfort the sisters and to show that he too regarded death as an evil \u2014 though an evil he was about to overcome.\""
+              "note": "Chrysostom: \"Jesus wept. He wept not as one ignorant of what would happen, nor as doubting his own power, but to show that he was truly human, to show that he felt real grief at real death. He wept to comfort the sisters and to show that he too regarded death as an evil — though an evil he was about to overcome.\""
             }
           ]
         },
         "hist": {
-          "context": "Four Days in the Tomb\nThe detail that Lazarus had been in the tomb four days (v.17) is theologically significant. Jewish tradition held that the soul hovered near the body for three days in hope of return; after three days decomposition was visible and the soul departed finally. By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience or a three-day hover. \"He stinketh\" (v.39, KJV) \u2014 Martha's pragmatic observation \u2014 confirms the death is genuine and total.\n\nThe Seventh Sign\nThe raising of Lazarus is the seventh and climactic sign in John's Gospel \u2014 deliberately ordered so that the resurrection of a dead man is the final demonstration of who Jesus is before the cross. The sign's effect is double: many Jews believed (v.45); the Sanhedrin resolved to kill Jesus (11:47-53). The sign that demonstrates Jesus has power over death also triggers the events that will lead to his own death."
+          "context": "Four Days in the Tomb\nThe detail that Lazarus had been in the tomb four days (v.17) is theologically significant. Jewish tradition held that the soul hovered near the body for three days in hope of return; after three days decomposition was visible and the soul departed finally. By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience or a three-day hover. \"He stinketh\" (v.39, KJV) — Martha's pragmatic observation — confirms the death is genuine and total.\n\nThe Seventh Sign\nThe raising of Lazarus is the seventh and climactic sign in John's Gospel — deliberately ordered so that the resurrection of a dead man is the final demonstration of who Jesus is before the cross. The sign's effect is double: many Jews believed (v.45); the Sanhedrin resolved to kill Jesus (11:47-53). The sign that demonstrates Jesus has power over death also triggers the events that will lead to his own death."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201337 \u2014 Jesus Arrives; Mary and Martha; Jesus Weeps",
+      "header": "Verses 17–37 — Jesus Arrives; Mary and Martha; Jesus Weeps",
       "verse_start": 17,
       "verse_end": 37,
       "panels": {
@@ -130,47 +130,47 @@
             "word": "sympherei",
             "transliteration": "sym-PHE-rei",
             "gloss": "it is expedient / it is profitable",
-            "paragraph": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei \u2014 a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
+            "paragraph": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei — a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
-            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus \u2014 Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
+            "coords": "31.7742° N, 35.2659° E",
+            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus — Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 53:8",
-              "note": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" \u2014 the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express."
+              "note": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" — the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express."
             },
             {
               "ref": "John 18:14",
-              "note": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" \u2014 John refers back to this moment at the trial, reminding the reader of its ironic prophetic character."
+              "note": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" — John refers back to this moment at the trial, reminding the reader of its ironic prophetic character."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:49-52",
-              "note": "Caiaphas's statement is both the ugliest political calculation in the Gospel and the most accurate theological statement about the atonement outside of the explicit Passion narrative. He means: execute this man to prevent a Roman reprisal. John hears: one man dies in the place of the people so that the people may live. The scattered children of God (v.52) \u2014 the Gentiles \u2014 are brought into the scope of the one man's death. The high priest who plots the murder is the instrument of the prophecy he cannot understand."
+              "note": "Caiaphas's statement is both the ugliest political calculation in the Gospel and the most accurate theological statement about the atonement outside of the explicit Passion narrative. He means: execute this man to prevent a Roman reprisal. John hears: one man dies in the place of the people so that the people may live. The scattered children of God (v.52) — the Gentiles — are brought into the scope of the one man's death. The high priest who plots the murder is the instrument of the prophecy he cannot understand."
             },
             {
               "ref": "11:45-48",
-              "note": "The Sanhedrin's fear \u2014 \"everyone will believe in him, and then the Romans will come and take away our place and nation\" \u2014 reveals that the threat they fear from Jesus is political and institutional, not theological. MacArthur points out the tragic irony: the very thing they move to prevent (the destruction of the nation) was brought about by their action."
+              "note": "The Sanhedrin's fear — \"everyone will believe in him, and then the Romans will come and take away our place and nation\" — reveals that the threat they fear from Jesus is political and institutional, not theological. MacArthur points out the tragic irony: the very thing they move to prevent (the destruction of the nation) was brought about by their action."
             },
             {
               "ref": "11:53-57",
-              "note": "The plot to kill Jesus is now official policy, not individual spite. John notes Jesus withdrew to Ephraim and that the Passover was near \u2014 placing the coming crucifixion on the Passover calendar deliberately. The crowd wondering whether Jesus will come to the feast (v56) heightens the dramatic irony: he will come, and it will cost him everything."
+              "note": "The plot to kill Jesus is now official policy, not individual spite. John notes Jesus withdrew to Ephraim and that the Passover was near — placing the coming crucifixion on the Passover calendar deliberately. The crowd wondering whether Jesus will come to the feast (v56) heightens the dramatic irony: he will come, and it will cost him everything."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:51",
@@ -183,147 +183,103 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "11:49",
-              "note": "\"Who was high priest that year\" \u2014 John mentions the annual character of Caiaphas's high priesthood three times (11:49, 51; 18:13). This may be because Josephus describes several high priests serving in rapid succession in this period (though the high priesthood was technically for life). Caiaphas actually served unusually long: AD 18-36."
+              "note": "\"Who was high priest that year\" — John mentions the annual character of Caiaphas's high priesthood three times (11:49, 51; 18:13). This may be because Josephus describes several high priests serving in rapid succession in this period (though the high priesthood was technically for life). Caiaphas actually served unusually long: AD 18-36."
             },
             {
               "ref": "11:51-52",
-              "note": "The NET Bible notes that John's editorial comment (\"he did not say this on his own\") is unique in the Gospel \u2014 John explicitly interprets the speech as unconscious prophecy. The phrase \"scattered children of God\" (v52) picks up the Diaspora language of Jewish expectation and reapplies it: the ingathering of the nations is through the atoning death of Jesus. John cites Ezekiel 34:12 and 37:21 as the prophetic background."
+              "note": "The NET Bible notes that John's editorial comment (\"he did not say this on his own\") is unique in the Gospel — John explicitly interprets the speech as unconscious prophecy. The phrase \"scattered children of God\" (v52) picks up the Diaspora language of Jewish expectation and reapplies it: the ingathering of the nations is through the atoning death of Jesus. John cites Ezekiel 34:12 and 37:21 as the prophetic background."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "11:50",
-              "note": "Augustine: \"He spoke better than he knew. He said it out of wickedness, but God used it for salvation. A murderer's counsel became the voice of prophecy. One man should die for the people \u2014 yes, and not for that nation only, but to gather together the children of God who are scattered abroad.\""
+              "note": "Augustine: \"He spoke better than he knew. He said it out of wickedness, but God used it for salvation. A murderer's counsel became the voice of prophecy. One man should die for the people — yes, and not for that nation only, but to gather together the children of God who are scattered abroad.\""
             },
             {
               "ref": "11:49-52",
-              "note": "The Catena preserves Theophylact's observation that Caiaphas, by virtue of his office, retained the prophetic gift even while being personally wicked \u2014 as the Urim and Thummim functioned through the high-priestly office regardless of the individual. Cyril of Alexandria adds that \"the whole nation\" in v50 and \"the scattered children of God\" in v52 form a two-part prophecy: the particular atonement for Israel and the universal gathering of the Gentiles."
+              "note": "The Catena preserves Theophylact's observation that Caiaphas, by virtue of his office, retained the prophetic gift even while being personally wicked — as the Urim and Thummim functioned through the high-priestly office regardless of the individual. Cyril of Alexandria adds that \"the whole nation\" in v50 and \"the scattered children of God\" in v52 form a two-part prophecy: the particular atonement for Israel and the universal gathering of the Gentiles."
             }
           ]
         },
         "hist": {
-          "context": "Caiaphas's Unwitting Prophecy\nJohn explicitly identifies Caiaphas's statement as prophecy (v.51) \u2014 not despite its cynical political motivation but through it. Caiaphas intends a piece of political pragmatism: sacrifice one troublemaker to preserve the nation's peace with Rome. God speaks through this cynicism the deepest truth of the atonement: the one dies for the many. John's double-level narrative reaches its apex here: the very words used to condemn Jesus proclaim the gospel."
+          "context": "Caiaphas's Unwitting Prophecy\nJohn explicitly identifies Caiaphas's statement as prophecy (v.51) — not despite its cynical political motivation but through it. Caiaphas intends a piece of political pragmatism: sacrifice one troublemaker to preserve the nation's peace with Rome. God speaks through this cynicism the deepest truth of the atonement: the one dies for the many. John's double-level narrative reaches its apex here: the very words used to condemn Jesus proclaim the gospel."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 38\u201344 \u2014 The Tomb Opened; Lazarus Come Forth",
+      "header": "Verses 38–44 — The Tomb Opened; Lazarus Come Forth",
       "verse_start": 38,
       "verse_end": 44,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi h\u0113 anastasis kai h\u0113 z\u014d\u0113",
-            "transliteration": "e-GO ei-MI h\u0113 a-NAS-ta-sis kai h\u0113 ZO-\u0113",
+            "word": "egō eimi hē anastasis kai hē zōē",
+            "transliteration": "e-GO ei-MI hē a-NAS-ta-sis kai hē ZO-ē",
             "gloss": "I am the resurrection and the life",
-            "paragraph": "The fifth I am saying with predicate \u2014 and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense \u2014 the resurrection is present, not merely future, because it is a person, not merely an event."
+            "paragraph": "The fifth I am saying with predicate — and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense — the resurrection is present, not merely future, because it is a person, not merely an event."
           },
           {
             "word": "edakrysen",
             "transliteration": "e-DAK-ry-sen",
             "gloss": "Jesus wept",
-            "paragraph": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakry\u014d \u2014 to weep quietly, to shed tears \u2014 rather than klai\u014d (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
+            "paragraph": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakryō — to weep quietly, to shed tears — rather than klaiō (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
-            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus \u2014 Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
+            "coords": "31.7742° N, 35.2659° E",
+            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus — Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ezek 37:12-13",
-              "note": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" \u2014 the valley of dry bones as background for Lazarus's resurrection."
+              "note": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" — the valley of dry bones as background for Lazarus's resurrection."
             },
             {
               "ref": "1 Kgs 17:17-24",
-              "note": "Elijah raising the widow's son \u2014 the OT parallel that frames raising the dead as a prophetic act establishing divine credentials."
+              "note": "Elijah raising the widow's son — the OT parallel that frames raising the dead as a prophetic act establishing divine credentials."
             },
             {
               "ref": "Rom 8:11",
-              "note": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" \u2014 Paul's application of the resurrection principle to believers."
+              "note": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" — Paul's application of the resurrection principle to believers."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:4",
-              "note": "\"This sickness will not end in death. No, it is for God's glory so that God's Son may be glorified through it\" \u2014 the same theodicy principle as John 9:3. Jesus sees the illness not as a tragedy to be prevented but as the occasion for a revelation of divine glory. His two-day delay (v.6) is not negligence but purposive waiting: he is waiting until the death is unambiguous so the glory will be unmistakable."
-            },
-            {
-              "ref": "11:25-26",
-              "note": "\"I am the resurrection and the life\" \u2014 the saying has two parts: (1) \"The one who believes in me will live, even though they die\" \u2014 physical death does not end the life of the believer; (2) \"Whoever lives by believing in me will never die\" \u2014 the spiritual life in Christ has no terminus. The first addresses the believer who has died (like Lazarus); the second addresses the living believer. Together they cover the whole range of Christian mortality."
-            },
-            {
-              "ref": "11:35",
-              "note": "\"Jesus wept\" \u2014 the theological weight of this shortest verse is enormous. The omniscient Son of God, who knows he is about to raise Lazarus, weeps over his friend's death. Why? Not because death has surprised him or because he fears it cannot be reversed \u2014 but because death is genuinely grievous. God weeps over death even as he overcomes it. The tears are not performance but the expression of genuine solidarity with human suffering."
-            },
-            {
-              "ref": "11:43-44",
-              "note": "\"Lazarus, come forth!\" \u2014 the bare command, the response of a dead man. The graveclothes-bound figure emerging from the cave is one of the most visually powerful moments in the Gospels. Jesus then gives the command that will define the church's ongoing ministry: \"Loose him, and let him go.\" The raising is Jesus's work; the loosing is the community's work."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:4",
-              "note": "Calvin notes the deliberate delay as the most instructive element in the narrative: Jesus waits so that the glory of God may be displayed more fully. The lesson for suffering believers: God sometimes delays his answer to prayer not from indifference but from a purpose of greater revelation. The greater the darkness before the dawn, the more clearly the light is seen."
-            },
-            {
-              "ref": "11:25-27",
-              "note": "Martha's confession (\"I believe that you are the Messiah, the Son of God, who is to come into the world\") is, for Calvin, the most complete confession in John before Thomas's post-resurrection \"My Lord and my God!\" (20:28). It encompasses messiahship, divine Sonship, and incarnation. It is spoken in the context of grief and unanswered prayer \u2014 making it more remarkable, not less."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:33",
-              "note": "The two Greek verbs \u2014 embrimaomai (\"groaned/was deeply moved\") and tarasso (\"was troubled\") \u2014 are both strong emotional terms. The most natural reading is genuine emotional distress at the sight of Mary and the mourners weeping. Some scholars have argued Jesus was troubled by the unbelief he saw (v.37's critical question); others by the prospect of his own coming death (triggered by this anticipatory raising). The text does not specify the object of the groaning."
-            },
-            {
-              "ref": "11:44",
-              "note": "\"Loose him, and let him go\" \u2014 the Greek lysate auton kai aphete auton hupagein has been read theologically as a command to the church: the resurrection is Christ's work; the loosing of the graveclothes is the community's ministry \u2014 freeing those whom Christ has raised from the bindings of their former life."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:25",
-              "note": "Augustine: \"I am the resurrection \u2014 not merely 'I give resurrection' but 'I am the resurrection.' He himself is what he gives. He himself is what he promises. To have him is to have life. To lose him is to die. If you believe in me, even though you die, you will live \u2014 because I am the life.\""
-            },
-            {
-              "ref": "11:35",
-              "note": "Chrysostom: \"Jesus wept. He wept not as one ignorant of what would happen, nor as doubting his own power, but to show that he was truly human, to show that he felt real grief at real death. He wept to comfort the sisters and to show that he too regarded death as an evil \u2014 though an evil he was about to overcome.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Four Days in the Tomb\nThe detail that Lazarus had been in the tomb four days (v.17) is theologically significant. Jewish tradition held that the soul hovered near the body for three days in hope of return; after three days decomposition was visible and the soul departed finally. By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience or a three-day hover. \"He stinketh\" (v.39, KJV) \u2014 Martha's pragmatic observation \u2014 confirms the death is genuine and total.\n\nThe Seventh Sign\nThe raising of Lazarus is the seventh and climactic sign in John's Gospel \u2014 deliberately ordered so that the resurrection of a dead man is the final demonstration of who Jesus is before the cross. The sign's effect is double: many Jews believed (v.45); the Sanhedrin resolved to kill Jesus (11:47-53). The sign that demonstrates Jesus has power over death also triggers the events that will lead to his own death."
+          "context": "Four Days in the Tomb\nThe detail that Lazarus had been in the tomb four days (v.17) is theologically significant. Jewish tradition held that the soul hovered near the body for three days in hope of return; after three days decomposition was visible and the soul departed finally. By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience or a three-day hover. \"He stinketh\" (v.39, KJV) — Martha's pragmatic observation — confirms the death is genuine and total.\n\nThe Seventh Sign\nThe raising of Lazarus is the seventh and climactic sign in John's Gospel — deliberately ordered so that the resurrection of a dead man is the final demonstration of who Jesus is before the cross. The sign's effect is double: many Jews believed (v.45); the Sanhedrin resolved to kill Jesus (11:47-53). The sign that demonstrates Jesus has power over death also triggers the events that will lead to his own death."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 45\u201357 \u2014 The Sanhedrin Plots; Caiaphas\u2019 Prophecy",
+      "header": "Verses 45–57 — The Sanhedrin Plots; Caiaphas’ Prophecy",
       "verse_start": 45,
       "verse_end": 57,
       "panels": {
@@ -332,86 +288,46 @@
             "word": "sympherei",
             "transliteration": "sym-PHE-rei",
             "gloss": "it is expedient / it is profitable",
-            "paragraph": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei \u2014 a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
+            "paragraph": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei — a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
-            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus \u2014 Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
+            "coords": "31.7742° N, 35.2659° E",
+            "text": "A village on the eastern slope of the Mount of Olives, about 2 miles (3km) from Jerusalem (v.18). The home of Mary, Martha, and Lazarus — Jesus's closest family-friends in the Jerusalem area. He stayed here during the final week (12:1; Matt 21:17). The traditional site of Lazarus's tomb is preserved in the village of al-Eizariya (Arabic: \"the place of Lazarus\"), where a Byzantine-era tomb-chapel has been venerated since at least the 4th century AD."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 53:8",
-              "note": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" \u2014 the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express."
+              "note": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" — the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express."
             },
             {
               "ref": "John 18:14",
-              "note": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" \u2014 John refers back to this moment at the trial, reminding the reader of its ironic prophetic character."
+              "note": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" — John refers back to this moment at the trial, reminding the reader of its ironic prophetic character."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:49-52",
-              "note": "Caiaphas's statement is both the ugliest political calculation in the Gospel and the most accurate theological statement about the atonement outside of the explicit Passion narrative. He means: execute this man to prevent a Roman reprisal. John hears: one man dies in the place of the people so that the people may live. The scattered children of God (v.52) \u2014 the Gentiles \u2014 are brought into the scope of the one man's death. The high priest who plots the murder is the instrument of the prophecy he cannot understand."
-            },
-            {
-              "ref": "11:45-48",
-              "note": "The Sanhedrin's fear \u2014 \"everyone will believe in him, and then the Romans will come and take away our place and nation\" \u2014 reveals that the threat they fear from Jesus is political and institutional, not theological. MacArthur points out the tragic irony: the very thing they move to prevent (the destruction of the nation) was brought about by their action."
-            },
-            {
-              "ref": "11:53-57",
-              "note": "The plot to kill Jesus is now official policy, not individual spite. John notes Jesus withdrew to Ephraim and that the Passover was near \u2014 placing the coming crucifixion on the Passover calendar deliberately. The crowd wondering whether Jesus will come to the feast (v56) heightens the dramatic irony: he will come, and it will cost him everything."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:51",
-              "note": "Calvin uses Caiaphas as the supreme example of the fact that God can achieve his purposes through the most unlikely and even wicked instruments. Caiaphas had no intention of proclaiming the gospel; he was saving his political skin. But God's sovereign providence overruled his intention and made his words serve the purpose of divine revelation. Calvin connects this to his broader theology of secondary causation: human beings act freely; God's purpose is simultaneously accomplished."
-            },
-            {
-              "ref": "11:49-53",
-              "note": "Calvin identifies the irony of Caiaphas's prophecy as one of the most arresting moments in Scripture: \"the high priest, a wicked and unworthy man, was compelled to utter an oracle against his will.\" Calvin connects this to Balaam (Num 22-24) and argues that God sometimes uses ungodly instruments to proclaim his decrees precisely so that those decrees cannot be attributed to human wisdom or planning."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:49",
-              "note": "\"Who was high priest that year\" \u2014 John mentions the annual character of Caiaphas's high priesthood three times (11:49, 51; 18:13). This may be because Josephus describes several high priests serving in rapid succession in this period (though the high priesthood was technically for life). Caiaphas actually served unusually long: AD 18-36."
-            },
-            {
-              "ref": "11:51-52",
-              "note": "The NET Bible notes that John's editorial comment (\"he did not say this on his own\") is unique in the Gospel \u2014 John explicitly interprets the speech as unconscious prophecy. The phrase \"scattered children of God\" (v52) picks up the Diaspora language of Jewish expectation and reapplies it: the ingathering of the nations is through the atoning death of Jesus. John cites Ezekiel 34:12 and 37:21 as the prophetic background."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:50",
-              "note": "Augustine: \"He spoke better than he knew. He said it out of wickedness, but God used it for salvation. A murderer's counsel became the voice of prophecy. One man should die for the people \u2014 yes, and not for that nation only, but to gather together the children of God who are scattered abroad.\""
-            },
-            {
-              "ref": "11:49-52",
-              "note": "The Catena preserves Theophylact's observation that Caiaphas, by virtue of his office, retained the prophetic gift even while being personally wicked \u2014 as the Urim and Thummim functioned through the high-priestly office regardless of the individual. Cyril of Alexandria adds that \"the whole nation\" in v50 and \"the scattered children of God\" in v52 form a two-part prophecy: the particular atonement for Israel and the universal gathering of the Gentiles."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Caiaphas's Unwitting Prophecy\nJohn explicitly identifies Caiaphas's statement as prophecy (v.51) \u2014 not despite its cynical political motivation but through it. Caiaphas intends a piece of political pragmatism: sacrifice one troublemaker to preserve the nation's peace with Rome. God speaks through this cynicism the deepest truth of the atonement: the one dies for the many. John's double-level narrative reaches its apex here: the very words used to condemn Jesus proclaim the gospel."
+          "context": "Caiaphas's Unwitting Prophecy\nJohn explicitly identifies Caiaphas's statement as prophecy (v.51) — not despite its cynical political motivation but through it. Caiaphas intends a piece of political pragmatism: sacrifice one troublemaker to preserve the nation's peace with Rome. God speaks through this cynicism the deepest truth of the atonement: the one dies for the many. John's double-level narrative reaches its apex here: the very words used to condemn Jesus proclaim the gospel."
         }
       }
     }
@@ -421,20 +337,20 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience  Context  [(\"Caiaphas's Unwitting Prophecy\", \"John explicitly identifies Caiaphas's statement as prophecy (v\u2026"
+        "text": "By waiting four days, Jesus ensures that no one can attribute the resurrection to a near-death experience  Context  [(\"Caiaphas's Unwitting Prophecy\", \"John explicitly identifies Caiaphas's statement as prophecy (v…"
       },
       {
         "name": "Lazarus",
         "role": "Key biblical figure",
-        "text": "Context  [('Four Days in the Tomb', 'The detail that Lazarus had been in the tomb four days (v\u2026"
+        "text": "Context  [('Four Days in the Tomb', 'The detail that Lazarus had been in the tomb four days (v…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anastasis kai z\u014d\u0113 (11:25)</td><td>NIV/KJV/ESV/NRSV: \"resurrection and life\". Universal agreement. The two nouns are held together: resurrection (reversal of death) and life (positive existence). Jesus is both.</td></tr><tr><td class=\"t-label\">edakrysen (11:35)</td><td>NIV: \"Jesus wept\"; KJV: \"Jesus wept\"; ESV: \"Jesus wept\"; NRSV: \"Jesus began to weep\". Universal agreement on the two-word form; NRSV's \"began to weep\" captures the ingressive aorist.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anastasis kai zōē (11:25)</td><td>NIV/KJV/ESV/NRSV: \"resurrection and life\". Universal agreement. The two nouns are held together: resurrection (reversal of death) and life (positive existence). Jesus is both.</td></tr><tr><td class=\"t-label\">edakrysen (11:35)</td><td>NIV: \"Jesus wept\"; KJV: \"Jesus wept\"; ESV: \"Jesus wept\"; NRSV: \"Jesus began to weep\". Universal agreement on the two-word form; NRSV's \"began to weep\" captures the ingressive aorist.</td></tr>",
     "src": [
       {
         "title": "2 Kings 4:32-37",
         "quote": "Elisha raises the Shunammite woman's son: \"He went in, shut the door on the two of them and prayed to the Lord... the boy sneezed seven times and opened his eyes.\"",
-        "note": "The closest OT parallel to the Lazarus raising \u2014 a prophet brings back a dead child. The contrast with Jesus is deliberate: Elisha prays to the Lord and uses physical means; Jesus commands with his own authority and thanks the Father for hearing him."
+        "note": "The closest OT parallel to the Lazarus raising — a prophet brings back a dead child. The contrast with Jesus is deliberate: Elisha prays to the Lord and uses physical means; Jesus commands with his own authority and thanks the Father for hearing him."
       }
     ],
     "rec": [
@@ -444,24 +360,24 @@
       },
       {
         "who": "Caiaphas and the Problem of Evil-Serving Providence",
-        "text": "John's explicit identification of Caiaphas's cynical political calculation as unwitting prophecy has generated sustained theological reflection on how God uses evil for redemptive ends without becoming its author. Augustine's treatment in City of God, Calvin's doctrine of providential concurrence, and modern discussions of \"meticulous providence\" all grapple with the Caiaphas paradigm: wicked human intention \u2192 divine redemptive purpose, simultaneously, through the same act."
+        "text": "John's explicit identification of Caiaphas's cynical political calculation as unwitting prophecy has generated sustained theological reflection on how God uses evil for redemptive ends without becoming its author. Augustine's treatment in City of God, Calvin's doctrine of providential concurrence, and modern discussions of \"meticulous providence\" all grapple with the Caiaphas paradigm: wicked human intention → divine redemptive purpose, simultaneously, through the same act."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "The Seventh Sign \u2014 ch.11",
+          "label": "The Seventh Sign — ch.11",
           "text": "The raising of Lazarus is the seventh and climactic sign, bringing the Book of Signs (chs 1-12) to its conclusion. Seven is the number of completeness; the seventh sign surpasses all others by raising someone four days dead. After this sign, Jesus's own death and resurrection are the inevitable next movement.",
           "is_key": false
         },
         {
-          "label": "Double Meaning of \"Glorify\" \u2014 vv.4, 40",
-          "text": "\"God's Son may be glorified through it\" (v.4) and \"you will see the glory of God\" (v.40) \u2014 the glory revealed in Lazarus's raising anticipates the greater glorification of the cross-and-resurrection. In John, glory is paradoxically revealed in death overcome.",
+          "label": "Double Meaning of \"Glorify\" — vv.4, 40",
+          "text": "\"God's Son may be glorified through it\" (v.4) and \"you will see the glory of God\" (v.40) — the glory revealed in Lazarus's raising anticipates the greater glorification of the cross-and-resurrection. In John, glory is paradoxically revealed in death overcome.",
           "is_key": false
         },
         {
-          "label": "Death/Life Reversal \u2014 vv.25-26",
-          "text": "Martha's statement \"he will rise again in the resurrection at the last day\" (v24) is a conventional Jewish eschatology. Jesus deliberately shifts it to the present: \"I am the resurrection.\" John frames the entire chapter to climax at this redefinition \u2014 the raising of Lazarus becomes proof of the claim.",
+          "label": "Death/Life Reversal — vv.25-26",
+          "text": "Martha's statement \"he will rise again in the resurrection at the last day\" (v24) is a conventional Jewish eschatology. Jesus deliberately shifts it to the present: \"I am the resurrection.\" John frames the entire chapter to climax at this redefinition — the raising of Lazarus becomes proof of the claim.",
           "is_key": false
         }
       ],
@@ -469,40 +385,40 @@
     },
     "hebtext": [
       {
-        "word": "eg\u014d eimi h\u0113 anastasis kai h\u0113 z\u014d\u0113",
-        "tlit": "e-GO ei-MI h\u0113 a-NAS-ta-sis kai h\u0113 ZO-\u0113",
+        "word": "egō eimi hē anastasis kai hē zōē",
+        "tlit": "e-GO ei-MI hē a-NAS-ta-sis kai hē ZO-ē",
         "gloss": "I am the resurrection and the life",
-        "note": "The fifth I am saying with predicate \u2014 and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense \u2014 the resurrection is present, not merely future, because it is a person, not merely an event."
+        "note": "The fifth I am saying with predicate — and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense — the resurrection is present, not merely future, because it is a person, not merely an event."
       },
       {
         "word": "edakrysen",
         "tlit": "e-DAK-ry-sen",
         "gloss": "Jesus wept",
-        "note": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakry\u014d \u2014 to weep quietly, to shed tears \u2014 rather than klai\u014d (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
+        "note": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakryō — to weep quietly, to shed tears — rather than klaiō (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
       },
       {
         "word": "sympherei",
         "tlit": "sym-PHE-rei",
         "gloss": "it is expedient / it is profitable",
-        "note": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei \u2014 a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
+        "note": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei — a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
       },
       {
-        "word": "eg\u014d eimi h\u0113 anastasis kai h\u0113 z\u014d\u0113",
-        "tlit": "e-GO ei-MI h\u0113 a-NAS-ta-sis kai h\u0113 ZO-\u0113",
+        "word": "egō eimi hē anastasis kai hē zōē",
+        "tlit": "e-GO ei-MI hē a-NAS-ta-sis kai hē ZO-ē",
         "gloss": "I am the resurrection and the life",
-        "note": "The fifth I am saying with predicate \u2014 and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense \u2014 the resurrection is present, not merely future, because it is a person, not merely an event."
+        "note": "The fifth I am saying with predicate — and the most personally consoling. Jesus does not merely promise resurrection or give life as a future benefit; he is himself the resurrection and the life. Martha has a correct future-tense eschatology (\"he will rise at the last day,\" v.24); Jesus corrects not the content but the tense — the resurrection is present, not merely future, because it is a person, not merely an event."
       },
       {
         "word": "edakrysen",
         "tlit": "e-DAK-ry-sen",
         "gloss": "Jesus wept",
-        "note": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakry\u014d \u2014 to weep quietly, to shed tears \u2014 rather than klai\u014d (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
+        "note": "The shortest verse in the Bible (in English: \"Jesus wept\") uses dakryō — to weep quietly, to shed tears — rather than klaiō (to weep loudly/sob, used of Mary and the Jews, v.33). Jesus's tears are quiet, controlled, yet real. He is not performing grief for the crowd; he is genuinely moved. The tears are the most direct window into the humanity of the incarnate Son."
       },
       {
         "word": "sympherei",
         "tlit": "sym-PHE-rei",
         "gloss": "it is expedient / it is profitable",
-        "note": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei \u2014 a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
+        "note": "Caiaphas's pragmatic calculation (v.50: \"it is better for you that one man die\") uses the word sympherei — a political utility calculation. The irony John exposes is that Caiaphas's cynical political theology is also, unknowingly, the deepest theological truth: it was indeed necessary (though not in the way Caiaphas meant) that one man die for the people."
       }
     ],
     "thread": [
@@ -510,42 +426,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 37:12-13",
         "type": "Connection",
-        "text": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" \u2014 the valley of dry bones as background for Lazarus's resurrection.",
+        "text": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" — the valley of dry bones as background for Lazarus's resurrection.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 Kgs 17:17-24",
         "type": "Echo",
-        "text": "Elijah raising the widow's son \u2014 the OT parallel that frames raising the dead as a prophetic act establishing divine credentials.",
+        "text": "Elijah raising the widow's son — the OT parallel that frames raising the dead as a prophetic act establishing divine credentials.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Rom 8:11",
         "type": "Connection",
-        "text": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" \u2014 Paul's application of the resurrection principle to believers.",
+        "text": "\"The Spirit of him who raised Jesus from the dead is living in you; he who raised Christ from the dead will also give life to your mortal bodies\" — Paul's application of the resurrection principle to believers.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 53:8",
         "type": "Connection",
-        "text": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" \u2014 the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express.",
+        "text": "\"He was cut off from the land of the living; for the transgression of my people he was punished\" — the Servant's substitutionary death for the people, which Caiaphas's words unwittingly express.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 18:14",
         "type": "Connection",
-        "text": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" \u2014 John refers back to this moment at the trial, reminding the reader of its ironic prophetic character.",
+        "text": "\"Caiaphas was the one who had advised the Jewish leaders that it would be good if one man died for the people\" — John refers back to this moment at the trial, reminding the reader of its ironic prophetic character.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 37:12-13",
         "type": "Connection",
-        "text": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" \u2014 the valley of dry bones as background for Lazarus's resurrection.",
+        "text": "\"I will open your graves and bring you up from them... you will know that I am the Lord\" — the valley of dry bones as background for Lazarus's resurrection.",
         "direction": "backward"
       }
     ],
@@ -553,7 +469,7 @@
       {
         "ref": "11:1-2",
         "title": "Mary's identification",
-        "content": "John identifies Mary of Bethany as the one who \"poured perfume on the Lord and wiped his feet with her hair\" (v.2) \u2014 an event narrated in ch.12. This proleptic reference in ch.11 assumes the reader already knows the story from oral tradition before John narrates it in ch.12. No textual variant; the prolepsis is original.",
+        "content": "John identifies Mary of Bethany as the one who \"poured perfume on the Lord and wiped his feet with her hair\" (v.2) — an event narrated in ch.12. This proleptic reference in ch.11 assumes the reader already knows the story from oral tradition before John narrates it in ch.12. No textual variant; the prolepsis is original.",
         "note": "The identification is John's characteristic technique of clarifying characters before their major appearances."
       }
     ],
@@ -574,7 +490,7 @@
           {
             "name": "Both",
             "proponents": "N.T. Wright and others",
-            "argument": "The weeping is both genuine grief (solidarity with the sisters) and something harder to name \u2014 perhaps the weight of what is being asked of him, the shadow of his own coming death over the scene."
+            "argument": "The weeping is both genuine grief (solidarity with the sisters) and something harder to name — perhaps the weight of what is being asked of him, the shadow of his own coming death over the scene."
           }
         ]
       }
@@ -606,7 +522,7 @@
           "score": 10
         }
       ],
-      "note": "John 11 is the Gospel's emotional and theological climax before the passion. The raising of Lazarus crystallises every major theme: light and darkness (the two-day wait, the twelve-hours-of-daylight saying), belief and unbelief (many believe; some report to the Pharisees), Jesus's identity (I am the resurrection and the life), and the coming cross (Caiaphas's prophecy, the Sanhedrin's plot). The chapter weeps and commands and raises \u2014 and in doing so triggers the chain of events that will lead to the raising of the one who raises."
+      "note": "John 11 is the Gospel's emotional and theological climax before the passion. The raising of Lazarus crystallises every major theme: light and darkness (the two-day wait, the twelve-hours-of-daylight saying), belief and unbelief (many believe; some report to the Pharisees), Jesus's identity (I am the resurrection and the life), and the coming cross (Caiaphas's prophecy, the Sanhedrin's plot). The chapter weeps and commands and raises — and in doing so triggers the chain of events that will lead to the raising of the one who raises."
     }
   },
   "vhl_groups": [
@@ -725,12 +641,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Lord, if you had been here, my brother would not have died' (v. 21). Both sisters say it. Jesus weeps (v. 35)\u2014shortest verse, deepest emotion. He doesn't explain; he enters grief.",
+      "tip": "'Lord, if you had been here, my brother would not have died' (v. 21). Both sisters say it. Jesus weeps (v. 35)—shortest verse, deepest emotion. He doesn't explain; he enters grief.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 2,
-      "tip": "'I am the resurrection and the life' (v. 25). Not 'I bring' or 'I teach'\u2014'I AM.' Resurrection isn't just future event; it's present person. Lazarus emerges, four days dead. Death obeys Jesus' command.",
+      "tip": "'I am the resurrection and the life' (v. 25). Not 'I bring' or 'I teach'—'I AM.' Resurrection isn't just future event; it's present person. Lazarus emerges, four days dead. Death obeys Jesus' command.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/12.json
+++ b/content/john/12.json
@@ -7,34 +7,34 @@
   "subtitle": "The Triumphal Entry and the Hour Has Come",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 Anointing at Bethany; Plot Against Lazarus",
+      "header": "Verses 1–11 — Anointing at Bethany; Plot Against Lazarus",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
         "heb": [
           {
-            "word": "h\u0113 h\u014dra elelythen",
-            "transliteration": "h\u0113 HO-ra e-LE-ly-then",
+            "word": "hē hōra elelythen",
+            "transliteration": "hē HO-ra e-LE-ly-then",
             "gloss": "the hour has come",
-            "paragraph": "The phrase that has been deferred throughout the Gospel \u2014 \"the hour has not yet come\" (2:4; 7:30; 8:20) \u2014 now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 \u2014 the seed falls and dies) and the hour of glory (v.23 \u2014 the Son of Man is glorified)."
+            "paragraph": "The phrase that has been deferred throughout the Gospel — \"the hour has not yet come\" (2:4; 7:30; 8:20) — now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 — the seed falls and dies) and the hour of glory (v.23 — the Son of Man is glorified)."
           },
           {
             "word": "kokkos tou sitou",
             "transliteration": "KOK-kos tou SI-tou",
             "gloss": "a kernel of wheat",
-            "paragraph": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 \u2014 anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
+            "paragraph": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 — anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
+            "coords": "31.7742° N, 35.2659° E",
             "text": "Six days before Passover, Jesus returns to Bethany for the anointing dinner (12:1-2). The village on the Mount of Olives' eastern slope was Jesus's regular base during the Jerusalem visits. The dinner at which Mary anoints Jesus is held here; the next day the triumphal entry begins from the Bethphage/Bethany area on the Mount of Olives."
           }
         ],
@@ -42,41 +42,41 @@
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" \u2014 the triumphal entry prophecy John cites (v.15), abbreviated."
+              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" — the triumphal entry prophecy John cites (v.15), abbreviated."
             },
             {
               "ref": "Ps 118:25-26",
-              "note": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" \u2014 the Hallel psalm the crowd shouts; Hosanna (h\u014dsanna) means \"Save, we pray!\" \u2014 a cry that is simultaneously praise and petition."
+              "note": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" — the Hallel psalm the crowd shouts; Hosanna (hōsanna) means \"Save, we pray!\" — a cry that is simultaneously praise and petition."
             },
             {
               "ref": "Isa 6:9-10",
-              "note": "\"He has blinded their eyes and hardened their hearts\" \u2014 cited in v.40 to explain Israel's unbelief after all the signs."
+              "note": "\"He has blinded their eyes and hardened their hearts\" — cited in v.40 to explain Israel's unbelief after all the signs."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:3",
-              "note": "Mary poured a pound of nard on Jesus's feet and wiped it with her hair. A pound of nard was worth a year's wages \u2014 the most extravagant possible act of devotion. The house was filled with fragrance. Judas objects on economic grounds (v.5); Jesus defends on theological grounds: she is anointing for burial. Every act of lavish devotion to Christ is implicitly an act in preparation for, and in response to, his death."
+              "note": "Mary poured a pound of nard on Jesus's feet and wiped it with her hair. A pound of nard was worth a year's wages — the most extravagant possible act of devotion. The house was filled with fragrance. Judas objects on economic grounds (v.5); Jesus defends on theological grounds: she is anointing for burial. Every act of lavish devotion to Christ is implicitly an act in preparation for, and in response to, his death."
             },
             {
               "ref": "12:23-24",
-              "note": "\"The hour has come for the Son of Man to be glorified.\" Then immediately: \"Unless a grain of wheat falls to the ground and dies...\" The glorification is the death. John consistently presents the cross as the moment of greatest glory \u2014 not despite the suffering but through it. The grain of wheat parable says: the death is not the end of the story but the beginning of the harvest."
+              "note": "\"The hour has come for the Son of Man to be glorified.\" Then immediately: \"Unless a grain of wheat falls to the ground and dies...\" The glorification is the death. John consistently presents the cross as the moment of greatest glory — not despite the suffering but through it. The grain of wheat parable says: the death is not the end of the story but the beginning of the harvest."
             },
             {
               "ref": "12:25",
-              "note": "\"Anyone who loves their life will lose it, while anyone who hates their life in this world will keep it for eternal life\" \u2014 the paradox of discipleship stated in the most compressed form. \"Hates their life\" is Semitic hyperbole for \"loves less by comparison\" (cf. Luke 14:26): the person who does not cling to their earthly life as the ultimate value will find that their life is kept by God. The person who makes self-preservation the supreme value will ultimately lose even that."
+              "note": "\"Anyone who loves their life will lose it, while anyone who hates their life in this world will keep it for eternal life\" — the paradox of discipleship stated in the most compressed form. \"Hates their life\" is Semitic hyperbole for \"loves less by comparison\" (cf. Luke 14:26): the person who does not cling to their earthly life as the ultimate value will find that their life is kept by God. The person who makes self-preservation the supreme value will ultimately lose even that."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:7",
-              "note": "\"Leave her alone. It was intended that she should save this perfume for the day of my burial\" \u2014 Calvin defends Mary against Judas's charge not by denying the importance of the poor but by establishing the hierarchy: there are moments when extraordinary devotion to Christ is appropriate and necessary, and those moments supersede the ordinary obligation of charity. The anointing is not instead of caring for the poor; it is the once-for-all act that money cannot replace."
+              "note": "\"Leave her alone. It was intended that she should save this perfume for the day of my burial\" — Calvin defends Mary against Judas's charge not by denying the importance of the poor but by establishing the hierarchy: there are moments when extraordinary devotion to Christ is appropriate and necessary, and those moments supersede the ordinary obligation of charity. The anointing is not instead of caring for the poor; it is the once-for-all act that money cannot replace."
             },
             {
               "ref": "12:25",
@@ -85,20 +85,20 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "12:3",
-              "note": "\"About a pint of pure nard\" \u2014 litralatras, a Roman pound (approximately 327 grams or 12 ounces). Nard (nardos pistik\u0113s, \"genuine nard\") was an expensive aromatic oil imported from northern India, derived from the Nardostachys jatamansi plant. The word pistik\u0113s may mean \"genuine/authentic\" or \"liquid\" or relate to pistachio. A pound of such ointment worth a year's wages (300 denarii, v.5) would have been the household's most valuable possession."
+              "note": "\"About a pint of pure nard\" — litralatras, a Roman pound (approximately 327 grams or 12 ounces). Nard (nardos pistikēs, \"genuine nard\") was an expensive aromatic oil imported from northern India, derived from the Nardostachys jatamansi plant. The word pistikēs may mean \"genuine/authentic\" or \"liquid\" or relate to pistachio. A pound of such ointment worth a year's wages (300 denarii, v.5) would have been the household's most valuable possession."
             },
             {
               "ref": "12:20-21",
-              "note": "\"Some Greeks among those who went up to worship\" \u2014 these are almost certainly God-fearers (Gentile adherents to Judaism) or proselytes who had come to Jerusalem for Passover. Their request (\"we would like to see Jesus\") triggers the announcement of the hour. Their arrival at the threshold of the passion narrative signals the universal scope of the cross \u2014 the Son of Man will draw all people to himself (v.32)."
+              "note": "\"Some Greeks among those who went up to worship\" — these are almost certainly God-fearers (Gentile adherents to Judaism) or proselytes who had come to Jerusalem for Passover. Their request (\"we would like to see Jesus\") triggers the announcement of the hour. Their arrival at the threshold of the passion narrative signals the universal scope of the cross — the Son of Man will draw all people to himself (v.32)."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "12:24",
@@ -106,33 +106,33 @@
             },
             {
               "ref": "12:3",
-              "note": "Chrysostom: \"She poured the ointment on his feet and wiped them with her hair. What love! What devotion! She makes her head \u2014 which is the most honoured part of her body \u2014 the servant of his feet. This is love: to reverse all proper order of honour in the service of the beloved.\""
+              "note": "Chrysostom: \"She poured the ointment on his feet and wiped them with her hair. What love! What devotion! She makes her head — which is the most honoured part of her body — the servant of his feet. This is love: to reverse all proper order of honour in the service of the beloved.\""
             }
           ]
         },
         "hist": {
-          "context": "Mary's Anointing\nThe anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany; she anoints Jesus's feet rather than his head; the objector is named as Judas Iscariot; and Jesus explicitly connects it to his burial preparation. The \"pound of pure nard\" (litralatras of nardos pistik\u0113s) was an extraordinarily expensive imported perfume \u2014 the household's most valuable possession \u2014 poured out entirely.\n\nThe Triumphal Entry in John\nJohn's account of the entry is shorter than the Synoptics but adds two significant details: (1) the crowd carries palm branches and shouts \"Blessed is the King of Israel\" \u2014 explicitly messianic; (2) John notes that the disciples did not understand at the time but understood after the glorification (v.16). The post-resurrection interpretive framework is John's explicit hermeneutical key for the whole Gospel."
+          "context": "Mary's Anointing\nThe anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany; she anoints Jesus's feet rather than his head; the objector is named as Judas Iscariot; and Jesus explicitly connects it to his burial preparation. The \"pound of pure nard\" (litralatras of nardos pistikēs) was an extraordinarily expensive imported perfume — the household's most valuable possession — poured out entirely.\n\nThe Triumphal Entry in John\nJohn's account of the entry is shorter than the Synoptics but adds two significant details: (1) the crowd carries palm branches and shouts \"Blessed is the King of Israel\" — explicitly messianic; (2) John notes that the disciples did not understand at the time but understood after the glorification (v.16). The post-resurrection interpretive framework is John's explicit hermeneutical key for the whole Gospel."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201326 \u2014 The Triumphal Entry; Greeks Seek Jesus",
+      "header": "Verses 12–26 — The Triumphal Entry; Greeks Seek Jesus",
       "verse_start": 12,
       "verse_end": 26,
       "panels": {
         "heb": [
           {
-            "word": "hyps\u014dth\u014d ek t\u0113s g\u0113s",
-            "transliteration": "hyp-SO-tho ek t\u0113s GES",
+            "word": "hypsōthō ek tēs gēs",
+            "transliteration": "hyp-SO-tho ek tēs GES",
             "gloss": "lifted up from the earth",
-            "paragraph": "The third and final lifting-up prediction (3:14; 8:28; 12:32). Each has added a new dimension: healing through the lifted-up (3:14); divine self-revelation through the lifting (8:28); universal drawing through the lifting (12:32). \"I will draw all people to myself\" \u2014 the cross is not merely the vehicle of individual salvation but the universal gravitational centre of human history, drawing from every nation, culture, and time."
+            "paragraph": "The third and final lifting-up prediction (3:14; 8:28; 12:32). Each has added a new dimension: healing through the lifted-up (3:14); divine self-revelation through the lifting (8:28); universal drawing through the lifting (12:32). \"I will draw all people to myself\" — the cross is not merely the vehicle of individual salvation but the universal gravitational centre of human history, drawing from every nation, culture, and time."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
+            "coords": "31.7742° N, 35.2659° E",
             "text": "Six days before Passover, Jesus returns to Bethany for the anointing dinner (12:1-2). The village on the Mount of Olives' eastern slope was Jesus's regular base during the Jerusalem visits. The dinner at which Mary anoints Jesus is held here; the next day the triumphal entry begins from the Bethphage/Bethany area on the Mount of Olives."
           }
         ],
@@ -140,103 +140,103 @@
           "refs": [
             {
               "ref": "Isa 53:1",
-              "note": "\"Who has believed our message and to whom has the arm of the Lord been revealed?\" \u2014 cited in v.38 for the unbelief of the Jewish leadership."
+              "note": "\"Who has believed our message and to whom has the arm of the Lord been revealed?\" — cited in v.38 for the unbelief of the Jewish leadership."
             },
             {
               "ref": "Isa 6:9-10",
-              "note": "\"He has blinded their eyes and hardened their hearts\" \u2014 cited in v.40, applied to Israel's response to Jesus's signs."
+              "note": "\"He has blinded their eyes and hardened their hearts\" — cited in v.40, applied to Israel's response to Jesus's signs."
             },
             {
               "ref": "John 8:56",
-              "note": "\"Isaiah said this because he saw Jesus's glory\" \u2014 connecting to Isa 6:1 (\"I saw the Lord\") and the pre-incarnate Christ."
+              "note": "\"Isaiah said this because he saw Jesus's glory\" — connecting to Isa 6:1 (\"I saw the Lord\") and the pre-incarnate Christ."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:27-28",
-              "note": "\"Now my soul is troubled... Father, glorify your name!\" \u2014 John's equivalent of Gethsemane. The troubling of the soul (tetaraktai h\u0113 psych\u0113 mou) is the same verb used in 11:33 and 13:21. Jesus does not pray \"Father, save me from this hour\" \u2014 not because he feels no dread but because the hour is the very purpose for which he came. The prayer immediately becomes \"Father, glorify your name\" \u2014 the self-gift of the will we saw anticipated in 10:17-18."
+              "note": "\"Now my soul is troubled... Father, glorify your name!\" — John's equivalent of Gethsemane. The troubling of the soul (tetaraktai hē psychē mou) is the same verb used in 11:33 and 13:21. Jesus does not pray \"Father, save me from this hour\" — not because he feels no dread but because the hour is the very purpose for which he came. The prayer immediately becomes \"Father, glorify your name\" — the self-gift of the will we saw anticipated in 10:17-18."
             },
             {
               "ref": "12:31-32",
-              "note": "\"Now is the time for judgment on this world; now the prince of this world will be driven out. And I, when I am lifted up from the earth, will draw all people to myself\" \u2014 the cross is simultaneously judgment on the world's ruler, defeat of the prince of darkness, and universal attraction. The decisive cosmic event of history is happening in what looks like a criminal execution."
+              "note": "\"Now is the time for judgment on this world; now the prince of this world will be driven out. And I, when I am lifted up from the earth, will draw all people to myself\" — the cross is simultaneously judgment on the world's ruler, defeat of the prince of darkness, and universal attraction. The decisive cosmic event of history is happening in what looks like a criminal execution."
             },
             {
               "ref": "12:43",
-              "note": "\"They loved human praise more than praise from God\" \u2014 the anatomy of spiritual failure. It is not ignorance (they had the signs) or principled disagreement (they \"believed\") but social cowardice driven by love of approval. The love of human praise is the specific idolatry that prevents public confession of Christ. This is the sin of the secret believer."
+              "note": "\"They loved human praise more than praise from God\" — the anatomy of spiritual failure. It is not ignorance (they had the signs) or principled disagreement (they \"believed\") but social cowardice driven by love of approval. The love of human praise is the specific idolatry that prevents public confession of Christ. This is the sin of the secret believer."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:31",
-              "note": "\"Now the prince of this world will be driven out\" \u2014 Calvin sees the cross as the decisive battle in the cosmic war between God and evil. The defeat of the \"prince of this world\" is not immediate in outward appearance (evil continues after the cross) but decisive in principle: the legal and moral claim of evil over humanity has been broken. The remaining activity of the devil is the thrashing of a defeated enemy."
+              "note": "\"Now the prince of this world will be driven out\" — Calvin sees the cross as the decisive battle in the cosmic war between God and evil. The defeat of the \"prince of this world\" is not immediate in outward appearance (evil continues after the cross) but decisive in principle: the legal and moral claim of evil over humanity has been broken. The remaining activity of the devil is the thrashing of a defeated enemy."
             },
             {
               "ref": "12:40",
-              "note": "The hardening passage (Isa 6:9-10) raises the question of divine agency in human unbelief. Calvin insists that God does not compel people to sin but does harden those who have already chosen rebellion \u2014 removing the possibility of repentance as a just judicial act. The hardening is not the first step in the chain but a response to prior and persistent rejection."
+              "note": "The hardening passage (Isa 6:9-10) raises the question of divine agency in human unbelief. Calvin insists that God does not compel people to sin but does harden those who have already chosen rebellion — removing the possibility of repentance as a just judicial act. The hardening is not the first step in the chain but a response to prior and persistent rejection."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "12:41",
-              "note": "\"Isaiah said this because he saw Jesus's glory and spoke about him\" \u2014 John's claim that the glory Isaiah saw in Isa 6:1 was the pre-incarnate Christ's glory is one of the most striking OT Christological identifications in the NT. It connects John 1:18 (the Son makes the Father known) with Isa 6 (Isaiah saw \"the Lord\"): what Isaiah saw was the Son who reveals the Father \u2014 therefore Isaiah saw Jesus's glory."
+              "note": "\"Isaiah said this because he saw Jesus's glory and spoke about him\" — John's claim that the glory Isaiah saw in Isa 6:1 was the pre-incarnate Christ's glory is one of the most striking OT Christological identifications in the NT. It connects John 1:18 (the Son makes the Father known) with Isa 6 (Isaiah saw \"the Lord\"): what Isaiah saw was the Son who reveals the Father — therefore Isaiah saw Jesus's glory."
             },
             {
               "ref": "12:32",
-              "note": "\"Will draw all people to myself\" \u2014 Helk\u014d again (cf. 6:44). The question of whether this is a universal effectual drawing or a universal offer is the same debate as in 6:44. Here the universal scope is emphasized by the contrast with the Jewish-only assumption of the crowd (v.34); the cross is not for one nation only but draws from every people."
+              "note": "\"Will draw all people to myself\" — Helkō again (cf. 6:44). The question of whether this is a universal effectual drawing or a universal offer is the same debate as in 6:44. Here the universal scope is emphasized by the contrast with the Jewish-only assumption of the crowd (v.34); the cross is not for one nation only but draws from every people."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "12:32",
-              "note": "Augustine: \"I will draw all people to myself. Not all without exception \u2014 but all kinds of people: Jew and Greek, slave and free, male and female, from every nation and language. The cross is the universal magnet that draws the scattered children of God together.\""
+              "note": "Augustine: \"I will draw all people to myself. Not all without exception — but all kinds of people: Jew and Greek, slave and free, male and female, from every nation and language. The cross is the universal magnet that draws the scattered children of God together.\""
             },
             {
               "ref": "12:27",
-              "note": "Chrysostom: \"What shall I say? Father, save me from this hour? He did not say 'save me from this hour' \u2014 he refused this prayer. He shows us that it was in his power to avoid the cross if he had chosen; and he chose not to. This voluntary death is what makes it a sacrifice: not the compulsion of the executioners but the willingness of the one crucified.\""
+              "note": "Chrysostom: \"What shall I say? Father, save me from this hour? He did not say 'save me from this hour' — he refused this prayer. He shows us that it was in his power to avoid the cross if he had chosen; and he chose not to. This voluntary death is what makes it a sacrifice: not the compulsion of the executioners but the willingness of the one crucified.\""
             }
           ]
         },
         "hist": {
-          "context": "Isaiah 53 and the Servant's Suffering\nJohn cites Isaiah 53:1 (v.38) and Isaiah 6:10 (v.40) to explain Israel's unbelief. The connection to Isaiah 6 is significant: the hardening that resulted from Isaiah's prophetic ministry is the same hardening that Jesus's signs have produced. John then makes an extraordinary statement: \"Isaiah said this because he saw Jesus's glory and spoke about him\" (v.41). Isaiah's throne-room vision in Isa 6 was a vision of the pre-incarnate Christ \u2014 a direct claim to Jesus's pre-existence and divine glory.\n\nThe Secret Believers\nJohn 12:42-43 introduces a group not found in the Synoptics: leaders who believed but would not confess \"because of the Pharisees... for they loved human praise more than praise from God.\" John does not name them (Joseph of Arimathea and Nicodemus are possible candidates, 19:38-39). The passage raises the question of whether secret faith is real faith \u2014 John's answer seems to be that it is incomplete at best."
+          "context": "Isaiah 53 and the Servant's Suffering\nJohn cites Isaiah 53:1 (v.38) and Isaiah 6:10 (v.40) to explain Israel's unbelief. The connection to Isaiah 6 is significant: the hardening that resulted from Isaiah's prophetic ministry is the same hardening that Jesus's signs have produced. John then makes an extraordinary statement: \"Isaiah said this because he saw Jesus's glory and spoke about him\" (v.41). Isaiah's throne-room vision in Isa 6 was a vision of the pre-incarnate Christ — a direct claim to Jesus's pre-existence and divine glory.\n\nThe Secret Believers\nJohn 12:42-43 introduces a group not found in the Synoptics: leaders who believed but would not confess \"because of the Pharisees... for they loved human praise more than praise from God.\" John does not name them (Joseph of Arimathea and Nicodemus are possible candidates, 19:38-39). The passage raises the question of whether secret faith is real faith — John's answer seems to be that it is incomplete at best."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 27\u201350 \u2014 The Son of Man Lifted Up; Unbelief and the Father\u2019s Voice",
+      "header": "Verses 27–50 — The Son of Man Lifted Up; Unbelief and the Father’s Voice",
       "verse_start": 27,
       "verse_end": 50,
       "panels": {
         "heb": [
           {
-            "word": "h\u0113 h\u014dra elelythen",
-            "transliteration": "h\u0113 HO-ra e-LE-ly-then",
+            "word": "hē hōra elelythen",
+            "transliteration": "hē HO-ra e-LE-ly-then",
             "gloss": "the hour has come",
-            "paragraph": "The phrase that has been deferred throughout the Gospel \u2014 \"the hour has not yet come\" (2:4; 7:30; 8:20) \u2014 now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 \u2014 the seed falls and dies) and the hour of glory (v.23 \u2014 the Son of Man is glorified)."
+            "paragraph": "The phrase that has been deferred throughout the Gospel — \"the hour has not yet come\" (2:4; 7:30; 8:20) — now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 — the seed falls and dies) and the hour of glory (v.23 — the Son of Man is glorified)."
           },
           {
             "word": "kokkos tou sitou",
             "transliteration": "KOK-kos tou SI-tou",
             "gloss": "a kernel of wheat",
-            "paragraph": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 \u2014 anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
+            "paragraph": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 — anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
           }
         ],
         "places": [
           {
             "name": "Bethany",
-            "coords": "31.7742\u00b0 N, 35.2659\u00b0 E",
+            "coords": "31.7742° N, 35.2659° E",
             "text": "Six days before Passover, Jesus returns to Bethany for the anointing dinner (12:1-2). The village on the Mount of Olives' eastern slope was Jesus's regular base during the Jerusalem visits. The dinner at which Mary anoints Jesus is held here; the next day the triumphal entry begins from the Bethphage/Bethany area on the Mount of Olives."
           }
         ],
@@ -244,76 +244,36 @@
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" \u2014 the triumphal entry prophecy John cites (v.15), abbreviated."
+              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" — the triumphal entry prophecy John cites (v.15), abbreviated."
             },
             {
               "ref": "Ps 118:25-26",
-              "note": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" \u2014 the Hallel psalm the crowd shouts; Hosanna (h\u014dsanna) means \"Save, we pray!\" \u2014 a cry that is simultaneously praise and petition."
+              "note": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" — the Hallel psalm the crowd shouts; Hosanna (hōsanna) means \"Save, we pray!\" — a cry that is simultaneously praise and petition."
             },
             {
               "ref": "Isa 6:9-10",
-              "note": "\"He has blinded their eyes and hardened their hearts\" \u2014 cited in v.40 to explain Israel's unbelief after all the signs."
+              "note": "\"He has blinded their eyes and hardened their hearts\" — cited in v.40 to explain Israel's unbelief after all the signs."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:3",
-              "note": "Mary poured a pound of nard on Jesus's feet and wiped it with her hair. A pound of nard was worth a year's wages \u2014 the most extravagant possible act of devotion. The house was filled with fragrance. Judas objects on economic grounds (v.5); Jesus defends on theological grounds: she is anointing for burial. Every act of lavish devotion to Christ is implicitly an act in preparation for, and in response to, his death."
-            },
-            {
-              "ref": "12:23-24",
-              "note": "\"The hour has come for the Son of Man to be glorified.\" Then immediately: \"Unless a grain of wheat falls to the ground and dies...\" The glorification is the death. John consistently presents the cross as the moment of greatest glory \u2014 not despite the suffering but through it. The grain of wheat parable says: the death is not the end of the story but the beginning of the harvest."
-            },
-            {
-              "ref": "12:25",
-              "note": "\"Anyone who loves their life will lose it, while anyone who hates their life in this world will keep it for eternal life\" \u2014 the paradox of discipleship stated in the most compressed form. \"Hates their life\" is Semitic hyperbole for \"loves less by comparison\" (cf. Luke 14:26): the person who does not cling to their earthly life as the ultimate value will find that their life is kept by God. The person who makes self-preservation the supreme value will ultimately lose even that."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "\"Leave her alone. It was intended that she should save this perfume for the day of my burial\" \u2014 Calvin defends Mary against Judas's charge not by denying the importance of the poor but by establishing the hierarchy: there are moments when extraordinary devotion to Christ is appropriate and necessary, and those moments supersede the ordinary obligation of charity. The anointing is not instead of caring for the poor; it is the once-for-all act that money cannot replace."
-            },
-            {
-              "ref": "12:25",
-              "note": "Calvin connects \"hates their life in this world\" to the entire theology of cross-bearing in the Gospels: the Christian life involves a genuine dying to self, not merely a pious metaphor. Those who cling to the present world-order will lose even that; those who release it in response to Christ's call will find it transformed and returned in the age to come."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:3",
-              "note": "\"About a pint of pure nard\" \u2014 litralatras, a Roman pound (approximately 327 grams or 12 ounces). Nard (nardos pistik\u0113s, \"genuine nard\") was an expensive aromatic oil imported from northern India, derived from the Nardostachys jatamansi plant. The word pistik\u0113s may mean \"genuine/authentic\" or \"liquid\" or relate to pistachio. A pound of such ointment worth a year's wages (300 denarii, v.5) would have been the household's most valuable possession."
-            },
-            {
-              "ref": "12:20-21",
-              "note": "\"Some Greeks among those who went up to worship\" \u2014 these are almost certainly God-fearers (Gentile adherents to Judaism) or proselytes who had come to Jerusalem for Passover. Their request (\"we would like to see Jesus\") triggers the announcement of the hour. Their arrival at the threshold of the passion narrative signals the universal scope of the cross \u2014 the Son of Man will draw all people to himself (v.32)."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "12:24",
-              "note": "Augustine: \"Unless a grain of wheat falls into the earth and dies... What is the grain of wheat? Christ. What is the death? The cross. What is the harvest? The resurrection. What are the many seeds? The nations who believe. He was alone; he died; he rose; and he was not alone anymore.\""
-            },
-            {
-              "ref": "12:3",
-              "note": "Chrysostom: \"She poured the ointment on his feet and wiped them with her hair. What love! What devotion! She makes her head \u2014 which is the most honoured part of her body \u2014 the servant of his feet. This is love: to reverse all proper order of honour in the service of the beloved.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Mary's Anointing\nThe anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany; she anoints Jesus's feet rather than his head; the objector is named as Judas Iscariot; and Jesus explicitly connects it to his burial preparation. The \"pound of pure nard\" (litralatras of nardos pistik\u0113s) was an extraordinarily expensive imported perfume \u2014 the household's most valuable possession \u2014 poured out entirely.\n\nThe Triumphal Entry in John\nJohn's account of the entry is shorter than the Synoptics but adds two significant details: (1) the crowd carries palm branches and shouts \"Blessed is the King of Israel\" \u2014 explicitly messianic; (2) John notes that the disciples did not understand at the time but understood after the glorification (v.16). The post-resurrection interpretive framework is John's explicit hermeneutical key for the whole Gospel."
+          "context": "Mary's Anointing\nThe anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany; she anoints Jesus's feet rather than his head; the objector is named as Judas Iscariot; and Jesus explicitly connects it to his burial preparation. The \"pound of pure nard\" (litralatras of nardos pistikēs) was an extraordinarily expensive imported perfume — the household's most valuable possession — poured out entirely.\n\nThe Triumphal Entry in John\nJohn's account of the entry is shorter than the Synoptics but adds two significant details: (1) the crowd carries palm branches and shouts \"Blessed is the King of Israel\" — explicitly messianic; (2) John notes that the disciples did not understand at the time but understood after the glorification (v.16). The post-resurrection interpretive framework is John's explicit hermeneutical key for the whole Gospel."
         }
       }
     }
@@ -323,15 +283,15 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "she anoints Jesus\\'s feet rather than his head\u2026"
+        "text": "she anoints Jesus\\'s feet rather than his head…"
       },
       {
         "name": "Mary",
         "role": "Key biblical figure",
-        "text": "Context  [(\"Mary's Anointing\", 'The anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany\u2026"
+        "text": "Context  [(\"Mary's Anointing\", 'The anointing at Bethany parallels the Synoptic accounts but with characteristic Johannine differences: the woman is identified as Mary of Bethany…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">nardos pistik\u0113s (12:3)</td><td>NIV: \"pure nard\"; KJV: \"spikenard, very costly\"; ESV: \"pure nard\"; NRSV: \"pure nard\". The word pistik\u0113s (genuine/liquid?) is rendered \"pure\" by NIV/ESV/NRSV. The costliness is captured better by the \"year's wages\" note.</td></tr><tr><td class=\"t-label\">pantas (12:32)</td><td>NIV: \"all people\"; KJV: \"all men\"; ESV: \"all people\"; NRSV: \"all people\". Universal agreement. The scope (\"all people\") is accurate; the mechanism (drawing as irresistible vs. universal offer) is the theological debate.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">nardos pistikēs (12:3)</td><td>NIV: \"pure nard\"; KJV: \"spikenard, very costly\"; ESV: \"pure nard\"; NRSV: \"pure nard\". The word pistikēs (genuine/liquid?) is rendered \"pure\" by NIV/ESV/NRSV. The costliness is captured better by the \"year's wages\" note.</td></tr><tr><td class=\"t-label\">pantas (12:32)</td><td>NIV: \"all people\"; KJV: \"all men\"; ESV: \"all people\"; NRSV: \"all people\". Universal agreement. The scope (\"all people\") is accurate; the mechanism (drawing as irresistible vs. universal offer) is the theological debate.</td></tr>",
     "src": [
       {
         "title": "Isaiah 6:1-4",
@@ -342,7 +302,7 @@
     "rec": [
       {
         "who": "Mary's Anointing in Christian Devotion",
-        "text": "\"Wherever this gospel is preached throughout the world, what she has done will also be told, in memory of her\" (Matt 26:13). Mary of Bethany's act has been commemorated in Christian devotion for two millennia. The extravagance of the gift \u2014 pouring out everything \u2014 has been cited in every generation as the model of genuine devotion to Christ. Gerard Manley Hopkins's poem \"The Wreck of the Deutschland\" echoes the \"lovely in limbs, and lovely in eyes not his\" language of lavish self-gift in response to Christ."
+        "text": "\"Wherever this gospel is preached throughout the world, what she has done will also be told, in memory of her\" (Matt 26:13). Mary of Bethany's act has been commemorated in Christian devotion for two millennia. The extravagance of the gift — pouring out everything — has been cited in every generation as the model of genuine devotion to Christ. Gerard Manley Hopkins's poem \"The Wreck of the Deutschland\" echoes the \"lovely in limbs, and lovely in eyes not his\" language of lavish self-gift in response to Christ."
       },
       {
         "who": "\"I Will Draw All People\" and Atonement Theology",
@@ -352,13 +312,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Book of Signs Closure \u2014 vv.37-43",
-          "text": "Chapter 12 closes the public ministry with a theological summary (vv.37-43) citing Isaiah 53:1 and 6:10. John identifies the hardening of Israel's heart as the fulfilment of prophecy, not its contradiction \u2014 a literary device that reframes the entire signs narrative as expected, not surprising.",
+          "label": "Book of Signs Closure — vv.37-43",
+          "text": "Chapter 12 closes the public ministry with a theological summary (vv.37-43) citing Isaiah 53:1 and 6:10. John identifies the hardening of Israel's heart as the fulfilment of prophecy, not its contradiction — a literary device that reframes the entire signs narrative as expected, not surprising.",
           "is_key": false
         },
         {
-          "label": "Anointing / Entry / Greeks \u2014 Structural Triad",
-          "text": "The chapter's three scenes form a deliberate sequence: Mary's anointing (private worship, vv.1-8) \u2192 triumphal entry (public acclamation, vv.12-19) \u2192 Greeks seeking Jesus (Gentile inclusion, vv.20-26). The movement from intimate discipleship to universal mission models the Gospel's expanding scope.",
+          "label": "Anointing / Entry / Greeks — Structural Triad",
+          "text": "The chapter's three scenes form a deliberate sequence: Mary's anointing (private worship, vv.1-8) → triumphal entry (public acclamation, vv.12-19) → Greeks seeking Jesus (Gentile inclusion, vv.20-26). The movement from intimate discipleship to universal mission models the Gospel's expanding scope.",
           "is_key": false
         }
       ],
@@ -366,34 +326,34 @@
     },
     "hebtext": [
       {
-        "word": "h\u0113 h\u014dra elelythen",
-        "tlit": "h\u0113 HO-ra e-LE-ly-then",
+        "word": "hē hōra elelythen",
+        "tlit": "hē HO-ra e-LE-ly-then",
         "gloss": "the hour has come",
-        "note": "The phrase that has been deferred throughout the Gospel \u2014 \"the hour has not yet come\" (2:4; 7:30; 8:20) \u2014 now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 \u2014 the seed falls and dies) and the hour of glory (v.23 \u2014 the Son of Man is glorified)."
+        "note": "The phrase that has been deferred throughout the Gospel — \"the hour has not yet come\" (2:4; 7:30; 8:20) — now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 — the seed falls and dies) and the hour of glory (v.23 — the Son of Man is glorified)."
       },
       {
         "word": "kokkos tou sitou",
         "tlit": "KOK-kos tou SI-tou",
         "gloss": "a kernel of wheat",
-        "note": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 \u2014 anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
+        "note": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 — anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
       },
       {
-        "word": "hyps\u014dth\u014d ek t\u0113s g\u0113s",
-        "tlit": "hyp-SO-tho ek t\u0113s GES",
+        "word": "hypsōthō ek tēs gēs",
+        "tlit": "hyp-SO-tho ek tēs GES",
         "gloss": "lifted up from the earth",
-        "note": "The third and final lifting-up prediction (3:14; 8:28; 12:32). Each has added a new dimension: healing through the lifted-up (3:14); divine self-revelation through the lifting (8:28); universal drawing through the lifting (12:32). \"I will draw all people to myself\" \u2014 the cross is not merely the vehicle of individual salvation but the universal gravitational centre of human history, drawing from every nation, culture, and time."
+        "note": "The third and final lifting-up prediction (3:14; 8:28; 12:32). Each has added a new dimension: healing through the lifted-up (3:14); divine self-revelation through the lifting (8:28); universal drawing through the lifting (12:32). \"I will draw all people to myself\" — the cross is not merely the vehicle of individual salvation but the universal gravitational centre of human history, drawing from every nation, culture, and time."
       },
       {
-        "word": "h\u0113 h\u014dra elelythen",
-        "tlit": "h\u0113 HO-ra e-LE-ly-then",
+        "word": "hē hōra elelythen",
+        "tlit": "hē HO-ra e-LE-ly-then",
         "gloss": "the hour has come",
-        "note": "The phrase that has been deferred throughout the Gospel \u2014 \"the hour has not yet come\" (2:4; 7:30; 8:20) \u2014 now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 \u2014 the seed falls and dies) and the hour of glory (v.23 \u2014 the Son of Man is glorified)."
+        "note": "The phrase that has been deferred throughout the Gospel — \"the hour has not yet come\" (2:4; 7:30; 8:20) — now arrives. The Greeks' request (\"we would like to see Jesus\") triggers it: the first Gentile inquiry at the threshold of the passion is the sign that the universal scope of the cross is imminent. The \"hour\" is simultaneously the hour of death (v.24 — the seed falls and dies) and the hour of glory (v.23 — the Son of Man is glorified)."
       },
       {
         "word": "kokkos tou sitou",
         "tlit": "KOK-kos tou SI-tou",
         "gloss": "a kernel of wheat",
-        "note": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 \u2014 anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
+        "note": "The agricultural image (v.24) is Jesus's self-description as the seed that must die to produce a harvest. The principle applies universally (v.25 — anyone who loves/hates their life) but its primary referent is Jesus himself: his death is the condition for the many seeds (the believing community). The death is necessary; the fruitfulness is guaranteed."
       }
     ],
     "thread": [
@@ -401,42 +361,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Zech 9:9",
         "type": "Connection",
-        "text": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" \u2014 the triumphal entry prophecy John cites (v.15), abbreviated.",
+        "text": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" — the triumphal entry prophecy John cites (v.15), abbreviated.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 118:25-26",
         "type": "Connection",
-        "text": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" \u2014 the Hallel psalm the crowd shouts; Hosanna (h\u014dsanna) means \"Save, we pray!\" \u2014 a cry that is simultaneously praise and petition.",
+        "text": "\"Hosanna!\" \"Blessed is he who comes in the name of the Lord!\" — the Hallel psalm the crowd shouts; Hosanna (hōsanna) means \"Save, we pray!\" — a cry that is simultaneously praise and petition.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 6:9-10",
         "type": "Connection",
-        "text": "\"He has blinded their eyes and hardened their hearts\" \u2014 cited in v.40 to explain Israel's unbelief after all the signs.",
+        "text": "\"He has blinded their eyes and hardened their hearts\" — cited in v.40 to explain Israel's unbelief after all the signs.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 53:1",
         "type": "Connection",
-        "text": "\"Who has believed our message and to whom has the arm of the Lord been revealed?\" \u2014 cited in v.38 for the unbelief of the Jewish leadership.",
+        "text": "\"Who has believed our message and to whom has the arm of the Lord been revealed?\" — cited in v.38 for the unbelief of the Jewish leadership.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 6:9-10",
         "type": "Connection",
-        "text": "\"He has blinded their eyes and hardened their hearts\" \u2014 cited in v.40, applied to Israel's response to Jesus's signs.",
+        "text": "\"He has blinded their eyes and hardened their hearts\" — cited in v.40, applied to Israel's response to Jesus's signs.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 8:56",
         "type": "Connection",
-        "text": "\"Isaiah said this because he saw Jesus's glory\" \u2014 connecting to Isa 6:1 (\"I saw the Lord\") and the pre-incarnate Christ.",
+        "text": "\"Isaiah said this because he saw Jesus's glory\" — connecting to Isa 6:1 (\"I saw the Lord\") and the pre-incarnate Christ.",
         "direction": "backward"
       }
     ],
@@ -444,7 +404,7 @@
       {
         "ref": "12:7",
         "title": "\"It was intended that she should save this perfume for the day of my burial\"",
-        "content": "The Greek aphes aut\u0113n, hina eis t\u0113n h\u0113meran tou entaphiasmou mou t\u0113r\u0113s\u0113 auto is difficult. The subjunctive t\u0113r\u0113s\u0113 could be: \"let her keep it for my burial day\" (future-orientated, if any remains) or \"she has kept it for my burial day\" (she already reserved it for this). NA28 follows a rendering that preserves the ambiguity.",
+        "content": "The Greek aphes autēn, hina eis tēn hēmeran tou entaphiasmou mou tērēsē auto is difficult. The subjunctive tērēsē could be: \"let her keep it for my burial day\" (future-orientated, if any remains) or \"she has kept it for my burial day\" (she already reserved it for this). NA28 follows a rendering that preserves the ambiguity.",
         "note": "The text is secure; the translation difficulty is real. Either way, Jesus defends the act as burial-anointing, not waste."
       }
     ],
@@ -460,7 +420,7 @@
           {
             "name": "Yes: universal atonement scope, not universal salvation",
             "proponents": "Arminian, Catholic, most Anglican scholars",
-            "argument": "\"All people\" means every individual \u2014 the cross provides sufficient atonement for all. Whether all are saved depends on their response. The drawing is real but resistible (6:44 shows that drawing is necessary; it does not show it is irresistible)."
+            "argument": "\"All people\" means every individual — the cross provides sufficient atonement for all. Whether all are saved depends on their response. The drawing is real but resistible (6:44 shows that drawing is necessary; it does not show it is irresistible)."
           },
           {
             "name": "Universal salvation (apokatastasis)",
@@ -616,7 +576,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Mary anoints Jesus' feet with expensive perfume. Judas objects\u2014'Why wasn't this sold?' (v. 5). John notes: 'He was a thief' (v. 6). Extravagant devotion versus calculated criticism.",
+      "tip": "Mary anoints Jesus' feet with expensive perfume. Judas objects—'Why wasn't this sold?' (v. 5). John notes: 'He was a thief' (v. 6). Extravagant devotion versus calculated criticism.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/john/13.json
+++ b/content/john/13.json
@@ -4,72 +4,72 @@
   "book_dir": "john",
   "chapter_num": 13,
   "title": "John 13",
-  "subtitle": "The Last Supper \u2014 Washing of Feet",
+  "subtitle": "The Last Supper — Washing of Feet",
   "timeline_link": {
     "event_id": "last-supper",
-    "text": "See on Timeline \u2014 The Last Supper"
+    "text": "See on Timeline — The Last Supper"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201317 \u2014 Jesus Washes the Disciples\u2019 Feet",
+      "header": "Verses 1–17 — Jesus Washes the Disciples’ Feet",
       "verse_start": 1,
       "verse_end": 17,
       "panels": {
         "heb": [
           {
-            "word": "eis telos \u0113gap\u0113sen",
-            "transliteration": "eis TE-los \u0113-GA-pe-sen",
+            "word": "eis telos ēgapēsen",
+            "transliteration": "eis TE-los ē-GA-pe-sen",
             "gloss": "he loved them to the end / to the uttermost",
             "paragraph": "The phrase (v.1) frames the entire farewell section (chs 13-17) and the passion. Eis telos means both \"to the end\" (to the point of death) and \"to the uttermost\" (completely, fully, without remainder). Both meanings belong: Jesus's love runs to its temporal limit (death) and to its qualitative limit (everything given). The foot-washing is the enacted parable of this love."
           },
           {
-            "word": "nipt\u014d",
+            "word": "niptō",
             "transliteration": "nip-TO",
             "gloss": "wash (hands/feet)",
-            "paragraph": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities \u2014 feet or hands \u2014 as opposed to the full bath (lou\u014d, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (lou\u014d, given once) versus ongoing maintenance washing (nipt\u014d, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
+            "paragraph": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities — feet or hands — as opposed to the full bath (louō, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (louō, given once) versus ongoing maintenance washing (niptō, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Luke 22:24-27",
-              "note": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" \u2014 Luke's parallel to the foot-washing's theological point, placed at the Last Supper."
+              "note": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" — Luke's parallel to the foot-washing's theological point, placed at the Last Supper."
             },
             {
               "ref": "Phil 2:5-8",
-              "note": "\"He made himself nothing by taking the very nature of a servant\" \u2014 Paul's hymn that theologises the pattern the foot-washing enacts."
+              "note": "\"He made himself nothing by taking the very nature of a servant\" — Paul's hymn that theologises the pattern the foot-washing enacts."
             },
             {
               "ref": "Ps 41:9",
-              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 cited in v.18 for Judas's betrayal."
+              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — cited in v.18 for Judas's betrayal."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:1",
-              "note": "\"Having loved his own who were in the world, he loved them to the end\" \u2014 the most comprehensive statement of Jesus's love in the Gospel. \"His own\" (tous idious) \u2014 the same phrase used in 1:11 for the rejection (\"his own did not receive him\"). Those who did receive him are loved \"to the end.\" The foot-washing chapter begins with a statement of the love it enacts."
+              "note": "\"Having loved his own who were in the world, he loved them to the end\" — the most comprehensive statement of Jesus's love in the Gospel. \"His own\" (tous idious) — the same phrase used in 1:11 for the rejection (\"his own did not receive him\"). Those who did receive him are loved \"to the end.\" The foot-washing chapter begins with a statement of the love it enacts."
             },
             {
               "ref": "13:4-5",
-              "note": "The sequence is significant: Jesus \"knew that the Father had put all things under his power\" (v.3) \u2014 then \"he got up and wrapped a towel around his waist.\" The sovereign authority grounds the humble service; the service does not contradict the authority but expresses it. This is the Incarnation in compressed form: omnipotence in a servant's towel."
+              "note": "The sequence is significant: Jesus \"knew that the Father had put all things under his power\" (v.3) — then \"he got up and wrapped a towel around his waist.\" The sovereign authority grounds the humble service; the service does not contradict the authority but expresses it. This is the Incarnation in compressed form: omnipotence in a servant's towel."
             },
             {
               "ref": "13:8",
-              "note": "\"Unless I wash you, you have no part with me\" \u2014 the foot-washing is not merely exemplary (do as I do) but in some sense necessary for relationship with Jesus. The cleansing he provides is not optional; Peter's refusal, however well-intentioned, would sever the relationship. The same principle applies to the cross: the cleansing accomplished there cannot be refused without losing the relationship."
+              "note": "\"Unless I wash you, you have no part with me\" — the foot-washing is not merely exemplary (do as I do) but in some sense necessary for relationship with Jesus. The cleansing he provides is not optional; Peter's refusal, however well-intentioned, would sever the relationship. The same principle applies to the cross: the cleansing accomplished there cannot be refused without losing the relationship."
             },
             {
               "ref": "13:14-15",
-              "note": "\"I have set you an example that you should do as I have done for you\" \u2014 the foot-washing creates an ethical imperative. The disciples are to serve one another with the same humility with which the Lord served them. This is not a command to wash feet literally (though that practice has been maintained in various traditions) but to embody servant-leadership in every form."
+              "note": "\"I have set you an example that you should do as I have done for you\" — the foot-washing creates an ethical imperative. The disciples are to serve one another with the same humility with which the Lord served them. This is not a command to wash feet literally (though that practice has been maintained in various traditions) but to embody servant-leadership in every form."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:8",
@@ -77,25 +77,25 @@
             },
             {
               "ref": "13:16",
-              "note": "\"No servant is greater than his master\" \u2014 Calvin applies this as a universal principle of Christian service: the posture of the servant is not beneath the dignity of the one who follows Christ; it is the essential form of that following. Any ministry that seeks dignity rather than usefulness has failed to learn from the foot-washing."
+              "note": "\"No servant is greater than his master\" — Calvin applies this as a universal principle of Christian service: the posture of the servant is not beneath the dignity of the one who follows Christ; it is the essential form of that following. Any ministry that seeks dignity rather than usefulness has failed to learn from the foot-washing."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:10",
-              "note": "The distinction between lou\u014d (complete bath) and nipt\u014d (partial washing of extremities) may allude to the baptismal practice: baptism as the complete cleansing of regeneration, with subsequent repentance as the ongoing partial cleansing. This reading is not certain \u2014 the primary meaning of the distinction may be entirely within the narrative (Judas is not clean because he has not received the complete cleansing that comes from faith in Jesus, not from the foot-washing itself)."
+              "note": "The distinction between louō (complete bath) and niptō (partial washing of extremities) may allude to the baptismal practice: baptism as the complete cleansing of regeneration, with subsequent repentance as the ongoing partial cleansing. This reading is not certain — the primary meaning of the distinction may be entirely within the narrative (Judas is not clean because he has not received the complete cleansing that comes from faith in Jesus, not from the foot-washing itself)."
             },
             {
               "ref": "13:2",
-              "note": "\"The devil had already prompted Judas\" \u2014 the Greek ballontos eis t\u0113n kardian (having put into the heart) uses the same idiom as \"the sower casting seed.\" The devil plants the thought of betrayal; Judas chooses to cultivate it. The co-responsibility of supernatural prompting and human decision is held together without resolving the tension."
+              "note": "\"The devil had already prompted Judas\" — the Greek ballontos eis tēn kardian (having put into the heart) uses the same idiom as \"the sower casting seed.\" The devil plants the thought of betrayal; Judas chooses to cultivate it. The co-responsibility of supernatural prompting and human decision is held together without resolving the tension."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "13:4-5",
@@ -103,214 +103,170 @@
             },
             {
               "ref": "13:14",
-              "note": "Chrysostom: \"If the Lord and Teacher washed the feet of his disciples, how much more should we wash one another's feet? Not just feet \u2014 but whatever is lower and more menial, that is what the command requires. The measure of our service to each other is the measure of his service to us.\""
+              "note": "Chrysostom: \"If the Lord and Teacher washed the feet of his disciples, how much more should we wash one another's feet? Not just feet — but whatever is lower and more menial, that is what the command requires. The measure of our service to each other is the measure of his service to us.\""
             }
           ]
         },
         "hist": {
-          "context": "Foot-Washing in the First Century\nFoot-washing was the work of the lowest slave in a household \u2014 so menial that Jewish law specified that even a Hebrew slave could not be required to wash his master's feet. When a great teacher or important guest arrived, the feet were washed by servants or voluntarily by a devoted disciple. For the master to wash the servant's feet reversed every social hierarchy. Jesus performs the act knowing full well who he is (v.3: knowing all things were in his hands, he washed feet) \u2014 the power and the service are simultaneous.\n\nJohn's Passover Timing\nJohn places the Last Supper one day before the Synoptics \u2014 John has it on Nisan 13 (before Passover, 13:1), while the Synoptics place it on Nisan 14 (the Passover meal itself). This means in John, Jesus dies at the time the Passover lambs are being slaughtered (18:28 \u2014 to eat the Passover). The theological point: Jesus is the Passover Lamb slaughtered when the lambs are slaughtered."
+          "context": "Foot-Washing in the First Century\nFoot-washing was the work of the lowest slave in a household — so menial that Jewish law specified that even a Hebrew slave could not be required to wash his master's feet. When a great teacher or important guest arrived, the feet were washed by servants or voluntarily by a devoted disciple. For the master to wash the servant's feet reversed every social hierarchy. Jesus performs the act knowing full well who he is (v.3: knowing all things were in his hands, he washed feet) — the power and the service are simultaneous.\n\nJohn's Passover Timing\nJohn places the Last Supper one day before the Synoptics — John has it on Nisan 13 (before Passover, 13:1), while the Synoptics place it on Nisan 14 (the Passover meal itself). This means in John, Jesus dies at the time the Passover lambs are being slaughtered (18:28 — to eat the Passover). The theological point: Jesus is the Passover Lamb slaughtered when the lambs are slaughtered."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 18\u201330 \u2014 The Betrayer Identified; Judas Departs",
+      "header": "Verses 18–30 — The Betrayer Identified; Judas Departs",
       "verse_start": 18,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "entol\u0113n kain\u0113n",
+            "word": "entolēn kainēn",
             "transliteration": "en-to-LEN kai-NEN",
             "gloss": "a new commandment",
-            "paragraph": "The newness (kain\u0113n) of the commandment (v.34) is not its content \u2014 love is an OT command (Lev 19:18) \u2014 but its standard: \"as I have loved you.\" The measure of mutual love is now the love of Christ demonstrated in foot-washing and cross. The old commandment said \"love your neighbour as yourself\"; the new commandment says \"love one another as I have loved you.\" The standard has been raised from the human to the divine."
+            "paragraph": "The newness (kainēn) of the commandment (v.34) is not its content — love is an OT command (Lev 19:18) — but its standard: \"as I have loved you.\" The measure of mutual love is now the love of Christ demonstrated in foot-washing and cross. The old commandment said \"love your neighbour as yourself\"; the new commandment says \"love one another as I have loved you.\" The standard has been raised from the human to the divine."
           },
           {
             "word": "nyx",
             "transliteration": "nyx",
             "gloss": "night",
-            "paragraph": "\"And it was night\" (v.30) \u2014 John's most compressed theological statement. Three words in Greek (\u0113n de nyx) bearing the full weight of the light/darkness theme that began in 1:5. Judas goes out into the night \u2014 not merely the physical darkness of a Jerusalem evening but the spiritual darkness he has chosen. The contrast with the \"light of the world\" (8:12) who remains at the table is the chapter's structural irony."
+            "paragraph": "\"And it was night\" (v.30) — John's most compressed theological statement. Three words in Greek (ēn de nyx) bearing the full weight of the light/darkness theme that began in 1:5. Judas goes out into the night — not merely the physical darkness of a Jerusalem evening but the spiritual darkness he has chosen. The contrast with the \"light of the world\" (8:12) who remains at the table is the chapter's structural irony."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Lev 19:18",
-              "note": "\"Love your neighbour as yourself\" \u2014 the old commandment that the new commandment supersedes in standard if not in content."
+              "note": "\"Love your neighbour as yourself\" — the old commandment that the new commandment supersedes in standard if not in content."
             },
             {
               "ref": "1 John 4:11",
-              "note": "\"Dear friends, since God so loved us, we also ought to love one another\" \u2014 John's epistolary application of the new commandment."
+              "note": "\"Dear friends, since God so loved us, we also ought to love one another\" — John's epistolary application of the new commandment."
             },
             {
               "ref": "Rom 13:8-10",
-              "note": "\"Love one another, for whoever loves others has fulfilled the law... Love is the fulfillment of the law\" \u2014 Paul's parallel development of the love commandment."
+              "note": "\"Love one another, for whoever loves others has fulfilled the law... Love is the fulfillment of the law\" — Paul's parallel development of the love commandment."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:27",
-              "note": "\"What you are about to do, do quickly\" \u2014 Jesus's command to Judas is among the most haunting sentences in the Gospel. He does not prevent the betrayal; he directs it. The one who is about to be betrayed commands the betrayal. This is not fatalistic resignation but sovereign orchestration: the passion is Jesus's own act, not merely something done to him."
+              "note": "\"What you are about to do, do quickly\" — Jesus's command to Judas is among the most haunting sentences in the Gospel. He does not prevent the betrayal; he directs it. The one who is about to be betrayed commands the betrayal. This is not fatalistic resignation but sovereign orchestration: the passion is Jesus's own act, not merely something done to him."
             },
             {
               "ref": "13:30",
-              "note": "\"And it was night\" \u2014 the departure of Judas releases the Farewell Discourse. The upper room is now purified of its one impure element; the intimate conversation of the final hours can begin. John's Gospel is structured around these two spaces: the darkness Judas enters (the world's judgment) and the light of the upper room (the disciples being prepared for what is coming)."
+              "note": "\"And it was night\" — the departure of Judas releases the Farewell Discourse. The upper room is now purified of its one impure element; the intimate conversation of the final hours can begin. John's Gospel is structured around these two spaces: the darkness Judas enters (the world's judgment) and the light of the upper room (the disciples being prepared for what is coming)."
             },
             {
               "ref": "13:34-35",
-              "note": "\"A new commandment I give you: Love one another. As I have loved you, so you must love one another\" \u2014 the \"new\" is the standard. The community of Christ is to be recognisable not by its theology alone but by the quality of its internal love. \"By this everyone will know that you are my disciples\" \u2014 the community's love is the Gospel's public witness. The command is not peripheral but central; it is how the world will identify the church."
+              "note": "\"A new commandment I give you: Love one another. As I have loved you, so you must love one another\" — the \"new\" is the standard. The community of Christ is to be recognisable not by its theology alone but by the quality of its internal love. \"By this everyone will know that you are my disciples\" — the community's love is the Gospel's public witness. The command is not peripheral but central; it is how the world will identify the church."
             },
             {
               "ref": "13:38",
-              "note": "\"Before the rooster crows, you will disown me three times\" \u2014 spoken with perfect foreknowledge, without condemnation. Jesus does not rebuke Peter's confidence; he simply tells him what will happen. The prediction is both a warning (Peter needs to know his own fragility) and a preparation for the restoration that will follow. Three denials will be met by three \"do you love me?\" questions (21:15-17)."
+              "note": "\"Before the rooster crows, you will disown me three times\" — spoken with perfect foreknowledge, without condemnation. Jesus does not rebuke Peter's confidence; he simply tells him what will happen. The prediction is both a warning (Peter needs to know his own fragility) and a preparation for the restoration that will follow. Three denials will be met by three \"do you love me?\" questions (21:15-17)."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:34",
-              "note": "Calvin connects the new commandment to the Holy Spirit: the love of Christ is the measure, but human beings cannot love with Christ's measure by their own power. The commandment is therefore simultaneously a demand and an implicit promise \u2014 the Spirit who enables Christ's love in believers is what makes the commandment possible, not merely obligatory."
+              "note": "Calvin connects the new commandment to the Holy Spirit: the love of Christ is the measure, but human beings cannot love with Christ's measure by their own power. The commandment is therefore simultaneously a demand and an implicit promise — the Spirit who enables Christ's love in believers is what makes the commandment possible, not merely obligatory."
             },
             {
               "ref": "13:38",
-              "note": "Calvin uses the prediction of Peter's denial as evidence that human self-knowledge is deeply flawed: Peter sincerely believed he would die for Jesus; Jesus knew he would deny him three times before morning. The lesson is that confidence in one's own spiritual strength is itself a spiritual danger. The cure is not pessimism but dependence \u2014 the kind of dependence that Peter will eventually learn through his failure."
+              "note": "Calvin uses the prediction of Peter's denial as evidence that human self-knowledge is deeply flawed: Peter sincerely believed he would die for Jesus; Jesus knew he would deny him three times before morning. The lesson is that confidence in one's own spiritual strength is itself a spiritual danger. The cure is not pessimism but dependence — the kind of dependence that Peter will eventually learn through his failure."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:23",
-              "note": "\"The disciple whom Jesus loved, was reclining next to him\" \u2014 the Greek anakeimenon en t\u014d kolp\u014d (reclining in the bosom) echoes the language of 1:18 (the Son \"in the bosom of the Father\"). The beloved disciple occupies with Jesus the relationship that Jesus occupies with the Father \u2014 the intimacy of the inner circle."
+              "note": "\"The disciple whom Jesus loved, was reclining next to him\" — the Greek anakeimenon en tō kolpō (reclining in the bosom) echoes the language of 1:18 (the Son \"in the bosom of the Father\"). The beloved disciple occupies with Jesus the relationship that Jesus occupies with the Father — the intimacy of the inner circle."
             },
             {
               "ref": "13:34",
-              "note": "\"A new commandment\" \u2014 the novelty lies not in the command to love but in the paradigm: \"as I have loved you.\" Jesus's self-sacrificial love has set an entirely new standard. The OT said \"love as you love yourself\"; Jesus says \"love as I have loved you\" \u2014 a standard that requires the cross as its measure."
+              "note": "\"A new commandment\" — the novelty lies not in the command to love but in the paradigm: \"as I have loved you.\" Jesus's self-sacrificial love has set an entirely new standard. The OT said \"love as you love yourself\"; Jesus says \"love as I have loved you\" — a standard that requires the cross as its measure."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "13:34",
-              "note": "Augustine: \"'Love one another as I have loved you.' What is the measure? 'As I have loved you.' And how did he love us? He laid down his life for us. So the commandment is: lay down your life for one another. Not just with words and good wishes \u2014 but with actions, with sacrifice, with the actual giving of what costs you something.\""
+              "note": "Augustine: \"'Love one another as I have loved you.' What is the measure? 'As I have loved you.' And how did he love us? He laid down his life for us. So the commandment is: lay down your life for one another. Not just with words and good wishes — but with actions, with sacrifice, with the actual giving of what costs you something.\""
             },
             {
               "ref": "13:30",
-              "note": "Chrysostom: \"It was night \u2014 night in his soul, night in his deeds. He went out into the darkness of his purpose. The light was in the room; he went away from the light. This is the anatomy of every sin: leaving the light and going into the night.\""
+              "note": "Chrysostom: \"It was night — night in his soul, night in his deeds. He went out into the darkness of his purpose. The light was in the room; he went away from the light. This is the anatomy of every sin: leaving the light and going into the night.\""
             }
           ]
         },
         "hist": {
-          "context": "The Beloved Disciple\nThe \"disciple whom Jesus loved\" (v.23) appears for the first time here, reclining next to Jesus at the meal. He appears at the cross (19:26-27), the empty tomb (20:2-10), the Sea of Galilee appearance (21:7, 20), and is identified as the author of the Gospel (21:24). The consistent anonymity of the \"beloved disciple\" within the Gospel he wrote is itself a form of the self-effacement that John's Gospel commends.\n\n\"And It Was Night\"\nJohn's three-word theological statement at Judas's departure is among the most laden sentences in the Gospel. The light/darkness theme of the prologue (1:5) culminates here: the one who has chosen darkness exits into it. The door closes on Judas and opens on the Farewell Discourse \u2014 Jesus alone with the eleven, the light concentrated in the upper room as the darkness gathers outside."
+          "context": "The Beloved Disciple\nThe \"disciple whom Jesus loved\" (v.23) appears for the first time here, reclining next to Jesus at the meal. He appears at the cross (19:26-27), the empty tomb (20:2-10), the Sea of Galilee appearance (21:7, 20), and is identified as the author of the Gospel (21:24). The consistent anonymity of the \"beloved disciple\" within the Gospel he wrote is itself a form of the self-effacement that John's Gospel commends.\n\n\"And It Was Night\"\nJohn's three-word theological statement at Judas's departure is among the most laden sentences in the Gospel. The light/darkness theme of the prologue (1:5) culminates here: the one who has chosen darkness exits into it. The door closes on Judas and opens on the Farewell Discourse — Jesus alone with the eleven, the light concentrated in the upper room as the darkness gathers outside."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201338 \u2014 The New Commandment; Peter\u2019s Denial Predicted",
+      "header": "Verses 31–38 — The New Commandment; Peter’s Denial Predicted",
       "verse_start": 31,
       "verse_end": 38,
       "panels": {
         "heb": [
           {
-            "word": "eis telos \u0113gap\u0113sen",
-            "transliteration": "eis TE-los \u0113-GA-pe-sen",
+            "word": "eis telos ēgapēsen",
+            "transliteration": "eis TE-los ē-GA-pe-sen",
             "gloss": "he loved them to the end / to the uttermost",
             "paragraph": "The phrase (v.1) frames the entire farewell section (chs 13-17) and the passion. Eis telos means both \"to the end\" (to the point of death) and \"to the uttermost\" (completely, fully, without remainder). Both meanings belong: Jesus's love runs to its temporal limit (death) and to its qualitative limit (everything given). The foot-washing is the enacted parable of this love."
           },
           {
-            "word": "nipt\u014d",
+            "word": "niptō",
             "transliteration": "nip-TO",
             "gloss": "wash (hands/feet)",
-            "paragraph": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities \u2014 feet or hands \u2014 as opposed to the full bath (lou\u014d, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (lou\u014d, given once) versus ongoing maintenance washing (nipt\u014d, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
+            "paragraph": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities — feet or hands — as opposed to the full bath (louō, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (louō, given once) versus ongoing maintenance washing (niptō, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Luke 22:24-27",
-              "note": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" \u2014 Luke's parallel to the foot-washing's theological point, placed at the Last Supper."
+              "note": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" — Luke's parallel to the foot-washing's theological point, placed at the Last Supper."
             },
             {
               "ref": "Phil 2:5-8",
-              "note": "\"He made himself nothing by taking the very nature of a servant\" \u2014 Paul's hymn that theologises the pattern the foot-washing enacts."
+              "note": "\"He made himself nothing by taking the very nature of a servant\" — Paul's hymn that theologises the pattern the foot-washing enacts."
             },
             {
               "ref": "Ps 41:9",
-              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 cited in v.18 for Judas's betrayal."
+              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — cited in v.18 for Judas's betrayal."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:1",
-              "note": "\"Having loved his own who were in the world, he loved them to the end\" \u2014 the most comprehensive statement of Jesus's love in the Gospel. \"His own\" (tous idious) \u2014 the same phrase used in 1:11 for the rejection (\"his own did not receive him\"). Those who did receive him are loved \"to the end.\" The foot-washing chapter begins with a statement of the love it enacts."
-            },
-            {
-              "ref": "13:4-5",
-              "note": "The sequence is significant: Jesus \"knew that the Father had put all things under his power\" (v.3) \u2014 then \"he got up and wrapped a towel around his waist.\" The sovereign authority grounds the humble service; the service does not contradict the authority but expresses it. This is the Incarnation in compressed form: omnipotence in a servant's towel."
-            },
-            {
-              "ref": "13:8",
-              "note": "\"Unless I wash you, you have no part with me\" \u2014 the foot-washing is not merely exemplary (do as I do) but in some sense necessary for relationship with Jesus. The cleansing he provides is not optional; Peter's refusal, however well-intentioned, would sever the relationship. The same principle applies to the cross: the cleansing accomplished there cannot be refused without losing the relationship."
-            },
-            {
-              "ref": "13:14-15",
-              "note": "\"I have set you an example that you should do as I have done for you\" \u2014 the foot-washing creates an ethical imperative. The disciples are to serve one another with the same humility with which the Lord served them. This is not a command to wash feet literally (though that practice has been maintained in various traditions) but to embody servant-leadership in every form."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:8",
-              "note": "Calvin distinguishes two dimensions of the foot-washing: (1) the exemplary (we must serve one another humbly) and (2) the sacramental (without Christ's cleansing, we have no part with him). The second dimension points to the atonement: as Peter must receive the washing or be excluded, so all must receive the cleansing of the cross or remain outside the covenant. Calvin uses this to argue that the foot-washing, while not a sacrament in the technical sense, bears sacramental significance."
-            },
-            {
-              "ref": "13:16",
-              "note": "\"No servant is greater than his master\" \u2014 Calvin applies this as a universal principle of Christian service: the posture of the servant is not beneath the dignity of the one who follows Christ; it is the essential form of that following. Any ministry that seeks dignity rather than usefulness has failed to learn from the foot-washing."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:10",
-              "note": "The distinction between lou\u014d (complete bath) and nipt\u014d (partial washing of extremities) may allude to the baptismal practice: baptism as the complete cleansing of regeneration, with subsequent repentance as the ongoing partial cleansing. This reading is not certain \u2014 the primary meaning of the distinction may be entirely within the narrative (Judas is not clean because he has not received the complete cleansing that comes from faith in Jesus, not from the foot-washing itself)."
-            },
-            {
-              "ref": "13:2",
-              "note": "\"The devil had already prompted Judas\" \u2014 the Greek ballontos eis t\u0113n kardian (having put into the heart) uses the same idiom as \"the sower casting seed.\" The devil plants the thought of betrayal; Judas chooses to cultivate it. The co-responsibility of supernatural prompting and human decision is held together without resolving the tension."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "13:4-5",
-              "note": "Augustine: \"He who suspended the earth laid it aside; he who clothes the world with its beauty took off his garments; he who washes away sins with his blood poured water into a basin. He who is served by the angels wrapped himself in a towel. This is what John says: having loved his own, he loved them to the end.\""
-            },
-            {
-              "ref": "13:14",
-              "note": "Chrysostom: \"If the Lord and Teacher washed the feet of his disciples, how much more should we wash one another's feet? Not just feet \u2014 but whatever is lower and more menial, that is what the command requires. The measure of our service to each other is the measure of his service to us.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Foot-Washing in the First Century\nFoot-washing was the work of the lowest slave in a household \u2014 so menial that Jewish law specified that even a Hebrew slave could not be required to wash his master's feet. When a great teacher or important guest arrived, the feet were washed by servants or voluntarily by a devoted disciple. For the master to wash the servant's feet reversed every social hierarchy. Jesus performs the act knowing full well who he is (v.3: knowing all things were in his hands, he washed feet) \u2014 the power and the service are simultaneous.\n\nJohn's Passover Timing\nJohn places the Last Supper one day before the Synoptics \u2014 John has it on Nisan 13 (before Passover, 13:1), while the Synoptics place it on Nisan 14 (the Passover meal itself). This means in John, Jesus dies at the time the Passover lambs are being slaughtered (18:28 \u2014 to eat the Passover). The theological point: Jesus is the Passover Lamb slaughtered when the lambs are slaughtered."
+          "context": "Foot-Washing in the First Century\nFoot-washing was the work of the lowest slave in a household — so menial that Jewish law specified that even a Hebrew slave could not be required to wash his master's feet. When a great teacher or important guest arrived, the feet were washed by servants or voluntarily by a devoted disciple. For the master to wash the servant's feet reversed every social hierarchy. Jesus performs the act knowing full well who he is (v.3: knowing all things were in his hands, he washed feet) — the power and the service are simultaneous.\n\nJohn's Passover Timing\nJohn places the Last Supper one day before the Synoptics — John has it on Nisan 13 (before Passover, 13:1), while the Synoptics place it on Nisan 14 (the Passover meal itself). This means in John, Jesus dies at the time the Passover lambs are being slaughtered (18:28 — to eat the Passover). The theological point: Jesus is the Passover Lamb slaughtered when the lambs are slaughtered."
         }
       }
     }
@@ -320,21 +276,21 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "For the master to wash the servant's feet reversed every s  Context  [('The Beloved Disciple', 'The \"disciple whom Jesus loved\" (v\u2026"
+        "text": "For the master to wash the servant's feet reversed every s  Context  [('The Beloved Disciple', 'The \"disciple whom Jesus loved\" (v…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eis telos (13:1)</td><td>NIV: \"to the end / to the full extent\"; KJV: \"unto the end\"; ESV: \"to the end\"; NRSV: \"to the end\". NIV footnote offers \"to the full extent.\" Both temporal and qualitative meanings should be preserved.</td></tr><tr><td class=\"t-label\">kain\u0113n (13:34)</td><td>NIV: \"new\"; KJV: \"new\"; ESV: \"new\"; NRSV: \"new\". All agree. The quality of newness (kainos vs. neos) is a commentary point, not a translation difference.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eis telos (13:1)</td><td>NIV: \"to the end / to the full extent\"; KJV: \"unto the end\"; ESV: \"to the end\"; NRSV: \"to the end\". NIV footnote offers \"to the full extent.\" Both temporal and qualitative meanings should be preserved.</td></tr><tr><td class=\"t-label\">kainēn (13:34)</td><td>NIV: \"new\"; KJV: \"new\"; ESV: \"new\"; NRSV: \"new\". All agree. The quality of newness (kainos vs. neos) is a commentary point, not a translation difference.</td></tr>",
     "src": [
       {
         "title": "Psalm 41:9",
         "quote": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me.\"",
-        "note": "The Psalm of the suffering righteous one betrayed by his table companion \u2014 cited in John 13:18 for Judas's betrayal."
+        "note": "The Psalm of the suffering righteous one betrayed by his table companion — cited in John 13:18 for Judas's betrayal."
       }
     ],
     "rec": [
       {
         "who": "Foot-Washing in Christian Tradition",
-        "text": "The mandatum (Latin: commandment, from John 13:34 \u2014 \"a new commandment I give you\") gave its name to the Maundy Thursday liturgy in Christian tradition. The service of foot-washing on Maundy Thursday \u2014 practised in Catholic, Anglican, Lutheran, and many evangelical traditions \u2014 enacts the command of John 13:14. In some traditions it is a sacrament; in others an ordinance; in all it is a dramatic proclamation of servant-leadership as the model of Christian community."
+        "text": "The mandatum (Latin: commandment, from John 13:34 — \"a new commandment I give you\") gave its name to the Maundy Thursday liturgy in Christian tradition. The service of foot-washing on Maundy Thursday — practised in Catholic, Anglican, Lutheran, and many evangelical traditions — enacts the command of John 13:14. In some traditions it is a sacrament; in others an ordinance; in all it is a dramatic proclamation of servant-leadership as the model of Christian community."
       },
       {
         "who": "\"And It Was Night\" in Christian Reflection on Evil",
@@ -344,13 +300,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Enacted Parable \u2014 vv.1-17",
-          "text": "The foot-washing is John's replacement for the Synoptic institution of the Lord's Supper \u2014 an enacted parable that both models servant-love and carries sacramental resonance. As the bread and cup in the Synoptics represent the body and blood, the washing represents the cleansing that makes relationship with Jesus possible.",
+          "label": "Enacted Parable — vv.1-17",
+          "text": "The foot-washing is John's replacement for the Synoptic institution of the Lord's Supper — an enacted parable that both models servant-love and carries sacramental resonance. As the bread and cup in the Synoptics represent the body and blood, the washing represents the cleansing that makes relationship with Jesus possible.",
           "is_key": false
         },
         {
-          "label": "Footwashing as Acted Prophecy \u2014 vv.1-17",
-          "text": "The washing anticipates the cross: Jesus takes the servant's position (rising, laying aside garments, taking them again \u2014 vv.4-5, 12) in language that deliberately echoes 10:17-18 (laying down and taking up his life). The enacted parable must be read alongside the farewell discourses as pre-cross commentary.",
+          "label": "Footwashing as Acted Prophecy — vv.1-17",
+          "text": "The washing anticipates the cross: Jesus takes the servant's position (rising, laying aside garments, taking them again — vv.4-5, 12) in language that deliberately echoes 10:17-18 (laying down and taking up his life). The enacted parable must be read alongside the farewell discourses as pre-cross commentary.",
           "is_key": false
         }
       ],
@@ -358,40 +314,40 @@
     },
     "hebtext": [
       {
-        "word": "eis telos \u0113gap\u0113sen",
-        "tlit": "eis TE-los \u0113-GA-pe-sen",
+        "word": "eis telos ēgapēsen",
+        "tlit": "eis TE-los ē-GA-pe-sen",
         "gloss": "he loved them to the end / to the uttermost",
         "note": "The phrase (v.1) frames the entire farewell section (chs 13-17) and the passion. Eis telos means both \"to the end\" (to the point of death) and \"to the uttermost\" (completely, fully, without remainder). Both meanings belong: Jesus's love runs to its temporal limit (death) and to its qualitative limit (everything given). The foot-washing is the enacted parable of this love."
       },
       {
-        "word": "nipt\u014d",
+        "word": "niptō",
         "tlit": "nip-TO",
         "gloss": "wash (hands/feet)",
-        "note": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities \u2014 feet or hands \u2014 as opposed to the full bath (lou\u014d, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (lou\u014d, given once) versus ongoing maintenance washing (nipt\u014d, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
+        "note": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities — feet or hands — as opposed to the full bath (louō, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (louō, given once) versus ongoing maintenance washing (niptō, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
       },
       {
-        "word": "entol\u0113n kain\u0113n",
+        "word": "entolēn kainēn",
         "tlit": "en-to-LEN kai-NEN",
         "gloss": "a new commandment",
-        "note": "The newness (kain\u0113n) of the commandment (v.34) is not its content \u2014 love is an OT command (Lev 19:18) \u2014 but its standard: \"as I have loved you.\" The measure of mutual love is now the love of Christ demonstrated in foot-washing and cross. The old commandment said \"love your neighbour as yourself\"; the new commandment says \"love one another as I have loved you.\" The standard has been raised from the human to the divine."
+        "note": "The newness (kainēn) of the commandment (v.34) is not its content — love is an OT command (Lev 19:18) — but its standard: \"as I have loved you.\" The measure of mutual love is now the love of Christ demonstrated in foot-washing and cross. The old commandment said \"love your neighbour as yourself\"; the new commandment says \"love one another as I have loved you.\" The standard has been raised from the human to the divine."
       },
       {
         "word": "nyx",
         "tlit": "nyx",
         "gloss": "night",
-        "note": "\"And it was night\" (v.30) \u2014 John's most compressed theological statement. Three words in Greek (\u0113n de nyx) bearing the full weight of the light/darkness theme that began in 1:5. Judas goes out into the night \u2014 not merely the physical darkness of a Jerusalem evening but the spiritual darkness he has chosen. The contrast with the \"light of the world\" (8:12) who remains at the table is the chapter's structural irony."
+        "note": "\"And it was night\" (v.30) — John's most compressed theological statement. Three words in Greek (ēn de nyx) bearing the full weight of the light/darkness theme that began in 1:5. Judas goes out into the night — not merely the physical darkness of a Jerusalem evening but the spiritual darkness he has chosen. The contrast with the \"light of the world\" (8:12) who remains at the table is the chapter's structural irony."
       },
       {
-        "word": "eis telos \u0113gap\u0113sen",
-        "tlit": "eis TE-los \u0113-GA-pe-sen",
+        "word": "eis telos ēgapēsen",
+        "tlit": "eis TE-los ē-GA-pe-sen",
         "gloss": "he loved them to the end / to the uttermost",
         "note": "The phrase (v.1) frames the entire farewell section (chs 13-17) and the passion. Eis telos means both \"to the end\" (to the point of death) and \"to the uttermost\" (completely, fully, without remainder). Both meanings belong: Jesus's love runs to its temporal limit (death) and to its qualitative limit (everything given). The foot-washing is the enacted parable of this love."
       },
       {
-        "word": "nipt\u014d",
+        "word": "niptō",
         "tlit": "nip-TO",
         "gloss": "wash (hands/feet)",
-        "note": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities \u2014 feet or hands \u2014 as opposed to the full bath (lou\u014d, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (lou\u014d, given once) versus ongoing maintenance washing (nipt\u014d, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
+        "note": "The specific word (v.5, 6, 8, 10, 12, 14) for washing extremities — feet or hands — as opposed to the full bath (louō, v.10). The distinction Jesus draws in v.10 (\"those who have had a bath need only to wash their feet\") uses both: complete cleansing (louō, given once) versus ongoing maintenance washing (niptō, needed repeatedly). The foot-washing is both exemplary (serve as I serve) and sacramental (without my cleansing, you have no part with me)."
       }
     ],
     "thread": [
@@ -399,42 +355,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Luke 22:24-27",
         "type": "Echo",
-        "text": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" \u2014 Luke's parallel to the foot-washing's theological point, placed at the Last Supper.",
+        "text": "\"A dispute also arose among them as to which of them was considered to be greatest... I am among you as one who serves\" — Luke's parallel to the foot-washing's theological point, placed at the Last Supper.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Phil 2:5-8",
         "type": "Connection",
-        "text": "\"He made himself nothing by taking the very nature of a servant\" \u2014 Paul's hymn that theologises the pattern the foot-washing enacts.",
+        "text": "\"He made himself nothing by taking the very nature of a servant\" — Paul's hymn that theologises the pattern the foot-washing enacts.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 41:9",
         "type": "Connection",
-        "text": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 cited in v.18 for Judas's betrayal.",
+        "text": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — cited in v.18 for Judas's betrayal.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Lev 19:18",
         "type": "Connection",
-        "text": "\"Love your neighbour as yourself\" \u2014 the old commandment that the new commandment supersedes in standard if not in content.",
+        "text": "\"Love your neighbour as yourself\" — the old commandment that the new commandment supersedes in standard if not in content.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 John 4:11",
         "type": "Connection",
-        "text": "\"Dear friends, since God so loved us, we also ought to love one another\" \u2014 John's epistolary application of the new commandment.",
+        "text": "\"Dear friends, since God so loved us, we also ought to love one another\" — John's epistolary application of the new commandment.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Rom 13:8-10",
         "type": "Fulfilment",
-        "text": "\"Love one another, for whoever loves others has fulfilled the law... Love is the fulfillment of the law\" \u2014 Paul's parallel development of the love commandment.",
+        "text": "\"Love one another, for whoever loves others has fulfilled the law... Love is the fulfillment of the law\" — Paul's parallel development of the love commandment.",
         "direction": "backward"
       }
     ],
@@ -443,7 +399,7 @@
         "ref": "13:32",
         "title": "\"If God is glorified in him...\"",
         "content": "The first clause (\"If God is glorified in him\") is omitted in some important MSS (P66, Sinaiticus). NA28 includes it. If omitted, the text reads simply: \"God will glorify the Son in himself and will glorify him at once.\" If included, the conditional sets up the reciprocal glorification. The longer text makes the argument more explicit.",
-        "note": "The evidence is mixed; NA28 includes the clause with a note. The theology is unaffected either way \u2014 the mutual glorification of Father and Son at the cross is John's consistent teaching."
+        "note": "The evidence is mixed; NA28 includes the clause with a note. The theology is unaffected either way — the mutual glorification of Father and Son at the cross is John's consistent teaching."
       }
     ],
     "debate": [
@@ -495,7 +451,7 @@
           "score": 10
         }
       ],
-      "note": "John 13 begins the Book of Glory and opens with the most concentrated statement of love in the Gospel: \"having loved his own who were in the world, he loved them to the end.\" Everything that follows \u2014 foot-washing, betrayal identification, new commandment, denial prediction \u2014 flows from this opening declaration of love. The chapter's structure is love in action (foot-washing) \u2192 love betrayed (Judas) \u2192 love commanded (new commandment) \u2192 love tested (Peter's coming denial). The night Judas walks into and the love Jesus commands are the chapter's two poles."
+      "note": "John 13 begins the Book of Glory and opens with the most concentrated statement of love in the Gospel: \"having loved his own who were in the world, he loved them to the end.\" Everything that follows — foot-washing, betrayal identification, new commandment, denial prediction — flows from this opening declaration of love. The chapter's structure is love in action (foot-washing) → love betrayed (Judas) → love commanded (new commandment) → love tested (Peter's coming denial). The night Judas walks into and the love Jesus commands are the chapter's two poles."
     }
   },
   "vhl_groups": [
@@ -614,7 +570,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Jesus knew that the hour had come' (v. 1). The Book of Signs (1-12) yields to the Book of Glory (13-21). Intimate farewell replaces public ministry. He washes feet\u2014slave work. 'You call me Teacher and Lord... I have set you an example.'",
+      "tip": "'Jesus knew that the hour had come' (v. 1). The Book of Signs (1-12) yields to the Book of Glory (13-21). Intimate farewell replaces public ministry. He washes feet—slave work. 'You call me Teacher and Lord... I have set you an example.'",
       "genre_tag": "structure_guide"
     },
     {

--- a/content/john/17.json
+++ b/content/john/17.json
@@ -7,73 +7,73 @@
   "subtitle": "Jesus' High Priestly Prayer",
   "timeline_link": {
     "event_id": "last-supper",
-    "text": "See on Timeline \u2014 The Last Supper"
+    "text": "See on Timeline — The Last Supper"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20135 \u2014 Jesus Prays for Himself: Glorify Your Son",
+      "header": "Verses 1–5 — Jesus Prays for Himself: Glorify Your Son",
       "verse_start": 1,
       "verse_end": 5,
       "panels": {
         "heb": [
           {
-            "word": "hagiason autous en t\u0113 al\u0113theia",
-            "transliteration": "ha-gia-son au-TOUS en t\u0113 a-LE-thei-a",
+            "word": "hagiason autous en tē alētheia",
+            "transliteration": "ha-gia-son au-TOUS en tē a-LE-thei-a",
             "gloss": "sanctify them in the truth",
-            "paragraph": "Hagiaz\u014d (v.17, 19) \u2014 to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth \u2014 specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
+            "paragraph": "Hagiazō (v.17, 19) — to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth — specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
           },
           {
-            "word": "kath\u014ds",
+            "word": "kathōs",
             "transliteration": "ka-THOS",
             "gloss": "just as / even as",
-            "paragraph": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) \u2014 each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) \u2014 the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) \u2014 the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
+            "paragraph": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) — each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) — the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) — the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 28:29-30",
-              "note": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies \u2014 the typological background for Jesus's high priestly intercession."
+              "note": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies — the typological background for Jesus's high priestly intercession."
             },
             {
               "ref": "Heb 7:25",
-              "note": "\"He always lives to intercede for them\" \u2014 the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17."
+              "note": "\"He always lives to intercede for them\" — the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17."
             },
             {
               "ref": "Ps 4:6-7",
-              "note": "\"Let the light of your face shine on us\" \u2014 the priestly blessing background for the \"glory\" language of vv.1-5."
+              "note": "\"Let the light of your face shine on us\" — the priestly blessing background for the \"glory\" language of vv.1-5."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:3",
-              "note": "\"This is eternal life: that they know you, the only true God, and Jesus Christ, whom you have sent\" \u2014 the most important sentence in the prayer for soteriology. Eternal life is defined as relationship, not duration. The knowledge (gin\u014dsk\u014d \u2014 intimate, personal, experiential) is both the content and the condition of eternal life. The \"only true God\" \u2014 the exclusivity guards against syncretism: this knowing is not knowing about any divine being but knowing the specific Father of Jesus Christ."
+              "note": "\"This is eternal life: that they know you, the only true God, and Jesus Christ, whom you have sent\" — the most important sentence in the prayer for soteriology. Eternal life is defined as relationship, not duration. The knowledge (ginōskō — intimate, personal, experiential) is both the content and the condition of eternal life. The \"only true God\" — the exclusivity guards against syncretism: this knowing is not knowing about any divine being but knowing the specific Father of Jesus Christ."
             },
             {
               "ref": "17:4-5",
-              "note": "\"I have brought you glory on earth by finishing the work you gave me to do. And now, Father, glorify me in your presence with the glory I had with you before the world began\" \u2014 two of the most theologically dense sentences in John. (1) Jesus declares his mission complete before the cross \u2014 \"finishing\" (teleiosas, aorist participle) refers to the completed totality of his obedient life, of which the cross is the final act. (2) He asks for the restoration of the pre-incarnate glory \u2014 the glory shared with the Father \"before the world began\" (pro tou ton kosmon einai), a direct claim to eternal pre-existence with the Father."
+              "note": "\"I have brought you glory on earth by finishing the work you gave me to do. And now, Father, glorify me in your presence with the glory I had with you before the world began\" — two of the most theologically dense sentences in John. (1) Jesus declares his mission complete before the cross — \"finishing\" (teleiosas, aorist participle) refers to the completed totality of his obedient life, of which the cross is the final act. (2) He asks for the restoration of the pre-incarnate glory — the glory shared with the Father \"before the world began\" (pro tou ton kosmon einai), a direct claim to eternal pre-existence with the Father."
             },
             {
               "ref": "17:15",
-              "note": "\"My prayer is not that you take them out of the world but that you protect them from the evil one\" \u2014 the rejection of escapism as the Christian posture. Jesus does not pray for the disciples to be removed from the dangerous world; he prays for their protection within it. The Christian vocation is engagement, not withdrawal. The prayer for protection \"from the evil one\" (apo tou pon\u0113rou) acknowledges the reality of spiritual warfare without endorsing the withdrawal from the world it might seem to require."
+              "note": "\"My prayer is not that you take them out of the world but that you protect them from the evil one\" — the rejection of escapism as the Christian posture. Jesus does not pray for the disciples to be removed from the dangerous world; he prays for their protection within it. The Christian vocation is engagement, not withdrawal. The prayer for protection \"from the evil one\" (apo tou ponērou) acknowledges the reality of spiritual warfare without endorsing the withdrawal from the world it might seem to require."
             },
             {
               "ref": "17:17-19",
-              "note": "\"Sanctify them by the truth; your word is truth. As you sent me into the world, I have sent them into the world. For them I sanctify myself, that they too may be truly sanctified\" \u2014 the three-part logic of Christian sanctification: (1) the means: truth/the word; (2) the mission: sent into the world; (3) the ground: Jesus's own self-consecration for them. The disciples are sanctified because Jesus first consecrated himself \u2014 his sanctification is the basis and model of theirs."
+              "note": "\"Sanctify them by the truth; your word is truth. As you sent me into the world, I have sent them into the world. For them I sanctify myself, that they too may be truly sanctified\" — the three-part logic of Christian sanctification: (1) the means: truth/the word; (2) the mission: sent into the world; (3) the ground: Jesus's own self-consecration for them. The disciples are sanctified because Jesus first consecrated himself — his sanctification is the basis and model of theirs."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:4",
-              "note": "Calvin reads \"I have finished the work you gave me to do\" as the completed obedience of the entire life \u2014 not merely the cross, though the cross is the culmination. The whole life of Jesus was the work: his teaching, his miracles, his relationships, his suffering, and supremely his death. The prayer is offered from the position of one who has run the race and is about to cross the finishing line."
+              "note": "Calvin reads \"I have finished the work you gave me to do\" as the completed obedience of the entire life — not merely the cross, though the cross is the culmination. The whole life of Jesus was the work: his teaching, his miracles, his relationships, his suffering, and supremely his death. The prayer is offered from the position of one who has run the race and is about to cross the finishing line."
             },
             {
               "ref": "17:15",
@@ -82,98 +82,98 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:3",
-              "note": "\"Jesus Christ, whom you have sent\" \u2014 this is one of the only places in John where Jesus uses his full name \"Jesus Christ\" in direct speech. It is slightly unusual \u2014 almost as if he is speaking from the perspective of the church's later confession. Some scholars have suggested this verse is an editorial insertion by the evangelist; others accept it as Jesus's own language. Either way, the theology is thoroughly Johannine."
+              "note": "\"Jesus Christ, whom you have sent\" — this is one of the only places in John where Jesus uses his full name \"Jesus Christ\" in direct speech. It is slightly unusual — almost as if he is speaking from the perspective of the church's later confession. Some scholars have suggested this verse is an editorial insertion by the evangelist; others accept it as Jesus's own language. Either way, the theology is thoroughly Johannine."
             },
             {
               "ref": "17:12",
-              "note": "\"None has been lost except the one doomed to destruction so that Scripture would be fulfilled\" \u2014 ho huios t\u0113s ap\u014dleias (the son of destruction) \u2014 used only here in John and in 2 Thess 2:3 for the man of lawlessness. Judas is designated by his function: he is the one whom the Scripture predicted would be lost. The \"so that Scripture would be fulfilled\" places even Judas's betrayal within the framework of divine providence without removing his moral responsibility."
+              "note": "\"None has been lost except the one doomed to destruction so that Scripture would be fulfilled\" — ho huios tēs apōleias (the son of destruction) — used only here in John and in 2 Thess 2:3 for the man of lawlessness. Judas is designated by his function: he is the one whom the Scripture predicted would be lost. The \"so that Scripture would be fulfilled\" places even Judas's betrayal within the framework of divine providence without removing his moral responsibility."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:3",
-              "note": "Augustine: \"This is eternal life: that they know you. Not 'this leads to eternal life' or 'this earns eternal life' \u2014 this IS eternal life. The knowing is the life. To know God truly is not to approach life; it is to have it. Therefore eternal life begins now, in this knowing, and continues forever \u2014 because God is inexhaustible and the knowing never ends.\""
+              "note": "Augustine: \"This is eternal life: that they know you. Not 'this leads to eternal life' or 'this earns eternal life' — this IS eternal life. The knowing is the life. To know God truly is not to approach life; it is to have it. Therefore eternal life begins now, in this knowing, and continues forever — because God is inexhaustible and the knowing never ends.\""
             },
             {
               "ref": "17:17",
-              "note": "Chrysostom: \"Sanctify them in the truth; your word is truth. The sanctification is not by water alone, not by ceremony alone \u2014 it is by truth. And truth is the word of God. The disciples are made holy not by rituals but by the word of God entering them, transforming them, setting them apart for God's purposes.\""
+              "note": "Chrysostom: \"Sanctify them in the truth; your word is truth. The sanctification is not by water alone, not by ceremony alone — it is by truth. And truth is the word of God. The disciples are made holy not by rituals but by the word of God entering them, transforming them, setting them apart for God's purposes.\""
             }
           ]
         },
         "hist": {
-          "context": "The High Priestly Prayer\nJohn 17 has been called \"the Holy of Holies of the New Testament\" (Bengel) \u2014 the most intimate conversation between the Father and Son recorded in Scripture. It is simultaneously a prayer, a final report (vv.4, 6-8: \"I have done what you gave me to do\"), a petition for protection and unity (vv.11-15), a commissioning of the disciples (v.18), and an intercession for all future believers (vv.20-26). Its structure mirrors the Aaronic High Priest's entry into the Holy of Holies on the Day of Atonement \u2014 Jesus enters the Father's presence on behalf of his people.\n\nEternal Life as Knowing\nThe definition of eternal life in v.3 \u2014 \"that they know you, the only true God, and Jesus Christ, whom you have sent\" \u2014 is the most compressed statement of soteriology in John. Eternal life is not primarily a duration (endless time) but a relationship (knowing God and his Son). The word \"know\" (gin\u014dsk\u014d) in John's vocabulary is intimate, experiential knowledge, not merely propositional information. Eternal life begins in the present moment of knowing, not at death or resurrection."
+          "context": "The High Priestly Prayer\nJohn 17 has been called \"the Holy of Holies of the New Testament\" (Bengel) — the most intimate conversation between the Father and Son recorded in Scripture. It is simultaneously a prayer, a final report (vv.4, 6-8: \"I have done what you gave me to do\"), a petition for protection and unity (vv.11-15), a commissioning of the disciples (v.18), and an intercession for all future believers (vv.20-26). Its structure mirrors the Aaronic High Priest's entry into the Holy of Holies on the Day of Atonement — Jesus enters the Father's presence on behalf of his people.\n\nEternal Life as Knowing\nThe definition of eternal life in v.3 — \"that they know you, the only true God, and Jesus Christ, whom you have sent\" — is the most compressed statement of soteriology in John. Eternal life is not primarily a duration (endless time) but a relationship (knowing God and his Son). The word \"know\" (ginōskō) in John's vocabulary is intimate, experiential knowledge, not merely propositional information. Eternal life begins in the present moment of knowing, not at death or resurrection."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 6\u201319 \u2014 Jesus Prays for the Disciples: Sanctify Them in the Truth",
+      "header": "Verses 6–19 — Jesus Prays for the Disciples: Sanctify Them in the Truth",
       "verse_start": 6,
       "verse_end": 19,
       "panels": {
         "heb": [
           {
-            "word": "hina \u014dsin hen",
+            "word": "hina ōsin hen",
             "transliteration": "hi-NA o-SIN hen",
             "gloss": "that they may be one",
-            "paragraph": "The unity Jesus prays for (vv.21-23) uses the same neuter hen as 10:30 (\"I and the Father are one\"). The unity of believers is modelled on \u2014 and shares in \u2014 the unity of the Father and Son. This is not organisational uniformity (all in one institution) but the organic, Spirit-given unity that comes from sharing the same life. The purpose clause (\"that the world may believe/know\") makes Christian unity a missiological imperative: the world's conviction is partly produced by the visible oneness of the church."
+            "paragraph": "The unity Jesus prays for (vv.21-23) uses the same neuter hen as 10:30 (\"I and the Father are one\"). The unity of believers is modelled on — and shares in — the unity of the Father and Son. This is not organisational uniformity (all in one institution) but the organic, Spirit-given unity that comes from sharing the same life. The purpose clause (\"that the world may believe/know\") makes Christian unity a missiological imperative: the world's conviction is partly produced by the visible oneness of the church."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Eph 4:3-6",
-              "note": "\"Make every effort to keep the unity of the Spirit through the bond of peace. There is one body and one Spirit... one Lord, one faith, one baptism, one God and Father of all\" \u2014 Paul's development of the unity prayer of John 17."
+              "note": "\"Make every effort to keep the unity of the Spirit through the bond of peace. There is one body and one Spirit... one Lord, one faith, one baptism, one God and Father of all\" — Paul's development of the unity prayer of John 17."
             },
             {
               "ref": "1 Cor 1:10",
-              "note": "\"I appeal to you, brothers and sisters, in the name of our Lord Jesus Christ, that all of you agree with one another in what you say and that there be no divisions among you\" \u2014 the practical application of the unity prayer to a divided church."
+              "note": "\"I appeal to you, brothers and sisters, in the name of our Lord Jesus Christ, that all of you agree with one another in what you say and that there be no divisions among you\" — the practical application of the unity prayer to a divided church."
             },
             {
               "ref": "Rev 21:3-4",
-              "note": "\"God himself will be with them and be their God... He will wipe every tear from their eyes\" \u2014 the eschatological fulfilment of v.24: being with Jesus where he is and seeing his glory."
+              "note": "\"God himself will be with them and be their God... He will wipe every tear from their eyes\" — the eschatological fulfilment of v.24: being with Jesus where he is and seeing his glory."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:21",
-              "note": "\"That all of them may be one, Father, just as you are in me and I am in you. May they also be in us so that the world may believe that you have sent me\" \u2014 the prayer for unity is missiological, not merely ecclesiological. The visible unity of believers is intended to produce the world's belief. This places an extraordinary burden on the church's divisions: every schism is a wound in the church's witness. The ecumenical movements of the 20th century have correctly identified this verse as the theological mandate for pursuing visible Christian unity \u2014 even when they have sometimes pursued it at the expense of doctrinal faithfulness."
+              "note": "\"That all of them may be one, Father, just as you are in me and I am in you. May they also be in us so that the world may believe that you have sent me\" — the prayer for unity is missiological, not merely ecclesiological. The visible unity of believers is intended to produce the world's belief. This places an extraordinary burden on the church's divisions: every schism is a wound in the church's witness. The ecumenical movements of the 20th century have correctly identified this verse as the theological mandate for pursuing visible Christian unity — even when they have sometimes pursued it at the expense of doctrinal faithfulness."
             },
             {
               "ref": "17:24",
-              "note": "\"Father, I want those you have given me to be with me where I am, and to see my glory\" \u2014 the simplest and most direct statement of what heaven is in the NT. Heaven is being where Jesus is and seeing his glory. Not a place primarily, but a person. The beatific vision \u2014 seeing the glory of the Son in the presence of the Father \u2014 is the consummation of the eternal life that began with knowing God (v.3). The verb \"I want\" (thel\u014d) is Jesus expressing his deepest desire for those he loves."
+              "note": "\"Father, I want those you have given me to be with me where I am, and to see my glory\" — the simplest and most direct statement of what heaven is in the NT. Heaven is being where Jesus is and seeing his glory. Not a place primarily, but a person. The beatific vision — seeing the glory of the Son in the presence of the Father — is the consummation of the eternal life that began with knowing God (v.3). The verb \"I want\" (thelō) is Jesus expressing his deepest desire for those he loves."
             },
             {
               "ref": "17:26",
-              "note": "\"I have made you known to them, and will continue to make you known in order that the love you have for me may be in them and that I myself may be in them\" \u2014 the prayer's final petition is its deepest: that the Father's love for the Son may dwell in the disciples, and that the Son himself may be in them. The end of all Jesus's work \u2014 teaching, miracles, foot-washing, cross, resurrection \u2014 is this: the indwelling of the Trinity in the community of believers."
+              "note": "\"I have made you known to them, and will continue to make you known in order that the love you have for me may be in them and that I myself may be in them\" — the prayer's final petition is its deepest: that the Father's love for the Son may dwell in the disciples, and that the Son himself may be in them. The end of all Jesus's work — teaching, miracles, foot-washing, cross, resurrection — is this: the indwelling of the Trinity in the community of believers."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:21-23",
-              "note": "Calvin carefully distinguishes the unity Jesus prays for from both institutional uniformity and doctrinal indifferentism. The unity is not \"let all be in one church\" (organisational) nor \"let all agree on nothing in particular\" (doctrinal); it is the organic unity of those who share the same life in Christ. Where genuine life in Christ is shared, there is genuine unity \u2014 however many institutional forms it takes. Where the same life is not shared, no organisational union constitutes the unity Jesus prayed for."
+              "note": "Calvin carefully distinguishes the unity Jesus prays for from both institutional uniformity and doctrinal indifferentism. The unity is not \"let all be in one church\" (organisational) nor \"let all agree on nothing in particular\" (doctrinal); it is the organic unity of those who share the same life in Christ. Where genuine life in Christ is shared, there is genuine unity — however many institutional forms it takes. Where the same life is not shared, no organisational union constitutes the unity Jesus prayed for."
             },
             {
               "ref": "17:26",
-              "note": "Calvin reads the final petition \u2014 \"that I myself may be in them\" \u2014 as the summary of all Christian sanctification: the goal is not merely that believers have some of Christ's qualities or follow his example but that Christ himself dwells in them. The mystical union (Christ in us, we in Christ) is the beginning, middle, and end of the Christian life."
+              "note": "Calvin reads the final petition — \"that I myself may be in them\" — as the summary of all Christian sanctification: the goal is not merely that believers have some of Christ's qualities or follow his example but that Christ himself dwells in them. The mystical union (Christ in us, we in Christ) is the beginning, middle, and end of the Christian life."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:21",
@@ -181,126 +181,82 @@
             },
             {
               "ref": "17:24",
-              "note": "\"The glory you have given me because you loved me before the creation of the world\" \u2014 the pre-creation love of the Father for the Son, which grounds the Son's pre-creation glory. This is the fourth statement of pre-existence in the prayer (vv.5, 24 \u00d7 2) \u2014 John 17 is saturated with pre-incarnate Christology."
+              "note": "\"The glory you have given me because you loved me before the creation of the world\" — the pre-creation love of the Father for the Son, which grounds the Son's pre-creation glory. This is the fourth statement of pre-existence in the prayer (vv.5, 24 × 2) — John 17 is saturated with pre-incarnate Christology."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:21",
-              "note": "Cyril of Alexandria: \"That they may be one as we are one. The Son and the Father are one by nature; we are one by grace and love and participation. The model is the divine unity; the mode is different. But the reality of the unity \u2014 the sharing of the same life \u2014 is genuine in both cases.\""
+              "note": "Cyril of Alexandria: \"That they may be one as we are one. The Son and the Father are one by nature; we are one by grace and love and participation. The model is the divine unity; the mode is different. But the reality of the unity — the sharing of the same life — is genuine in both cases.\""
             },
             {
               "ref": "17:24",
-              "note": "Augustine: \"Father, I want those you have given me to be with me where I am. This is the whole desire of the Christian heart: to be where Christ is. Not merely to be in a pleasant place, not merely to be free from pain, but to be where he is \u2014 and seeing his glory, to be transformed by it.\""
+              "note": "Augustine: \"Father, I want those you have given me to be with me where I am. This is the whole desire of the Christian heart: to be where Christ is. Not merely to be in a pleasant place, not merely to be free from pain, but to be where he is — and seeing his glory, to be transformed by it.\""
             }
           ]
         },
         "hist": {
-          "context": "The Prayer for Future Believers\nThe prayer's horizon expands in v.20 to include all who will believe through the disciples' message \u2014 every Christian in history. Jesus prays specifically for the readers of John's Gospel, for those who heard the apostolic preaching in the first century, and for believers in every subsequent generation. The prayer is current and active: Hebrews 7:25 (\"he always lives to intercede for them\") means John 17 is still being prayed by the glorified Christ for every believer today.\n\nThe Glory Given to Believers\n\"I have given them the glory that you gave me\" (v.22) \u2014 one of the most extraordinary statements in the prayer. The disciples have received the same glory the Father gave the Son. This is not equality with the Son but participation in the Son's glory \u2014 the glory of the divine life, shared through the union with Christ that the prayer describes. Paul's \"glory to glory\" (2 Cor 3:18) and \"heirs of God and co-heirs with Christ\" (Rom 8:17) develop this Johannine claim."
+          "context": "The Prayer for Future Believers\nThe prayer's horizon expands in v.20 to include all who will believe through the disciples' message — every Christian in history. Jesus prays specifically for the readers of John's Gospel, for those who heard the apostolic preaching in the first century, and for believers in every subsequent generation. The prayer is current and active: Hebrews 7:25 (\"he always lives to intercede for them\") means John 17 is still being prayed by the glorified Christ for every believer today.\n\nThe Glory Given to Believers\n\"I have given them the glory that you gave me\" (v.22) — one of the most extraordinary statements in the prayer. The disciples have received the same glory the Father gave the Son. This is not equality with the Son but participation in the Son's glory — the glory of the divine life, shared through the union with Christ that the prayer describes. Paul's \"glory to glory\" (2 Cor 3:18) and \"heirs of God and co-heirs with Christ\" (Rom 8:17) develop this Johannine claim."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 20\u201326 \u2014 Jesus Prays for All Believers: That They May Be One",
+      "header": "Verses 20–26 — Jesus Prays for All Believers: That They May Be One",
       "verse_start": 20,
       "verse_end": 26,
       "panels": {
         "heb": [
           {
-            "word": "hagiason autous en t\u0113 al\u0113theia",
-            "transliteration": "ha-gia-son au-TOUS en t\u0113 a-LE-thei-a",
+            "word": "hagiason autous en tē alētheia",
+            "transliteration": "ha-gia-son au-TOUS en tē a-LE-thei-a",
             "gloss": "sanctify them in the truth",
-            "paragraph": "Hagiaz\u014d (v.17, 19) \u2014 to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth \u2014 specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
+            "paragraph": "Hagiazō (v.17, 19) — to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth — specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
           },
           {
-            "word": "kath\u014ds",
+            "word": "kathōs",
             "transliteration": "ka-THOS",
             "gloss": "just as / even as",
-            "paragraph": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) \u2014 each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) \u2014 the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) \u2014 the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
+            "paragraph": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) — each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) — the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) — the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 28:29-30",
-              "note": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies \u2014 the typological background for Jesus's high priestly intercession."
+              "note": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies — the typological background for Jesus's high priestly intercession."
             },
             {
               "ref": "Heb 7:25",
-              "note": "\"He always lives to intercede for them\" \u2014 the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17."
+              "note": "\"He always lives to intercede for them\" — the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17."
             },
             {
               "ref": "Ps 4:6-7",
-              "note": "\"Let the light of your face shine on us\" \u2014 the priestly blessing background for the \"glory\" language of vv.1-5."
+              "note": "\"Let the light of your face shine on us\" — the priestly blessing background for the \"glory\" language of vv.1-5."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:3",
-              "note": "\"This is eternal life: that they know you, the only true God, and Jesus Christ, whom you have sent\" \u2014 the most important sentence in the prayer for soteriology. Eternal life is defined as relationship, not duration. The knowledge (gin\u014dsk\u014d \u2014 intimate, personal, experiential) is both the content and the condition of eternal life. The \"only true God\" \u2014 the exclusivity guards against syncretism: this knowing is not knowing about any divine being but knowing the specific Father of Jesus Christ."
-            },
-            {
-              "ref": "17:4-5",
-              "note": "\"I have brought you glory on earth by finishing the work you gave me to do. And now, Father, glorify me in your presence with the glory I had with you before the world began\" \u2014 two of the most theologically dense sentences in John. (1) Jesus declares his mission complete before the cross \u2014 \"finishing\" (teleiosas, aorist participle) refers to the completed totality of his obedient life, of which the cross is the final act. (2) He asks for the restoration of the pre-incarnate glory \u2014 the glory shared with the Father \"before the world began\" (pro tou ton kosmon einai), a direct claim to eternal pre-existence with the Father."
-            },
-            {
-              "ref": "17:15",
-              "note": "\"My prayer is not that you take them out of the world but that you protect them from the evil one\" \u2014 the rejection of escapism as the Christian posture. Jesus does not pray for the disciples to be removed from the dangerous world; he prays for their protection within it. The Christian vocation is engagement, not withdrawal. The prayer for protection \"from the evil one\" (apo tou pon\u0113rou) acknowledges the reality of spiritual warfare without endorsing the withdrawal from the world it might seem to require."
-            },
-            {
-              "ref": "17:17-19",
-              "note": "\"Sanctify them by the truth; your word is truth. As you sent me into the world, I have sent them into the world. For them I sanctify myself, that they too may be truly sanctified\" \u2014 the three-part logic of Christian sanctification: (1) the means: truth/the word; (2) the mission: sent into the world; (3) the ground: Jesus's own self-consecration for them. The disciples are sanctified because Jesus first consecrated himself \u2014 his sanctification is the basis and model of theirs."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:4",
-              "note": "Calvin reads \"I have finished the work you gave me to do\" as the completed obedience of the entire life \u2014 not merely the cross, though the cross is the culmination. The whole life of Jesus was the work: his teaching, his miracles, his relationships, his suffering, and supremely his death. The prayer is offered from the position of one who has run the race and is about to cross the finishing line."
-            },
-            {
-              "ref": "17:15",
-              "note": "Calvin uses this verse to rebuke monastic withdrawal as a misunderstanding of Jesus's prayer. Jesus explicitly does not pray for removal from the world; he prays for protection within it. The Christian's place is in the world, engaged with it, not above it. The difference between the Christian and the world is not geographical (here vs. there) but spiritual (sanctified vs. unsanctified, protected vs. unprotected)."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:3",
-              "note": "\"Jesus Christ, whom you have sent\" \u2014 this is one of the only places in John where Jesus uses his full name \"Jesus Christ\" in direct speech. It is slightly unusual \u2014 almost as if he is speaking from the perspective of the church's later confession. Some scholars have suggested this verse is an editorial insertion by the evangelist; others accept it as Jesus's own language. Either way, the theology is thoroughly Johannine."
-            },
-            {
-              "ref": "17:12",
-              "note": "\"None has been lost except the one doomed to destruction so that Scripture would be fulfilled\" \u2014 ho huios t\u0113s ap\u014dleias (the son of destruction) \u2014 used only here in John and in 2 Thess 2:3 for the man of lawlessness. Judas is designated by his function: he is the one whom the Scripture predicted would be lost. The \"so that Scripture would be fulfilled\" places even Judas's betrayal within the framework of divine providence without removing his moral responsibility."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "17:3",
-              "note": "Augustine: \"This is eternal life: that they know you. Not 'this leads to eternal life' or 'this earns eternal life' \u2014 this IS eternal life. The knowing is the life. To know God truly is not to approach life; it is to have it. Therefore eternal life begins now, in this knowing, and continues forever \u2014 because God is inexhaustible and the knowing never ends.\""
-            },
-            {
-              "ref": "17:17",
-              "note": "Chrysostom: \"Sanctify them in the truth; your word is truth. The sanctification is not by water alone, not by ceremony alone \u2014 it is by truth. And truth is the word of God. The disciples are made holy not by rituals but by the word of God entering them, transforming them, setting them apart for God's purposes.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The High Priestly Prayer\nJohn 17 has been called \"the Holy of Holies of the New Testament\" (Bengel) \u2014 the most intimate conversation between the Father and Son recorded in Scripture. It is simultaneously a prayer, a final report (vv.4, 6-8: \"I have done what you gave me to do\"), a petition for protection and unity (vv.11-15), a commissioning of the disciples (v.18), and an intercession for all future believers (vv.20-26). Its structure mirrors the Aaronic High Priest's entry into the Holy of Holies on the Day of Atonement \u2014 Jesus enters the Father's presence on behalf of his people.\n\nEternal Life as Knowing\nThe definition of eternal life in v.3 \u2014 \"that they know you, the only true God, and Jesus Christ, whom you have sent\" \u2014 is the most compressed statement of soteriology in John. Eternal life is not primarily a duration (endless time) but a relationship (knowing God and his Son). The word \"know\" (gin\u014dsk\u014d) in John's vocabulary is intimate, experiential knowledge, not merely propositional information. Eternal life begins in the present moment of knowing, not at death or resurrection."
+          "context": "The High Priestly Prayer\nJohn 17 has been called \"the Holy of Holies of the New Testament\" (Bengel) — the most intimate conversation between the Father and Son recorded in Scripture. It is simultaneously a prayer, a final report (vv.4, 6-8: \"I have done what you gave me to do\"), a petition for protection and unity (vv.11-15), a commissioning of the disciples (v.18), and an intercession for all future believers (vv.20-26). Its structure mirrors the Aaronic High Priest's entry into the Holy of Holies on the Day of Atonement — Jesus enters the Father's presence on behalf of his people.\n\nEternal Life as Knowing\nThe definition of eternal life in v.3 — \"that they know you, the only true God, and Jesus Christ, whom you have sent\" — is the most compressed statement of soteriology in John. Eternal life is not primarily a duration (endless time) but a relationship (knowing God and his Son). The word \"know\" (ginōskō) in John's vocabulary is intimate, experiential knowledge, not merely propositional information. Eternal life begins in the present moment of knowing, not at death or resurrection."
         }
       }
     }
@@ -310,31 +266,31 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Jesus prays specifically for the readers of John\\'s Gospel, for those who heard the apostolic preaching in the first century, and for believers in every subsequent generation\u2026"
+        "text": "Jesus prays specifically for the readers of John\\'s Gospel, for those who heard the apostolic preaching in the first century, and for believers in every subsequent generation…"
       },
       {
         "name": "disciples",
         "role": "Key biblical figure",
-        "text": "11-15), a commissioning of the disciples (v\u2026"
+        "text": "11-15), a commissioning of the disciples (v…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">gin\u014dsk\u014dsin (17:3)</td><td>NIV: \"know\"; KJV: \"know\"; ESV: \"know\"; NRSV: \"know\". All agree. The present subjunctive (ongoing knowing) is a commentary point, not a translation difference.</td></tr><tr><td class=\"t-label\">hagiason (17:17)</td><td>NIV: \"sanctify\"; KJV: \"sanctify\"; ESV: \"sanctify\"; NRSV: \"sanctify\". Universal agreement. The word carries the full OT sense of consecration: set apart for God's purposes.</td></tr><tr><td class=\"t-label\">hen (17:21)</td><td>NIV/KJV/ESV/NRSV: \"one\". Universal agreement. The neuter (one thing/one reality) rather than masculine (one person) is a commentary point.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ginōskōsin (17:3)</td><td>NIV: \"know\"; KJV: \"know\"; ESV: \"know\"; NRSV: \"know\". All agree. The present subjunctive (ongoing knowing) is a commentary point, not a translation difference.</td></tr><tr><td class=\"t-label\">hagiason (17:17)</td><td>NIV: \"sanctify\"; KJV: \"sanctify\"; ESV: \"sanctify\"; NRSV: \"sanctify\". Universal agreement. The word carries the full OT sense of consecration: set apart for God's purposes.</td></tr><tr><td class=\"t-label\">hen (17:21)</td><td>NIV/KJV/ESV/NRSV: \"one\". Universal agreement. The neuter (one thing/one reality) rather than masculine (one person) is a commentary point.</td></tr>",
     "src": [
       {
         "title": "Hebrews 7:25",
         "quote": "\"He is able to save completely those who come to God through him, because he always lives to intercede for them.\"",
-        "note": "The Epistle to the Hebrews' theology of Christ's ongoing intercession \u2014 presenting John 17 as the permanent posture of the glorified High Priest before the Father."
+        "note": "The Epistle to the Hebrews' theology of Christ's ongoing intercession — presenting John 17 as the permanent posture of the glorified High Priest before the Father."
       },
       {
         "title": "Leviticus 16:1-34",
-        "quote": "The Day of Atonement \u2014 the High Priest entering the Holy of Holies with blood for the sins of the whole community. The typological background for Jesus's entry into the Father's presence in John 17.",
+        "quote": "The Day of Atonement — the High Priest entering the Holy of Holies with blood for the sins of the whole community. The typological background for Jesus's entry into the Father's presence in John 17.",
         "note": "John 17 is the NT's most explicit fulfilment of the Yom Kippur pattern: the unique priest, entering the divine presence, bearing the names of the people, interceding for forgiveness and unity."
       }
     ],
     "rec": [
       {
         "who": "\"The Holy of Holies of the New Testament\"",
-        "text": "Johann Albrecht Bengel called John 17 \"the holy of holies of the NT\" in his Gnomon Novi Testamenti (1742). The description has become the standard characterisation of the chapter in Christian devotion. Unlike the Lord's Prayer (Matt 6:9-13), which is given as a model for disciples to use, John 17 is not a prayer for others to repeat but a window into the Son's own communion with the Father \u2014 the closest Scripture brings the reader to the inner life of the Trinity."
+        "text": "Johann Albrecht Bengel called John 17 \"the holy of holies of the NT\" in his Gnomon Novi Testamenti (1742). The description has become the standard characterisation of the chapter in Christian devotion. Unlike the Lord's Prayer (Matt 6:9-13), which is given as a model for disciples to use, John 17 is not a prayer for others to repeat but a window into the Son's own communion with the Father — the closest Scripture brings the reader to the inner life of the Trinity."
       },
       {
         "who": "John 17 and Christian Ecumenism",
@@ -344,18 +300,18 @@
     "lit": {
       "rows": [
         {
-          "label": "\"Just As\" (kath\u014ds) as Structural Key \u2014 vv.11, 14, 16, 18, 21-23",
-          "text": "The recurring kath\u014ds (just as) draws the parallel between divine reality and human reality at six points: unity as in Father/Son; not of the world as Son is not; sent as Father sent Son; one as Father/Son are one. The Christian life is shaped by the divine life at every structural point \u2014 the prayer's deepest claim.",
+          "label": "\"Just As\" (kathōs) as Structural Key — vv.11, 14, 16, 18, 21-23",
+          "text": "The recurring kathōs (just as) draws the parallel between divine reality and human reality at six points: unity as in Father/Son; not of the world as Son is not; sent as Father sent Son; one as Father/Son are one. The Christian life is shaped by the divine life at every structural point — the prayer's deepest claim.",
           "is_key": false
         },
         {
-          "label": "Concentric Prayer Structure \u2014 vv.1-26",
-          "text": "The prayer moves in three concentric rings: Jesus prays for himself (vv.1-5: glorification), for the Eleven (vv.6-19: sanctification and protection), for all future believers (vv.20-26: unity and love). The rings are not merely sequential but interpenetrating \u2014 the glory of the Son is the ground of every subsequent request.",
+          "label": "Concentric Prayer Structure — vv.1-26",
+          "text": "The prayer moves in three concentric rings: Jesus prays for himself (vv.1-5: glorification), for the Eleven (vv.6-19: sanctification and protection), for all future believers (vv.20-26: unity and love). The rings are not merely sequential but interpenetrating — the glory of the Son is the ground of every subsequent request.",
           "is_key": false
         },
         {
-          "label": "Inclusio \u2014 Glory Language",
-          "text": "The prayer is bracketed by glory: \"glorify your Son\" (v1) and \"see my glory\" (v24). The repetition of \"eternal life\" (v2-3) and \"I have revealed you\" (v6, 26) creates a liturgical rhythm. John presents this as Jesus' high-priestly prayer \u2014 the literary counterpart to Hebrews' argument about Christ as eternal high priest.",
+          "label": "Inclusio — Glory Language",
+          "text": "The prayer is bracketed by glory: \"glorify your Son\" (v1) and \"see my glory\" (v24). The repetition of \"eternal life\" (v2-3) and \"I have revealed you\" (v6, 26) creates a liturgical rhythm. John presents this as Jesus' high-priestly prayer — the literary counterpart to Hebrews' argument about Christ as eternal high priest.",
           "is_key": false
         }
       ],
@@ -363,34 +319,34 @@
     },
     "hebtext": [
       {
-        "word": "hagiason autous en t\u0113 al\u0113theia",
-        "tlit": "ha-gia-son au-TOUS en t\u0113 a-LE-thei-a",
+        "word": "hagiason autous en tē alētheia",
+        "tlit": "ha-gia-son au-TOUS en tē a-LE-thei-a",
         "gloss": "sanctify them in the truth",
-        "note": "Hagiaz\u014d (v.17, 19) \u2014 to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth \u2014 specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
+        "note": "Hagiazō (v.17, 19) — to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth — specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
       },
       {
-        "word": "kath\u014ds",
+        "word": "kathōs",
         "tlit": "ka-THOS",
         "gloss": "just as / even as",
-        "note": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) \u2014 each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) \u2014 the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) \u2014 the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
+        "note": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) — each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) — the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) — the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
       },
       {
-        "word": "hina \u014dsin hen",
+        "word": "hina ōsin hen",
         "tlit": "hi-NA o-SIN hen",
         "gloss": "that they may be one",
-        "note": "The unity Jesus prays for (vv.21-23) uses the same neuter hen as 10:30 (\"I and the Father are one\"). The unity of believers is modelled on \u2014 and shares in \u2014 the unity of the Father and Son. This is not organisational uniformity (all in one institution) but the organic, Spirit-given unity that comes from sharing the same life. The purpose clause (\"that the world may believe/know\") makes Christian unity a missiological imperative: the world's conviction is partly produced by the visible oneness of the church."
+        "note": "The unity Jesus prays for (vv.21-23) uses the same neuter hen as 10:30 (\"I and the Father are one\"). The unity of believers is modelled on — and shares in — the unity of the Father and Son. This is not organisational uniformity (all in one institution) but the organic, Spirit-given unity that comes from sharing the same life. The purpose clause (\"that the world may believe/know\") makes Christian unity a missiological imperative: the world's conviction is partly produced by the visible oneness of the church."
       },
       {
-        "word": "hagiason autous en t\u0113 al\u0113theia",
-        "tlit": "ha-gia-son au-TOUS en t\u0113 a-LE-thei-a",
+        "word": "hagiason autous en tē alētheia",
+        "tlit": "ha-gia-son au-TOUS en tē a-LE-thei-a",
         "gloss": "sanctify them in the truth",
-        "note": "Hagiaz\u014d (v.17, 19) \u2014 to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth \u2014 specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
+        "note": "Hagiazō (v.17, 19) — to set apart as holy, to consecrate. The same root as hagios (holy) and the hagiasmos (sanctification) of Paul's letters. Jesus prays for the disciples' sanctification through the truth — specifically through the word (v.17: \"your word is truth\") and through his own self-consecration (v.19: \"for them I sanctify myself\"). The means of sanctification is the truth of God's word, applied by the Spirit to those the Father has given the Son."
       },
       {
-        "word": "kath\u014ds",
+        "word": "kathōs",
         "tlit": "ka-THOS",
         "gloss": "just as / even as",
-        "note": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) \u2014 each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) \u2014 the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) \u2014 the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
+        "note": "The most theologically loaded word in the prayer. It appears six times (vv.2, 11, 14, 16, 18, 21, 22, 23) — each time drawing a parallel between the divine relationship and the human one. \"That they may be one as we are one\" (v.11, 22) — the unity of believers is modelled on the unity of the Father and Son. \"As you sent me... I have sent them\" (v.18) — the disciples' mission mirrors the Son's mission. The prayer grounds all Christian reality in divine reality."
       }
     ],
     "thread": [
@@ -398,42 +354,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Exod 28:29-30",
         "type": "Connection",
-        "text": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies \u2014 the typological background for Jesus's high priestly intercession.",
+        "text": "The High Priest carrying the names of the twelve tribes on his breastplate into the Holy of Holies — the typological background for Jesus's high priestly intercession.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Heb 7:25",
         "type": "Connection",
-        "text": "\"He always lives to intercede for them\" \u2014 the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17.",
+        "text": "\"He always lives to intercede for them\" — the Epistle to the Hebrews' theology of Christ's ongoing intercession, rooted in the prayer of John 17.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 4:6-7",
         "type": "Connection",
-        "text": "\"Let the light of your face shine on us\" \u2014 the priestly blessing background for the \"glory\" language of vv.1-5.",
+        "text": "\"Let the light of your face shine on us\" — the priestly blessing background for the \"glory\" language of vv.1-5.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Eph 4:3-6",
         "type": "Connection",
-        "text": "\"Make every effort to keep the unity of the Spirit through the bond of peace. There is one body and one Spirit... one Lord, one faith, one baptism, one God and Father of all\" \u2014 Paul's development of the unity prayer of John 17.",
+        "text": "\"Make every effort to keep the unity of the Spirit through the bond of peace. There is one body and one Spirit... one Lord, one faith, one baptism, one God and Father of all\" — Paul's development of the unity prayer of John 17.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 Cor 1:10",
         "type": "Connection",
-        "text": "\"I appeal to you, brothers and sisters, in the name of our Lord Jesus Christ, that all of you agree with one another in what you say and that there be no divisions among you\" \u2014 the practical application of the unity prayer to a divided church.",
+        "text": "\"I appeal to you, brothers and sisters, in the name of our Lord Jesus Christ, that all of you agree with one another in what you say and that there be no divisions among you\" — the practical application of the unity prayer to a divided church.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Rev 21:3-4",
         "type": "Fulfilment",
-        "text": "\"God himself will be with them and be their God... He will wipe every tear from their eyes\" \u2014 the eschatological fulfilment of v.24: being with Jesus where he is and seeing his glory.",
+        "text": "\"God himself will be with them and be their God... He will wipe every tear from their eyes\" — the eschatological fulfilment of v.24: being with Jesus where he is and seeing his glory.",
         "direction": "backward"
       }
     ],
@@ -494,7 +450,7 @@
           "score": 10
         }
       ],
-      "note": "John 17 is the theological summit of the Gospel. The prayer encompasses eternity (pre-creation glory, v.5, 24), history (the completed work, v.4), the present crisis (protection in the world, v.15), and the eschatological future (being where Jesus is, v.24). Its central claim is the mutual indwelling of Father, Son, and believers \u2014 a unity modelled on and participating in the divine unity. \"I in them and you in me\" (v.23) is the Johannine summary of what salvation ultimately means: not merely forgiveness of sins but incorporation into the life of the Trinity."
+      "note": "John 17 is the theological summit of the Gospel. The prayer encompasses eternity (pre-creation glory, v.5, 24), history (the completed work, v.4), the present crisis (protection in the world, v.15), and the eschatological future (being where Jesus is, v.24). Its central claim is the mutual indwelling of Father, Son, and believers — a unity modelled on and participating in the divine unity. \"I in them and you in me\" (v.23) is the Johannine summary of what salvation ultimately means: not merely forgiveness of sins but incorporation into the life of the Trinity."
     }
   },
   "vhl_groups": [
@@ -618,7 +574,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'That all of them may be one, Father, just as you are in me and I am in you' (v. 21). Unity modeled on Trinity. Jesus prays for believers across time\u2014'those who will believe through their message.' We're in his prayer.",
+      "tip": "'That all of them may be one, Father, just as you are in me and I am in you' (v. 21). Unity modeled on Trinity. Jesus prays for believers across time—'those who will believe through their message.' We're in his prayer.",
       "genre_tag": "canonical_thread"
     }
   ]

--- a/content/john/18.json
+++ b/content/john/18.json
@@ -7,39 +7,39 @@
   "subtitle": "The Arrest and Trial Before Pilate",
   "timeline_link": {
     "event_id": "gethsemane",
-    "text": "See on Timeline \u2014 Gethsemane"
+    "text": "See on Timeline — Gethsemane"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201314 \u2014 The Arrest in Gethsemane; Jesus Before Annas",
+      "header": "Verses 1–14 — The Arrest in Gethsemane; Jesus Before Annas",
       "verse_start": 1,
       "verse_end": 14,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am he / I am",
-            "paragraph": "In v.5-6 the eg\u014d eimi causes the armed detachment to fall to the ground \u2014 a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
+            "paragraph": "In v.5-6 the egō eimi causes the armed detachment to fall to the ground — a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
           },
           {
-            "word": "pot\u0113rion",
+            "word": "potērion",
             "transliteration": "po-TE-ri-on",
             "gloss": "cup",
-            "paragraph": "\"Shall I not drink the cup the Father has given me?\" (v.11) \u2014 the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
+            "paragraph": "\"Shall I not drink the cup the Father has given me?\" (v.11) — the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
           }
         ],
         "places": [
           {
             "name": "Garden of Gethsemane",
-            "coords": "31.7792\u00b0 N, 35.2397\u00b0 E",
-            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" \u2014 the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
+            "coords": "31.7792° N, 35.2397° E",
+            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" — the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
           },
           {
             "name": "House of Annas / Caiaphas",
-            "coords": "31.7697\u00b0 N, 35.2285\u00b0 E",
+            "coords": "31.7697° N, 35.2285° E",
             "text": "Likely in the upper city (wealthy Herodian neighbourhood) on the western hill of Jerusalem. The Palatial Mansion excavated in the Jewish Quarter of the Old City may be the house of a member of the high priestly family. Jesus is taken here for the pre-trial hearing. The traditional \"House of Caiaphas\" is now the Church of St Peter in Gallicantu (Peter at the Cock-crow), marking the site of Peter's denial and the rooster's crow."
           }
         ],
@@ -47,41 +47,41 @@
           "refs": [
             {
               "ref": "Isa 51:17",
-              "note": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" \u2014 the OT cup-of-wrath imagery Jesus invokes in v.11."
+              "note": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" — the OT cup-of-wrath imagery Jesus invokes in v.11."
             },
             {
               "ref": "Ps 41:9",
-              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples."
+              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples."
             },
             {
               "ref": "Luke 22:39-46",
-              "note": "The Gethsemane prayer \u2014 the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11)."
+              "note": "The Gethsemane prayer — the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:4-6",
-              "note": "\"Jesus, knowing all that was going to happen to him, went out\" \u2014 the sovereign initiative is John's signature. He does not wait to be found; he goes out to meet them. The \"I am he\" that fells the soldiers is the most compressed theophany in the passion narratives: these are soldiers (Roman cohort = 600 men) with weapons, lanterns, and torches \u2014 and a single word from Jesus puts them on the ground. He is not arrested; he chooses to be apprehended."
+              "note": "\"Jesus, knowing all that was going to happen to him, went out\" — the sovereign initiative is John's signature. He does not wait to be found; he goes out to meet them. The \"I am he\" that fells the soldiers is the most compressed theophany in the passion narratives: these are soldiers (Roman cohort = 600 men) with weapons, lanterns, and torches — and a single word from Jesus puts them on the ground. He is not arrested; he chooses to be apprehended."
             },
             {
               "ref": "18:8-9",
-              "note": "\"Let these men go. This happened so that the words he had spoken would be fulfilled: 'I have not lost one of those you gave me'\" \u2014 the protective concern for the disciples at the moment of his own arrest. John connects the physical protection at Gethsemane to the eternal protection of 17:12. Jesus's care for the eleven at the arrest is the enactment of the prayer he had just prayed: \"protect them.\""
+              "note": "\"Let these men go. This happened so that the words he had spoken would be fulfilled: 'I have not lost one of those you gave me'\" — the protective concern for the disciples at the moment of his own arrest. John connects the physical protection at Gethsemane to the eternal protection of 17:12. Jesus's care for the eleven at the arrest is the enactment of the prayer he had just prayed: \"protect them.\""
             },
             {
               "ref": "18:11",
-              "note": "\"Shall I not drink the cup the Father has given me?\" \u2014 the cup is not merely suffering but wrath. The question is rhetorical \u2014 of course he will drink it; he came for this. But the question reveals the weight of what is being accepted: not just death but the Father's wrath against sin, fully and voluntarily absorbed. Peter's sword is well-intentioned but theologically catastrophic: if he prevents the arrest, he prevents the atonement."
+              "note": "\"Shall I not drink the cup the Father has given me?\" — the cup is not merely suffering but wrath. The question is rhetorical — of course he will drink it; he came for this. But the question reveals the weight of what is being accepted: not just death but the Father's wrath against sin, fully and voluntarily absorbed. Peter's sword is well-intentioned but theologically catastrophic: if he prevents the arrest, he prevents the atonement."
             },
             {
               "ref": "18:20-23",
-              "note": "Jesus before Annas: his response to the high priest's questions is a model of truthful self-defence. He does not deny his teaching (he spoke openly, v.20) but he refuses to incriminate himself by speculating about what his teaching meant. When struck, he does not retaliate but demands due process: \"if I said something wrong, testify as to what is wrong.\" He models dignity under injustice \u2014 the innocent party demanding the procedure its accusers claim to represent."
+              "note": "Jesus before Annas: his response to the high priest's questions is a model of truthful self-defence. He does not deny his teaching (he spoke openly, v.20) but he refuses to incriminate himself by speculating about what his teaching meant. When struck, he does not retaliate but demands due process: \"if I said something wrong, testify as to what is wrong.\" He models dignity under injustice — the innocent party demanding the procedure its accusers claim to represent."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:6",
@@ -89,44 +89,44 @@
             },
             {
               "ref": "18:20",
-              "note": "Calvin notes that Jesus's defence before Annas (\"I said nothing in secret\") is an appeal to the public record \u2014 the Pharisees' own witnesses could testify to his teaching. This is not evasion but the demand for due process that Jewish law required. The illegal midnight examination, the prejudged verdict, and the physical abuse all violate the law in the name of the law \u2014 the supreme irony of the Jewish trial."
+              "note": "Calvin notes that Jesus's defence before Annas (\"I said nothing in secret\") is an appeal to the public record — the Pharisees' own witnesses could testify to his teaching. This is not evasion but the demand for due process that Jewish law required. The illegal midnight examination, the prejudged verdict, and the physical abuse all violate the law in the name of the law — the supreme irony of the Jewish trial."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:3",
-              "note": "\"A detachment of soldiers\" \u2014 speira, a Roman military unit (cohort = 600 men, though possibly a maniple = 200). The presence of Roman soldiers alongside temple officials indicates the involvement of the Roman military in the arrest \u2014 suggesting Pilate had been informed and had authorised the use of force. The scale of the operation (torches, weapons, a military unit) reflects how seriously the authorities took the threat Jesus represented."
+              "note": "\"A detachment of soldiers\" — speira, a Roman military unit (cohort = 600 men, though possibly a maniple = 200). The presence of Roman soldiers alongside temple officials indicates the involvement of the Roman military in the arrest — suggesting Pilate had been informed and had authorised the use of force. The scale of the operation (torches, weapons, a military unit) reflects how seriously the authorities took the threat Jesus represented."
             },
             {
               "ref": "18:13",
-              "note": "\"Brought him first to Annas\" \u2014 Annas had been high priest AD 6-15. Five of his sons and son-in-law Caiaphas all held the high priesthood. The pre-trial before Annas is unique to John, consistent with eyewitness knowledge of Jerusalem politics."
+              "note": "\"Brought him first to Annas\" — Annas had been high priest AD 6-15. Five of his sons and son-in-law Caiaphas all held the high priesthood. The pre-trial before Annas is unique to John, consistent with eyewitness knowledge of Jerusalem politics."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:4-5",
-              "note": "Augustine: \"Jesus went out to meet those who came to take him. He went out \u2014 not dragged, not surprised, not fleeing, but going forward. He is not seized; he gives himself. The arrest is his act, not theirs. He who could have called twelve legions of angels chose instead to call out: Who do you seek? \u2014 and to answer: I am he.\""
+              "note": "Augustine: \"Jesus went out to meet those who came to take him. He went out — not dragged, not surprised, not fleeing, but going forward. He is not seized; he gives himself. The arrest is his act, not theirs. He who could have called twelve legions of angels chose instead to call out: Who do you seek? — and to answer: I am he.\""
             },
             {
               "ref": "18:11",
-              "note": "Chrysostom: \"Shall I not drink the cup the Father has given me? The cup is the Father's gift. Suffering from the Father's hand is different from suffering from human injustice \u2014 it is received as a gift. Not 'the cup the enemies force on me' but 'the cup the Father has given me.' This is the transformation of all suffering for the believer: it comes through human hands but from the Father's.\""
+              "note": "Chrysostom: \"Shall I not drink the cup the Father has given me? The cup is the Father's gift. Suffering from the Father's hand is different from suffering from human injustice — it is received as a gift. Not 'the cup the enemies force on me' but 'the cup the Father has given me.' This is the transformation of all suffering for the believer: it comes through human hands but from the Father's.\""
             }
           ]
         },
         "hist": {
-          "context": "The Garden Arrest in John\nJohn omits the Gethsemane prayer (Matt 26:36-46; Mark 14:32-42; Luke 22:39-46) but contains its theological equivalent in the \"cup\" question of v.11. He also uniquely records: the soldiers falling (vv.5-6), Jesus's protective request for the disciples (vv.8-9), the name of Malchus (v.10), and the detailed structure of the Jewish pre-trial before Annas (vv.12-24) before Caiaphas. John's eyewitness detail \u2014 the name of the servant, the detail that Peter was warming himself, the servant who challenged Peter being related to Malchus \u2014 suggests the beloved disciple (v.15: \"another disciple... known to the high priest\") as the source.\n\nPeter's Three Denials\nJohn structures the three denials carefully: (1) at the door with the servant girl (v.17); (2) at the fire with the servants (v.25); (3) with the relative of Malchus in the courtyard (v.26). Each one escalates: first a casual question answered casually, then a group challenge, then a direct personal challenge from someone who was present in the garden. The rooster's crow (v.27) is the signal that Jesus's prediction (13:38) has been fulfilled exactly."
+          "context": "The Garden Arrest in John\nJohn omits the Gethsemane prayer (Matt 26:36-46; Mark 14:32-42; Luke 22:39-46) but contains its theological equivalent in the \"cup\" question of v.11. He also uniquely records: the soldiers falling (vv.5-6), Jesus's protective request for the disciples (vv.8-9), the name of Malchus (v.10), and the detailed structure of the Jewish pre-trial before Annas (vv.12-24) before Caiaphas. John's eyewitness detail — the name of the servant, the detail that Peter was warming himself, the servant who challenged Peter being related to Malchus — suggests the beloved disciple (v.15: \"another disciple... known to the high priest\") as the source.\n\nPeter's Three Denials\nJohn structures the three denials carefully: (1) at the door with the servant girl (v.17); (2) at the fire with the servants (v.25); (3) with the relative of Malchus in the courtyard (v.26). Each one escalates: first a casual question answered casually, then a group challenge, then a direct personal challenge from someone who was present in the garden. The rooster's crow (v.27) is the signal that Jesus's prediction (13:38) has been fulfilled exactly."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 15\u201327 \u2014 Peter\u2019s Three Denials",
+      "header": "Verses 15–27 — Peter’s Three Denials",
       "verse_start": 15,
       "verse_end": 27,
       "panels": {
@@ -135,24 +135,24 @@
             "word": "basileia",
             "transliteration": "ba-si-LEI-a",
             "gloss": "kingdom",
-            "paragraph": "\"My kingdom is not of this world\" (v.36) \u2014 not \"not in this world\" (Jesus's kingdom is present in the world) but \"not of this world\" (it does not originate from or operate by the world's power structures). The distinction is source and method, not location. The kingdom's validation does not come through military force (\"my servants would not fight\") but through truth-speaking (v.37). Pilate cannot categorise this kingdom because it operates by principles he has no framework for."
+            "paragraph": "\"My kingdom is not of this world\" (v.36) — not \"not in this world\" (Jesus's kingdom is present in the world) but \"not of this world\" (it does not originate from or operate by the world's power structures). The distinction is source and method, not location. The kingdom's validation does not come through military force (\"my servants would not fight\") but through truth-speaking (v.37). Pilate cannot categorise this kingdom because it operates by principles he has no framework for."
           },
           {
-            "word": "al\u0113theia",
+            "word": "alētheia",
             "transliteration": "a-LE-thei-a",
             "gloss": "truth",
-            "paragraph": "The word that has run through John's Gospel from the prologue (\"grace and truth came through Jesus Christ,\" 1:17) reaches its ironic climax here. Pilate's \"what is truth?\" (v.38) is the question of a man who has the Truth standing in front of him and cannot recognise it. Whether his question is cynical dismissal, weary scepticism, or genuine philosophical inquiry, he walks away without waiting for the answer \u2014 the most tragic missed opportunity in the Gospel."
+            "paragraph": "The word that has run through John's Gospel from the prologue (\"grace and truth came through Jesus Christ,\" 1:17) reaches its ironic climax here. Pilate's \"what is truth?\" (v.38) is the question of a man who has the Truth standing in front of him and cannot recognise it. Whether his question is cynical dismissal, weary scepticism, or genuine philosophical inquiry, he walks away without waiting for the answer — the most tragic missed opportunity in the Gospel."
           }
         ],
         "places": [
           {
             "name": "Garden of Gethsemane",
-            "coords": "31.7792\u00b0 N, 35.2397\u00b0 E",
-            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" \u2014 the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
+            "coords": "31.7792° N, 35.2397° E",
+            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" — the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
           },
           {
             "name": "House of Annas / Caiaphas",
-            "coords": "31.7697\u00b0 N, 35.2285\u00b0 E",
+            "coords": "31.7697° N, 35.2285° E",
             "text": "Likely in the upper city (wealthy Herodian neighbourhood) on the western hill of Jerusalem. The Palatial Mansion excavated in the Jewish Quarter of the Old City may be the house of a member of the high priestly family. Jesus is taken here for the pre-trial hearing. The traditional \"House of Caiaphas\" is now the Church of St Peter in Gallicantu (Peter at the Cock-crow), marking the site of Peter's denial and the rooster's crow."
           }
         ],
@@ -160,41 +160,41 @@
           "refs": [
             {
               "ref": "Isa 53:7",
-              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" \u2014 the Servant's silence before his accusers, which John's Jesus does not entirely replicate (he speaks) but which frames the scene."
+              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" — the Servant's silence before his accusers, which John's Jesus does not entirely replicate (he speaks) but which frames the scene."
             },
             {
               "ref": "Dan 7:13-14",
-              "note": "\"There before me was one like a son of man... He was given authority, glory and sovereign power\" \u2014 the kingdom-not-of-this-world that Jesus describes to Pilate is the kingdom Daniel saw given to the Son of Man."
+              "note": "\"There before me was one like a son of man... He was given authority, glory and sovereign power\" — the kingdom-not-of-this-world that Jesus describes to Pilate is the kingdom Daniel saw given to the Son of Man."
             },
             {
               "ref": "Ps 2:6",
-              "note": "\"I have installed my king on Zion, my holy mountain\" \u2014 the divine king whom the nations resist, as Pilate and the chief priests resist Jesus."
+              "note": "\"I have installed my king on Zion, my holy mountain\" — the divine king whom the nations resist, as Pilate and the chief priests resist Jesus."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:28",
-              "note": "The Passover irony: they will not defile themselves by entering a Gentile's house, while they are plotting the murder of the one who is himself the Passover. The scrupulosity about ritual defilement in the service of judicial murder is the supreme example of majoring on minors while missing the main thing \u2014 a pattern Jesus had identified throughout his ministry (Matt 23:23-24)."
+              "note": "The Passover irony: they will not defile themselves by entering a Gentile's house, while they are plotting the murder of the one who is himself the Passover. The scrupulosity about ritual defilement in the service of judicial murder is the supreme example of majoring on minors while missing the main thing — a pattern Jesus had identified throughout his ministry (Matt 23:23-24)."
             },
             {
               "ref": "18:36",
-              "note": "\"My kingdom is not of this world\" \u2014 this is not a statement of otherworldliness (the kingdom is irrelevant to this world) but of origin and method. The kingdom's origin is heaven, not human politics; its method is truth-speaking, not force. The contrast is between earthly kingdoms (established and maintained by coercion) and Jesus's kingdom (established by testimony to truth and maintained by those who respond to truth)."
+              "note": "\"My kingdom is not of this world\" — this is not a statement of otherworldliness (the kingdom is irrelevant to this world) but of origin and method. The kingdom's origin is heaven, not human politics; its method is truth-speaking, not force. The contrast is between earthly kingdoms (established and maintained by coercion) and Jesus's kingdom (established by testimony to truth and maintained by those who respond to truth)."
             },
             {
               "ref": "18:37-38",
-              "note": "The juxtaposition of \"Everyone on the side of truth listens to me\" and \"What is truth?\" is John's sharpest dramatic irony. Jesus has just given Pilate the criterion for being on the side of truth \u2014 listening to him \u2014 and Pilate's immediate response is to ask whether truth even exists. He is simultaneously hearing the criterion for recognising truth and demonstrating that he does not meet it."
+              "note": "The juxtaposition of \"Everyone on the side of truth listens to me\" and \"What is truth?\" is John's sharpest dramatic irony. Jesus has just given Pilate the criterion for being on the side of truth — listening to him — and Pilate's immediate response is to ask whether truth even exists. He is simultaneously hearing the criterion for recognising truth and demonstrating that he does not meet it."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:36",
-              "note": "Calvin insists on the \"not of this world\" as a description of the kingdom's origin and power, not its location or relevance. The kingdom is engaged with the world \u2014 through truth, preaching, and the Spirit \u2014 but it does not operate by the world's categories of power. This is why Pilate cannot categorise Jesus: he is a king with no army, no territory, and no political programme, yet his claim is the most comprehensive sovereignty imaginable."
+              "note": "Calvin insists on the \"not of this world\" as a description of the kingdom's origin and power, not its location or relevance. The kingdom is engaged with the world — through truth, preaching, and the Spirit — but it does not operate by the world's categories of power. This is why Pilate cannot categorise Jesus: he is a king with no army, no territory, and no political programme, yet his claim is the most comprehensive sovereignty imaginable."
             },
             {
               "ref": "18:28",
@@ -203,24 +203,24 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:31",
-              "note": "\"We have no right to execute anyone\" \u2014 this statement has been debated by historians: did the Romans restrict Jewish capital punishment? The evidence suggests the Sanhedrin could execute for certain religious offences (e.g., Gentile entry into the inner Temple courts) but required Roman authorisation for capital punishment in general. John's note is historically plausible."
+              "note": "\"We have no right to execute anyone\" — this statement has been debated by historians: did the Romans restrict Jewish capital punishment? The evidence suggests the Sanhedrin could execute for certain religious offences (e.g., Gentile entry into the inner Temple courts) but required Roman authorisation for capital punishment in general. John's note is historically plausible."
             },
             {
               "ref": "18:38",
-              "note": "\"What is truth?\" \u2014 The question has been asked by every generation since. Three major interpretations: (1) Cynical dismissal (he doesn't care about truth); (2) Philosophical relativism (a Roman governor who has seen too many competing truth-claims); (3) Genuine inquiry, but deflected by political pressure. The narrative makes 1 or 2 most plausible \u2014 his immediate exit without waiting for an answer makes genuine inquiry unlikely."
+              "note": "\"What is truth?\" — The question has been asked by every generation since. Three major interpretations: (1) Cynical dismissal (he doesn't care about truth); (2) Philosophical relativism (a Roman governor who has seen too many competing truth-claims); (3) Genuine inquiry, but deflected by political pressure. The narrative makes 1 or 2 most plausible — his immediate exit without waiting for an answer makes genuine inquiry unlikely."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:36",
-              "note": "Augustine: \"My kingdom is not of this world. It is in this world, but not from this world. His servants do not fight \u2014 not because the kingdom is powerless, but because its power is not of the sword. The kingdom that conquers the world conquers it by truth, not by force; by the cross, not by armies.\""
+              "note": "Augustine: \"My kingdom is not of this world. It is in this world, but not from this world. His servants do not fight — not because the kingdom is powerless, but because its power is not of the sword. The kingdom that conquers the world conquers it by truth, not by force; by the cross, not by armies.\""
             },
             {
               "ref": "18:38",
@@ -229,39 +229,39 @@
           ]
         },
         "hist": {
-          "context": "The Passover Irony\nJohn's careful note (v.28) that the Jewish leaders would not enter the praetorium \"to avoid ceremonial uncleanness so that they could eat the Passover\" is one of the most devastating ironies in the Gospel. They are scrupulously observing the purity requirements for the Passover feast \u2014 while simultaneously engineering the murder of the Passover Lamb. They will eat the lamb that night; they are killing the Lamb in the morning.\n\n\"What Is Truth?\" \u2014 Pilate's Question\nPilate's question has been interpreted as: (1) cynical dismissal \u2014 he doesn't care about truth, only about political stability; (2) weary relativism \u2014 a Greco-Roman governor who has seen too much to believe in objective truth; (3) genuine philosophical inquiry, deflected by the pressure of the crowd. The narrative context (he immediately goes out without waiting for an answer) supports readings 1 or 2. The dramatic irony is that the answer to his question is standing in front of him."
+          "context": "The Passover Irony\nJohn's careful note (v.28) that the Jewish leaders would not enter the praetorium \"to avoid ceremonial uncleanness so that they could eat the Passover\" is one of the most devastating ironies in the Gospel. They are scrupulously observing the purity requirements for the Passover feast — while simultaneously engineering the murder of the Passover Lamb. They will eat the lamb that night; they are killing the Lamb in the morning.\n\n\"What Is Truth?\" — Pilate's Question\nPilate's question has been interpreted as: (1) cynical dismissal — he doesn't care about truth, only about political stability; (2) weary relativism — a Greco-Roman governor who has seen too much to believe in objective truth; (3) genuine philosophical inquiry, deflected by the pressure of the crowd. The narrative context (he immediately goes out without waiting for an answer) supports readings 1 or 2. The dramatic irony is that the answer to his question is standing in front of him."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 28\u201340 \u2014 Before Pilate: Are You the King of the Jews?",
+      "header": "Verses 28–40 — Before Pilate: Are You the King of the Jews?",
       "verse_start": 28,
       "verse_end": 40,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am he / I am",
-            "paragraph": "In v.5-6 the eg\u014d eimi causes the armed detachment to fall to the ground \u2014 a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
+            "paragraph": "In v.5-6 the egō eimi causes the armed detachment to fall to the ground — a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
           },
           {
-            "word": "pot\u0113rion",
+            "word": "potērion",
             "transliteration": "po-TE-ri-on",
             "gloss": "cup",
-            "paragraph": "\"Shall I not drink the cup the Father has given me?\" (v.11) \u2014 the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
+            "paragraph": "\"Shall I not drink the cup the Father has given me?\" (v.11) — the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
           }
         ],
         "places": [
           {
             "name": "Garden of Gethsemane",
-            "coords": "31.7792\u00b0 N, 35.2397\u00b0 E",
-            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" \u2014 the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
+            "coords": "31.7792° N, 35.2397° E",
+            "text": "Across the Kidron Valley from Jerusalem on the western slope of the Mount of Olives. The name Gethsemane means \"olive press\" — the garden contained an olive grove and oil press. Jesus regularly met with his disciples here (v.2), making it a natural location for Judas to bring the soldiers. Ancient olive trees still stand at the site, though they postdate Jesus's time; the site has been venerated since the 4th century. The Church of All Nations (Basilica of the Agony) was built over the traditional rock of prayer in 1924."
           },
           {
             "name": "House of Annas / Caiaphas",
-            "coords": "31.7697\u00b0 N, 35.2285\u00b0 E",
+            "coords": "31.7697° N, 35.2285° E",
             "text": "Likely in the upper city (wealthy Herodian neighbourhood) on the western hill of Jerusalem. The Palatial Mansion excavated in the Jewish Quarter of the Old City may be the house of a member of the high priestly family. Jesus is taken here for the pre-trial hearing. The traditional \"House of Caiaphas\" is now the Church of St Peter in Gallicantu (Peter at the Cock-crow), marking the site of Peter's denial and the rooster's crow."
           }
         ],
@@ -269,80 +269,36 @@
           "refs": [
             {
               "ref": "Isa 51:17",
-              "note": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" \u2014 the OT cup-of-wrath imagery Jesus invokes in v.11."
+              "note": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" — the OT cup-of-wrath imagery Jesus invokes in v.11."
             },
             {
               "ref": "Ps 41:9",
-              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples."
+              "note": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples."
             },
             {
               "ref": "Luke 22:39-46",
-              "note": "The Gethsemane prayer \u2014 the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11)."
+              "note": "The Gethsemane prayer — the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:4-6",
-              "note": "\"Jesus, knowing all that was going to happen to him, went out\" \u2014 the sovereign initiative is John's signature. He does not wait to be found; he goes out to meet them. The \"I am he\" that fells the soldiers is the most compressed theophany in the passion narratives: these are soldiers (Roman cohort = 600 men) with weapons, lanterns, and torches \u2014 and a single word from Jesus puts them on the ground. He is not arrested; he chooses to be apprehended."
-            },
-            {
-              "ref": "18:8-9",
-              "note": "\"Let these men go. This happened so that the words he had spoken would be fulfilled: 'I have not lost one of those you gave me'\" \u2014 the protective concern for the disciples at the moment of his own arrest. John connects the physical protection at Gethsemane to the eternal protection of 17:12. Jesus's care for the eleven at the arrest is the enactment of the prayer he had just prayed: \"protect them.\""
-            },
-            {
-              "ref": "18:11",
-              "note": "\"Shall I not drink the cup the Father has given me?\" \u2014 the cup is not merely suffering but wrath. The question is rhetorical \u2014 of course he will drink it; he came for this. But the question reveals the weight of what is being accepted: not just death but the Father's wrath against sin, fully and voluntarily absorbed. Peter's sword is well-intentioned but theologically catastrophic: if he prevents the arrest, he prevents the atonement."
-            },
-            {
-              "ref": "18:20-23",
-              "note": "Jesus before Annas: his response to the high priest's questions is a model of truthful self-defence. He does not deny his teaching (he spoke openly, v.20) but he refuses to incriminate himself by speculating about what his teaching meant. When struck, he does not retaliate but demands due process: \"if I said something wrong, testify as to what is wrong.\" He models dignity under injustice \u2014 the innocent party demanding the procedure its accusers claim to represent."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:6",
-              "note": "Calvin uses the falling of the soldiers to establish the voluntary character of the passion: Jesus could have destroyed his captors with a word; he chose instead to surrender. The cross is not the defeat of the Son of God but the sovereign execution of the plan of salvation. This is why the cross is simultaneously the greatest display of human wickedness and the greatest display of divine love."
-            },
-            {
-              "ref": "18:20",
-              "note": "Calvin notes that Jesus's defence before Annas (\"I said nothing in secret\") is an appeal to the public record \u2014 the Pharisees' own witnesses could testify to his teaching. This is not evasion but the demand for due process that Jewish law required. The illegal midnight examination, the prejudged verdict, and the physical abuse all violate the law in the name of the law \u2014 the supreme irony of the Jewish trial."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:3",
-              "note": "\"A detachment of soldiers\" \u2014 speira, a Roman military unit (cohort = 600 men, though possibly a maniple = 200). The presence of Roman soldiers alongside temple officials indicates the involvement of the Roman military in the arrest \u2014 suggesting Pilate had been informed and had authorised the use of force. The scale of the operation (torches, weapons, a military unit) reflects how seriously the authorities took the threat Jesus represented."
-            },
-            {
-              "ref": "18:13",
-              "note": "\"Brought him first to Annas\" \u2014 Annas had been high priest AD 6-15. Five of his sons and son-in-law Caiaphas all held the high priesthood. The pre-trial before Annas is unique to John, consistent with eyewitness knowledge of Jerusalem politics."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "18:4-5",
-              "note": "Augustine: \"Jesus went out to meet those who came to take him. He went out \u2014 not dragged, not surprised, not fleeing, but going forward. He is not seized; he gives himself. The arrest is his act, not theirs. He who could have called twelve legions of angels chose instead to call out: Who do you seek? \u2014 and to answer: I am he.\""
-            },
-            {
-              "ref": "18:11",
-              "note": "Chrysostom: \"Shall I not drink the cup the Father has given me? The cup is the Father's gift. Suffering from the Father's hand is different from suffering from human injustice \u2014 it is received as a gift. Not 'the cup the enemies force on me' but 'the cup the Father has given me.' This is the transformation of all suffering for the believer: it comes through human hands but from the Father's.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Garden Arrest in John\nJohn omits the Gethsemane prayer (Matt 26:36-46; Mark 14:32-42; Luke 22:39-46) but contains its theological equivalent in the \"cup\" question of v.11. He also uniquely records: the soldiers falling (vv.5-6), Jesus's protective request for the disciples (vv.8-9), the name of Malchus (v.10), and the detailed structure of the Jewish pre-trial before Annas (vv.12-24) before Caiaphas. John's eyewitness detail \u2014 the name of the servant, the detail that Peter was warming himself, the servant who challenged Peter being related to Malchus \u2014 suggests the beloved disciple (v.15: \"another disciple... known to the high priest\") as the source.\n\nPeter's Three Denials\nJohn structures the three denials carefully: (1) at the door with the servant girl (v.17); (2) at the fire with the servants (v.25); (3) with the relative of Malchus in the courtyard (v.26). Each one escalates: first a casual question answered casually, then a group challenge, then a direct personal challenge from someone who was present in the garden. The rooster's crow (v.27) is the signal that Jesus's prediction (13:38) has been fulfilled exactly."
+          "context": "The Garden Arrest in John\nJohn omits the Gethsemane prayer (Matt 26:36-46; Mark 14:32-42; Luke 22:39-46) but contains its theological equivalent in the \"cup\" question of v.11. He also uniquely records: the soldiers falling (vv.5-6), Jesus's protective request for the disciples (vv.8-9), the name of Malchus (v.10), and the detailed structure of the Jewish pre-trial before Annas (vv.12-24) before Caiaphas. John's eyewitness detail — the name of the servant, the detail that Peter was warming himself, the servant who challenged Peter being related to Malchus — suggests the beloved disciple (v.15: \"another disciple... known to the high priest\") as the source.\n\nPeter's Three Denials\nJohn structures the three denials carefully: (1) at the door with the servant girl (v.17); (2) at the fire with the servants (v.25); (3) with the relative of Malchus in the courtyard (v.26). Each one escalates: first a casual question answered casually, then a group challenge, then a direct personal challenge from someone who was present in the garden. The rooster's crow (v.27) is the signal that Jesus's prediction (13:38) has been fulfilled exactly."
         }
       }
     }
@@ -352,31 +308,31 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "5-6), Jesus\\'s protective request for the disciples (vv\u2026"
+        "text": "5-6), Jesus\\'s protective request for the disciples (vv…"
       },
       {
         "name": "disciples",
         "role": "Key biblical figure",
-        "text": "5-6), Jesus\\'s protective request for the disciples (vv\u2026"
+        "text": "5-6), Jesus\\'s protective request for the disciples (vv…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">pot\u0113rion (18:11)</td><td>NIV: \"cup\"; KJV: \"cup\"; ESV: \"cup\"; NRSV: \"cup\". Universal agreement. The theological weight (cup of wrath) is a commentary point.</td></tr><tr><td class=\"t-label\">ek tou kosmou toutou (18:36)</td><td>NIV: \"of this world\"; KJV: \"of this world\"; ESV: \"of this world\"; NRSV: \"from this world\". NRSV's \"from\" captures the origin nuance better than \"of.\" The kingdom's origin is not from the world; this is different from saying it is not in or for the world.</td></tr><tr><td class=\"t-label\">ti estin al\u0113theia (18:38)</td><td>NIV: \"What is truth?\"; KJV: \"What is truth?\"; ESV: \"What is truth?\"; NRSV: \"What is truth?\" Universal agreement on perhaps the most famous question in the Gospel.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">potērion (18:11)</td><td>NIV: \"cup\"; KJV: \"cup\"; ESV: \"cup\"; NRSV: \"cup\". Universal agreement. The theological weight (cup of wrath) is a commentary point.</td></tr><tr><td class=\"t-label\">ek tou kosmou toutou (18:36)</td><td>NIV: \"of this world\"; KJV: \"of this world\"; ESV: \"of this world\"; NRSV: \"from this world\". NRSV's \"from\" captures the origin nuance better than \"of.\" The kingdom's origin is not from the world; this is different from saying it is not in or for the world.</td></tr><tr><td class=\"t-label\">ti estin alētheia (18:38)</td><td>NIV: \"What is truth?\"; KJV: \"What is truth?\"; ESV: \"What is truth?\"; NRSV: \"What is truth?\" Universal agreement on perhaps the most famous question in the Gospel.</td></tr>",
     "src": [
       {
         "title": "Isaiah 53:7",
         "quote": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter, and as a sheep before its shearers is silent, so he did not open his mouth.\"",
-        "note": "The Suffering Servant's silence before accusers \u2014 the OT background for the passion narrative's portrayal of Jesus as the Lamb who does not resist."
+        "note": "The Suffering Servant's silence before accusers — the OT background for the passion narrative's portrayal of Jesus as the Lamb who does not resist."
       },
       {
         "title": "Daniel 7:13-14",
         "quote": "\"There before me was one like a son of man, coming with the clouds of heaven... He was given authority, glory and sovereign power; all nations and peoples of every language worshipped him.\"",
-        "note": "The Son of Man's kingdom \u2014 \"not of this world\" but given by the Ancient of Days \u2014 which Jesus describes to Pilate."
+        "note": "The Son of Man's kingdom — \"not of this world\" but given by the Ancient of Days — which Jesus describes to Pilate."
       }
     ],
     "rec": [
       {
-        "who": "\"What Is Truth?\" \u2014 Pilate's Question in Western Culture",
-        "text": "Pilate's question has achieved a cultural life far beyond the Gospel narrative. Francis Bacon's essay \"Of Truth\" (1597) opens with it. It became a trope of Renaissance scepticism, Enlightenment epistemology, and postmodern relativism \u2014 each era reading its own philosophical concerns back into Pilate's words. Christians have consistently responded: the answer was standing in front of him. The question marks not intellectual sophistication but the tragedy of proximity to truth without recognition."
+        "who": "\"What Is Truth?\" — Pilate's Question in Western Culture",
+        "text": "Pilate's question has achieved a cultural life far beyond the Gospel narrative. Francis Bacon's essay \"Of Truth\" (1597) opens with it. It became a trope of Renaissance scepticism, Enlightenment epistemology, and postmodern relativism — each era reading its own philosophical concerns back into Pilate's words. Christians have consistently responded: the answer was standing in front of him. The question marks not intellectual sophistication but the tragedy of proximity to truth without recognition."
       },
       {
         "who": "\"My Kingdom Is Not of This World\" in Political Theology",
@@ -386,18 +342,18 @@
     "lit": {
       "rows": [
         {
-          "label": "Irony of the Passover Scrupulosity \u2014 v.28",
-          "text": "The Jewish leaders avoid Pilate's house to remain ceremonially clean for the Passover \u2014 while orchestrating the death of the Passover Lamb. The ritual scrupulosity that excludes them from the praetorium does not exclude them from the murder. The irony is the sharpest in the passion narrative and one of the sharpest in the entire Gospel.",
+          "label": "Irony of the Passover Scrupulosity — v.28",
+          "text": "The Jewish leaders avoid Pilate's house to remain ceremonially clean for the Passover — while orchestrating the death of the Passover Lamb. The ritual scrupulosity that excludes them from the praetorium does not exclude them from the murder. The irony is the sharpest in the passion narrative and one of the sharpest in the entire Gospel.",
           "is_key": false
         },
         {
-          "label": "Seven-Scene Pilate Narrative \u2014 vv.28-19:16",
+          "label": "Seven-Scene Pilate Narrative — vv.28-19:16",
           "text": "John structures the Roman trial as seven alternating scenes: Pilate moves between the Jews outside (who will not enter to avoid defilement) and Jesus inside. Each scene escalates the charge and Pilate's resistance. The literary symmetry highlights Pilate's political capitulation against his own better judgment.",
           "is_key": false
         },
         {
-          "label": "Arrest Garden Echo \u2014 vv.1-11",
-          "text": "The Garden of Gethsemane is presented without the agony prayer of the Synoptics. Instead, Jesus steps forward and his \"I am he\" causes the soldiers to fall back (v6) \u2014 an involuntary theophanic response. John frames the arrest as Jesus sovereignly handing himself over, not being taken by force.",
+          "label": "Arrest Garden Echo — vv.1-11",
+          "text": "The Garden of Gethsemane is presented without the agony prayer of the Synoptics. Instead, Jesus steps forward and his \"I am he\" causes the soldiers to fall back (v6) — an involuntary theophanic response. John frames the arrest as Jesus sovereignly handing himself over, not being taken by force.",
           "is_key": false
         }
       ],
@@ -405,40 +361,40 @@
     },
     "hebtext": [
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am he / I am",
-        "note": "In v.5-6 the eg\u014d eimi causes the armed detachment to fall to the ground \u2014 a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
+        "note": "In v.5-6 the egō eimi causes the armed detachment to fall to the ground — a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
       },
       {
-        "word": "pot\u0113rion",
+        "word": "potērion",
         "tlit": "po-TE-ri-on",
         "gloss": "cup",
-        "note": "\"Shall I not drink the cup the Father has given me?\" (v.11) \u2014 the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
+        "note": "\"Shall I not drink the cup the Father has given me?\" (v.11) — the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
       },
       {
         "word": "basileia",
         "tlit": "ba-si-LEI-a",
         "gloss": "kingdom",
-        "note": "\"My kingdom is not of this world\" (v.36) \u2014 not \"not in this world\" (Jesus's kingdom is present in the world) but \"not of this world\" (it does not originate from or operate by the world's power structures). The distinction is source and method, not location. The kingdom's validation does not come through military force (\"my servants would not fight\") but through truth-speaking (v.37). Pilate cannot categorise this kingdom because it operates by principles he has no framework for."
+        "note": "\"My kingdom is not of this world\" (v.36) — not \"not in this world\" (Jesus's kingdom is present in the world) but \"not of this world\" (it does not originate from or operate by the world's power structures). The distinction is source and method, not location. The kingdom's validation does not come through military force (\"my servants would not fight\") but through truth-speaking (v.37). Pilate cannot categorise this kingdom because it operates by principles he has no framework for."
       },
       {
-        "word": "al\u0113theia",
+        "word": "alētheia",
         "tlit": "a-LE-thei-a",
         "gloss": "truth",
-        "note": "The word that has run through John's Gospel from the prologue (\"grace and truth came through Jesus Christ,\" 1:17) reaches its ironic climax here. Pilate's \"what is truth?\" (v.38) is the question of a man who has the Truth standing in front of him and cannot recognise it. Whether his question is cynical dismissal, weary scepticism, or genuine philosophical inquiry, he walks away without waiting for the answer \u2014 the most tragic missed opportunity in the Gospel."
+        "note": "The word that has run through John's Gospel from the prologue (\"grace and truth came through Jesus Christ,\" 1:17) reaches its ironic climax here. Pilate's \"what is truth?\" (v.38) is the question of a man who has the Truth standing in front of him and cannot recognise it. Whether his question is cynical dismissal, weary scepticism, or genuine philosophical inquiry, he walks away without waiting for the answer — the most tragic missed opportunity in the Gospel."
       },
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am he / I am",
-        "note": "In v.5-6 the eg\u014d eimi causes the armed detachment to fall to the ground \u2014 a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
+        "note": "In v.5-6 the egō eimi causes the armed detachment to fall to the ground — a theophanic response. John's passion narrative begins with a display of divine power so overwhelming that trained soldiers collapse before Jesus. He is not arrested; he surrenders. The \"I am\" that was used to claim the divine name (8:58) now functions as the word that lays low an armed cohort. The cross is not defeat; it is sovereign self-giving."
       },
       {
-        "word": "pot\u0113rion",
+        "word": "potērion",
         "tlit": "po-TE-ri-on",
         "gloss": "cup",
-        "note": "\"Shall I not drink the cup the Father has given me?\" (v.11) \u2014 the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
+        "note": "\"Shall I not drink the cup the Father has given me?\" (v.11) — the cup is the OT metaphor for God's wrath poured out in judgment (Ps 75:8; Isa 51:17; Jer 25:15; Ezek 23:32-34). Jesus does not merely suffer; he drinks the cup of divine wrath that sinners deserve. The willingness to drink the cup is John's equivalent of Gethsemane: the agonised prayer of the Synoptics is here compressed into one rhetorical question that contains the whole of substitutionary atonement."
       }
     ],
     "thread": [
@@ -446,42 +402,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Isa 51:17",
         "type": "Connection",
-        "text": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" \u2014 the OT cup-of-wrath imagery Jesus invokes in v.11.",
+        "text": "\"Awake, awake! Rise up, Jerusalem, you who have drunk from the hand of the Lord the cup of his wrath\" — the OT cup-of-wrath imagery Jesus invokes in v.11.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 41:9",
         "type": "Fulfilment",
-        "text": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" \u2014 fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples.",
+        "text": "\"Even my close friend, someone I trusted, one who shared my bread, has turned against me\" — fulfilled in Judas leading the soldiers to the garden where Jesus regularly met with his disciples.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Luke 22:39-46",
         "type": "Echo",
-        "text": "The Gethsemane prayer \u2014 the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11).",
+        "text": "The Gethsemane prayer — the Synoptic parallel to John's \"shall I not drink the cup?\" (v.11).",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 53:7",
         "type": "Connection",
-        "text": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" \u2014 the Servant's silence before his accusers, which John's Jesus does not entirely replicate (he speaks) but which frames the scene.",
+        "text": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" — the Servant's silence before his accusers, which John's Jesus does not entirely replicate (he speaks) but which frames the scene.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Dan 7:13-14",
         "type": "Connection",
-        "text": "\"There before me was one like a son of man... He was given authority, glory and sovereign power\" \u2014 the kingdom-not-of-this-world that Jesus describes to Pilate is the kingdom Daniel saw given to the Son of Man.",
+        "text": "\"There before me was one like a son of man... He was given authority, glory and sovereign power\" — the kingdom-not-of-this-world that Jesus describes to Pilate is the kingdom Daniel saw given to the Son of Man.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 2:6",
         "type": "Connection",
-        "text": "\"I have installed my king on Zion, my holy mountain\" \u2014 the divine king whom the nations resist, as Pilate and the chief priests resist Jesus.",
+        "text": "\"I have installed my king on Zion, my holy mountain\" — the divine king whom the nations resist, as Pilate and the chief priests resist Jesus.",
         "direction": "backward"
       }
     ],
@@ -489,7 +445,7 @@
       {
         "ref": "18:5-6",
         "title": "\"I am he\" and the soldiers falling",
-        "content": "No textual variant. The falling (epesan chamai) is secure in all manuscripts. The theological interpretation \u2014 whether this is a full theophany or simply the soldiers being startled and losing their footing \u2014 is the exegetical question.",
+        "content": "No textual variant. The falling (epesan chamai) is secure in all manuscripts. The theological interpretation — whether this is a full theophany or simply the soldiers being startled and losing their footing — is the exegetical question.",
         "note": "The text is not disputed; the interpretation is. The parallel with OT theophanies (Dan 10:9; Rev 1:17) and the overall Johannine context strongly favour reading the falling as a theophanic response to the divine name."
       }
     ],
@@ -505,7 +461,7 @@
           {
             "name": "No: the kingdom engages the world by different means",
             "proponents": "Most mainstream Catholic, Reformed, and evangelical scholars",
-            "argument": "\"Not of this world\" refers to origin and method, not location or relevance. The kingdom is present in and working through the world \u2014 through truth-bearing, justice-seeking, mercy-giving \u2014 but by the Spirit's power rather than coercion. The church engages political life by Christ's means: truth, love, and service."
+            "argument": "\"Not of this world\" refers to origin and method, not location or relevance. The kingdom is present in and working through the world — through truth-bearing, justice-seeking, mercy-giving — but by the Spirit's power rather than coercion. The church engages political life by Christ's means: truth, love, and service."
           },
           {
             "name": "The kingdom will eventually transform political structures",
@@ -542,7 +498,7 @@
           "score": 10
         }
       ],
-      "note": "John 18 is the passion narrative's first movement: the sovereign surrender of the Son of God. Everything John has established about Jesus's identity \u2014 the I AM who fells soldiers, the king whose kingdom is not of this world, the Lamb who willingly drinks the cup \u2014 is displayed in this chapter's series of encounters. The contrast between Peter (denying) and Jesus (affirming his identity under pressure) is the chapter's sharpest human drama. Pilate's \"what is truth?\" frames the whole: the Truth is on trial before a man who cannot recognise it."
+      "note": "John 18 is the passion narrative's first movement: the sovereign surrender of the Son of God. Everything John has established about Jesus's identity — the I AM who fells soldiers, the king whose kingdom is not of this world, the Lamb who willingly drinks the cup — is displayed in this chapter's series of encounters. The contrast between Peter (denying) and Jesus (affirming his identity under pressure) is the chapter's sharpest human drama. Pilate's \"what is truth?\" frames the whole: the Truth is on trial before a man who cannot recognise it."
     }
   },
   "vhl_groups": [
@@ -661,12 +617,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'I am he' (v. 5). The soldiers fall backward. Ego eimi\u2014'I AM.' Even at arrest, Jesus demonstrates power. He surrenders voluntarily; they don't capture him.",
+      "tip": "'I am he' (v. 5). The soldiers fall backward. Ego eimi—'I AM.' Even at arrest, Jesus demonstrates power. He surrenders voluntarily; they don't capture him.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 2,
-      "tip": "'What is truth?' (v. 38). Pilate's question goes unanswered\u2014or does it? Truth personified stands before him. Pilate interrogates Truth and finds 'no basis for a charge.' Irony saturates John's narrative.",
+      "tip": "'What is truth?' (v. 38). Pilate's question goes unanswered—or does it? Truth personified stands before him. Pilate interrogates Truth and finds 'no basis for a charge.' Irony saturates John's narrative.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/19.json
+++ b/content/john/19.json
@@ -7,13 +7,13 @@
   "subtitle": "The Crucifixion and Burial",
   "timeline_link": {
     "event_id": "crucifixion",
-    "text": "See on Timeline \u2014 Crucifixion"
+    "text": "See on Timeline — Crucifixion"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201316 \u2014 The Mocking, the Crown of Thorns; Pilate\u2019s Verdict",
+      "header": "Verses 1–16 — The Mocking, the Crown of Thorns; Pilate’s Verdict",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
@@ -22,54 +22,54 @@
             "word": "Ecce homo",
             "transliteration": "EC-ce HO-mo",
             "gloss": "Behold the man (Latin)",
-            "paragraph": "Pilate's declaration \"Here is the man!\" (idou ho anthr\u014dpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him \u2014 surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man \u2014 the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
+            "paragraph": "Pilate's declaration \"Here is the man!\" (idou ho anthrōpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him — surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man — the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
           },
           {
             "word": "titlos",
             "transliteration": "TIT-los",
             "gloss": "titulus / inscription (Latin loanword)",
-            "paragraph": "The titulus (v.19) \u2014 the placard stating the charge \u2014 was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek \u2014 the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
+            "paragraph": "The titulus (v.19) — the placard stating the charge — was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek — the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 12:1-13",
-              "note": "The Passover lamb \u2014 slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type."
+              "note": "The Passover lamb — slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type."
             },
             {
               "ref": "Isa 53:3-5",
-              "note": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" \u2014 the Suffering Servant whose treatment John's crucifixion narrative parallels."
+              "note": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" — the Suffering Servant whose treatment John's crucifixion narrative parallels."
             },
             {
               "ref": "Ps 22:18",
-              "note": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in vv.23-24."
+              "note": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in vv.23-24."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:5",
-              "note": "\"Here is the man!\" \u2014 Pilate's declaration is John's supreme dramatic irony. The beaten, mocked figure in a crown of thorns is the one in whom all human dignity resides, the one who is the image of God par excellence, the one whose suffering is simultaneously the nadir of human cruelty and the apex of divine love. \"Behold the man\" is the correct response \u2014 but for reasons Pilate cannot imagine."
+              "note": "\"Here is the man!\" — Pilate's declaration is John's supreme dramatic irony. The beaten, mocked figure in a crown of thorns is the one in whom all human dignity resides, the one who is the image of God par excellence, the one whose suffering is simultaneously the nadir of human cruelty and the apex of divine love. \"Behold the man\" is the correct response — but for reasons Pilate cannot imagine."
             },
             {
               "ref": "19:11",
-              "note": "\"You would have no power over me if it were not given to you from above\" \u2014 sovereignty over the passion is maintained throughout. Pilate thinks he has power to release or crucify; Jesus tells him where his power comes from and implies that its exercise in condemning the innocent is a divine permission, not a human achievement. The cross is not something that happened to Jesus against his will; it is the will of the Father, accomplished through human agency."
+              "note": "\"You would have no power over me if it were not given to you from above\" — sovereignty over the passion is maintained throughout. Pilate thinks he has power to release or crucify; Jesus tells him where his power comes from and implies that its exercise in condemning the innocent is a divine permission, not a human achievement. The cross is not something that happened to Jesus against his will; it is the will of the Father, accomplished through human agency."
             },
             {
               "ref": "19:15",
-              "note": "\"We have no king but Caesar\" \u2014 the chief priests' formal renunciation of the covenant. They have inverted everything: the one who claimed to be God's son is rejected; the Gentile emperor who claimed divinity is accepted as king. They have traded the Son for Caesar. The statement echoes 1 Samuel 8, where Israel first demanded an earthly king \u2014 a demand God called a rejection of himself."
+              "note": "\"We have no king but Caesar\" — the chief priests' formal renunciation of the covenant. They have inverted everything: the one who claimed to be God's son is rejected; the Gentile emperor who claimed divinity is accepted as king. They have traded the Son for Caesar. The statement echoes 1 Samuel 8, where Israel first demanded an earthly king — a demand God called a rejection of himself."
             },
             {
               "ref": "19:22",
-              "note": "\"What I have written, I have written\" \u2014 Pilate's stubborn insistence on the titulus is, for John, a providential act. Despite the chief priests' request to change it, Pilate refuses: \"What I have written, I have written.\" He does not know it, but his intransigence preserves the most accurate Christological statement of the crucifixion: \"Jesus of Nazareth, King of the Jews\" \u2014 true in three languages simultaneously."
+              "note": "\"What I have written, I have written\" — Pilate's stubborn insistence on the titulus is, for John, a providential act. Despite the chief priests' request to change it, Pilate refuses: \"What I have written, I have written.\" He does not know it, but his intransigence preserves the most accurate Christological statement of the crucifixion: \"Jesus of Nazareth, King of the Jews\" — true in three languages simultaneously."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:11",
@@ -77,29 +77,29 @@
             },
             {
               "ref": "19:15",
-              "note": "Calvin's verdict on \"we have no king but Caesar\" is unsparing: this is the moment of Israel's formal apostasy. The leaders who preserved every external form of Judaism have renounced its substance \u2014 the covenant kingship of YHWH. In embracing Caesar to reject Jesus, they have embraced exactly what the prophets warned against: the idolatrous pursuit of earthly security at the cost of divine fidelity."
+              "note": "Calvin's verdict on \"we have no king but Caesar\" is unsparing: this is the moment of Israel's formal apostasy. The leaders who preserved every external form of Judaism have renounced its substance — the covenant kingship of YHWH. In embracing Caesar to reject Jesus, they have embraced exactly what the prophets warned against: the idolatrous pursuit of earthly security at the cost of divine fidelity."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:13",
-              "note": "\"Sat down on the judge's seat\" \u2014 kathiz\u014d can be either transitive (he sat Jesus down) or intransitive (he himself sat down). NA28 follows the intransitive: Pilate sat on the judgment seat. Some Church Fathers read it transitively (he sat Jesus on the seat as a final mockery), but this reading is contextually unlikely \u2014 the formal sentencing requires Pilate to sit in judgment."
+              "note": "\"Sat down on the judge's seat\" — kathizō can be either transitive (he sat Jesus down) or intransitive (he himself sat down). NA28 follows the intransitive: Pilate sat on the judgment seat. Some Church Fathers read it transitively (he sat Jesus on the seat as a final mockery), but this reading is contextually unlikely — the formal sentencing requires Pilate to sit in judgment."
             },
             {
               "ref": "19:17",
-              "note": "\"Carrying his own cross\" \u2014 John does not mention Simon of Cyrene (Matt 27:32; Mark 15:21; Luke 23:26). The omission may be intentional: John emphasises Jesus's sovereignty throughout the passion \u2014 he carries his own cross, he gives up his spirit voluntarily (v.30). The Johannine passion is the passion of one who remains in control even in extremis."
+              "note": "\"Carrying his own cross\" — John does not mention Simon of Cyrene (Matt 27:32; Mark 15:21; Luke 23:26). The omission may be intentional: John emphasises Jesus's sovereignty throughout the passion — he carries his own cross, he gives up his spirit voluntarily (v.30). The Johannine passion is the passion of one who remains in control even in extremis."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:5",
-              "note": "Augustine: \"Behold the man. Indeed, behold the man whom the prophets foretold, whom the Psalms sang of, whom the Law prefigured. Behold the man \u2014 not merely a man, but the man, the second Adam who comes to restore what the first lost.\""
+              "note": "Augustine: \"Behold the man. Indeed, behold the man whom the prophets foretold, whom the Psalms sang of, whom the Law prefigured. Behold the man — not merely a man, but the man, the second Adam who comes to restore what the first lost.\""
             },
             {
               "ref": "19:22",
@@ -108,13 +108,13 @@
           ]
         },
         "hist": {
-          "context": "\"We Have No King But Caesar\"\nThe chief priests' declaration in v.15 \u2014 \"we have no king but Caesar\" \u2014 is the most theologically devastating statement in the passion narrative. Israel's entire history was defined by the claim that YHWH is their only king (1 Sam 8:7; Ps 10:16; Isa 26:13). To say \"we have no king but Caesar\" is to renounce the foundation of Jewish national identity and theology. They reject their king by embracing the Gentile emperor. John records it as the ultimate irony: in rejecting the Messiah, the religious leaders formally renounce their covenant identity.\n\nThe Day and Hour of the Crucifixion\nJohn's \"about noon\" (v.14 \u2014 h\u014ds hekt\u0113, the sixth hour) on the \"day of Preparation of the Passover\" (Nisan 14) aligns with the time when the Passover lambs were being slaughtered in the Temple \u2014 noon to 3pm. Jesus, the Lamb of God (1:29), dies at the time when the Passover lambs die. This is the crown of John's Passover typology: the Passover Lamb is slaughtered when the lambs are slaughtered."
+          "context": "\"We Have No King But Caesar\"\nThe chief priests' declaration in v.15 — \"we have no king but Caesar\" — is the most theologically devastating statement in the passion narrative. Israel's entire history was defined by the claim that YHWH is their only king (1 Sam 8:7; Ps 10:16; Isa 26:13). To say \"we have no king but Caesar\" is to renounce the foundation of Jewish national identity and theology. They reject their king by embracing the Gentile emperor. John records it as the ultimate irony: in rejecting the Messiah, the religious leaders formally renounce their covenant identity.\n\nThe Day and Hour of the Crucifixion\nJohn's \"about noon\" (v.14 — hōs hektē, the sixth hour) on the \"day of Preparation of the Passover\" (Nisan 14) aligns with the time when the Passover lambs were being slaughtered in the Temple — noon to 3pm. Jesus, the Lamb of God (1:29), dies at the time when the Passover lambs die. This is the crown of John's Passover typology: the Passover Lamb is slaughtered when the lambs are slaughtered."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201330 \u2014 The Crucifixion: It Is Finished",
+      "header": "Verses 17–30 — The Crucifixion: It Is Finished",
       "verse_start": 17,
       "verse_end": 30,
       "panels": {
@@ -123,10 +123,10 @@
             "word": "tetelestai",
             "transliteration": "te-TE-les-tai",
             "gloss": "it is finished / it is accomplished / it is paid",
-            "paragraph": "The single Greek word (v.30) is the most theologically loaded word in the passion narrative. Tetelestai is the perfect passive of tele\u014d \u2014 to complete, to accomplish, to fulfil. The perfect tense declares a completed action with permanent effect: \"It has been finished and stands finished.\" In the commercial world of the first century, tetelestai was written across paid receipts \u2014 \"paid in full.\" The word encompasses the completion of the work (4:34 \u2014 \"finishing the work of him who sent me\"), the fulfilment of Scripture, and the payment of the debt of sin."
+            "paragraph": "The single Greek word (v.30) is the most theologically loaded word in the passion narrative. Tetelestai is the perfect passive of teleō — to complete, to accomplish, to fulfil. The perfect tense declares a completed action with permanent effect: \"It has been finished and stands finished.\" In the commercial world of the first century, tetelestai was written across paid receipts — \"paid in full.\" The word encompasses the completion of the work (4:34 — \"finishing the work of him who sent me\"), the fulfilment of Scripture, and the payment of the debt of sin."
           },
           {
-            "word": "hyss\u014dpos",
+            "word": "hyssōpos",
             "transliteration": "hys-SO-pos",
             "gloss": "hyssop",
             "paragraph": "The hyssop branch used to lift the sponge to Jesus (v.29) is a detail unique to John among the passion accounts (the Synoptics say \"a stick/reed\"). Hyssop was the plant used to apply the Passover blood to the doorposts (Exod 12:22) and in purification rituals (Lev 14:4; Num 19:18; Ps 51:7). John's use of hyssop at the cross is deliberate: the blood of the true Passover Lamb is administered with the Passover plant."
@@ -136,49 +136,49 @@
           "refs": [
             {
               "ref": "Exod 12:46",
-              "note": "\"Do not break any of the bones\" \u2014 the Passover lamb command, fulfilled in v.33-36 when the soldiers do not break Jesus's legs."
+              "note": "\"Do not break any of the bones\" — the Passover lamb command, fulfilled in v.33-36 when the soldiers do not break Jesus's legs."
             },
             {
               "ref": "Ps 22:18",
-              "note": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in vv.23-24."
+              "note": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in vv.23-24."
             },
             {
               "ref": "Zech 12:10",
-              "note": "\"They will look on me, the one they have pierced, and they will mourn for him\" \u2014 cited in v.37 for the spear-thrust."
+              "note": "\"They will look on me, the one they have pierced, and they will mourn for him\" — cited in v.37 for the spear-thrust."
             },
             {
               "ref": "Ps 69:21",
-              "note": "\"They put gall in my food and gave me vinegar for my thirst\" \u2014 the wine vinegar of v.28-29."
+              "note": "\"They put gall in my food and gave me vinegar for my thirst\" — the wine vinegar of v.28-29."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:26-27",
-              "note": "\"Woman, here is your son... Here is your mother\" \u2014 Jesus's final act for another person before his death is provision for his mother. The beloved disciple becomes her son; she becomes his mother. The care is practical (she will be housed and provided for) and theological (a new family is formed at the foot of the cross \u2014 the community of the cross, defined not by blood but by relationship to Jesus)."
+              "note": "\"Woman, here is your son... Here is your mother\" — Jesus's final act for another person before his death is provision for his mother. The beloved disciple becomes her son; she becomes his mother. The care is practical (she will be housed and provided for) and theological (a new family is formed at the foot of the cross — the community of the cross, defined not by blood but by relationship to Jesus)."
             },
             {
               "ref": "19:30",
-              "note": "\"It is finished\" \u2014 tetelestai. Three dimensions: (1) The work is complete: the obedience of a lifetime, the redemption of humanity, the defeat of sin and death. (2) Scripture is fulfilled: every OT pointer has reached its destination. (3) The debt is paid: the commercial force of \"paid in full\" encompasses the substitutionary work. Then: \"He bowed his head and gave up his spirit\" \u2014 the same sovereign initiative as throughout the passion. He bows his head; he gives up his spirit. This is not death overtaking him; this is life freely surrendered."
+              "note": "\"It is finished\" — tetelestai. Three dimensions: (1) The work is complete: the obedience of a lifetime, the redemption of humanity, the defeat of sin and death. (2) Scripture is fulfilled: every OT pointer has reached its destination. (3) The debt is paid: the commercial force of \"paid in full\" encompasses the substitutionary work. Then: \"He bowed his head and gave up his spirit\" — the same sovereign initiative as throughout the passion. He bows his head; he gives up his spirit. This is not death overtaking him; this is life freely surrendered."
             },
             {
               "ref": "19:34-35",
-              "note": "\"A sudden flow of blood and water\" \u2014 John's rare first-person testimony (v.35: \"the man who saw it has given testimony\") marks this as a detail of exceptional importance. The blood and water together testify to: (1) the reality of the death (no swoon theory); (2) the atonement and its sacramental enactment; (3) the fulfilment of 7:38-39 (living water flowing from Jesus). The eyewitness staked his credibility on this detail: \"he knows that he tells the truth.\""
+              "note": "\"A sudden flow of blood and water\" — John's rare first-person testimony (v.35: \"the man who saw it has given testimony\") marks this as a detail of exceptional importance. The blood and water together testify to: (1) the reality of the death (no swoon theory); (2) the atonement and its sacramental enactment; (3) the fulfilment of 7:38-39 (living water flowing from Jesus). The eyewitness staked his credibility on this detail: \"he knows that he tells the truth.\""
             },
             {
               "ref": "19:38-40",
-              "note": "Nicodemus's third and final appearance: he comes in daylight, in public, with an extravagant quantity of spices (75 pounds \u2014 enough for a royal burial), to honour the one he first visited at night. The trajectory from darkness (3:2) through cautious defence (7:50-51) to public honour (19:39-40) is one of John's most carefully sustained character developments. The cross has accomplished what the discourses could not: it has drawn Nicodemus fully into the light."
+              "note": "Nicodemus's third and final appearance: he comes in daylight, in public, with an extravagant quantity of spices (75 pounds — enough for a royal burial), to honour the one he first visited at night. The trajectory from darkness (3:2) through cautious defence (7:50-51) to public honour (19:39-40) is one of John's most carefully sustained character developments. The cross has accomplished what the discourses could not: it has drawn Nicodemus fully into the light."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:30",
-              "note": "Calvin insists that \"it is finished\" encompasses the entire work of redemption \u2014 not just the suffering, but the obedience of the whole life. The cross is the culmination and completion of everything: the active obedience (doing what the law requires) and the passive obedience (bearing what the law threatens). Both are \"finished\" at this moment."
+              "note": "Calvin insists that \"it is finished\" encompasses the entire work of redemption — not just the suffering, but the obedience of the whole life. The cross is the culmination and completion of everything: the active obedience (doing what the law requires) and the passive obedience (bearing what the law threatens). Both are \"finished\" at this moment."
             },
             {
               "ref": "19:38-40",
@@ -187,20 +187,20 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:34",
-              "note": "\"Blood and water\" \u2014 the medical explanation most commonly proposed is haemopericardium (accumulation of fluid around the heart due to severe trauma), which would produce both blood and serum (watery fluid) when pierced. This is consistent with a death from cardiac rupture or, more commonly proposed, from the severe trauma of crucifixion and flogging. The detail confirms the physical reality of the death against any \"swoon theory.\""
+              "note": "\"Blood and water\" — the medical explanation most commonly proposed is haemopericardium (accumulation of fluid around the heart due to severe trauma), which would produce both blood and serum (watery fluid) when pierced. This is consistent with a death from cardiac rupture or, more commonly proposed, from the severe trauma of crucifixion and flogging. The detail confirms the physical reality of the death against any \"swoon theory.\""
             },
             {
               "ref": "19:14",
-              "note": "\"About noon\" vs Mark's \"third hour\" (9am) \u2014 the most significant chronological tension between John and the Synoptics. Solutions include: (1) different timekeeping conventions (Roman vs Jewish); (2) John rounds to the nearest three-hour period but with a different starting point; (3) both are approximate. John's noon fits his Passover Lamb typology; the tension with Mark has not been fully resolved."
+              "note": "\"About noon\" vs Mark's \"third hour\" (9am) — the most significant chronological tension between John and the Synoptics. Solutions include: (1) different timekeeping conventions (Roman vs Jewish); (2) John rounds to the nearest three-hour period but with a different starting point; (3) both are approximate. John's noon fits his Passover Lamb typology; the tension with Mark has not been fully resolved."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:30",
@@ -208,18 +208,18 @@
             },
             {
               "ref": "19:34",
-              "note": "Chrysostom: \"Blood and water came out. Not without purpose, not by chance. Because from those two, the church was built. The believers know what I mean: by water we are regenerated; by blood and flesh we are fed. From the side of Christ, as he slept on the cross, was born the church \u2014 as Eve was formed from the side of the sleeping Adam.\""
+              "note": "Chrysostom: \"Blood and water came out. Not without purpose, not by chance. Because from those two, the church was built. The believers know what I mean: by water we are regenerated; by blood and flesh we are fed. From the side of Christ, as he slept on the cross, was born the church — as Eve was formed from the side of the sleeping Adam.\""
             }
           ]
         },
         "hist": {
-          "context": "The Seamless Garment\nThe seamless robe (v.23) has been interpreted symbolically since at least Cyprian of Carthage: the seamless tunic represents the unity of the church, which cannot be divided without destroying it. More immediately, John records the fulfilment of Ps 22:18 in the soldiers' lot-casting \u2014 the specific fulfilment of Scripture in even the smallest details of the passion establishes the sovereignty of God over the event.\n\nBlood and Water from the Side\nThe eyewitness testimony of v.34-35 \u2014 blood and water from the pierced side \u2014 has generated extensive theological reflection: (1) Medical: evidence of fluid around the pericardium (confirming physical death); (2) Sacramental: blood = Eucharist, water = baptism; (3) Johannine: water has been the sign of the Spirit (7:38-39), and blood the sign of the atoning death (1:29). John explicitly invokes his eyewitness authority (v.35: \"the man who saw it has given testimony\") \u2014 a rare direct assertion of the Gospel's eyewitness character."
+          "context": "The Seamless Garment\nThe seamless robe (v.23) has been interpreted symbolically since at least Cyprian of Carthage: the seamless tunic represents the unity of the church, which cannot be divided without destroying it. More immediately, John records the fulfilment of Ps 22:18 in the soldiers' lot-casting — the specific fulfilment of Scripture in even the smallest details of the passion establishes the sovereignty of God over the event.\n\nBlood and Water from the Side\nThe eyewitness testimony of v.34-35 — blood and water from the pierced side — has generated extensive theological reflection: (1) Medical: evidence of fluid around the pericardium (confirming physical death); (2) Sacramental: blood = Eucharist, water = baptism; (3) Johannine: water has been the sign of the Spirit (7:38-39), and blood the sign of the atoning death (1:29). John explicitly invokes his eyewitness authority (v.35: \"the man who saw it has given testimony\") — a rare direct assertion of the Gospel's eyewitness character."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201342 \u2014 The Side Pierced; Burial in the Garden Tomb",
+      "header": "Verses 31–42 — The Side Pierced; Burial in the Garden Tomb",
       "verse_start": 31,
       "verse_end": 42,
       "panels": {
@@ -228,93 +228,49 @@
             "word": "Ecce homo",
             "transliteration": "EC-ce HO-mo",
             "gloss": "Behold the man (Latin)",
-            "paragraph": "Pilate's declaration \"Here is the man!\" (idou ho anthr\u014dpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him \u2014 surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man \u2014 the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
+            "paragraph": "Pilate's declaration \"Here is the man!\" (idou ho anthrōpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him — surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man — the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
           },
           {
             "word": "titlos",
             "transliteration": "TIT-los",
             "gloss": "titulus / inscription (Latin loanword)",
-            "paragraph": "The titulus (v.19) \u2014 the placard stating the charge \u2014 was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek \u2014 the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
+            "paragraph": "The titulus (v.19) — the placard stating the charge — was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek — the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 12:1-13",
-              "note": "The Passover lamb \u2014 slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type."
+              "note": "The Passover lamb — slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type."
             },
             {
               "ref": "Isa 53:3-5",
-              "note": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" \u2014 the Suffering Servant whose treatment John's crucifixion narrative parallels."
+              "note": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" — the Suffering Servant whose treatment John's crucifixion narrative parallels."
             },
             {
               "ref": "Ps 22:18",
-              "note": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in vv.23-24."
+              "note": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in vv.23-24."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:5",
-              "note": "\"Here is the man!\" \u2014 Pilate's declaration is John's supreme dramatic irony. The beaten, mocked figure in a crown of thorns is the one in whom all human dignity resides, the one who is the image of God par excellence, the one whose suffering is simultaneously the nadir of human cruelty and the apex of divine love. \"Behold the man\" is the correct response \u2014 but for reasons Pilate cannot imagine."
-            },
-            {
-              "ref": "19:11",
-              "note": "\"You would have no power over me if it were not given to you from above\" \u2014 sovereignty over the passion is maintained throughout. Pilate thinks he has power to release or crucify; Jesus tells him where his power comes from and implies that its exercise in condemning the innocent is a divine permission, not a human achievement. The cross is not something that happened to Jesus against his will; it is the will of the Father, accomplished through human agency."
-            },
-            {
-              "ref": "19:15",
-              "note": "\"We have no king but Caesar\" \u2014 the chief priests' formal renunciation of the covenant. They have inverted everything: the one who claimed to be God's son is rejected; the Gentile emperor who claimed divinity is accepted as king. They have traded the Son for Caesar. The statement echoes 1 Samuel 8, where Israel first demanded an earthly king \u2014 a demand God called a rejection of himself."
-            },
-            {
-              "ref": "19:22",
-              "note": "\"What I have written, I have written\" \u2014 Pilate's stubborn insistence on the titulus is, for John, a providential act. Despite the chief priests' request to change it, Pilate refuses: \"What I have written, I have written.\" He does not know it, but his intransigence preserves the most accurate Christological statement of the crucifixion: \"Jesus of Nazareth, King of the Jews\" \u2014 true in three languages simultaneously."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:11",
-              "note": "Calvin develops the doctrine of secondary causation from this verse: Pilate has real authority, but that authority comes from God and is exercised under God's providential governance. The condemnation of Jesus is simultaneously a human injustice (for which Pilate and the chief priests are accountable) and a divine act (which achieves the Father's purpose). The two levels of agency do not cancel each other; both are real."
-            },
-            {
-              "ref": "19:15",
-              "note": "Calvin's verdict on \"we have no king but Caesar\" is unsparing: this is the moment of Israel's formal apostasy. The leaders who preserved every external form of Judaism have renounced its substance \u2014 the covenant kingship of YHWH. In embracing Caesar to reject Jesus, they have embraced exactly what the prophets warned against: the idolatrous pursuit of earthly security at the cost of divine fidelity."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:13",
-              "note": "\"Sat down on the judge's seat\" \u2014 kathiz\u014d can be either transitive (he sat Jesus down) or intransitive (he himself sat down). NA28 follows the intransitive: Pilate sat on the judgment seat. Some Church Fathers read it transitively (he sat Jesus on the seat as a final mockery), but this reading is contextually unlikely \u2014 the formal sentencing requires Pilate to sit in judgment."
-            },
-            {
-              "ref": "19:17",
-              "note": "\"Carrying his own cross\" \u2014 John does not mention Simon of Cyrene (Matt 27:32; Mark 15:21; Luke 23:26). The omission may be intentional: John emphasises Jesus's sovereignty throughout the passion \u2014 he carries his own cross, he gives up his spirit voluntarily (v.30). The Johannine passion is the passion of one who remains in control even in extremis."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "19:5",
-              "note": "Augustine: \"Behold the man. Indeed, behold the man whom the prophets foretold, whom the Psalms sang of, whom the Law prefigured. Behold the man \u2014 not merely a man, but the man, the second Adam who comes to restore what the first lost.\""
-            },
-            {
-              "ref": "19:22",
-              "note": "Chrysostom: \"What I have written, I have written. Pilate does not know why he will not change it. He thinks it is stubbornness; it is providence. God uses the stubbornness of a Roman governor to preserve the most accurate inscription about his Son that the world has ever seen.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "\"We Have No King But Caesar\"\nThe chief priests' declaration in v.15 \u2014 \"we have no king but Caesar\" \u2014 is the most theologically devastating statement in the passion narrative. Israel's entire history was defined by the claim that YHWH is their only king (1 Sam 8:7; Ps 10:16; Isa 26:13). To say \"we have no king but Caesar\" is to renounce the foundation of Jewish national identity and theology. They reject their king by embracing the Gentile emperor. John records it as the ultimate irony: in rejecting the Messiah, the religious leaders formally renounce their covenant identity.\n\nThe Day and Hour of the Crucifixion\nJohn's \"about noon\" (v.14 \u2014 h\u014ds hekt\u0113, the sixth hour) on the \"day of Preparation of the Passover\" (Nisan 14) aligns with the time when the Passover lambs were being slaughtered in the Temple \u2014 noon to 3pm. Jesus, the Lamb of God (1:29), dies at the time when the Passover lambs die. This is the crown of John's Passover typology: the Passover Lamb is slaughtered when the lambs are slaughtered."
+          "context": "\"We Have No King But Caesar\"\nThe chief priests' declaration in v.15 — \"we have no king but Caesar\" — is the most theologically devastating statement in the passion narrative. Israel's entire history was defined by the claim that YHWH is their only king (1 Sam 8:7; Ps 10:16; Isa 26:13). To say \"we have no king but Caesar\" is to renounce the foundation of Jewish national identity and theology. They reject their king by embracing the Gentile emperor. John records it as the ultimate irony: in rejecting the Messiah, the religious leaders formally renounce their covenant identity.\n\nThe Day and Hour of the Crucifixion\nJohn's \"about noon\" (v.14 — hōs hektē, the sixth hour) on the \"day of Preparation of the Passover\" (Nisan 14) aligns with the time when the Passover lambs were being slaughtered in the Temple — noon to 3pm. Jesus, the Lamb of God (1:29), dies at the time when the Passover lambs die. This is the crown of John's Passover typology: the Passover Lamb is slaughtered when the lambs are slaughtered."
         }
       }
     }
@@ -342,9 +298,9 @@
         "text": "Jews is a key figure in Scripture Walkthrough."
       },
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       },
       {
         "name": "Thomas",
@@ -352,23 +308,23 @@
         "text": "Thomas is a key figure in Scripture Walkthrough."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">Idou ho anthr\u014dpos (19:5)</td><td>NIV: \"Here is the man!\"; KJV: \"Behold the man!\"; ESV: \"Behold the man!\"; NRSV: \"Here is the man!\" KJV/ESV's \"Behold\" preserves the demonstrative force and the liturgical resonance of Ecce Homo better than NIV's more conversational \"Here is.\"</td></tr><tr><td class=\"t-label\">Tetelestai (19:30)</td><td>NIV: \"It is finished\"; KJV: \"It is finished\"; ESV: \"It is finished\"; NRSV: \"It is finished\". Universal agreement. The perfect tense (completed with lasting effect) and the commercial resonance (paid in full) are commentary points, not translation differences.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">Idou ho anthrōpos (19:5)</td><td>NIV: \"Here is the man!\"; KJV: \"Behold the man!\"; ESV: \"Behold the man!\"; NRSV: \"Here is the man!\" KJV/ESV's \"Behold\" preserves the demonstrative force and the liturgical resonance of Ecce Homo better than NIV's more conversational \"Here is.\"</td></tr><tr><td class=\"t-label\">Tetelestai (19:30)</td><td>NIV: \"It is finished\"; KJV: \"It is finished\"; ESV: \"It is finished\"; NRSV: \"It is finished\". Universal agreement. The perfect tense (completed with lasting effect) and the commercial resonance (paid in full) are commentary points, not translation differences.</td></tr>",
     "src": [
       {
         "title": "Psalm 22:1-18",
         "quote": "\"My God, my God, why have you forsaken me?... They divide my clothes among them and cast lots for my garment.\"",
-        "note": "The psalm of the righteous sufferer that frames the passion narrative \u2014 cited directly in v.24 and quoted on the cross in the Synoptics."
+        "note": "The psalm of the righteous sufferer that frames the passion narrative — cited directly in v.24 and quoted on the cross in the Synoptics."
       },
       {
         "title": "Exodus 12:46",
-        "quote": "\"Do not break any of the bones\" \u2014 the Passover lamb command that John explicitly fulfils in v.33-36.",
+        "quote": "\"Do not break any of the bones\" — the Passover lamb command that John explicitly fulfils in v.33-36.",
         "note": "John's Passover Lamb typology is sealed by the unbroken bones: the soldiers' decision not to break Jesus's legs is the fulfilment of the Passover ordinance and the confirmation of the typological identity."
       }
     ],
     "rec": [
       {
         "who": "\"It Is Finished\" in Christian Theology",
-        "text": "Tetelestai (v.30) has been the foundation of the Reformed doctrine of the \"finished work of Christ\" \u2014 the principle that the atonement is complete and requires no supplement. Against the medieval Catholic idea that the Mass re-presents or continues the sacrifice, the Reformers argued that \"it is finished\" means the sacrifice was offered once for all (Heb 10:10-14) and its effects are permanently available to faith. The word has been set to music in every generation \u2014 from Bach's St John Passion to modern worship \u2014 and inscribed on altarpieces, gravestones, and churches worldwide."
+        "text": "Tetelestai (v.30) has been the foundation of the Reformed doctrine of the \"finished work of Christ\" — the principle that the atonement is complete and requires no supplement. Against the medieval Catholic idea that the Mass re-presents or continues the sacrifice, the Reformers argued that \"it is finished\" means the sacrifice was offered once for all (Heb 10:10-14) and its effects are permanently available to faith. The word has been set to music in every generation — from Bach's St John Passion to modern worship — and inscribed on altarpieces, gravestones, and churches worldwide."
       },
       {
         "who": "The Seamless Robe and the Unity of the Church",
@@ -378,13 +334,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Fulfilment Formula \u2014 Four Citations",
+          "label": "Fulfilment Formula — Four Citations",
           "text": "John uses the fulfilment formula four times in chapter 19 (vv.24, 28, 36, 37), citing Psalm 22:18, Psalm 69:21, Psalm 34:20, and Zechariah 12:10. The density of citations is unique in John and functions as a literary argument: the crucifixion is not a defeat but a precise divine programme unfolding in real time.",
           "is_key": false
         },
         {
-          "label": "Chiasm \u2014 Pilate Trial / Cross Sequence",
-          "text": "The crucifixion narrative mirrors the trial: crown of thorns (18:2) / \"Here is the man\" echoes in \"Here is your king\" (19:14-15). The inscription \"Jesus of Nazareth, King of the Jews\" in three languages (v20) forms the literary centre \u2014 the ironic public proclamation of the truth the trial sought to deny.",
+          "label": "Chiasm — Pilate Trial / Cross Sequence",
+          "text": "The crucifixion narrative mirrors the trial: crown of thorns (18:2) / \"Here is the man\" echoes in \"Here is your king\" (19:14-15). The inscription \"Jesus of Nazareth, King of the Jews\" in three languages (v20) forms the literary centre — the ironic public proclamation of the truth the trial sought to deny.",
           "is_key": false
         }
       ],
@@ -395,22 +351,22 @@
         "word": "Ecce homo",
         "tlit": "EC-ce HO-mo",
         "gloss": "Behold the man (Latin)",
-        "note": "Pilate's declaration \"Here is the man!\" (idou ho anthr\u014dpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him \u2014 surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man \u2014 the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
+        "note": "Pilate's declaration \"Here is the man!\" (idou ho anthrōpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him — surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man — the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
       },
       {
         "word": "titlos",
         "tlit": "TIT-los",
         "gloss": "titulus / inscription (Latin loanword)",
-        "note": "The titulus (v.19) \u2014 the placard stating the charge \u2014 was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek \u2014 the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
+        "note": "The titulus (v.19) — the placard stating the charge — was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek — the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
       },
       {
         "word": "tetelestai",
         "tlit": "te-TE-les-tai",
         "gloss": "it is finished / it is accomplished / it is paid",
-        "note": "The single Greek word (v.30) is the most theologically loaded word in the passion narrative. Tetelestai is the perfect passive of tele\u014d \u2014 to complete, to accomplish, to fulfil. The perfect tense declares a completed action with permanent effect: \"It has been finished and stands finished.\" In the commercial world of the first century, tetelestai was written across paid receipts \u2014 \"paid in full.\" The word encompasses the completion of the work (4:34 \u2014 \"finishing the work of him who sent me\"), the fulfilment of Scripture, and the payment of the debt of sin."
+        "note": "The single Greek word (v.30) is the most theologically loaded word in the passion narrative. Tetelestai is the perfect passive of teleō — to complete, to accomplish, to fulfil. The perfect tense declares a completed action with permanent effect: \"It has been finished and stands finished.\" In the commercial world of the first century, tetelestai was written across paid receipts — \"paid in full.\" The word encompasses the completion of the work (4:34 — \"finishing the work of him who sent me\"), the fulfilment of Scripture, and the payment of the debt of sin."
       },
       {
-        "word": "hyss\u014dpos",
+        "word": "hyssōpos",
         "tlit": "hys-SO-pos",
         "gloss": "hyssop",
         "note": "The hyssop branch used to lift the sponge to Jesus (v.29) is a detail unique to John among the passion accounts (the Synoptics say \"a stick/reed\"). Hyssop was the plant used to apply the Passover blood to the doorposts (Exod 12:22) and in purification rituals (Lev 14:4; Num 19:18; Ps 51:7). John's use of hyssop at the cross is deliberate: the blood of the true Passover Lamb is administered with the Passover plant."
@@ -419,13 +375,13 @@
         "word": "Ecce homo",
         "tlit": "EC-ce HO-mo",
         "gloss": "Behold the man (Latin)",
-        "note": "Pilate's declaration \"Here is the man!\" (idou ho anthr\u014dpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him \u2014 surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man \u2014 the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
+        "note": "Pilate's declaration \"Here is the man!\" (idou ho anthrōpos, v.5) is the moment that gave Christian art and devotion the phrase Ecce Homo. Pilate intends it as a display of a beaten, mocked prisoner: look at him — surely he is no threat, no king. John's irony is that the declaration is profoundly true at a level Pilate cannot see: this is the Man — the Son of Man, the second Adam, the representative human, the one in whom humanity is restored. \"Behold the man\" is simultaneously mockery and proclamation."
       },
       {
         "word": "titlos",
         "tlit": "TIT-los",
         "gloss": "titulus / inscription (Latin loanword)",
-        "note": "The titulus (v.19) \u2014 the placard stating the charge \u2014 was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek \u2014 the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
+        "note": "The titulus (v.19) — the placard stating the charge — was a standard feature of Roman crucifixion, carried before the condemned or attached to the cross. John records it in three languages (Aramaic, Latin, Greek — the three great languages of the ancient world) and preserves Pilate's insistence on keeping it as written: \"What I have written, I have written.\" The inscription is simultaneously the charge (rebellion), the mockery (king of the Jews), and John's deepest irony: it is the truest thing written in the passion narrative."
       }
     ],
     "thread": [
@@ -433,42 +389,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Exod 12:1-13",
         "type": "Fulfilment",
-        "text": "The Passover lamb \u2014 slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type.",
+        "text": "The Passover lamb — slaughtered at twilight on Nisan 14, whose blood protected Israel. Jesus is crucified on Nisan 14 at the hour the lambs are slaughtered (v.14), fulfilling the type.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 53:3-5",
         "type": "Echo",
-        "text": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" \u2014 the Suffering Servant whose treatment John's crucifixion narrative parallels.",
+        "text": "\"He was despised and rejected... he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him\" — the Suffering Servant whose treatment John's crucifixion narrative parallels.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 22:18",
         "type": "Fulfilment",
-        "text": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in vv.23-24.",
+        "text": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in vv.23-24.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Exod 12:46",
         "type": "Fulfilment",
-        "text": "\"Do not break any of the bones\" \u2014 the Passover lamb command, fulfilled in v.33-36 when the soldiers do not break Jesus's legs.",
+        "text": "\"Do not break any of the bones\" — the Passover lamb command, fulfilled in v.33-36 when the soldiers do not break Jesus's legs.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 22:18",
         "type": "Fulfilment",
-        "text": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in vv.23-24.",
+        "text": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in vv.23-24.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Zech 12:10",
         "type": "Connection",
-        "text": "\"They will look on me, the one they have pierced, and they will mourn for him\" \u2014 cited in v.37 for the spear-thrust.",
+        "text": "\"They will look on me, the one they have pierced, and they will mourn for him\" — cited in v.37 for the spear-thrust.",
         "direction": "backward"
       }
     ],
@@ -476,7 +432,7 @@
       {
         "ref": "19:29",
         "title": "\"Hyssop\" vs \"javelin\"",
-        "content": "A few late MSS read hyss\u014d (javelin/spear) rather than hyss\u014dp\u014d (hyssop). NA28 follows hyss\u014dp\u014d as the overwhelming consensus. The \"javelin\" reading was proposed to resolve the practical difficulty of lifting a sponge on a hyssop stalk (a small plant), but the Passover typological significance of hyssop makes it almost certainly original.",
+        "content": "A few late MSS read hyssō (javelin/spear) rather than hyssōpō (hyssop). NA28 follows hyssōpō as the overwhelming consensus. The \"javelin\" reading was proposed to resolve the practical difficulty of lifting a sponge on a hyssop stalk (a small plant), but the Passover typological significance of hyssop makes it almost certainly original.",
         "note": "The hyssop reading is overwhelmingly attested and theologically significant. The \"javelin\" reading is a late scribal attempt to resolve a perceived difficulty."
       }
     ],
@@ -487,12 +443,12 @@
           {
             "name": "Medical: physical confirmation of death",
             "proponents": "Most medical scholars, many NT commentators",
-            "argument": "The blood and water are the physiological result of the spear-thrust \u2014 a pericardial effusion. The detail confirms the physical reality of the death against any swoon theory. The eyewitness emphasis (v.35) suggests John knew this detail would be challenged."
+            "argument": "The blood and water are the physiological result of the spear-thrust — a pericardial effusion. The detail confirms the physical reality of the death against any swoon theory. The eyewitness emphasis (v.35) suggests John knew this detail would be challenged."
           },
           {
             "name": "Sacramental: baptism and Eucharist",
             "proponents": "Augustine, most Catholic and Orthodox interpreters",
-            "argument": "Water = baptism; blood = Eucharist. The two sacraments flow from Christ's side as Eve came from Adam's side \u2014 the church born from the cross. Chrysostom: \"From the side of Christ was born the church, as Eve from the side of the sleeping Adam.\""
+            "argument": "Water = baptism; blood = Eucharist. The two sacraments flow from Christ's side as Eve came from Adam's side — the church born from the cross. Chrysostom: \"From the side of Christ was born the church, as Eve from the side of the sleeping Adam.\""
           },
           {
             "name": "Johannine symbolic: Spirit and atonement",
@@ -529,7 +485,7 @@
           "score": 10
         }
       ],
-      "note": "John 19 is the Gospel's darkest and brightest hour simultaneously. The darkness: judicial murder, the renunciation of God's covenant (\"no king but Caesar\"), the death of the Son of God. The brightness: sovereign surrender (\"he bowed his head and gave up his spirit\"), the single word of completion (tetelestai), the Passover Lamb who dies at the appointed hour on the appointed day with not a bone broken. Every detail \u2014 the hyssop, the seamless robe, the unbroken bones, the piercing \u2014 is the precise fulfilment of Scripture, confirming that what looks like chaos is in fact perfect plan. The man who said \"it is finished\" means it."
+      "note": "John 19 is the Gospel's darkest and brightest hour simultaneously. The darkness: judicial murder, the renunciation of God's covenant (\"no king but Caesar\"), the death of the Son of God. The brightness: sovereign surrender (\"he bowed his head and gave up his spirit\"), the single word of completion (tetelestai), the Passover Lamb who dies at the appointed hour on the appointed day with not a bone broken. Every detail — the hyssop, the seamless robe, the unbroken bones, the piercing — is the precise fulfilment of Scripture, confirming that what looks like chaos is in fact perfect plan. The man who said \"it is finished\" means it."
     }
   },
   "vhl_groups": [
@@ -648,12 +604,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Here is your king!' (v. 14). Pilate's mockery speaks truth. Thorns, purple robe, 'Hail, King of the Jews!'\u2014sarcasm that accidentally crowns. John sees coronation where Rome sees humiliation.",
+      "tip": "'Here is your king!' (v. 14). Pilate's mockery speaks truth. Thorns, purple robe, 'Hail, King of the Jews!'—sarcasm that accidentally crowns. John sees coronation where Rome sees humiliation.",
       "genre_tag": "literary_pattern"
     },
     {
       "after_section": 2,
-      "tip": "'It is finished' (v. 30). Tetelestai\u2014'completed,' 'accomplished,' 'paid in full.' Not defeat but triumph. The mission ends; salvation is secured. Jesus bows his head and gives up his spirit\u2014voluntarily.",
+      "tip": "'It is finished' (v. 30). Tetelestai—'completed,' 'accomplished,' 'paid in full.' Not defeat but triumph. The mission ends; salvation is secured. Jesus bows his head and gives up his spirit—voluntarily.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/2.json
+++ b/content/john/2.json
@@ -7,25 +7,25 @@
   "subtitle": "The Wedding at Cana and Cleansing of the Temple",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 The Wedding at Cana: The First Sign",
+      "header": "Verses 1–11 — The Wedding at Cana: The First Sign",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
         "heb": [
           {
-            "word": "s\u0113meion",
+            "word": "sēmeion",
             "transliteration": "SAY-mei-on",
             "gloss": "sign",
-            "paragraph": "John never uses the word \"miracle\" (dynamis, act of power) \u2014 he consistently uses s\u0113meion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
+            "paragraph": "John never uses the word \"miracle\" (dynamis, act of power) — he consistently uses sēmeion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
           },
           {
-            "word": "h\u014dra mou",
+            "word": "hōra mou",
             "transliteration": "HO-ra mou",
             "gloss": "my hour",
             "paragraph": "Jesus's response (v.4) introduces one of John's most significant recurring themes: \"my hour\" or \"the hour.\" Throughout John, the hour has not yet come (2:4; 7:30; 8:20) until the passion, when it arrives (12:23; 13:1; 17:1). The \"hour\" is the cross-and-resurrection event that the entire Gospel is structured toward."
@@ -34,12 +34,12 @@
         "places": [
           {
             "name": "Cana of Galilee",
-            "coords": "32.8461\u00b0 N, 35.3521\u00b0 E",
+            "coords": "32.8461° N, 35.3521° E",
             "text": "The site of Jesus's first sign, identified with modern Khirbet Qana north of Nazareth, though Kafr Kanna (on the road from Nazareth to Tiberias) has been the traditional pilgrimage site since the Byzantine period. Nathanael was from Cana (John 21:2), making it likely he was present at the wedding. The village is in the heart of lower Galilee, about 5 miles north of Nazareth."
           },
           {
             "name": "Capernaum",
-            "coords": "32.8807\u00b0 N, 35.5743\u00b0 E",
+            "coords": "32.8807° N, 35.5743° E",
             "text": "Jesus's base of operations during his Galilean ministry (Matt 4:13 calls it \"his own town\"). After the Cana wedding, Jesus went to Capernaum with his family and disciples (v.12). The excavated remains of an ancient synagogue (on top of which a later 4th-century synagogue was built) and a house traditionally identified as Peter's house are visible today on the north shore of the Sea of Galilee."
           }
         ],
@@ -47,71 +47,71 @@
           "refs": [
             {
               "ref": "Amos 9:13-14",
-              "note": "\"New wine will drip from the mountains\" \u2014 the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form."
+              "note": "\"New wine will drip from the mountains\" — the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form."
             },
             {
               "ref": "Gen 49:11",
-              "note": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" \u2014 Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king."
+              "note": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" — Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king."
             },
             {
               "ref": "John 4:46",
-              "note": "Jesus returns to Cana for the second sign \u2014 healing the royal official's son \u2014 structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4."
+              "note": "Jesus returns to Cana for the second sign — healing the royal official's son — structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:4",
-              "note": "\"My hour has not yet come\" \u2014 the hour is the cross. The Cross is the lens through which every miracle and teaching in John must be read. The first sign is not an isolated wonder but the opening note of a symphony that resolves in the passion."
+              "note": "\"My hour has not yet come\" — the hour is the cross. The Cross is the lens through which every miracle and teaching in John must be read. The first sign is not an isolated wonder but the opening note of a symphony that resolves in the passion."
             },
             {
               "ref": "2:6",
-              "note": "Six stone jars \u2014 not seven (the number of completeness). The purification jars of the old order are transformed to produce the wine of the new. Jesus does not abolish the Jewish purification system but fulfils and supersedes it: the water of ritual cleansing becomes the wine of messianic celebration. Six is the number of incompleteness waiting for its seventh."
+              "note": "Six stone jars — not seven (the number of completeness). The purification jars of the old order are transformed to produce the wine of the new. Jesus does not abolish the Jewish purification system but fulfils and supersedes it: the water of ritual cleansing becomes the wine of messianic celebration. Six is the number of incompleteness waiting for its seventh."
             },
             {
               "ref": "2:10",
-              "note": "\"You have saved the best till now\" \u2014 the bridegroom of the wedding unwittingly articulates the Gospel's central claim about redemptive history. God saved the best till now: the old covenant was good; the new covenant surpasses it. The pattern of grace is consistently escalating, not diminishing."
+              "note": "\"You have saved the best till now\" — the bridegroom of the wedding unwittingly articulates the Gospel's central claim about redemptive history. God saved the best till now: the old covenant was good; the new covenant surpasses it. The pattern of grace is consistently escalating, not diminishing."
             },
             {
               "ref": "2:11",
-              "note": "\"Revealed his glory\" \u2014 the glory (doxa) that the disciples saw at the Transfiguration in Matthew/Mark/Luke, John never narrates directly. Instead, John presents the glory as revealed throughout the ministry in signs and words, culminating in the cross (12:23: \"The hour has come for the Son of Man to be glorified\")."
+              "note": "\"Revealed his glory\" — the glory (doxa) that the disciples saw at the Transfiguration in Matthew/Mark/Luke, John never narrates directly. Instead, John presents the glory as revealed throughout the ministry in signs and words, culminating in the cross (12:23: \"The hour has come for the Son of Man to be glorified\")."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:3-5",
-              "note": "Calvin notes that Mary's request is not wrong in itself \u2014 she wants to help the couple in their need \u2014 but her expectation of how Jesus should respond reveals an assumption about her authority over him. Jesus's gentle correction establishes that even the closest human relationships do not override the Father's governance of his mission. Mary's response \u2014 \"do whatever he tells you\" \u2014 is her finest moment: she defers completely to his authority."
+              "note": "Calvin notes that Mary's request is not wrong in itself — she wants to help the couple in their need — but her expectation of how Jesus should respond reveals an assumption about her authority over him. Jesus's gentle correction establishes that even the closest human relationships do not override the Father's governance of his mission. Mary's response — \"do whatever he tells you\" — is her finest moment: she defers completely to his authority."
             },
             {
               "ref": "2:11",
-              "note": "The disciples believed. Calvin insists that the faith produced by the sign is genuine but incomplete \u2014 it will deepen through the whole course of the Gospel. This is John's pattern: signs produce initial faith that must be deepened by encounter with the person of Jesus himself, culminating in the resurrection."
+              "note": "The disciples believed. Calvin insists that the faith produced by the sign is genuine but incomplete — it will deepen through the whole course of the Gospel. This is John's pattern: signs produce initial faith that must be deepened by encounter with the person of Jesus himself, culminating in the resurrection."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:6",
-              "note": "Each stone jar held 2-3 metr\u0113tas (one metr\u0113tas = approximately 9 gallons). Six jars \u00d7 20-30 gallons = 120-180 gallons of wine. The quantity is deliberately excessive \u2014 a sign of eschatological superabundance, not merely a social solution. Stone jars (rather than clay) were used because stone does not contract ritual impurity."
+              "note": "Each stone jar held 2-3 metrētas (one metrētas = approximately 9 gallons). Six jars × 20-30 gallons = 120-180 gallons of wine. The quantity is deliberately excessive — a sign of eschatological superabundance, not merely a social solution. Stone jars (rather than clay) were used because stone does not contract ritual impurity."
             },
             {
               "ref": "2:4",
-              "note": "\"Woman\" (gynai) \u2014 addressed to women generally in the Greco-Roman world without disrespect. Jesus uses the same address to Mary from the cross (19:26), and to Mary Magdalene after the resurrection (20:15). It is a form of respectful address, not a rebuke."
+              "note": "\"Woman\" (gynai) — addressed to women generally in the Greco-Roman world without disrespect. Jesus uses the same address to Mary from the cross (19:26), and to Mary Magdalene after the resurrection (20:15). It is a form of respectful address, not a rebuke."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "2:5",
-              "note": "Augustine: \"His mother said to the servants, 'Whatever he says to you, do it.' Admirable words. She pointed to the one who, as God, can do what is impossible for humans. 'Whatever he says to you, do it' \u2014 this is the only teaching we need for the whole of life: obedience to the word of Christ.\""
+              "note": "Augustine: \"His mother said to the servants, 'Whatever he says to you, do it.' Admirable words. She pointed to the one who, as God, can do what is impossible for humans. 'Whatever he says to you, do it' — this is the only teaching we need for the whole of life: obedience to the word of Christ.\""
             },
             {
               "ref": "2:9-10",
@@ -120,13 +120,13 @@
           ]
         },
         "hist": {
-          "context": "Wedding Feasts in First-Century Galilee\nJewish wedding feasts in the first century lasted seven days (cf. Judg 14:12). Running out of wine was a serious social failure \u2014 it would have shamed the bridegroom's family for years. Jesus's mother's concern is therefore not trivial. The six stone jars (v.6) used for Jewish purification rituals held 20-30 gallons each \u2014 producing perhaps 120-180 gallons of wine in total, an extravagant abundance that signals the eschatological superabundance of the messianic age (cf. Amos 9:13-14; Joel 3:18).\n\n\"Woman, why do you involve me?\"\nJesus's address to his mother as \"Woman\" (gynai) sounds cold in English but was not disrespectful in Greek \u2014 he uses the same address at the cross (19:26). The question \"what is that to me and to you?\" (a Semitic idiom) indicates Jesus is not refusing but redirecting: his actions are not governed by family obligation but by the Father's timing. His mother's instruction to the servants (\"Do whatever he tells you\") shows she understands the message."
+          "context": "Wedding Feasts in First-Century Galilee\nJewish wedding feasts in the first century lasted seven days (cf. Judg 14:12). Running out of wine was a serious social failure — it would have shamed the bridegroom's family for years. Jesus's mother's concern is therefore not trivial. The six stone jars (v.6) used for Jewish purification rituals held 20-30 gallons each — producing perhaps 120-180 gallons of wine in total, an extravagant abundance that signals the eschatological superabundance of the messianic age (cf. Amos 9:13-14; Joel 3:18).\n\n\"Woman, why do you involve me?\"\nJesus's address to his mother as \"Woman\" (gynai) sounds cold in English but was not disrespectful in Greek — he uses the same address at the cross (19:26). The question \"what is that to me and to you?\" (a Semitic idiom) indicates Jesus is not refusing but redirecting: his actions are not governed by family obligation but by the Father's timing. His mother's instruction to the servants (\"Do whatever he tells you\") shows she understands the message."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201322 \u2014 The Temple Cleansing: Destroy This Temple",
+      "header": "Verses 12–22 — The Temple Cleansing: Destroy This Temple",
       "verse_start": 12,
       "verse_end": 22,
       "panels": {
@@ -135,10 +135,10 @@
             "word": "naos",
             "transliteration": "na-OS",
             "gloss": "temple / sanctuary (inner building)",
-            "paragraph": "Jesus says \"Destroy this naos\" (v.19) \u2014 not hieron (the whole Temple complex) but naos (the inner sanctuary itself, the Holy of Holies and Holy Place). The Synoptics use hieron for the Temple area; John's precision here is significant: Jesus is identifying his body with the most sacred space in Judaism \u2014 not the outer courts but the very dwelling place of God."
+            "paragraph": "Jesus says \"Destroy this naos\" (v.19) — not hieron (the whole Temple complex) but naos (the inner sanctuary itself, the Holy of Holies and Holy Place). The Synoptics use hieron for the Temple area; John's precision here is significant: Jesus is identifying his body with the most sacred space in Judaism — not the outer courts but the very dwelling place of God."
           },
           {
-            "word": "\u0113geir\u014d",
+            "word": "ēgeirō",
             "transliteration": "ay-GAY-ro",
             "gloss": "raise up / rouse",
             "paragraph": "The verb (v.19) is deliberately ambiguous: it can mean to rebuild a demolished building or to raise someone from the dead. The hearers take it architecturally; John's editorial comment (v.21) reveals the resurrection meaning. The ambiguity is characteristic of Johannine double meaning."
@@ -147,23 +147,23 @@
         "places": [
           {
             "name": "Jerusalem Temple Mount",
-            "coords": "31.7781\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Herodian Temple complex \u2014 rebuilt by Herod the Great beginning c. 20 BC and still under construction 46 years later at Jesus's first Passover visit. The Temple Mount platform covered 35 acres; the outer Court of the Gentiles was surrounded by colonnaded porticos. The money changers and animal sellers operated in the outer court, particularly in the Royal Portico on the south side. Jesus enters this space and claims it as \"my Father's house\" \u2014 the first of several Passover visits in John."
+            "coords": "31.7781° N, 35.2354° E",
+            "text": "The Herodian Temple complex — rebuilt by Herod the Great beginning c. 20 BC and still under construction 46 years later at Jesus's first Passover visit. The Temple Mount platform covered 35 acres; the outer Court of the Gentiles was surrounded by colonnaded porticos. The money changers and animal sellers operated in the outer court, particularly in the Royal Portico on the south side. Jesus enters this space and claims it as \"my Father's house\" — the first of several Passover visits in John."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ps 69:9",
-              "note": "\"Zeal for your house consumes me\" \u2014 the Psalm the disciples remembered (v.17), applied to Jesus's consuming passion for the Father's house. Significantly, in the Psalm the second half reads \"and the insults of those who insult you fall on me\" \u2014 Jesus absorbs the rejection directed at God."
+              "note": "\"Zeal for your house consumes me\" — the Psalm the disciples remembered (v.17), applied to Jesus's consuming passion for the Father's house. Significantly, in the Psalm the second half reads \"and the insults of those who insult you fall on me\" — Jesus absorbs the rejection directed at God."
             },
             {
               "ref": "Zech 14:21",
-              "note": "\"There will no longer be a Canaanite (merchant) in the house of the Lord Almighty\" \u2014 the eschatological promise of a purified Temple that Jesus enacts proleptically."
+              "note": "\"There will no longer be a Canaanite (merchant) in the house of the Lord Almighty\" — the eschatological promise of a purified Temple that Jesus enacts proleptically."
             },
             {
               "ref": "Isa 56:7",
-              "note": "\"My house will be called a house of prayer for all nations\" \u2014 the Temple's true purpose that the money changers have obscured."
+              "note": "\"My house will be called a house of prayer for all nations\" — the Temple's true purpose that the money changers have obscured."
             }
           ],
           "echoes": [
@@ -172,60 +172,60 @@
               "target_ref": "John 2:17",
               "type": "direct_quote",
               "source_context": "The psalmist's zeal for God's house consumes him; he bears reproach for God's sake. This is a righteous sufferer who is mistreated because of his devotion to God.",
-              "connection": "The disciples remember this verse when Jesus cleanses the temple. His zealous action fulfills the psalmist's consuming devotion \u2014 and will lead to the same reproach.",
+              "connection": "The disciples remember this verse when Jesus cleanses the temple. His zealous action fulfills the psalmist's consuming devotion — and will lead to the same reproach.",
               "significance": "John signals that Jesus' temple action is not political protest but prophetic fulfillment. The righteous sufferer's zeal for God's dwelling anticipates Jesus' passion."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:15-16",
-              "note": "The whip made of cords \u2014 a deliberate, premeditated action, not a momentary loss of temper. Jesus took time to braid a whip; the action is calculated. This is holy anger: \"zeal for your house will consume me.\" The distinction between righteous indignation and sinful anger is that righteous anger is directed at the desecration of what is holy, not at personal offence."
+              "note": "The whip made of cords — a deliberate, premeditated action, not a momentary loss of temper. Jesus took time to braid a whip; the action is calculated. This is holy anger: \"zeal for your house will consume me.\" The distinction between righteous indignation and sinful anger is that righteous anger is directed at the desecration of what is holy, not at personal offence."
             },
             {
               "ref": "2:19",
-              "note": "\"Destroy this temple, and I will raise it in three days\" \u2014 the most compressed prediction of the passion and resurrection in the Gospel. The ambiguity is the point: the hearers hear a building; Jesus means his body; the disciples understand after the resurrection. The statement will be used against Jesus at his trial (Matt 26:61) \u2014 a false accusation that is ironically true in a sense his accusers could not perceive."
+              "note": "\"Destroy this temple, and I will raise it in three days\" — the most compressed prediction of the passion and resurrection in the Gospel. The ambiguity is the point: the hearers hear a building; Jesus means his body; the disciples understand after the resurrection. The statement will be used against Jesus at his trial (Matt 26:61) — a false accusation that is ironically true in a sense his accusers could not perceive."
             },
             {
               "ref": "2:24-25",
-              "note": "\"Jesus would not entrust himself to them, for he knew all people.\" The Greek is a wordplay: many \"believed\" (episteusan) in him, but he did not \"entrust\" (episteusen) himself to them. Surface faith produced by signs is not the faith Jesus is after. He knows what is in people \u2014 Nicodemus is about to demonstrate this immediately in chapter 3."
+              "note": "\"Jesus would not entrust himself to them, for he knew all people.\" The Greek is a wordplay: many \"believed\" (episteusan) in him, but he did not \"entrust\" (episteusen) himself to them. Surface faith produced by signs is not the faith Jesus is after. He knows what is in people — Nicodemus is about to demonstrate this immediately in chapter 3."
             },
             {
               "ref": "2:21",
-              "note": "\"The temple he had spoken of was his body\" \u2014 John's editorial comment connects the Temple and the Incarnation: Jesus's body is the new naos, the new dwelling place of God's glory. The Tabernacle was the old form; Solomon's Temple was a permanent form; Jesus's body is the final, definitive Temple \u2014 and it is also what rose from the dead."
+              "note": "\"The temple he had spoken of was his body\" — John's editorial comment connects the Temple and the Incarnation: Jesus's body is the new naos, the new dwelling place of God's glory. The Tabernacle was the old form; Solomon's Temple was a permanent form; Jesus's body is the final, definitive Temple — and it is also what rose from the dead."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:14-17",
-              "note": "Calvin defends the Temple cleansing as a prophetic act, not mere anger. The prophets performed symbolic actions as living proclamations; Jesus does the same. The whip does not harm persons \u2014 it drives out animals. The overturning of tables is a demonstration against an institution, not an assault on individuals. Calvin connects this to the church's ongoing responsibility to expel commercial exploitation from worship."
+              "note": "Calvin defends the Temple cleansing as a prophetic act, not mere anger. The prophets performed symbolic actions as living proclamations; Jesus does the same. The whip does not harm persons — it drives out animals. The overturning of tables is a demonstration against an institution, not an assault on individuals. Calvin connects this to the church's ongoing responsibility to expel commercial exploitation from worship."
             },
             {
               "ref": "2:23-25",
-              "note": "The distinction between sign-faith and genuine faith is critical for Calvin. Many believed in Jesus's \"name\" (v.23) \u2014 they accepted his credentials \u2014 but Jesus knew their hearts contained no deeper root. Sign-faith is the faith that asks \"what can you do for me?\" True faith is the faith that asks \"who are you and how do I belong to you?\" Nicodemus in the next chapter is the dramatic illustration."
+              "note": "The distinction between sign-faith and genuine faith is critical for Calvin. Many believed in Jesus's \"name\" (v.23) — they accepted his credentials — but Jesus knew their hearts contained no deeper root. Sign-faith is the faith that asks \"what can you do for me?\" True faith is the faith that asks \"who are you and how do I belong to you?\" Nicodemus in the next chapter is the dramatic illustration."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:20",
-              "note": "\"Forty-six years to build\" \u2014 The present tense in Greek (oikodome\u014d) suggests construction was still ongoing, consistent with Josephus's testimony that the Temple was not completed until AD 63, seven years before its destruction."
+              "note": "\"Forty-six years to build\" — The present tense in Greek (oikodomeō) suggests construction was still ongoing, consistent with Josephus's testimony that the Temple was not completed until AD 63, seven years before its destruction."
             },
             {
               "ref": "2:22",
-              "note": "\"They believed the scripture and the words that Jesus had spoken\" \u2014 the resurrection became the interpretive key that unlocked both Scripture and Jesus's words. Before the resurrection, the disciples could not connect \"destroy this temple\" with the resurrection; after it, everything fell into place. This pattern \u2014 post-resurrection understanding \u2014 is characteristic of John."
+              "note": "\"They believed the scripture and the words that Jesus had spoken\" — the resurrection became the interpretive key that unlocked both Scripture and Jesus's words. Before the resurrection, the disciples could not connect \"destroy this temple\" with the resurrection; after it, everything fell into place. This pattern — post-resurrection understanding — is characteristic of John."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "2:17",
@@ -238,25 +238,25 @@
           ]
         },
         "hist": {
-          "context": "John's Temple Cleansing at the Beginning vs. the Synoptics at the End\nThe Synoptics place the Temple cleansing in Passion Week (Matt 21; Mark 11; Luke 19). John places it at the very start of the ministry. Options: (1) Two separate cleansings; (2) John has deliberately moved it for theological reasons (to introduce the \"temple of his body\" theme early); (3) John preserves the original chronology that the Synoptics moved. Most scholars accept either option 1 or option 2. The theological placement at the start of John is fitting: Jesus immediately establishes his authority over the most sacred institution of Judaism.\n\nThe Money Changers and the Temple Economy\nPilgrims travelling long distances could not bring animals for sacrifice. The Temple authorities had established a system of approved animals sold in the Temple courts and money changers who converted Roman and foreign coins (bearing graven images, prohibited in the Temple) into Tyrian shekels acceptable for the Temple tax. The system was economically necessary but had become exploitative \u2014 prices were inflated, the high priest's family controlled the concessions, and what should have been a house of prayer had become a bazaar."
+          "context": "John's Temple Cleansing at the Beginning vs. the Synoptics at the End\nThe Synoptics place the Temple cleansing in Passion Week (Matt 21; Mark 11; Luke 19). John places it at the very start of the ministry. Options: (1) Two separate cleansings; (2) John has deliberately moved it for theological reasons (to introduce the \"temple of his body\" theme early); (3) John preserves the original chronology that the Synoptics moved. Most scholars accept either option 1 or option 2. The theological placement at the start of John is fitting: Jesus immediately establishes his authority over the most sacred institution of Judaism.\n\nThe Money Changers and the Temple Economy\nPilgrims travelling long distances could not bring animals for sacrifice. The Temple authorities had established a system of approved animals sold in the Temple courts and money changers who converted Roman and foreign coins (bearing graven images, prohibited in the Temple) into Tyrian shekels acceptable for the Temple tax. The system was economically necessary but had become exploitative — prices were inflated, the high priest's family controlled the concessions, and what should have been a house of prayer had become a bazaar."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201325 \u2014 Many Believe, But Jesus Knows All Hearts",
+      "header": "Verses 23–25 — Many Believe, But Jesus Knows All Hearts",
       "verse_start": 23,
       "verse_end": 25,
       "panels": {
         "heb": [
           {
-            "word": "s\u0113meion",
+            "word": "sēmeion",
             "transliteration": "SAY-mei-on",
             "gloss": "sign",
-            "paragraph": "John never uses the word \"miracle\" (dynamis, act of power) \u2014 he consistently uses s\u0113meion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
+            "paragraph": "John never uses the word \"miracle\" (dynamis, act of power) — he consistently uses sēmeion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
           },
           {
-            "word": "h\u014dra mou",
+            "word": "hōra mou",
             "transliteration": "HO-ra mou",
             "gloss": "my hour",
             "paragraph": "Jesus's response (v.4) introduces one of John's most significant recurring themes: \"my hour\" or \"the hour.\" Throughout John, the hour has not yet come (2:4; 7:30; 8:20) until the passion, when it arrives (12:23; 13:1; 17:1). The \"hour\" is the cross-and-resurrection event that the entire Gospel is structured toward."
@@ -265,12 +265,12 @@
         "places": [
           {
             "name": "Cana of Galilee",
-            "coords": "32.8461\u00b0 N, 35.3521\u00b0 E",
+            "coords": "32.8461° N, 35.3521° E",
             "text": "The site of Jesus's first sign, identified with modern Khirbet Qana north of Nazareth, though Kafr Kanna (on the road from Nazareth to Tiberias) has been the traditional pilgrimage site since the Byzantine period. Nathanael was from Cana (John 21:2), making it likely he was present at the wedding. The village is in the heart of lower Galilee, about 5 miles north of Nazareth."
           },
           {
             "name": "Capernaum",
-            "coords": "32.8807\u00b0 N, 35.5743\u00b0 E",
+            "coords": "32.8807° N, 35.5743° E",
             "text": "Jesus's base of operations during his Galilean ministry (Matt 4:13 calls it \"his own town\"). After the Cana wedding, Jesus went to Capernaum with his family and disciples (v.12). The excavated remains of an ancient synagogue (on top of which a later 4th-century synagogue was built) and a house traditionally identified as Peter's house are visible today on the north shore of the Sea of Galilee."
           }
         ],
@@ -278,80 +278,36 @@
           "refs": [
             {
               "ref": "Amos 9:13-14",
-              "note": "\"New wine will drip from the mountains\" \u2014 the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form."
+              "note": "\"New wine will drip from the mountains\" — the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form."
             },
             {
               "ref": "Gen 49:11",
-              "note": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" \u2014 Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king."
+              "note": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" — Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king."
             },
             {
               "ref": "John 4:46",
-              "note": "Jesus returns to Cana for the second sign \u2014 healing the royal official's son \u2014 structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4."
+              "note": "Jesus returns to Cana for the second sign — healing the royal official's son — structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:4",
-              "note": "\"My hour has not yet come\" \u2014 the hour is the cross. The Cross is the lens through which every miracle and teaching in John must be read. The first sign is not an isolated wonder but the opening note of a symphony that resolves in the passion."
-            },
-            {
-              "ref": "2:6",
-              "note": "Six stone jars \u2014 not seven (the number of completeness). The purification jars of the old order are transformed to produce the wine of the new. Jesus does not abolish the Jewish purification system but fulfils and supersedes it: the water of ritual cleansing becomes the wine of messianic celebration. Six is the number of incompleteness waiting for its seventh."
-            },
-            {
-              "ref": "2:10",
-              "note": "\"You have saved the best till now\" \u2014 the bridegroom of the wedding unwittingly articulates the Gospel's central claim about redemptive history. God saved the best till now: the old covenant was good; the new covenant surpasses it. The pattern of grace is consistently escalating, not diminishing."
-            },
-            {
-              "ref": "2:11",
-              "note": "\"Revealed his glory\" \u2014 the glory (doxa) that the disciples saw at the Transfiguration in Matthew/Mark/Luke, John never narrates directly. Instead, John presents the glory as revealed throughout the ministry in signs and words, culminating in the cross (12:23: \"The hour has come for the Son of Man to be glorified\")."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:3-5",
-              "note": "Calvin notes that Mary's request is not wrong in itself \u2014 she wants to help the couple in their need \u2014 but her expectation of how Jesus should respond reveals an assumption about her authority over him. Jesus's gentle correction establishes that even the closest human relationships do not override the Father's governance of his mission. Mary's response \u2014 \"do whatever he tells you\" \u2014 is her finest moment: she defers completely to his authority."
-            },
-            {
-              "ref": "2:11",
-              "note": "The disciples believed. Calvin insists that the faith produced by the sign is genuine but incomplete \u2014 it will deepen through the whole course of the Gospel. This is John's pattern: signs produce initial faith that must be deepened by encounter with the person of Jesus himself, culminating in the resurrection."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:6",
-              "note": "Each stone jar held 2-3 metr\u0113tas (one metr\u0113tas = approximately 9 gallons). Six jars \u00d7 20-30 gallons = 120-180 gallons of wine. The quantity is deliberately excessive \u2014 a sign of eschatological superabundance, not merely a social solution. Stone jars (rather than clay) were used because stone does not contract ritual impurity."
-            },
-            {
-              "ref": "2:4",
-              "note": "\"Woman\" (gynai) \u2014 addressed to women generally in the Greco-Roman world without disrespect. Jesus uses the same address to Mary from the cross (19:26), and to Mary Magdalene after the resurrection (20:15). It is a form of respectful address, not a rebuke."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "2:5",
-              "note": "Augustine: \"His mother said to the servants, 'Whatever he says to you, do it.' Admirable words. She pointed to the one who, as God, can do what is impossible for humans. 'Whatever he says to you, do it' \u2014 this is the only teaching we need for the whole of life: obedience to the word of Christ.\""
-            },
-            {
-              "ref": "2:9-10",
-              "note": "Chrysostom: \"The master of the feast said the best wine was kept to last. Was not this also the case with the creation? First came the shadows and figures of the law; then, in the fullness of time, the reality and truth came through Jesus Christ. The best was indeed saved for last.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Wedding Feasts in First-Century Galilee\nJewish wedding feasts in the first century lasted seven days (cf. Judg 14:12). Running out of wine was a serious social failure \u2014 it would have shamed the bridegroom's family for years. Jesus's mother's concern is therefore not trivial. The six stone jars (v.6) used for Jewish purification rituals held 20-30 gallons each \u2014 producing perhaps 120-180 gallons of wine in total, an extravagant abundance that signals the eschatological superabundance of the messianic age (cf. Amos 9:13-14; Joel 3:18).\n\n\"Woman, why do you involve me?\"\nJesus's address to his mother as \"Woman\" (gynai) sounds cold in English but was not disrespectful in Greek \u2014 he uses the same address at the cross (19:26). The question \"what is that to me and to you?\" (a Semitic idiom) indicates Jesus is not refusing but redirecting: his actions are not governed by family obligation but by the Father's timing. His mother's instruction to the servants (\"Do whatever he tells you\") shows she understands the message."
+          "context": "Wedding Feasts in First-Century Galilee\nJewish wedding feasts in the first century lasted seven days (cf. Judg 14:12). Running out of wine was a serious social failure — it would have shamed the bridegroom's family for years. Jesus's mother's concern is therefore not trivial. The six stone jars (v.6) used for Jewish purification rituals held 20-30 gallons each — producing perhaps 120-180 gallons of wine in total, an extravagant abundance that signals the eschatological superabundance of the messianic age (cf. Amos 9:13-14; Joel 3:18).\n\n\"Woman, why do you involve me?\"\nJesus's address to his mother as \"Woman\" (gynai) sounds cold in English but was not disrespectful in Greek — he uses the same address at the cross (19:26). The question \"what is that to me and to you?\" (a Semitic idiom) indicates Jesus is not refusing but redirecting: his actions are not governed by family obligation but by the Father's timing. His mother's instruction to the servants (\"Do whatever he tells you\") shows she understands the message."
         }
       }
     }
@@ -361,26 +317,26 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Jesus's mother's concern is therefore not trivial\u2026"
+        "text": "Jesus's mother's concern is therefore not trivial…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">gynai (2:4)</td><td>NIV: \"Woman\"; KJV: \"Woman\"; ESV: \"Woman\"; NRSV: \"Woman\". Universal agreement. The word is not disrespectful but sounds more clinical in modern English than it did in first-century Greek.</td></tr><tr><td class=\"t-label\">s\u0113meion (2:11)</td><td>NIV: \"signs\"; KJV: \"miracles\" (misleadingly); ESV: \"signs\"; NRSV: \"signs\". NIV/ESV/NRSV correctly render s\u0113meion as \"sign\" \u2014 preserving John's intentional distinction from dynamis (act of power).</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">gynai (2:4)</td><td>NIV: \"Woman\"; KJV: \"Woman\"; ESV: \"Woman\"; NRSV: \"Woman\". Universal agreement. The word is not disrespectful but sounds more clinical in modern English than it did in first-century Greek.</td></tr><tr><td class=\"t-label\">sēmeion (2:11)</td><td>NIV: \"signs\"; KJV: \"miracles\" (misleadingly); ESV: \"signs\"; NRSV: \"signs\". NIV/ESV/NRSV correctly render sēmeion as \"sign\" — preserving John's intentional distinction from dynamis (act of power).</td></tr>",
     "src": [
       {
         "title": "Amos 9:13-14",
         "quote": "\"New wine will drip from the mountains and flow from all the hills, and I will bring my people Israel back from exile.\"",
-        "note": "The OT eschatological vision of superabundant wine as the sign of restoration \u2014 the backdrop against which the Cana sign achieves its messianic significance. The excessive quantity of wine (120-180 gallons) is the sign's first theological statement."
+        "note": "The OT eschatological vision of superabundant wine as the sign of restoration — the backdrop against which the Cana sign achieves its messianic significance. The excessive quantity of wine (120-180 gallons) is the sign's first theological statement."
       },
       {
         "title": "Psalm 69:9",
         "quote": "\"Zeal for your house consumes me, and the insults of those who insult you fall on me.\"",
-        "note": "The passion psalm the disciples recalled at the Temple cleansing (2:17). The full verse connects the Temple zeal with the suffering that follows \u2014 the disciples recognised this connection only after the resurrection."
+        "note": "The passion psalm the disciples recalled at the Temple cleansing (2:17). The full verse connects the Temple zeal with the suffering that follows — the disciples recognised this connection only after the resurrection."
       }
     ],
     "rec": [
       {
         "who": "The First Sign in Christian Art",
-        "text": "The water-into-wine at Cana is one of the most frequently depicted miracle scenes in early Christian art \u2014 appearing in the Roman catacombs as early as the 3rd century and in the Ravenna mosaics. Its artistic prominence reflects its theological importance as the first revelation of the divine glory in flesh."
+        "text": "The water-into-wine at Cana is one of the most frequently depicted miracle scenes in early Christian art — appearing in the Roman catacombs as early as the 3rd century and in the Ravenna mosaics. Its artistic prominence reflects its theological importance as the first revelation of the divine glory in flesh."
       },
       {
         "who": "The Temple Cleansing in Church Reform Movements",
@@ -390,13 +346,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Replacement Motif \u2014 vv.6-11; 19-21",
-          "text": "Six stone jars for Jewish purification \u2192 wine of messianic feasting. The Temple of stone \u2192 the temple of his body. John consistently presents Jesus as fulfilling and replacing the institutions of Judaism: water\u2192wine (purification\u2192celebration), Temple\u2192body.",
+          "label": "Replacement Motif — vv.6-11; 19-21",
+          "text": "Six stone jars for Jewish purification → wine of messianic feasting. The Temple of stone → the temple of his body. John consistently presents Jesus as fulfilling and replacing the institutions of Judaism: water→wine (purification→celebration), Temple→body.",
           "is_key": false
         },
         {
-          "label": "Witness Brackets \u2014 ch.2\u20134",
-          "text": "The Cana-to-Cana bracket (2:1-11 / 4:46-54) frames the Nicodemus and Samaritan encounters. Both Cana miracles involve a request, a rebuke, an act of faith, and a sign \u2014 forming an intentional literary arch across three chapters.",
+          "label": "Witness Brackets — ch.2–4",
+          "text": "The Cana-to-Cana bracket (2:1-11 / 4:46-54) frames the Nicodemus and Samaritan encounters. Both Cana miracles involve a request, a rebuke, an act of faith, and a sign — forming an intentional literary arch across three chapters.",
           "is_key": false
         }
       ],
@@ -404,13 +360,13 @@
     },
     "hebtext": [
       {
-        "word": "s\u0113meion",
+        "word": "sēmeion",
         "tlit": "SAY-mei-on",
         "gloss": "sign",
-        "note": "John never uses the word \"miracle\" (dynamis, act of power) \u2014 he consistently uses s\u0113meion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
+        "note": "John never uses the word \"miracle\" (dynamis, act of power) — he consistently uses sēmeion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
       },
       {
-        "word": "h\u014dra mou",
+        "word": "hōra mou",
         "tlit": "HO-ra mou",
         "gloss": "my hour",
         "note": "Jesus's response (v.4) introduces one of John's most significant recurring themes: \"my hour\" or \"the hour.\" Throughout John, the hour has not yet come (2:4; 7:30; 8:20) until the passion, when it arrives (12:23; 13:1; 17:1). The \"hour\" is the cross-and-resurrection event that the entire Gospel is structured toward."
@@ -419,22 +375,22 @@
         "word": "naos",
         "tlit": "na-OS",
         "gloss": "temple / sanctuary (inner building)",
-        "note": "Jesus says \"Destroy this naos\" (v.19) \u2014 not hieron (the whole Temple complex) but naos (the inner sanctuary itself, the Holy of Holies and Holy Place). The Synoptics use hieron for the Temple area; John's precision here is significant: Jesus is identifying his body with the most sacred space in Judaism \u2014 not the outer courts but the very dwelling place of God."
+        "note": "Jesus says \"Destroy this naos\" (v.19) — not hieron (the whole Temple complex) but naos (the inner sanctuary itself, the Holy of Holies and Holy Place). The Synoptics use hieron for the Temple area; John's precision here is significant: Jesus is identifying his body with the most sacred space in Judaism — not the outer courts but the very dwelling place of God."
       },
       {
-        "word": "\u0113geir\u014d",
+        "word": "ēgeirō",
         "tlit": "ay-GAY-ro",
         "gloss": "raise up / rouse",
         "note": "The verb (v.19) is deliberately ambiguous: it can mean to rebuild a demolished building or to raise someone from the dead. The hearers take it architecturally; John's editorial comment (v.21) reveals the resurrection meaning. The ambiguity is characteristic of Johannine double meaning."
       },
       {
-        "word": "s\u0113meion",
+        "word": "sēmeion",
         "tlit": "SAY-mei-on",
         "gloss": "sign",
-        "note": "John never uses the word \"miracle\" (dynamis, act of power) \u2014 he consistently uses s\u0113meion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
+        "note": "John never uses the word \"miracle\" (dynamis, act of power) — he consistently uses sēmeion (sign). Signs are miracles that mean something beyond their physical effect: they point to a deeper reality. The water-to-wine is the first of seven signs in John, each revealing a dimension of Jesus's identity and glory."
       },
       {
-        "word": "h\u014dra mou",
+        "word": "hōra mou",
         "tlit": "HO-ra mou",
         "gloss": "my hour",
         "note": "Jesus's response (v.4) introduces one of John's most significant recurring themes: \"my hour\" or \"the hour.\" Throughout John, the hour has not yet come (2:4; 7:30; 8:20) until the passion, when it arrives (12:23; 13:1; 17:1). The \"hour\" is the cross-and-resurrection event that the entire Gospel is structured toward."
@@ -445,42 +401,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Amos 9:13-14",
         "type": "Connection",
-        "text": "\"New wine will drip from the mountains\" \u2014 the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form.",
+        "text": "\"New wine will drip from the mountains\" — the OT eschatological image of superabundant wine as a sign of the messianic age, which the Cana miracle enacts in compressed form.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Gen 49:11",
         "type": "Connection",
-        "text": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" \u2014 Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king.",
+        "text": "\"He will tether his donkey to a vine, his colt to the choicest branch; he will wash his garments in wine\" — Jacob's blessing on Judah, which later tradition read as messianic, with wine as the sign of the coming king.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 4:46",
         "type": "Connection",
-        "text": "Jesus returns to Cana for the second sign \u2014 healing the royal official's son \u2014 structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4.",
+        "text": "Jesus returns to Cana for the second sign — healing the royal official's son — structurally linking the two Cana episodes as bookends around the Jerusalem ministry of ch.2-4.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 69:9",
         "type": "Connection",
-        "text": "\"Zeal for your house consumes me\" \u2014 the Psalm the disciples remembered (v.17), applied to Jesus's consuming passion for the Father's house. Significantly, in the Psalm the second half reads \"and the insults of those who insult you fall on me\" \u2014 Jesus\u2026",
+        "text": "\"Zeal for your house consumes me\" — the Psalm the disciples remembered (v.17), applied to Jesus's consuming passion for the Father's house. Significantly, in the Psalm the second half reads \"and the insults of those who insult you fall on me\" — Jesus…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Zech 14:21",
         "type": "Connection",
-        "text": "\"There will no longer be a Canaanite (merchant) in the house of the Lord Almighty\" \u2014 the eschatological promise of a purified Temple that Jesus enacts proleptically.",
+        "text": "\"There will no longer be a Canaanite (merchant) in the house of the Lord Almighty\" — the eschatological promise of a purified Temple that Jesus enacts proleptically.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 56:7",
         "type": "Connection",
-        "text": "\"My house will be called a house of prayer for all nations\" \u2014 the Temple's true purpose that the money changers have obscured.",
+        "text": "\"My house will be called a house of prayer for all nations\" — the Temple's true purpose that the money changers have obscured.",
         "direction": "backward"
       }
     ],
@@ -536,7 +492,7 @@
           "score": 10
         }
       ],
-      "note": "John 2 introduces the replacement motif that will run through the entire Gospel: Jesus does not merely add to Judaism's institutions but fulfils and supersedes them. The purification jars become vessels for messianic wine; the physical Temple becomes the temple of his body. Both signs reveal his glory and produce belief \u2014 but the chapter closes with a warning about the quality of that belief. Signs draw crowds; only personal encounter with the person of Jesus produces the faith that \"abides.\""
+      "note": "John 2 introduces the replacement motif that will run through the entire Gospel: Jesus does not merely add to Judaism's institutions but fulfils and supersedes them. The purification jars become vessels for messianic wine; the physical Temple becomes the temple of his body. Both signs reveal his glory and produce belief — but the chapter closes with a warning about the quality of that belief. Signs draw crowds; only personal encounter with the person of Jesus produces the faith that \"abides.\""
     }
   },
   "vhl_groups": [

--- a/content/john/20.json
+++ b/content/john/20.json
@@ -7,13 +7,13 @@
   "subtitle": "The Resurrection",
   "timeline_link": {
     "event_id": "resurrection",
-    "text": "See on Timeline \u2014 The Resurrection"
+    "text": "See on Timeline — The Resurrection"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201310 \u2014 The Empty Tomb: The Beloved Disciple Believes",
+      "header": "Verses 1–10 — The Empty Tomb: The Beloved Disciple Believes",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
@@ -22,37 +22,37 @@
             "word": "Mariam",
             "transliteration": "Ma-RI-am",
             "gloss": "Mary (Aramaic form)",
-            "paragraph": "When Jesus speaks her name \u2014 \"Mary\" (v.16, using the Aramaic Mariam) \u2014 it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
+            "paragraph": "When Jesus speaks her name — \"Mary\" (v.16, using the Aramaic Mariam) — it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
           },
           {
-            "word": "m\u0113 mou haptou",
-            "transliteration": "m\u0113 mou HAP-tou",
+            "word": "mē mou haptou",
+            "transliteration": "mē mou HAP-tou",
             "gloss": "do not hold on to me / do not cling to me",
-            "paragraph": "The instruction (v.17) has been variously translated and interpreted. Hapt\u014d can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (m\u0113 + present imperative) usually means \"stop doing something already in progress\" \u2014 she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate \u2014 the Spirit-mediated presence that is greater than the physical proximity."
+            "paragraph": "The instruction (v.17) has been variously translated and interpreted. Haptō can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (mē + present imperative) usually means \"stop doing something already in progress\" — she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate — the Spirit-mediated presence that is greater than the physical proximity."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Song of Sol 3:1-4",
-              "note": "\"I looked for the one my heart loves... I found him whom my soul loves\" \u2014 the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter."
+              "note": "\"I looked for the one my heart loves... I found him whom my soul loves\" — the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter."
             },
             {
               "ref": "John 10:3-4",
-              "note": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" \u2014 fulfilled in Mary's recognition at the sound of her name."
+              "note": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" — fulfilled in Mary's recognition at the sound of her name."
             },
             {
               "ref": "1 Cor 15:4-8",
-              "note": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" \u2014 Paul's summary of resurrection appearances, in which the Johannine appearances fit."
+              "note": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" — Paul's summary of resurrection appearances, in which the Johannine appearances fit."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:6-7",
-              "note": "\"He saw the strips of linen lying there, as well as the cloth that had been wrapped around Jesus' head. The cloth was still lying in its place, separate from the linen\" \u2014 the specific detail of the face-cloth \"rolled up by itself\" is the key to the beloved disciple's belief. The word entylygmenon (rolled up / folded) and the separate placement indicate that the body was not stolen \u2014 it was resurrected. The cloths are a silent testimony: the resurrection left its shape behind."
+              "note": "\"He saw the strips of linen lying there, as well as the cloth that had been wrapped around Jesus' head. The cloth was still lying in its place, separate from the linen\" — the specific detail of the face-cloth \"rolled up by itself\" is the key to the beloved disciple's belief. The word entylygmenon (rolled up / folded) and the separate placement indicate that the body was not stolen — it was resurrected. The cloths are a silent testimony: the resurrection left its shape behind."
             },
             {
               "ref": "20:16-17",
@@ -60,12 +60,12 @@
             },
             {
               "ref": "20:17",
-              "note": "\"Do not hold on to me... Go instead to my brothers\" \u2014 the first task of the resurrection community is proclamation, not possession. Mary wants to stay with him; Jesus sends her away \u2014 not to deprive her of his presence but to extend his presence through her witness. The resurrection is not a private gift to be kept; it is a public event to be announced. The first commissioned preacher of the resurrection is a woman sent by the risen Lord."
+              "note": "\"Do not hold on to me... Go instead to my brothers\" — the first task of the resurrection community is proclamation, not possession. Mary wants to stay with him; Jesus sends her away — not to deprive her of his presence but to extend his presence through her witness. The resurrection is not a private gift to be kept; it is a public event to be announced. The first commissioned preacher of the resurrection is a woman sent by the risen Lord."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:17",
@@ -73,44 +73,44 @@
             },
             {
               "ref": "20:8",
-              "note": "Calvin uses the beloved disciple's \"saw and believed\" as evidence that faith does not always require direct encounter with the risen Christ \u2014 indirect evidence, properly received, can generate genuine Easter faith. The empty tomb and the arranged grave clothes are sufficient evidence for one whose heart is properly disposed."
+              "note": "Calvin uses the beloved disciple's \"saw and believed\" as evidence that faith does not always require direct encounter with the risen Christ — indirect evidence, properly received, can generate genuine Easter faith. The empty tomb and the arranged grave clothes are sufficient evidence for one whose heart is properly disposed."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:7",
-              "note": "\"The cloth was still lying in its place, separate from the linen\" \u2014 the word entylygmenon (rolled up/folded) has been used to argue for a very specific arrangement: the face-cloth, no longer wrapped around a head, collapsed into its folds while maintaining something of its original shape \u2014 evidence that the body passed through it. This is a possible but not certain reading of the Greek."
+              "note": "\"The cloth was still lying in its place, separate from the linen\" — the word entylygmenon (rolled up/folded) has been used to argue for a very specific arrangement: the face-cloth, no longer wrapped around a head, collapsed into its folds while maintaining something of its original shape — evidence that the body passed through it. This is a possible but not certain reading of the Greek."
             },
             {
               "ref": "20:17",
-              "note": "\"I am ascending to my Father and your Father, to my God and your God\" \u2014 the careful distinction: not \"our Father\" (which would equate the Son's unique Sonship with the disciples' adopted sonship) but \"my Father and your Father.\" The disciples' relationship to the Father is real but derived from and different from the Son's unique relationship. Ruth 1:16's \"your God will be my God\" provides the covenantal background for the language."
+              "note": "\"I am ascending to my Father and your Father, to my God and your God\" — the careful distinction: not \"our Father\" (which would equate the Son's unique Sonship with the disciples' adopted sonship) but \"my Father and your Father.\" The disciples' relationship to the Father is real but derived from and different from the Son's unique relationship. Ruth 1:16's \"your God will be my God\" provides the covenantal background for the language."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:16",
-              "note": "Augustine: \"He called her by name and she recognised him by his voice. He had been speaking to her already without her recognising him; it was the name that unlocked the recognition. For the Lord knows his own and his own know him \u2014 but they know him not by sight alone but by the voice of intimacy.\""
+              "note": "Augustine: \"He called her by name and she recognised him by his voice. He had been speaking to her already without her recognising him; it was the name that unlocked the recognition. For the Lord knows his own and his own know him — but they know him not by sight alone but by the voice of intimacy.\""
             },
             {
               "ref": "20:17",
-              "note": "Chrysostom: \"Do not hold on to me. He does not say 'do not touch me' as if he were a ghost. He says 'do not cling.' Release the form in which you knew me, because the relationship is being transformed. You will know me in a new way \u2014 through the Spirit, in the community, in the breaking of bread. That knowing will be more intimate, not less.\""
+              "note": "Chrysostom: \"Do not hold on to me. He does not say 'do not touch me' as if he were a ghost. He says 'do not cling.' Release the form in which you knew me, because the relationship is being transformed. You will know me in a new way — through the Spirit, in the community, in the breaking of bread. That knowing will be more intimate, not less.\""
             }
           ]
         },
         "hist": {
-          "context": "The Grave Clothes\nJohn's specific detail about the grave clothes (vv.6-7) \u2014 the linen strips lying there, the face-cloth \"rolled up in a place by itself\" \u2014 is significant for two reasons: (1) it rules out theft (grave-robbers would not have unwrapped the body and left the cloths neatly arranged); (2) the arrangement suggests that the resurrection body passed through the cloths, leaving them lying in the shape of a body (like a cocoon from which a butterfly has emerged). The beloved disciple \"saw and believed\" (v.8) on the basis of this visual evidence alone, before the angels or the appearance to Mary.\n\n\"I Have Seen the Lord\"\nMary's proclamation (v.18) \u2014 \"I have seen the Lord\" \u2014 is the first resurrection announcement in John's Gospel and one of the first in all of Christian history. The recipient of Jesus's first post-resurrection appearance is a woman \u2014 a Galilean woman from whom seven demons had been cast out \u2014 not a religious authority, not a political leader, not even a member of the Twelve. The resurrection's first witness is deliberately chosen from those the world would least credit."
+          "context": "The Grave Clothes\nJohn's specific detail about the grave clothes (vv.6-7) — the linen strips lying there, the face-cloth \"rolled up in a place by itself\" — is significant for two reasons: (1) it rules out theft (grave-robbers would not have unwrapped the body and left the cloths neatly arranged); (2) the arrangement suggests that the resurrection body passed through the cloths, leaving them lying in the shape of a body (like a cocoon from which a butterfly has emerged). The beloved disciple \"saw and believed\" (v.8) on the basis of this visual evidence alone, before the angels or the appearance to Mary.\n\n\"I Have Seen the Lord\"\nMary's proclamation (v.18) — \"I have seen the Lord\" — is the first resurrection announcement in John's Gospel and one of the first in all of Christian history. The recipient of Jesus's first post-resurrection appearance is a woman — a Galilean woman from whom seven demons had been cast out — not a religious authority, not a political leader, not even a member of the Twelve. The resurrection's first witness is deliberately chosen from those the world would least credit."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201318 \u2014 Mary Magdalene Sees the Risen Lord",
+      "header": "Verses 11–18 — Mary Magdalene Sees the Risen Lord",
       "verse_start": 11,
       "verse_end": 18,
       "panels": {
@@ -119,80 +119,80 @@
             "word": "Ho kyrios mou kai ho theos mou",
             "transliteration": "ho KY-ri-os mou kai ho the-OS mou",
             "gloss": "My Lord and my God",
-            "paragraph": "Thomas's confession (v.28) is the Christological climax of John's Gospel \u2014 the declaration that closes the inclusio opened in 1:1 (\"the Word was God\"). The two divine titles (Kyrios and Theos) applied directly to Jesus in the vocative is the most explicit confession of his full divinity in the Gospels. It answers the Pharisees' charge of 10:33 (\"you claim to be God\"), the soldiers' falling before the I AM (18:6), and the prologue's opening declaration. Every Christological claim in the Gospel converges on this eight-word confession."
+            "paragraph": "Thomas's confession (v.28) is the Christological climax of John's Gospel — the declaration that closes the inclusio opened in 1:1 (\"the Word was God\"). The two divine titles (Kyrios and Theos) applied directly to Jesus in the vocative is the most explicit confession of his full divinity in the Gospels. It answers the Pharisees' charge of 10:33 (\"you claim to be God\"), the soldiers' falling before the I AM (18:6), and the prologue's opening declaration. Every Christological claim in the Gospel converges on this eight-word confession."
           },
           {
-            "word": "enetyph\u0113sen",
+            "word": "enetyphēsen",
             "transliteration": "e-ne-TY-phe-sen",
             "gloss": "breathed on them",
-            "paragraph": "Jesus \"breathed on\" (v.22) the disciples \u2014 the word (emphysa\u014d) is used only here in the NT, but appears in the LXX of Gen 2:7 (God \"breathed into\" Adam the breath of life) and Ezek 37:9 (the breath breathed into the dry bones). The new creation and the new covenant are inaugurated by the same gesture: the risen Jesus breathing the Spirit into the new humanity."
+            "paragraph": "Jesus \"breathed on\" (v.22) the disciples — the word (emphysaō) is used only here in the NT, but appears in the LXX of Gen 2:7 (God \"breathed into\" Adam the breath of life) and Ezek 37:9 (the breath breathed into the dry bones). The new creation and the new covenant are inaugurated by the same gesture: the risen Jesus breathing the Spirit into the new humanity."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 2:7",
-              "note": "\"Then the Lord God formed a man from the dust of the ground and breathed into his nostrils the breath of life\" \u2014 the creation-of-Adam scene echoed in Jesus breathing the Spirit on the disciples."
+              "note": "\"Then the Lord God formed a man from the dust of the ground and breathed into his nostrils the breath of life\" — the creation-of-Adam scene echoed in Jesus breathing the Spirit on the disciples."
             },
             {
               "ref": "Ezek 37:9",
-              "note": "\"Prophesy to the breath... 'Come, breath, from the four winds and breathe into these slain, that they may live'\" \u2014 the valley of dry bones, whose enlivening breath prefigures the resurrection community receiving the Spirit."
+              "note": "\"Prophesy to the breath... 'Come, breath, from the four winds and breathe into these slain, that they may live'\" — the valley of dry bones, whose enlivening breath prefigures the resurrection community receiving the Spirit."
             },
             {
               "ref": "Rom 10:9",
-              "note": "\"If you declare with your mouth, 'Jesus is Lord,' and believe in your heart that God raised him from the dead, you will be saved\" \u2014 Paul's summary of the confessional response that Thomas's \"my Lord and my God\" exemplifies."
+              "note": "\"If you declare with your mouth, 'Jesus is Lord,' and believe in your heart that God raised him from the dead, you will be saved\" — Paul's summary of the confessional response that Thomas's \"my Lord and my God\" exemplifies."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:19",
-              "note": "\"The doors were locked for fear... Jesus came and stood among them\" \u2014 the resurrection body passes through locked doors. This is not dematerialisation but transformation: the resurrection body has properties unavailable to natural bodies. It can be touched (v.27), eats (Luke 24:42-43), and yet passes through locked doors and appears suddenly. Paul's \"spiritual body\" (1 Cor 15:44) \u2014 not immaterial, but transformed and no longer subject to physical limitations \u2014 is what John's resurrection narratives demonstrate."
+              "note": "\"The doors were locked for fear... Jesus came and stood among them\" — the resurrection body passes through locked doors. This is not dematerialisation but transformation: the resurrection body has properties unavailable to natural bodies. It can be touched (v.27), eats (Luke 24:42-43), and yet passes through locked doors and appears suddenly. Paul's \"spiritual body\" (1 Cor 15:44) — not immaterial, but transformed and no longer subject to physical limitations — is what John's resurrection narratives demonstrate."
             },
             {
               "ref": "20:22-23",
-              "note": "\"Receive the Holy Spirit. If you forgive anyone's sins, their sins are forgiven\" \u2014 the giving of the Spirit is connected to the authority to forgive. The forgiveness of sins is the immediate purpose of the Spirit's gift in the resurrection context. This authority is not the power to grant or withhold salvation at personal discretion, but the authority to proclaim the gospel and declare the forgiveness that Christ has achieved \u2014 the church's apostolic preaching function."
+              "note": "\"Receive the Holy Spirit. If you forgive anyone's sins, their sins are forgiven\" — the giving of the Spirit is connected to the authority to forgive. The forgiveness of sins is the immediate purpose of the Spirit's gift in the resurrection context. This authority is not the power to grant or withhold salvation at personal discretion, but the authority to proclaim the gospel and declare the forgiveness that Christ has achieved — the church's apostolic preaching function."
             },
             {
               "ref": "20:28",
-              "note": "\"My Lord and my God!\" \u2014 the climax of the Gospel. Thomas, the most sceptical of the disciples, makes the most comprehensive confession. His doubt is resolved not by argument but by personal encounter. Jesus does not say \"good thinking, Thomas \u2014 your logic led you to the right conclusion\"; he says \"because you have seen me, you have believed.\" The confession is generated by encounter, not deduction. This is John's model of faith throughout: not intellectual conviction but personal recognition."
+              "note": "\"My Lord and my God!\" — the climax of the Gospel. Thomas, the most sceptical of the disciples, makes the most comprehensive confession. His doubt is resolved not by argument but by personal encounter. Jesus does not say \"good thinking, Thomas — your logic led you to the right conclusion\"; he says \"because you have seen me, you have believed.\" The confession is generated by encounter, not deduction. This is John's model of faith throughout: not intellectual conviction but personal recognition."
             },
             {
               "ref": "20:29",
-              "note": "\"Blessed are those who have not seen and yet have believed\" \u2014 the beatitude for all subsequent Christians. Every Christian after the first Easter Sunday believes without seeing the risen Jesus physically. Jesus declares them blessed \u2014 not disadvantaged. The faith of the non-eyewitness is the normative, expected, and honoured form of Christian faith. The Gospel was written precisely to enable this faith (vv.30-31)."
+              "note": "\"Blessed are those who have not seen and yet have believed\" — the beatitude for all subsequent Christians. Every Christian after the first Easter Sunday believes without seeing the risen Jesus physically. Jesus declares them blessed — not disadvantaged. The faith of the non-eyewitness is the normative, expected, and honoured form of Christian faith. The Gospel was written precisely to enable this faith (vv.30-31)."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:22-23",
-              "note": "Calvin's interpretation of the authority to forgive (v.23): this is the authority to proclaim the gospel \u2014 to declare sins forgiven on the basis of faith in Christ. It is not a sacramental power granted to priests individually but the apostolic preaching authority to proclaim justification by faith. When the church declares the forgiveness of the repentant sinner, it is exercising the authority Christ granted on Easter evening."
+              "note": "Calvin's interpretation of the authority to forgive (v.23): this is the authority to proclaim the gospel — to declare sins forgiven on the basis of faith in Christ. It is not a sacramental power granted to priests individually but the apostolic preaching authority to proclaim justification by faith. When the church declares the forgiveness of the repentant sinner, it is exercising the authority Christ granted on Easter evening."
             },
             {
               "ref": "20:29",
-              "note": "Calvin notes that the blessing of those who have not seen is not a consolation prize for inferior faith but a statement that the normative mode of Christian faith \u2014 trusting the testimony of the eyewitnesses without direct physical encounter \u2014 is itself blessed. The written Gospel (vv.30-31) exists precisely to enable this blessed believing."
+              "note": "Calvin notes that the blessing of those who have not seen is not a consolation prize for inferior faith but a statement that the normative mode of Christian faith — trusting the testimony of the eyewitnesses without direct physical encounter — is itself blessed. The written Gospel (vv.30-31) exists precisely to enable this blessed believing."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:22",
-              "note": "\"Receive the Holy Spirit\" \u2014 whether this is the same event as Pentecost (Acts 2) or a distinct prior gift is a major exegetical question. The majority evangelical view is that John 20:22 is a proleptic or anticipatory gift \u2014 perhaps enabling the disciples to understand what is happening \u2014 while Pentecost is the full empowerment for mission. The minority view is that John and Luke describe the same event from different angles."
+              "note": "\"Receive the Holy Spirit\" — whether this is the same event as Pentecost (Acts 2) or a distinct prior gift is a major exegetical question. The majority evangelical view is that John 20:22 is a proleptic or anticipatory gift — perhaps enabling the disciples to understand what is happening — while Pentecost is the full empowerment for mission. The minority view is that John and Luke describe the same event from different angles."
             },
             {
               "ref": "20:31",
-              "note": "\"That you may believe\" \u2014 the manuscript tradition is divided between pisteus\u0113te (aorist subjunctive: come to believe, for unbelievers) and pisteu\u0113te (present subjunctive: continue believing, for believers). NA28 follows the present subjunctive (continue believing), suggesting the Gospel was written for a community of believers to deepen their faith rather than as an evangelistic tract for outsiders. Both purposes may be in view."
+              "note": "\"That you may believe\" — the manuscript tradition is divided between pisteusēte (aorist subjunctive: come to believe, for unbelievers) and pisteuēte (present subjunctive: continue believing, for believers). NA28 follows the present subjunctive (continue believing), suggesting the Gospel was written for a community of believers to deepen their faith rather than as an evangelistic tract for outsiders. Both purposes may be in view."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:28",
@@ -200,18 +200,18 @@
             },
             {
               "ref": "20:29",
-              "note": "Chrysostom: \"Blessed are those who have not seen and yet have believed. He is speaking of you, and of us, and of all who come after. For we have not seen, and yet we believe. We are more blessed than those who saw \u2014 for their faith was compelled by sight; ours is given freely, without compulsion.\""
+              "note": "Chrysostom: \"Blessed are those who have not seen and yet have believed. He is speaking of you, and of us, and of all who come after. For we have not seen, and yet we believe. We are more blessed than those who saw — for their faith was compelled by sight; ours is given freely, without compulsion.\""
             }
           ]
         },
         "hist": {
-          "context": "The Johannine Pentecost\nThe breathing of the Spirit (vv.22-23) on the evening of Easter Sunday creates a Johannine \"Pentecost\" that is earlier and more intimate than Luke's (Acts 2). The relationship between John's giving of the Spirit (20:22) and Luke's Pentecost (Acts 2) has been debated: (1) Two separate events \u2014 John gives a proleptic or partial gift; Acts gives the full gift; (2) One event, told differently \u2014 John emphasising the gift, Luke the empowerment. Either way, the risen Jesus as the source of the Spirit (16:7) is fulfilled on Easter evening.\n\nThomas \u2014 Doubt and Confession\nThomas's trajectory is the Gospel's most dramatic individual conversion: from \"let us go that we may die with him\" (11:16, gloomy courage) to \"unless I see... I will not believe\" (25, honest scepticism) to \"my Lord and my God!\" (28, complete confession). The sceptic who demands the most evidence makes the highest confession. Jesus does not rebuke Thomas for his doubts; he meets them precisely. The blessing of v.29 is not for those who believe despite no evidence, but for those who believe without the specific physical evidence Thomas required."
+          "context": "The Johannine Pentecost\nThe breathing of the Spirit (vv.22-23) on the evening of Easter Sunday creates a Johannine \"Pentecost\" that is earlier and more intimate than Luke's (Acts 2). The relationship between John's giving of the Spirit (20:22) and Luke's Pentecost (Acts 2) has been debated: (1) Two separate events — John gives a proleptic or partial gift; Acts gives the full gift; (2) One event, told differently — John emphasising the gift, Luke the empowerment. Either way, the risen Jesus as the source of the Spirit (16:7) is fulfilled on Easter evening.\n\nThomas — Doubt and Confession\nThomas's trajectory is the Gospel's most dramatic individual conversion: from \"let us go that we may die with him\" (11:16, gloomy courage) to \"unless I see... I will not believe\" (25, honest scepticism) to \"my Lord and my God!\" (28, complete confession). The sceptic who demands the most evidence makes the highest confession. Jesus does not rebuke Thomas for his doubts; he meets them precisely. The blessing of v.29 is not for those who believe despite no evidence, but for those who believe without the specific physical evidence Thomas required."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 19\u201331 \u2014 Appearances to the Disciples; Thomas: My Lord and My God",
+      "header": "Verses 19–31 — Appearances to the Disciples; Thomas: My Lord and My God",
       "verse_start": 19,
       "verse_end": 31,
       "panels": {
@@ -220,89 +220,49 @@
             "word": "Mariam",
             "transliteration": "Ma-RI-am",
             "gloss": "Mary (Aramaic form)",
-            "paragraph": "When Jesus speaks her name \u2014 \"Mary\" (v.16, using the Aramaic Mariam) \u2014 it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
+            "paragraph": "When Jesus speaks her name — \"Mary\" (v.16, using the Aramaic Mariam) — it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
           },
           {
-            "word": "m\u0113 mou haptou",
-            "transliteration": "m\u0113 mou HAP-tou",
+            "word": "mē mou haptou",
+            "transliteration": "mē mou HAP-tou",
             "gloss": "do not hold on to me / do not cling to me",
-            "paragraph": "The instruction (v.17) has been variously translated and interpreted. Hapt\u014d can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (m\u0113 + present imperative) usually means \"stop doing something already in progress\" \u2014 she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate \u2014 the Spirit-mediated presence that is greater than the physical proximity."
+            "paragraph": "The instruction (v.17) has been variously translated and interpreted. Haptō can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (mē + present imperative) usually means \"stop doing something already in progress\" — she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate — the Spirit-mediated presence that is greater than the physical proximity."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Song of Sol 3:1-4",
-              "note": "\"I looked for the one my heart loves... I found him whom my soul loves\" \u2014 the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter."
+              "note": "\"I looked for the one my heart loves... I found him whom my soul loves\" — the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter."
             },
             {
               "ref": "John 10:3-4",
-              "note": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" \u2014 fulfilled in Mary's recognition at the sound of her name."
+              "note": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" — fulfilled in Mary's recognition at the sound of her name."
             },
             {
               "ref": "1 Cor 15:4-8",
-              "note": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" \u2014 Paul's summary of resurrection appearances, in which the Johannine appearances fit."
+              "note": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" — Paul's summary of resurrection appearances, in which the Johannine appearances fit."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:6-7",
-              "note": "\"He saw the strips of linen lying there, as well as the cloth that had been wrapped around Jesus' head. The cloth was still lying in its place, separate from the linen\" \u2014 the specific detail of the face-cloth \"rolled up by itself\" is the key to the beloved disciple's belief. The word entylygmenon (rolled up / folded) and the separate placement indicate that the body was not stolen \u2014 it was resurrected. The cloths are a silent testimony: the resurrection left its shape behind."
-            },
-            {
-              "ref": "20:16-17",
-              "note": "\"Mary.\" One word. She had not recognised him visually; she had not recognised him by his question. She recognised him by the sound of her name. The good shepherd calls his own sheep by name; they know his voice (10:3-4). The resurrection is first received not through sight or argument but through the personal address of the risen shepherd to one he knows by name."
-            },
-            {
-              "ref": "20:17",
-              "note": "\"Do not hold on to me... Go instead to my brothers\" \u2014 the first task of the resurrection community is proclamation, not possession. Mary wants to stay with him; Jesus sends her away \u2014 not to deprive her of his presence but to extend his presence through her witness. The resurrection is not a private gift to be kept; it is a public event to be announced. The first commissioned preacher of the resurrection is a woman sent by the risen Lord."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:17",
-              "note": "Calvin's interpretation: \"I have not yet ascended to the Father\" does not mean Jesus is in an intermediate state between death and ascension where physical contact is inappropriate. Rather, Jesus is redirecting Mary from seeking a physical, local relationship with him (which the ascension will end) toward the spiritual, universal relationship the Spirit will mediate. The resurrection body can be touched (Thomas, v.27); the point is not untouchability but the necessary transformation of the relationship."
-            },
-            {
-              "ref": "20:8",
-              "note": "Calvin uses the beloved disciple's \"saw and believed\" as evidence that faith does not always require direct encounter with the risen Christ \u2014 indirect evidence, properly received, can generate genuine Easter faith. The empty tomb and the arranged grave clothes are sufficient evidence for one whose heart is properly disposed."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "\"The cloth was still lying in its place, separate from the linen\" \u2014 the word entylygmenon (rolled up/folded) has been used to argue for a very specific arrangement: the face-cloth, no longer wrapped around a head, collapsed into its folds while maintaining something of its original shape \u2014 evidence that the body passed through it. This is a possible but not certain reading of the Greek."
-            },
-            {
-              "ref": "20:17",
-              "note": "\"I am ascending to my Father and your Father, to my God and your God\" \u2014 the careful distinction: not \"our Father\" (which would equate the Son's unique Sonship with the disciples' adopted sonship) but \"my Father and your Father.\" The disciples' relationship to the Father is real but derived from and different from the Son's unique relationship. Ruth 1:16's \"your God will be my God\" provides the covenantal background for the language."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "20:16",
-              "note": "Augustine: \"He called her by name and she recognised him by his voice. He had been speaking to her already without her recognising him; it was the name that unlocked the recognition. For the Lord knows his own and his own know him \u2014 but they know him not by sight alone but by the voice of intimacy.\""
-            },
-            {
-              "ref": "20:17",
-              "note": "Chrysostom: \"Do not hold on to me. He does not say 'do not touch me' as if he were a ghost. He says 'do not cling.' Release the form in which you knew me, because the relationship is being transformed. You will know me in a new way \u2014 through the Spirit, in the community, in the breaking of bread. That knowing will be more intimate, not less.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Grave Clothes\nJohn's specific detail about the grave clothes (vv.6-7) \u2014 the linen strips lying there, the face-cloth \"rolled up in a place by itself\" \u2014 is significant for two reasons: (1) it rules out theft (grave-robbers would not have unwrapped the body and left the cloths neatly arranged); (2) the arrangement suggests that the resurrection body passed through the cloths, leaving them lying in the shape of a body (like a cocoon from which a butterfly has emerged). The beloved disciple \"saw and believed\" (v.8) on the basis of this visual evidence alone, before the angels or the appearance to Mary.\n\n\"I Have Seen the Lord\"\nMary's proclamation (v.18) \u2014 \"I have seen the Lord\" \u2014 is the first resurrection announcement in John's Gospel and one of the first in all of Christian history. The recipient of Jesus's first post-resurrection appearance is a woman \u2014 a Galilean woman from whom seven demons had been cast out \u2014 not a religious authority, not a political leader, not even a member of the Twelve. The resurrection's first witness is deliberately chosen from those the world would least credit."
+          "context": "The Grave Clothes\nJohn's specific detail about the grave clothes (vv.6-7) — the linen strips lying there, the face-cloth \"rolled up in a place by itself\" — is significant for two reasons: (1) it rules out theft (grave-robbers would not have unwrapped the body and left the cloths neatly arranged); (2) the arrangement suggests that the resurrection body passed through the cloths, leaving them lying in the shape of a body (like a cocoon from which a butterfly has emerged). The beloved disciple \"saw and believed\" (v.8) on the basis of this visual evidence alone, before the angels or the appearance to Mary.\n\n\"I Have Seen the Lord\"\nMary's proclamation (v.18) — \"I have seen the Lord\" — is the first resurrection announcement in John's Gospel and one of the first in all of Christian history. The recipient of Jesus's first post-resurrection appearance is a woman — a Galilean woman from whom seven demons had been cast out — not a religious authority, not a political leader, not even a member of the Twelve. The resurrection's first witness is deliberately chosen from those the world would least credit."
         }
       }
     }
@@ -330,9 +290,9 @@
         "text": "Jews is a key figure in Scripture Walkthrough."
       },
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       },
       {
         "name": "Thomas",
@@ -340,43 +300,43 @@
         "text": "Thomas is a key figure in Scripture Walkthrough."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">m\u0113 mou haptou (20:17)</td><td>NIV: \"do not hold on to me\"; KJV: \"touch me not\"; ESV: \"do not cling to me\"; NRSV: \"do not hold on to me\". The present imperative with negative (stop doing) is better captured by NIV/ESV/NRSV than KJV's \"touch me not\" (which implies no physical contact is possible, contradicting v.27).</td></tr><tr><td class=\"t-label\">enephys\u0113sen (20:22)</td><td>NIV: \"breathed on them\"; KJV: \"breathed on them\"; ESV: \"breathed on them\"; NRSV: \"breathed on them\". Universal agreement. The Gen 2:7 / Ezek 37 allusion is a commentary point.</td></tr><tr><td class=\"t-label\">ho theos mou (20:28)</td><td>NIV/KJV/ESV/NRSV: \"my God\". Universal agreement. Jehovah's Witnesses translate this as an exclamation (\"Oh, my God!\") rather than a vocative addressed to Jesus, but the Greek grammar (direct address: \"my Lord and my God\") does not support this.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">mē mou haptou (20:17)</td><td>NIV: \"do not hold on to me\"; KJV: \"touch me not\"; ESV: \"do not cling to me\"; NRSV: \"do not hold on to me\". The present imperative with negative (stop doing) is better captured by NIV/ESV/NRSV than KJV's \"touch me not\" (which implies no physical contact is possible, contradicting v.27).</td></tr><tr><td class=\"t-label\">enephysēsen (20:22)</td><td>NIV: \"breathed on them\"; KJV: \"breathed on them\"; ESV: \"breathed on them\"; NRSV: \"breathed on them\". Universal agreement. The Gen 2:7 / Ezek 37 allusion is a commentary point.</td></tr><tr><td class=\"t-label\">ho theos mou (20:28)</td><td>NIV/KJV/ESV/NRSV: \"my God\". Universal agreement. Jehovah's Witnesses translate this as an exclamation (\"Oh, my God!\") rather than a vocative addressed to Jesus, but the Greek grammar (direct address: \"my Lord and my God\") does not support this.</td></tr>",
     "src": [
       {
         "title": "Genesis 2:7",
         "quote": "\"Then the Lord God formed a man from the dust of the ground and breathed into his nostrils the breath of life, and the man became a living being.\"",
-        "note": "The creation-of-Adam scene that Jesus's breathing on the disciples (v.22) deliberately echoes \u2014 the new creation inaugurated by the risen last Adam."
+        "note": "The creation-of-Adam scene that Jesus's breathing on the disciples (v.22) deliberately echoes — the new creation inaugurated by the risen last Adam."
       },
       {
         "title": "1 Corinthians 15:3-8",
-        "quote": "Paul's earliest account of the resurrection appearances \u2014 including \"he appeared to Cephas, and then to the Twelve\" and \"he appeared to more than five hundred of the brothers and sisters at the same time.\"",
+        "quote": "Paul's earliest account of the resurrection appearances — including \"he appeared to Cephas, and then to the Twelve\" and \"he appeared to more than five hundred of the brothers and sisters at the same time.\"",
         "note": "The wider apostolic testimony to the resurrection within which John's accounts fit. Paul's list and John's narrative are complementary, not contradictory."
       }
     ],
     "rec": [
       {
-        "who": "\"My Lord and My God\" \u2014 Thomas's Confession in Christian Worship",
-        "text": "Thomas's confession became the standard act of personal devotion at the elevation of the host in the Latin Mass (the moment the consecrated bread is raised) \u2014 speaking the words as a direct address to the body of Christ present in the sacrament. The phrase is also used in Eastern Orthodoxy as a response to the Gospel reading. Its use as a personal address to Christ encapsulates the entire devotional tradition of direct, intimate relationship with Jesus that John's Gospel fosters."
+        "who": "\"My Lord and My God\" — Thomas's Confession in Christian Worship",
+        "text": "Thomas's confession became the standard act of personal devotion at the elevation of the host in the Latin Mass (the moment the consecrated bread is raised) — speaking the words as a direct address to the body of Christ present in the sacrament. The phrase is also used in Eastern Orthodoxy as a response to the Gospel reading. Its use as a personal address to Christ encapsulates the entire devotional tradition of direct, intimate relationship with Jesus that John's Gospel fosters."
       },
       {
-        "who": "\"Blessed Are Those Who Have Not Seen and Yet Have Believed\" \u2014 The Beatitude for All Later Christians",
-        "text": "John 20:29 is the NT's most direct pastoral address to post-apostolic Christians. It was cited by Origen (3rd century), Augustine (5th century), and every subsequent theologian dealing with the question of whether faith without direct encounter with the risen Christ is inferior. The answer: it is blessed. The faith that trusts the testimony of the eyewitnesses \u2014 the faith that reads this Gospel \u2014 is the faith Jesus declares happy."
+        "who": "\"Blessed Are Those Who Have Not Seen and Yet Have Believed\" — The Beatitude for All Later Christians",
+        "text": "John 20:29 is the NT's most direct pastoral address to post-apostolic Christians. It was cited by Origen (3rd century), Augustine (5th century), and every subsequent theologian dealing with the question of whether faith without direct encounter with the risen Christ is inferior. The answer: it is blessed. The faith that trusts the testimony of the eyewitnesses — the faith that reads this Gospel — is the faith Jesus declares happy."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "The Purpose Statement \u2014 vv.30-31",
-          "text": "Verses 30-31 constitute the Gospel's original conclusion (ch.21 is an epilogue): \"these are written that you may believe that Jesus is the Messiah, the Son of God, and that by believing you may have life in his name.\" The purpose statement inverts the structure of the Gospel: the signs were performed to produce belief (30 \u2192 31); the words were recorded to enable the same belief for subsequent generations. The Gospel is written for exactly the reader who is reading it.",
+          "label": "The Purpose Statement — vv.30-31",
+          "text": "Verses 30-31 constitute the Gospel's original conclusion (ch.21 is an epilogue): \"these are written that you may believe that Jesus is the Messiah, the Son of God, and that by believing you may have life in his name.\" The purpose statement inverts the structure of the Gospel: the signs were performed to produce belief (30 → 31); the words were recorded to enable the same belief for subsequent generations. The Gospel is written for exactly the reader who is reading it.",
           "is_key": false
         },
         {
           "label": "Seven Resurrection Appearances Pattern",
-          "text": "John 20-21 records seven post-resurrection appearances (Mary at tomb; disciples without Thomas; Thomas; disciples at sea; Peter's restoration; etc.), mirroring the seven signs of chs 1-12. The Gospel's architecture is thus perfectly balanced \u2014 seven signs of the Book of Signs answered by seven encounters in the Book of Glory.",
+          "text": "John 20-21 records seven post-resurrection appearances (Mary at tomb; disciples without Thomas; Thomas; disciples at sea; Peter's restoration; etc.), mirroring the seven signs of chs 1-12. The Gospel's architecture is thus perfectly balanced — seven signs of the Book of Signs answered by seven encounters in the Book of Glory.",
           "is_key": false
         },
         {
-          "label": "Closing Inclusio \u2014 vv.28-31",
+          "label": "Closing Inclusio — vv.28-31",
           "text": "Thomas's confession \"My Lord and my God\" (v28) is the Gospel's theological climax, answering the Prologue's \"the Word was God\" (1:1). John's original conclusion (vv.30-31) states the Gospel's purpose explicitly: these signs are written so you may believe. The literary arc from 1:1 to 20:28 is perfectly sealed.",
           "is_key": false
         }
@@ -388,37 +348,37 @@
         "word": "Mariam",
         "tlit": "Ma-RI-am",
         "gloss": "Mary (Aramaic form)",
-        "note": "When Jesus speaks her name \u2014 \"Mary\" (v.16, using the Aramaic Mariam) \u2014 it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
+        "note": "When Jesus speaks her name — \"Mary\" (v.16, using the Aramaic Mariam) — it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
       },
       {
-        "word": "m\u0113 mou haptou",
-        "tlit": "m\u0113 mou HAP-tou",
+        "word": "mē mou haptou",
+        "tlit": "mē mou HAP-tou",
         "gloss": "do not hold on to me / do not cling to me",
-        "note": "The instruction (v.17) has been variously translated and interpreted. Hapt\u014d can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (m\u0113 + present imperative) usually means \"stop doing something already in progress\" \u2014 she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate \u2014 the Spirit-mediated presence that is greater than the physical proximity."
+        "note": "The instruction (v.17) has been variously translated and interpreted. Haptō can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (mē + present imperative) usually means \"stop doing something already in progress\" — she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate — the Spirit-mediated presence that is greater than the physical proximity."
       },
       {
         "word": "Ho kyrios mou kai ho theos mou",
         "tlit": "ho KY-ri-os mou kai ho the-OS mou",
         "gloss": "My Lord and my God",
-        "note": "Thomas's confession (v.28) is the Christological climax of John's Gospel \u2014 the declaration that closes the inclusio opened in 1:1 (\"the Word was God\"). The two divine titles (Kyrios and Theos) applied directly to Jesus in the vocative is the most explicit confession of his full divinity in the Gospels. It answers the Pharisees' charge of 10:33 (\"you claim to be God\"), the soldiers' falling before the I AM (18:6), and the prologue's opening declaration. Every Christological claim in the Gospel converges on this eight-word confession."
+        "note": "Thomas's confession (v.28) is the Christological climax of John's Gospel — the declaration that closes the inclusio opened in 1:1 (\"the Word was God\"). The two divine titles (Kyrios and Theos) applied directly to Jesus in the vocative is the most explicit confession of his full divinity in the Gospels. It answers the Pharisees' charge of 10:33 (\"you claim to be God\"), the soldiers' falling before the I AM (18:6), and the prologue's opening declaration. Every Christological claim in the Gospel converges on this eight-word confession."
       },
       {
-        "word": "enetyph\u0113sen",
+        "word": "enetyphēsen",
         "tlit": "e-ne-TY-phe-sen",
         "gloss": "breathed on them",
-        "note": "Jesus \"breathed on\" (v.22) the disciples \u2014 the word (emphysa\u014d) is used only here in the NT, but appears in the LXX of Gen 2:7 (God \"breathed into\" Adam the breath of life) and Ezek 37:9 (the breath breathed into the dry bones). The new creation and the new covenant are inaugurated by the same gesture: the risen Jesus breathing the Spirit into the new humanity."
+        "note": "Jesus \"breathed on\" (v.22) the disciples — the word (emphysaō) is used only here in the NT, but appears in the LXX of Gen 2:7 (God \"breathed into\" Adam the breath of life) and Ezek 37:9 (the breath breathed into the dry bones). The new creation and the new covenant are inaugurated by the same gesture: the risen Jesus breathing the Spirit into the new humanity."
       },
       {
         "word": "Mariam",
         "tlit": "Ma-RI-am",
         "gloss": "Mary (Aramaic form)",
-        "note": "When Jesus speaks her name \u2014 \"Mary\" (v.16, using the Aramaic Mariam) \u2014 it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
+        "note": "When Jesus speaks her name — \"Mary\" (v.16, using the Aramaic Mariam) — it is the only word he speaks. Her name, spoken by the risen Jesus, is the moment of recognition. This is the fulfilment of 10:3 (\"he calls his own sheep by name\") and 10:27 (\"my sheep listen to my voice\"). The resurrection is not first announced through an argument or a demonstration but through a name spoken personally by the risen shepherd."
       },
       {
-        "word": "m\u0113 mou haptou",
-        "tlit": "m\u0113 mou HAP-tou",
+        "word": "mē mou haptou",
+        "tlit": "mē mou HAP-tou",
         "gloss": "do not hold on to me / do not cling to me",
-        "note": "The instruction (v.17) has been variously translated and interpreted. Hapt\u014d can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (m\u0113 + present imperative) usually means \"stop doing something already in progress\" \u2014 she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate \u2014 the Spirit-mediated presence that is greater than the physical proximity."
+        "note": "The instruction (v.17) has been variously translated and interpreted. Haptō can mean \"touch\" or \"hold/cling.\" The present imperative with the negative (mē + present imperative) usually means \"stop doing something already in progress\" — she is already holding him, and he asks her to stop. The reason given (\"for I have not yet ascended to the Father\") suggests she needs to release the relationship she knew in order to receive the new relationship that the ascension will inaugurate — the Spirit-mediated presence that is greater than the physical proximity."
       }
     ],
     "thread": [
@@ -426,42 +386,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Song of Sol 3:1-4",
         "type": "Connection",
-        "text": "\"I looked for the one my heart loves... I found him whom my soul loves\" \u2014 the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter.",
+        "text": "\"I looked for the one my heart loves... I found him whom my soul loves\" — the beloved seeking the one who has gone, finding him unexpectedly in the garden. The Song of Songs garden-meeting provides the literary background for Mary's garden encounter.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 10:3-4",
         "type": "Fulfilment",
-        "text": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" \u2014 fulfilled in Mary's recognition at the sound of her name.",
+        "text": "\"He calls his own sheep by name and leads them out... his sheep follow him because they know his voice\" — fulfilled in Mary's recognition at the sound of her name.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 Cor 15:4-8",
         "type": "Connection",
-        "text": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" \u2014 Paul's summary of resurrection appearances, in which the Johannine appearances fit.",
+        "text": "\"He was raised on the third day according to the Scriptures, and... he appeared to Cephas, and then to the Twelve... and last of all he appeared to me\" — Paul's summary of resurrection appearances, in which the Johannine appearances fit.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Gen 2:7",
         "type": "Echo",
-        "text": "\"Then the Lord God formed a man from the dust of the ground and breathed into his nostrils the breath of life\" \u2014 the creation-of-Adam scene echoed in Jesus breathing the Spirit on the disciples.",
+        "text": "\"Then the Lord God formed a man from the dust of the ground and breathed into his nostrils the breath of life\" — the creation-of-Adam scene echoed in Jesus breathing the Spirit on the disciples.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 37:9",
-        "type": "Type\u2192Antitype",
-        "text": "\"Prophesy to the breath... 'Come, breath, from the four winds and breathe into these slain, that they may live'\" \u2014 the valley of dry bones, whose enlivening breath prefigures the resurrection community receiving the Spirit.",
+        "type": "Type→Antitype",
+        "text": "\"Prophesy to the breath... 'Come, breath, from the four winds and breathe into these slain, that they may live'\" — the valley of dry bones, whose enlivening breath prefigures the resurrection community receiving the Spirit.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Rom 10:9",
         "type": "Connection",
-        "text": "\"If you declare with your mouth, 'Jesus is Lord,' and believe in your heart that God raised him from the dead, you will be saved\" \u2014 Paul's summary of the confessional response that Thomas's \"my Lord and my God\" exemplifies.",
+        "text": "\"If you declare with your mouth, 'Jesus is Lord,' and believe in your heart that God raised him from the dead, you will be saved\" — Paul's summary of the confessional response that Thomas's \"my Lord and my God\" exemplifies.",
         "direction": "backward"
       }
     ],
@@ -469,7 +429,7 @@
       {
         "ref": "20:31",
         "title": "Aorist vs present subjunctive: \"come to believe\" vs \"continue believing\"",
-        "content": "The manuscript tradition is genuinely divided between pisteus\u0113te (aorist) and pisteu\u0113te (present). NA28 follows the present (continue believing) with a note on the variant. The choice affects whether the Gospel is primarily evangelistic (aorist \u2014 bring to faith) or catechetical (present \u2014 sustain faith). Both purposes are served by the Gospel.",
+        "content": "The manuscript tradition is genuinely divided between pisteusēte (aorist) and pisteuēte (present). NA28 follows the present (continue believing) with a note on the variant. The choice affects whether the Gospel is primarily evangelistic (aorist — bring to faith) or catechetical (present — sustain faith). Both purposes are served by the Gospel.",
         "note": "The textual evidence is evenly divided. The present tense fits the context of the Farewell Discourse (written for the disciples) better; the aorist fits the broader context of a book designed to produce faith in all who read it. The Gospel serves both purposes."
       }
     ],
@@ -480,7 +440,7 @@
           {
             "name": "Different events: proleptic gift then full gift",
             "proponents": "Most evangelical and Reformed scholars",
-            "argument": "John 20:22 is a preliminary or anticipatory gift of the Spirit \u2014 preparing the disciples for the mission Jesus assigns. Pentecost (Acts 2) is the full empowerment for the worldwide mission. The same Spirit is given in two stages or dimensions."
+            "argument": "John 20:22 is a preliminary or anticipatory gift of the Spirit — preparing the disciples for the mission Jesus assigns. Pentecost (Acts 2) is the full empowerment for the worldwide mission. The same Spirit is given in two stages or dimensions."
           },
           {
             "name": "Same event: two descriptions",
@@ -522,7 +482,7 @@
           "score": 10
         }
       ],
-      "note": "John 20 is Easter morning \u2014 the pivot of the Gospel and of human history. Three encounters structure the chapter: the beloved disciple believes from evidence (vv.1-10); Mary recognises the shepherd's voice (vv.11-18); Thomas doubts and confesses (vv.24-28). Each encounter models a different dimension of Easter faith: faith from evidence, faith from personal address, faith through encounter with the wounded body. The chapter closes with the Gospel's original purpose statement (vv.30-31): these signs were written to produce and sustain belief, by which readers may have life in his name. The resurrection is the answer to everything the cross appeared to deny."
+      "note": "John 20 is Easter morning — the pivot of the Gospel and of human history. Three encounters structure the chapter: the beloved disciple believes from evidence (vv.1-10); Mary recognises the shepherd's voice (vv.11-18); Thomas doubts and confesses (vv.24-28). Each encounter models a different dimension of Easter faith: faith from evidence, faith from personal address, faith through encounter with the wounded body. The chapter closes with the Gospel's original purpose statement (vv.30-31): these signs were written to produce and sustain belief, by which readers may have life in his name. The resurrection is the answer to everything the cross appeared to deny."
     }
   },
   "vhl_groups": [
@@ -641,12 +601,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'He saw and believed' (v. 8). The beloved disciple sees grave clothes and believes\u2014before seeing Jesus. Faith precedes sight. Mary sees Jesus and mistakes him for the gardener. Recognition comes when he speaks her name.",
+      "tip": "'He saw and believed' (v. 8). The beloved disciple sees grave clothes and believes—before seeing Jesus. Faith precedes sight. Mary sees Jesus and mistakes him for the gardener. Recognition comes when he speaks her name.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 2,
-      "tip": "'Blessed are those who have not seen and yet have believed' (v. 29). Thomas doubted; Jesus accommodated. But a greater blessing awaits faith without sight. That's us\u2014believing without touching wounds.",
+      "tip": "'Blessed are those who have not seen and yet have believed' (v. 29). Thomas doubted; Jesus accommodated. But a greater blessing awaits faith without sight. That's us—believing without touching wounds.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/3.json
+++ b/content/john/3.json
@@ -4,117 +4,117 @@
   "book_dir": "john",
   "chapter_num": 3,
   "title": "John 3",
-  "subtitle": "Jesus and Nicodemus \u2014 You Must Be Born Again",
+  "subtitle": "Jesus and Nicodemus — You Must Be Born Again",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20138 \u2014 Born of the Spirit: You Must Be Born Again",
+      "header": "Verses 1–8 — Born of the Spirit: You Must Be Born Again",
       "verse_start": 1,
       "verse_end": 8,
       "panels": {
         "heb": [
           {
-            "word": "an\u014dthen",
+            "word": "anōthen",
             "transliteration": "a-NO-then",
             "gloss": "born again / born from above",
-            "paragraph": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above \u2014 it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
+            "paragraph": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above — it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
           },
           {
             "word": "pneuma",
             "transliteration": "PNEU-ma",
             "gloss": "wind / spirit",
-            "paragraph": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality \u2014 both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
+            "paragraph": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality — both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Num 21:8-9",
-              "note": "The bronze serpent Moses lifted up in the wilderness \u2014 anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instrument of death."
+              "note": "The bronze serpent Moses lifted up in the wilderness — anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instrument of death."
             },
             {
               "ref": "Ezek 36:25-27",
-              "note": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" \u2014 the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\""
+              "note": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" — the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\""
             },
             {
               "ref": "Titus 3:5",
-              "note": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" \u2014 Paul's parallel to the born-of-water-and-Spirit language."
+              "note": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" — Paul's parallel to the born-of-water-and-Spirit language."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:3",
-              "note": "\"You must be born again\" \u2014 dei (must): divine necessity. This is not a suggestion or an ideal but a requirement for entry into the kingdom. The new birth is not moral reformation, religious education, or sacramental initiation \u2014 it is a radical regeneration that precedes and enables all else. Nicodemus's question about impossibility (v.4) is the right question: he correctly perceives that what Jesus demands is humanly impossible. That is the point."
+              "note": "\"You must be born again\" — dei (must): divine necessity. This is not a suggestion or an ideal but a requirement for entry into the kingdom. The new birth is not moral reformation, religious education, or sacramental initiation — it is a radical regeneration that precedes and enables all else. Nicodemus's question about impossibility (v.4) is the right question: he correctly perceives that what Jesus demands is humanly impossible. That is the point."
             },
             {
               "ref": "3:5-6",
-              "note": "\"Born of water and the Spirit\" \u2014 multiple interpretations: (1) physical birth (amniotic fluid) and spiritual birth; (2) baptism and the Spirit; (3) the washing of the word and the Spirit (Eph 5:26). The most natural reading in context is that water refers to the Spirit's cleansing work (Ezek 36:25-27) rather than baptismal water. \"Flesh gives birth to flesh\" \u2014 human effort produces only more human effort; only the Spirit produces spiritual life."
+              "note": "\"Born of water and the Spirit\" — multiple interpretations: (1) physical birth (amniotic fluid) and spiritual birth; (2) baptism and the Spirit; (3) the washing of the word and the Spirit (Eph 5:26). The most natural reading in context is that water refers to the Spirit's cleansing work (Ezek 36:25-27) rather than baptismal water. \"Flesh gives birth to flesh\" — human effort produces only more human effort; only the Spirit produces spiritual life."
             },
             {
               "ref": "3:14-15",
-              "note": "The bronze serpent typology is startling: the snake was the instrument of death and judgment, yet the act of looking at it brought life. The cross is similarly the place of divine judgment \u2014 Jesus becomes \"sin for us\" (2 Cor 5:21) \u2014 yet looking to him in faith is the means of life. The lifted-up language (hyps\u014dth\u0113nai) also means exaltation: the cross is simultaneously humiliation and glorification in John."
+              "note": "The bronze serpent typology is startling: the snake was the instrument of death and judgment, yet the act of looking at it brought life. The cross is similarly the place of divine judgment — Jesus becomes \"sin for us\" (2 Cor 5:21) — yet looking to him in faith is the means of life. The lifted-up language (hypsōthēnai) also means exaltation: the cross is simultaneously humiliation and glorification in John."
             },
             {
               "ref": "3:16",
-              "note": "\"For God so loved the world\" \u2014 hout\u014ds \u0113gap\u0113sen ho theos: not \"so much\" (quantity) but \"in this way\" (manner). The manner of God's love is the gift of the Son. The love is defined by the act, not the act by the love. \"Shall not perish but have eternal life\" \u2014 two destinies, one determining factor: belief in the one and only Son."
+              "note": "\"For God so loved the world\" — houtōs ēgapēsen ho theos: not \"so much\" (quantity) but \"in this way\" (manner). The manner of God's love is the gift of the Son. The love is defined by the act, not the act by the love. \"Shall not perish but have eternal life\" — two destinies, one determining factor: belief in the one and only Son."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:5",
-              "note": "Calvin firmly resists the reading of \"water\" as baptismal water. The context is about regeneration, not sacraments; Nicodemus asks about being born again, not about being baptised. Calvin argues \"water and Spirit\" is a hendiadys (two words for one thing): the purifying, renewing work of the Spirit described in Ezekiel 36. This does not deny baptism's importance elsewhere \u2014 it preserves the passage's primary meaning."
+              "note": "Calvin firmly resists the reading of \"water\" as baptismal water. The context is about regeneration, not sacraments; Nicodemus asks about being born again, not about being baptised. Calvin argues \"water and Spirit\" is a hendiadys (two words for one thing): the purifying, renewing work of the Spirit described in Ezekiel 36. This does not deny baptism's importance elsewhere — it preserves the passage's primary meaning."
             },
             {
               "ref": "3:16",
-              "note": "\"God so loved the world\" \u2014 Calvin insists this cannot be used to argue for universal salvation. The \"world\" here means humanity in its widest extent, not every individual. The gift of the Son is given for \"whoever believes\" \u2014 the offer is universal; the reception is particular. The verse establishes the breadth of the offer, not a guaranteed outcome for all."
+              "note": "\"God so loved the world\" — Calvin insists this cannot be used to argue for universal salvation. The \"world\" here means humanity in its widest extent, not every individual. The gift of the Son is given for \"whoever believes\" — the offer is universal; the reception is particular. The verse establishes the breadth of the offer, not a guaranteed outcome for all."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:5",
-              "note": "\"Born of water and the Spirit\" \u2014 the interpretive options are well represented in scholarship. The \"water = physical birth\" view (amniotic fluid) is grammatically possible but physiologically uncertain. The \"water = baptism\" view is widespread patristically. The \"water and Spirit as hendiadys\" view (Calvin) has strong contextual support from Ezek 36:25-27, which Jesus's interlocutor \u2014 \"Israel's teacher\" \u2014 should have known."
+              "note": "\"Born of water and the Spirit\" — the interpretive options are well represented in scholarship. The \"water = physical birth\" view (amniotic fluid) is grammatically possible but physiologically uncertain. The \"water = baptism\" view is widespread patristically. The \"water and Spirit as hendiadys\" view (Calvin) has strong contextual support from Ezek 36:25-27, which Jesus's interlocutor — \"Israel's teacher\" — should have known."
             },
             {
               "ref": "3:16",
-              "note": "Hout\u014ds... h\u014dste \u2014 the Greek construction means \"in this way... with the result that.\" The verse is not saying God loved so intensely that he gave; it is saying God loved in this particular way \u2014 namely, by giving his Son \u2014 with the result that whoever believes will have eternal life. The manner of the love is the gift."
+              "note": "Houtōs... hōste — the Greek construction means \"in this way... with the result that.\" The verse is not saying God loved so intensely that he gave; it is saying God loved in this particular way — namely, by giving his Son — with the result that whoever believes will have eternal life. The manner of the love is the gift."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "3:3",
-              "note": "Augustine: \"What does 'born again' mean? It means to be made new. And to be made new is to be made a child of God. For what Adam lost \u2014 the image and likeness of God \u2014 the new birth restores. But this birth is not from human will or human blood; it is from God.\""
+              "note": "Augustine: \"What does 'born again' mean? It means to be made new. And to be made new is to be made a child of God. For what Adam lost — the image and likeness of God — the new birth restores. But this birth is not from human will or human blood; it is from God.\""
             },
             {
               "ref": "3:16",
-              "note": "Chrysostom: \"He said 'gave' \u2014 not sent as a servant, not commissioned as a prophet, but gave as a father gives his son. The love is measured by the gift: the gift is measured by what was given \u2014 the one and only Son. This is the depth of God's love: that he gave what was most dear to him for those who were his enemies.\""
+              "note": "Chrysostom: \"He said 'gave' — not sent as a servant, not commissioned as a prophet, but gave as a father gives his son. The love is measured by the gift: the gift is measured by what was given — the one and only Son. This is the depth of God's love: that he gave what was most dear to him for those who were his enemies.\""
             }
           ]
         },
         "hist": {
-          "context": "Nicodemus: A Portrait\nNicodemus is one of John's most carefully drawn characters. He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus's burial (19:39). His trajectory is one of gradual, costly movement toward full discipleship \u2014 beginning at night (darkness), ending in daylight at the cross. He is a Pharisee, a member of the Sanhedrin, and \"Israel's teacher\" (v.10) \u2014 the most qualified religious authority in Jerusalem, yet completely unable to grasp what Jesus is saying about spiritual rebirth.\n\nJohn 3:16 in Context\nThe most famous verse in the Bible sits within a sustained meditation on judgment and salvation. The \"God so loved the world\" is not a sentimental assertion but a theological bomb: the world (kosmos) in John is the realm of darkness and hostility to God (1:10; 7:7; 15:18). God's love is directed at precisely this hostile world \u2014 not a world that deserves love but one that has rejected the light. The love is measured not by its object's worthiness but by the gift's cost: \"he gave his one and only Son.\""
+          "context": "Nicodemus: A Portrait\nNicodemus is one of John's most carefully drawn characters. He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus's burial (19:39). His trajectory is one of gradual, costly movement toward full discipleship — beginning at night (darkness), ending in daylight at the cross. He is a Pharisee, a member of the Sanhedrin, and \"Israel's teacher\" (v.10) — the most qualified religious authority in Jerusalem, yet completely unable to grasp what Jesus is saying about spiritual rebirth.\n\nJohn 3:16 in Context\nThe most famous verse in the Bible sits within a sustained meditation on judgment and salvation. The \"God so loved the world\" is not a sentimental assertion but a theological bomb: the world (kosmos) in John is the realm of darkness and hostility to God (1:10; 7:7; 15:18). God's love is directed at precisely this hostile world — not a world that deserves love but one that has rejected the light. The love is measured not by its object's worthiness but by the gift's cost: \"he gave his one and only Son.\""
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 9\u201321 \u2014 The Son of Man Lifted Up: John 3:16",
+      "header": "Verses 9–21 — The Son of Man Lifted Up: John 3:16",
       "verse_start": 9,
       "verse_end": 21,
       "panels": {
@@ -123,76 +123,76 @@
             "word": "ho philos tou nymphiou",
             "transliteration": "ho PHI-los tou nym-PHI-ou",
             "gloss": "friend of the bridegroom",
-            "paragraph": "The \"best man\" of the ancient world \u2014 the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" \u2014 the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
+            "paragraph": "The \"best man\" of the ancient world — the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" — the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
           },
           {
             "word": "dei auton auxanein",
             "transliteration": "dei au-TON aux-A-nein",
             "gloss": "he must increase",
-            "paragraph": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture \u2014 and John says it with joy, not regret."
+            "paragraph": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture — and John says it with joy, not regret."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Hos 2:19-20",
-              "note": "\"I will betroth you to me forever\" \u2014 God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim."
+              "note": "\"I will betroth you to me forever\" — God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim."
             },
             {
               "ref": "Rev 19:7",
-              "note": "\"The wedding of the Lamb has come, and his bride has made herself ready\" \u2014 the eschatological fulfilment of the bridegroom motif."
+              "note": "\"The wedding of the Lamb has come, and his bride has made herself ready\" — the eschatological fulfilment of the bridegroom motif."
             },
             {
               "ref": "John 15:11",
-              "note": "\"I have told you this so that my joy may be in you and that your joy may be complete\" \u2014 Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\""
+              "note": "\"I have told you this so that my joy may be in you and that your joy may be complete\" — Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\""
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:29",
-              "note": "\"The friend of the bridegroom\" \u2014 in the ancient Near East the paranymph arranged the marriage, brought the bride to the groom, and stood guard outside the bridal chamber. His moment of supreme joy was hearing the bridegroom's voice from within. John has done his job: he has prepared the way, brought Israel to the point of encounter, and now hears the bridegroom's voice. His joy is complete precisely at the moment of his eclipse."
+              "note": "\"The friend of the bridegroom\" — in the ancient Near East the paranymph arranged the marriage, brought the bride to the groom, and stood guard outside the bridal chamber. His moment of supreme joy was hearing the bridegroom's voice from within. John has done his job: he has prepared the way, brought Israel to the point of encounter, and now hears the bridegroom's voice. His joy is complete precisely at the moment of his eclipse."
             },
             {
               "ref": "3:30",
-              "note": "\"He must become greater; I must become less\" \u2014 arguably the most important sentence any Christian worker can internalise. All ministry is preparation; all Christian service is pointing away from self toward Christ. The Baptist models what Paul will articulate: \"I have been crucified with Christ and I no longer live, but Christ lives in me\" (Gal 2:20)."
+              "note": "\"He must become greater; I must become less\" — arguably the most important sentence any Christian worker can internalise. All ministry is preparation; all Christian service is pointing away from self toward Christ. The Baptist models what Paul will articulate: \"I have been crucified with Christ and I no longer live, but Christ lives in me\" (Gal 2:20)."
             },
             {
               "ref": "3:36",
-              "note": "\"God's wrath remains on them\" \u2014 the present tense is significant: condemnation is not a future event awaiting the last judgment but a present condition for those who reject the Son. Belief produces present possession of eternal life (3:16); rejection means the wrath that rested on humanity before Christ remains, unlifted. The cross removes the wrath for those who believe; for those who reject it, the wrath continues."
+              "note": "\"God's wrath remains on them\" — the present tense is significant: condemnation is not a future event awaiting the last judgment but a present condition for those who reject the Son. Belief produces present possession of eternal life (3:16); rejection means the wrath that rested on humanity before Christ remains, unlifted. The cross removes the wrath for those who believe; for those who reject it, the wrath continues."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:29-30",
-              "note": "Calvin uses the bridegroom passage to warn against all forms of ministry that make the minister rather than Christ the centre. The minister who seeks honour for himself is not a friend of the bridegroom but a rival \u2014 he is trying to steal the bride. True ministry is self-diminishing, pointing always away from itself to the one it serves."
+              "note": "Calvin uses the bridegroom passage to warn against all forms of ministry that make the minister rather than Christ the centre. The minister who seeks honour for himself is not a friend of the bridegroom but a rival — he is trying to steal the bride. True ministry is self-diminishing, pointing always away from itself to the one it serves."
             },
             {
               "ref": "3:36",
-              "note": "Calvin insists that eternal life is a present possession, not merely a future hope: \"Whoever believes in the Son has (echei \u2014 present tense) eternal life.\" Eternal life begins at the moment of faith, not at death. The present possession of eternal life is what makes death a transition rather than a terminus."
+              "note": "Calvin insists that eternal life is a present possession, not merely a future hope: \"Whoever believes in the Son has (echei — present tense) eternal life.\" Eternal life begins at the moment of faith, not at death. The present possession of eternal life is what makes death a transition rather than a terminus."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:22",
-              "note": "\"Jesus and his disciples... baptized\" \u2014 4:2 clarifies that \"in fact it was not Jesus who baptized, but his disciples.\" John records both facts honestly: 3:22 gives the general picture (Jesus's movement baptised); 4:2 gives the specific correction (Jesus personally did not baptise). This is one of John's characteristic parenthetical clarifications."
+              "note": "\"Jesus and his disciples... baptized\" — 4:2 clarifies that \"in fact it was not Jesus who baptized, but his disciples.\" John records both facts honestly: 3:22 gives the general picture (Jesus's movement baptised); 4:2 gives the specific correction (Jesus personally did not baptise). This is one of John's characteristic parenthetical clarifications."
             },
             {
               "ref": "3:36",
-              "note": "\"Whoever rejects the Son will not see life\" \u2014 the Greek apeith\u014dn (rejecting/disobeying) is a stronger word than merely \"not believing.\" It combines intellectual rejection with active disobedience \u2014 a refusal that is both cognitive and moral. This explains why the consequence is present wrath, not merely future judgment."
+              "note": "\"Whoever rejects the Son will not see life\" — the Greek apeithōn (rejecting/disobeying) is a stronger word than merely \"not believing.\" It combines intellectual rejection with active disobedience — a refusal that is both cognitive and moral. This explains why the consequence is present wrath, not merely future judgment."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "3:30",
@@ -200,119 +200,75 @@
             },
             {
               "ref": "3:29",
-              "note": "Chrysostom: \"The friend of the bridegroom does not seek to take the bride for himself. So John, like a true friend, kept the bride for the bridegroom and rejoiced to give her away. The greatest reproach to a paranymph would be to fall in love with the bride himself \u2014 and so it is the greatest reproach to a minister of the gospel to seek his own glory rather than Christ's.\""
+              "note": "Chrysostom: \"The friend of the bridegroom does not seek to take the bride for himself. So John, like a true friend, kept the bride for the bridegroom and rejoiced to give her away. The greatest reproach to a paranymph would be to fall in love with the bride himself — and so it is the greatest reproach to a minister of the gospel to seek his own glory rather than Christ's.\""
             }
           ]
         },
         "hist": {
-          "context": "The Bridegroom Motif\nThe OT consistently used the bridegroom/bride image for God's relationship with Israel (Hos 2:19-20; Isa 62:5; Jer 2:2). Jesus applying this imagery to himself (and John using it of himself as \"friend of the bridegroom\") is an implicit claim to be YHWH in relation to his people \u2014 the divine bridegroom come to claim his bride. This becomes explicit in Revelation 19:7-9 and 21:2.\n\nJohn and Jesus Baptising Simultaneously\nThe picture of John and Jesus both baptising in Judea simultaneously (3:22-24) is unique to John and historically specific. John's disciples' concern (\"everyone is going to him\") reveals the transition underway: the forerunner's movement is being absorbed into the movement it pointed toward."
+          "context": "The Bridegroom Motif\nThe OT consistently used the bridegroom/bride image for God's relationship with Israel (Hos 2:19-20; Isa 62:5; Jer 2:2). Jesus applying this imagery to himself (and John using it of himself as \"friend of the bridegroom\") is an implicit claim to be YHWH in relation to his people — the divine bridegroom come to claim his bride. This becomes explicit in Revelation 19:7-9 and 21:2.\n\nJohn and Jesus Baptising Simultaneously\nThe picture of John and Jesus both baptising in Judea simultaneously (3:22-24) is unique to John and historically specific. John's disciples' concern (\"everyone is going to him\") reveals the transition underway: the forerunner's movement is being absorbed into the movement it pointed toward."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 22\u201330 \u2014 John the Baptist\u2019s Witness: He Must Increase",
+      "header": "Verses 22–30 — John the Baptist’s Witness: He Must Increase",
       "verse_start": 22,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "an\u014dthen",
+            "word": "anōthen",
             "transliteration": "a-NO-then",
             "gloss": "born again / born from above",
-            "paragraph": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above \u2014 it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
+            "paragraph": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above — it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
           },
           {
             "word": "pneuma",
             "transliteration": "PNEU-ma",
             "gloss": "wind / spirit",
-            "paragraph": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality \u2014 both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
+            "paragraph": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality — both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Num 21:8-9",
-              "note": "The bronze serpent Moses lifted up in the wilderness \u2014 anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instrument of death."
+              "note": "The bronze serpent Moses lifted up in the wilderness — anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instrument of death."
             },
             {
               "ref": "Ezek 36:25-27",
-              "note": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" \u2014 the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\""
+              "note": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" — the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\""
             },
             {
               "ref": "Titus 3:5",
-              "note": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" \u2014 Paul's parallel to the born-of-water-and-Spirit language."
+              "note": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" — Paul's parallel to the born-of-water-and-Spirit language."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:3",
-              "note": "\"You must be born again\" \u2014 dei (must): divine necessity. This is not a suggestion or an ideal but a requirement for entry into the kingdom. The new birth is not moral reformation, religious education, or sacramental initiation \u2014 it is a radical regeneration that precedes and enables all else. Nicodemus's question about impossibility (v.4) is the right question: he correctly perceives that what Jesus demands is humanly impossible. That is the point."
-            },
-            {
-              "ref": "3:5-6",
-              "note": "\"Born of water and the Spirit\" \u2014 multiple interpretations: (1) physical birth (amniotic fluid) and spiritual birth; (2) baptism and the Spirit; (3) the washing of the word and the Spirit (Eph 5:26). The most natural reading in context is that water refers to the Spirit's cleansing work (Ezek 36:25-27) rather than baptismal water. \"Flesh gives birth to flesh\" \u2014 human effort produces only more human effort; only the Spirit produces spiritual life."
-            },
-            {
-              "ref": "3:14-15",
-              "note": "The bronze serpent typology is startling: the snake was the instrument of death and judgment, yet the act of looking at it brought life. The cross is similarly the place of divine judgment \u2014 Jesus becomes \"sin for us\" (2 Cor 5:21) \u2014 yet looking to him in faith is the means of life. The lifted-up language (hyps\u014dth\u0113nai) also means exaltation: the cross is simultaneously humiliation and glorification in John."
-            },
-            {
-              "ref": "3:16",
-              "note": "\"For God so loved the world\" \u2014 hout\u014ds \u0113gap\u0113sen ho theos: not \"so much\" (quantity) but \"in this way\" (manner). The manner of God's love is the gift of the Son. The love is defined by the act, not the act by the love. \"Shall not perish but have eternal life\" \u2014 two destinies, one determining factor: belief in the one and only Son."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "Calvin firmly resists the reading of \"water\" as baptismal water. The context is about regeneration, not sacraments; Nicodemus asks about being born again, not about being baptised. Calvin argues \"water and Spirit\" is a hendiadys (two words for one thing): the purifying, renewing work of the Spirit described in Ezekiel 36. This does not deny baptism's importance elsewhere \u2014 it preserves the passage's primary meaning."
-            },
-            {
-              "ref": "3:16",
-              "note": "\"God so loved the world\" \u2014 Calvin insists this cannot be used to argue for universal salvation. The \"world\" here means humanity in its widest extent, not every individual. The gift of the Son is given for \"whoever believes\" \u2014 the offer is universal; the reception is particular. The verse establishes the breadth of the offer, not a guaranteed outcome for all."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "\"Born of water and the Spirit\" \u2014 the interpretive options are well represented in scholarship. The \"water = physical birth\" view (amniotic fluid) is grammatically possible but physiologically uncertain. The \"water = baptism\" view is widespread patristically. The \"water and Spirit as hendiadys\" view (Calvin) has strong contextual support from Ezek 36:25-27, which Jesus's interlocutor \u2014 \"Israel's teacher\" \u2014 should have known."
-            },
-            {
-              "ref": "3:16",
-              "note": "Hout\u014ds... h\u014dste \u2014 the Greek construction means \"in this way... with the result that.\" The verse is not saying God loved so intensely that he gave; it is saying God loved in this particular way \u2014 namely, by giving his Son \u2014 with the result that whoever believes will have eternal life. The manner of the love is the gift."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "3:3",
-              "note": "Augustine: \"What does 'born again' mean? It means to be made new. And to be made new is to be made a child of God. For what Adam lost \u2014 the image and likeness of God \u2014 the new birth restores. But this birth is not from human will or human blood; it is from God.\""
-            },
-            {
-              "ref": "3:16",
-              "note": "Chrysostom: \"He said 'gave' \u2014 not sent as a servant, not commissioned as a prophet, but gave as a father gives his son. The love is measured by the gift: the gift is measured by what was given \u2014 the one and only Son. This is the depth of God's love: that he gave what was most dear to him for those who were his enemies.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Nicodemus: A Portrait\nNicodemus is one of John's most carefully drawn characters. He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus's burial (19:39). His trajectory is one of gradual, costly movement toward full discipleship \u2014 beginning at night (darkness), ending in daylight at the cross. He is a Pharisee, a member of the Sanhedrin, and \"Israel's teacher\" (v.10) \u2014 the most qualified religious authority in Jerusalem, yet completely unable to grasp what Jesus is saying about spiritual rebirth.\n\nJohn 3:16 in Context\nThe most famous verse in the Bible sits within a sustained meditation on judgment and salvation. The \"God so loved the world\" is not a sentimental assertion but a theological bomb: the world (kosmos) in John is the realm of darkness and hostility to God (1:10; 7:7; 15:18). God's love is directed at precisely this hostile world \u2014 not a world that deserves love but one that has rejected the light. The love is measured not by its object's worthiness but by the gift's cost: \"he gave his one and only Son.\""
+          "context": "Nicodemus: A Portrait\nNicodemus is one of John's most carefully drawn characters. He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus's burial (19:39). His trajectory is one of gradual, costly movement toward full discipleship — beginning at night (darkness), ending in daylight at the cross. He is a Pharisee, a member of the Sanhedrin, and \"Israel's teacher\" (v.10) — the most qualified religious authority in Jerusalem, yet completely unable to grasp what Jesus is saying about spiritual rebirth.\n\nJohn 3:16 in Context\nThe most famous verse in the Bible sits within a sustained meditation on judgment and salvation. The \"God so loved the world\" is not a sentimental assertion but a theological bomb: the world (kosmos) in John is the realm of darkness and hostility to God (1:10; 7:7; 15:18). God's love is directed at precisely this hostile world — not a world that deserves love but one that has rejected the light. The love is measured not by its object's worthiness but by the gift's cost: \"he gave his one and only Son.\""
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 31\u201336 \u2014 The One Who Comes From Above",
+      "header": "Verses 31–36 — The One Who Comes From Above",
       "verse_start": 31,
       "verse_end": 36,
       "panels": {
@@ -321,89 +277,49 @@
             "word": "ho philos tou nymphiou",
             "transliteration": "ho PHI-los tou nym-PHI-ou",
             "gloss": "friend of the bridegroom",
-            "paragraph": "The \"best man\" of the ancient world \u2014 the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" \u2014 the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
+            "paragraph": "The \"best man\" of the ancient world — the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" — the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
           },
           {
             "word": "dei auton auxanein",
             "transliteration": "dei au-TON aux-A-nein",
             "gloss": "he must increase",
-            "paragraph": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture \u2014 and John says it with joy, not regret."
+            "paragraph": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture — and John says it with joy, not regret."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Hos 2:19-20",
-              "note": "\"I will betroth you to me forever\" \u2014 God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim."
+              "note": "\"I will betroth you to me forever\" — God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim."
             },
             {
               "ref": "Rev 19:7",
-              "note": "\"The wedding of the Lamb has come, and his bride has made herself ready\" \u2014 the eschatological fulfilment of the bridegroom motif."
+              "note": "\"The wedding of the Lamb has come, and his bride has made herself ready\" — the eschatological fulfilment of the bridegroom motif."
             },
             {
               "ref": "John 15:11",
-              "note": "\"I have told you this so that my joy may be in you and that your joy may be complete\" \u2014 Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\""
+              "note": "\"I have told you this so that my joy may be in you and that your joy may be complete\" — Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\""
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:29",
-              "note": "\"The friend of the bridegroom\" \u2014 in the ancient Near East the paranymph arranged the marriage, brought the bride to the groom, and stood guard outside the bridal chamber. His moment of supreme joy was hearing the bridegroom's voice from within. John has done his job: he has prepared the way, brought Israel to the point of encounter, and now hears the bridegroom's voice. His joy is complete precisely at the moment of his eclipse."
-            },
-            {
-              "ref": "3:30",
-              "note": "\"He must become greater; I must become less\" \u2014 arguably the most important sentence any Christian worker can internalise. All ministry is preparation; all Christian service is pointing away from self toward Christ. The Baptist models what Paul will articulate: \"I have been crucified with Christ and I no longer live, but Christ lives in me\" (Gal 2:20)."
-            },
-            {
-              "ref": "3:36",
-              "note": "\"God's wrath remains on them\" \u2014 the present tense is significant: condemnation is not a future event awaiting the last judgment but a present condition for those who reject the Son. Belief produces present possession of eternal life (3:16); rejection means the wrath that rested on humanity before Christ remains, unlifted. The cross removes the wrath for those who believe; for those who reject it, the wrath continues."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:29-30",
-              "note": "Calvin uses the bridegroom passage to warn against all forms of ministry that make the minister rather than Christ the centre. The minister who seeks honour for himself is not a friend of the bridegroom but a rival \u2014 he is trying to steal the bride. True ministry is self-diminishing, pointing always away from itself to the one it serves."
-            },
-            {
-              "ref": "3:36",
-              "note": "Calvin insists that eternal life is a present possession, not merely a future hope: \"Whoever believes in the Son has (echei \u2014 present tense) eternal life.\" Eternal life begins at the moment of faith, not at death. The present possession of eternal life is what makes death a transition rather than a terminus."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:22",
-              "note": "\"Jesus and his disciples... baptized\" \u2014 4:2 clarifies that \"in fact it was not Jesus who baptized, but his disciples.\" John records both facts honestly: 3:22 gives the general picture (Jesus's movement baptised); 4:2 gives the specific correction (Jesus personally did not baptise). This is one of John's characteristic parenthetical clarifications."
-            },
-            {
-              "ref": "3:36",
-              "note": "\"Whoever rejects the Son will not see life\" \u2014 the Greek apeith\u014dn (rejecting/disobeying) is a stronger word than merely \"not believing.\" It combines intellectual rejection with active disobedience \u2014 a refusal that is both cognitive and moral. This explains why the consequence is present wrath, not merely future judgment."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "3:30",
-              "note": "Bernard of Clairvaux: \"He must increase, I must decrease. He who says this truly loves. For love does not seek its own. The friend of the bridegroom stands and hears him, and rejoices greatly because of the bridegroom's voice. This is perfect love: not to seek one's own glory but the glory of the beloved.\""
-            },
-            {
-              "ref": "3:29",
-              "note": "Chrysostom: \"The friend of the bridegroom does not seek to take the bride for himself. So John, like a true friend, kept the bride for the bridegroom and rejoiced to give her away. The greatest reproach to a paranymph would be to fall in love with the bride himself \u2014 and so it is the greatest reproach to a minister of the gospel to seek his own glory rather than Christ's.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Bridegroom Motif\nThe OT consistently used the bridegroom/bride image for God's relationship with Israel (Hos 2:19-20; Isa 62:5; Jer 2:2). Jesus applying this imagery to himself (and John using it of himself as \"friend of the bridegroom\") is an implicit claim to be YHWH in relation to his people \u2014 the divine bridegroom come to claim his bride. This becomes explicit in Revelation 19:7-9 and 21:2.\n\nJohn and Jesus Baptising Simultaneously\nThe picture of John and Jesus both baptising in Judea simultaneously (3:22-24) is unique to John and historically specific. John's disciples' concern (\"everyone is going to him\") reveals the transition underway: the forerunner's movement is being absorbed into the movement it pointed toward."
+          "context": "The Bridegroom Motif\nThe OT consistently used the bridegroom/bride image for God's relationship with Israel (Hos 2:19-20; Isa 62:5; Jer 2:2). Jesus applying this imagery to himself (and John using it of himself as \"friend of the bridegroom\") is an implicit claim to be YHWH in relation to his people — the divine bridegroom come to claim his bride. This becomes explicit in Revelation 19:7-9 and 21:2.\n\nJohn and Jesus Baptising Simultaneously\nThe picture of John and Jesus both baptising in Judea simultaneously (3:22-24) is unique to John and historically specific. John's disciples' concern (\"everyone is going to him\") reveals the transition underway: the forerunner's movement is being absorbed into the movement it pointed toward."
         }
       }
     }
@@ -413,25 +329,25 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus\\'s burial (19:39)\u2026"
+        "text": "He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus\\'s burial (19:39)…"
       },
       {
         "name": "disciples",
         "role": "Key biblical figure",
-        "text": "His trajectory is one of gradual, costly movement toward full discipleship \u2014 beginning at night (darkness), ending in daylight at the cross\u2026"
+        "text": "His trajectory is one of gradual, costly movement toward full discipleship — beginning at night (darkness), ending in daylight at the cross…"
       },
       {
         "name": "Pharisees",
         "role": "Key biblical figure",
-        "text": "He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus\\'s burial (19:39)\u2026"
+        "text": "He appears three times: here (night visit, 3:1-21), defending Jesus before the Pharisees (7:50-51), and providing spices for Jesus\\'s burial (19:39)…"
       },
       {
         "name": "Nicodemus",
         "role": "Key biblical figure",
-        "text": "Context  [('Nicodemus: A Portrait', 'Nicodemus is one of John\\'s most carefully drawn characters\u2026"
+        "text": "Context  [('Nicodemus: A Portrait', 'Nicodemus is one of John\\'s most carefully drawn characters…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">an\u014dthen (3:3)</td><td>NIV: \"born again\"; KJV: \"born again\"; ESV: \"born again\"; NRSV: \"born from above\". The NRSV preserves both meanings by choosing the \"from above\" dimension; most others choose \"again.\" Both are theologically correct and both are meant.</td></tr><tr><td class=\"t-label\">hout\u014ds (3:16)</td><td>NIV: \"so loved\" (implying degree); ESV: \"so loved\" (implying degree); NRSV: \"loved... so much\". The Greek hout\u014ds more naturally means \"in this way\" (manner) than \"so much\" (degree). The NIV's \"so loved\" is traditional but slightly misleading about the grammar.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anōthen (3:3)</td><td>NIV: \"born again\"; KJV: \"born again\"; ESV: \"born again\"; NRSV: \"born from above\". The NRSV preserves both meanings by choosing the \"from above\" dimension; most others choose \"again.\" Both are theologically correct and both are meant.</td></tr><tr><td class=\"t-label\">houtōs (3:16)</td><td>NIV: \"so loved\" (implying degree); ESV: \"so loved\" (implying degree); NRSV: \"loved... so much\". The Greek houtōs more naturally means \"in this way\" (manner) than \"so much\" (degree). The NIV's \"so loved\" is traditional but slightly misleading about the grammar.</td></tr>",
     "src": [
       {
         "title": "Numbers 21:4-9",
@@ -441,33 +357,33 @@
       {
         "title": "Ezekiel 36:25-27",
         "quote": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you... I will put my Spirit in you.\"",
-        "note": "The background for \"born of water and the Spirit\" \u2014 the promise of new covenant cleansing and Spirit-indwelling that Jesus identifies as the content of the new birth."
+        "note": "The background for \"born of water and the Spirit\" — the promise of new covenant cleansing and Spirit-indwelling that Jesus identifies as the content of the new birth."
       }
     ],
     "rec": [
       {
         "who": "John 3:16 in Western Culture",
-        "text": "John 3:16 has been called \"the gospel in miniature\" and has achieved a unique cultural presence \u2014 printed on cardboard signs at sporting events, memorised as the first Bible verse by millions, tattooed and embroidered worldwide. Martin Luther called it \"the heart of the Bible, the gospel in miniature, the whole of Christian doctrine.\" Its ubiquity has, paradoxically, made it harder to read carefully \u2014 the very familiarity obscures the precision and weight of its theology."
+        "text": "John 3:16 has been called \"the gospel in miniature\" and has achieved a unique cultural presence — printed on cardboard signs at sporting events, memorised as the first Bible verse by millions, tattooed and embroidered worldwide. Martin Luther called it \"the heart of the Bible, the gospel in miniature, the whole of Christian doctrine.\" Its ubiquity has, paradoxically, made it harder to read carefully — the very familiarity obscures the precision and weight of its theology."
       },
       {
         "who": "\"Born Again\" in Modern Christianity",
-        "text": "The phrase \"born again\" (an\u014dthen, 3:3) became a defining descriptor of evangelical Christianity in the 20th century, particularly after President Jimmy Carter described himself as \"born-again\" in 1976. The cultural use of the phrase has often domesticated what Jesus presents as a radical impossibility made possible only by divine action \u2014 far from a simple decision or commitment, the new birth is a sovereign act of the Spirit that precedes and enables human response."
+        "text": "The phrase \"born again\" (anōthen, 3:3) became a defining descriptor of evangelical Christianity in the 20th century, particularly after President Jimmy Carter described himself as \"born-again\" in 1976. The cultural use of the phrase has often domesticated what Jesus presents as a radical impossibility made possible only by divine action — far from a simple decision or commitment, the new birth is a sovereign act of the Spirit that precedes and enables human response."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Misunderstanding as Device \u2014 vv.3-10",
-          "text": "John uses deliberate misunderstanding to drive theological disclosure: Nicodemus takes \"born again\" literally \u2192 Jesus explains the spiritual meaning. This pattern \u2014 character misunderstands \u2192 Jesus deepens the teaching \u2014 recurs throughout the Gospel (4:11, 15; 6:34, 52; 11:11-12; 14:5, 8).",
+          "label": "Misunderstanding as Device — vv.3-10",
+          "text": "John uses deliberate misunderstanding to drive theological disclosure: Nicodemus takes \"born again\" literally → Jesus explains the spiritual meaning. This pattern — character misunderstands → Jesus deepens the teaching — recurs throughout the Gospel (4:11, 15; 6:34, 52; 11:11-12; 14:5, 8).",
           "is_key": false
         },
         {
-          "label": "Descent/Ascent Motif \u2014 vv.13-17",
+          "label": "Descent/Ascent Motif — vv.13-17",
           "text": "\"No one has gone into heaven except the one who came from heaven.\" The Son of Man descends (Incarnation), is lifted up (Cross), and ascends (Resurrection/Ascension). This vertical movement frames the entire soteriology: only the one from above can bring life from above.",
           "is_key": false
         },
         {
-          "label": "Descending/Ascending Motif \u2014 vv.13, 31",
+          "label": "Descending/Ascending Motif — vv.13, 31",
           "text": "John uses spatial language deliberately: the Son of Man \"descended from heaven\" (v13) and will be \"lifted up\" (v14). The pattern of descent and ascent recurs throughout the Gospel, linking incarnation, crucifixion, and glorification into a single theological movement.",
           "is_key": false
         }
@@ -476,52 +392,52 @@
     },
     "hebtext": [
       {
-        "word": "an\u014dthen",
+        "word": "anōthen",
         "tlit": "a-NO-then",
         "gloss": "born again / born from above",
-        "note": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above \u2014 it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
+        "note": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above — it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
       },
       {
         "word": "pneuma",
         "tlit": "PNEU-ma",
         "gloss": "wind / spirit",
-        "note": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality \u2014 both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
+        "note": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality — both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
       },
       {
         "word": "ho philos tou nymphiou",
         "tlit": "ho PHI-los tou nym-PHI-ou",
         "gloss": "friend of the bridegroom",
-        "note": "The \"best man\" of the ancient world \u2014 the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" \u2014 the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
+        "note": "The \"best man\" of the ancient world — the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" — the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
       },
       {
         "word": "dei auton auxanein",
         "tlit": "dei au-TON aux-A-nein",
         "gloss": "he must increase",
-        "note": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture \u2014 and John says it with joy, not regret."
+        "note": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture — and John says it with joy, not regret."
       },
       {
-        "word": "an\u014dthen",
+        "word": "anōthen",
         "tlit": "a-NO-then",
         "gloss": "born again / born from above",
-        "note": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above \u2014 it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
+        "note": "The Greek word (v.3) is deliberately double-valued: it means both \"again\" (a second time) and \"from above\" (from heaven). Nicodemus hears only the first meaning and responds with the absurdity of re-entering the womb. Jesus intends both: the new birth is a second birth AND a birth from above — it is heavenly in origin, not human. The ambiguity is a Johannine device to force the reader to hold both meanings simultaneously."
       },
       {
         "word": "pneuma",
         "tlit": "PNEU-ma",
         "gloss": "wind / spirit",
-        "note": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality \u2014 both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
+        "note": "The same Greek word (v.8) means both \"wind\" and \"spirit.\" Jesus's illustration (\"the wind blows where it pleases\") uses the natural phenomenon to describe the divine reality — both invisible, both powerful, both evidenced by their effects rather than by direct observation. The bilingual Semitic background reinforces this: Hebrew ruach and Aramaic rucha similarly mean both wind and spirit."
       },
       {
         "word": "ho philos tou nymphiou",
         "tlit": "ho PHI-los tou nym-PHI-ou",
         "gloss": "friend of the bridegroom",
-        "note": "The \"best man\" of the ancient world \u2014 the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" \u2014 the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
+        "note": "The \"best man\" of the ancient world — the one who arranges the wedding, stands by the bridegroom, and rejoices at his voice. The metaphor (v.29) is John's most complete self-description: his joy is not in being the centre but in hearing the bridegroom's voice and stepping aside. \"That joy is mine, and it is now complete\" — the Baptist's mission is fulfilled not in his own ministry but in the bridegroom's arrival."
       },
       {
         "word": "dei auton auxanein",
         "tlit": "dei au-TON aux-A-nein",
         "gloss": "he must increase",
-        "note": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture \u2014 and John says it with joy, not regret."
+        "note": "The divine necessity (dei) of the Baptist's decrease is not resignation but theology: it was always the plan. The Baptist's glory was always borrowed, a pointer. \"He must become greater; I must become less\" (v.30) is perhaps the single most self-effacing statement in all of Scripture — and John says it with joy, not regret."
       }
     ],
     "thread": [
@@ -529,42 +445,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Num 21:8-9",
         "type": "Connection",
-        "text": "The bronze serpent Moses lifted up in the wilderness \u2014 anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instr\u2026",
+        "text": "The bronze serpent Moses lifted up in the wilderness — anyone bitten by a snake who looked at it lived. Jesus identifies himself as the one \"lifted up\" in the same way: to look to him in faith (belief) is to receive life from what should be the instr…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 36:25-27",
         "type": "Connection",
-        "text": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" \u2014 the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\"",
+        "text": "\"I will sprinkle clean water on you... I will give you a new heart and put a new spirit in you\" — the OT promise of water and spirit renewal that underlies Jesus's \"born of water and Spirit.\"",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Titus 3:5",
         "type": "Echo",
-        "text": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" \u2014 Paul's parallel to the born-of-water-and-Spirit language.",
+        "text": "\"He saved us through the washing of rebirth and renewing by the Holy Spirit\" — Paul's parallel to the born-of-water-and-Spirit language.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Hos 2:19-20",
         "type": "Connection",
-        "text": "\"I will betroth you to me forever\" \u2014 God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim.",
+        "text": "\"I will betroth you to me forever\" — God as husband/bridegroom to Israel, the OT background for Jesus's bridegroom claim.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Rev 19:7",
         "type": "Fulfilment",
-        "text": "\"The wedding of the Lamb has come, and his bride has made herself ready\" \u2014 the eschatological fulfilment of the bridegroom motif.",
+        "text": "\"The wedding of the Lamb has come, and his bride has made herself ready\" — the eschatological fulfilment of the bridegroom motif.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 15:11",
         "type": "Echo",
-        "text": "\"I have told you this so that my joy may be in you and that your joy may be complete\" \u2014 Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\"",
+        "text": "\"I have told you this so that my joy may be in you and that your joy may be complete\" — Jesus's own joy-language echoes the Baptist's \"that joy is mine, and it is now complete.\"",
         "direction": "backward"
       }
     ],
@@ -572,8 +488,8 @@
       {
         "ref": "3:13",
         "title": "\"Who is in heaven\"",
-        "content": "Some MSS add \"who is in heaven\" after \"Son of Man\" \u2014 emphasising the simultaneous heavenly and earthly presence of the incarnate Son. NA28 omits this phrase as a later addition. If original, it would be a remarkable statement of omnipresence during the Incarnation; its absence in the best witnesses suggests scribal addition.",
-        "note": "The phrase is almost certainly a later theological gloss \u2014 added to assert the Son's continuing heavenly presence even while on earth. It makes a true theological point but is not original to John."
+        "content": "Some MSS add \"who is in heaven\" after \"Son of Man\" — emphasising the simultaneous heavenly and earthly presence of the incarnate Son. NA28 omits this phrase as a later addition. If original, it would be a remarkable statement of omnipresence during the Incarnation; its absence in the best witnesses suggests scribal addition.",
+        "note": "The phrase is almost certainly a later theological gloss — added to assert the Son's continuing heavenly presence even while on earth. It makes a true theological point but is not original to John."
       }
     ],
     "debate": [
@@ -588,7 +504,7 @@
           {
             "name": "Water = the Spirit's cleansing work (hendiadys)",
             "proponents": "Calvin, most Reformed interpreters",
-            "argument": "Water and Spirit describe the same event \u2014 the Spirit's purifying regenerative work promised in Ezek 36:25-27. The OT background and the immediate context (Nicodemus doesn't know baptism yet) favour this reading."
+            "argument": "Water and Spirit describe the same event — the Spirit's purifying regenerative work promised in Ezek 36:25-27. The OT background and the immediate context (Nicodemus doesn't know baptism yet) favour this reading."
           },
           {
             "name": "Water = physical birth",
@@ -625,7 +541,7 @@
           "score": 10
         }
       ],
-      "note": "John 3 is the Gospel's theological centre in miniature. The new birth (3:3-8) establishes that entry into the kingdom requires a divine act, not human effort. The lifted-up Son (3:14-15) connects that act to the cross. John 3:16 summarises the entire economy of salvation: divine love \u2192 the gift of the Son \u2192 the possibility of belief \u2192 the alternative of eternal life or perishing. The Baptist's final witness (3:29-30) models the appropriate human response to this economy: decrease before the one who must increase."
+      "note": "John 3 is the Gospel's theological centre in miniature. The new birth (3:3-8) establishes that entry into the kingdom requires a divine act, not human effort. The lifted-up Son (3:14-15) connects that act to the cross. John 3:16 summarises the entire economy of salvation: divine love → the gift of the Son → the possibility of belief → the alternative of eternal life or perishing. The Baptist's final witness (3:29-30) models the appropriate human response to this economy: decrease before the one who must increase."
     }
   },
   "vhl_groups": [

--- a/content/john/4.json
+++ b/content/john/4.json
@@ -7,39 +7,39 @@
   "subtitle": "The Woman at the Well",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201326 \u2014 The Samaritan Woman: Living Water",
+      "header": "Verses 1–26 — The Samaritan Woman: Living Water",
       "verse_start": 1,
       "verse_end": 26,
       "panels": {
         "heb": [
           {
-            "word": "hyd\u014dr z\u014dn",
+            "word": "hydōr zōn",
             "transliteration": "HY-dor ZON",
             "gloss": "living water",
             "paragraph": "The phrase (v.10) carries a double meaning. In the OT, \"living water\" is flowing spring water as opposed to stagnant cistern water (Gen 26:19; Jer 2:13). The woman hears this natural meaning; Jesus means the Spirit and eternal life. The Jeremiah background is particularly pointed: God accuses Israel of forsaking him, \"the spring of living water,\" and digging broken cisterns. Jesus is the spring Israel abandoned, now offering living water to a Samaritan."
           },
           {
-            "word": "proskyne\u014d",
+            "word": "proskyneō",
             "transliteration": "pros-ky-NEH-o",
             "gloss": "worship / bow down",
-            "paragraph": "The word appears eight times in vv.20-24 \u2014 nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement \u2014 Spirit-enabled, truth-grounded encounter with the Father."
+            "paragraph": "The word appears eight times in vv.20-24 — nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement — Spirit-enabled, truth-grounded encounter with the Father."
           }
         ],
         "places": [
           {
             "name": "Sychar / Jacob's Well",
-            "coords": "32.2094\u00b0 N, 35.2853\u00b0 E",
-            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land \u2014 the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
+            "coords": "32.2094° N, 35.2853° E",
+            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land — the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
           },
           {
             "name": "Mount Gerizim",
-            "coords": "32.1980\u00b0 N, 35.2733\u00b0 E",
+            "coords": "32.1980° N, 35.2733° E",
             "text": "The sacred mountain of the Samaritans, visible from Jacob's Well. The Samaritans built their temple here (destroyed by the Hasmonean John Hyrcanus in 128 BC) and continued to regard it as the true place of worship. The woman's question about worship location (4:20) is not deflection but genuine theological dispute. Jesus's answer transcends both Gerizim and Jerusalem, pointing to the new mode of worship the Spirit's coming will inaugurate."
           }
         ],
@@ -47,75 +47,75 @@
           "refs": [
             {
               "ref": "Jer 2:13",
-              "note": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" \u2014 the OT background for Jesus's \"living water\" offer."
+              "note": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" — the OT background for Jesus's \"living water\" offer."
             },
             {
               "ref": "Isa 12:3",
-              "note": "\"With joy you will draw water from the wells of salvation\" \u2014 the eschatological drawing of water as a metaphor for receiving salvation."
+              "note": "\"With joy you will draw water from the wells of salvation\" — the eschatological drawing of water as a metaphor for receiving salvation."
             },
             {
               "ref": "Gen 29:1-14",
-              "note": "Jacob meets Rachel at a well \u2014 one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this pattern, with the woman as the one who runs to tell the town."
+              "note": "Jacob meets Rachel at a well — one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this pattern, with the woman as the one who runs to tell the town."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:4",
-              "note": "\"He had to go through Samaria\" \u2014 edei (divine necessity). Geographically, Jews often avoided Samaria by going through Perea (the Jordan Valley route). The divine compulsion was not geographical but salvific: the Father had ordained this encounter. The woman at the well is the reason Jesus \"had to\" go through Samaria."
+              "note": "\"He had to go through Samaria\" — edei (divine necessity). Geographically, Jews often avoided Samaria by going through Perea (the Jordan Valley route). The divine compulsion was not geographical but salvific: the Father had ordained this encounter. The woman at the well is the reason Jesus \"had to\" go through Samaria."
             },
             {
               "ref": "4:10",
-              "note": "\"If you knew the gift of God and who it is that asks you\" \u2014 the double revelation: (1) what is being offered (living water = eternal life); (2) who is offering it (the Son of God). Ignorance of the giver prevents recognition of the gift. This is John's consistent pattern: recognising Jesus's identity is the precondition for receiving what he offers."
+              "note": "\"If you knew the gift of God and who it is that asks you\" — the double revelation: (1) what is being offered (living water = eternal life); (2) who is offering it (the Son of God). Ignorance of the giver prevents recognition of the gift. This is John's consistent pattern: recognising Jesus's identity is the precondition for receiving what he offers."
             },
             {
               "ref": "4:23-24",
-              "note": "\"Worship in Spirit and truth\" \u2014 not an either/or but a both/and. Spirit: worship enabled by the Holy Spirit, not by human religious effort. Truth: worship centred on the reality of who God is as revealed in Jesus Christ, not on traditions about sacred places. The Father actively seeks such worshippers \u2014 the only statement in the Gospel about something the Father is looking for."
+              "note": "\"Worship in Spirit and truth\" — not an either/or but a both/and. Spirit: worship enabled by the Holy Spirit, not by human religious effort. Truth: worship centred on the reality of who God is as revealed in Jesus Christ, not on traditions about sacred places. The Father actively seeks such worshippers — the only statement in the Gospel about something the Father is looking for."
             },
             {
               "ref": "4:26",
-              "note": "\"I am he\" (eg\u014d eimi) \u2014 the first of the absolute \"I am\" statements in John, here with the implied predicate \"the Messiah.\" The woman had said \"Messiah is coming\"; Jesus responds with the divine name. The statement is simultaneously a messianic claim and, in the context of John's theology, an echo of the divine name revealed to Moses (Exod 3:14)."
+              "note": "\"I am he\" (egō eimi) — the first of the absolute \"I am\" statements in John, here with the implied predicate \"the Messiah.\" The woman had said \"Messiah is coming\"; Jesus responds with the divine name. The statement is simultaneously a messianic claim and, in the context of John's theology, an echo of the divine name revealed to Moses (Exod 3:14)."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:13-14",
-              "note": "The water Jesus gives \"becomes in them a spring\" \u2014 this is Calvin's favourite image of regeneration: the Spirit is not an external force applied from outside but a living principle implanted within the believer, continuously renewing. The contrast with Jacob's well (good water, but you get thirsty again) is the contrast between religion as external ritual and faith as internal transformation."
+              "note": "The water Jesus gives \"becomes in them a spring\" — this is Calvin's favourite image of regeneration: the Spirit is not an external force applied from outside but a living principle implanted within the believer, continuously renewing. The contrast with Jacob's well (good water, but you get thirsty again) is the contrast between religion as external ritual and faith as internal transformation."
             },
             {
               "ref": "4:22",
-              "note": "\"Salvation is from the Jews\" \u2014 Calvin uses this to guard against anti-Judaism: God's covenant with Israel is not abrogated by the Gentile mission. The Jewish people were the custodians of the oracles of God (Rom 3:2), the line of promise through which the Saviour came. Gentile salvation flows through Jewish rootedness."
+              "note": "\"Salvation is from the Jews\" — Calvin uses this to guard against anti-Judaism: God's covenant with Israel is not abrogated by the Gentile mission. The Jewish people were the custodians of the oracles of God (Rom 3:2), the line of promise through which the Saviour came. Gentile salvation flows through Jewish rootedness."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "4:9",
-              "note": "\"Jews do not associate with Samaritans\" \u2014 the Greek ou synchrontai can mean \"do not use vessels in common with\" (not sharing cups/jars) as well as \"do not associate with.\" The RSV margin and some commentators prefer the vessel-sharing meaning, which makes the social dimension of Jesus's request even more pointed."
+              "note": "\"Jews do not associate with Samaritans\" — the Greek ou synchrontai can mean \"do not use vessels in common with\" (not sharing cups/jars) as well as \"do not associate with.\" The RSV margin and some commentators prefer the vessel-sharing meaning, which makes the social dimension of Jesus's request even more pointed."
             },
             {
               "ref": "4:26",
-              "note": "Eg\u014d eimi ho lal\u014dn soi \u2014 \"I am, the one speaking to you.\" This is the only place in John where Jesus explicitly claims messiahship to a specific person before the Passion. The choice of recipient is deliberately subversive: a Samaritan woman, multiply-married, at midday \u2014 the most marginalized possible recipient for the most explicit possible self-disclosure."
+              "note": "Egō eimi ho lalōn soi — \"I am, the one speaking to you.\" This is the only place in John where Jesus explicitly claims messiahship to a specific person before the Passion. The choice of recipient is deliberately subversive: a Samaritan woman, multiply-married, at midday — the most marginalized possible recipient for the most explicit possible self-disclosure."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "4:7",
-              "note": "Augustine: \"He is thirsty for her faith. He asks her for a drink in order to give her a drink. He begs from her who is a beggar, that she may not know her beggary. The Lord of all is thirsty \u2014 yet not for water but for her salvation.\""
+              "note": "Augustine: \"He is thirsty for her faith. He asks her for a drink in order to give her a drink. He begs from her who is a beggar, that she may not know her beggary. The Lord of all is thirsty — yet not for water but for her salvation.\""
             },
             {
               "ref": "4:23-24",
-              "note": "Cyril of Alexandria: \"God is Spirit \u2014 he is not confined to one place but fills all things. Therefore the worship that pleases him is not tied to any mountain or any temple but is the worship of the inner person, in the Spirit he gives and in the truth of his Son.\""
+              "note": "Cyril of Alexandria: \"God is Spirit — he is not confined to one place but fills all things. Therefore the worship that pleases him is not tied to any mountain or any temple but is the worship of the inner person, in the Spirit he gives and in the truth of his Son.\""
             }
           ]
         },
@@ -126,7 +126,7 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 27\u201342 \u2014 The Harvest Is Ready; Many Samaritans Believe",
+      "header": "Verses 27–42 — The Harvest Is Ready; Many Samaritans Believe",
       "verse_start": 27,
       "verse_end": 42,
       "panels": {
@@ -135,18 +135,18 @@
             "word": "basilikos",
             "transliteration": "ba-si-li-KOS",
             "gloss": "royal official / king's officer",
-            "paragraph": "The term (v.46) indicates someone in the service of Herod Antipas \u2014 likely a military or administrative officer. He is the highest-status person Jesus heals in John, yet he comes with all the urgency of a desperate father, not a dignitary. His approach to Jesus \u2014 begging, urgency, no dignity \u2014 is the Gospel's picture of how official status dissolves before the need of a child."
+            "paragraph": "The term (v.46) indicates someone in the service of Herod Antipas — likely a military or administrative officer. He is the highest-status person Jesus heals in John, yet he comes with all the urgency of a desperate father, not a dignitary. His approach to Jesus — begging, urgency, no dignity — is the Gospel's picture of how official status dissolves before the need of a child."
           }
         ],
         "places": [
           {
             "name": "Sychar / Jacob's Well",
-            "coords": "32.2094\u00b0 N, 35.2853\u00b0 E",
-            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land \u2014 the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
+            "coords": "32.2094° N, 35.2853° E",
+            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land — the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
           },
           {
             "name": "Mount Gerizim",
-            "coords": "32.1980\u00b0 N, 35.2733\u00b0 E",
+            "coords": "32.1980° N, 35.2733° E",
             "text": "The sacred mountain of the Samaritans, visible from Jacob's Well. The Samaritans built their temple here (destroyed by the Hasmonean John Hyrcanus in 128 BC) and continued to regard it as the true place of worship. The woman's question about worship location (4:20) is not deflection but genuine theological dispute. Jesus's answer transcends both Gerizim and Jerusalem, pointing to the new mode of worship the Spirit's coming will inaugurate."
           }
         ],
@@ -154,55 +154,55 @@
           "refs": [
             {
               "ref": "Matt 8:5-13",
-              "note": "The parallel healing of a centurion's servant \u2014 also at a distance, also involving a Gentile officer, also a rebuke about sign-dependence. The two accounts may be the same event recorded differently, or two separate but structurally parallel healings."
+              "note": "The parallel healing of a centurion's servant — also at a distance, also involving a Gentile officer, also a rebuke about sign-dependence. The two accounts may be the same event recorded differently, or two separate but structurally parallel healings."
             },
             {
               "ref": "1 Kgs 17:17-24",
-              "note": "Elijah raises the widow's son \u2014 the OT background for healing from death's door as a prophetic act establishing the prophet's credentials."
+              "note": "Elijah raises the widow's son — the OT background for healing from death's door as a prophetic act establishing the prophet's credentials."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:48",
-              "note": "\"Unless you people see signs and wonders, you will never believe\" \u2014 this is directed not at the official specifically (you plural) but at the Galilean crowd in general. The rebuke is about the quality of their faith: it is sign-dependent, not word-dependent. The official's response (v.49) is not defensive \u2014 he simply repeats his plea. Jesus then gives him exactly what sign-faith cannot command: a word without evidence, healing without presence."
+              "note": "\"Unless you people see signs and wonders, you will never believe\" — this is directed not at the official specifically (you plural) but at the Galilean crowd in general. The rebuke is about the quality of their faith: it is sign-dependent, not word-dependent. The official's response (v.49) is not defensive — he simply repeats his plea. Jesus then gives him exactly what sign-faith cannot command: a word without evidence, healing without presence."
             },
             {
               "ref": "4:50",
-              "note": "\"The man took Jesus at his word and departed\" \u2014 episteusen t\u014d log\u014d. The dative case: he believed the word itself, not just the man who spoke it. This is the transition from sign-faith to word-faith. He went away with nothing but a spoken assurance \u2014 and his son was healed. This is the model of saving faith in John: trust the word of Jesus without requiring visible confirmation first."
+              "note": "\"The man took Jesus at his word and departed\" — episteusen tō logō. The dative case: he believed the word itself, not just the man who spoke it. This is the transition from sign-faith to word-faith. He went away with nothing but a spoken assurance — and his son was healed. This is the model of saving faith in John: trust the word of Jesus without requiring visible confirmation first."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:48",
-              "note": "Calvin notes that Jesus's rebuke is not a refusal but a test. He is probing whether the man wants a sign or wants life for his son. The official's persistence through the rebuke reveals the quality of his concern \u2014 he is not shopping for miracles but desperate for his son's life. The rebuke strips away any sign-seeking pretence and leaves the naked request: \"Sir, come down before my child dies.\" That prayer Jesus answers immediately."
+              "note": "Calvin notes that Jesus's rebuke is not a refusal but a test. He is probing whether the man wants a sign or wants life for his son. The official's persistence through the rebuke reveals the quality of his concern — he is not shopping for miracles but desperate for his son's life. The rebuke strips away any sign-seeking pretence and leaves the naked request: \"Sir, come down before my child dies.\" That prayer Jesus answers immediately."
             },
             {
               "ref": "4:42",
-              "note": "Calvin observes that the Samaritans' confession \u2014 \"we know that this man really is the Savior of the world\" \u2014 surpasses the disciples' understanding at this stage in the narrative. Their use of \"Savior of the world\" (rather than \"Messiah of Israel\") is Calvin's proof that genuine faith perceives Christ's universal dominion, not merely his national role."
+              "note": "Calvin observes that the Samaritans' confession — \"we know that this man really is the Savior of the world\" — surpasses the disciples' understanding at this stage in the narrative. Their use of \"Savior of the world\" (rather than \"Messiah of Israel\") is Calvin's proof that genuine faith perceives Christ's universal dominion, not merely his national role."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "4:44",
-              "note": "\"A prophet has no honor in his own country\" \u2014 this parenthetical creates a tension: if Galilee is Jesus's \"own country,\" why does it receive him (v.45)? The resolution may be that Galilee received him because of what he did in Jerusalem (not his home territory), or that \"his own country\" refers to Judea (his people). The tension is probably intentional \u2014 Galilean reception is enthusiastic but still sign-dependent (v.48)."
+              "note": "\"A prophet has no honor in his own country\" — this parenthetical creates a tension: if Galilee is Jesus's \"own country,\" why does it receive him (v.45)? The resolution may be that Galilee received him because of what he did in Jerusalem (not his home territory), or that \"his own country\" refers to Judea (his people). The tension is probably intentional — Galilean reception is enthusiastic but still sign-dependent (v.48)."
             },
             {
               "ref": "4:46",
-              "note": "The NET Bible notes that the royal official (basilikos) was likely a Herodian court officer \u2014 not a Roman centurion (as in the Synoptic parallel). John's account emphasizes the officer's gradual faith: he came requesting a healing presence (v47), accepted a word only (v50: \"the man took Jesus at his word\"), and only confirmed the miracle afterward \u2014 underscoring John's faith-before-sight theme."
+              "note": "The NET Bible notes that the royal official (basilikos) was likely a Herodian court officer — not a Roman centurion (as in the Synoptic parallel). John's account emphasizes the officer's gradual faith: he came requesting a healing presence (v47), accepted a word only (v50: \"the man took Jesus at his word\"), and only confirmed the miracle afterward — underscoring John's faith-before-sight theme."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "4:50",
@@ -210,44 +210,44 @@
             },
             {
               "ref": "4:39-42",
-              "note": "The Catena preserves Augustine's comment that the Samaritans who \"urged him to stay\" (v40) model the posture of every true believer: not content with secondary testimony, they want direct encounter. Chrysostom adds that the two days Jesus spent in Samaria is a prophetic figure \u2014 the two days representing the two peoples (Jew and Gentile) who would receive the Gospel in successive ages."
+              "note": "The Catena preserves Augustine's comment that the Samaritans who \"urged him to stay\" (v40) model the posture of every true believer: not content with secondary testimony, they want direct encounter. Chrysostom adds that the two days Jesus spent in Samaria is a prophetic figure — the two days representing the two peoples (Jew and Gentile) who would receive the Gospel in successive ages."
             }
           ]
         },
         "hist": {
-          "context": "The Second Sign\nJohn explicitly numbers this as the \"second sign\" (v.54), forming a bracket with the first sign at Cana (2:11): two Cana signs frame the Jerusalem and Samaria material of chs 2-4. Both signs involve transformation: water to wine (quality transformed), a dying child healed at a distance (life restored). The second sign goes further: the healing occurs with no physical presence, no touch, no object \u2014 only a word spoken across 20 miles of geography.\n\nFaith Before Evidence\nThe official believes before he sees: \"The man took Jesus at his word and departed\" (v.50). He does not wait for a sign; he acts on the spoken word. The servants' confirmation en route is the evidence that follows faith, not the basis for it. This is John's model of mature faith: \"You believe because you have seen me. Blessed are those who have not seen and yet have believed\" (20:29)."
+          "context": "The Second Sign\nJohn explicitly numbers this as the \"second sign\" (v.54), forming a bracket with the first sign at Cana (2:11): two Cana signs frame the Jerusalem and Samaria material of chs 2-4. Both signs involve transformation: water to wine (quality transformed), a dying child healed at a distance (life restored). The second sign goes further: the healing occurs with no physical presence, no touch, no object — only a word spoken across 20 miles of geography.\n\nFaith Before Evidence\nThe official believes before he sees: \"The man took Jesus at his word and departed\" (v.50). He does not wait for a sign; he acts on the spoken word. The servants' confirmation en route is the evidence that follows faith, not the basis for it. This is John's model of mature faith: \"You believe because you have seen me. Blessed are those who have not seen and yet have believed\" (20:29)."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 43\u201354 \u2014 The Royal Official\u2019s Son: The Second Sign",
+      "header": "Verses 43–54 — The Royal Official’s Son: The Second Sign",
       "verse_start": 43,
       "verse_end": 54,
       "panels": {
         "heb": [
           {
-            "word": "hyd\u014dr z\u014dn",
+            "word": "hydōr zōn",
             "transliteration": "HY-dor ZON",
             "gloss": "living water",
             "paragraph": "The phrase (v.10) carries a double meaning. In the OT, \"living water\" is flowing spring water as opposed to stagnant cistern water (Gen 26:19; Jer 2:13). The woman hears this natural meaning; Jesus means the Spirit and eternal life. The Jeremiah background is particularly pointed: God accuses Israel of forsaking him, \"the spring of living water,\" and digging broken cisterns. Jesus is the spring Israel abandoned, now offering living water to a Samaritan."
           },
           {
-            "word": "proskyne\u014d",
+            "word": "proskyneō",
             "transliteration": "pros-ky-NEH-o",
             "gloss": "worship / bow down",
-            "paragraph": "The word appears eight times in vv.20-24 \u2014 nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement \u2014 Spirit-enabled, truth-grounded encounter with the Father."
+            "paragraph": "The word appears eight times in vv.20-24 — nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement — Spirit-enabled, truth-grounded encounter with the Father."
           }
         ],
         "places": [
           {
             "name": "Sychar / Jacob's Well",
-            "coords": "32.2094\u00b0 N, 35.2853\u00b0 E",
-            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land \u2014 the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
+            "coords": "32.2094° N, 35.2853° E",
+            "text": "The well near ancient Shechem (modern Nablus) in Samaria, traditionally identified with the well that Jacob dug (Gen 33:18-20; 48:22). The site is one of the most reliably identified in the Holy Land — the Greek Orthodox Church of Saint Photini (the Samaritan woman) has been built over the well, which still exists at a depth of 30 metres. \"Jacob's well was there\" (4:6) is one of John's characteristic matter-of-fact geographical notes that archaeology has confirmed."
           },
           {
             "name": "Mount Gerizim",
-            "coords": "32.1980\u00b0 N, 35.2733\u00b0 E",
+            "coords": "32.1980° N, 35.2733° E",
             "text": "The sacred mountain of the Samaritans, visible from Jacob's Well. The Samaritans built their temple here (destroyed by the Hasmonean John Hyrcanus in 128 BC) and continued to regard it as the true place of worship. The woman's question about worship location (4:20) is not deflection but genuine theological dispute. Jesus's answer transcends both Gerizim and Jerusalem, pointing to the new mode of worship the Spirit's coming will inaugurate."
           }
         ],
@@ -255,77 +255,33 @@
           "refs": [
             {
               "ref": "Jer 2:13",
-              "note": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" \u2014 the OT background for Jesus's \"living water\" offer."
+              "note": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" — the OT background for Jesus's \"living water\" offer."
             },
             {
               "ref": "Isa 12:3",
-              "note": "\"With joy you will draw water from the wells of salvation\" \u2014 the eschatological drawing of water as a metaphor for receiving salvation."
+              "note": "\"With joy you will draw water from the wells of salvation\" — the eschatological drawing of water as a metaphor for receiving salvation."
             },
             {
               "ref": "Gen 29:1-14",
-              "note": "Jacob meets Rachel at a well \u2014 one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this pattern, with the woman as the one who runs to tell the town."
+              "note": "Jacob meets Rachel at a well — one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this pattern, with the woman as the one who runs to tell the town."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:4",
-              "note": "\"He had to go through Samaria\" \u2014 edei (divine necessity). Geographically, Jews often avoided Samaria by going through Perea (the Jordan Valley route). The divine compulsion was not geographical but salvific: the Father had ordained this encounter. The woman at the well is the reason Jesus \"had to\" go through Samaria."
-            },
-            {
-              "ref": "4:10",
-              "note": "\"If you knew the gift of God and who it is that asks you\" \u2014 the double revelation: (1) what is being offered (living water = eternal life); (2) who is offering it (the Son of God). Ignorance of the giver prevents recognition of the gift. This is John's consistent pattern: recognising Jesus's identity is the precondition for receiving what he offers."
-            },
-            {
-              "ref": "4:23-24",
-              "note": "\"Worship in Spirit and truth\" \u2014 not an either/or but a both/and. Spirit: worship enabled by the Holy Spirit, not by human religious effort. Truth: worship centred on the reality of who God is as revealed in Jesus Christ, not on traditions about sacred places. The Father actively seeks such worshippers \u2014 the only statement in the Gospel about something the Father is looking for."
-            },
-            {
-              "ref": "4:26",
-              "note": "\"I am he\" (eg\u014d eimi) \u2014 the first of the absolute \"I am\" statements in John, here with the implied predicate \"the Messiah.\" The woman had said \"Messiah is coming\"; Jesus responds with the divine name. The statement is simultaneously a messianic claim and, in the context of John's theology, an echo of the divine name revealed to Moses (Exod 3:14)."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:13-14",
-              "note": "The water Jesus gives \"becomes in them a spring\" \u2014 this is Calvin's favourite image of regeneration: the Spirit is not an external force applied from outside but a living principle implanted within the believer, continuously renewing. The contrast with Jacob's well (good water, but you get thirsty again) is the contrast between religion as external ritual and faith as internal transformation."
-            },
-            {
-              "ref": "4:22",
-              "note": "\"Salvation is from the Jews\" \u2014 Calvin uses this to guard against anti-Judaism: God's covenant with Israel is not abrogated by the Gentile mission. The Jewish people were the custodians of the oracles of God (Rom 3:2), the line of promise through which the Saviour came. Gentile salvation flows through Jewish rootedness."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:9",
-              "note": "\"Jews do not associate with Samaritans\" \u2014 the Greek ou synchrontai can mean \"do not use vessels in common with\" (not sharing cups/jars) as well as \"do not associate with.\" The RSV margin and some commentators prefer the vessel-sharing meaning, which makes the social dimension of Jesus's request even more pointed."
-            },
-            {
-              "ref": "4:26",
-              "note": "Eg\u014d eimi ho lal\u014dn soi \u2014 \"I am, the one speaking to you.\" This is the only place in John where Jesus explicitly claims messiahship to a specific person before the Passion. The choice of recipient is deliberately subversive: a Samaritan woman, multiply-married, at midday \u2014 the most marginalized possible recipient for the most explicit possible self-disclosure."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "4:7",
-              "note": "Augustine: \"He is thirsty for her faith. He asks her for a drink in order to give her a drink. He begs from her who is a beggar, that she may not know her beggary. The Lord of all is thirsty \u2014 yet not for water but for her salvation.\""
-            },
-            {
-              "ref": "4:23-24",
-              "note": "Cyril of Alexandria: \"God is Spirit \u2014 he is not confined to one place but fills all things. Therefore the worship that pleases him is not tied to any mountain or any temple but is the worship of the inner person, in the Spirit he gives and in the truth of his Son.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "Samaritans and Jews\nSamaritans were the descendants of the mixed population settled in Israel by the Assyrians after 722 BC, intermarried with surviving Israelites. They accepted only the Pentateuch as scripture and worshipped on Mount Gerizim, which they identified as the true site of the Mosaic command to worship. Jewish-Samaritan relations were hostile; a Jew drawing water from a Samaritan woman's jar would incur ritual impurity. Jesus's request for water (v.7) and his sustained conversation with a woman in public (v.27) both violate conventional social boundaries simultaneously.\n\nThe Five Husbands\nCommentators have proposed symbolic readings: the five husbands = the five foreign nations whose gods Samaria adopted (2 Kgs 17:24-34); the current man = the false religion of Gerizim. More naturally, Jesus reveals the specific details of the woman's domestic life as evidence of his prophetic knowledge. The symbolic and literal readings need not be mutually exclusive."
@@ -338,26 +294,26 @@
       {
         "name": "Jews",
         "role": "Key biblical figure",
-        "text": "Context  [('Samaritans and Jews', \"Samaritans were the descendants of the mixed population settled in Israel by the Assyrians after 722 BC, intermarried with surviving Israelites\u2026"
+        "text": "Context  [('Samaritans and Jews', \"Samaritans were the descendants of the mixed population settled in Israel by the Assyrians after 722 BC, intermarried with surviving Israelites…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">hyd\u014dr z\u014dn (4:10)</td><td>NIV: \"living water\"; KJV: \"living water\"; ESV: \"living water\"; NRSV: \"living water\". Universal agreement. The natural meaning (flowing spring water) and the theological meaning (eternal life through the Spirit) both apply.</td></tr><tr><td class=\"t-label\">en pneumati kai al\u0113theia (4:23)</td><td>NIV: \"in the Spirit and in truth\"; KJV: \"in spirit and in truth\"; ESV: \"in spirit and in truth\"; NRSV: \"in spirit and truth\". NIV capitalises Spirit (pointing to the Holy Spirit); others leave uncapitalised. The capital is probably correct: the Spirit who enables worship is the Holy Spirit.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">hydōr zōn (4:10)</td><td>NIV: \"living water\"; KJV: \"living water\"; ESV: \"living water\"; NRSV: \"living water\". Universal agreement. The natural meaning (flowing spring water) and the theological meaning (eternal life through the Spirit) both apply.</td></tr><tr><td class=\"t-label\">en pneumati kai alētheia (4:23)</td><td>NIV: \"in the Spirit and in truth\"; KJV: \"in spirit and in truth\"; ESV: \"in spirit and in truth\"; NRSV: \"in spirit and truth\". NIV capitalises Spirit (pointing to the Holy Spirit); others leave uncapitalised. The capital is probably correct: the Spirit who enables worship is the Holy Spirit.</td></tr>",
     "src": [
       {
         "title": "Jeremiah 2:13",
         "quote": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water.\"",
-        "note": "The OT image that underlies Jesus's \"living water\" offer \u2014 God himself as the spring his people have abandoned."
+        "note": "The OT image that underlies Jesus's \"living water\" offer — God himself as the spring his people have abandoned."
       },
       {
         "title": "Genesis 29:1-14",
         "quote": "Jacob meets Rachel at a well: \"He rolled the stone away from the mouth of the well and watered the sheep of his uncle Laban... Jacob kissed Rachel and began to weep aloud.\"",
-        "note": "The betrothal well-scene in Genesis that John echoes. Jesus meets the woman at Jacob's well \u2014 the narrative connection is deliberate, casting Jesus as the true bridegroom seeking his bride."
+        "note": "The betrothal well-scene in Genesis that John echoes. Jesus meets the woman at Jacob's well — the narrative connection is deliberate, casting Jesus as the true bridegroom seeking his bride."
       }
     ],
     "rec": [
       {
         "who": "The Samaritan Woman in Christian Tradition",
-        "text": "The Samaritan woman is named Photini (\"the luminous one\") in Eastern Orthodox tradition and venerated as \"equal to the apostles\" for her evangelism of her town. Her feast day is celebrated in the Orthodox calendar in the fifth week of Pascha. She represents the prototype of the unexpected evangelist \u2014 the one the religious establishment would have least chosen as the Messiah's first missionary to a non-Jewish population."
+        "text": "The Samaritan woman is named Photini (\"the luminous one\") in Eastern Orthodox tradition and venerated as \"equal to the apostles\" for her evangelism of her town. Her feast day is celebrated in the Orthodox calendar in the fifth week of Pascha. She represents the prototype of the unexpected evangelist — the one the religious establishment would have least chosen as the Messiah's first missionary to a non-Jewish population."
       },
       {
         "who": "\"Worship in Spirit and Truth\" in Liturgical Reform",
@@ -367,18 +323,18 @@
     "lit": {
       "rows": [
         {
-          "label": "The Well-Meeting Pattern \u2014 ch.4 and Gen 24, 29; Exod 2",
-          "text": "John consciously echoes the OT betrothal well-scenes. A man meets a woman at a well, asks for water, reveals his identity, the woman runs to tell others, the man is invited to stay. Jesus is the true Jacob, the true Moses \u2014 the divine bridegroom seeking his people.",
+          "label": "The Well-Meeting Pattern — ch.4 and Gen 24, 29; Exod 2",
+          "text": "John consciously echoes the OT betrothal well-scenes. A man meets a woman at a well, asks for water, reveals his identity, the woman runs to tell others, the man is invited to stay. Jesus is the true Jacob, the true Moses — the divine bridegroom seeking his people.",
           "is_key": false
         },
         {
-          "label": "Misunderstanding Sequence \u2014 vv.10-15",
-          "text": "Living water \u2192 she thinks of well water / not coming to draw. This is the fourth misunderstanding in John so far (3:3, 3:9, 4:11) \u2014 each one occasions a deeper disclosure. The woman's literal reading of \"living water\" forces Jesus to explain the spiritual reality.",
+          "label": "Misunderstanding Sequence — vv.10-15",
+          "text": "Living water → she thinks of well water / not coming to draw. This is the fourth misunderstanding in John so far (3:3, 3:9, 4:11) — each one occasions a deeper disclosure. The woman's literal reading of \"living water\" forces Jesus to explain the spiritual reality.",
           "is_key": false
         },
         {
-          "label": "Harvest Metaphor Bridge \u2014 vv.35-38",
-          "text": "Jesus shifts from the woman's story to a universal mission statement using agricultural imagery. The four-month gap of normal harvest collapses \u2014 \"the fields are already white.\" This functions as a transition pivot between the individual encounter and the Samaritan community's response.",
+          "label": "Harvest Metaphor Bridge — vv.35-38",
+          "text": "Jesus shifts from the woman's story to a universal mission statement using agricultural imagery. The four-month gap of normal harvest collapses — \"the fields are already white.\" This functions as a transition pivot between the individual encounter and the Samaritan community's response.",
           "is_key": false
         }
       ],
@@ -386,34 +342,34 @@
     },
     "hebtext": [
       {
-        "word": "hyd\u014dr z\u014dn",
+        "word": "hydōr zōn",
         "tlit": "HY-dor ZON",
         "gloss": "living water",
         "note": "The phrase (v.10) carries a double meaning. In the OT, \"living water\" is flowing spring water as opposed to stagnant cistern water (Gen 26:19; Jer 2:13). The woman hears this natural meaning; Jesus means the Spirit and eternal life. The Jeremiah background is particularly pointed: God accuses Israel of forsaking him, \"the spring of living water,\" and digging broken cisterns. Jesus is the spring Israel abandoned, now offering living water to a Samaritan."
       },
       {
-        "word": "proskyne\u014d",
+        "word": "proskyneō",
         "tlit": "pros-ky-NEH-o",
         "gloss": "worship / bow down",
-        "note": "The word appears eight times in vv.20-24 \u2014 nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement \u2014 Spirit-enabled, truth-grounded encounter with the Father."
+        "note": "The word appears eight times in vv.20-24 — nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement — Spirit-enabled, truth-grounded encounter with the Father."
       },
       {
         "word": "basilikos",
         "tlit": "ba-si-li-KOS",
         "gloss": "royal official / king's officer",
-        "note": "The term (v.46) indicates someone in the service of Herod Antipas \u2014 likely a military or administrative officer. He is the highest-status person Jesus heals in John, yet he comes with all the urgency of a desperate father, not a dignitary. His approach to Jesus \u2014 begging, urgency, no dignity \u2014 is the Gospel's picture of how official status dissolves before the need of a child."
+        "note": "The term (v.46) indicates someone in the service of Herod Antipas — likely a military or administrative officer. He is the highest-status person Jesus heals in John, yet he comes with all the urgency of a desperate father, not a dignitary. His approach to Jesus — begging, urgency, no dignity — is the Gospel's picture of how official status dissolves before the need of a child."
       },
       {
-        "word": "hyd\u014dr z\u014dn",
+        "word": "hydōr zōn",
         "tlit": "HY-dor ZON",
         "gloss": "living water",
         "note": "The phrase (v.10) carries a double meaning. In the OT, \"living water\" is flowing spring water as opposed to stagnant cistern water (Gen 26:19; Jer 2:13). The woman hears this natural meaning; Jesus means the Spirit and eternal life. The Jeremiah background is particularly pointed: God accuses Israel of forsaking him, \"the spring of living water,\" and digging broken cisterns. Jesus is the spring Israel abandoned, now offering living water to a Samaritan."
       },
       {
-        "word": "proskyne\u014d",
+        "word": "proskyneō",
         "tlit": "pros-ky-NEH-o",
         "gloss": "worship / bow down",
-        "note": "The word appears eight times in vv.20-24 \u2014 nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement \u2014 Spirit-enabled, truth-grounded encounter with the Father."
+        "note": "The word appears eight times in vv.20-24 — nowhere else in John. The woman's question about the proper place of worship is redirected by Jesus to the proper manner: in Spirit and in truth. The true worship that the Father seeks is not defined by geography (Jerusalem or Gerizim) but by the nature of the worshipper's engagement — Spirit-enabled, truth-grounded encounter with the Father."
       }
     ],
     "thread": [
@@ -421,42 +377,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Jer 2:13",
         "type": "Connection",
-        "text": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" \u2014 the OT background for Jesus's \"living water\" offer.",
+        "text": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" — the OT background for Jesus's \"living water\" offer.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 12:3",
         "type": "Connection",
-        "text": "\"With joy you will draw water from the wells of salvation\" \u2014 the eschatological drawing of water as a metaphor for receiving salvation.",
+        "text": "\"With joy you will draw water from the wells of salvation\" — the eschatological drawing of water as a metaphor for receiving salvation.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Gen 29:1-14",
         "type": "Connection",
-        "text": "Jacob meets Rachel at a well \u2014 one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this\u2026",
+        "text": "Jacob meets Rachel at a well — one of a series of well-meetings in the OT (Rebekah, Exod 2:16-17) that follow a betrothal pattern: man meets woman at well, waters sheep, runs to tell family, meal prepared. Jesus's meeting at Jacob's well follows this…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Matt 8:5-13",
         "type": "Echo",
-        "text": "The parallel healing of a centurion's servant \u2014 also at a distance, also involving a Gentile officer, also a rebuke about sign-dependence. The two accounts may be the same event recorded differently, or two separate but structurally parallel healings\u2026",
+        "text": "The parallel healing of a centurion's servant — also at a distance, also involving a Gentile officer, also a rebuke about sign-dependence. The two accounts may be the same event recorded differently, or two separate but structurally parallel healings…",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "1 Kgs 17:17-24",
         "type": "Connection",
-        "text": "Elijah raises the widow's son \u2014 the OT background for healing from death's door as a prophetic act establishing the prophet's credentials.",
+        "text": "Elijah raises the widow's son — the OT background for healing from death's door as a prophetic act establishing the prophet's credentials.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Jer 2:13",
         "type": "Connection",
-        "text": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" \u2014 the OT background for Jesus's \"living water\" offer.",
+        "text": "\"My people have forsaken me, the spring of living water, and have dug their own cisterns, broken cisterns that cannot hold water\" — the OT background for Jesus's \"living water\" offer.",
         "direction": "backward"
       }
     ],
@@ -465,7 +421,7 @@
         "ref": "4:9",
         "title": "\"For Jews do not associate with Samaritans\"",
         "content": "Some important MSS omit this editorial note. NA28 includes it. The note explains the woman's astonishment; its omission may reflect scribal abbreviation rather than a different text tradition.",
-        "note": "The note is almost certainly original \u2014 it is the kind of geographical-cultural explanation John provides for readers unfamiliar with Palestinian customs (cf. 1:38, 41; 2:6; 3:24)."
+        "note": "The note is almost certainly original — it is the kind of geographical-cultural explanation John provides for readers unfamiliar with Palestinian customs (cf. 1:38, 41; 2:6; 3:24)."
       }
     ],
     "debate": [
@@ -512,7 +468,7 @@
           "score": 10
         }
       ],
-      "note": "John 4 is the Gospel's most sustained portrait of one-on-one evangelism. Jesus crosses every social boundary \u2014 Jew/Samaritan, male/female, pure/impure \u2014 to offer living water to the last person the religious establishment would have approached. The conversation moves from physical thirst to spiritual need to worship to messianic identity, and the woman moves from defensive questioning to honest confession to joyful proclamation. The chapter closes with the disciples' harvest image: the fields are already white, and unexpected reapers (a Samaritan woman) are already at work."
+      "note": "John 4 is the Gospel's most sustained portrait of one-on-one evangelism. Jesus crosses every social boundary — Jew/Samaritan, male/female, pure/impure — to offer living water to the last person the religious establishment would have approached. The conversation moves from physical thirst to spiritual need to worship to messianic identity, and the woman moves from defensive questioning to honest confession to joyful proclamation. The chapter closes with the disciples' harvest image: the fields are already white, and unexpected reapers (a Samaritan woman) are already at work."
     }
   },
   "vhl_groups": [
@@ -631,12 +587,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'If you knew the gift of God and who it is that asks you for a drink' (v. 10). The Samaritan woman knows neither. Jesus crosses every boundary\u2014gender, ethnicity, moral status. Living water transcends Jacob's well.",
+      "tip": "'If you knew the gift of God and who it is that asks you for a drink' (v. 10). The Samaritan woman knows neither. Jesus crosses every boundary—gender, ethnicity, moral status. Living water transcends Jacob's well.",
       "genre_tag": "theological_insight"
     },
     {
       "after_section": 2,
-      "tip": "'The fields are ripe for harvest' (v. 35). Samaritans stream toward Jesus; the disciples just see lunch. Different eyes, different harvests. Many Samaritans believe\u2014outsiders receive what insiders miss.",
+      "tip": "'The fields are ripe for harvest' (v. 35). Samaritans stream toward Jesus; the disciples just see lunch. Different eyes, different harvests. Many Samaritans believe—outsiders receive what insiders miss.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/john/5.json
+++ b/content/john/5.json
@@ -7,34 +7,34 @@
   "subtitle": "The Healing at the Pool and the Son's Authority",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201315 \u2014 The Pool of Bethesda: Rise and Walk",
+      "header": "Verses 1–15 — The Pool of Bethesda: Rise and Walk",
       "verse_start": 1,
       "verse_end": 15,
       "panels": {
         "heb": [
           {
-            "word": "theleis hygi\u0113s genesthai",
-            "transliteration": "THE-leis hy-GI-\u0113s ge-NES-thai",
+            "word": "theleis hygiēs genesthai",
+            "transliteration": "THE-leis hy-GI-ēs ge-NES-thai",
             "gloss": "Do you want to get well?",
-            "paragraph": "Jesus's question to the man (v.6) is not therapeutic conversation \u2014 it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
+            "paragraph": "Jesus's question to the man (v.6) is not therapeutic conversation — it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
           },
           {
-            "word": "ison heautou poi\u014dn t\u014d the\u014d",
+            "word": "ison heautou poiōn tō theō",
             "transliteration": "I-son heau-TOU poi-ON to the-O",
             "gloss": "making himself equal with God",
-            "paragraph": "The Jewish leaders' charge (v.18) is not a misunderstanding \u2014 it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 \u2014 doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
+            "paragraph": "The Jewish leaders' charge (v.18) is not a misunderstanding — it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 — doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
           }
         ],
         "places": [
           {
             "name": "Pool of Bethesda",
-            "coords": "31.7810\u00b0 N, 35.2367\u00b0 E",
+            "coords": "31.7810° N, 35.2367° E",
             "text": "Near the Sheep Gate (northeast of the Temple Mount), the Pool of Bethesda was a large double-pool complex used for ritual purification. Excavations since 1888 have confirmed John's description precisely: two pools separated by a rock-cut partition, with four outer colonnades and one central colonnade producing exactly five porticoes. The pool is now visible beneath the Church of Saint Anne in Jerusalem. This is one of the most important archaeological confirmations of John's Gospel."
           }
         ],
@@ -42,50 +42,50 @@
           "refs": [
             {
               "ref": "Deut 2:14",
-              "note": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" \u2014 Israel's 38 years of wilderness wandering, the same duration as the man's illness."
+              "note": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" — Israel's 38 years of wilderness wandering, the same duration as the man's illness."
             },
             {
               "ref": "Ezek 36:26-27",
-              "note": "\"I will give you a new heart and put a new spirit in you\" \u2014 the divine initiative in restoration that parallels Jesus's healing without any request from the man."
+              "note": "\"I will give you a new heart and put a new spirit in you\" — the divine initiative in restoration that parallels Jesus's healing without any request from the man."
             },
             {
               "ref": "Mark 2:1-12",
-              "note": "The healing of the paralytic let down through the roof \u2014 parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity."
+              "note": "The healing of the paralytic let down through the roof — parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:6",
-              "note": "\"Do you want to get well?\" \u2014 the question exposes the man's helplessness but also tests his orientation. His answer reveals he is focused on method (the pool, being helped in) rather than person. He does not ask Jesus for help \u2014 he explains why the usual method hasn't worked. Jesus bypasses the method entirely and addresses the man directly. Salvation works the same way: it comes not through our performance of the right ritual at the right moment but through direct encounter with the person of Christ."
+              "note": "\"Do you want to get well?\" — the question exposes the man's helplessness but also tests his orientation. His answer reveals he is focused on method (the pool, being helped in) rather than person. He does not ask Jesus for help — he explains why the usual method hasn't worked. Jesus bypasses the method entirely and addresses the man directly. Salvation works the same way: it comes not through our performance of the right ritual at the right moment but through direct encounter with the person of Christ."
             },
             {
               "ref": "5:14",
-              "note": "\"Stop sinning or something worse may happen to you\" \u2014 Jesus does not teach here that illness is always the consequence of specific sin (he explicitly rejects that in 9:3). But he recognises that in this man's case there was a connection, and the healing requires moral as well as physical response. The warning is pastoral, not juridical."
+              "note": "\"Stop sinning or something worse may happen to you\" — Jesus does not teach here that illness is always the consequence of specific sin (he explicitly rejects that in 9:3). But he recognises that in this man's case there was a connection, and the healing requires moral as well as physical response. The warning is pastoral, not juridical."
             },
             {
               "ref": "5:17",
-              "note": "\"My Father is always at his work to this very day, and I too am working\" \u2014 a stunning Sabbath claim. Jewish theology held that God continued to sustain creation on the Sabbath (providential upholding is not work that violates the Sabbath). Jesus claims to do exactly what the Father does \u2014 including on the Sabbath. The logic of his opponents is correct: this is equality with God. Jesus does not deny it; he develops it in the discourse that follows."
+              "note": "\"My Father is always at his work to this very day, and I too am working\" — a stunning Sabbath claim. Jewish theology held that God continued to sustain creation on the Sabbath (providential upholding is not work that violates the Sabbath). Jesus claims to do exactly what the Father does — including on the Sabbath. The logic of his opponents is correct: this is equality with God. Jesus does not deny it; he develops it in the discourse that follows."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:14",
-              "note": "Calvin uses \"stop sinning or something worse may happen to you\" to argue that physical suffering can serve as divine chastisement in individual cases, without being a universal principle (as Jesus explicitly denies in 9:3). The pastoral wisdom is: when suffering comes, it is worth examining one's life \u2014 not because all suffering is punitive but because sometimes it is, and the examination has value regardless."
+              "note": "Calvin uses \"stop sinning or something worse may happen to you\" to argue that physical suffering can serve as divine chastisement in individual cases, without being a universal principle (as Jesus explicitly denies in 9:3). The pastoral wisdom is: when suffering comes, it is worth examining one's life — not because all suffering is punitive but because sometimes it is, and the examination has value regardless."
             },
             {
               "ref": "5:17-18",
-              "note": "The Jewish leaders correctly infer that Jesus is claiming equality with God \u2014 and they correctly identify this as the logical consequence of his \"my Father\" language. Calvin notes that Jesus does not dispute their inference; he confirms it and develops it in the discourse. The equality is real, not metaphorical."
+              "note": "The Jewish leaders correctly infer that Jesus is claiming equality with God — and they correctly identify this as the logical consequence of his \"my Father\" language. Calvin notes that Jesus does not dispute their inference; he confirms it and develops it in the discourse. The equality is real, not metaphorical."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:3b-4",
@@ -93,12 +93,12 @@
             },
             {
               "ref": "5:2",
-              "note": "\"Bethesda\" \u2014 the name means \"house of mercy\" or \"house of flowing water\" in Aramaic. The manuscripts vary: Bethzatha, Bethsaida, Bethesda. NA28 follows \"Bethesda\" as the best-attested reading."
+              "note": "\"Bethesda\" — the name means \"house of mercy\" or \"house of flowing water\" in Aramaic. The manuscripts vary: Bethzatha, Bethsaida, Bethesda. NA28 follows \"Bethesda\" as the best-attested reading."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "5:6",
@@ -106,27 +106,27 @@
             },
             {
               "ref": "5:17",
-              "note": "Augustine: \"My Father works until now and I work. He does not say 'my Father worked and now rests and I also rest,' but 'my Father works until now' \u2014 that is, right up to this moment \u2014 'and I too am working.' The Father's Sabbath rest is not idleness but a hidden working; the Son's working on the Sabbath is the visible expression of that hidden work.\""
+              "note": "Augustine: \"My Father works until now and I work. He does not say 'my Father worked and now rests and I also rest,' but 'my Father works until now' — that is, right up to this moment — 'and I too am working.' The Father's Sabbath rest is not idleness but a hidden working; the Son's working on the Sabbath is the visible expression of that hidden work.\""
             }
           ]
         },
         "hist": {
-          "context": "The Pool of Bethesda\nArchaeological excavations in Jerusalem have confirmed the existence of the Pool of Bethesda near the Sheep Gate, with its five covered colonnades \u2014 exactly as John describes (v.2). The twin pools with the central colonnade creating five porticoes were discovered in the 19th century. This is one of John's precise topographical details now confirmed by archaeology, supporting the eyewitness character of the Gospel.\n\nThirty-Eight Years\nThe specific duration is probably historical, not symbolic \u2014 though early interpreters connected it to Israel's 38 years of wilderness wandering after Kadesh Barnea (Deut 2:14). Whether intentional or not, the parallel is suggestive: the man's condition mirrors Israel's long period of helplessness, waiting for a deliverance that never came through its own efforts."
+          "context": "The Pool of Bethesda\nArchaeological excavations in Jerusalem have confirmed the existence of the Pool of Bethesda near the Sheep Gate, with its five covered colonnades — exactly as John describes (v.2). The twin pools with the central colonnade creating five porticoes were discovered in the 19th century. This is one of John's precise topographical details now confirmed by archaeology, supporting the eyewitness character of the Gospel.\n\nThirty-Eight Years\nThe specific duration is probably historical, not symbolic — though early interpreters connected it to Israel's 38 years of wilderness wandering after Kadesh Barnea (Deut 2:14). Whether intentional or not, the parallel is suggestive: the man's condition mirrors Israel's long period of helplessness, waiting for a deliverance that never came through its own efforts."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 16\u201330 \u2014 The Son\u2019s Authority: Equal with the Father",
+      "header": "Verses 16–30 — The Son’s Authority: Equal with the Father",
       "verse_start": 16,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "z\u014dopoie\u014d",
+            "word": "zōopoieō",
             "transliteration": "zo-o-poi-EH-o",
             "gloss": "give life / make alive",
-            "paragraph": "The verb (v.21) appears six times in John 5 and is one of John's most theologically concentrated words. The exclusive divine prerogative to give life \u2014 exercised by the Father in resurrection \u2014 is now delegated to the Son. This is not a general claim to healing but a claim to the same life-giving power that reverses death itself."
+            "paragraph": "The verb (v.21) appears six times in John 5 and is one of John's most theologically concentrated words. The exclusive divine prerogative to give life — exercised by the Father in resurrection — is now delegated to the Son. This is not a general claim to healing but a claim to the same life-giving power that reverses death itself."
           },
           {
             "word": "martyia",
@@ -138,7 +138,7 @@
         "places": [
           {
             "name": "Pool of Bethesda",
-            "coords": "31.7810\u00b0 N, 35.2367\u00b0 E",
+            "coords": "31.7810° N, 35.2367° E",
             "text": "Near the Sheep Gate (northeast of the Temple Mount), the Pool of Bethesda was a large double-pool complex used for ritual purification. Excavations since 1888 have confirmed John's description precisely: two pools separated by a rock-cut partition, with four outer colonnades and one central colonnade producing exactly five porticoes. The pool is now visible beneath the Church of Saint Anne in Jerusalem. This is one of the most important archaeological confirmations of John's Gospel."
           }
         ],
@@ -146,41 +146,41 @@
           "refs": [
             {
               "ref": "Deut 19:15",
-              "note": "\"A matter must be established by the testimony of two or three witnesses\" \u2014 the legal framework Jesus employs by presenting four witnesses for his claims."
+              "note": "\"A matter must be established by the testimony of two or three witnesses\" — the legal framework Jesus employs by presenting four witnesses for his claims."
             },
             {
               "ref": "Dan 12:2",
-              "note": "\"Multitudes who sleep in the dust of the earth will awake: some to everlasting life, others to shame and everlasting contempt\" \u2014 the OT resurrection background for v.29."
+              "note": "\"Multitudes who sleep in the dust of the earth will awake: some to everlasting life, others to shame and everlasting contempt\" — the OT resurrection background for v.29."
             },
             {
               "ref": "Luke 16:31",
-              "note": "\"If they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" \u2014 the same critique of Moses-reading-without-following as vv.45-47."
+              "note": "\"If they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" — the same critique of Moses-reading-without-following as vv.45-47."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:19-20",
-              "note": "\"The Son can do nothing by himself; he can do only what he sees his Father doing.\" This is not a statement of limitation but of perfect unity of will and action. The Son does not act independently because he does not want to: his will is perfectly aligned with the Father's. The analogy is of an apprentice who learns by watching the master \u2014 except that the apprentice here has perfect knowledge and perfect conformity. The relationship is one of love (v.20), not merely hierarchy."
+              "note": "\"The Son can do nothing by himself; he can do only what he sees his Father doing.\" This is not a statement of limitation but of perfect unity of will and action. The Son does not act independently because he does not want to: his will is perfectly aligned with the Father's. The analogy is of an apprentice who learns by watching the master — except that the apprentice here has perfect knowledge and perfect conformity. The relationship is one of love (v.20), not merely hierarchy."
             },
             {
               "ref": "5:24",
-              "note": "\"Whoever hears my word and believes him who sent me has eternal life and will not be judged but has crossed over from death to life\" \u2014 the perfect tense \"has crossed over\" (metabeb\u0113ken) indicates a completed transition: the believer is already on the life side of the death/life divide. Judgment is not a future threat for the one who believes; the verdict has already been given. This is John's consistent realised eschatology."
+              "note": "\"Whoever hears my word and believes him who sent me has eternal life and will not be judged but has crossed over from death to life\" — the perfect tense \"has crossed over\" (metabebēken) indicates a completed transition: the believer is already on the life side of the death/life divide. Judgment is not a future threat for the one who believes; the verdict has already been given. This is John's consistent realised eschatology."
             },
             {
               "ref": "5:39-40",
-              "note": "\"You study the Scriptures diligently because you think that in them you have eternal life. These are the very Scriptures that testify about me, yet you refuse to come to me to have life.\" One of the most searching statements in the Gospel: the Bible does not itself give life \u2014 it points to the one who does. The Pharisees had the Scriptures and missed the person the Scriptures pointed to. Scripture is the signpost; Jesus is the destination."
+              "note": "\"You study the Scriptures diligently because you think that in them you have eternal life. These are the very Scriptures that testify about me, yet you refuse to come to me to have life.\" One of the most searching statements in the Gospel: the Bible does not itself give life — it points to the one who does. The Pharisees had the Scriptures and missed the person the Scriptures pointed to. Scripture is the signpost; Jesus is the destination."
             },
             {
               "ref": "5:45-47",
-              "note": "\"Your accuser is Moses\" \u2014 the irony is devastating. The religious leaders claim Moses as their authority for rejecting Jesus; Jesus says Moses is their accuser because Moses wrote about him. The Scriptures they weaponise against Jesus are the Scriptures that, rightly read, convict them of rejecting the one Moses anticipated."
+              "note": "\"Your accuser is Moses\" — the irony is devastating. The religious leaders claim Moses as their authority for rejecting Jesus; Jesus says Moses is their accuser because Moses wrote about him. The Scriptures they weaponise against Jesus are the Scriptures that, rightly read, convict them of rejecting the one Moses anticipated."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:19",
@@ -193,20 +193,20 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:28-29",
-              "note": "\"All who are in their graves will hear his voice\" \u2014 a future resurrection of all, both righteous and wicked. This is one of the clearest statements of a general bodily resurrection in John, alongside an explicit final judgment based on deeds. It stands alongside the realised eschatology of v.24-25, both being true: eternal life is present now for believers (realised); the final resurrection is still future (futurist)."
+              "note": "\"All who are in their graves will hear his voice\" — a future resurrection of all, both righteous and wicked. This is one of the clearest statements of a general bodily resurrection in John, alongside an explicit final judgment based on deeds. It stands alongside the realised eschatology of v.24-25, both being true: eternal life is present now for believers (realised); the final resurrection is still future (futurist)."
             },
             {
               "ref": "5:44",
-              "note": "\"How can you believe since you accept glory from one another but do not seek the glory that comes from the only God?\" \u2014 the social and psychological analysis of unbelief: the desire for human approval creates a structural barrier to faith. This analysis anticipates the secret believers among the Pharisees who would not confess Jesus \"for fear they would be put out of the synagogue; for they loved human praise more than praise from God\" (12:42-43)."
+              "note": "\"How can you believe since you accept glory from one another but do not seek the glory that comes from the only God?\" — the social and psychological analysis of unbelief: the desire for human approval creates a structural barrier to faith. This analysis anticipates the secret believers among the Pharisees who would not confess Jesus \"for fear they would be put out of the synagogue; for they loved human praise more than praise from God\" (12:42-43)."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "5:39-40",
@@ -214,39 +214,39 @@
             },
             {
               "ref": "5:24",
-              "note": "Chrysostom: \"He has crossed over from death to life \u2014 past tense, completed action. Not 'will cross over' but 'has crossed over.' The transition is not at death but at faith. From the moment of believing, eternal life is possessed; the judgment that all fear has already been passed for the one who believes."
+              "note": "Chrysostom: \"He has crossed over from death to life — past tense, completed action. Not 'will cross over' but 'has crossed over.' The transition is not at death but at faith. From the moment of believing, eternal life is possessed; the judgment that all fear has already been passed for the one who believes."
             }
           ]
         },
         "hist": {
-          "context": "The Discourse Structure\nThe discourse of 5:19-47 is John's first extended Christological teaching. It follows the pattern that recurs throughout John: a sign \u2192 controversy \u2192 extended discourse explaining the sign's theological significance. The healing (5:1-18) generates the Sabbath/equality controversy; the discourse (5:19-47) unpacks what \"equal with God\" means: shared life-giving, shared judgment, shared honor.\n\nThe Four Witnesses\nJewish law required two or three witnesses to establish a testimony (Deut 17:6; 19:15). Jesus presents four, arranged in ascending order: John the Baptist (human, reliable but limited), the works (divine, more weighty), the Father's testimony (the definitive divine witness), and the Scriptures/Moses (the authority the opponents claim but do not actually heed)."
+          "context": "The Discourse Structure\nThe discourse of 5:19-47 is John's first extended Christological teaching. It follows the pattern that recurs throughout John: a sign → controversy → extended discourse explaining the sign's theological significance. The healing (5:1-18) generates the Sabbath/equality controversy; the discourse (5:19-47) unpacks what \"equal with God\" means: shared life-giving, shared judgment, shared honor.\n\nThe Four Witnesses\nJewish law required two or three witnesses to establish a testimony (Deut 17:6; 19:15). Jesus presents four, arranged in ascending order: John the Baptist (human, reliable but limited), the works (divine, more weighty), the Father's testimony (the definitive divine witness), and the Scriptures/Moses (the authority the opponents claim but do not actually heed)."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201347 \u2014 Witnesses to the Son: John, Works, Father, Scripture",
+      "header": "Verses 31–47 — Witnesses to the Son: John, Works, Father, Scripture",
       "verse_start": 31,
       "verse_end": 47,
       "panels": {
         "heb": [
           {
-            "word": "theleis hygi\u0113s genesthai",
-            "transliteration": "THE-leis hy-GI-\u0113s ge-NES-thai",
+            "word": "theleis hygiēs genesthai",
+            "transliteration": "THE-leis hy-GI-ēs ge-NES-thai",
             "gloss": "Do you want to get well?",
-            "paragraph": "Jesus's question to the man (v.6) is not therapeutic conversation \u2014 it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
+            "paragraph": "Jesus's question to the man (v.6) is not therapeutic conversation — it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
           },
           {
-            "word": "ison heautou poi\u014dn t\u014d the\u014d",
+            "word": "ison heautou poiōn tō theō",
             "transliteration": "I-son heau-TOU poi-ON to the-O",
             "gloss": "making himself equal with God",
-            "paragraph": "The Jewish leaders' charge (v.18) is not a misunderstanding \u2014 it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 \u2014 doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
+            "paragraph": "The Jewish leaders' charge (v.18) is not a misunderstanding — it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 — doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
           }
         ],
         "places": [
           {
             "name": "Pool of Bethesda",
-            "coords": "31.7810\u00b0 N, 35.2367\u00b0 E",
+            "coords": "31.7810° N, 35.2367° E",
             "text": "Near the Sheep Gate (northeast of the Temple Mount), the Pool of Bethesda was a large double-pool complex used for ritual purification. Excavations since 1888 have confirmed John's description precisely: two pools separated by a rock-cut partition, with four outer colonnades and one central colonnade producing exactly five porticoes. The pool is now visible beneath the Church of Saint Anne in Jerusalem. This is one of the most important archaeological confirmations of John's Gospel."
           }
         ],
@@ -254,76 +254,36 @@
           "refs": [
             {
               "ref": "Deut 2:14",
-              "note": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" \u2014 Israel's 38 years of wilderness wandering, the same duration as the man's illness."
+              "note": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" — Israel's 38 years of wilderness wandering, the same duration as the man's illness."
             },
             {
               "ref": "Ezek 36:26-27",
-              "note": "\"I will give you a new heart and put a new spirit in you\" \u2014 the divine initiative in restoration that parallels Jesus's healing without any request from the man."
+              "note": "\"I will give you a new heart and put a new spirit in you\" — the divine initiative in restoration that parallels Jesus's healing without any request from the man."
             },
             {
               "ref": "Mark 2:1-12",
-              "note": "The healing of the paralytic let down through the roof \u2014 parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity."
+              "note": "The healing of the paralytic let down through the roof — parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "\"Do you want to get well?\" \u2014 the question exposes the man's helplessness but also tests his orientation. His answer reveals he is focused on method (the pool, being helped in) rather than person. He does not ask Jesus for help \u2014 he explains why the usual method hasn't worked. Jesus bypasses the method entirely and addresses the man directly. Salvation works the same way: it comes not through our performance of the right ritual at the right moment but through direct encounter with the person of Christ."
-            },
-            {
-              "ref": "5:14",
-              "note": "\"Stop sinning or something worse may happen to you\" \u2014 Jesus does not teach here that illness is always the consequence of specific sin (he explicitly rejects that in 9:3). But he recognises that in this man's case there was a connection, and the healing requires moral as well as physical response. The warning is pastoral, not juridical."
-            },
-            {
-              "ref": "5:17",
-              "note": "\"My Father is always at his work to this very day, and I too am working\" \u2014 a stunning Sabbath claim. Jewish theology held that God continued to sustain creation on the Sabbath (providential upholding is not work that violates the Sabbath). Jesus claims to do exactly what the Father does \u2014 including on the Sabbath. The logic of his opponents is correct: this is equality with God. Jesus does not deny it; he develops it in the discourse that follows."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:14",
-              "note": "Calvin uses \"stop sinning or something worse may happen to you\" to argue that physical suffering can serve as divine chastisement in individual cases, without being a universal principle (as Jesus explicitly denies in 9:3). The pastoral wisdom is: when suffering comes, it is worth examining one's life \u2014 not because all suffering is punitive but because sometimes it is, and the examination has value regardless."
-            },
-            {
-              "ref": "5:17-18",
-              "note": "The Jewish leaders correctly infer that Jesus is claiming equality with God \u2014 and they correctly identify this as the logical consequence of his \"my Father\" language. Calvin notes that Jesus does not dispute their inference; he confirms it and develops it in the discourse. The equality is real, not metaphorical."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:3b-4",
-              "note": "Verses 3b-4 (\"waiting for the moving of the waters. From time to time an angel of the Lord would come down and stir up the waters...\") are absent from the oldest and best manuscripts (P66, P75, Sinaiticus, Vaticanus). NA28 omits them entirely. They are a later scribal addition explaining the popular belief about the pool's healing properties that the man references in v.7."
-            },
-            {
-              "ref": "5:2",
-              "note": "\"Bethesda\" \u2014 the name means \"house of mercy\" or \"house of flowing water\" in Aramaic. The manuscripts vary: Bethzatha, Bethsaida, Bethesda. NA28 follows \"Bethesda\" as the best-attested reading."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "5:6",
-              "note": "Chrysostom: \"Do you want to get well? Why does he ask? He already knows. He asks not to learn but to open the man's desire, to kindle his hope, to prepare him to receive the gift. The question is the first part of the cure.\""
-            },
-            {
-              "ref": "5:17",
-              "note": "Augustine: \"My Father works until now and I work. He does not say 'my Father worked and now rests and I also rest,' but 'my Father works until now' \u2014 that is, right up to this moment \u2014 'and I too am working.' The Father's Sabbath rest is not idleness but a hidden working; the Son's working on the Sabbath is the visible expression of that hidden work.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Pool of Bethesda\nArchaeological excavations in Jerusalem have confirmed the existence of the Pool of Bethesda near the Sheep Gate, with its five covered colonnades \u2014 exactly as John describes (v.2). The twin pools with the central colonnade creating five porticoes were discovered in the 19th century. This is one of John's precise topographical details now confirmed by archaeology, supporting the eyewitness character of the Gospel.\n\nThirty-Eight Years\nThe specific duration is probably historical, not symbolic \u2014 though early interpreters connected it to Israel's 38 years of wilderness wandering after Kadesh Barnea (Deut 2:14). Whether intentional or not, the parallel is suggestive: the man's condition mirrors Israel's long period of helplessness, waiting for a deliverance that never came through its own efforts."
+          "context": "The Pool of Bethesda\nArchaeological excavations in Jerusalem have confirmed the existence of the Pool of Bethesda near the Sheep Gate, with its five covered colonnades — exactly as John describes (v.2). The twin pools with the central colonnade creating five porticoes were discovered in the 19th century. This is one of John's precise topographical details now confirmed by archaeology, supporting the eyewitness character of the Gospel.\n\nThirty-Eight Years\nThe specific duration is probably historical, not symbolic — though early interpreters connected it to Israel's 38 years of wilderness wandering after Kadesh Barnea (Deut 2:14). Whether intentional or not, the parallel is suggestive: the man's condition mirrors Israel's long period of helplessness, waiting for a deliverance that never came through its own efforts."
         }
       }
     }
@@ -351,9 +311,9 @@
         "text": "Jews is a key figure in Scripture Walkthrough."
       },
       {
-        "name": "Peter\u2197 People",
+        "name": "Peter↗ People",
         "role": "Lead apostle; spokesperson for the Jerusalem church",
-        "text": "Peter (Simon bar Jonah) dominates Acts 1\u201312 as the church\u2019s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4\u20135), raises Tabitha (Acts 9:36\u201342), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod\u2019s prison by an angel (Acts 12) closes his narrative in Acts; Paul\u2019s story takes over from ch.13."
+        "text": "Peter (Simon bar Jonah) dominates Acts 1–12 as the church’s primary spokesman and miracle-worker. He preaches at Pentecost (Acts 2), heals at the Beautiful Gate (Acts 3), defends before the Sanhedrin (Acts 4–5), raises Tabitha (Acts 9:36–42), and receives the vision that opens the gospel to Gentiles (Acts 10). His release from Herod’s prison by an angel (Acts 12) closes his narrative in Acts; Paul’s story takes over from ch.13."
       },
       {
         "name": "Thomas",
@@ -361,30 +321,30 @@
         "text": "Thomas is a key figure in Scripture Walkthrough."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ergazetai (5:17)</td><td>NIV: \"is always at his work\"; KJV: \"worketh hitherto\"; ESV: \"is working still\"; NRSV: \"is still working\". The present tense (\"is working\") captures the continuous divine activity that justifies Jesus's Sabbath healing.</td></tr><tr><td class=\"t-label\">metabeb\u0113ken (5:24)</td><td>NIV: \"has crossed over\"; KJV: \"is passed\"; ESV: \"has passed\"; NRSV: \"has passed\". The perfect tense indicating completed action is captured by NIV/ESV; KJV's \"is passed\" is slightly weaker.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ergazetai (5:17)</td><td>NIV: \"is always at his work\"; KJV: \"worketh hitherto\"; ESV: \"is working still\"; NRSV: \"is still working\". The present tense (\"is working\") captures the continuous divine activity that justifies Jesus's Sabbath healing.</td></tr><tr><td class=\"t-label\">metabebēken (5:24)</td><td>NIV: \"has crossed over\"; KJV: \"is passed\"; ESV: \"has passed\"; NRSV: \"has passed\". The perfect tense indicating completed action is captured by NIV/ESV; KJV's \"is passed\" is slightly weaker.</td></tr>",
     "src": [
       {
         "title": "Deuteronomy 19:15",
         "quote": "\"One witness is not enough to convict anyone accused of any crime or offense they may have committed. A matter must be established by the testimony of two or three witnesses.\"",
-        "note": "The legal principle Jesus's four-witness argument (5:31-47) exceeds \u2014 he provides double the minimum requirement for legal testimony."
+        "note": "The legal principle Jesus's four-witness argument (5:31-47) exceeds — he provides double the minimum requirement for legal testimony."
       }
     ],
     "rec": [
       {
         "who": "\"You Search the Scriptures\" in Hermeneutical Debate",
-        "text": "John 5:39-40 has been a touchstone in debates about the proper use of Scripture. The Reformation principle of sola scriptura has sometimes been misread as making Scripture itself the final object of faith; 5:39-40 corrects this by insisting that Scripture points beyond itself to Christ. Karl Barth's theology of revelation \u2014 Scripture as witness to revelation rather than revelation itself \u2014 draws heavily on this Johannine logic."
+        "text": "John 5:39-40 has been a touchstone in debates about the proper use of Scripture. The Reformation principle of sola scriptura has sometimes been misread as making Scripture itself the final object of faith; 5:39-40 corrects this by insisting that Scripture points beyond itself to Christ. Karl Barth's theology of revelation — Scripture as witness to revelation rather than revelation itself — draws heavily on this Johannine logic."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Legal Proceeding Structure \u2014 vv.31-47",
-          "text": "The section is structured as a formal legal defence: charge (v.18: making himself equal with God), Jesus's response to the charge (vv.19-30), presentation of witnesses (vv.31-47). John consistently frames controversy as courtroom drama \u2014 the whole Gospel can be read as a trial in which Jesus is simultaneously defendant, witness, and judge.",
+          "label": "Legal Proceeding Structure — vv.31-47",
+          "text": "The section is structured as a formal legal defence: charge (v.18: making himself equal with God), Jesus's response to the charge (vv.19-30), presentation of witnesses (vv.31-47). John consistently frames controversy as courtroom drama — the whole Gospel can be read as a trial in which Jesus is simultaneously defendant, witness, and judge.",
           "is_key": false
         },
         {
-          "label": "Sabbath Frame \u2014 vv.1-18 and the Law",
-          "text": "The healing on the Sabbath is not incidental but structural: it triggers the legal dispute that dominates the chapter. John frames Jesus's defense (vv.17-47) as a formal legal proceeding with witnesses (the Father, John, works, Scripture) \u2014 patterned after Hebrew trial rhetoric.",
+          "label": "Sabbath Frame — vv.1-18 and the Law",
+          "text": "The healing on the Sabbath is not incidental but structural: it triggers the legal dispute that dominates the chapter. John frames Jesus's defense (vv.17-47) as a formal legal proceeding with witnesses (the Father, John, works, Scripture) — patterned after Hebrew trial rhetoric.",
           "is_key": false
         }
       ],
@@ -392,22 +352,22 @@
     },
     "hebtext": [
       {
-        "word": "theleis hygi\u0113s genesthai",
-        "tlit": "THE-leis hy-GI-\u0113s ge-NES-thai",
+        "word": "theleis hygiēs genesthai",
+        "tlit": "THE-leis hy-GI-ēs ge-NES-thai",
         "gloss": "Do you want to get well?",
-        "note": "Jesus's question to the man (v.6) is not therapeutic conversation \u2014 it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
+        "note": "Jesus's question to the man (v.6) is not therapeutic conversation — it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
       },
       {
-        "word": "ison heautou poi\u014dn t\u014d the\u014d",
+        "word": "ison heautou poiōn tō theō",
         "tlit": "I-son heau-TOU poi-ON to the-O",
         "gloss": "making himself equal with God",
-        "note": "The Jewish leaders' charge (v.18) is not a misunderstanding \u2014 it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 \u2014 doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
+        "note": "The Jewish leaders' charge (v.18) is not a misunderstanding — it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 — doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
       },
       {
-        "word": "z\u014dopoie\u014d",
+        "word": "zōopoieō",
         "tlit": "zo-o-poi-EH-o",
         "gloss": "give life / make alive",
-        "note": "The verb (v.21) appears six times in John 5 and is one of John's most theologically concentrated words. The exclusive divine prerogative to give life \u2014 exercised by the Father in resurrection \u2014 is now delegated to the Son. This is not a general claim to healing but a claim to the same life-giving power that reverses death itself."
+        "note": "The verb (v.21) appears six times in John 5 and is one of John's most theologically concentrated words. The exclusive divine prerogative to give life — exercised by the Father in resurrection — is now delegated to the Son. This is not a general claim to healing but a claim to the same life-giving power that reverses death itself."
       },
       {
         "word": "martyia",
@@ -416,16 +376,16 @@
         "note": "The word and its cognates appear 9 times in vv.31-40, structuring the passage as a formal legal argument. Jesus presents four witnesses to his identity: (1) John the Baptist (vv.33-35); (2) his works (v.36); (3) the Father's own testimony (vv.37-38); (4) the Scriptures/Moses (vv.39-47). The passage is structured as a legal deposition responding to the charge of making himself equal with God."
       },
       {
-        "word": "theleis hygi\u0113s genesthai",
-        "tlit": "THE-leis hy-GI-\u0113s ge-NES-thai",
+        "word": "theleis hygiēs genesthai",
+        "tlit": "THE-leis hy-GI-ēs ge-NES-thai",
         "gloss": "Do you want to get well?",
-        "note": "Jesus's question to the man (v.6) is not therapeutic conversation \u2014 it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
+        "note": "Jesus's question to the man (v.6) is not therapeutic conversation — it is a theological penetration. Thirty-eight years of illness shapes identity; the question asks whether the man wants the identity change that healing brings. The man's answer reveals he does not yet understand: he thinks in terms of getting into the pool faster, not of a word that can heal without the pool."
       },
       {
-        "word": "ison heautou poi\u014dn t\u014d the\u014d",
+        "word": "ison heautou poiōn tō theō",
         "tlit": "I-son heau-TOU poi-ON to the-O",
         "gloss": "making himself equal with God",
-        "note": "The Jewish leaders' charge (v.18) is not a misunderstanding \u2014 it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 \u2014 doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
+        "note": "The Jewish leaders' charge (v.18) is not a misunderstanding — it is the correct inference from Jesus's claim. To call God \"my Father\" in the specific sense Jesus means (v.17 — doing what the Father does, working as the Father works) is to claim a unique divine Sonship that constitutes equality with God. The charge that would eventually condemn Jesus (19:7) is first formulated here."
       }
     ],
     "thread": [
@@ -433,42 +393,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Deut 2:14",
         "type": "Connection",
-        "text": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" \u2014 Israel's 38 years of wilderness wandering, the same duration as the man's illness.",
+        "text": "\"Thirty-eight years had passed from the time we left Kadesh Barnea until we crossed the Zered Valley\" — Israel's 38 years of wilderness wandering, the same duration as the man's illness.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 36:26-27",
         "type": "Echo",
-        "text": "\"I will give you a new heart and put a new spirit in you\" \u2014 the divine initiative in restoration that parallels Jesus's healing without any request from the man.",
+        "text": "\"I will give you a new heart and put a new spirit in you\" — the divine initiative in restoration that parallels Jesus's healing without any request from the man.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Mark 2:1-12",
         "type": "Echo",
-        "text": "The healing of the paralytic let down through the roof \u2014 parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity.",
+        "text": "The healing of the paralytic let down through the roof — parallel themes of Sabbath controversy, the connection between sin and illness (directly addressed in 5:14), and the authority to heal as evidence of divine identity.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Deut 19:15",
         "type": "Connection",
-        "text": "\"A matter must be established by the testimony of two or three witnesses\" \u2014 the legal framework Jesus employs by presenting four witnesses for his claims.",
+        "text": "\"A matter must be established by the testimony of two or three witnesses\" — the legal framework Jesus employs by presenting four witnesses for his claims.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Dan 12:2",
         "type": "Connection",
-        "text": "\"Multitudes who sleep in the dust of the earth will awake: some to everlasting life, others to shame and everlasting contempt\" \u2014 the OT resurrection background for v.29.",
+        "text": "\"Multitudes who sleep in the dust of the earth will awake: some to everlasting life, others to shame and everlasting contempt\" — the OT resurrection background for v.29.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Luke 16:31",
         "type": "Connection",
-        "text": "\"If they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" \u2014 the same critique of Moses-reading-without-following as vv.45-47.",
+        "text": "\"If they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" — the same critique of Moses-reading-without-following as vv.45-47.",
         "direction": "backward"
       }
     ],
@@ -477,7 +437,7 @@
         {
           "ref": "5:3b-4",
           "title": "Angel stirring the water",
-          "content": "NA28 omits vv.3b-4 entirely \u2014 absent from P66, P75, Sinaiticus, and Vaticanus. Almost certainly a scribal addition explaining the popular superstition about the pool's healing properties. The man's reference to \"when the water is stirred\" (v.7) makes sense without the explanatory gloss.",
+          "content": "NA28 omits vv.3b-4 entirely — absent from P66, P75, Sinaiticus, and Vaticanus. Almost certainly a scribal addition explaining the popular superstition about the pool's healing properties. The man's reference to \"when the water is stirred\" (v.7) makes sense without the explanatory gloss.",
           "note": "The omission is virtually certain. The best witnesses unanimously lack the passage; it reads as an explanatory gloss for readers unfamiliar with the local tradition."
         }
       ],
@@ -513,7 +473,7 @@
             }
           ],
           "consensus": "Virtually all textual critics classify 5:3b-4 as a scribal interpolation. The passage is absent from the best witnesses, shows non-Johannine vocabulary, and was clearly added to explain an otherwise puzzling reference to popular belief.",
-          "significance": "The interpolation shows how ancient copyists functioned as interpreters. The scribe who added verse 4 was not inventing theology but explaining what the local population believed. The episode itself is unaffected \u2014 Jesus's act of healing on the Sabbath stands regardless of which theory of the pool is correct."
+          "significance": "The interpolation shows how ancient copyists functioned as interpreters. The scribe who added verse 4 was not inventing theology but explaining what the local population believed. The episode itself is unaffected — Jesus's act of healing on the Sabbath stands regardless of which theory of the pool is correct."
         }
       ]
     },
@@ -561,7 +521,7 @@
           "score": 10
         }
       ],
-      "note": "John 5 develops the \"equal with God\" charge of 5:18 into the most explicit Christological discourse in the Gospel so far. The Son gives life (as the Father gives life), exercises judgment (as the Father exercises judgment), and receives honor (as the Father receives honor). These three divine prerogatives \u2014 life, judgment, honor \u2014 constitute the argument: Jesus is not merely a great teacher or prophet but the one who does what only God does. The chapter ends with a devastating reversal: the accusers' own scriptures and their own Moses accuse them."
+      "note": "John 5 develops the \"equal with God\" charge of 5:18 into the most explicit Christological discourse in the Gospel so far. The Son gives life (as the Father gives life), exercises judgment (as the Father exercises judgment), and receives honor (as the Father receives honor). These three divine prerogatives — life, judgment, honor — constitute the argument: Jesus is not merely a great teacher or prophet but the one who does what only God does. The chapter ends with a devastating reversal: the accusers' own scriptures and their own Moses accuse them."
     }
   },
   "vhl_groups": [
@@ -685,7 +645,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'My Father is always at his work to this very day, and I too am working' (v. 17). Sabbath controversy escalates: Jesus claims divine prerogative. 'Making himself equal with God' (v. 18)\u2014the Jews understand the claim.",
+      "tip": "'My Father is always at his work to this very day, and I too am working' (v. 17). Sabbath controversy escalates: Jesus claims divine prerogative. 'Making himself equal with God' (v. 18)—the Jews understand the claim.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/6.json
+++ b/content/john/6.json
@@ -7,34 +7,34 @@
   "subtitle": "The Bread of Life",
   "timeline_link": {
     "event_id": "feeding-five-thousand",
-    "text": "See on Timeline \u2014 Feeding of the Five Thousand"
+    "text": "See on Timeline — Feeding of the Five Thousand"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201321 \u2014 Feeding Five Thousand; Walking on Water",
+      "header": "Verses 1–21 — Feeding Five Thousand; Walking on Water",
       "verse_start": 1,
       "verse_end": 21,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am / It is I",
-            "paragraph": "Jesus's words to the frightened disciples (v.20) \u2014 ego eimi \u2014 are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany \u2014 God walking on the sea (Job 9:8; Ps 77:19)."
+            "paragraph": "Jesus's words to the frightened disciples (v.20) — ego eimi — are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany — God walking on the sea (Job 9:8; Ps 77:19)."
           },
           {
-            "word": "eucharist\u014d",
+            "word": "eucharistō",
             "transliteration": "eu-cha-ris-TO",
             "gloss": "give thanks / eucharist",
-            "paragraph": "Jesus \"gave thanks\" (eucharist\u0113sas, v.11, v.23) before distributing the bread \u2014 the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
+            "paragraph": "Jesus \"gave thanks\" (eucharistēsas, v.11, v.23) before distributing the bread — the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
           }
         ],
         "places": [
           {
             "name": "Sea of Galilee",
-            "coords": "32.8208\u00b0 N, 35.5847\u00b0 E",
+            "coords": "32.8208° N, 35.5847° E",
             "text": "Also called the Sea of Tiberias (after the city Herod Antipas built on its western shore, named for Emperor Tiberius). A freshwater lake 13 miles long and 8 miles wide, 680 feet below sea level. Famous for sudden violent storms funnelled from the surrounding hills. Jesus walked on this lake (6:19), calmed its storms (Mark 4:39), and most of his Galilean ministry centred on its northern shore. The feeding of the 5,000 took place on its northeastern shore."
           }
         ],
@@ -42,41 +42,41 @@
           "refs": [
             {
               "ref": "Exod 16:1-36",
-              "note": "The manna in the wilderness \u2014 the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse."
+              "note": "The manna in the wilderness — the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse."
             },
             {
               "ref": "Job 9:8",
-              "note": "\"He alone stretches out the heavens and treads on the waves of the sea\" \u2014 walking on the sea as an exclusively divine attribute."
+              "note": "\"He alone stretches out the heavens and treads on the waves of the sea\" — walking on the sea as an exclusively divine attribute."
             },
             {
               "ref": "Ps 107:23-32",
-              "note": "God stilling the storm and bringing the boat safely to harbor \u2014 the psalm background for the sea-crossing episode."
+              "note": "God stilling the storm and bringing the boat safely to harbor — the psalm background for the sea-crossing episode."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:6",
-              "note": "\"He asked this only to test him, for he already had in mind what he was going to do\" \u2014 John's editorial note reveals the divine knowledge and pedagogical intent behind the question. Philip's calculation (half a year's wages insufficient for a bite each) is accurate within the natural order; Jesus is operating in a different order. The question is designed to establish the disciples' recognition that what is about to happen is impossible by natural means."
+              "note": "\"He asked this only to test him, for he already had in mind what he was going to do\" — John's editorial note reveals the divine knowledge and pedagogical intent behind the question. Philip's calculation (half a year's wages insufficient for a bite each) is accurate within the natural order; Jesus is operating in a different order. The question is designed to establish the disciples' recognition that what is about to happen is impossible by natural means."
             },
             {
               "ref": "6:12",
-              "note": "\"Gather the pieces that are left over. Let nothing be wasted\" \u2014 the twelve baskets of leftovers exceed the original five loaves many times over. The superabundance is the sign: messianic provision does not merely meet the need \u2014 it overflows it. And yet Jesus commands careful stewardship of the overflow. Miraculous provision and responsible care for resources are not incompatible."
+              "note": "\"Gather the pieces that are left over. Let nothing be wasted\" — the twelve baskets of leftovers exceed the original five loaves many times over. The superabundance is the sign: messianic provision does not merely meet the need — it overflows it. And yet Jesus commands careful stewardship of the overflow. Miraculous provision and responsible care for resources are not incompatible."
             },
             {
               "ref": "6:15",
-              "note": "\"Jesus, knowing that they intended to come and make him king by force, withdrew\" \u2014 the crowd's messianic enthusiasm is real but wrong. They want a political-military messiah who will feed armies and overthrow Rome. Jesus withdraws from this precisely to protect the nature of his kingship: he will be king, but through the cross, not through crowd acclamation."
+              "note": "\"Jesus, knowing that they intended to come and make him king by force, withdrew\" — the crowd's messianic enthusiasm is real but wrong. They want a political-military messiah who will feed armies and overthrow Rome. Jesus withdraws from this precisely to protect the nature of his kingship: he will be king, but through the cross, not through crowd acclamation."
             },
             {
               "ref": "6:20",
-              "note": "\"It is I; don't be afraid\" \u2014 eg\u014d eimi is both the practical reassurance (it's me, not a ghost) and the divine name. The disciples' fear before a theophany is the standard biblical response to divine presence. Jesus's \"don't be afraid\" is the standard divine response to human terror at the presence of the holy."
+              "note": "\"It is I; don't be afraid\" — egō eimi is both the practical reassurance (it's me, not a ghost) and the divine name. The disciples' fear before a theophany is the standard biblical response to divine presence. Jesus's \"don't be afraid\" is the standard divine response to human terror at the presence of the holy."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:11-12",
@@ -89,60 +89,60 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "6:4",
-              "note": "\"The Jewish Passover was near\" \u2014 one of three Passovers mentioned in John (2:13; 6:4; 11:55), providing the chronological structure for a three-year ministry. This middle Passover anchors the Galilean ministry between the Jerusalem Passover of ch.2-5 and the Jerusalem Passover of the passion."
+              "note": "\"The Jewish Passover was near\" — one of three Passovers mentioned in John (2:13; 6:4; 11:55), providing the chronological structure for a three-year ministry. This middle Passover anchors the Galilean ministry between the Jerusalem Passover of ch.2-5 and the Jerusalem Passover of the passion."
             },
             {
               "ref": "6:21",
-              "note": "\"Immediately the boat reached the shore where they were heading\" \u2014 possibly a second miracle (instantaneous arrival) or simply the natural result of the storm ceasing when Jesus entered. John does not specify. The ambiguity may be intentional."
+              "note": "\"Immediately the boat reached the shore where they were heading\" — possibly a second miracle (instantaneous arrival) or simply the natural result of the storm ceasing when Jesus entered. John does not specify. The ambiguity may be intentional."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "6:11",
-              "note": "Augustine: \"Five loaves and two fish: what are these among so many? But when the Lord blesses, the little becomes much. The blessing multiplies the bread in the hands of those distributing it, not in the mass of the bread itself. The miracle is continuous \u2014 from hand to hand the bread increases."
+              "note": "Augustine: \"Five loaves and two fish: what are these among so many? But when the Lord blesses, the little becomes much. The blessing multiplies the bread in the hands of those distributing it, not in the mass of the bread itself. The miracle is continuous — from hand to hand the bread increases."
             },
             {
               "ref": "6:20",
-              "note": "Chrysostom: \"It is I \u2014 do not be afraid. He first identified himself, then commanded them not to fear. For to know who was present was the cure of their fear. When they knew it was not a phantom but the Lord, their fear dissolved into wonder and then into worship.\""
+              "note": "Chrysostom: \"It is I — do not be afraid. He first identified himself, then commanded them not to fear. For to know who was present was the cure of their fear. When they knew it was not a phantom but the Lord, their fear dissolved into wonder and then into worship.\""
             }
           ]
         },
         "hist": {
-          "context": "Passover Setting\nJohn specifies that \"the Jewish Passover Festival was near\" (v.4) \u2014 placing the feeding in the Passover framework and connecting it to the Exodus manna. The feeding of 5,000 echoes Moses feeding Israel in the wilderness (Exod 16; Num 11); the discourse (6:31-58) makes the Exodus connection explicit. Jesus is the new Moses who gives not bread from heaven (manna) but is himself the bread from heaven.\n\nWalking on Water as Theophany\nThe OT consistently attributes walking on the sea to God alone: \"He alone stretches out the heavens and treads on the waves of the sea\" (Job 9:8). \"Your path led through the sea, your way through the mighty waters\" (Ps 77:19). When Jesus walks on water and says \"I am\" (eg\u014d eimi), John is presenting a theophany: the disciples are in the presence of YHWH."
+          "context": "Passover Setting\nJohn specifies that \"the Jewish Passover Festival was near\" (v.4) — placing the feeding in the Passover framework and connecting it to the Exodus manna. The feeding of 5,000 echoes Moses feeding Israel in the wilderness (Exod 16; Num 11); the discourse (6:31-58) makes the Exodus connection explicit. Jesus is the new Moses who gives not bread from heaven (manna) but is himself the bread from heaven.\n\nWalking on Water as Theophany\nThe OT consistently attributes walking on the sea to God alone: \"He alone stretches out the heavens and treads on the waves of the sea\" (Job 9:8). \"Your path led through the sea, your way through the mighty waters\" (Ps 77:19). When Jesus walks on water and says \"I am\" (egō eimi), John is presenting a theophany: the disciples are in the presence of YHWH."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 22\u201340 \u2014 The Bread of Life Discourse: I Am the Bread",
+      "header": "Verses 22–40 — The Bread of Life Discourse: I Am the Bread",
       "verse_start": 22,
       "verse_end": 40,
       "panels": {
         "heb": [
           {
-            "word": "Eg\u014d eimi ho artos t\u0113s z\u014d\u0113s",
-            "transliteration": "e-GO ei-MI ho AR-tos t\u0113s ZO-\u0113s",
+            "word": "Egō eimi ho artos tēs zōēs",
+            "transliteration": "e-GO ei-MI ho AR-tos tēs ZO-ēs",
             "gloss": "I am the bread of life",
-            "paragraph": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses eg\u014d eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
+            "paragraph": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses egō eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
           },
           {
-            "word": "tr\u014dg\u014d",
+            "word": "trōgō",
             "transliteration": "TRO-go",
             "gloss": "eat / gnaw / munch (physical eating)",
-            "paragraph": "In vv.54-58, John shifts from the more general phag\u014d (eat) to the more physical tr\u014dg\u014d (to munch, chew \u2014 used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
+            "paragraph": "In vv.54-58, John shifts from the more general phagō (eat) to the more physical trōgō (to munch, chew — used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
           }
         ],
         "places": [
           {
             "name": "Sea of Galilee",
-            "coords": "32.8208\u00b0 N, 35.5847\u00b0 E",
+            "coords": "32.8208° N, 35.5847° E",
             "text": "Also called the Sea of Tiberias (after the city Herod Antipas built on its western shore, named for Emperor Tiberius). A freshwater lake 13 miles long and 8 miles wide, 680 feet below sea level. Famous for sudden violent storms funnelled from the surrounding hills. Jesus walked on this lake (6:19), calmed its storms (Mark 4:39), and most of his Galilean ministry centred on its northern shore. The feeding of the 5,000 took place on its northeastern shore."
           }
         ],
@@ -150,7 +150,7 @@
           "refs": [
             {
               "ref": "Exod 16:4",
-              "note": "\"I will rain down bread from heaven for you\" \u2014 the manna promise that the crowd invokes (v.31) and Jesus reinterprets."
+              "note": "\"I will rain down bread from heaven for you\" — the manna promise that the crowd invokes (v.31) and Jesus reinterprets."
             },
             {
               "ref": "Ps 78:24-25",
@@ -158,43 +158,43 @@
             },
             {
               "ref": "Isa 55:1-3",
-              "note": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" \u2014 the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35)."
+              "note": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" — the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35)."
             }
           ],
           "echoes": [
             {
-              "source_ref": "Exodus 16:4\u201315",
-              "target_ref": "John 6:31\u201335",
+              "source_ref": "Exodus 16:4–15",
+              "target_ref": "John 6:31–35",
               "type": "typological",
-              "source_context": "God rained bread from heaven each morning in the wilderness. The manna was mysterious \u2014 'What is it?' \u2014 appearing with the dew, sustaining Israel for forty years.",
+              "source_context": "God rained bread from heaven each morning in the wilderness. The manna was mysterious — 'What is it?' — appearing with the dew, sustaining Israel for forty years.",
               "connection": "Jesus declares himself the true bread from heaven that gives life to the world. The manna sustained physical life temporarily; Jesus gives eternal life. Moses gave bread; the Father gives the Son.",
               "significance": "The Bread of Life discourse develops extended typology: the manna was good but temporary; whoever eats this bread will live forever. The wilderness provision pointed forward to incarnation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:29",
-              "note": "\"The work of God is this: to believe in the one he has sent\" \u2014 the most compressed answer to the religion-as-work problem in the NT. The crowd asks what works they must perform; Jesus answers that the one work God requires is not a work at all in the usual sense but a disposition of trust. Faith is the \"work\" God commands \u2014 and it is entirely God-enabled (v.44)."
+              "note": "\"The work of God is this: to believe in the one he has sent\" — the most compressed answer to the religion-as-work problem in the NT. The crowd asks what works they must perform; Jesus answers that the one work God requires is not a work at all in the usual sense but a disposition of trust. Faith is the \"work\" God commands — and it is entirely God-enabled (v.44)."
             },
             {
               "ref": "6:37",
-              "note": "\"All those the Father gives me will come to me, and whoever comes to me I will never drive away\" \u2014 two sides of divine election and human coming. Divine election (the Father gives) does not preclude human coming; human coming does not preclude divine election. Both are affirmed simultaneously. The security offered is absolute: Jesus will \"never drive away\" (ou m\u0113 ekbal\u014d \u2014 double negative for strongest possible negation) any who come."
+              "note": "\"All those the Father gives me will come to me, and whoever comes to me I will never drive away\" — two sides of divine election and human coming. Divine election (the Father gives) does not preclude human coming; human coming does not preclude divine election. Both are affirmed simultaneously. The security offered is absolute: Jesus will \"never drive away\" (ou mē ekbalō — double negative for strongest possible negation) any who come."
             },
             {
               "ref": "6:44",
-              "note": "\"No one can come to me unless the Father who sent me draws them\" \u2014 one of John's strongest statements of divine initiative in salvation. The Greek helk\u014d (draws) can mean \"drag\" (as in dragging a net, v.21:6). Coming to Jesus is not an unaided human decision; it is the result of the Father's drawing. The Arminian tradition reads this as a universal drawing (cf. 12:32 \u2014 \"I will draw all people\"); the Calvinist tradition reads it as an efficacious drawing of the elect."
+              "note": "\"No one can come to me unless the Father who sent me draws them\" — one of John's strongest statements of divine initiative in salvation. The Greek helkō (draws) can mean \"drag\" (as in dragging a net, v.21:6). Coming to Jesus is not an unaided human decision; it is the result of the Father's drawing. The Arminian tradition reads this as a universal drawing (cf. 12:32 — \"I will draw all people\"); the Calvinist tradition reads it as an efficacious drawing of the elect."
             },
             {
               "ref": "6:63",
-              "note": "\"The Spirit gives life; the flesh counts for nothing\" \u2014 this verse is the key to interpreting the whole discourse. \"Flesh\" here does not mean \"my flesh\" (v.51) but human flesh as the organ of perception: unaided human understanding cannot grasp the spiritual reality Jesus offers. The words are \"full of the Spirit and life\" \u2014 they must be received spiritually, not carnally. This suggests that \"eating\" throughout the discourse is a figure for receiving by faith, not for physical ingestion."
+              "note": "\"The Spirit gives life; the flesh counts for nothing\" — this verse is the key to interpreting the whole discourse. \"Flesh\" here does not mean \"my flesh\" (v.51) but human flesh as the organ of perception: unaided human understanding cannot grasp the spiritual reality Jesus offers. The words are \"full of the Spirit and life\" — they must be received spiritually, not carnally. This suggests that \"eating\" throughout the discourse is a figure for receiving by faith, not for physical ingestion."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:44",
@@ -202,25 +202,25 @@
             },
             {
               "ref": "6:63",
-              "note": "\"The Spirit gives life; the flesh counts for nothing\" \u2014 Calvin argues strongly that the eating of vv.53-58 is not a reference to the Eucharist but to faith. The words are \"spirit and life\" \u2014 spiritual realities received by the Spirit through faith, not physical elements. The Eucharist is the sign of this spiritual eating, not the eating itself."
+              "note": "\"The Spirit gives life; the flesh counts for nothing\" — Calvin argues strongly that the eating of vv.53-58 is not a reference to the Eucharist but to faith. The words are \"spirit and life\" — spiritual realities received by the Spirit through faith, not physical elements. The Eucharist is the sign of this spiritual eating, not the eating itself."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "6:44",
-              "note": "Helk\u014d (draw) \u2014 used elsewhere in John for dragging a net (21:6, 11) and for Jesus drawing all people to himself (12:32). The question of whether this drawing is universal or particular is one of the major hermeneutical divides in Reformed and Arminian theology. John 12:32 uses the same verb for drawing \"all people,\" suggesting at minimum a universal offer; 6:44 suggests that those who come have been specifically drawn by the Father."
+              "note": "Helkō (draw) — used elsewhere in John for dragging a net (21:6, 11) and for Jesus drawing all people to himself (12:32). The question of whether this drawing is universal or particular is one of the major hermeneutical divides in Reformed and Arminian theology. John 12:32 uses the same verb for drawing \"all people,\" suggesting at minimum a universal offer; 6:44 suggests that those who come have been specifically drawn by the Father."
             },
             {
               "ref": "6:54",
-              "note": "Tr\u014dg\u014d (eat/chew) vs phag\u014d (eat) \u2014 the shift to the more physical verb in vv.54-58 intensifies the statement. Whether this physicality points to the sacrament (the elements of the Eucharist) or simply emphasises the reality of spiritual appropriation is the central exegetical question of the passage."
+              "note": "Trōgō (eat/chew) vs phagō (eat) — the shift to the more physical verb in vv.54-58 intensifies the statement. Whether this physicality points to the sacrament (the elements of the Eucharist) or simply emphasises the reality of spiritual appropriation is the central exegetical question of the passage."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "6:35",
@@ -228,39 +228,39 @@
             },
             {
               "ref": "6:68-69",
-              "note": "Chrysostom: \"Lord, to whom shall we go? He does not say 'we will not go' \u2014 but 'to whom shall we go?' As if to say: You have us completely. There is nowhere else. We have tried everything else and found it empty. You have the words of eternal life: where else would we look?\""
+              "note": "Chrysostom: \"Lord, to whom shall we go? He does not say 'we will not go' — but 'to whom shall we go?' As if to say: You have us completely. There is nowhere else. We have tried everything else and found it empty. You have the words of eternal life: where else would we look?\""
             }
           ]
         },
         "hist": {
-          "context": "The Manna Typology\nThe crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v.31) to demand a sign like Moses's manna. Jesus corrects two assumptions: (1) Moses did not give the manna \u2014 the Father did; (2) the manna was not the true bread from heaven \u2014 that is what the Father is now giving. The typological argument is that manna was a shadow pointing to Christ, who is the substance. Those who ate manna died; those who eat this bread live forever (v.49-51).\n\nDivision and Departure\nThe discourse produces the most dramatic departure in the Gospel: \"many of his disciples turned back and no longer followed him\" (v.66). This is not the crowd \u2014 it is disciples. The hard teaching about eating his flesh and drinking his blood functions as a sifting: those who cannot accept the claim that Jesus is himself the life-giving gift depart. Peter's confession (v.68-69) stands in sharp contrast as the model of perseverant faith."
+          "context": "The Manna Typology\nThe crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v.31) to demand a sign like Moses's manna. Jesus corrects two assumptions: (1) Moses did not give the manna — the Father did; (2) the manna was not the true bread from heaven — that is what the Father is now giving. The typological argument is that manna was a shadow pointing to Christ, who is the substance. Those who ate manna died; those who eat this bread live forever (v.49-51).\n\nDivision and Departure\nThe discourse produces the most dramatic departure in the Gospel: \"many of his disciples turned back and no longer followed him\" (v.66). This is not the crowd — it is disciples. The hard teaching about eating his flesh and drinking his blood functions as a sifting: those who cannot accept the claim that Jesus is himself the life-giving gift depart. Peter's confession (v.68-69) stands in sharp contrast as the model of perseverant faith."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 41\u201359 \u2014 The Hard Teaching: Eat My Flesh, Drink My Blood",
+      "header": "Verses 41–59 — The Hard Teaching: Eat My Flesh, Drink My Blood",
       "verse_start": 41,
       "verse_end": 59,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am / It is I",
-            "paragraph": "Jesus's words to the frightened disciples (v.20) \u2014 ego eimi \u2014 are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany \u2014 God walking on the sea (Job 9:8; Ps 77:19)."
+            "paragraph": "Jesus's words to the frightened disciples (v.20) — ego eimi — are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany — God walking on the sea (Job 9:8; Ps 77:19)."
           },
           {
-            "word": "eucharist\u014d",
+            "word": "eucharistō",
             "transliteration": "eu-cha-ris-TO",
             "gloss": "give thanks / eucharist",
-            "paragraph": "Jesus \"gave thanks\" (eucharist\u0113sas, v.11, v.23) before distributing the bread \u2014 the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
+            "paragraph": "Jesus \"gave thanks\" (eucharistēsas, v.11, v.23) before distributing the bread — the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
           }
         ],
         "places": [
           {
             "name": "Sea of Galilee",
-            "coords": "32.8208\u00b0 N, 35.5847\u00b0 E",
+            "coords": "32.8208° N, 35.5847° E",
             "text": "Also called the Sea of Tiberias (after the city Herod Antipas built on its western shore, named for Emperor Tiberius). A freshwater lake 13 miles long and 8 miles wide, 680 feet below sea level. Famous for sudden violent storms funnelled from the surrounding hills. Jesus walked on this lake (6:19), calmed its storms (Mark 4:39), and most of his Galilean ministry centred on its northern shore. The feeding of the 5,000 took place on its northeastern shore."
           }
         ],
@@ -268,107 +268,63 @@
           "refs": [
             {
               "ref": "Exod 16:1-36",
-              "note": "The manna in the wilderness \u2014 the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse."
+              "note": "The manna in the wilderness — the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse."
             },
             {
               "ref": "Job 9:8",
-              "note": "\"He alone stretches out the heavens and treads on the waves of the sea\" \u2014 walking on the sea as an exclusively divine attribute."
+              "note": "\"He alone stretches out the heavens and treads on the waves of the sea\" — walking on the sea as an exclusively divine attribute."
             },
             {
               "ref": "Ps 107:23-32",
-              "note": "God stilling the storm and bringing the boat safely to harbor \u2014 the psalm background for the sea-crossing episode."
+              "note": "God stilling the storm and bringing the boat safely to harbor — the psalm background for the sea-crossing episode."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:6",
-              "note": "\"He asked this only to test him, for he already had in mind what he was going to do\" \u2014 John's editorial note reveals the divine knowledge and pedagogical intent behind the question. Philip's calculation (half a year's wages insufficient for a bite each) is accurate within the natural order; Jesus is operating in a different order. The question is designed to establish the disciples' recognition that what is about to happen is impossible by natural means."
-            },
-            {
-              "ref": "6:12",
-              "note": "\"Gather the pieces that are left over. Let nothing be wasted\" \u2014 the twelve baskets of leftovers exceed the original five loaves many times over. The superabundance is the sign: messianic provision does not merely meet the need \u2014 it overflows it. And yet Jesus commands careful stewardship of the overflow. Miraculous provision and responsible care for resources are not incompatible."
-            },
-            {
-              "ref": "6:15",
-              "note": "\"Jesus, knowing that they intended to come and make him king by force, withdrew\" \u2014 the crowd's messianic enthusiasm is real but wrong. They want a political-military messiah who will feed armies and overthrow Rome. Jesus withdraws from this precisely to protect the nature of his kingship: he will be king, but through the cross, not through crowd acclamation."
-            },
-            {
-              "ref": "6:20",
-              "note": "\"It is I; don't be afraid\" \u2014 eg\u014d eimi is both the practical reassurance (it's me, not a ghost) and the divine name. The disciples' fear before a theophany is the standard biblical response to divine presence. Jesus's \"don't be afraid\" is the standard divine response to human terror at the presence of the holy."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:11-12",
-              "note": "Calvin connects the gathering of leftovers to the doctrine of providence: God provides not only what is needed in the moment but with surplus, and the surplus is to be preserved, not wasted. Miraculous provision does not excuse carelessness with material resources; the miracle establishes divine ownership of all provision, which demands responsible stewardship."
-            },
-            {
-              "ref": "6:15",
-              "note": "Calvin uses Jesus's withdrawal from the would-be king-makers to argue against any theology that makes earthly political power the goal of Christ's mission. The church's temptation in every generation is to secure by political means what can only be secured by the cross. Jesus refuses this precisely where his popularity is highest."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:4",
-              "note": "\"The Jewish Passover was near\" \u2014 one of three Passovers mentioned in John (2:13; 6:4; 11:55), providing the chronological structure for a three-year ministry. This middle Passover anchors the Galilean ministry between the Jerusalem Passover of ch.2-5 and the Jerusalem Passover of the passion."
-            },
-            {
-              "ref": "6:21",
-              "note": "\"Immediately the boat reached the shore where they were heading\" \u2014 possibly a second miracle (instantaneous arrival) or simply the natural result of the storm ceasing when Jesus entered. John does not specify. The ambiguity may be intentional."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "6:11",
-              "note": "Augustine: \"Five loaves and two fish: what are these among so many? But when the Lord blesses, the little becomes much. The blessing multiplies the bread in the hands of those distributing it, not in the mass of the bread itself. The miracle is continuous \u2014 from hand to hand the bread increases."
-            },
-            {
-              "ref": "6:20",
-              "note": "Chrysostom: \"It is I \u2014 do not be afraid. He first identified himself, then commanded them not to fear. For to know who was present was the cure of their fear. When they knew it was not a phantom but the Lord, their fear dissolved into wonder and then into worship.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Passover Setting\nJohn specifies that \"the Jewish Passover Festival was near\" (v.4) \u2014 placing the feeding in the Passover framework and connecting it to the Exodus manna. The feeding of 5,000 echoes Moses feeding Israel in the wilderness (Exod 16; Num 11); the discourse (6:31-58) makes the Exodus connection explicit. Jesus is the new Moses who gives not bread from heaven (manna) but is himself the bread from heaven.\n\nWalking on Water as Theophany\nThe OT consistently attributes walking on the sea to God alone: \"He alone stretches out the heavens and treads on the waves of the sea\" (Job 9:8). \"Your path led through the sea, your way through the mighty waters\" (Ps 77:19). When Jesus walks on water and says \"I am\" (eg\u014d eimi), John is presenting a theophany: the disciples are in the presence of YHWH."
+          "context": "Passover Setting\nJohn specifies that \"the Jewish Passover Festival was near\" (v.4) — placing the feeding in the Passover framework and connecting it to the Exodus manna. The feeding of 5,000 echoes Moses feeding Israel in the wilderness (Exod 16; Num 11); the discourse (6:31-58) makes the Exodus connection explicit. Jesus is the new Moses who gives not bread from heaven (manna) but is himself the bread from heaven.\n\nWalking on Water as Theophany\nThe OT consistently attributes walking on the sea to God alone: \"He alone stretches out the heavens and treads on the waves of the sea\" (Job 9:8). \"Your path led through the sea, your way through the mighty waters\" (Ps 77:19). When Jesus walks on water and says \"I am\" (egō eimi), John is presenting a theophany: the disciples are in the presence of YHWH."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 60\u201371 \u2014 Many Disciples Leave; Peter\u2019s Confession",
+      "header": "Verses 60–71 — Many Disciples Leave; Peter’s Confession",
       "verse_start": 60,
       "verse_end": 71,
       "panels": {
         "heb": [
           {
-            "word": "Eg\u014d eimi ho artos t\u0113s z\u014d\u0113s",
-            "transliteration": "e-GO ei-MI ho AR-tos t\u0113s ZO-\u0113s",
+            "word": "Egō eimi ho artos tēs zōēs",
+            "transliteration": "e-GO ei-MI ho AR-tos tēs ZO-ēs",
             "gloss": "I am the bread of life",
-            "paragraph": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses eg\u014d eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
+            "paragraph": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses egō eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
           },
           {
-            "word": "tr\u014dg\u014d",
+            "word": "trōgō",
             "transliteration": "TRO-go",
             "gloss": "eat / gnaw / munch (physical eating)",
-            "paragraph": "In vv.54-58, John shifts from the more general phag\u014d (eat) to the more physical tr\u014dg\u014d (to munch, chew \u2014 used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
+            "paragraph": "In vv.54-58, John shifts from the more general phagō (eat) to the more physical trōgō (to munch, chew — used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
           }
         ],
         "places": [
           {
             "name": "Sea of Galilee",
-            "coords": "32.8208\u00b0 N, 35.5847\u00b0 E",
+            "coords": "32.8208° N, 35.5847° E",
             "text": "Also called the Sea of Tiberias (after the city Herod Antipas built on its western shore, named for Emperor Tiberius). A freshwater lake 13 miles long and 8 miles wide, 680 feet below sea level. Famous for sudden violent storms funnelled from the surrounding hills. Jesus walked on this lake (6:19), calmed its storms (Mark 4:39), and most of his Galilean ministry centred on its northern shore. The feeding of the 5,000 took place on its northeastern shore."
           }
         ],
@@ -376,7 +332,7 @@
           "refs": [
             {
               "ref": "Exod 16:4",
-              "note": "\"I will rain down bread from heaven for you\" \u2014 the manna promise that the crowd invokes (v.31) and Jesus reinterprets."
+              "note": "\"I will rain down bread from heaven for you\" — the manna promise that the crowd invokes (v.31) and Jesus reinterprets."
             },
             {
               "ref": "Ps 78:24-25",
@@ -384,72 +340,28 @@
             },
             {
               "ref": "Isa 55:1-3",
-              "note": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" \u2014 the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35)."
+              "note": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" — the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:29",
-              "note": "\"The work of God is this: to believe in the one he has sent\" \u2014 the most compressed answer to the religion-as-work problem in the NT. The crowd asks what works they must perform; Jesus answers that the one work God requires is not a work at all in the usual sense but a disposition of trust. Faith is the \"work\" God commands \u2014 and it is entirely God-enabled (v.44)."
-            },
-            {
-              "ref": "6:37",
-              "note": "\"All those the Father gives me will come to me, and whoever comes to me I will never drive away\" \u2014 two sides of divine election and human coming. Divine election (the Father gives) does not preclude human coming; human coming does not preclude divine election. Both are affirmed simultaneously. The security offered is absolute: Jesus will \"never drive away\" (ou m\u0113 ekbal\u014d \u2014 double negative for strongest possible negation) any who come."
-            },
-            {
-              "ref": "6:44",
-              "note": "\"No one can come to me unless the Father who sent me draws them\" \u2014 one of John's strongest statements of divine initiative in salvation. The Greek helk\u014d (draws) can mean \"drag\" (as in dragging a net, v.21:6). Coming to Jesus is not an unaided human decision; it is the result of the Father's drawing. The Arminian tradition reads this as a universal drawing (cf. 12:32 \u2014 \"I will draw all people\"); the Calvinist tradition reads it as an efficacious drawing of the elect."
-            },
-            {
-              "ref": "6:63",
-              "note": "\"The Spirit gives life; the flesh counts for nothing\" \u2014 this verse is the key to interpreting the whole discourse. \"Flesh\" here does not mean \"my flesh\" (v.51) but human flesh as the organ of perception: unaided human understanding cannot grasp the spiritual reality Jesus offers. The words are \"full of the Spirit and life\" \u2014 they must be received spiritually, not carnally. This suggests that \"eating\" throughout the discourse is a figure for receiving by faith, not for physical ingestion."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:44",
-              "note": "Calvin uses this verse as the foundation of his doctrine of irresistible grace: the Father's drawing is not merely an offer or enticement but an efficacious action that ensures the drawn person will come. However, Calvin carefully guards against a mechanical reading: the drawing is the work of the Spirit in the inner person, not a coercion of the will, but a renovation of the will so that it freely chooses what was divinely ordained."
-            },
-            {
-              "ref": "6:63",
-              "note": "\"The Spirit gives life; the flesh counts for nothing\" \u2014 Calvin argues strongly that the eating of vv.53-58 is not a reference to the Eucharist but to faith. The words are \"spirit and life\" \u2014 spiritual realities received by the Spirit through faith, not physical elements. The Eucharist is the sign of this spiritual eating, not the eating itself."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:44",
-              "note": "Helk\u014d (draw) \u2014 used elsewhere in John for dragging a net (21:6, 11) and for Jesus drawing all people to himself (12:32). The question of whether this drawing is universal or particular is one of the major hermeneutical divides in Reformed and Arminian theology. John 12:32 uses the same verb for drawing \"all people,\" suggesting at minimum a universal offer; 6:44 suggests that those who come have been specifically drawn by the Father."
-            },
-            {
-              "ref": "6:54",
-              "note": "Tr\u014dg\u014d (eat/chew) vs phag\u014d (eat) \u2014 the shift to the more physical verb in vv.54-58 intensifies the statement. Whether this physicality points to the sacrament (the elements of the Eucharist) or simply emphasises the reality of spiritual appropriation is the central exegetical question of the passage."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "6:35",
-              "note": "Augustine: \"He said 'come to me' and 'believe in me' as if they were the same thing. Coming is believing, and believing is coming. For faith is the feet of the soul, and the feet of the soul carry it to Christ.\""
-            },
-            {
-              "ref": "6:68-69",
-              "note": "Chrysostom: \"Lord, to whom shall we go? He does not say 'we will not go' \u2014 but 'to whom shall we go?' As if to say: You have us completely. There is nowhere else. We have tried everything else and found it empty. You have the words of eternal life: where else would we look?\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Manna Typology\nThe crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v.31) to demand a sign like Moses's manna. Jesus corrects two assumptions: (1) Moses did not give the manna \u2014 the Father did; (2) the manna was not the true bread from heaven \u2014 that is what the Father is now giving. The typological argument is that manna was a shadow pointing to Christ, who is the substance. Those who ate manna died; those who eat this bread live forever (v.49-51).\n\nDivision and Departure\nThe discourse produces the most dramatic departure in the Gospel: \"many of his disciples turned back and no longer followed him\" (v.66). This is not the crowd \u2014 it is disciples. The hard teaching about eating his flesh and drinking his blood functions as a sifting: those who cannot accept the claim that Jesus is himself the life-giving gift depart. Peter's confession (v.68-69) stands in sharp contrast as the model of perseverant faith."
+          "context": "The Manna Typology\nThe crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v.31) to demand a sign like Moses's manna. Jesus corrects two assumptions: (1) Moses did not give the manna — the Father did; (2) the manna was not the true bread from heaven — that is what the Father is now giving. The typological argument is that manna was a shadow pointing to Christ, who is the substance. Those who ate manna died; those who eat this bread live forever (v.49-51).\n\nDivision and Departure\nThe discourse produces the most dramatic departure in the Gospel: \"many of his disciples turned back and no longer followed him\" (v.66). This is not the crowd — it is disciples. The hard teaching about eating his flesh and drinking his blood functions as a sifting: those who cannot accept the claim that Jesus is himself the life-giving gift depart. Peter's confession (v.68-69) stands in sharp contrast as the model of perseverant faith."
         }
       }
     }
@@ -459,15 +371,15 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Jesus is the new Moses who gives not bread from heaven (manna) but   Context  [('The Manna Typology', 'The crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v\u2026"
+        "text": "Jesus is the new Moses who gives not bread from heaven (manna) but   Context  [('The Manna Typology', 'The crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v…"
       },
       {
         "name": "crowd",
         "role": "Key biblical figure",
-        "text": "Jesus is the new Moses who gives not bread from heaven (manna) but   Context  [('The Manna Typology', 'The crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v\u2026"
+        "text": "Jesus is the new Moses who gives not bread from heaven (manna) but   Context  [('The Manna Typology', 'The crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eg\u014d eimi ho artos t\u0113s z\u014d\u0113s (6:35)</td><td>NIV/KJV/ESV/NRSV: \"I am the bread of life.\" Universal agreement. The first of the seven I am sayings with explicit predicate.</td></tr><tr><td class=\"t-label\">helk\u014d (6:44)</td><td>NIV: \"draws\"; KJV: \"draw\"; ESV: \"draw\"; NRSV: \"draw\". Universal agreement on the word; the theological interpretation (irresistible grace or universal invitation) depends on wider theological commitments, not translation choice.</td></tr><tr><td class=\"t-label\">tr\u014dg\u014d (6:54)</td><td>NIV: \"eats\"; KJV: \"eateth\"; ESV: \"feeds on\"; NRSV: \"eats\". ESV's \"feeds on\" captures something of the ongoing, intimate character of tr\u014dg\u014d better than the neutral \"eats.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">egō eimi ho artos tēs zōēs (6:35)</td><td>NIV/KJV/ESV/NRSV: \"I am the bread of life.\" Universal agreement. The first of the seven I am sayings with explicit predicate.</td></tr><tr><td class=\"t-label\">helkō (6:44)</td><td>NIV: \"draws\"; KJV: \"draw\"; ESV: \"draw\"; NRSV: \"draw\". Universal agreement on the word; the theological interpretation (irresistible grace or universal invitation) depends on wider theological commitments, not translation choice.</td></tr><tr><td class=\"t-label\">trōgō (6:54)</td><td>NIV: \"eats\"; KJV: \"eateth\"; ESV: \"feeds on\"; NRSV: \"eats\". ESV's \"feeds on\" captures something of the ongoing, intimate character of trōgō better than the neutral \"eats.\"</td></tr>",
     "src": [
       {
         "title": "Exodus 16:4, 14-15",
@@ -483,108 +395,108 @@
     "rec": [
       {
         "who": "The Bread of Life Discourse and Eucharistic Theology",
-        "text": "John 6:51-58 is the most contested Eucharistic text in the NT. The Catholic and Orthodox traditions read it as the foundation of their theology of Real Presence \u2014 the bread and wine of the Eucharist are truly the flesh and blood of Christ. The Protestant tradition (especially Zwingli and Calvin) reads v.63 as the interpretive key: the eating is spiritual, and the Eucharist is a sign of that spiritual reality. The Lutheran tradition holds a mediating position (real bodily presence \"in, with and under\" the elements). The debate has generated more theological writing than almost any other single biblical passage."
+        "text": "John 6:51-58 is the most contested Eucharistic text in the NT. The Catholic and Orthodox traditions read it as the foundation of their theology of Real Presence — the bread and wine of the Eucharist are truly the flesh and blood of Christ. The Protestant tradition (especially Zwingli and Calvin) reads v.63 as the interpretive key: the eating is spiritual, and the Eucharist is a sign of that spiritual reality. The Lutheran tradition holds a mediating position (real bodily presence \"in, with and under\" the elements). The debate has generated more theological writing than almost any other single biblical passage."
       },
       {
-        "who": "John 6:66 \u2014 \"Many Disciples Turned Back\"",
-        "text": "This verse has been cited in every generation as a warning against soft discipleship. Dietrich Bonhoeffer's Cost of Discipleship (1937) opens with this scene: the church in every generation faces the same choice as the crowd \u2014 to follow for the benefits Jesus provides or to follow because he has the words of eternal life. The hard teaching is not an accident; it is a sifting."
+        "who": "John 6:66 — \"Many Disciples Turned Back\"",
+        "text": "This verse has been cited in every generation as a warning against soft discipleship. Dietrich Bonhoeffer's Cost of Discipleship (1937) opens with this scene: the church in every generation faces the same choice as the crowd — to follow for the benefits Jesus provides or to follow because he has the words of eternal life. The hard teaching is not an accident; it is a sifting."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Discourse Structure \u2014 vv.26-59",
-          "text": "The discourse follows John's typical pattern: statement \u2192 misunderstanding \u2192 clarification \u2192 deeper statement. Jesus offers \"food that endures\" \u2192 they ask for it literally \u2192 he identifies himself as the bread \u2192 they grumble about his origin \u2192 he intensifies: eat my flesh and drink my blood \u2192 many leave. Each misunderstanding drives the revelation deeper.",
+          "label": "Discourse Structure — vv.26-59",
+          "text": "The discourse follows John's typical pattern: statement → misunderstanding → clarification → deeper statement. Jesus offers \"food that endures\" → they ask for it literally → he identifies himself as the bread → they grumble about his origin → he intensifies: eat my flesh and drink my blood → many leave. Each misunderstanding drives the revelation deeper.",
           "is_key": false
         },
         {
-          "label": "Manna Typology \u2014 vv.31-58",
-          "text": "Old manna (temporary, those who ate died) vs. new bread (permanent, those who eat live forever). The entire discourse is structured as a typological argument: Moses and manna \u2192 Jesus as fulfilment and replacement.",
+          "label": "Manna Typology — vv.31-58",
+          "text": "Old manna (temporary, those who ate died) vs. new bread (permanent, those who eat live forever). The entire discourse is structured as a typological argument: Moses and manna → Jesus as fulfilment and replacement.",
           "is_key": false
         },
         {
-          "label": "Moses Typology \u2014 vv.30-35, 49-51",
+          "label": "Moses Typology — vv.30-35, 49-51",
           "text": "The crowd's request for a sign like Moses's manna (v30) allows Jesus to reinterpret Exodus 16. John structures the discourse so Jesus first corrects the attribution (Moses did not give it; my Father gives) then escalates the claim: he is not merely like the manna, he is the manna.",
           "is_key": false
         }
       ],
       "note": "",
       "chiasm": {
-        "title": "John 6 \u2014 The Bread of Life Discourse",
+        "title": "John 6 — The Bread of Life Discourse",
         "pairs": [
           {
             "label": "A",
-            "top": "The sign: Jesus feeds five thousand with five loaves and two fish on the mountain. The crowd wants to make him king by force (vv.1\u201315)",
-            "bottom": "The crisis: many disciples turn back and no longer follow him. Jesus asks the Twelve: \u2018You do not want to leave too, do you?\u2019 Peter: \u2018Lord, to whom shall we go?\u2019 (vv.60\u201371)",
+            "top": "The sign: Jesus feeds five thousand with five loaves and two fish on the mountain. The crowd wants to make him king by force (vv.1–15)",
+            "bottom": "The crisis: many disciples turn back and no longer follow him. Jesus asks the Twelve: ‘You do not want to leave too, do you?’ Peter: ‘Lord, to whom shall we go?’ (vv.60–71)",
             "color": "#8B7CB8"
           },
           {
             "label": "B",
-            "top": "Jesus walks on the sea at night; the disciples are terrified. \u2018It is I (ego eimi); do not be afraid\u2019 (vv.16\u201321)",
-            "bottom": "Jesus teaches that no one can come to him unless drawn by the Father, and he will raise them up at the last day (vv.43\u201359)",
+            "top": "Jesus walks on the sea at night; the disciples are terrified. ‘It is I (ego eimi); do not be afraid’ (vv.16–21)",
+            "bottom": "Jesus teaches that no one can come to him unless drawn by the Father, and he will raise them up at the last day (vv.43–59)",
             "color": "#5b8fb9"
           },
           {
             "label": "C",
-            "top": "The crowd follows Jesus across the lake seeking more bread. Jesus challenges them: \u2018You are looking for me because you ate the loaves, not because you saw signs\u2019 (vv.22\u201327)",
-            "bottom": "The Jews grumble: \u2018Is this not Jesus, the son of Joseph? How can he say he came down from heaven?\u2019 The offense is not the miracle but the identity claim (vv.41\u201342)",
+            "top": "The crowd follows Jesus across the lake seeking more bread. Jesus challenges them: ‘You are looking for me because you ate the loaves, not because you saw signs’ (vv.22–27)",
+            "bottom": "The Jews grumble: ‘Is this not Jesus, the son of Joseph? How can he say he came down from heaven?’ The offense is not the miracle but the identity claim (vv.41–42)",
             "color": "#5fa87a"
           }
         ],
         "center": {
           "label": "X",
-          "text": "I am the bread of life. Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty. Your ancestors ate manna in the wilderness, yet they died. But here is the bread that comes down from heaven, which anyone may eat and not die. I am the living bread that came down from heaven (vv.28\u201340). The center is the ego eimi declaration that reinterprets the entire Exodus manna tradition: the bread God gives is not a substance but a person. The discourse spirals outward from this identity claim into offense, division, and the Twelve\u2019s fragile faith."
+          "text": "I am the bread of life. Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty. Your ancestors ate manna in the wilderness, yet they died. But here is the bread that comes down from heaven, which anyone may eat and not die. I am the living bread that came down from heaven (vv.28–40). The center is the ego eimi declaration that reinterprets the entire Exodus manna tradition: the bread God gives is not a substance but a person. The discourse spirals outward from this identity claim into offense, division, and the Twelve’s fragile faith."
         }
       }
     },
     "hebtext": [
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am / It is I",
-        "note": "Jesus's words to the frightened disciples (v.20) \u2014 ego eimi \u2014 are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany \u2014 God walking on the sea (Job 9:8; Ps 77:19)."
+        "note": "Jesus's words to the frightened disciples (v.20) — ego eimi — are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany — God walking on the sea (Job 9:8; Ps 77:19)."
       },
       {
-        "word": "eucharist\u014d",
+        "word": "eucharistō",
         "tlit": "eu-cha-ris-TO",
         "gloss": "give thanks / eucharist",
-        "note": "Jesus \"gave thanks\" (eucharist\u0113sas, v.11, v.23) before distributing the bread \u2014 the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
+        "note": "Jesus \"gave thanks\" (eucharistēsas, v.11, v.23) before distributing the bread — the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
       },
       {
-        "word": "Eg\u014d eimi ho artos t\u0113s z\u014d\u0113s",
-        "tlit": "e-GO ei-MI ho AR-tos t\u0113s ZO-\u0113s",
+        "word": "Egō eimi ho artos tēs zōēs",
+        "tlit": "e-GO ei-MI ho AR-tos tēs ZO-ēs",
         "gloss": "I am the bread of life",
-        "note": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses eg\u014d eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
+        "note": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses egō eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
       },
       {
-        "word": "tr\u014dg\u014d",
+        "word": "trōgō",
         "tlit": "TRO-go",
         "gloss": "eat / gnaw / munch (physical eating)",
-        "note": "In vv.54-58, John shifts from the more general phag\u014d (eat) to the more physical tr\u014dg\u014d (to munch, chew \u2014 used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
+        "note": "In vv.54-58, John shifts from the more general phagō (eat) to the more physical trōgō (to munch, chew — used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
       },
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am / It is I",
-        "note": "Jesus's words to the frightened disciples (v.20) \u2014 ego eimi \u2014 are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany \u2014 God walking on the sea (Job 9:8; Ps 77:19)."
+        "note": "Jesus's words to the frightened disciples (v.20) — ego eimi — are simultaneously the natural reassurance \"It's me\" and the divine name \"I AM\" from Exod 3:14 / Isa 43:10. The disciples hear comfort; the reader of John's Gospel hears the divine name. The walking on water is not merely a nature miracle but a theophany — God walking on the sea (Job 9:8; Ps 77:19)."
       },
       {
-        "word": "eucharist\u014d",
+        "word": "eucharistō",
         "tlit": "eu-cha-ris-TO",
         "gloss": "give thanks / eucharist",
-        "note": "Jesus \"gave thanks\" (eucharist\u0113sas, v.11, v.23) before distributing the bread \u2014 the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
+        "note": "Jesus \"gave thanks\" (eucharistēsas, v.11, v.23) before distributing the bread — the same eucharistic action he performs at the Last Supper. John does not narrate the institution of the Eucharist at the Last Supper (ch.13 replaces it with the foot-washing); ch.6 is John's sustained meditation on the Eucharistic meaning of Jesus's self-giving."
       },
       {
-        "word": "Eg\u014d eimi ho artos t\u0113s z\u014d\u0113s",
-        "tlit": "e-GO ei-MI ho AR-tos t\u0113s ZO-\u0113s",
+        "word": "Egō eimi ho artos tēs zōēs",
+        "tlit": "e-GO ei-MI ho AR-tos tēs ZO-ēs",
         "gloss": "I am the bread of life",
-        "note": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses eg\u014d eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
+        "note": "The first of the seven \"I am\" sayings with an explicit predicate in John (6:35, 48; 8:12; 10:7, 11; 11:25; 14:6; 15:1). Each uses egō eimi with a metaphorical predicate to define one dimension of Jesus's person and work. \"Bread of life\" combines the sustenance image (I provide what you need to live) with the divine name (I am). The statement is simultaneously claim to divine identity and offer of spiritual sustenance."
       },
       {
-        "word": "tr\u014dg\u014d",
+        "word": "trōgō",
         "tlit": "TRO-go",
         "gloss": "eat / gnaw / munch (physical eating)",
-        "note": "In vv.54-58, John shifts from the more general phag\u014d (eat) to the more physical tr\u014dg\u014d (to munch, chew \u2014 used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
+        "note": "In vv.54-58, John shifts from the more general phagō (eat) to the more physical trōgō (to munch, chew — used of animals eating). This intensification resists any purely metaphorical reading: Jesus is insisting on the concreteness of what he offers. Whether this points to the Eucharist (Catholic/Orthodox) or is a figure for believing (Protestant) turns on the interpretation of v.63: \"The Spirit gives life; the flesh counts for nothing.\""
       }
     ],
     "thread": [
@@ -592,28 +504,28 @@
         "anchor": "Scripture Walkthrough",
         "target": "Exod 16:1-36",
         "type": "Connection",
-        "text": "The manna in the wilderness \u2014 the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse.",
+        "text": "The manna in the wilderness — the background the crowd (6:31) and Jesus himself (6:49-58) explicitly invoke in the Bread of Life discourse.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Job 9:8",
         "type": "Connection",
-        "text": "\"He alone stretches out the heavens and treads on the waves of the sea\" \u2014 walking on the sea as an exclusively divine attribute.",
+        "text": "\"He alone stretches out the heavens and treads on the waves of the sea\" — walking on the sea as an exclusively divine attribute.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 107:23-32",
         "type": "Connection",
-        "text": "God stilling the storm and bringing the boat safely to harbor \u2014 the psalm background for the sea-crossing episode.",
+        "text": "God stilling the storm and bringing the boat safely to harbor — the psalm background for the sea-crossing episode.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Exod 16:4",
         "type": "Connection",
-        "text": "\"I will rain down bread from heaven for you\" \u2014 the manna promise that the crowd invokes (v.31) and Jesus reinterprets.",
+        "text": "\"I will rain down bread from heaven for you\" — the manna promise that the crowd invokes (v.31) and Jesus reinterprets.",
         "direction": "backward"
       },
       {
@@ -627,7 +539,7 @@
         "anchor": "Scripture Walkthrough",
         "target": "Isa 55:1-3",
         "type": "Connection",
-        "text": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" \u2014 the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35).",
+        "text": "\"Come, all you who are thirsty, come to the waters... Listen, listen to me, and eat what is good\" — the Isaiah background for Jesus's invitation \"Whoever comes to me will never go hungry, and whoever believes in me will never be thirsty\" (v.35).",
         "direction": "backward"
       }
     ],
@@ -641,7 +553,7 @@
       {
         "ref": "6:69",
         "title": "\"The Holy One of God\" vs other readings",
-        "content": "Some MSS read \"the Christ, the Son of the living God\" (harmonising with Matt 16:16) or \"the Son of God.\" NA28 follows the distinctive \"Holy One of God\" as the hardest reading \u2014 less likely to be a scribal creation and more likely to have been changed toward the more familiar confessions.",
+        "content": "Some MSS read \"the Christ, the Son of the living God\" (harmonising with Matt 16:16) or \"the Son of God.\" NA28 follows the distinctive \"Holy One of God\" as the hardest reading — less likely to be a scribal creation and more likely to have been changed toward the more familiar confessions.",
         "note": "\"Holy One of God\" is almost certainly original. It is the most unusual of the confessional titles and has the best manuscript support."
       }
     ],
@@ -652,7 +564,7 @@
           {
             "name": "Yes: reference to the Eucharist",
             "proponents": "Catholic, Orthodox, many Protestant scholars (Brown, Hoskyns)",
-            "argument": "The language shifts to the physical tr\u014dg\u014d; the flesh/blood pairing is the eucharistic formula; the synagogue setting doesn't preclude post-resurrection sacramental reference. John deliberately replaces the Last Supper institution with this discourse."
+            "argument": "The language shifts to the physical trōgō; the flesh/blood pairing is the eucharistic formula; the synagogue setting doesn't preclude post-resurrection sacramental reference. John deliberately replaces the Last Supper institution with this discourse."
           },
           {
             "name": "No: metaphorical reference to faith",
@@ -694,7 +606,7 @@
           "score": 10
         }
       ],
-      "note": "John 6 is the Bread of Life chapter and one of the most theologically dense chapters in the Gospel. The feeding miracle is the sign; the discourse is its interpretation. Jesus identifies himself as what the manna pointed to \u2014 the true bread from heaven \u2014 and demands a response that goes far beyond acceptance of a miracle. The chapter reaches its crisis at v.66: many disciples depart. Peter's response \u2014 \"to whom shall we go?\" \u2014 is the model of faith at its most stripped-back and honest: not triumphant confession but desperate attachment to the one who alone has the words of eternal life."
+      "note": "John 6 is the Bread of Life chapter and one of the most theologically dense chapters in the Gospel. The feeding miracle is the sign; the discourse is its interpretation. Jesus identifies himself as what the manna pointed to — the true bread from heaven — and demands a response that goes far beyond acceptance of a miracle. The chapter reaches its crisis at v.66: many disciples depart. Peter's response — \"to whom shall we go?\" — is the model of faith at its most stripped-back and honest: not triumphant confession but desperate attachment to the one who alone has the words of eternal life."
     }
   },
   "vhl_groups": [
@@ -813,7 +725,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Five loaves, two fish, five thousand fed\u2014then they want to make him king (v. 15). Jesus withdraws. They want bread; he offers himself. The crowd follows for full stomachs, not full hearts.",
+      "tip": "Five loaves, two fish, five thousand fed—then they want to make him king (v. 15). Jesus withdraws. They want bread; he offers himself. The crowd follows for full stomachs, not full hearts.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/john/7.json
+++ b/content/john/7.json
@@ -10,7 +10,7 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201324 \u2014 Feast of Tabernacles: Jesus Teaches in the Temple",
+      "header": "Verses 1–24 — Feast of Tabernacles: Jesus Teaches in the Temple",
       "verse_start": 1,
       "verse_end": 24,
       "panels": {
@@ -19,58 +19,58 @@
             "word": "kairos",
             "transliteration": "KAI-ros",
             "gloss": "the appointed time / the right moment",
-            "paragraph": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos \u2014 the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast \u2014 secretly, v.10 \u2014 it is because the kairos permits it, not because he has changed his mind."
+            "paragraph": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos — the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast — secretly, v.10 — it is because the kairos permits it, not because he has changed his mind."
           },
           {
-            "word": "didach\u0113",
+            "word": "didachē",
             "transliteration": "di-da-CHE",
             "gloss": "teaching / doctrine",
-            "paragraph": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will \u2014 a criterion available to anyone willing to do God's will."
+            "paragraph": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will — a criterion available to anyone willing to do God's will."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Lev 23:33-43",
-              "note": "The Feast of Tabernacles commanded in Torah \u2014 the seven-day feast of booths commemorating the wilderness wandering."
+              "note": "The Feast of Tabernacles commanded in Torah — the seven-day feast of booths commemorating the wilderness wandering."
             },
             {
               "ref": "Deut 18:15-18",
-              "note": "\"The Lord your God will raise up for you a prophet like me from among you\" \u2014 \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter."
+              "note": "\"The Lord your God will raise up for you a prophet like me from among you\" — \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter."
             },
             {
               "ref": "Zech 14:16-19",
-              "note": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles \u2014 the eschatological horizon behind the feast Jesus attends."
+              "note": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles — the eschatological horizon behind the feast Jesus attends."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:5",
-              "note": "\"Even his own brothers did not believe in him\" \u2014 the most intimate rejection in the Gospel before the passion. Those who grew up with him, who knew him most closely in the natural realm, were furthest from recognising him in the spiritual realm. Proximity to Jesus in the flesh is not the same as faith. The same principle applies to those who are culturally Christian without genuine saving faith."
+              "note": "\"Even his own brothers did not believe in him\" — the most intimate rejection in the Gospel before the passion. Those who grew up with him, who knew him most closely in the natural realm, were furthest from recognising him in the spiritual realm. Proximity to Jesus in the flesh is not the same as faith. The same principle applies to those who are culturally Christian without genuine saving faith."
             },
             {
               "ref": "7:17",
-              "note": "\"Anyone who chooses to do God's will shall find out whether my teaching comes from God\" \u2014 the epistemological principle for testing religious teaching: moral alignment with God's will precedes cognitive certainty about divine origin. Those who want to know if Jesus is from God must first commit to doing God's will. The commitment is prior to the certainty. Faith precedes full understanding."
+              "note": "\"Anyone who chooses to do God's will shall find out whether my teaching comes from God\" — the epistemological principle for testing religious teaching: moral alignment with God's will precedes cognitive certainty about divine origin. Those who want to know if Jesus is from God must first commit to doing God's will. The commitment is prior to the certainty. Faith precedes full understanding."
             },
             {
               "ref": "7:28-29",
-              "note": "Jesus's ironic \"Yes, you know me\" \u2014 they think they know him (son of Joseph, from Galilee). They do not know the essential thing: he is from the Father, sent by the Father, and knows the Father as no human being ever has. The origin they know (Galilee) is incidental; the origin they don't know (the Father) is definitive."
+              "note": "Jesus's ironic \"Yes, you know me\" — they think they know him (son of Joseph, from Galilee). They do not know the essential thing: he is from the Father, sent by the Father, and knows the Father as no human being ever has. The origin they know (Galilee) is incidental; the origin they don't know (the Father) is definitive."
             },
             {
               "ref": "7:30",
-              "note": "\"His hour had not yet come\" \u2014 for the third time in John (2:4; 7:30; 8:20), the \"hour\" protects Jesus from premature seizure. The enemies are real; their intentions are murderous; but they are restrained by a divine timing that they cannot override. The cross will happen at the appointed hour, not before."
+              "note": "\"His hour had not yet come\" — for the third time in John (2:4; 7:30; 8:20), the \"hour\" protects Jesus from premature seizure. The enemies are real; their intentions are murderous; but they are restrained by a divine timing that they cannot override. The cross will happen at the appointed hour, not before."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:5",
-              "note": "Calvin draws a sharp lesson from the brothers' unbelief: external proximity to Christ \u2014 sharing his home, seeing his works, hearing his teaching \u2014 does not produce faith. Faith is a gift of the Spirit; without it, the most intimate natural relationship with Jesus is spiritually blind. This disposes of any theology that makes gradual familiarity with Christian culture the path to saving faith."
+              "note": "Calvin draws a sharp lesson from the brothers' unbelief: external proximity to Christ — sharing his home, seeing his works, hearing his teaching — does not produce faith. Faith is a gift of the Spirit; without it, the most intimate natural relationship with Jesus is spiritually blind. This disposes of any theology that makes gradual familiarity with Christian culture the path to saving faith."
             },
             {
               "ref": "7:17",
@@ -79,24 +79,24 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:8",
-              "note": "\"I am not going up to this festival\" \u2014 some MSS read \"not yet going up\" (ou p\u014d, adding p\u014d) to resolve the apparent contradiction with v.10 where he does go up. NA28 follows \"not going up\" (ouk) as the harder reading \u2014 the \"not yet\" appears to be a scribal harmonisation. Jesus's statement in v.8 is about his public messianic manifestation, not about whether he will attend at all."
+              "note": "\"I am not going up to this festival\" — some MSS read \"not yet going up\" (ou pō, adding pō) to resolve the apparent contradiction with v.10 where he does go up. NA28 follows \"not going up\" (ouk) as the harder reading — the \"not yet\" appears to be a scribal harmonisation. Jesus's statement in v.8 is about his public messianic manifestation, not about whether he will attend at all."
             },
             {
               "ref": "7:15",
-              "note": "The question about Jesus's learning without formal training echoes the social world of literacy and education in the first century: formal rabbinic ordination (smicha) required years of study and authorization by a recognized teacher. Jesus's authority bypasses this system entirely \u2014 a fact that is both his strength with the crowds and his problem with the establishment."
+              "note": "The question about Jesus's learning without formal training echoes the social world of literacy and education in the first century: formal rabbinic ordination (smicha) required years of study and authorization by a recognized teacher. Jesus's authority bypasses this system entirely — a fact that is both his strength with the crowds and his problem with the establishment."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "7:5",
-              "note": "Chrysostom: \"His brothers did not believe in him \u2014 the same with whom he had lived so many years. This is a hard thing. Familiarity breeds contempt for great things; those who live with prophets and saints often become insensible to their greatness. Distance lends wonder; nearness breeds familiarity.\""
+              "note": "Chrysostom: \"His brothers did not believe in him — the same with whom he had lived so many years. This is a hard thing. Familiarity breeds contempt for great things; those who live with prophets and saints often become insensible to their greatness. Distance lends wonder; nearness breeds familiarity.\""
             },
             {
               "ref": "7:17",
@@ -105,63 +105,63 @@
           ]
         },
         "hist": {
-          "context": "The Feast of Tabernacles\nSukkot (Tabernacles) was the most joyful of the three pilgrimage feasts, celebrating the harvest and commemorating the wilderness wandering. For seven days, Israelites lived in temporary booths (sukkoth). The feast included the water-drawing ceremony (Simchat Beit HaSho'evah): priests drew water from the Pool of Siloam each morning and poured it on the altar, accompanied by singing and flute-playing. The feast also included the illumination ceremony: four golden lampstands in the Temple's Court of Women. Jesus's declarations in ch.7-8 (\"rivers of living water,\" \"I am the light of the world\") directly address these two ceremonies.\n\nMessianic Speculation\nThe debate about whether Jesus is the Messiah runs through the chapter in multiple registers: (1) does he have the right Galilean origin? (2) does no one know where the Messiah comes from? (3) will the Messiah do more signs? (4) will authorities protect him if he's the Messiah? John presents the irony that all these speculations miss the deeper truth: Jesus's true origin is not Bethlehem or Galilee but \"from him who sent me\" \u2014 from the Father."
+          "context": "The Feast of Tabernacles\nSukkot (Tabernacles) was the most joyful of the three pilgrimage feasts, celebrating the harvest and commemorating the wilderness wandering. For seven days, Israelites lived in temporary booths (sukkoth). The feast included the water-drawing ceremony (Simchat Beit HaSho'evah): priests drew water from the Pool of Siloam each morning and poured it on the altar, accompanied by singing and flute-playing. The feast also included the illumination ceremony: four golden lampstands in the Temple's Court of Women. Jesus's declarations in ch.7-8 (\"rivers of living water,\" \"I am the light of the world\") directly address these two ceremonies.\n\nMessianic Speculation\nThe debate about whether Jesus is the Messiah runs through the chapter in multiple registers: (1) does he have the right Galilean origin? (2) does no one know where the Messiah comes from? (3) will the Messiah do more signs? (4) will authorities protect him if he's the Messiah? John presents the irony that all these speculations miss the deeper truth: Jesus's true origin is not Bethlehem or Galilee but \"from him who sent me\" — from the Father."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 25\u201344 \u2014 Is This the Messiah? Division Among the People",
+      "header": "Verses 25–44 — Is This the Messiah? Division Among the People",
       "verse_start": 25,
       "verse_end": 44,
       "panels": {
         "heb": [
           {
-            "word": "potamoi hydatos z\u014dntos",
+            "word": "potamoi hydatos zōntos",
             "transliteration": "po-ta-MOI HY-da-tos ZON-tos",
             "gloss": "rivers of living water",
-            "paragraph": "Jesus's declaration on the last day of Tabernacles (v.37-38) alludes directly to the water-drawing ceremony of Sukkot \u2014 the daily procession from the Pool of Siloam to the Temple altar. Where the ceremony used water from a pool in Jerusalem, Jesus offers rivers of living water flowing from within the believer. John's interpretation (v.39) is unambiguous: the rivers of living water are the Holy Spirit, not yet given because Jesus had not yet been glorified (the cross and resurrection)."
+            "paragraph": "Jesus's declaration on the last day of Tabernacles (v.37-38) alludes directly to the water-drawing ceremony of Sukkot — the daily procession from the Pool of Siloam to the Temple altar. Where the ceremony used water from a pool in Jerusalem, Jesus offers rivers of living water flowing from within the believer. John's interpretation (v.39) is unambiguous: the rivers of living water are the Holy Spirit, not yet given because Jesus had not yet been glorified (the cross and resurrection)."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 55:1",
-              "note": "\"Come, all you who are thirsty, come to the waters\" \u2014 the invitation echoed in Jesus's cry \"let anyone who is thirsty come to me.\""
+              "note": "\"Come, all you who are thirsty, come to the waters\" — the invitation echoed in Jesus's cry \"let anyone who is thirsty come to me.\""
             },
             {
               "ref": "Zech 14:8",
-              "note": "\"Living water will flow out from Jerusalem... in summer and in winter\" \u2014 the eschatological living-water promise Jesus claims to fulfil."
+              "note": "\"Living water will flow out from Jerusalem... in summer and in winter\" — the eschatological living-water promise Jesus claims to fulfil."
             },
             {
               "ref": "Ezek 47:1-12",
-              "note": "The river flowing from the Temple in Ezekiel's vision \u2014 perhaps the closest OT antecedent to \"rivers of living water flowing from within.\""
+              "note": "The river flowing from the Temple in Ezekiel's vision — perhaps the closest OT antecedent to \"rivers of living water flowing from within.\""
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:37-38",
-              "note": "\"On the last and greatest day of the festival, Jesus stood and said in a loud voice\" \u2014 the only time in John Jesus \"stood\" to teach (he normally sat). The loud voice and the standing signal a formal, public, climactic declaration. At the precise moment when the water ceremony was at its most elaborate, Jesus invites anyone who is thirsty to come to him. The ceremony is the sermon illustration he is interpreting."
+              "note": "\"On the last and greatest day of the festival, Jesus stood and said in a loud voice\" — the only time in John Jesus \"stood\" to teach (he normally sat). The loud voice and the standing signal a formal, public, climactic declaration. At the precise moment when the water ceremony was at its most elaborate, Jesus invites anyone who is thirsty to come to him. The ceremony is the sermon illustration he is interpreting."
             },
             {
               "ref": "7:39",
-              "note": "\"Up to that time the Spirit had not been given, since Jesus had not yet been glorified\" \u2014 John's editorial note is crucial: the outpouring of the Spirit is contingent on Jesus's glorification (the cross, resurrection, and ascension). The rivers of living water cannot flow until after the passion. This connects the Spirit's gift to the atonement: the Spirit is the fruit of the cross."
+              "note": "\"Up to that time the Spirit had not been given, since Jesus had not yet been glorified\" — John's editorial note is crucial: the outpouring of the Spirit is contingent on Jesus's glorification (the cross, resurrection, and ascension). The rivers of living water cannot flow until after the passion. This connects the Spirit's gift to the atonement: the Spirit is the fruit of the cross."
             },
             {
               "ref": "7:46",
-              "note": "\"No one ever spoke the way this man does\" \u2014 the temple guards, sent to arrest Jesus, return empty-handed with this explanation. Even those whose explicit job is to oppose Jesus cannot follow through when they actually hear him. His words carry an authority that bypasses hostile intent. The Pharisees' response \u2014 \"you mean he has deceived you also?\" \u2014 is the contempt of those who have decided not to hear."
+              "note": "\"No one ever spoke the way this man does\" — the temple guards, sent to arrest Jesus, return empty-handed with this explanation. Even those whose explicit job is to oppose Jesus cannot follow through when they actually hear him. His words carry an authority that bypasses hostile intent. The Pharisees' response — \"you mean he has deceived you also?\" — is the contempt of those who have decided not to hear."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:38-39",
-              "note": "Calvin insists on the connection between \"rivers of living water\" and the Spirit: the Spirit is the water, and the Spirit is given only after the glorification of Christ. This means all genuine spiritual life in the believer is post-resurrection life \u2014 life drawn from the risen, glorified Christ by the Spirit. There is no genuine spiritual vitality except what flows from the glorified Saviour through the Spirit."
+              "note": "Calvin insists on the connection between \"rivers of living water\" and the Spirit: the Spirit is the water, and the Spirit is given only after the glorification of Christ. This means all genuine spiritual life in the believer is post-resurrection life — life drawn from the risen, glorified Christ by the Spirit. There is no genuine spiritual vitality except what flows from the glorified Saviour through the Spirit."
             },
             {
               "ref": "7:51",
@@ -170,11 +170,11 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:38",
-              "note": "\"As Scripture has said, rivers of living water will flow from within them\" \u2014 the source of the citation is disputed. Options: (1) a composite of several OT texts (Isa 44:3; 55:1; Ezek 47:1-12; Zech 14:8); (2) a reference to Ps 78:15-16 (God splitting rocks so water gushed out); (3) the citation refers to Jesus (the water flows from him) rather than the believer. The punctuation of vv.37-38 is significant: \"Let the one who believes in me drink. As Scripture has said, rivers of living water will flow from within him\" could refer to Jesus as the source rather than the believer."
+              "note": "\"As Scripture has said, rivers of living water will flow from within them\" — the source of the citation is disputed. Options: (1) a composite of several OT texts (Isa 44:3; 55:1; Ezek 47:1-12; Zech 14:8); (2) a reference to Ps 78:15-16 (God splitting rocks so water gushed out); (3) the citation refers to Jesus (the water flows from him) rather than the believer. The punctuation of vv.37-38 is significant: \"Let the one who believes in me drink. As Scripture has said, rivers of living water will flow from within him\" could refer to Jesus as the source rather than the believer."
             },
             {
               "ref": "7:53-8:11",
@@ -183,11 +183,11 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "7:37-38",
-              "note": "Augustine: \"He cried out on the last great day of the feast. His voice must reach all; all must hear it. He stands \u2014 as a teacher, as a herald, as one who has something important to say. Let anyone who is thirsty come to me: he calls all, condemns none. He only requires that they be thirsty \u2014 that they feel their need.\""
+              "note": "Augustine: \"He cried out on the last great day of the feast. His voice must reach all; all must hear it. He stands — as a teacher, as a herald, as one who has something important to say. Let anyone who is thirsty come to me: he calls all, condemns none. He only requires that they be thirsty — that they feel their need.\""
             },
             {
               "ref": "7:46",
@@ -196,13 +196,13 @@
           ]
         },
         "hist": {
-          "context": "The Last Day of the Feast\nThe seventh day of Tabernacles was marked by a sevenfold procession around the altar with the water-drawing ceremony, recalling the fall of Jericho. Some traditions held that the eighth day (Shemini Atzeret) was the climactic day. Jesus chooses this specific moment \u2014 the water ceremony at its most elaborate \u2014 to declare himself the source of the water the ceremony pointed to.\n\nNicodemus's Intervention\nNicodemus's second appearance (v.50-52) shows his gradual movement toward Jesus. He does not yet confess Jesus openly; he appeals to procedural justice \u2014 \"does our law condemn a man without first hearing him?\" It is not much, but it is more than silence. The Pharisees' contemptuous response (\"are you from Galilee, too?\") treats any sympathy with Jesus as disqualifying."
+          "context": "The Last Day of the Feast\nThe seventh day of Tabernacles was marked by a sevenfold procession around the altar with the water-drawing ceremony, recalling the fall of Jericho. Some traditions held that the eighth day (Shemini Atzeret) was the climactic day. Jesus chooses this specific moment — the water ceremony at its most elaborate — to declare himself the source of the water the ceremony pointed to.\n\nNicodemus's Intervention\nNicodemus's second appearance (v.50-52) shows his gradual movement toward Jesus. He does not yet confess Jesus openly; he appeals to procedural justice — \"does our law condemn a man without first hearing him?\" It is not much, but it is more than silence. The Pharisees' contemptuous response (\"are you from Galilee, too?\") treats any sympathy with Jesus as disqualifying."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 45\u201353 \u2014 Officers Return Empty-Handed; Nicodemus Speaks Up",
+      "header": "Verses 45–53 — Officers Return Empty-Handed; Nicodemus Speaks Up",
       "verse_start": 45,
       "verse_end": 53,
       "panels": {
@@ -211,93 +211,49 @@
             "word": "kairos",
             "transliteration": "KAI-ros",
             "gloss": "the appointed time / the right moment",
-            "paragraph": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos \u2014 the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast \u2014 secretly, v.10 \u2014 it is because the kairos permits it, not because he has changed his mind."
+            "paragraph": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos — the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast — secretly, v.10 — it is because the kairos permits it, not because he has changed his mind."
           },
           {
-            "word": "didach\u0113",
+            "word": "didachē",
             "transliteration": "di-da-CHE",
             "gloss": "teaching / doctrine",
-            "paragraph": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will \u2014 a criterion available to anyone willing to do God's will."
+            "paragraph": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will — a criterion available to anyone willing to do God's will."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Lev 23:33-43",
-              "note": "The Feast of Tabernacles commanded in Torah \u2014 the seven-day feast of booths commemorating the wilderness wandering."
+              "note": "The Feast of Tabernacles commanded in Torah — the seven-day feast of booths commemorating the wilderness wandering."
             },
             {
               "ref": "Deut 18:15-18",
-              "note": "\"The Lord your God will raise up for you a prophet like me from among you\" \u2014 \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter."
+              "note": "\"The Lord your God will raise up for you a prophet like me from among you\" — \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter."
             },
             {
               "ref": "Zech 14:16-19",
-              "note": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles \u2014 the eschatological horizon behind the feast Jesus attends."
+              "note": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles — the eschatological horizon behind the feast Jesus attends."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:5",
-              "note": "\"Even his own brothers did not believe in him\" \u2014 the most intimate rejection in the Gospel before the passion. Those who grew up with him, who knew him most closely in the natural realm, were furthest from recognising him in the spiritual realm. Proximity to Jesus in the flesh is not the same as faith. The same principle applies to those who are culturally Christian without genuine saving faith."
-            },
-            {
-              "ref": "7:17",
-              "note": "\"Anyone who chooses to do God's will shall find out whether my teaching comes from God\" \u2014 the epistemological principle for testing religious teaching: moral alignment with God's will precedes cognitive certainty about divine origin. Those who want to know if Jesus is from God must first commit to doing God's will. The commitment is prior to the certainty. Faith precedes full understanding."
-            },
-            {
-              "ref": "7:28-29",
-              "note": "Jesus's ironic \"Yes, you know me\" \u2014 they think they know him (son of Joseph, from Galilee). They do not know the essential thing: he is from the Father, sent by the Father, and knows the Father as no human being ever has. The origin they know (Galilee) is incidental; the origin they don't know (the Father) is definitive."
-            },
-            {
-              "ref": "7:30",
-              "note": "\"His hour had not yet come\" \u2014 for the third time in John (2:4; 7:30; 8:20), the \"hour\" protects Jesus from premature seizure. The enemies are real; their intentions are murderous; but they are restrained by a divine timing that they cannot override. The cross will happen at the appointed hour, not before."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:5",
-              "note": "Calvin draws a sharp lesson from the brothers' unbelief: external proximity to Christ \u2014 sharing his home, seeing his works, hearing his teaching \u2014 does not produce faith. Faith is a gift of the Spirit; without it, the most intimate natural relationship with Jesus is spiritually blind. This disposes of any theology that makes gradual familiarity with Christian culture the path to saving faith."
-            },
-            {
-              "ref": "7:17",
-              "note": "The criterion of doing God's will as the condition for knowing divine teaching is, for Calvin, a description of the regenerate person: only those already renewed by the Spirit genuinely will God's will. So the statement is not a general invitation to moral striving as a path to knowledge but a description of how the Spirit-renewed person receives and recognises divine truth."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:8",
-              "note": "\"I am not going up to this festival\" \u2014 some MSS read \"not yet going up\" (ou p\u014d, adding p\u014d) to resolve the apparent contradiction with v.10 where he does go up. NA28 follows \"not going up\" (ouk) as the harder reading \u2014 the \"not yet\" appears to be a scribal harmonisation. Jesus's statement in v.8 is about his public messianic manifestation, not about whether he will attend at all."
-            },
-            {
-              "ref": "7:15",
-              "note": "The question about Jesus's learning without formal training echoes the social world of literacy and education in the first century: formal rabbinic ordination (smicha) required years of study and authorization by a recognized teacher. Jesus's authority bypasses this system entirely \u2014 a fact that is both his strength with the crowds and his problem with the establishment."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "7:5",
-              "note": "Chrysostom: \"His brothers did not believe in him \u2014 the same with whom he had lived so many years. This is a hard thing. Familiarity breeds contempt for great things; those who live with prophets and saints often become insensible to their greatness. Distance lends wonder; nearness breeds familiarity.\""
-            },
-            {
-              "ref": "7:17",
-              "note": "Augustine: \"If anyone wills to do his will, he shall know whether the teaching is from God or whether I speak from myself. The will is prior to the knowledge. The door to knowledge is opened by the will. Not to know first and then to will, but to will first in order to know.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Feast of Tabernacles\nSukkot (Tabernacles) was the most joyful of the three pilgrimage feasts, celebrating the harvest and commemorating the wilderness wandering. For seven days, Israelites lived in temporary booths (sukkoth). The feast included the water-drawing ceremony (Simchat Beit HaSho'evah): priests drew water from the Pool of Siloam each morning and poured it on the altar, accompanied by singing and flute-playing. The feast also included the illumination ceremony: four golden lampstands in the Temple's Court of Women. Jesus's declarations in ch.7-8 (\"rivers of living water,\" \"I am the light of the world\") directly address these two ceremonies.\n\nMessianic Speculation\nThe debate about whether Jesus is the Messiah runs through the chapter in multiple registers: (1) does he have the right Galilean origin? (2) does no one know where the Messiah comes from? (3) will the Messiah do more signs? (4) will authorities protect him if he's the Messiah? John presents the irony that all these speculations miss the deeper truth: Jesus's true origin is not Bethlehem or Galilee but \"from him who sent me\" \u2014 from the Father."
+          "context": "The Feast of Tabernacles\nSukkot (Tabernacles) was the most joyful of the three pilgrimage feasts, celebrating the harvest and commemorating the wilderness wandering. For seven days, Israelites lived in temporary booths (sukkoth). The feast included the water-drawing ceremony (Simchat Beit HaSho'evah): priests drew water from the Pool of Siloam each morning and poured it on the altar, accompanied by singing and flute-playing. The feast also included the illumination ceremony: four golden lampstands in the Temple's Court of Women. Jesus's declarations in ch.7-8 (\"rivers of living water,\" \"I am the light of the world\") directly address these two ceremonies.\n\nMessianic Speculation\nThe debate about whether Jesus is the Messiah runs through the chapter in multiple registers: (1) does he have the right Galilean origin? (2) does no one know where the Messiah comes from? (3) will the Messiah do more signs? (4) will authorities protect him if he's the Messiah? John presents the irony that all these speculations miss the deeper truth: Jesus's true origin is not Bethlehem or Galilee but \"from him who sent me\" — from the Father."
         }
       }
     }
@@ -307,7 +263,7 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Jesus chooses this specific moment \u2014 the water ceremony at its most elaborate \u2014 to declare himself the source of the water the c  Context  [('The Feast of Tabernacles', 'Sukkot (Tabernacles) was the most joyful of the three pilgrimage feast\u2026"
+        "text": "Jesus chooses this specific moment — the water ceremony at its most elaborate — to declare himself the source of the water the c  Context  [('The Feast of Tabernacles', 'Sukkot (Tabernacles) was the most joyful of the three pilgrimage feast…"
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">kairos (7:6)</td><td>NIV: \"the right time\"; KJV: \"time\"; ESV: \"time\"; NRSV: \"time\". NIV captures the qualitative sense of kairos (\"the right time\") better than the neutral \"time.\"</td></tr><tr><td class=\"t-label\">ekraxen (7:37)</td><td>NIV: \"said in a loud voice\"; KJV: \"cried\"; ESV: \"cried out\"; NRSV: \"cried out\". ESV/NRSV's \"cried out\" better captures the urgency and volume of the declaration.</td></tr>",
@@ -320,34 +276,34 @@
       {
         "title": "Ezekiel 47:1-12",
         "quote": "The river flowing from the Temple threshold, growing deeper and deeper, bringing life wherever it flows.",
-        "note": "The vision John draws on for \"rivers of living water\" \u2014 the Temple as the source of life-giving water, now fulfilled in Jesus and his Spirit-giving ministry."
+        "note": "The vision John draws on for \"rivers of living water\" — the Temple as the source of life-giving water, now fulfilled in Jesus and his Spirit-giving ministry."
       }
     ],
     "rec": [
       {
-        "who": "\"No One Ever Spoke Like This Man\" \u2014 The Authority of Jesus's Teaching",
-        "text": "The temple guards' involuntary testimony (7:46) has been cited in every generation as evidence of Jesus's unique rhetorical power. C.S. Lewis's trilemma argument (Lord, Liar, or Lunatic) draws on this pattern: those who encountered Jesus personally found his teaching qualitatively different from anything else \u2014 it could not be explained as ordinary human teaching, however gifted. The guards provide the most compressed version of this argument in the NT."
+        "who": "\"No One Ever Spoke Like This Man\" — The Authority of Jesus's Teaching",
+        "text": "The temple guards' involuntary testimony (7:46) has been cited in every generation as evidence of Jesus's unique rhetorical power. C.S. Lewis's trilemma argument (Lord, Liar, or Lunatic) draws on this pattern: those who encountered Jesus personally found his teaching qualitatively different from anything else — it could not be explained as ordinary human teaching, however gifted. The guards provide the most compressed version of this argument in the NT."
       },
       {
         "who": "The Feast of Tabernacles and Christian Eschatology",
-        "text": "The water-drawing ceremony and lampstand illumination of Sukkot, which Jesus interprets in chs 7-8, became important themes in early Christian eschatological imagination. Zechariah 14 (the eschatological Tabernacles passage) was read as pointing to the ingathering of all nations at the end of history. Jesus's reinterpretation of the feast as fulfilled in himself \u2014 \"come to me and drink\" \u2014 reorients the eschatological hope from a future feast to a present encounter."
+        "text": "The water-drawing ceremony and lampstand illumination of Sukkot, which Jesus interprets in chs 7-8, became important themes in early Christian eschatological imagination. Zechariah 14 (the eschatological Tabernacles passage) was read as pointing to the ingathering of all nations at the end of history. Jesus's reinterpretation of the feast as fulfilled in himself — \"come to me and drink\" — reorients the eschatological hope from a future feast to a present encounter."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Division as Literary Theme \u2014 vv.40-44, 45-52",
+          "label": "Division as Literary Theme — vv.40-44, 45-52",
           "text": "Chapter 7 systematically presents division at every level: the crowd (v.40-43), the guards (v.45-46), the Pharisees (v.47-49), the Sanhedrin (v.50-52). The \"great division\" that Jesus said he brings (Luke 12:51) is demonstrated structurally as well as stated. Every encounter with Jesus produces a split.",
           "is_key": false
         },
         {
-          "label": "Ironical Misunderstanding \u2014 vv.27, 41-42",
-          "text": "The crowd's objections (\"we know where he is from,\" \"can the Messiah come from Galilee?\") are all technically correct within their limited frame \u2014 yet ironically wrong because they miss Jesus's true origin (from the Father). John consistently constructs arguments where the speakers are right on their own terms but catastrophically wrong on the deeper level.",
+          "label": "Ironical Misunderstanding — vv.27, 41-42",
+          "text": "The crowd's objections (\"we know where he is from,\" \"can the Messiah come from Galilee?\") are all technically correct within their limited frame — yet ironically wrong because they miss Jesus's true origin (from the Father). John consistently constructs arguments where the speakers are right on their own terms but catastrophically wrong on the deeper level.",
           "is_key": false
         },
         {
-          "label": "Festival Irony \u2014 vv.2-14",
-          "text": "John uses the Festival of Tabernacles as a literary frame. The feast recalls the wilderness wanderings (booths), the water ceremony, and the torch-lighting \u2014 all of which Jesus explicitly fulfills or supersedes in chapters 7-8. The brothers' unbelief (v5) mirrors Israel's wilderness murmuring.",
+          "label": "Festival Irony — vv.2-14",
+          "text": "John uses the Festival of Tabernacles as a literary frame. The feast recalls the wilderness wanderings (booths), the water ceremony, and the torch-lighting — all of which Jesus explicitly fulfills or supersedes in chapters 7-8. The brothers' unbelief (v5) mirrors Israel's wilderness murmuring.",
           "is_key": false
         }
       ],
@@ -358,31 +314,31 @@
         "word": "kairos",
         "tlit": "KAI-ros",
         "gloss": "the appointed time / the right moment",
-        "note": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos \u2014 the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast \u2014 secretly, v.10 \u2014 it is because the kairos permits it, not because he has changed his mind."
+        "note": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos — the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast — secretly, v.10 — it is because the kairos permits it, not because he has changed his mind."
       },
       {
-        "word": "didach\u0113",
+        "word": "didachē",
         "tlit": "di-da-CHE",
         "gloss": "teaching / doctrine",
-        "note": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will \u2014 a criterion available to anyone willing to do God's will."
+        "note": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will — a criterion available to anyone willing to do God's will."
       },
       {
-        "word": "potamoi hydatos z\u014dntos",
+        "word": "potamoi hydatos zōntos",
         "tlit": "po-ta-MOI HY-da-tos ZON-tos",
         "gloss": "rivers of living water",
-        "note": "Jesus's declaration on the last day of Tabernacles (v.37-38) alludes directly to the water-drawing ceremony of Sukkot \u2014 the daily procession from the Pool of Siloam to the Temple altar. Where the ceremony used water from a pool in Jerusalem, Jesus offers rivers of living water flowing from within the believer. John's interpretation (v.39) is unambiguous: the rivers of living water are the Holy Spirit, not yet given because Jesus had not yet been glorified (the cross and resurrection)."
+        "note": "Jesus's declaration on the last day of Tabernacles (v.37-38) alludes directly to the water-drawing ceremony of Sukkot — the daily procession from the Pool of Siloam to the Temple altar. Where the ceremony used water from a pool in Jerusalem, Jesus offers rivers of living water flowing from within the believer. John's interpretation (v.39) is unambiguous: the rivers of living water are the Holy Spirit, not yet given because Jesus had not yet been glorified (the cross and resurrection)."
       },
       {
         "word": "kairos",
         "tlit": "KAI-ros",
         "gloss": "the appointed time / the right moment",
-        "note": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos \u2014 the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast \u2014 secretly, v.10 \u2014 it is because the kairos permits it, not because he has changed his mind."
+        "note": "Jesus's repeated \"my time has not yet come\" (vv.6, 8) uses kairos — the loaded, purpose-filled moment, not merely chronological time (chronos). His movements and self-disclosure are governed by a divine timetable that his brothers (who think like the world) cannot perceive. When he does go to the feast — secretly, v.10 — it is because the kairos permits it, not because he has changed his mind."
       },
       {
-        "word": "didach\u0113",
+        "word": "didachē",
         "tlit": "di-da-CHE",
         "gloss": "teaching / doctrine",
-        "note": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will \u2014 a criterion available to anyone willing to do God's will."
+        "note": "The crowd's amazement at Jesus's teaching without formal rabbinic education (v.15) frames the discourse. Jesus's response (v.16-17) distinguishes teaching that seeks its own glory from teaching that glorifies the one who sent it. The criterion of truth is not source credentials but alignment with God's will — a criterion available to anyone willing to do God's will."
       }
     ],
     "thread": [
@@ -390,42 +346,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Lev 23:33-43",
         "type": "Connection",
-        "text": "The Feast of Tabernacles commanded in Torah \u2014 the seven-day feast of booths commemorating the wilderness wandering.",
+        "text": "The Feast of Tabernacles commanded in Torah — the seven-day feast of booths commemorating the wilderness wandering.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Deut 18:15-18",
         "type": "Connection",
-        "text": "\"The Lord your God will raise up for you a prophet like me from among you\" \u2014 \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter.",
+        "text": "\"The Lord your God will raise up for you a prophet like me from among you\" — \"the Prophet\" the crowd expects (v.40), one of the messianic categories in play throughout the chapter.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Zech 14:16-19",
         "type": "Connection",
-        "text": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles \u2014 the eschatological horizon behind the feast Jesus attends.",
+        "text": "The eschatological promise that all nations will come to Jerusalem for the Feast of Tabernacles — the eschatological horizon behind the feast Jesus attends.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 55:1",
         "type": "Echo",
-        "text": "\"Come, all you who are thirsty, come to the waters\" \u2014 the invitation echoed in Jesus's cry \"let anyone who is thirsty come to me.\"",
+        "text": "\"Come, all you who are thirsty, come to the waters\" — the invitation echoed in Jesus's cry \"let anyone who is thirsty come to me.\"",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Zech 14:8",
         "type": "Fulfilment",
-        "text": "\"Living water will flow out from Jerusalem... in summer and in winter\" \u2014 the eschatological living-water promise Jesus claims to fulfil.",
+        "text": "\"Living water will flow out from Jerusalem... in summer and in winter\" — the eschatological living-water promise Jesus claims to fulfil.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ezek 47:1-12",
         "type": "Connection",
-        "text": "The river flowing from the Temple in Ezekiel's vision \u2014 perhaps the closest OT antecedent to \"rivers of living water flowing from within.\"",
+        "text": "The river flowing from the Temple in Ezekiel's vision — perhaps the closest OT antecedent to \"rivers of living water flowing from within.\"",
         "direction": "backward"
       }
     ],
@@ -433,13 +389,13 @@
       {
         "ref": "7:8",
         "title": "\"Not going up\" vs \"not yet going up\"",
-        "content": "NA28 reads ouk (not going up); some MSS read oup\u014d (not yet going up). The oup\u014d reading harmonises with v.10 where Jesus does go up. NA28 follows ouk as the harder reading.",
-        "note": "The \"not yet\" is almost certainly a scribal harmonisation. Jesus's statement is about his public messianic self-disclosure, not about physical attendance \u2014 so v.10 does not contradict v.8 even with ouk."
+        "content": "NA28 reads ouk (not going up); some MSS read oupō (not yet going up). The oupō reading harmonises with v.10 where Jesus does go up. NA28 follows ouk as the harder reading.",
+        "note": "The \"not yet\" is almost certainly a scribal harmonisation. Jesus's statement is about his public messianic self-disclosure, not about physical attendance — so v.10 does not contradict v.8 even with ouk."
       }
     ],
     "debate": [
       {
-        "title": "Where do the \"rivers of living water\" flow from \u2014 the believer or Jesus?",
+        "title": "Where do the \"rivers of living water\" flow from — the believer or Jesus?",
         "positions": [
           {
             "name": "From the believer",
@@ -481,7 +437,7 @@
           "score": 10
         }
       ],
-      "note": "John 7 is the chapter of division and timing. Every scene produces a split \u2014 the crowd, the guards, the Sanhedrin \u2014 while Jesus moves through it all governed by a divine timing that his opponents cannot override (\"his hour had not yet come,\" v.30). The Feast of Tabernacles provides the liturgical setting for the chapter's climax: the water-drawing ceremony at its peak, and Jesus standing and crying out \"let anyone who is thirsty come to me.\" The invitation is eschatological \u2014 fulfilled in the Spirit who will flow from the glorified Christ."
+      "note": "John 7 is the chapter of division and timing. Every scene produces a split — the crowd, the guards, the Sanhedrin — while Jesus moves through it all governed by a divine timing that his opponents cannot override (\"his hour had not yet come,\" v.30). The Feast of Tabernacles provides the liturgical setting for the chapter's climax: the water-drawing ceremony at its peak, and Jesus standing and crying out \"let anyone who is thirsty come to me.\" The invitation is eschatological — fulfilled in the Spirit who will flow from the glorified Christ."
     }
   },
   "vhl_groups": [
@@ -605,7 +561,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'Let anyone who is thirsty come to me and drink' (v. 37). On the festival's great day, Jesus stands and shouts. Rivers of living water\u2014the Spirit, John explains (v. 39). Pentecost is previewed.",
+      "tip": "'Let anyone who is thirsty come to me and drink' (v. 37). On the festival's great day, Jesus stands and shouts. Rivers of living water—the Spirit, John explains (v. 39). Pentecost is previewed.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/8.json
+++ b/content/john/8.json
@@ -10,63 +10,63 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 The Woman Caught in Adultery",
+      "header": "Verses 1–11 — The Woman Caught in Adultery",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi to ph\u014ds tou kosmou",
+            "word": "egō eimi to phōs tou kosmou",
             "transliteration": "e-GO ei-MI to PHOS tou KOS-mou",
             "gloss": "I am the light of the world",
-            "paragraph": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" \u2014 the promise is permanent: ou m\u0113 (double negative), never."
+            "paragraph": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" — the promise is permanent: ou mē (double negative), never."
           },
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am / I am he",
-            "paragraph": "In v.24 and v.28, eg\u014d eimi appears without a predicate \u2014 the absolute form. \"If you do not believe that I am he...\" \u2014 the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 \u2014 they try to stone him) confirm this is a divine name claim."
+            "paragraph": "In v.24 and v.28, egō eimi appears without a predicate — the absolute form. \"If you do not believe that I am he...\" — the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 — they try to stone him) confirm this is a divine name claim."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 3:14",
-              "note": "\"I am who I am\" \u2014 the divine name whose absolute form (eg\u014d eimi) Jesus claims in vv.24, 28, 58."
+              "note": "\"I am who I am\" — the divine name whose absolute form (egō eimi) Jesus claims in vv.24, 28, 58."
             },
             {
               "ref": "Isa 43:10",
-              "note": "\"You are my witnesses... that you may know and believe me and understand that I am he\" \u2014 the specific I am context from Isaiah that v.24 echoes."
+              "note": "\"You are my witnesses... that you may know and believe me and understand that I am he\" — the specific I am context from Isaiah that v.24 echoes."
             },
             {
               "ref": "Ps 36:9",
-              "note": "\"For with you is the fountain of life; in your light we see light\" \u2014 the OT background for light as a divine attribute."
+              "note": "\"For with you is the fountain of life; in your light we see light\" — the OT background for light as a divine attribute."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:7",
-              "note": "\"Let any one of you who is without sin be the first to throw a stone at her\" \u2014 Jesus does not dispute the law's legitimacy or the woman's guilt. He turns the instrument of condemnation back on the condemners. The law requires not just witnesses but morally qualified witnesses. The older ones leave first \u2014 the more experience of life, the more honest the self-assessment. Jesus is left as the only one qualified to condemn \u2014 and he chooses not to."
+              "note": "\"Let any one of you who is without sin be the first to throw a stone at her\" — Jesus does not dispute the law's legitimacy or the woman's guilt. He turns the instrument of condemnation back on the condemners. The law requires not just witnesses but morally qualified witnesses. The older ones leave first — the more experience of life, the more honest the self-assessment. Jesus is left as the only one qualified to condemn — and he chooses not to."
             },
             {
               "ref": "8:11",
-              "note": "\"Neither do I condemn you... Go now and leave your life of sin\" \u2014 two parts that must not be separated. The non-condemnation is not a dismissal of the sin but a grant of grace that creates moral obligation. \"Leave your life of sin\" is not an afterthought; it is the purpose of the forgiveness. Grace that does not produce moral change has not been received."
+              "note": "\"Neither do I condemn you... Go now and leave your life of sin\" — two parts that must not be separated. The non-condemnation is not a dismissal of the sin but a grant of grace that creates moral obligation. \"Leave your life of sin\" is not an afterthought; it is the purpose of the forgiveness. Grace that does not produce moral change has not been received."
             },
             {
               "ref": "8:12",
-              "note": "\"I am the light of the world\" \u2014 spoken to the Pharisees who have just tried to trap him. The claim is eschatological: in Isaiah 42:6, the Servant is \"a light for the Gentiles.\" Jesus is claiming to be the one Isaiah described. The Pharisees correctly hear a messianic claim and challenge his right to bear his own witness."
+              "note": "\"I am the light of the world\" — spoken to the Pharisees who have just tried to trap him. The claim is eschatological: in Isaiah 42:6, the Servant is \"a light for the Gentiles.\" Jesus is claiming to be the one Isaiah described. The Pharisees correctly hear a messianic claim and challenge his right to bear his own witness."
             },
             {
               "ref": "8:24",
-              "note": "\"If you do not believe that I am he, you will die in your sins\" \u2014 the absolute eg\u014d eimi without predicate. This is not merely a messianic claim but the divine name. The consequence of rejecting this claim is dying in sin \u2014 the most sobering statement in the chapter."
+              "note": "\"If you do not believe that I am he, you will die in your sins\" — the absolute egō eimi without predicate. This is not merely a messianic claim but the divine name. The consequence of rejecting this claim is dying in sin — the most sobering statement in the chapter."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:11",
@@ -74,29 +74,29 @@
             },
             {
               "ref": "8:24",
-              "note": "\"If you do not believe that I am he\" \u2014 Calvin reads eg\u014d eimi as the claim to be the promised Messiah, with the divine name resonance as secondary. He argues that the primary referent is messianic identity: if you do not believe I am the Messiah God sent, you will die in your sins. This is not a lesser claim than the divine name reading \u2014 it is the same claim approached from its historical-scriptural rather than its philosophical-ontological dimension."
+              "note": "\"If you do not believe that I am he\" — Calvin reads egō eimi as the claim to be the promised Messiah, with the divine name resonance as secondary. He argues that the primary referent is messianic identity: if you do not believe I am the Messiah God sent, you will die in your sins. This is not a lesser claim than the divine name reading — it is the same claim approached from its historical-scriptural rather than its philosophical-ontological dimension."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "8:1-11",
-              "note": "The Pericope Adulterae \u2014 NA28 places it in double brackets with a footnote explaining its absence from the best manuscripts. The NRSV, ESV, and NIV include it but with footnotes noting its disputed status. No reliable translation should omit it entirely given its canonical status, but the textual note is essential. The story's internal character is consistent with Jesus's ministry style even if not with John's literary style."
+              "note": "The Pericope Adulterae — NA28 places it in double brackets with a footnote explaining its absence from the best manuscripts. The NRSV, ESV, and NIV include it but with footnotes noting its disputed status. No reliable translation should omit it entirely given its canonical status, but the textual note is essential. The story's internal character is consistent with Jesus's ministry style even if not with John's literary style."
             },
             {
               "ref": "8:28",
-              "note": "\"When you have lifted up the Son of Man\" \u2014 this is the second of three lifted-up predictions in John (3:14; 8:28; 12:32). Each deepens the meaning: ch.3 connects to the bronze serpent (healing through the lifted-up); ch.8 adds the divine-name revelation (you will know eg\u014d eimi when you lift me up); ch.12 adds universal drawing (I will draw all people to myself)."
+              "note": "\"When you have lifted up the Son of Man\" — this is the second of three lifted-up predictions in John (3:14; 8:28; 12:32). Each deepens the meaning: ch.3 connects to the bronze serpent (healing through the lifted-up); ch.8 adds the divine-name revelation (you will know egō eimi when you lift me up); ch.12 adds universal drawing (I will draw all people to myself)."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "8:7",
-              "note": "Augustine: \"He who had no sin spoke to the sinners. He did not say 'let the one who has no such sin throw the first stone' but simply 'who is without sin.' Because they were all sinners, they all went away. The Lord was left alone with the woman. He is the judge; she is the accused. But the judge did not condemn \u2014 because he came not to condemn the world but to save it.\""
+              "note": "Augustine: \"He who had no sin spoke to the sinners. He did not say 'let the one who has no such sin throw the first stone' but simply 'who is without sin.' Because they were all sinners, they all went away. The Lord was left alone with the woman. He is the judge; she is the accused. But the judge did not condemn — because he came not to condemn the world but to save it.\""
             },
             {
               "ref": "8:12",
@@ -105,95 +105,95 @@
           ]
         },
         "hist": {
-          "context": "The Pericope Adulterae (7:53\u20138:11)\nThe story of the woman caught in adultery is absent from all the earliest and best manuscripts of John (P66, P75, Sinaiticus, Vaticanus). It appears in different locations in different manuscripts \u2014 some after John 7:36, some after John 21:25, some in Luke after 21:38. The style differs from John's. Most NT scholars regard it as an ancient tradition about Jesus (probably authentic in substance) that circulated independently and was eventually inserted here. It is included in the canon and carries pastoral authority, but its textual status means it should not bear the weight of unique doctrines.\n\nThe Lampstand Ceremony\nDuring the Feast of Tabernacles, four golden lampstands (menorot) in the Court of Women were lit each evening, illuminating all Jerusalem according to the Talmud. The ceremony commemorated the pillar of fire in the wilderness. Jesus's declaration \"I am the light of the world\" (v.12) is spoken in this setting, claiming to be what the ceremony symbolises."
+          "context": "The Pericope Adulterae (7:53–8:11)\nThe story of the woman caught in adultery is absent from all the earliest and best manuscripts of John (P66, P75, Sinaiticus, Vaticanus). It appears in different locations in different manuscripts — some after John 7:36, some after John 21:25, some in Luke after 21:38. The style differs from John's. Most NT scholars regard it as an ancient tradition about Jesus (probably authentic in substance) that circulated independently and was eventually inserted here. It is included in the canon and carries pastoral authority, but its textual status means it should not bear the weight of unique doctrines.\n\nThe Lampstand Ceremony\nDuring the Feast of Tabernacles, four golden lampstands (menorot) in the Court of Women were lit each evening, illuminating all Jerusalem according to the Talmud. The ceremony commemorated the pillar of fire in the wilderness. Jesus's declaration \"I am the light of the world\" (v.12) is spoken in this setting, claiming to be what the ceremony symbolises."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201330 \u2014 I Am the Light of the World; Where I Am Going",
+      "header": "Verses 12–30 — I Am the Light of the World; Where I Am Going",
       "verse_start": 12,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "prin Abraam genesthai eg\u014d eimi",
+            "word": "prin Abraam genesthai egō eimi",
             "transliteration": "prin ab-ra-AM ge-NES-thai e-GO ei-MI",
             "gloss": "Before Abraham was born, I am",
-            "paragraph": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist \u2014 a past event) I am (present \u2014 continuous existence).\" Jesus does not say \"I was\" \u2014 which would merely assert prior existence. He says \"I am\" \u2014 asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
+            "paragraph": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist — a past event) I am (present — continuous existence).\" Jesus does not say \"I was\" — which would merely assert prior existence. He says \"I am\" — asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
           },
           {
-            "word": "pat\u0113r tou pseusmatos",
+            "word": "patēr tou pseusmatos",
             "transliteration": "pa-TER tou PSEUS-ma-tos",
             "gloss": "father of lies",
-            "paragraph": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character \u2014 it is his \"native language\" (en tois idiois)."
+            "paragraph": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character — it is his \"native language\" (en tois idiois)."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 3:4-5",
-              "note": "The serpent's lie (\"you will not certainly die\") \u2014 the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\""
+              "note": "The serpent's lie (\"you will not certainly die\") — the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\""
             },
             {
               "ref": "Gen 15:6-21",
-              "note": "The covenant ceremony in which God showed Abraham the future \u2014 possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\""
+              "note": "The covenant ceremony in which God showed Abraham the future — possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\""
             },
             {
               "ref": "Exod 3:14",
-              "note": "\"God said to Moses, 'I am who I am'\" \u2014 the divine name that \"before Abraham was, I am\" explicitly invokes."
+              "note": "\"God said to Moses, 'I am who I am'\" — the divine name that \"before Abraham was, I am\" explicitly invokes."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:32",
-              "note": "\"The truth will set you free\" \u2014 not truth as abstract proposition but truth as person: \"I am the way and the truth and the life\" (14:6). Freedom comes from knowing and abiding in the one who is truth. The context (v.31: \"if you hold to my teaching\") makes clear that this is relational and moral freedom \u2014 freedom from the slavery of sin \u2014 not intellectual or political liberation."
+              "note": "\"The truth will set you free\" — not truth as abstract proposition but truth as person: \"I am the way and the truth and the life\" (14:6). Freedom comes from knowing and abiding in the one who is truth. The context (v.31: \"if you hold to my teaching\") makes clear that this is relational and moral freedom — freedom from the slavery of sin — not intellectual or political liberation."
             },
             {
               "ref": "8:44",
-              "note": "\"You belong to your father, the devil\" \u2014 the most direct confrontation in John. Jesus is not calling his interlocutors bad people by human standards; he is making an ontological claim: their spiritual parentage is revealed by their behaviour \u2014 seeking to kill him (like the murderer from the beginning), rejecting the truth (like the father of lies). The test of spiritual paternity is moral and behavioural, not ethnic."
+              "note": "\"You belong to your father, the devil\" — the most direct confrontation in John. Jesus is not calling his interlocutors bad people by human standards; he is making an ontological claim: their spiritual parentage is revealed by their behaviour — seeking to kill him (like the murderer from the beginning), rejecting the truth (like the father of lies). The test of spiritual paternity is moral and behavioural, not ethnic."
             },
             {
               "ref": "8:56",
-              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" \u2014 the pre-existence claim is implicit here before the explicit \"I am\" of v.58. Jesus not only existed before Abraham's birth; he was the object of Abraham's forward-looking joy. The covenant promises given to Abraham were ultimately promises about Christ."
+              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" — the pre-existence claim is implicit here before the explicit \"I am\" of v.58. Jesus not only existed before Abraham's birth; he was the object of Abraham's forward-looking joy. The covenant promises given to Abraham were ultimately promises about Christ."
             },
             {
               "ref": "8:58",
-              "note": "\"Before Abraham was born, I am!\" \u2014 the eg\u014d eimi without predicate, asserting eternal present existence. The claim transcends chronological sequence: Jesus is not claiming merely to have preceded Abraham but to exist in the divine eternal present that is prior to all time. The immediate stoning attempt confirms the hearers understood this as a divine name claim (blasphemy was punishable by stoning, Lev 24:16)."
+              "note": "\"Before Abraham was born, I am!\" — the egō eimi without predicate, asserting eternal present existence. The claim transcends chronological sequence: Jesus is not claiming merely to have preceded Abraham but to exist in the divine eternal present that is prior to all time. The immediate stoning attempt confirms the hearers understood this as a divine name claim (blasphemy was punishable by stoning, Lev 24:16)."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:34-36",
-              "note": "Calvin develops the slavery/freedom dialectic along the lines of Romans 6: everyone is a slave to their dominant master \u2014 sin or righteousness. The freedom Jesus offers is not the absence of constraint but freedom from sin's tyranny, which is simultaneously freedom for righteousness. \"If the Son sets you free, you will be free indeed\" \u2014 the Son's freedom is the only genuine freedom; all other claimed freedom is slavery to something worse."
+              "note": "Calvin develops the slavery/freedom dialectic along the lines of Romans 6: everyone is a slave to their dominant master — sin or righteousness. The freedom Jesus offers is not the absence of constraint but freedom from sin's tyranny, which is simultaneously freedom for righteousness. \"If the Son sets you free, you will be free indeed\" — the Son's freedom is the only genuine freedom; all other claimed freedom is slavery to something worse."
             },
             {
               "ref": "8:58",
-              "note": "Calvin is cautious about the eternal-present reading, preferring to see the statement as primarily about pre-existence and messianic dignity: Jesus existed before Abraham in his divine nature. However, Calvin does not dispute that eg\u014d eimi carries divine resonance. The statement transcends historical priority and touches the divine essence: \"Christ always existed because he was the eternal wisdom of God.\""
+              "note": "Calvin is cautious about the eternal-present reading, preferring to see the statement as primarily about pre-existence and messianic dignity: Jesus existed before Abraham in his divine nature. However, Calvin does not dispute that egō eimi carries divine resonance. The statement transcends historical priority and touches the divine essence: \"Christ always existed because he was the eternal wisdom of God.\""
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "8:44",
-              "note": "\"He was a murderer from the beginning\" \u2014 connecting to Gen 3 (death entering through the serpent's deception) and possibly Gen 4 (Cain's murder prompted by the devil, 1 John 3:12). \"Father of lies\" \u2014 the devil's nature is not that he occasionally lies but that lying is his essential character (\"his native language\" \u2014 en tois idiois, literally \"in his own things\")."
+              "note": "\"He was a murderer from the beginning\" — connecting to Gen 3 (death entering through the serpent's deception) and possibly Gen 4 (Cain's murder prompted by the devil, 1 John 3:12). \"Father of lies\" — the devil's nature is not that he occasionally lies but that lying is his essential character (\"his native language\" — en tois idiois, literally \"in his own things\")."
             },
             {
               "ref": "8:56",
-              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" \u2014 the verb \"saw\" (eiden, aorist) suggests a specific visionary experience, most likely the covenant ceremony of Gen 15 or possibly the testing at Moriah (Gen 22), where Abraham saw the ram and the promise of divine provision \u2014 a type of the substitutionary atonement."
+              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" — the verb \"saw\" (eiden, aorist) suggests a specific visionary experience, most likely the covenant ceremony of Gen 15 or possibly the testing at Moriah (Gen 22), where Abraham saw the ram and the promise of divine provision — a type of the substitutionary atonement."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "8:32",
@@ -201,214 +201,126 @@
             },
             {
               "ref": "8:58",
-              "note": "Chrysostom: \"Before Abraham was born, I am. Not 'I was' but 'I am' \u2014 the present that has no beginning and no end. He does not say 'before Abraham was born, I was' as if describing a prior time, but 'I am' \u2014 always existing, without beginning, the eternal present. This is why they took up stones: they understood the claim perfectly.\""
+              "note": "Chrysostom: \"Before Abraham was born, I am. Not 'I was' but 'I am' — the present that has no beginning and no end. He does not say 'before Abraham was born, I was' as if describing a prior time, but 'I am' — always existing, without beginning, the eternal present. This is why they took up stones: they understood the claim perfectly.\""
             }
           ]
         },
         "hist": {
-          "context": "\"The Truth Will Set You Free\"\nOne of the most quoted statements of Jesus, usually detached from its context. The freedom Jesus offers is freedom from slavery to sin (v.34), not freedom as general autonomy or self-realisation. The context is a debate about whether Abraham's physical descendants are spiritually free \u2014 Jesus insists that ethnic or religious heritage provides no exemption from sin's bondage. Only the Son can grant genuine freedom (v.36).\n\n\"Abraham Rejoiced to See My Day\"\nJesus's claim in v.56 \u2014 that Abraham saw and rejoiced at \"my day\" \u2014 is one of the most provocative statements in ch.8. The Jewish tradition included various accounts of Abraham being shown the future (cf. Gen 15 Covenant of the Pieces; the Apocalypse of Abraham). Jesus claims Abraham's joy was specifically anticipatory joy at the Messiah's coming. The \"day\" he saw was the day of Jesus."
+          "context": "\"The Truth Will Set You Free\"\nOne of the most quoted statements of Jesus, usually detached from its context. The freedom Jesus offers is freedom from slavery to sin (v.34), not freedom as general autonomy or self-realisation. The context is a debate about whether Abraham's physical descendants are spiritually free — Jesus insists that ethnic or religious heritage provides no exemption from sin's bondage. Only the Son can grant genuine freedom (v.36).\n\n\"Abraham Rejoiced to See My Day\"\nJesus's claim in v.56 — that Abraham saw and rejoiced at \"my day\" — is one of the most provocative statements in ch.8. The Jewish tradition included various accounts of Abraham being shown the future (cf. Gen 15 Covenant of the Pieces; the Apocalypse of Abraham). Jesus claims Abraham's joy was specifically anticipatory joy at the Messiah's coming. The \"day\" he saw was the day of Jesus."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201347 \u2014 The Truth Will Set You Free; Children of the Devil",
+      "header": "Verses 31–47 — The Truth Will Set You Free; Children of the Devil",
       "verse_start": 31,
       "verse_end": 47,
       "panels": {
         "heb": [
           {
-            "word": "eg\u014d eimi to ph\u014ds tou kosmou",
+            "word": "egō eimi to phōs tou kosmou",
             "transliteration": "e-GO ei-MI to PHOS tou KOS-mou",
             "gloss": "I am the light of the world",
-            "paragraph": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" \u2014 the promise is permanent: ou m\u0113 (double negative), never."
+            "paragraph": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" — the promise is permanent: ou mē (double negative), never."
           },
           {
-            "word": "eg\u014d eimi",
+            "word": "egō eimi",
             "transliteration": "e-GO ei-MI",
             "gloss": "I am / I am he",
-            "paragraph": "In v.24 and v.28, eg\u014d eimi appears without a predicate \u2014 the absolute form. \"If you do not believe that I am he...\" \u2014 the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 \u2014 they try to stone him) confirm this is a divine name claim."
+            "paragraph": "In v.24 and v.28, egō eimi appears without a predicate — the absolute form. \"If you do not believe that I am he...\" — the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 — they try to stone him) confirm this is a divine name claim."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 3:14",
-              "note": "\"I am who I am\" \u2014 the divine name whose absolute form (eg\u014d eimi) Jesus claims in vv.24, 28, 58."
+              "note": "\"I am who I am\" — the divine name whose absolute form (egō eimi) Jesus claims in vv.24, 28, 58."
             },
             {
               "ref": "Isa 43:10",
-              "note": "\"You are my witnesses... that you may know and believe me and understand that I am he\" \u2014 the specific I am context from Isaiah that v.24 echoes."
+              "note": "\"You are my witnesses... that you may know and believe me and understand that I am he\" — the specific I am context from Isaiah that v.24 echoes."
             },
             {
               "ref": "Ps 36:9",
-              "note": "\"For with you is the fountain of life; in your light we see light\" \u2014 the OT background for light as a divine attribute."
+              "note": "\"For with you is the fountain of life; in your light we see light\" — the OT background for light as a divine attribute."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:7",
-              "note": "\"Let any one of you who is without sin be the first to throw a stone at her\" \u2014 Jesus does not dispute the law's legitimacy or the woman's guilt. He turns the instrument of condemnation back on the condemners. The law requires not just witnesses but morally qualified witnesses. The older ones leave first \u2014 the more experience of life, the more honest the self-assessment. Jesus is left as the only one qualified to condemn \u2014 and he chooses not to."
-            },
-            {
-              "ref": "8:11",
-              "note": "\"Neither do I condemn you... Go now and leave your life of sin\" \u2014 two parts that must not be separated. The non-condemnation is not a dismissal of the sin but a grant of grace that creates moral obligation. \"Leave your life of sin\" is not an afterthought; it is the purpose of the forgiveness. Grace that does not produce moral change has not been received."
-            },
-            {
-              "ref": "8:12",
-              "note": "\"I am the light of the world\" \u2014 spoken to the Pharisees who have just tried to trap him. The claim is eschatological: in Isaiah 42:6, the Servant is \"a light for the Gentiles.\" Jesus is claiming to be the one Isaiah described. The Pharisees correctly hear a messianic claim and challenge his right to bear his own witness."
-            },
-            {
-              "ref": "8:24",
-              "note": "\"If you do not believe that I am he, you will die in your sins\" \u2014 the absolute eg\u014d eimi without predicate. This is not merely a messianic claim but the divine name. The consequence of rejecting this claim is dying in sin \u2014 the most sobering statement in the chapter."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:11",
-              "note": "Calvin insists on the inseparability of \"neither do I condemn you\" and \"leave your life of sin.\" The grace that forgives is simultaneously the grace that transforms. To receive the forgiveness without the moral demand is to misunderstand both. Calvin explicitly rejects the libertine reading that uses \"neither do I condemn\" as a license for continuing sin."
-            },
-            {
-              "ref": "8:24",
-              "note": "\"If you do not believe that I am he\" \u2014 Calvin reads eg\u014d eimi as the claim to be the promised Messiah, with the divine name resonance as secondary. He argues that the primary referent is messianic identity: if you do not believe I am the Messiah God sent, you will die in your sins. This is not a lesser claim than the divine name reading \u2014 it is the same claim approached from its historical-scriptural rather than its philosophical-ontological dimension."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:1-11",
-              "note": "The Pericope Adulterae \u2014 NA28 places it in double brackets with a footnote explaining its absence from the best manuscripts. The NRSV, ESV, and NIV include it but with footnotes noting its disputed status. No reliable translation should omit it entirely given its canonical status, but the textual note is essential. The story's internal character is consistent with Jesus's ministry style even if not with John's literary style."
-            },
-            {
-              "ref": "8:28",
-              "note": "\"When you have lifted up the Son of Man\" \u2014 this is the second of three lifted-up predictions in John (3:14; 8:28; 12:32). Each deepens the meaning: ch.3 connects to the bronze serpent (healing through the lifted-up); ch.8 adds the divine-name revelation (you will know eg\u014d eimi when you lift me up); ch.12 adds universal drawing (I will draw all people to myself)."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:7",
-              "note": "Augustine: \"He who had no sin spoke to the sinners. He did not say 'let the one who has no such sin throw the first stone' but simply 'who is without sin.' Because they were all sinners, they all went away. The Lord was left alone with the woman. He is the judge; she is the accused. But the judge did not condemn \u2014 because he came not to condemn the world but to save it.\""
-            },
-            {
-              "ref": "8:12",
-              "note": "Chrysostom: \"I am the light of the world. Not of one nation, not of one people, but of the whole world. And what is the light? The sun illumines the body; I illuminate the soul. The sun makes visible the things of earth; I reveal the things of heaven.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Pericope Adulterae (7:53\u20138:11)\nThe story of the woman caught in adultery is absent from all the earliest and best manuscripts of John (P66, P75, Sinaiticus, Vaticanus). It appears in different locations in different manuscripts \u2014 some after John 7:36, some after John 21:25, some in Luke after 21:38. The style differs from John's. Most NT scholars regard it as an ancient tradition about Jesus (probably authentic in substance) that circulated independently and was eventually inserted here. It is included in the canon and carries pastoral authority, but its textual status means it should not bear the weight of unique doctrines.\n\nThe Lampstand Ceremony\nDuring the Feast of Tabernacles, four golden lampstands (menorot) in the Court of Women were lit each evening, illuminating all Jerusalem according to the Talmud. The ceremony commemorated the pillar of fire in the wilderness. Jesus's declaration \"I am the light of the world\" (v.12) is spoken in this setting, claiming to be what the ceremony symbolises."
+          "context": "The Pericope Adulterae (7:53–8:11)\nThe story of the woman caught in adultery is absent from all the earliest and best manuscripts of John (P66, P75, Sinaiticus, Vaticanus). It appears in different locations in different manuscripts — some after John 7:36, some after John 21:25, some in Luke after 21:38. The style differs from John's. Most NT scholars regard it as an ancient tradition about Jesus (probably authentic in substance) that circulated independently and was eventually inserted here. It is included in the canon and carries pastoral authority, but its textual status means it should not bear the weight of unique doctrines.\n\nThe Lampstand Ceremony\nDuring the Feast of Tabernacles, four golden lampstands (menorot) in the Court of Women were lit each evening, illuminating all Jerusalem according to the Talmud. The ceremony commemorated the pillar of fire in the wilderness. Jesus's declaration \"I am the light of the world\" (v.12) is spoken in this setting, claiming to be what the ceremony symbolises."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 48\u201359 \u2014 Before Abraham Was, I Am",
+      "header": "Verses 48–59 — Before Abraham Was, I Am",
       "verse_start": 48,
       "verse_end": 59,
       "panels": {
         "heb": [
           {
-            "word": "prin Abraam genesthai eg\u014d eimi",
+            "word": "prin Abraam genesthai egō eimi",
             "transliteration": "prin ab-ra-AM ge-NES-thai e-GO ei-MI",
             "gloss": "Before Abraham was born, I am",
-            "paragraph": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist \u2014 a past event) I am (present \u2014 continuous existence).\" Jesus does not say \"I was\" \u2014 which would merely assert prior existence. He says \"I am\" \u2014 asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
+            "paragraph": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist — a past event) I am (present — continuous existence).\" Jesus does not say \"I was\" — which would merely assert prior existence. He says \"I am\" — asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
           },
           {
-            "word": "pat\u0113r tou pseusmatos",
+            "word": "patēr tou pseusmatos",
             "transliteration": "pa-TER tou PSEUS-ma-tos",
             "gloss": "father of lies",
-            "paragraph": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character \u2014 it is his \"native language\" (en tois idiois)."
+            "paragraph": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character — it is his \"native language\" (en tois idiois)."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 3:4-5",
-              "note": "The serpent's lie (\"you will not certainly die\") \u2014 the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\""
+              "note": "The serpent's lie (\"you will not certainly die\") — the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\""
             },
             {
               "ref": "Gen 15:6-21",
-              "note": "The covenant ceremony in which God showed Abraham the future \u2014 possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\""
+              "note": "The covenant ceremony in which God showed Abraham the future — possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\""
             },
             {
               "ref": "Exod 3:14",
-              "note": "\"God said to Moses, 'I am who I am'\" \u2014 the divine name that \"before Abraham was, I am\" explicitly invokes."
+              "note": "\"God said to Moses, 'I am who I am'\" — the divine name that \"before Abraham was, I am\" explicitly invokes."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:32",
-              "note": "\"The truth will set you free\" \u2014 not truth as abstract proposition but truth as person: \"I am the way and the truth and the life\" (14:6). Freedom comes from knowing and abiding in the one who is truth. The context (v.31: \"if you hold to my teaching\") makes clear that this is relational and moral freedom \u2014 freedom from the slavery of sin \u2014 not intellectual or political liberation."
-            },
-            {
-              "ref": "8:44",
-              "note": "\"You belong to your father, the devil\" \u2014 the most direct confrontation in John. Jesus is not calling his interlocutors bad people by human standards; he is making an ontological claim: their spiritual parentage is revealed by their behaviour \u2014 seeking to kill him (like the murderer from the beginning), rejecting the truth (like the father of lies). The test of spiritual paternity is moral and behavioural, not ethnic."
-            },
-            {
-              "ref": "8:56",
-              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" \u2014 the pre-existence claim is implicit here before the explicit \"I am\" of v.58. Jesus not only existed before Abraham's birth; he was the object of Abraham's forward-looking joy. The covenant promises given to Abraham were ultimately promises about Christ."
-            },
-            {
-              "ref": "8:58",
-              "note": "\"Before Abraham was born, I am!\" \u2014 the eg\u014d eimi without predicate, asserting eternal present existence. The claim transcends chronological sequence: Jesus is not claiming merely to have preceded Abraham but to exist in the divine eternal present that is prior to all time. The immediate stoning attempt confirms the hearers understood this as a divine name claim (blasphemy was punishable by stoning, Lev 24:16)."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:34-36",
-              "note": "Calvin develops the slavery/freedom dialectic along the lines of Romans 6: everyone is a slave to their dominant master \u2014 sin or righteousness. The freedom Jesus offers is not the absence of constraint but freedom from sin's tyranny, which is simultaneously freedom for righteousness. \"If the Son sets you free, you will be free indeed\" \u2014 the Son's freedom is the only genuine freedom; all other claimed freedom is slavery to something worse."
-            },
-            {
-              "ref": "8:58",
-              "note": "Calvin is cautious about the eternal-present reading, preferring to see the statement as primarily about pre-existence and messianic dignity: Jesus existed before Abraham in his divine nature. However, Calvin does not dispute that eg\u014d eimi carries divine resonance. The statement transcends historical priority and touches the divine essence: \"Christ always existed because he was the eternal wisdom of God.\""
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:44",
-              "note": "\"He was a murderer from the beginning\" \u2014 connecting to Gen 3 (death entering through the serpent's deception) and possibly Gen 4 (Cain's murder prompted by the devil, 1 John 3:12). \"Father of lies\" \u2014 the devil's nature is not that he occasionally lies but that lying is his essential character (\"his native language\" \u2014 en tois idiois, literally \"in his own things\")."
-            },
-            {
-              "ref": "8:56",
-              "note": "\"Abraham rejoiced at the thought of seeing my day; he saw it and was glad\" \u2014 the verb \"saw\" (eiden, aorist) suggests a specific visionary experience, most likely the covenant ceremony of Gen 15 or possibly the testing at Moriah (Gen 22), where Abraham saw the ram and the promise of divine provision \u2014 a type of the substitutionary atonement."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:32",
-              "note": "Augustine: \"You will know the truth, and the truth will set you free. Who are the slaves? Those who are ruled by sin. What does it mean to know the truth? To know Christ. For he said 'I am the truth.' The knowledge that frees is not information about truth but personal knowledge of the Truth who is a person.\""
-            },
-            {
-              "ref": "8:58",
-              "note": "Chrysostom: \"Before Abraham was born, I am. Not 'I was' but 'I am' \u2014 the present that has no beginning and no end. He does not say 'before Abraham was born, I was' as if describing a prior time, but 'I am' \u2014 always existing, without beginning, the eternal present. This is why they took up stones: they understood the claim perfectly.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "\"The Truth Will Set You Free\"\nOne of the most quoted statements of Jesus, usually detached from its context. The freedom Jesus offers is freedom from slavery to sin (v.34), not freedom as general autonomy or self-realisation. The context is a debate about whether Abraham's physical descendants are spiritually free \u2014 Jesus insists that ethnic or religious heritage provides no exemption from sin's bondage. Only the Son can grant genuine freedom (v.36).\n\n\"Abraham Rejoiced to See My Day\"\nJesus's claim in v.56 \u2014 that Abraham saw and rejoiced at \"my day\" \u2014 is one of the most provocative statements in ch.8. The Jewish tradition included various accounts of Abraham being shown the future (cf. Gen 15 Covenant of the Pieces; the Apocalypse of Abraham). Jesus claims Abraham's joy was specifically anticipatory joy at the Messiah's coming. The \"day\" he saw was the day of Jesus."
+          "context": "\"The Truth Will Set You Free\"\nOne of the most quoted statements of Jesus, usually detached from its context. The freedom Jesus offers is freedom from slavery to sin (v.34), not freedom as general autonomy or self-realisation. The context is a debate about whether Abraham's physical descendants are spiritually free — Jesus insists that ethnic or religious heritage provides no exemption from sin's bondage. Only the Son can grant genuine freedom (v.36).\n\n\"Abraham Rejoiced to See My Day\"\nJesus's claim in v.56 — that Abraham saw and rejoiced at \"my day\" — is one of the most provocative statements in ch.8. The Jewish tradition included various accounts of Abraham being shown the future (cf. Gen 15 Covenant of the Pieces; the Apocalypse of Abraham). Jesus claims Abraham's joy was specifically anticipatory joy at the Messiah's coming. The \"day\" he saw was the day of Jesus."
         }
       }
     }
@@ -418,10 +330,10 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Most NT scholars regard it as an ancient traditio  Context  [('\"The Truth Will Set You Free\"', \"One of the most quoted statements of Jesus, usually detached from its context\u2026"
+        "text": "Most NT scholars regard it as an ancient traditio  Context  [('\"The Truth Will Set You Free\"', \"One of the most quoted statements of Jesus, usually detached from its context…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anamart\u0113tos (8:7)</td><td>NIV: \"without sin\"; KJV: \"without sin\"; ESV: \"without sin\"; NRSV: \"without sin\". Universal agreement.</td></tr><tr><td class=\"t-label\">al\u0113theia (8:32)</td><td>NIV: \"truth\"; KJV: \"truth\"; ESV: \"truth\"; NRSV: \"truth\". Universal agreement. The theological weight lies in recognising that \"truth\" here ultimately refers to a person (14:6), not a proposition.</td></tr><tr><td class=\"t-label\">eg\u014d eimi (8:58)</td><td>NIV: \"I am!\"; KJV: \"I am\"; ESV: \"I am\"; NRSV: \"I am\". Universal agreement on the translation; universal disagreement on the theological weight \u2014 from mere assertion of pre-existence to full divine name claim.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anamartētos (8:7)</td><td>NIV: \"without sin\"; KJV: \"without sin\"; ESV: \"without sin\"; NRSV: \"without sin\". Universal agreement.</td></tr><tr><td class=\"t-label\">alētheia (8:32)</td><td>NIV: \"truth\"; KJV: \"truth\"; ESV: \"truth\"; NRSV: \"truth\". Universal agreement. The theological weight lies in recognising that \"truth\" here ultimately refers to a person (14:6), not a proposition.</td></tr><tr><td class=\"t-label\">egō eimi (8:58)</td><td>NIV: \"I am!\"; KJV: \"I am\"; ESV: \"I am\"; NRSV: \"I am\". Universal agreement on the translation; universal disagreement on the theological weight — from mere assertion of pre-existence to full divine name claim.</td></tr>",
     "src": [
       {
         "title": "Isaiah 43:10",
@@ -432,27 +344,27 @@
     "rec": [
       {
         "who": "\"The Truth Will Set You Free\" in Western Culture",
-        "text": "John 8:32 is one of the most quoted biblical phrases in Western secular culture \u2014 typically detached from its context and used to support intellectual freedom, free speech, or democratic values. The phrase is inscribed at the entrance to CIA headquarters in Langley, Virginia (1950), and appears in countless university mottos. The irony noted by biblical scholars is that the original context makes freedom entirely dependent on personal relationship with Jesus \u2014 the furthest possible thing from abstract intellectual autonomy."
+        "text": "John 8:32 is one of the most quoted biblical phrases in Western secular culture — typically detached from its context and used to support intellectual freedom, free speech, or democratic values. The phrase is inscribed at the entrance to CIA headquarters in Langley, Virginia (1950), and appears in countless university mottos. The irony noted by biblical scholars is that the original context makes freedom entirely dependent on personal relationship with Jesus — the furthest possible thing from abstract intellectual autonomy."
       },
       {
         "who": "\"Before Abraham Was, I Am\" in Christological Debate",
-        "text": "John 8:58 has been at the centre of every major Christological controversy. Arius (3rd-4th century) accepted Christ's pre-existence but denied his eternal deity \u2014 the Council of Nicaea (AD 325) rejected this precisely on the basis of texts like 8:58. Jehovah's Witnesses translate the verse as \"before Abraham came into existence, I have been\" to avoid the divine name resonance. The verse remains one of the most exegetically and theologically contested in the NT."
+        "text": "John 8:58 has been at the centre of every major Christological controversy. Arius (3rd-4th century) accepted Christ's pre-existence but denied his eternal deity — the Council of Nicaea (AD 325) rejected this precisely on the basis of texts like 8:58. Jehovah's Witnesses translate the verse as \"before Abraham came into existence, I have been\" to avoid the divine name resonance. The verse remains one of the most exegetically and theologically contested in the NT."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Escalating I Am Claims \u2014 vv.12, 24, 28, 58",
-          "text": "Four I am statements in chapter 8, escalating in explicitness: I am the light (predicate) \u2192 I am he (implicit predicate, messianic) \u2192 when you lift me up you will know I am (absolute, passion-linked) \u2192 before Abraham was, I am (absolute, eternal present). The chapter is structured around this escalation.",
+          "label": "Escalating I Am Claims — vv.12, 24, 28, 58",
+          "text": "Four I am statements in chapter 8, escalating in explicitness: I am the light (predicate) → I am he (implicit predicate, messianic) → when you lift me up you will know I am (absolute, passion-linked) → before Abraham was, I am (absolute, eternal present). The chapter is structured around this escalation.",
           "is_key": false
         },
         {
-          "label": "Father Contrast \u2014 vv.38-44",
-          "text": "Jesus and his opponents each speak of \"their father\" \u2014 Jesus speaks what he has heard from his Father (God); they do what they have heard from their father (the devil). The contrast is drawn with deliberate symmetry: two father-child relationships, two sets of actions, two opposite outcomes.",
+          "label": "Father Contrast — vv.38-44",
+          "text": "Jesus and his opponents each speak of \"their father\" — Jesus speaks what he has heard from his Father (God); they do what they have heard from their father (the devil). The contrast is drawn with deliberate symmetry: two father-child relationships, two sets of actions, two opposite outcomes.",
           "is_key": false
         },
         {
-          "label": "Trial Structure \u2014 ch.8",
+          "label": "Trial Structure — ch.8",
           "text": "The entire chapter is organized as a legal confrontation. The Pharisees raise the two-witness rule (v13); Jesus responds with two witnesses (himself and the Father, v18). The escalating \"I Am\" claims function as courtroom testimony building to the ultimate disclosure (v58).",
           "is_key": false
         }
@@ -461,52 +373,52 @@
     },
     "hebtext": [
       {
-        "word": "eg\u014d eimi to ph\u014ds tou kosmou",
+        "word": "egō eimi to phōs tou kosmou",
         "tlit": "e-GO ei-MI to PHOS tou KOS-mou",
         "gloss": "I am the light of the world",
-        "note": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" \u2014 the promise is permanent: ou m\u0113 (double negative), never."
+        "note": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" — the promise is permanent: ou mē (double negative), never."
       },
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am / I am he",
-        "note": "In v.24 and v.28, eg\u014d eimi appears without a predicate \u2014 the absolute form. \"If you do not believe that I am he...\" \u2014 the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 \u2014 they try to stone him) confirm this is a divine name claim."
+        "note": "In v.24 and v.28, egō eimi appears without a predicate — the absolute form. \"If you do not believe that I am he...\" — the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 — they try to stone him) confirm this is a divine name claim."
       },
       {
-        "word": "prin Abraam genesthai eg\u014d eimi",
+        "word": "prin Abraam genesthai egō eimi",
         "tlit": "prin ab-ra-AM ge-NES-thai e-GO ei-MI",
         "gloss": "Before Abraham was born, I am",
-        "note": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist \u2014 a past event) I am (present \u2014 continuous existence).\" Jesus does not say \"I was\" \u2014 which would merely assert prior existence. He says \"I am\" \u2014 asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
+        "note": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist — a past event) I am (present — continuous existence).\" Jesus does not say \"I was\" — which would merely assert prior existence. He says \"I am\" — asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
       },
       {
-        "word": "pat\u0113r tou pseusmatos",
+        "word": "patēr tou pseusmatos",
         "tlit": "pa-TER tou PSEUS-ma-tos",
         "gloss": "father of lies",
-        "note": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character \u2014 it is his \"native language\" (en tois idiois)."
+        "note": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character — it is his \"native language\" (en tois idiois)."
       },
       {
-        "word": "eg\u014d eimi to ph\u014ds tou kosmou",
+        "word": "egō eimi to phōs tou kosmou",
         "tlit": "e-GO ei-MI to PHOS tou KOS-mou",
         "gloss": "I am the light of the world",
-        "note": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" \u2014 the promise is permanent: ou m\u0113 (double negative), never."
+        "note": "The second I am saying with predicate (v.12), spoken during the Feast of Tabernacles when four great golden menorot illuminated the Temple's Court of Women through the night. Jesus declares himself the reality that the lampstands symbolise. Light in John's Gospel is the first creation (Gen 1:3), a divine attribute (1 John 1:5), and the metaphor for life, truth, and revelation. \"Whoever follows me will never walk in darkness\" — the promise is permanent: ou mē (double negative), never."
       },
       {
-        "word": "eg\u014d eimi",
+        "word": "egō eimi",
         "tlit": "e-GO ei-MI",
         "gloss": "I am / I am he",
-        "note": "In v.24 and v.28, eg\u014d eimi appears without a predicate \u2014 the absolute form. \"If you do not believe that I am he...\" \u2014 the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 \u2014 they try to stone him) confirm this is a divine name claim."
+        "note": "In v.24 and v.28, egō eimi appears without a predicate — the absolute form. \"If you do not believe that I am he...\" — the \"he\" is added by translators; the Greek is simply \"I am.\" Jesus is using the divine name of Exod 3:14 and especially Isa 43:10 (\"you are my witnesses that I am he\"). The context and the opponents' reaction (v.59 — they try to stone him) confirm this is a divine name claim."
       },
       {
-        "word": "prin Abraam genesthai eg\u014d eimi",
+        "word": "prin Abraam genesthai egō eimi",
         "tlit": "prin ab-ra-AM ge-NES-thai e-GO ei-MI",
         "gloss": "Before Abraham was born, I am",
-        "note": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist \u2014 a past event) I am (present \u2014 continuous existence).\" Jesus does not say \"I was\" \u2014 which would merely assert prior existence. He says \"I am\" \u2014 asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
+        "note": "The climax of ch.8 and one of the most explosive statements in the Gospel. The grammar is deliberately wrong: \"before Abraham was born (aorist — a past event) I am (present — continuous existence).\" Jesus does not say \"I was\" — which would merely assert prior existence. He says \"I am\" — asserting the eternal present of divine existence that is not bounded by past or future. The opponents' response (taking up stones for blasphemy, v.59) confirms they understood this as a claim to the divine name."
       },
       {
-        "word": "pat\u0113r tou pseusmatos",
+        "word": "patēr tou pseusmatos",
         "tlit": "pa-TER tou PSEUS-ma-tos",
         "gloss": "father of lies",
-        "note": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character \u2014 it is his \"native language\" (en tois idiois)."
+        "note": "Jesus's characterisation of the devil (v.44) as the father of lies and a murderer from the beginning is the most direct statement in the NT about the devil's nature and activity. The \"murder from the beginning\" connects to the Fall (death entering through the devil's deception, Gen 3) and possibly Cain's murder of Abel (1 John 3:12). Lying is not incidental to the devil's character — it is his \"native language\" (en tois idiois)."
       }
     ],
     "thread": [
@@ -514,65 +426,65 @@
         "anchor": "Scripture Walkthrough",
         "target": "Exod 3:14",
         "type": "Connection",
-        "text": "\"I am who I am\" \u2014 the divine name whose absolute form (eg\u014d eimi) Jesus claims in vv.24, 28, 58.",
+        "text": "\"I am who I am\" — the divine name whose absolute form (egō eimi) Jesus claims in vv.24, 28, 58.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 43:10",
         "type": "Echo",
-        "text": "\"You are my witnesses... that you may know and believe me and understand that I am he\" \u2014 the specific I am context from Isaiah that v.24 echoes.",
+        "text": "\"You are my witnesses... that you may know and believe me and understand that I am he\" — the specific I am context from Isaiah that v.24 echoes.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 36:9",
         "type": "Connection",
-        "text": "\"For with you is the fountain of life; in your light we see light\" \u2014 the OT background for light as a divine attribute.",
+        "text": "\"For with you is the fountain of life; in your light we see light\" — the OT background for light as a divine attribute.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Gen 3:4-5",
         "type": "Connection",
-        "text": "The serpent's lie (\"you will not certainly die\") \u2014 the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\"",
+        "text": "The serpent's lie (\"you will not certainly die\") — the first lie in Scripture, which Jesus connects to the devil being a \"murderer from the beginning\" and \"the father of lies.\"",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Gen 15:6-21",
         "type": "Connection",
-        "text": "The covenant ceremony in which God showed Abraham the future \u2014 possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\"",
+        "text": "The covenant ceremony in which God showed Abraham the future — possibly the occasion Jesus refers to in \"Abraham rejoiced at the thought of seeing my day.\"",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Exod 3:14",
         "type": "Connection",
-        "text": "\"God said to Moses, 'I am who I am'\" \u2014 the divine name that \"before Abraham was, I am\" explicitly invokes.",
+        "text": "\"God said to Moses, 'I am who I am'\" — the divine name that \"before Abraham was, I am\" explicitly invokes.",
         "direction": "backward"
       }
     ],
     "tx": {
       "notes": [
         {
-          "ref": "7:53\u20138:11",
-          "title": "Pericope Adulterae \u2014 not original to John",
+          "ref": "7:53–8:11",
+          "title": "Pericope Adulterae — not original to John",
           "content": "Absent from P66, P75, Sinaiticus, Vaticanus, Alexandrinus, and most early versions. Found in various locations in different manuscripts. NA28 places it in double brackets.",
           "note": "The passage is almost certainly not original to John's Gospel. It likely represents genuine Jesus tradition that circulated independently. Its canonical status is accepted by most traditions despite its textual uncertainty."
         },
         {
           "ref": "8:57",
           "title": "\"You are not yet fifty years old\"",
-          "content": "Some interpreters have used the \"fifty\" to argue Jesus was around 46-49 years old, not 30 (contradicting Luke 3:23). More likely \"fifty\" is simply the round number for the end of a man's active years (cf. Num 4:3) \u2014 not a precise age estimate.",
+          "content": "Some interpreters have used the \"fifty\" to argue Jesus was around 46-49 years old, not 30 (contradicting Luke 3:23). More likely \"fifty\" is simply the round number for the end of a man's active years (cf. Num 4:3) — not a precise age estimate.",
           "note": "No textual variant; the \"fifty\" is original. The exegetical problem is hermeneutical, not textual."
         }
       ],
       "stories": [
         {
           "title": "The Woman Caught in Adultery",
-          "passage": "John 7:53\u20138:11",
-          "summary": "This vivid narrative of Jesus forgiving an adulteress is absent from the oldest and most reliable manuscripts of John. It appears to float in the tradition \u2014 found in different locations in different manuscripts \u2014 suggesting it was a widely circulated independent story later inserted into John.",
+          "passage": "John 7:53–8:11",
+          "summary": "This vivid narrative of Jesus forgiving an adulteress is absent from the oldest and most reliable manuscripts of John. It appears to float in the tradition — found in different locations in different manuscripts — suggesting it was a widely circulated independent story later inserted into John.",
           "evidence": [
             {
               "manuscript": "Papyrus 66 (c. 200)",
@@ -611,7 +523,7 @@
               "reading": "Present at John 7:53"
             }
           ],
-          "consensus": "Virtually all textual critics agree that the passage was not originally part of John's Gospel. The vocabulary is markedly non-Johannine. However, most scholars regard the story as historically authentic \u2014 a genuine episode from Jesus's ministry preserved in oral tradition.",
+          "consensus": "Virtually all textual critics agree that the passage was not originally part of John's Gospel. The vocabulary is markedly non-Johannine. However, most scholars regard the story as historically authentic — a genuine episode from Jesus's ministry preserved in oral tradition.",
           "significance": "The story's uncertain textual home does not diminish its theological power. It embodies the Johannine theme of Jesus as life-giver and judge-who-does-not-condemn. Augustine noted that some teachers removed it to prevent women from concluding that adultery was pardonable."
         }
       ]
@@ -621,9 +533,9 @@
         "title": "Does \"before Abraham was, I am\" assert eternal deity or simply pre-existence?",
         "positions": [
           {
-            "name": "Full divine name claim \u2014 eternal deity",
+            "name": "Full divine name claim — eternal deity",
             "proponents": "Most evangelical scholars, MacArthur, Carson, Keener",
-            "argument": "The eg\u014d eimi without predicate, the deliberate grammatical contrast (aorist genesthai vs present eimi), and the immediate stoning attempt (for blasphemy) all confirm a divine name claim. This is not merely pre-existence but eternal self-existent being."
+            "argument": "The egō eimi without predicate, the deliberate grammatical contrast (aorist genesthai vs present eimi), and the immediate stoning attempt (for blasphemy) all confirm a divine name claim. This is not merely pre-existence but eternal self-existent being."
           },
           {
             "name": "Pre-existence, not necessarily full deity",
@@ -660,7 +572,7 @@
           "score": 10
         }
       ],
-      "note": "John 8 is the chapter of ultimate identity claims. The light declaration (v.12), the freedom promise (v.32), the Father-knowledge claims (vv.19, 54-55), and the absolute I am statements culminate in the most explosive sentence of the Galilean ministry: \"Before Abraham was, I am.\" The chapter moves relentlessly from claim to counter-claim to attempted stoning \u2014 a trajectory that will end at the cross. Every I am statement is simultaneously an invitation (come to the light, know the truth, be set free) and a confrontation with the darkness that hates it."
+      "note": "John 8 is the chapter of ultimate identity claims. The light declaration (v.12), the freedom promise (v.32), the Father-knowledge claims (vv.19, 54-55), and the absolute I am statements culminate in the most explosive sentence of the Galilean ministry: \"Before Abraham was, I am.\" The chapter moves relentlessly from claim to counter-claim to attempted stoning — a trajectory that will end at the cross. Every I am statement is simultaneously an invitation (come to the light, know the truth, be set free) and a confrontation with the darkness that hates it."
     }
   },
   "vhl_groups": [
@@ -784,7 +696,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'Before Abraham was born, I AM!' (v. 58). Not 'I was'\u2014present tense divine name. The Jews pick up stones; they understand. Jesus claims Yahweh's identity. Either blasphemy or truth.",
+      "tip": "'Before Abraham was born, I AM!' (v. 58). Not 'I was'—present tense divine name. The Jews pick up stones; they understand. Jesus claims Yahweh's identity. Either blasphemy or truth.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/john/9.json
+++ b/content/john/9.json
@@ -7,13 +7,13 @@
   "subtitle": "The Man Born Blind",
   "timeline_link": {
     "event_id": "feeding-five-thousand",
-    "text": "See on Timeline \u2014 Feeding of the Five Thousand"
+    "text": "See on Timeline — Feeding of the Five Thousand"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201312 \u2014 The Man Born Blind: Neither This Man Nor His Parents Sinned",
+      "header": "Verses 1–12 — The Man Born Blind: Neither This Man Nor His Parents Sinned",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
@@ -22,78 +22,78 @@
             "word": "Siloam",
             "transliteration": "Si-LO-am",
             "gloss": "Sent",
-            "paragraph": "John translates the pool's name: \"Siloam (which means Sent)\" \u2014 v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostell\u014d) is one of John's most freighted words \u2014 it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" \u2014 a double layer of meaning."
+            "paragraph": "John translates the pool's name: \"Siloam (which means Sent)\" — v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostellō) is one of John's most freighted words — it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" — a double layer of meaning."
           },
           {
-            "word": "\u0113noichth\u0113san autou hoi ophthalmoi",
-            "transliteration": "\u0113-noi-CHTH\u0112-san au-TOU hoi oph-thal-MOI",
+            "word": "ēnoichthēsan autou hoi ophthalmoi",
+            "transliteration": "ē-noi-CHTHĒ-san au-TOU hoi oph-thal-MOI",
             "gloss": "his eyes were opened",
-            "paragraph": "The passive divine voice \u2014 \"were opened\" \u2014 runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
+            "paragraph": "The passive divine voice — \"were opened\" — runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
           }
         ],
         "places": [
           {
             "name": "Pool of Siloam",
-            "coords": "31.7726\u00b0 N, 35.2354\u00b0 E",
-            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man \u2014 one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
+            "coords": "31.7726° N, 35.2354° E",
+            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man — one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 29:18",
-              "note": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" \u2014 the messianic promise of healing the blind."
+              "note": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" — the messianic promise of healing the blind."
             },
             {
               "ref": "Isa 42:7",
-              "note": "\"To open eyes that are blind\" \u2014 one of the Servant's tasks, here enacted by Jesus."
+              "note": "\"To open eyes that are blind\" — one of the Servant's tasks, here enacted by Jesus."
             },
             {
               "ref": "Ps 146:8",
-              "note": "\"The Lord gives sight to the blind\" \u2014 a divine prerogative now exercised by Jesus."
+              "note": "\"The Lord gives sight to the blind\" — a divine prerogative now exercised by Jesus."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:3",
-              "note": "\"This happened so that the works of God might be displayed in him\" \u2014 perhaps the most important answer in the NT to the question of why suffering exists. The man's 38 years of blindness (if he was an adult) or however many years of congenital blindness were not punishment for sin \u2014 they were the preparation for this moment of divine revelation. The suffering had a purpose that transcended its apparent meaninglessness. This does not answer all theodicy questions, but it reshapes the framework."
+              "note": "\"This happened so that the works of God might be displayed in him\" — perhaps the most important answer in the NT to the question of why suffering exists. The man's 38 years of blindness (if he was an adult) or however many years of congenital blindness were not punishment for sin — they were the preparation for this moment of divine revelation. The suffering had a purpose that transcended its apparent meaninglessness. This does not answer all theodicy questions, but it reshapes the framework."
             },
             {
               "ref": "9:6-7",
-              "note": "Jesus makes mud with saliva and sends the man to wash \u2014 a two-stage healing that requires obedience. Unlike the lame man at Bethesda (5:6-9, healed immediately by a word), this healing requires the man to act in faith before he receives his sight. He goes to Siloam blind; he returns seeing. The method is deliberately inefficient by any medical standard \u2014 it is designed to require faith."
+              "note": "Jesus makes mud with saliva and sends the man to wash — a two-stage healing that requires obedience. Unlike the lame man at Bethesda (5:6-9, healed immediately by a word), this healing requires the man to act in faith before he receives his sight. He goes to Siloam blind; he returns seeing. The method is deliberately inefficient by any medical standard — it is designed to require faith."
             },
             {
               "ref": "9:25",
-              "note": "\"One thing I do know. I was blind but now I see!\" \u2014 the most compressed and irrefutable testimony in the Gospel. The man cannot answer the theological questions; he can only witness to his experience. But his experience is sufficient: personal transformation is the primary evidence. No theological argument can undo \"I was blind but now I see.\""
+              "note": "\"One thing I do know. I was blind but now I see!\" — the most compressed and irrefutable testimony in the Gospel. The man cannot answer the theological questions; he can only witness to his experience. But his experience is sufficient: personal transformation is the primary evidence. No theological argument can undo \"I was blind but now I see.\""
             },
             {
               "ref": "9:34",
-              "note": "\"You were steeped in sin at your birth; how dare you lecture us!\" \u2014 the Pharisees' final resort to the assumption they had started with (sin = disability). Their question has been refuted by the facts; their theology has been exposed as false; so they resort to personal attack and expulsion. The thrown-out man will be found by Jesus (v.35) \u2014 the shepherd seeking the sheep the establishment has cast out."
+              "note": "\"You were steeped in sin at your birth; how dare you lecture us!\" — the Pharisees' final resort to the assumption they had started with (sin = disability). Their question has been refuted by the facts; their theology has been exposed as false; so they resort to personal attack and expulsion. The thrown-out man will be found by Jesus (v.35) — the shepherd seeking the sheep the establishment has cast out."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:3",
-              "note": "Calvin uses this verse to argue against both extremes in theodicy: (1) the Stoic/rationalist view that suffering is morally neutral and has no meaning; (2) the moralistic view that suffering is always punitive. The Christian view is that suffering has a purpose given by God \u2014 a purpose not always visible to the sufferer but real. The blind man's purpose was revealed in a specific act of healing; the purpose of most suffering is revealed only eschatologically."
+              "note": "Calvin uses this verse to argue against both extremes in theodicy: (1) the Stoic/rationalist view that suffering is morally neutral and has no meaning; (2) the moralistic view that suffering is always punitive. The Christian view is that suffering has a purpose given by God — a purpose not always visible to the sufferer but real. The blind man's purpose was revealed in a specific act of healing; the purpose of most suffering is revealed only eschatologically."
             },
             {
               "ref": "9:22",
-              "note": "Calvin notes the parents' failure with pastoral realism: they are caught between love for their son and fear for themselves, and fear wins. This is not presented approvingly \u2014 it is a portrait of the social cost of discipleship in the Jewish context. The excommunication threat explains much of the secrecy and division that runs through John's Gospel."
+              "note": "Calvin notes the parents' failure with pastoral realism: they are caught between love for their son and fear for themselves, and fear wins. This is not presented approvingly — it is a portrait of the social cost of discipleship in the Jewish context. The excommunication threat explains much of the secrecy and division that runs through John's Gospel."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:7",
-              "note": "\"The Pool of Siloam (which means Sent)\" \u2014 the pool was fed by the Gihon spring through Hezekiah's tunnel (2 Chr 32:30). Excavations in 2004-2005 confirmed the location and the first-century date of the pool Jesus sent the man to. The name interpretation (Siloam = sent) is John's characteristic practice of exploiting double meanings in names and places."
+              "note": "\"The Pool of Siloam (which means Sent)\" — the pool was fed by the Gihon spring through Hezekiah's tunnel (2 Chr 32:30). Excavations in 2004-2005 confirmed the location and the first-century date of the pool Jesus sent the man to. The name interpretation (Siloam = sent) is John's characteristic practice of exploiting double meanings in names and places."
             },
             {
               "ref": "9:6",
@@ -102,105 +102,105 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "9:3",
-              "note": "Augustine: \"Neither this man sinned nor his parents \u2014 but so that the works of God might be manifested in him. The works of God \u2014 what are they? That God made man; that man sinned; that God redeemed man. All of this is 'the works of God.' This man's blindness is the canvas on which God will paint his glory.\""
+              "note": "Augustine: \"Neither this man sinned nor his parents — but so that the works of God might be manifested in him. The works of God — what are they? That God made man; that man sinned; that God redeemed man. All of this is 'the works of God.' This man's blindness is the canvas on which God will paint his glory.\""
             },
             {
               "ref": "9:25",
-              "note": "Chrysostom: \"He does not say 'I know he is righteous' or 'I know he is from God' \u2014 for he does not yet know these things. He says what he does know: I was blind and now I see. This is the testimony that cannot be refuted, the argument that cannot be answered: personal experience of transformation.\""
+              "note": "Chrysostom: \"He does not say 'I know he is righteous' or 'I know he is from God' — for he does not yet know these things. He says what he does know: I was blind and now I see. This is the testimony that cannot be refuted, the argument that cannot be answered: personal experience of transformation.\""
             }
           ]
         },
         "hist": {
-          "context": "The Theodicy Question\nThe disciples' question \u2014 \"who sinned, this man or his parents?\" (v.2) \u2014 reflects a common Jewish assumption that suffering was caused by specific sin. Jesus refuses both options: \"neither this man nor his parents sinned.\" He redirects the question entirely: the purpose is not punitive but revelatory \u2014 \"that the works of God might be displayed in him.\" This is one of the most important theodicy statements in the NT: God's purpose in suffering may be revelation, not retribution.\n\nProgressive Confession\nThe blind man's understanding of Jesus deepens through the chapter under pressure: \"the man they call Jesus\" (v.11) \u2192 \"he is a prophet\" (v.17) \u2192 \"a man from God\" (v.33) \u2192 \"Lord, I believe\" and worship (v.38). Each Pharisaic interrogation, rather than undermining his faith, deepens it. The man who starts knowing nothing about Jesus ends worshipping him. The Pharisees' investigation has the opposite of its intended effect."
+          "context": "The Theodicy Question\nThe disciples' question — \"who sinned, this man or his parents?\" (v.2) — reflects a common Jewish assumption that suffering was caused by specific sin. Jesus refuses both options: \"neither this man nor his parents sinned.\" He redirects the question entirely: the purpose is not punitive but revelatory — \"that the works of God might be displayed in him.\" This is one of the most important theodicy statements in the NT: God's purpose in suffering may be revelation, not retribution.\n\nProgressive Confession\nThe blind man's understanding of Jesus deepens through the chapter under pressure: \"the man they call Jesus\" (v.11) → \"he is a prophet\" (v.17) → \"a man from God\" (v.33) → \"Lord, I believe\" and worship (v.38). Each Pharisaic interrogation, rather than undermining his faith, deepens it. The man who starts knowing nothing about Jesus ends worshipping him. The Pharisees' investigation has the opposite of its intended effect."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201334 \u2014 The Pharisees Interrogate the Healed Man",
+      "header": "Verses 13–34 — The Pharisees Interrogate the Healed Man",
       "verse_start": 13,
       "verse_end": 34,
       "panels": {
         "heb": [
           {
-            "word": "prosekyn\u0113sen aut\u014d",
-            "transliteration": "pros-e-KY-n\u0113-sen au-TO",
+            "word": "prosekynēsen autō",
+            "transliteration": "pros-e-KY-nē-sen au-TO",
             "gloss": "worshipped him",
-            "paragraph": "The verb proskyne\u014d (v.38) is used in John and the NT for worship of God (4:20-24; Rev 4:10) as well as respectful obeisance to humans (Matt 18:26). In context \u2014 the man has just declared \"Lord, I believe\" \u2014 and John's high Christology \u2014 the word means genuine worship. This is the natural culmination of the chapter's progressive confession: the man who was blind from birth ends by worshipping the Son of Man as Lord."
+            "paragraph": "The verb proskyneō (v.38) is used in John and the NT for worship of God (4:20-24; Rev 4:10) as well as respectful obeisance to humans (Matt 18:26). In context — the man has just declared \"Lord, I believe\" — and John's high Christology — the word means genuine worship. This is the natural culmination of the chapter's progressive confession: the man who was blind from birth ends by worshipping the Son of Man as Lord."
           }
         ],
         "places": [
           {
             "name": "Pool of Siloam",
-            "coords": "31.7726\u00b0 N, 35.2354\u00b0 E",
-            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man \u2014 one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
+            "coords": "31.7726° N, 35.2354° E",
+            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man — one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 6:9-10",
-              "note": "\"Be ever hearing, but never understanding; be ever seeing, but never perceiving\" \u2014 the hardening of Israel's sight that Jesus's ministry enacts as judgment on those who reject him."
+              "note": "\"Be ever hearing, but never understanding; be ever seeing, but never perceiving\" — the hardening of Israel's sight that Jesus's ministry enacts as judgment on those who reject him."
             },
             {
               "ref": "John 12:40",
-              "note": "\"He has blinded their eyes and hardened their hearts, so they can neither see with their eyes... nor understand with their hearts\" \u2014 John applies Isa 6 to the Jewish leadership's rejection of Jesus."
+              "note": "\"He has blinded their eyes and hardened their hearts, so they can neither see with their eyes... nor understand with their hearts\" — John applies Isa 6 to the Jewish leadership's rejection of Jesus."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:39-41",
-              "note": "The closing verses complete the chapter's ironic structure. Jesus came for judgment \u2014 not to condemn individuals (3:17) but to reveal who already is and is not responding to the light. The judgment is by revelation, not by condemnation. The Pharisees' claim to spiritual sight (\"Are we blind too?\") is their condemnation: they have enough light to be responsible for refusing it. The man born blind had no prior light \u2014 he was not responsible for his condition. The Pharisees had Moses, the Prophets, and the signs of Jesus \u2014 and chose darkness. \"Your guilt remains.\""
+              "note": "The closing verses complete the chapter's ironic structure. Jesus came for judgment — not to condemn individuals (3:17) but to reveal who already is and is not responding to the light. The judgment is by revelation, not by condemnation. The Pharisees' claim to spiritual sight (\"Are we blind too?\") is their condemnation: they have enough light to be responsible for refusing it. The man born blind had no prior light — he was not responsible for his condition. The Pharisees had Moses, the Prophets, and the signs of Jesus — and chose darkness. \"Your guilt remains.\""
             },
             {
               "ref": "9:35-38",
-              "note": "Jesus seeks out the man after his expulsion \u2014 a detail unique to John. The question \"Do you believe in the Son of Man?\" is the Gospel's discipleship call reduced to its essence. The man's progression from \"Who is he, sir?\" to \"Lord, I believe\" followed by worship is the normative conversion pattern John presents throughout his Gospel."
+              "note": "Jesus seeks out the man after his expulsion — a detail unique to John. The question \"Do you believe in the Son of Man?\" is the Gospel's discipleship call reduced to its essence. The man's progression from \"Who is he, sir?\" to \"Lord, I believe\" followed by worship is the normative conversion pattern John presents throughout his Gospel."
             },
             {
               "ref": "9:40-41",
-              "note": "The Pharisees' question \"Are we blind too?\" is rhetorical \u2014 they expect a no. Jesus's answer subverts the expectation entirely. Genuine blindness (acknowledging it) would be forgivable; their claim to sight makes them culpable. MacArthur notes this is the precise definition of willful unbelief \u2014 possessing enough light to be responsible, yet refusing it."
+              "note": "The Pharisees' question \"Are we blind too?\" is rhetorical — they expect a no. Jesus's answer subverts the expectation entirely. Genuine blindness (acknowledging it) would be forgivable; their claim to sight makes them culpable. MacArthur notes this is the precise definition of willful unbelief — possessing enough light to be responsible, yet refusing it."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:41",
-              "note": "\"If you were blind, you would not be guilty of sin\" \u2014 Calvin uses this to distinguish invincible ignorance (genuine blindness that cannot be helped) from willful blindness (refusing to see what is available to be seen). The Pharisees had every spiritual resource available: Scripture, the signs, the witness of the healed man. Their blindness was chosen, not forced. Chosen blindness is guilty blindness."
+              "note": "\"If you were blind, you would not be guilty of sin\" — Calvin uses this to distinguish invincible ignorance (genuine blindness that cannot be helped) from willful blindness (refusing to see what is available to be seen). The Pharisees had every spiritual resource available: Scripture, the signs, the witness of the healed man. Their blindness was chosen, not forced. Chosen blindness is guilty blindness."
             },
             {
               "ref": "9:39",
-              "note": "Calvin sees the judgment saying of v39 not as a contradiction of 3:17 but as its necessary complement. Christ did not come to condemn, yet his coming inevitably produces a crisis of division. Calvin's term is \"adventitious condemnation\" \u2014 judgment that adheres to unbelief, not as purpose but as consequence. The light does not destroy; those who flee it condemn themselves."
+              "note": "Calvin sees the judgment saying of v39 not as a contradiction of 3:17 but as its necessary complement. Christ did not come to condemn, yet his coming inevitably produces a crisis of division. Calvin's term is \"adventitious condemnation\" — judgment that adheres to unbelief, not as purpose but as consequence. The light does not destroy; those who flee it condemn themselves."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:35",
-              "note": "\"Do you believe in the Son of Man?\" \u2014 Jesus seeks out the man who was cast out. The Good Shepherd (ch.10) seeks the lost sheep; here he seeks the one thrown out by the establishment. The question is Jesus's own initiative \u2014 he heard what happened and came looking. Faith is enabled by an encounter that Jesus himself initiates."
+              "note": "\"Do you believe in the Son of Man?\" — Jesus seeks out the man who was cast out. The Good Shepherd (ch.10) seeks the lost sheep; here he seeks the one thrown out by the establishment. The question is Jesus's own initiative — he heard what happened and came looking. Faith is enabled by an encounter that Jesus himself initiates."
             },
             {
               "ref": "9:39-41",
-              "note": "The NET Bible notes the wordplay on \"judgment\" (krima) and \"blind\" (typhlos): Jesus came into the world for a krima of reversal \u2014 those who are blind (admit it) will see; those who claim to see (deny it) become blind. The Pharisees' question \"Are we blind too?\" shows they understood the implication. Their sin \"remains\" (v41) because they have closed off the one path of escape: honest acknowledgment of need."
+              "note": "The NET Bible notes the wordplay on \"judgment\" (krima) and \"blind\" (typhlos): Jesus came into the world for a krima of reversal — those who are blind (admit it) will see; those who claim to see (deny it) become blind. The Pharisees' question \"Are we blind too?\" shows they understood the implication. Their sin \"remains\" (v41) because they have closed off the one path of escape: honest acknowledgment of need."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "9:39",
-              "note": "Augustine: \"For judgment I came into this world \u2014 not that I might judge, but that the judgment might come through me. The one who was blind and now sees: judgment has come on the one who was seeing but now is blind. What does 'now is blind' mean? Those who think they see, who are proud of their knowledge, and refuse to submit to the physician \u2014 they remain in their blindness through pride.\""
+              "note": "Augustine: \"For judgment I came into this world — not that I might judge, but that the judgment might come through me. The one who was blind and now sees: judgment has come on the one who was seeing but now is blind. What does 'now is blind' mean? Those who think they see, who are proud of their knowledge, and refuse to submit to the physician — they remain in their blindness through pride.\""
             },
             {
               "ref": "9:38-41",
@@ -215,7 +215,7 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 35\u201341 \u2014 Jesus Finds the Man; The Blindness of the Pharisees",
+      "header": "Verses 35–41 — Jesus Finds the Man; The Blindness of the Pharisees",
       "verse_start": 35,
       "verse_end": 41,
       "panels": {
@@ -224,100 +224,56 @@
             "word": "Siloam",
             "transliteration": "Si-LO-am",
             "gloss": "Sent",
-            "paragraph": "John translates the pool's name: \"Siloam (which means Sent)\" \u2014 v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostell\u014d) is one of John's most freighted words \u2014 it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" \u2014 a double layer of meaning."
+            "paragraph": "John translates the pool's name: \"Siloam (which means Sent)\" — v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostellō) is one of John's most freighted words — it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" — a double layer of meaning."
           },
           {
-            "word": "\u0113noichth\u0113san autou hoi ophthalmoi",
-            "transliteration": "\u0113-noi-CHTH\u0112-san au-TOU hoi oph-thal-MOI",
+            "word": "ēnoichthēsan autou hoi ophthalmoi",
+            "transliteration": "ē-noi-CHTHĒ-san au-TOU hoi oph-thal-MOI",
             "gloss": "his eyes were opened",
-            "paragraph": "The passive divine voice \u2014 \"were opened\" \u2014 runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
+            "paragraph": "The passive divine voice — \"were opened\" — runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
           }
         ],
         "places": [
           {
             "name": "Pool of Siloam",
-            "coords": "31.7726\u00b0 N, 35.2354\u00b0 E",
-            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man \u2014 one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
+            "coords": "31.7726° N, 35.2354° E",
+            "text": "Located at the southern end of the City of David, the Pool of Siloam was fed by Hezekiah's tunnel from the Gihon Spring. It was used for ritual purification and was the source of the water drawn each morning during Tabernacles in the water-drawing ceremony. Archaeological excavations in 2004-2005 confirmed the first-century pool where Jesus sent the blind man — one of the most dramatic recent confirmations of Johannine geography. The pool is now partially excavated and open to visitors."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 29:18",
-              "note": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" \u2014 the messianic promise of healing the blind."
+              "note": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" — the messianic promise of healing the blind."
             },
             {
               "ref": "Isa 42:7",
-              "note": "\"To open eyes that are blind\" \u2014 one of the Servant's tasks, here enacted by Jesus."
+              "note": "\"To open eyes that are blind\" — one of the Servant's tasks, here enacted by Jesus."
             },
             {
               "ref": "Ps 146:8",
-              "note": "\"The Lord gives sight to the blind\" \u2014 a divine prerogative now exercised by Jesus."
+              "note": "\"The Lord gives sight to the blind\" — a divine prerogative now exercised by Jesus."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:3",
-              "note": "\"This happened so that the works of God might be displayed in him\" \u2014 perhaps the most important answer in the NT to the question of why suffering exists. The man's 38 years of blindness (if he was an adult) or however many years of congenital blindness were not punishment for sin \u2014 they were the preparation for this moment of divine revelation. The suffering had a purpose that transcended its apparent meaninglessness. This does not answer all theodicy questions, but it reshapes the framework."
-            },
-            {
-              "ref": "9:6-7",
-              "note": "Jesus makes mud with saliva and sends the man to wash \u2014 a two-stage healing that requires obedience. Unlike the lame man at Bethesda (5:6-9, healed immediately by a word), this healing requires the man to act in faith before he receives his sight. He goes to Siloam blind; he returns seeing. The method is deliberately inefficient by any medical standard \u2014 it is designed to require faith."
-            },
-            {
-              "ref": "9:25",
-              "note": "\"One thing I do know. I was blind but now I see!\" \u2014 the most compressed and irrefutable testimony in the Gospel. The man cannot answer the theological questions; he can only witness to his experience. But his experience is sufficient: personal transformation is the primary evidence. No theological argument can undo \"I was blind but now I see.\""
-            },
-            {
-              "ref": "9:34",
-              "note": "\"You were steeped in sin at your birth; how dare you lecture us!\" \u2014 the Pharisees' final resort to the assumption they had started with (sin = disability). Their question has been refuted by the facts; their theology has been exposed as false; so they resort to personal attack and expulsion. The thrown-out man will be found by Jesus (v.35) \u2014 the shepherd seeking the sheep the establishment has cast out."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:3",
-              "note": "Calvin uses this verse to argue against both extremes in theodicy: (1) the Stoic/rationalist view that suffering is morally neutral and has no meaning; (2) the moralistic view that suffering is always punitive. The Christian view is that suffering has a purpose given by God \u2014 a purpose not always visible to the sufferer but real. The blind man's purpose was revealed in a specific act of healing; the purpose of most suffering is revealed only eschatologically."
-            },
-            {
-              "ref": "9:22",
-              "note": "Calvin notes the parents' failure with pastoral realism: they are caught between love for their son and fear for themselves, and fear wins. This is not presented approvingly \u2014 it is a portrait of the social cost of discipleship in the Jewish context. The excommunication threat explains much of the secrecy and division that runs through John's Gospel."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:7",
-              "note": "\"The Pool of Siloam (which means Sent)\" \u2014 the pool was fed by the Gihon spring through Hezekiah's tunnel (2 Chr 32:30). Excavations in 2004-2005 confirmed the location and the first-century date of the pool Jesus sent the man to. The name interpretation (Siloam = sent) is John's characteristic practice of exploiting double meanings in names and places."
-            },
-            {
-              "ref": "9:6",
-              "note": "The use of saliva in healing is attested in Greco-Roman medicine (Pliny the Elder credits it healing properties) and appears in Mark 7:33 and 8:23. Jesus's use of mud made of saliva may be deliberately employing a recognised healing practice to make the extraordinary miracle more recognisable, or it may be the creation-from-dust echo (Gen 2:7)."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:3",
-              "note": "Augustine: \"Neither this man sinned nor his parents \u2014 but so that the works of God might be manifested in him. The works of God \u2014 what are they? That God made man; that man sinned; that God redeemed man. All of this is 'the works of God.' This man's blindness is the canvas on which God will paint his glory.\""
-            },
-            {
-              "ref": "9:25",
-              "note": "Chrysostom: \"He does not say 'I know he is righteous' or 'I know he is from God' \u2014 for he does not yet know these things. He says what he does know: I was blind and now I see. This is the testimony that cannot be refuted, the argument that cannot be answered: personal experience of transformation.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Theodicy Question\nThe disciples' question \u2014 \"who sinned, this man or his parents?\" (v.2) \u2014 reflects a common Jewish assumption that suffering was caused by specific sin. Jesus refuses both options: \"neither this man nor his parents sinned.\" He redirects the question entirely: the purpose is not punitive but revelatory \u2014 \"that the works of God might be displayed in him.\" This is one of the most important theodicy statements in the NT: God's purpose in suffering may be revelation, not retribution.\n\nProgressive Confession\nThe blind man's understanding of Jesus deepens through the chapter under pressure: \"the man they call Jesus\" (v.11) \u2192 \"he is a prophet\" (v.17) \u2192 \"a man from God\" (v.33) \u2192 \"Lord, I believe\" and worship (v.38). Each Pharisaic interrogation, rather than undermining his faith, deepens it. The man who starts knowing nothing about Jesus ends worshipping him. The Pharisees' investigation has the opposite of its intended effect."
+          "context": "The Theodicy Question\nThe disciples' question — \"who sinned, this man or his parents?\" (v.2) — reflects a common Jewish assumption that suffering was caused by specific sin. Jesus refuses both options: \"neither this man nor his parents sinned.\" He redirects the question entirely: the purpose is not punitive but revelatory — \"that the works of God might be displayed in him.\" This is one of the most important theodicy statements in the NT: God's purpose in suffering may be revelation, not retribution.\n\nProgressive Confession\nThe blind man's understanding of Jesus deepens through the chapter under pressure: \"the man they call Jesus\" (v.11) → \"he is a prophet\" (v.17) → \"a man from God\" (v.33) → \"Lord, I believe\" and worship (v.38). Each Pharisaic interrogation, rather than undermining his faith, deepens it. The man who starts knowing nothing about Jesus ends worshipping him. The Pharisees' investigation has the opposite of its intended effect."
         }
       }
     }
@@ -327,20 +283,20 @@
       {
         "name": "Jesus",
         "role": "Key biblical figure",
-        "text": "Jesus refuses both options: \"neither this man nor his parents sinned\u2026"
+        "text": "Jesus refuses both options: \"neither this man nor his parents sinned…"
       },
       {
         "name": "disciples",
         "role": "Key biblical figure",
-        "text": "Context  [('The Theodicy Question', 'The disciples\\' question \u2014 \"who sinned, this man or his parents?\" (v\u2026"
+        "text": "Context  [('The Theodicy Question', 'The disciples\\' question — \"who sinned, this man or his parents?\" (v…"
       },
       {
         "name": "Pharisees",
         "role": "Key biblical figure",
-        "text": "Those who claimed to see (the Pharisees, the religious establishment) are revealed to be blind\u2026"
+        "text": "Those who claimed to see (the Pharisees, the religious establishment) are revealed to be blind…"
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">hina (9:3)</td><td>NIV: \"so that\"; KJV: \"that\"; ESV: \"that\"; NRSV: \"so that\". The purpose clause (hina + subjunctive) can express either purpose (\"in order that\") or result (\"with the result that\"). \"So that the works of God might be displayed\" is purpose \u2014 God has a purpose in the man's blindness.</td></tr><tr><td class=\"t-label\">Siloam (9:7)</td><td>All major versions: \"Siloam (which means Sent)\". John's translation of the name is retained in all translations; the theological point (apostell\u014d = the Sent one) is typically handled in commentary, not translation.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">hina (9:3)</td><td>NIV: \"so that\"; KJV: \"that\"; ESV: \"that\"; NRSV: \"so that\". The purpose clause (hina + subjunctive) can express either purpose (\"in order that\") or result (\"with the result that\"). \"So that the works of God might be displayed\" is purpose — God has a purpose in the man's blindness.</td></tr><tr><td class=\"t-label\">Siloam (9:7)</td><td>All major versions: \"Siloam (which means Sent)\". John's translation of the name is retained in all translations; the theological point (apostellō = the Sent one) is typically handled in commentary, not translation.</td></tr>",
     "src": [
       {
         "title": "Isaiah 42:6-7",
@@ -351,7 +307,7 @@
     "rec": [
       {
         "who": "\"I Was Blind But Now I See\" in Conversion Narratives",
-        "text": "John 9:25 has provided the template for Christian conversion testimony for two millennia. John Newton's \"Amazing Grace\" (1772) \u2014 \"I once was lost but now am found, was blind, but now I see\" \u2014 is the most famous literary echo. The pattern (radical before/after contrast, personal experiential testimony resistant to philosophical refutation) has shaped evangelical conversion narrative from the early church through the present."
+        "text": "John 9:25 has provided the template for Christian conversion testimony for two millennia. John Newton's \"Amazing Grace\" (1772) — \"I once was lost but now am found, was blind, but now I see\" — is the most famous literary echo. The pattern (radical before/after contrast, personal experiential testimony resistant to philosophical refutation) has shaped evangelical conversion narrative from the early church through the present."
       },
       {
         "who": "The Sixth Sign and the Sabbath Controversy",
@@ -361,18 +317,18 @@
     "lit": {
       "rows": [
         {
-          "label": "Narrative Irony \u2014 vv.39-41",
-          "text": "Those who can see are revealed as blind; the man born blind receives sight. This reversal operates on both the physical and spiritual levels simultaneously throughout the chapter \u2014 John's most sustained use of the light/darkness, sight/blindness metaphor.",
+          "label": "Narrative Irony — vv.39-41",
+          "text": "Those who can see are revealed as blind; the man born blind receives sight. This reversal operates on both the physical and spiritual levels simultaneously throughout the chapter — John's most sustained use of the light/darkness, sight/blindness metaphor.",
           "is_key": false
         },
         {
-          "label": "Four-Stage Confession \u2014 vv.11, 17, 33, 38",
-          "text": "The man's growing understanding of Jesus is mapped across four statements: \"the man called Jesus\" \u2192 \"he is a prophet\" \u2192 \"if he were not from God, he could do nothing\" \u2192 \"Lord, I believe.\" John structures this as a deliberate counterpoint to the Pharisees' four-stage rejection across the same chapter.",
+          "label": "Four-Stage Confession — vv.11, 17, 33, 38",
+          "text": "The man's growing understanding of Jesus is mapped across four statements: \"the man called Jesus\" → \"he is a prophet\" → \"if he were not from God, he could do nothing\" → \"Lord, I believe.\" John structures this as a deliberate counterpoint to the Pharisees' four-stage rejection across the same chapter.",
           "is_key": false
         },
         {
-          "label": "Irony \u2014 Sight and Blindness",
-          "text": "John's central irony operates on two levels simultaneously. The man born blind progressively gains both physical and spiritual sight. The Pharisees who claim to see (v41) are progressively shown to be blind. The chapter's final verdict (v39-41) inverts all expected outcomes \u2014 judgment falls on those who judged.",
+          "label": "Irony — Sight and Blindness",
+          "text": "John's central irony operates on two levels simultaneously. The man born blind progressively gains both physical and spiritual sight. The Pharisees who claim to see (v41) are progressively shown to be blind. The chapter's final verdict (v39-41) inverts all expected outcomes — judgment falls on those who judged.",
           "is_key": false
         }
       ],
@@ -383,31 +339,31 @@
         "word": "Siloam",
         "tlit": "Si-LO-am",
         "gloss": "Sent",
-        "note": "John translates the pool's name: \"Siloam (which means Sent)\" \u2014 v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostell\u014d) is one of John's most freighted words \u2014 it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" \u2014 a double layer of meaning."
+        "note": "John translates the pool's name: \"Siloam (which means Sent)\" — v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostellō) is one of John's most freighted words — it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" — a double layer of meaning."
       },
       {
-        "word": "\u0113noichth\u0113san autou hoi ophthalmoi",
-        "tlit": "\u0113-noi-CHTH\u0112-san au-TOU hoi oph-thal-MOI",
+        "word": "ēnoichthēsan autou hoi ophthalmoi",
+        "tlit": "ē-noi-CHTHĒ-san au-TOU hoi oph-thal-MOI",
         "gloss": "his eyes were opened",
-        "note": "The passive divine voice \u2014 \"were opened\" \u2014 runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
+        "note": "The passive divine voice — \"were opened\" — runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
       },
       {
-        "word": "prosekyn\u0113sen aut\u014d",
-        "tlit": "pros-e-KY-n\u0113-sen au-TO",
+        "word": "prosekynēsen autō",
+        "tlit": "pros-e-KY-nē-sen au-TO",
         "gloss": "worshipped him",
-        "note": "The verb proskyne\u014d (v.38) is used in John and the NT for worship of God (4:20-24; Rev 4:10) as well as respectful obeisance to humans (Matt 18:26). In context \u2014 the man has just declared \"Lord, I believe\" \u2014 and John's high Christology \u2014 the word means genuine worship. This is the natural culmination of the chapter's progressive confession: the man who was blind from birth ends by worshipping the Son of Man as Lord."
+        "note": "The verb proskyneō (v.38) is used in John and the NT for worship of God (4:20-24; Rev 4:10) as well as respectful obeisance to humans (Matt 18:26). In context — the man has just declared \"Lord, I believe\" — and John's high Christology — the word means genuine worship. This is the natural culmination of the chapter's progressive confession: the man who was blind from birth ends by worshipping the Son of Man as Lord."
       },
       {
         "word": "Siloam",
         "tlit": "Si-LO-am",
         "gloss": "Sent",
-        "note": "John translates the pool's name: \"Siloam (which means Sent)\" \u2014 v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostell\u014d) is one of John's most freighted words \u2014 it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" \u2014 a double layer of meaning."
+        "note": "John translates the pool's name: \"Siloam (which means Sent)\" — v.7. The name interpretation is theological, not just linguistic: the pool is called \"Sent\" because its water was sent from the Gihon Spring. Jesus sends the blind man to a pool called \"Sent.\" The word sent (apostellō) is one of John's most freighted words — it describes Jesus's own identity as the one sent by the Father (3:17; 4:34; 5:36). The man is healed by going to the \"Sent one\" — a double layer of meaning."
       },
       {
-        "word": "\u0113noichth\u0113san autou hoi ophthalmoi",
-        "tlit": "\u0113-noi-CHTH\u0112-san au-TOU hoi oph-thal-MOI",
+        "word": "ēnoichthēsan autou hoi ophthalmoi",
+        "tlit": "ē-noi-CHTHĒ-san au-TOU hoi oph-thal-MOI",
         "gloss": "his eyes were opened",
-        "note": "The passive divine voice \u2014 \"were opened\" \u2014 runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
+        "note": "The passive divine voice — \"were opened\" — runs through the chapter. The man's eyes are opened (v.10, 14, 17, 21, 26, 30, 32); his mind is opened to faith (v.35-38); the Pharisees' eyes are opened in condemnation (v.39-41). John uses the single miraculous act as a lens for the entire chapter's meditation on spiritual sight and blindness."
       }
     ],
     "thread": [
@@ -415,42 +371,42 @@
         "anchor": "Scripture Walkthrough",
         "target": "Isa 29:18",
         "type": "Connection",
-        "text": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" \u2014 the messianic promise of healing the blind.",
+        "text": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" — the messianic promise of healing the blind.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 42:7",
         "type": "Connection",
-        "text": "\"To open eyes that are blind\" \u2014 one of the Servant's tasks, here enacted by Jesus.",
+        "text": "\"To open eyes that are blind\" — one of the Servant's tasks, here enacted by Jesus.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Ps 146:8",
         "type": "Connection",
-        "text": "\"The Lord gives sight to the blind\" \u2014 a divine prerogative now exercised by Jesus.",
+        "text": "\"The Lord gives sight to the blind\" — a divine prerogative now exercised by Jesus.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 6:9-10",
         "type": "Connection",
-        "text": "\"Be ever hearing, but never understanding; be ever seeing, but never perceiving\" \u2014 the hardening of Israel's sight that Jesus's ministry enacts as judgment on those who reject him.",
+        "text": "\"Be ever hearing, but never understanding; be ever seeing, but never perceiving\" — the hardening of Israel's sight that Jesus's ministry enacts as judgment on those who reject him.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "John 12:40",
         "type": "Connection",
-        "text": "\"He has blinded their eyes and hardened their hearts, so they can neither see with their eyes... nor understand with their hearts\" \u2014 John applies Isa 6 to the Jewish leadership's rejection of Jesus.",
+        "text": "\"He has blinded their eyes and hardened their hearts, so they can neither see with their eyes... nor understand with their hearts\" — John applies Isa 6 to the Jewish leadership's rejection of Jesus.",
         "direction": "backward"
       },
       {
         "anchor": "Scripture Walkthrough",
         "target": "Isa 29:18",
         "type": "Connection",
-        "text": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" \u2014 the messianic promise of healing the blind.",
+        "text": "\"In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see\" — the messianic promise of healing the blind.",
         "direction": "backward"
       }
     ],
@@ -459,7 +415,7 @@
         "ref": "9:35",
         "title": "\"Son of Man\" vs \"Son of God\"",
         "content": "Some MSS (P75, B, Coptic versions) read \"Son of God\" rather than \"Son of Man.\" NA28 follows \"Son of Man\" as better attested and the harder reading (scribes would more naturally change \"Son of Man\" to the more familiar soteriological title \"Son of God\").",
-        "note": "\"Son of Man\" is almost certainly original. The title fits the Danielic context of John's Gospel and the man's subsequent worship \u2014 a human title that proves to deserve divine worship."
+        "note": "\"Son of Man\" is almost certainly original. The title fits the Danielic context of John's Gospel and the man's subsequent worship — a human title that proves to deserve divine worship."
       }
     ],
     "debate": [
@@ -511,7 +467,7 @@
           "score": 10
         }
       ],
-      "note": "John 9 is John's most dramatically structured chapter \u2014 a tightly organised courtroom drama in seven scenes. At its centre is the man born blind, whose progressive confession under pressure is the Gospel's clearest portrait of saving faith. Around him the chapter's central irony operates: those who claim to see are revealed as blind; the one born without sight receives both physical and spiritual vision. The chapter ends where the prologue began: \"the light shines in the darkness, and the darkness has not overcome it.\""
+      "note": "John 9 is John's most dramatically structured chapter — a tightly organised courtroom drama in seven scenes. At its centre is the man born blind, whose progressive confession under pressure is the Gospel's clearest portrait of saving faith. Around him the chapter's central irony operates: those who claim to see are revealed as blind; the one born without sight receives both physical and spiritual vision. The chapter ends where the prologue began: \"the light shines in the darkness, and the darkness has not overcome it.\""
     }
   },
   "vhl_groups": [

--- a/content/joshua/10.json
+++ b/content/joshua/10.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:16",
-              "note": "MacArthur: The passage on kings in the cave; public execution reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "10:17",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "10:18",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "10:19",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:16",
-              "note": "Calvin: On kings in the cave; public execution: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "10:17",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:16",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "10:17",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:16",
-              "note": "Hess: The archaeological and textual evidence for kings in the cave; public execution in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "10:18",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:16",
-              "note": "Howard: The canonical placement of this passage on kings in the cave; public execution within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "10:17",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses kings in the cave; public execution. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:29",
-              "note": "MacArthur: The passage on rapid conquest of southern Canaan reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "10:30",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "10:31",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "10:32",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:29",
-              "note": "Calvin: On rapid conquest of southern Canaan: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "10:30",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:29",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "10:30",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:29",
-              "note": "Hess: The archaeological and textual evidence for rapid conquest of southern Canaan in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "10:31",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:29",
-              "note": "Howard: The canonical placement of this passage on rapid conquest of southern Canaan within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "10:30",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses rapid conquest of southern Canaan. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/11.json
+++ b/content/joshua/11.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:16",
-              "note": "MacArthur: The passage on conquest summary; the land had rest from war reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "11:17",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "11:18",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "11:19",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:16",
-              "note": "Calvin: On conquest summary; the land had rest from war: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "11:17",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:16",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "11:17",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:16",
-              "note": "Hess: The archaeological and textual evidence for conquest summary; the land had rest from war in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "11:18",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:16",
-              "note": "Howard: The canonical placement of this passage on conquest summary; the land had rest from war within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "11:17",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses conquest summary; the land had rest from war. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/12.json
+++ b/content/joshua/12.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "MacArthur: The passage on the comprehensive catalogue of conquest reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "12:8",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "12:9",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "12:10",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "Calvin: On the comprehensive catalogue of conquest: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "12:8",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "12:8",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "Hess: The archaeological and textual evidence for the comprehensive catalogue of conquest in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "12:9",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:7",
-              "note": "Howard: The canonical placement of this passage on the comprehensive catalogue of conquest within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "12:8",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the comprehensive catalogue of conquest. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/13.json
+++ b/content/joshua/13.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "MacArthur: The passage on eastern tribal territories reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "13:16",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "13:17",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "13:18",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Calvin: On eastern tribal territories: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "13:16",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "13:16",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Hess: The archaeological and textual evidence for eastern tribal territories in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "13:17",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Howard: The canonical placement of this passage on eastern tribal territories within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "13:16",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses eastern tribal territories. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/14.json
+++ b/content/joshua/14.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:6",
-              "note": "MacArthur: The passage on Caleb's faith speech; Hebron awarded reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "14:7",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "14:8",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "14:9",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:6",
-              "note": "Calvin: On Caleb's faith speech; Hebron awarded: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "14:7",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:6",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "14:7",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:6",
-              "note": "Hess: The archaeological and textual evidence for Caleb's faith speech; Hebron awarded in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "14:8",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:6",
-              "note": "Howard: The canonical placement of this passage on Caleb's faith speech; Hebron awarded within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "14:7",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Caleb's faith speech; Hebron awarded. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/15.json
+++ b/content/joshua/15.json
@@ -147,46 +147,16 @@
             {
               "ref": "15:13",
               "note": "MacArthur: The passage on Caleb's conquest; Othniel; Achsah; comprehensive town list reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "15:14",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "15:15",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "15:16",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "Calvin: On Caleb's conquest; Othniel; Achsah; comprehensive town list: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "15:14",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "15:14",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +164,12 @@
             {
               "ref": "15:13",
               "note": "Hess: The archaeological and textual evidence for Caleb's conquest; Othniel; Achsah; comprehensive town list in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "15:15",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:13",
-              "note": "Howard: The canonical placement of this passage on Caleb's conquest; Othniel; Achsah; comprehensive town list within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "15:14",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Caleb's conquest; Othniel; Achsah; comprehensive town list. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/16.json
+++ b/content/joshua/16.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:6",
-              "note": "MacArthur: The passage on Gezer's inhabitants remain; forced labour reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "16:7",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "16:8",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "16:9",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:6",
-              "note": "Calvin: On Gezer's inhabitants remain; forced labour: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "16:7",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:6",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "16:7",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "16:6",
               "note": "Hess: The archaeological and textual evidence for Gezer's inhabitants remain; forced labour in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "16:8",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:6",
-              "note": "Howard: The canonical placement of this passage on Gezer's inhabitants remain; forced labour within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "16:7",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Gezer's inhabitants remain; forced labour. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/17.json
+++ b/content/joshua/17.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "MacArthur: The passage on complaint about insufficient land; Joshua's challenge reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "17:8",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "17:9",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "17:10",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "Calvin: On complaint about insufficient land; Joshua's challenge: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "17:8",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "17:8",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "17:7",
               "note": "Hess: The archaeological and textual evidence for complaint about insufficient land; Joshua's challenge in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "17:9",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "Howard: The canonical placement of this passage on complaint about insufficient land; Joshua's challenge within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "17:8",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses complaint about insufficient land; Joshua's challenge. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/18.json
+++ b/content/joshua/18.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:11",
-              "note": "MacArthur: The passage on Benjamin's territory between Judah and Ephraim reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "18:12",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "18:13",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "18:14",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:11",
-              "note": "Calvin: On Benjamin's territory between Judah and Ephraim: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "18:12",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:11",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "18:12",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:11",
-              "note": "Hess: The archaeological and textual evidence for Benjamin's territory between Judah and Ephraim in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "18:13",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:11",
-              "note": "Howard: The canonical placement of this passage on Benjamin's territory between Judah and Ephraim within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "18:12",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Benjamin's territory between Judah and Ephraim. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/19.json
+++ b/content/joshua/19.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:32",
-              "note": "MacArthur: The passage on final allotments; Joshua's own inheritance reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "19:33",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "19:34",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "19:35",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:32",
-              "note": "Calvin: On final allotments; Joshua's own inheritance: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "19:33",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:32",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "19:33",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:32",
-              "note": "Hess: The archaeological and textual evidence for final allotments; Joshua's own inheritance in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "19:34",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:32",
-              "note": "Howard: The canonical placement of this passage on final allotments; Joshua's own inheritance within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "19:33",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses final allotments; Joshua's own inheritance. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/20.json
+++ b/content/joshua/20.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "MacArthur: The passage on Kedesh, Shechem, Hebron, Bezer, Ramoth, Golan reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "20:8",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "20:9",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "20:10",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "Calvin: On Kedesh, Shechem, Hebron, Bezer, Ramoth, Golan: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "20:8",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "20:8",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "Hess: The archaeological and textual evidence for Kedesh, Shechem, Hebron, Bezer, Ramoth, Golan in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "20:9",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "Howard: The canonical placement of this passage on Kedesh, Shechem, Hebron, Bezer, Ramoth, Golan within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "20:8",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Kedesh, Shechem, Hebron, Bezer, Ramoth, Golan. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/21.json
+++ b/content/joshua/21.json
@@ -147,46 +147,16 @@
             {
               "ref": "21:43",
               "note": "MacArthur: The passage on \"Not one of all the LORD's good promises failed; every one was fulfilled\" reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "21:44",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "21:45",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "21:46",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:43",
-              "note": "Calvin: On \"Not one of all the LORD's good promises failed; every one was fulfilled\": God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "21:44",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:43",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "21:44",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +164,12 @@
             {
               "ref": "21:43",
               "note": "Hess: The archaeological and textual evidence for \"Not one of all the LORD's good promises failed; every one was fulfilled\" in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "21:45",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:43",
-              "note": "Howard: The canonical placement of this passage on \"Not one of all the LORD's good promises failed; every one was fulfilled\" within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "21:44",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"Not one of all the LORD's good promises failed; every one was fulfilled\". The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/22.json
+++ b/content/joshua/22.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:10",
-              "note": "MacArthur: The passage on altar built; western tribes mobilise; Phinehas sent reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "22:11",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "22:12",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "22:13",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:10",
-              "note": "Calvin: On altar built; western tribes mobilise; Phinehas sent: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "22:11",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:10",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "22:11",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "22:10",
               "note": "Hess: The archaeological and textual evidence for altar built; western tribes mobilise; Phinehas sent in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "22:12",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:10",
-              "note": "Howard: The canonical placement of this passage on altar built; western tribes mobilise; Phinehas sent within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "22:11",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses altar built; western tribes mobilise; Phinehas sent. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,76 +199,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:21",
-              "note": "MacArthur: The passage on the altar is a memorial of unity, not rebellion reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "22:22",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "22:23",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "22:24",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:21",
-              "note": "Calvin: On the altar is a memorial of unity, not rebellion: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "22:22",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:21",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "22:22",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:21",
-              "note": "Hess: The archaeological and textual evidence for the altar is a memorial of unity, not rebellion in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "22:23",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "22:21",
-              "note": "Howard: The canonical placement of this passage on the altar is a memorial of unity, not rebellion within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "22:22",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the altar is a memorial of unity, not rebellion. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/23.json
+++ b/content/joshua/23.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:9",
-              "note": "MacArthur: The passage on conditional promise; consequences of disobedience reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "23:10",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "23:11",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "23:12",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:9",
-              "note": "Calvin: On conditional promise; consequences of disobedience: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "23:10",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:9",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "23:10",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "23:9",
               "note": "Hess: The archaeological and textual evidence for conditional promise; consequences of disobedience in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "23:11",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "23:9",
-              "note": "Howard: The canonical placement of this passage on conditional promise; consequences of disobedience within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "23:10",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses conditional promise; consequences of disobedience. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/24.json
+++ b/content/joshua/24.json
@@ -147,46 +147,16 @@
             {
               "ref": "24:14",
               "note": "MacArthur: The passage on Joshua's challenge; the people's threefold commitment reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "24:15",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "24:16",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "24:17",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "Calvin: On Joshua's challenge; the people's threefold commitment: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "24:15",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "24:15",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +164,12 @@
             {
               "ref": "24:14",
               "note": "Hess: The archaeological and textual evidence for Joshua's challenge; the people's threefold commitment in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "24:16",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:14",
-              "note": "Howard: The canonical placement of this passage on Joshua's challenge; the people's threefold commitment within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "24:15",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Joshua's challenge; the people's threefold commitment. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,50 +204,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:25",
-              "note": "MacArthur: The passage on stone witness at Shechem; burials; Joseph's bones reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "24:26",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "24:27",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "24:28",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:25",
-              "note": "Calvin: On stone witness at Shechem; burials; Joseph's bones: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "24:26",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:25",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "24:26",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -298,25 +220,12 @@
             {
               "ref": "24:25",
               "note": "Hess: The archaeological and textual evidence for stone witness at Shechem; burials; Joseph's bones in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "24:27",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "24:25",
-              "note": "Howard: The canonical placement of this passage on stone witness at Shechem; burials; Joseph's bones within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "24:26",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses stone witness at Shechem; burials; Joseph's bones. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/3.json
+++ b/content/joshua/3.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:9",
-              "note": "MacArthur: The passage on miraculous crossing; waters pile up at Adam reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "3:10",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "3:11",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "3:12",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:9",
-              "note": "Calvin: On miraculous crossing; waters pile up at Adam: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "3:10",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:9",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "3:10",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:9",
-              "note": "Hess: The archaeological and textual evidence for miraculous crossing; waters pile up at Adam in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "3:11",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:9",
-              "note": "Howard: The canonical placement of this passage on miraculous crossing; waters pile up at Adam within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "3:10",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses miraculous crossing; waters pile up at Adam. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/4.json
+++ b/content/joshua/4.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:15",
-              "note": "MacArthur: The passage on waters return; Israel's camp established reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "4:16",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "4:17",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "4:18",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:15",
-              "note": "Calvin: On waters return; Israel's camp established: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "4:16",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:15",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "4:16",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:15",
-              "note": "Hess: The archaeological and textual evidence for waters return; Israel's camp established in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "4:17",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:15",
-              "note": "Howard: The canonical placement of this passage on waters return; Israel's camp established within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "4:16",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses waters return; Israel's camp established. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/5.json
+++ b/content/joshua/5.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "MacArthur: The passage on Passover; eating produce of the land reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "5:11",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "5:12",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "5:13",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "Calvin: On Passover; eating produce of the land: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "5:11",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "5:11",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "Hess: The archaeological and textual evidence for Passover; eating produce of the land in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "5:12",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "Howard: The canonical placement of this passage on Passover; eating produce of the land within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "5:11",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Passover; eating produce of the land. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,76 +194,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "MacArthur: The passage on the divine warrior appears to Joshua reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "5:14",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "5:15",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "5:16",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "Calvin: On the divine warrior appears to Joshua: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "5:14",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "5:14",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "Hess: The archaeological and textual evidence for the divine warrior appears to Joshua in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "5:15",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "Howard: The canonical placement of this passage on the divine warrior appears to Joshua within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "5:14",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the divine warrior appears to Joshua. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/6.json
+++ b/content/joshua/6.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:15",
-              "note": "MacArthur: The passage on walls collapse; the ḥērem executed reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "6:16",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "6:17",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "6:18",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:15",
-              "note": "Calvin: On walls collapse; the ḥērem executed: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "6:16",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:15",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "6:16",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "6:15",
               "note": "Hess: The archaeological and textual evidence for walls collapse; the ḥērem executed in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "6:17",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:15",
-              "note": "Howard: The canonical placement of this passage on walls collapse; the ḥērem executed within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "6:16",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses walls collapse; the ḥērem executed. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,76 +199,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:22",
-              "note": "MacArthur: The passage on Rahab's family rescued; Jericho cursed reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "6:23",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "6:24",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "6:25",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:22",
-              "note": "Calvin: On Rahab's family rescued; Jericho cursed: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "6:23",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:22",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "6:23",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:22",
-              "note": "Hess: The archaeological and textual evidence for Rahab's family rescued; Jericho cursed in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "6:24",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:22",
-              "note": "Howard: The canonical placement of this passage on Rahab's family rescued; Jericho cursed within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "6:23",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Rahab's family rescued; Jericho cursed. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/7.json
+++ b/content/joshua/7.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "MacArthur: The passage on Achan's confession; stoning and burning reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "7:17",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "7:18",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "7:19",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "Calvin: On Achan's confession; stoning and burning: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "7:17",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "7:17",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "Hess: The archaeological and textual evidence for Achan's confession; stoning and burning in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "7:18",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "Howard: The canonical placement of this passage on Achan's confession; stoning and burning within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "7:17",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Achan's confession; stoning and burning. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/8.json
+++ b/content/joshua/8.json
@@ -143,50 +143,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:18",
-              "note": "MacArthur: The passage on Ai destroyed; body displayed at the gate reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "8:19",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "8:20",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "8:21",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:18",
-              "note": "Calvin: On Ai destroyed; body displayed at the gate: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "8:19",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:18",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "8:19",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -194,25 +159,12 @@
             {
               "ref": "8:18",
               "note": "Hess: The archaeological and textual evidence for Ai destroyed; body displayed at the gate in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "8:20",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:18",
-              "note": "Howard: The canonical placement of this passage on Ai destroyed; body displayed at the gate within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "8:19",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Ai destroyed; body displayed at the gate. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
@@ -247,50 +199,15 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:30",
-              "note": "MacArthur: The passage on covenant renewal; blessings and curses read reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "8:31",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "8:32",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "8:33",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:30",
-              "note": "Calvin: On covenant renewal; blessings and curses read: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "8:31",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:30",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "8:31",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
@@ -298,25 +215,12 @@
             {
               "ref": "8:30",
               "note": "Hess: The archaeological and textual evidence for covenant renewal; blessings and curses read in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "8:32",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
             }
           ]
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:30",
-              "note": "Howard: The canonical placement of this passage on covenant renewal; blessings and curses read within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "8:31",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses covenant renewal; blessings and curses read. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/joshua/9.json
+++ b/content/joshua/9.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:16",
-              "note": "MacArthur: The passage on oath stands but Gibeonites become woodcutters reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
-            },
-            {
-              "ref": "9:17",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "9:18",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "9:19",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:16",
-              "note": "Calvin: On oath stands but Gibeonites become woodcutters: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
-            },
-            {
-              "ref": "9:17",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:16",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
-            },
-            {
-              "ref": "9:17",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
-            }
-          ]
+          "notes": []
         },
         "hess": {
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:16",
-              "note": "Hess: The archaeological and textual evidence for oath stands but Gibeonites become woodcutters in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "9:18",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
-            }
-          ]
+          "notes": []
         },
         "howard": {
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:16",
-              "note": "Howard: The canonical placement of this passage on oath stands but Gibeonites become woodcutters within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "9:17",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses oath stands but Gibeonites become woodcutters. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."

--- a/content/judges/1.json
+++ b/content/judges/1.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "MacArthur: The passage on catalogue of compromise; Canaanites remain demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "1:20",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "1:21",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "1:22",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Calvin: On catalogue of compromise; Canaanites remain: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "1:20",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "1:20",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Block: On catalogue of compromise; Canaanites remain: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "1:21",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "1:19",
-              "note": "Webb: On catalogue of compromise; Canaanites remain: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "1:20",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses catalogue of compromise; Canaanites remain. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/10.json
+++ b/content/judges/10.json
@@ -147,72 +147,24 @@
             {
               "ref": "10:6",
               "note": "MacArthur: The passage on \"go and cry out to the gods you have chosen\" — then relents demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "10:7",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "10:8",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "10:9",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Calvin: On \"go and cry out to the gods you have chosen\" — then relents: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "10:7",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "10:7",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Block: On \"go and cry out to the gods you have chosen\" — then relents: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "10:8",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "10:6",
-              "note": "Webb: On \"go and cry out to the gods you have chosen\" — then relents: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "10:7",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"go and cry out to the gods you have chosen\" — then relents. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/11.json
+++ b/content/judges/11.json
@@ -147,72 +147,24 @@
             {
               "ref": "11:12",
               "note": "MacArthur: The passage on historical argument for Israel's land rights; diplomacy fails demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "11:13",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "11:14",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "11:15",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Calvin: On historical argument for Israel's land rights; diplomacy fails: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "11:13",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "11:13",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Block: On historical argument for Israel's land rights; diplomacy fails: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "11:14",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12",
-              "note": "Webb: On historical argument for Israel's land rights; diplomacy fails: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "11:13",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses historical argument for Israel's land rights; diplomacy fails. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."
@@ -251,72 +203,24 @@
             {
               "ref": "11:29",
               "note": "MacArthur: The passage on the Spirit comes; the vow; his daughter is the cost demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "11:30",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "11:31",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "11:32",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:29",
-              "note": "Calvin: On the Spirit comes; the vow; his daughter is the cost: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "11:30",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:29",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "11:30",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:29",
-              "note": "Block: On the Spirit comes; the vow; his daughter is the cost: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "11:31",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:29",
-              "note": "Webb: On the Spirit comes; the vow; his daughter is the cost: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "11:30",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the Spirit comes; the vow; his daughter is the cost. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/12.json
+++ b/content/judges/12.json
@@ -147,72 +147,24 @@
             {
               "ref": "12:8",
               "note": "MacArthur: The passage on three brief judgeships; wealth and large families demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "12:9",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "12:10",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "12:11",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:8",
-              "note": "Calvin: On three brief judgeships; wealth and large families: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "12:9",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:8",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "12:9",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:8",
-              "note": "Block: On three brief judgeships; wealth and large families: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "12:10",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:8",
-              "note": "Webb: On three brief judgeships; wealth and large families: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "12:9",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses three brief judgeships; wealth and large families. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/13.json
+++ b/content/judges/13.json
@@ -147,72 +147,24 @@
             {
               "ref": "13:15",
               "note": "MacArthur: The passage on sacrifice consumed by flame; \"the Spirit began to stir him\" demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "13:16",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "13:17",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "13:18",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Calvin: On sacrifice consumed by flame; \"the Spirit began to stir him\": God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "13:16",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "13:16",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Block: On sacrifice consumed by flame; \"the Spirit began to stir him\": the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "13:17",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:15",
-              "note": "Webb: On sacrifice consumed by flame; \"the Spirit began to stir him\": the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "13:16",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses sacrifice consumed by flame; \"the Spirit began to stir him\". The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/14.json
+++ b/content/judges/14.json
@@ -147,72 +147,24 @@
             {
               "ref": "14:10",
               "note": "MacArthur: The passage on \"out of the eater, something to eat\" — rage and abandonment demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "14:11",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "14:12",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "14:13",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:10",
-              "note": "Calvin: On \"out of the eater, something to eat\" — rage and abandonment: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "14:11",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:10",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "14:11",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:10",
-              "note": "Block: On \"out of the eater, something to eat\" — rage and abandonment: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "14:12",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:10",
-              "note": "Webb: On \"out of the eater, something to eat\" — rage and abandonment: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "14:11",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"out of the eater, something to eat\" — rage and abandonment. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/15.json
+++ b/content/judges/15.json
@@ -147,72 +147,24 @@
             {
               "ref": "15:9",
               "note": "MacArthur: The passage on Lehi; supernatural strength; water from the rock demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "15:10",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "15:11",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "15:12",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "Calvin: On Lehi; supernatural strength; water from the rock: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "15:10",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "15:10",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "Block: On Lehi; supernatural strength; water from the rock: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "15:11",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:9",
-              "note": "Webb: On Lehi; supernatural strength; water from the rock: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "15:10",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Lehi; supernatural strength; water from the rock. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/16.json
+++ b/content/judges/16.json
@@ -147,72 +147,24 @@
             {
               "ref": "16:4",
               "note": "MacArthur: The passage on three lies; the fourth time, the truth; \"the LORD had left him\" demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "16:5",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "16:6",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "16:7",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:4",
-              "note": "Calvin: On three lies; the fourth time, the truth; \"the LORD had left him\": God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "16:5",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:4",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "16:5",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:4",
-              "note": "Block: On three lies; the fourth time, the truth; \"the LORD had left him\": the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "16:6",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:4",
-              "note": "Webb: On three lies; the fourth time, the truth; \"the LORD had left him\": the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "16:5",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses three lies; the fourth time, the truth; \"the LORD had left him\". The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."
@@ -251,72 +203,24 @@
             {
               "ref": "16:23",
               "note": "MacArthur: The passage on Dagon's temple; blind prayer; 3,000 Philistines; final victory demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "16:24",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "16:25",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "16:26",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:23",
-              "note": "Calvin: On Dagon's temple; blind prayer; 3,000 Philistines; final victory: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "16:24",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:23",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "16:24",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:23",
-              "note": "Block: On Dagon's temple; blind prayer; 3,000 Philistines; final victory: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "16:25",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "16:23",
-              "note": "Webb: On Dagon's temple; blind prayer; 3,000 Philistines; final victory: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "16:24",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Dagon's temple; blind prayer; 3,000 Philistines; final victory. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/17.json
+++ b/content/judges/17.json
@@ -147,72 +147,24 @@
             {
               "ref": "17:7",
               "note": "MacArthur: The passage on a wandering Levite hired; \"now I know the LORD will prosper me\" demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "17:8",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "17:9",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "17:10",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "Calvin: On a wandering Levite hired; \"now I know the LORD will prosper me\": God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "17:8",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "17:8",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "Block: On a wandering Levite hired; \"now I know the LORD will prosper me\": the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "17:9",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7",
-              "note": "Webb: On a wandering Levite hired; \"now I know the LORD will prosper me\": the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "17:8",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses a wandering Levite hired; \"now I know the LORD will prosper me\". The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/18.json
+++ b/content/judges/18.json
@@ -147,72 +147,24 @@
             {
               "ref": "18:14",
               "note": "MacArthur: The passage on armed theft; the Levite happily upgrades; idol worship until the exile demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "18:15",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "18:16",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "18:17",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:14",
-              "note": "Calvin: On armed theft; the Levite happily upgrades; idol worship until the exile: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "18:15",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:14",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "18:15",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:14",
-              "note": "Block: On armed theft; the Levite happily upgrades; idol worship until the exile: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "18:16",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "18:14",
-              "note": "Webb: On armed theft; the Levite happily upgrades; idol worship until the exile: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "18:15",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses armed theft; the Levite happily upgrades; idol worship until the exile. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/19.json
+++ b/content/judges/19.json
@@ -147,72 +147,24 @@
             {
               "ref": "19:16",
               "note": "MacArthur: The passage on gang rape and murder; the body dismembered and sent to all tribes demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "19:17",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "19:18",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "19:19",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:16",
-              "note": "Calvin: On gang rape and murder; the body dismembered and sent to all tribes: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "19:17",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:16",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "19:17",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:16",
-              "note": "Block: On gang rape and murder; the body dismembered and sent to all tribes: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "19:18",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "19:16",
-              "note": "Webb: On gang rape and murder; the body dismembered and sent to all tribes: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "19:17",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses gang rape and murder; the body dismembered and sent to all tribes. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/2.json
+++ b/content/judges/2.json
@@ -147,72 +147,24 @@
             {
               "ref": "2:6",
               "note": "MacArthur: The passage on the generation that knew God dies; the cycle begins demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "2:7",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "2:8",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "2:9",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:6",
-              "note": "Calvin: On the generation that knew God dies; the cycle begins: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "2:7",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:6",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "2:7",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:6",
-              "note": "Block: On the generation that knew God dies; the cycle begins: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "2:8",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:6",
-              "note": "Webb: On the generation that knew God dies; the cycle begins: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "2:7",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses the generation that knew God dies; the cycle begins. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/20.json
+++ b/content/judges/20.json
@@ -147,72 +147,24 @@
             {
               "ref": "20:18",
               "note": "MacArthur: The passage on Israel defeated twice; seeks God; third assault destroys Benjamin demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "20:19",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "20:20",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "20:21",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:18",
-              "note": "Calvin: On Israel defeated twice; seeks God; third assault destroys Benjamin: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "20:19",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:18",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "20:19",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:18",
-              "note": "Block: On Israel defeated twice; seeks God; third assault destroys Benjamin: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "20:20",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "20:18",
-              "note": "Webb: On Israel defeated twice; seeks God; third assault destroys Benjamin: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "20:19",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Israel defeated twice; seeks God; third assault destroys Benjamin. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/21.json
+++ b/content/judges/21.json
@@ -147,46 +147,16 @@
             {
               "ref": "21:13",
               "note": "MacArthur: The passage on kidnap brides at the festival; the book's final verdict: moral anarchy demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "21:14",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "21:15",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "21:16",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:13",
-              "note": "Calvin: On kidnap brides at the festival; the book's final verdict: moral anarchy: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "21:14",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:13",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "21:14",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
@@ -194,25 +164,12 @@
             {
               "ref": "21:13",
               "note": "Block: On kidnap brides at the festival; the book's final verdict: moral anarchy: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "21:15",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
             }
           ]
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "21:13",
-              "note": "Webb: On kidnap brides at the festival; the book's final verdict: moral anarchy: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "21:14",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses kidnap brides at the festival; the book's final verdict: moral anarchy. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/3.json
+++ b/content/judges/3.json
@@ -151,76 +151,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:12",
-              "note": "MacArthur: The passage on Eglon of Moab; the concealed dagger; 80 years rest demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "3:13",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "3:14",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "3:15",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:12",
-              "note": "Calvin: On Eglon of Moab; the concealed dagger; 80 years rest: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "3:13",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:12",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "3:13",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:12",
-              "note": "Block: On Eglon of Moab; the concealed dagger; 80 years rest: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "3:14",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:12",
-              "note": "Webb: On Eglon of Moab; the concealed dagger; 80 years rest: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "3:13",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Eglon of Moab; the concealed dagger; 80 years rest. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."
@@ -259,72 +206,24 @@
             {
               "ref": "3:31",
               "note": "MacArthur: The passage on one-verse deliverer; unconventional weapon demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "3:32",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "3:33",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "3:34",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:31",
-              "note": "Calvin: On one-verse deliverer; unconventional weapon: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "3:32",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:31",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "3:32",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:31",
-              "note": "Block: On one-verse deliverer; unconventional weapon: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "3:33",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:31",
-              "note": "Webb: On one-verse deliverer; unconventional weapon: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "3:32",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses one-verse deliverer; unconventional weapon. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/4.json
+++ b/content/judges/4.json
@@ -143,76 +143,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:11",
-              "note": "MacArthur: The passage on divine intervention; Sisera flees; Jael's decisive act demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "4:12",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "4:13",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "4:14",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:11",
-              "note": "Calvin: On divine intervention; Sisera flees; Jael's decisive act: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "4:12",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:11",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "4:12",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:11",
-              "note": "Block: On divine intervention; Sisera flees; Jael's decisive act: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "4:13",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "4:11",
-              "note": "Webb: On divine intervention; Sisera flees; Jael's decisive act: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "4:12",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses divine intervention; Sisera flees; Jael's decisive act. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/5.json
+++ b/content/judges/5.json
@@ -147,72 +147,24 @@
             {
               "ref": "5:19",
               "note": "MacArthur: The passage on poetic battle account; ironic ending with the enemy's mother demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "5:20",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "5:21",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "5:22",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:19",
-              "note": "Calvin: On poetic battle account; ironic ending with the enemy's mother: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "5:20",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:19",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "5:20",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:19",
-              "note": "Block: On poetic battle account; ironic ending with the enemy's mother: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "5:21",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:19",
-              "note": "Webb: On poetic battle account; ironic ending with the enemy's mother: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "5:20",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses poetic battle account; ironic ending with the enemy's mother. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/6.json
+++ b/content/judges/6.json
@@ -147,72 +147,24 @@
             {
               "ref": "6:11",
               "note": "MacArthur: The passage on threshing in hiding; \"the LORD is with you, mighty warrior\" demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "6:12",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "6:13",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "6:14",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:11",
-              "note": "Calvin: On threshing in hiding; \"the LORD is with you, mighty warrior\": God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "6:12",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:11",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "6:12",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:11",
-              "note": "Block: On threshing in hiding; \"the LORD is with you, mighty warrior\": the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "6:13",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:11",
-              "note": "Webb: On threshing in hiding; \"the LORD is with you, mighty warrior\": the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "6:12",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses threshing in hiding; \"the LORD is with you, mighty warrior\". The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."
@@ -247,76 +199,23 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:25",
-              "note": "MacArthur: The passage on night raid on the altar; two fleece signs demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "6:26",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "6:27",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "6:28",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:25",
-              "note": "Calvin: On night raid on the altar; two fleece signs: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "6:26",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:25",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "6:26",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:25",
-              "note": "Block: On night raid on the altar; two fleece signs: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "6:27",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "6:25",
-              "note": "Webb: On night raid on the altar; two fleece signs: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "6:26",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses night raid on the altar; two fleece signs. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/7.json
+++ b/content/judges/7.json
@@ -147,72 +147,24 @@
             {
               "ref": "7:9",
               "note": "MacArthur: The passage on dream of barley loaf; torches and trumpets; Midian routed demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "7:10",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "7:11",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "7:12",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "Calvin: On dream of barley loaf; torches and trumpets; Midian routed: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "7:10",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "7:10",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "Block: On dream of barley loaf; torches and trumpets; Midian routed: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "7:11",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "Webb: On dream of barley loaf; torches and trumpets; Midian routed: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "7:10",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses dream of barley loaf; torches and trumpets; Midian routed. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/8.json
+++ b/content/judges/8.json
@@ -147,72 +147,24 @@
             {
               "ref": "8:22",
               "note": "MacArthur: The passage on \"the LORD will rule over you\" — then immediately makes an idol demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "8:23",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "8:24",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "8:25",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:22",
-              "note": "Calvin: On \"the LORD will rule over you\" — then immediately makes an idol: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "8:23",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:22",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "8:23",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:22",
-              "note": "Block: On \"the LORD will rule over you\" — then immediately makes an idol: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "8:24",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:22",
-              "note": "Webb: On \"the LORD will rule over you\" — then immediately makes an idol: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "8:23",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses \"the LORD will rule over you\" — then immediately makes an idol. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/judges/9.json
+++ b/content/judges/9.json
@@ -147,72 +147,24 @@
             {
               "ref": "9:22",
               "note": "MacArthur: The passage on Shechem revolts; tower burned; a woman's millstone ends the tyrant demonstrates the consequences of covenant unfaithfulness — not as abstract theology but as lived disaster. When Israel forsakes God, God does not merely withdraw blessing; he actively delivers them into the hands of their enemies."
-            },
-            {
-              "ref": "9:23",
-              "note": "MacArthur: Yet even in judgment, God's compassion prevails. When the people cry out, he raises a deliverer. The cycle reveals a God who is both just and merciful — who punishes sin but cannot ultimately abandon the people he has chosen."
-            },
-            {
-              "ref": "9:24",
-              "note": "MacArthur: The judges themselves are deeply flawed. This is not accidental but theological: God uses broken instruments to accomplish his purposes, ensuring that the glory belongs to him, not to the deliverer. No judge is the Messiah; every judge points to the need for one."
-            },
-            {
-              "ref": "9:25",
-              "note": "MacArthur: The NT reads the Judges period as both warning and hope. Hebrews 11:32 lists Gideon, Barak, Samson, and Jephthah among the faithful — not because they were perfect, but because, in their best moments, they trusted God against impossible odds."
             }
           ]
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:22",
-              "note": "Calvin: On Shechem revolts; tower burned; a woman's millstone ends the tyrant: God's patience with Israel across repeated cycles of apostasy and deliverance displays the persistence of covenant grace. He does not abandon his people when they abandon him — though he disciplines them severely. This is the pattern of every believer's life."
-            },
-            {
-              "ref": "9:23",
-              "note": "Calvin: The practical application for the church is sobering: spiritual decline is not sudden but cyclical. Each generation must fight the same battles of faith. Inherited religion without personal conviction produces exactly the moral chaos described in Judges."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:22",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain with characteristic markers of the Deuteronomistic editorial framework. The repeated formula \"the Israelites did evil in the eyes of the LORD\" (wayyaʿăśû... hāraʿ bĕʿênê YHWH) frames each cycle."
-            },
-            {
-              "ref": "9:23",
-              "note": "NET Note: Key terms carry specific theological weight:šāpaṭ(\"to judge\") means not merely judicial arbitration but executive leadership and military deliverance — the \"judges\" are better understood as \"deliverers\" or \"champions.\""
-            }
-          ]
+          "notes": []
         },
         "block": {
           "source": "Daniel I. Block, Judges, Ruth, New American Commentary (1999) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:22",
-              "note": "Block: On Shechem revolts; tower burned; a woman's millstone ends the tyrant: the narrative here exhibits the characteristic Judges cycle — Israel's failure provokes divine discipline, which produces a cry for help, which God answers through a flawed but Spirit-empowered deliverer. The pattern is theological, not merely historical."
-            },
-            {
-              "ref": "9:24",
-              "note": "Block: The literary artistry of this section is deliberate: the narrator uses irony, wordplay, and structural echoes to expose the gap between what Israel should be (a covenant people) and what it has become (indistinguishable from Canaan)."
-            }
-          ]
+          "notes": []
         },
         "webb": {
           "source": "Barry G. Webb, The Book of Judges, NICOT (2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:22",
-              "note": "Webb: On Shechem revolts; tower burned; a woman's millstone ends the tyrant: the placement of this episode within the book's larger structure advances the thesis of progressive deterioration. Each judge cycle descends further from the Othniel paradigm (3:7-11), demonstrating that human deliverance without heart-change produces only temporary relief."
-            },
-            {
-              "ref": "9:23",
-              "note": "Webb: The theological irony is central to the narrator's purpose — God uses increasingly unlikely and morally compromised agents to deliver Israel, demonstrating that salvation depends on divine grace, not human virtue."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "This section addresses Shechem revolts; tower burned; a woman's millstone ends the tyrant. The narrative advances the book's central argument: when Israel forsakes the covenant, disaster follows; when Israel cries out, God raises a deliverer — but each cycle descends further into moral compromise."

--- a/content/leviticus/10.json
+++ b/content/leviticus/10.json
@@ -159,10 +159,6 @@
             {
               "ref": "10:19–20",
               "note": "Calvin: Aaron's answer reveals that even the most exact ceremonies must yield to the spirit of the law when circumstances demand. God is not served by rigid external performance that ignores the interior condition of the worshipper. The priests mourning their brothers could not have eaten the sacrifice with the joy and gratitude that its proper reception required. Moses recognises this — and so must we in our own worship."
-            },
-            {
-              "ref": "10:12",
-              "note": "Calvin: The passage on Nadab and Abihu demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "10:19",
               "note": "NET Note: Aaron's defence turns on the word \"today\" (hayyôm). The sin offering is to be eaten \"on the day it is offered\" (6:26) — and today is the day his sons were killed by divine fire. On that specific day, he argues, eating it would have been ritually and theologically impossible. The contextual qualifier \"today\" appears twice in his two-clause argument."
-            },
-            {
-              "ref": "10:12",
-              "note": "NET Note: The Hebrew vocabulary in this section on Nadab and Abihu employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/11.json
+++ b/content/leviticus/11.json
@@ -163,10 +163,6 @@
             {
               "ref": "11:24–40",
               "note": "Calvin: The defilement from carcass contact teaches the believer to maintain separation from spiritual death — the corruption of the world, the deadness of false religion, the decay of sin. Though the specific laws are fulfilled, the principle of avoiding contamination by what is spiritually \"dead\" applies to the Christian life."
-            },
-            {
-              "ref": "11:24",
-              "note": "Calvin: The passage on clean and unclean animals demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -176,10 +172,6 @@
             {
               "ref": "11:45",
               "note": "NET Note: \"I brought you up out of Egypt to be your God\" — the Exodus is cited as the ground of the holiness imperative. Redemption creates obligation. Because YHWH acted to deliver Israel, Israel owes him holy living. The food laws are not a burden but a response to grace."
-            },
-            {
-              "ref": "11:24",
-              "note": "NET Note: The Hebrew vocabulary in this section on clean and unclean animals employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/12.json
+++ b/content/leviticus/12.json
@@ -149,10 +149,6 @@
             {
               "ref": "12:6–8",
               "note": "Calvin: The sin offering at the end of the purification period teaches the universal need for mediation between fallen humanity and holy God. Every return to full covenant standing requires atonement — Christ is that covering, once for all."
-            },
-            {
-              "ref": "12:6",
-              "note": "Calvin: The passage on purification after childbirth demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -162,10 +158,6 @@
             {
               "ref": "12:8",
               "note": "NET Note: 'If she cannot afford a lamb' — the poverty provision appears in Lev 5:7 and 14:21–22 also. It is a recurring structural element of the purity legislation, ensuring full access to purification for the poorest members of the covenant community."
-            },
-            {
-              "ref": "12:6",
-              "note": "NET Note: The Hebrew vocabulary in this section on purification after childbirth employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/13.json
+++ b/content/leviticus/13.json
@@ -157,10 +157,6 @@
             {
               "ref": "13:47–59",
               "note": "Calvin: The extension of the purity laws to garments teaches that no material thing is beyond the reach of holiness or contamination. The Christian is called not only to personal holiness but to maintain a holy environment — \"hating even the garment stained by the flesh\" (Jude 23). The whole material life is a spiritual concern."
-            },
-            {
-              "ref": "13:47",
-              "note": "Calvin: The passage on skin diseases demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -170,10 +166,6 @@
             {
               "ref": "13:51",
               "note": "NET Note: \"Spreading ṣāraʿat\" in fabric is likely a mould or mildew condition — perhaps Aspergillus or similar fungi that spread through organic material. The green and reddish coloration (v.49) matches some mould species. The category is taxonomically consistent with skin disease: spreading, boundary-violating contamination."
-            },
-            {
-              "ref": "13:47",
-              "note": "NET Note: The Hebrew vocabulary in this section on skin diseases employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/14.json
+++ b/content/leviticus/14.json
@@ -153,10 +153,6 @@
             {
               "ref": "14:33–53",
               "note": "Calvin: The house-ṣāraʿat laws teach that no sphere of human life is exempt from the concern for holiness. The home, no less than the body, is subject to divine scrutiny. The Christian is called to maintain holy homes — not merely in ritual purity but in the absence of corruption, falsehood, and moral contamination."
-            },
-            {
-              "ref": "14:33",
-              "note": "Calvin: The passage on cleansing rituals demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -166,10 +162,6 @@
             {
               "ref": "14:34",
               "note": "NET Note: \"I will put a spreading mould in a house\" — the divine first-person is striking and unusual. It suggests that house ṣāraʿat is not merely natural mould but a divinely permitted condition requiring priestly attention. The theological frame: Israel's material world is under covenant governance, not merely natural law."
-            },
-            {
-              "ref": "14:33",
-              "note": "NET Note: The Hebrew vocabulary in this section on cleansing rituals employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/15.json
+++ b/content/leviticus/15.json
@@ -159,10 +159,6 @@
             {
               "ref": "15:19–30",
               "note": "Calvin: The menstrual impurity laws have been misused to condemn women throughout history. Calvin understood them correctly: they are ritual provisions, not moral condemnations. The woman's body is no more \"sinful\" than the man's discharge. Both require the same courtesy of ritual management, the same acknowledgment that even natural processes must be brought within the framework of holiness."
-            },
-            {
-              "ref": "15:19",
-              "note": "Calvin: The passage on bodily discharges demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "15:31",
               "note": "NET Note: \"So they will not die in their uncleanness\" — the penalty for defiling the sanctuary through unmanaged impurity is death. This is consistent with the death of Nadab and Abihu (Lev 10) and with the warning of Lev 22:3. The divine presence is not merely culturally present but lethally holy; its mismanagement is fatal."
-            },
-            {
-              "ref": "15:19",
-              "note": "NET Note: The Hebrew vocabulary in this section on bodily discharges employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/16.json
+++ b/content/leviticus/16.json
@@ -163,10 +163,6 @@
             {
               "ref": "16:20–22",
               "note": "Calvin: The scapegoat is among the most vivid types of Christ in the entire Torah. The double hand-laying, the comprehensive confession, the goat bearing the nation's sins away — all fulfilled in Christ, who bore our iniquities into the wilderness of death and did not return under their weight, but rose victorious. The sins are gone because the one who bore them overcame the wilderness."
-            },
-            {
-              "ref": "16:20",
-              "note": "Calvin: The passage on Day of Atonement demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -176,10 +172,6 @@
             {
               "ref": "16:22",
               "note": "NET Note: \"A remote place\" (ʾereṣ gĕzērāh) — literally \"a land of separation/cutting off.\" The precise location is unspecified; the point is distance and irreversibility. The Mishnah (Yoma 6:4–8) later specified a cliff near Jerusalem from which the scapegoat was pushed; the biblical text simply requires the wilderness removal."
-            },
-            {
-              "ref": "16:20",
-              "note": "NET Note: The Hebrew vocabulary in this section on Day of Atonement employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/17.json
+++ b/content/leviticus/17.json
@@ -155,10 +155,6 @@
             {
               "ref": "17:10–14",
               "note": "Calvin: The blood prohibition teaches the profound reverence we owe to the life that God has given. Every living creature's blood is a sacrament of the life that belongs to its Creator. When Christ spills his blood, he is giving the ultimate life — his own divine-human life — as the final and definitive atonement. The Levitical prohibition is the grammar that makes the cross intelligible."
-            },
-            {
-              "ref": "17:10",
-              "note": "Calvin: The passage on blood prohibition demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -168,10 +164,6 @@
             {
               "ref": "17:11",
               "note": "NET Note: \"Nepeš\" (life/soul/self) is typically translated \"life\" in this context. The equation nepeš = blood = atonement has generated extensive theological debate. The text does not say blood is the nepeš, but that the nepeš of the flesh is \"in\" (bĕ) the blood — a locative, not an identity statement. The life-force resides in the blood; blood is the carrier and symbol of life, not life itself."
-            },
-            {
-              "ref": "17:10",
-              "note": "NET Note: The Hebrew vocabulary in this section on blood prohibition employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/18.json
+++ b/content/leviticus/18.json
@@ -163,10 +163,6 @@
             {
               "ref": "18:24–30",
               "note": "Calvin: The land-vomiting metaphor teaches that the moral order is not merely legal but ontological — built into the structure of creation. Societies that systematically violate sexual ethics destroy themselves; they are \"vomited out\" by the creation order they have violated. History confirms this repeatedly. The laws of Lev 18 are not arbitrary cultural norms but reflections of the created order."
-            },
-            {
-              "ref": "18:19",
-              "note": "Calvin: The passage on sexual prohibitions demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -176,10 +172,6 @@
             {
               "ref": "18:21",
               "note": "NET Note: \"Molech\" (hammolek) — a deity associated with child sacrifice, worshipped in the Valley of Hinnom (Topheth). The identity of Molech is debated: a specific Canaanite deity, a general term for a type of votive offering, or a vocalization of \"king\" (melek) with the vowels of \"shame\" (bōšet). The practice is condemned throughout the OT (Lev 20:2–5; 2 Kgs 16:3; 21:6; 23:10; Jer 32:35)."
-            },
-            {
-              "ref": "18:19",
-              "note": "NET Note: The Hebrew vocabulary in this section on sexual prohibitions employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/19.json
+++ b/content/leviticus/19.json
@@ -155,10 +155,6 @@
             {
               "ref": "19:35–36",
               "note": "Calvin: The honest weights and measures laws demonstrate that commerce is a theological matter. Every transaction in which someone cheats on measure is a lie about reality — a violation of the truthfulness that God's own character demands. The merchant who uses false weights is not merely breaking a commercial rule; they are defaming the God of truth in whom they claim to believe."
-            },
-            {
-              "ref": "19:19",
-              "note": "Calvin: The passage on holiness code demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -168,10 +164,6 @@
             {
               "ref": "19:27",
               "note": "NET Note: \"Do not cut the hair at the sides of your head or clip off the edges of your beard\" — the prohibition targets specific Canaanite mourning practices associated with the dead (cf. Deut 14:1; Jer 16:6). The body-marking associated with death-cult religion (tattoos, v.28; consulting the dead, v.31) would blur the boundary between Israel and the surrounding death-religion cultures."
-            },
-            {
-              "ref": "19:19",
-              "note": "NET Note: The Hebrew vocabulary in this section on holiness code employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/2.json
+++ b/content/leviticus/2.json
@@ -169,10 +169,6 @@
             {
               "ref": "2:14–16",
               "note": "Calvin: The firstfruits typify Christ, who is himself the first and best offering — the truly holy one presented to God on behalf of all. In him the harvest of redemption is consecrated."
-            },
-            {
-              "ref": "2:11",
-              "note": "Calvin: The passage on grain offering demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },

--- a/content/leviticus/20.json
+++ b/content/leviticus/20.json
@@ -159,10 +159,6 @@
             {
               "ref": "20:22–26",
               "note": "Calvin: The holiness summary teaches that Christian distinctiveness is not cultural preference but theological necessity. As Israel was to be different from Egypt and Canaan, the church is to be different from the world — not in withdrawal but in the quality of its life together. The church's ethics are a form of witness: they declare the character of the God who has separated his people to himself."
-            },
-            {
-              "ref": "20:17",
-              "note": "Calvin: The passage on penalties for sin demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "20:26",
               "note": "NET Note: \"I have set you apart from the nations to be my own\" — the Hiphil of bādal, the same verb God uses in Gen 1 to separate light from darkness, water from water, land from sea. Israel's election is portrayed as a creative act analogous to the ordering of creation. Their distinctiveness is cosmological, not merely cultural."
-            },
-            {
-              "ref": "20:17",
-              "note": "NET Note: The Hebrew vocabulary in this section on penalties for sin employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/21.json
+++ b/content/leviticus/21.json
@@ -145,10 +145,6 @@
             {
               "ref": "21:16–24",
               "note": "Calvin: The disqualification of physically imperfect priests from altar service is a shadow of the requirement for moral perfection. No human priest meets the standard completely — they all offer with \"blemishes\" of sin and weakness. Christ alone fulfils the priestly ideal: without blemish of sin, he offers the perfect sacrifice. His high priesthood is the reality these shadows obscured."
-            },
-            {
-              "ref": "21:16",
-              "note": "Calvin: The passage on priestly holiness demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -158,10 +154,6 @@
             {
               "ref": "21:23",
               "note": "NET Note: The disqualified priest \"shall not come near the veil or approach the altar, because he has a defect\" — his exclusion is spatial, not social. He stands at the threshold of the altar but cannot approach it. He participates in the priestly community fully (eating the holy food) but cannot perform the representative act of approach before God."
-            },
-            {
-              "ref": "21:16",
-              "note": "NET Note: The Hebrew vocabulary in this section on priestly holiness employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/22.json
+++ b/content/leviticus/22.json
@@ -151,10 +151,6 @@
             {
               "ref": "22:31–33",
               "note": "Calvin: The chapter's closing summary is the Holiness Code's crowning statement: obedience is both the response to redemption (\"I brought you out of Egypt\") and the expression of consecration (\"I am the Lord who makes you holy\"). The Christian life is identical in structure: the cross is the motive, holiness is the fruit, and the sanctifying Spirit is the agent."
-            },
-            {
-              "ref": "22:17",
-              "note": "Calvin: The passage on sacrificial standards demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -164,10 +160,6 @@
             {
               "ref": "22:32",
               "note": "NET Note: \"I must be acknowledged as holy\" — the Niphal of qādaš, literally \"I will be hallowed/sanctified.\" God's holiness is not diminished by Israel's failures, but it is dishonoured before the watching nations. The concept of ḥillûl haShem (name-profaning) becomes central in Ezekiel's theology of exile (Ezek 36:20–23): Israel's unfaithfulness caused God's name to be profaned among the nations."
-            },
-            {
-              "ref": "22:17",
-              "note": "NET Note: The Hebrew vocabulary in this section on sacrificial standards employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/23.json
+++ b/content/leviticus/23.json
@@ -159,10 +159,6 @@
             {
               "ref": "23:33–43",
               "note": "Calvin: Tabernacles points to the eternal feast — the great gathering of all God's people at the end of the age, dwelling in God's presence not temporarily but forever. The booth is the symbol of our present condition: pilgrims in temporary dwellings, awaiting the permanent city whose builder and maker is God (Heb 11:10). The feast calls Israel — and us — to hold the present lightly and the future firmly."
-            },
-            {
-              "ref": "23:23",
-              "note": "Calvin: The passage on appointed feasts demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "23:36",
               "note": "NET Note: \"On the eighth day hold a sacred assembly and present a food offering to the Lord. It is the closing special assembly; do no regular work\" — the šĕmînî ʿaṣeret (\"eighth-day restraint\") is a separate feast appended to Tabernacles. Rabbinic tradition treats it as a distinct holiday (eventually becoming Simchat Torah in diaspora Judaism). Its significance: the number eight signals new creation beyond the seven-day week."
-            },
-            {
-              "ref": "23:23",
-              "note": "NET Note: The Hebrew vocabulary in this section on appointed feasts employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/24.json
+++ b/content/leviticus/24.json
@@ -155,10 +155,6 @@
             {
               "ref": "24:17–22",
               "note": "Calvin: The lex talionis teaches the fundamental equality of all persons before the law — the same penalty applies regardless of status or origin. This principle, extended by Christ, becomes the foundation of Christian ethics: every human being bears the image of God and deserves equal dignity and equal justice. The NT deepens this: not merely equal retaliation but equal love (Matt 5:44–45)."
-            },
-            {
-              "ref": "24:10",
-              "note": "Calvin: The passage on lampstand and showbread demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -168,10 +164,6 @@
             {
               "ref": "24:16",
               "note": "NET Note: \"Anyone who blasphemes the name of the Lord is to be put to death. The entire assembly must stone them.\" The community's collective participation in the execution is deliberate — blasphemy is an offence against the whole covenant community, not merely against the individual God. The community that tolerates blasphemy shares its guilt (cf. Lev 20:4–5)."
-            },
-            {
-              "ref": "24:10",
-              "note": "NET Note: The Hebrew vocabulary in this section on lampstand and showbread employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/25.json
+++ b/content/leviticus/25.json
@@ -159,10 +159,6 @@
             {
               "ref": "25:35–55",
               "note": "Calvin: The poverty provisions of Lev 25 challenge the church in every generation. The no-interest loan, the Jubilee release, the kinsman-redeemer obligation — these are not merely ancient regulations but expressions of the covenant ethic of solidarity. Those who have been redeemed by God are obligated to act redemptively toward their neighbours. The gospel creates economic ethics."
-            },
-            {
-              "ref": "25:29",
-              "note": "Calvin: The passage on sabbatical and jubilee demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "25:36",
               "note": "NET Note: \"Do not take interest or any profit from them\" — nešek (literally \"bite,\" interest on money) and tarbît/marbît (increase, interest on food) are both prohibited. The two terms together cover all forms of profit from loans to the poor. This absolute prohibition on poverty-lending interest is unique in the ancient Near East, where interest rates of 20–33% were common."
-            },
-            {
-              "ref": "25:29",
-              "note": "NET Note: The Hebrew vocabulary in this section on sabbatical and jubilee employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/26.json
+++ b/content/leviticus/26.json
@@ -159,10 +159,6 @@
             {
               "ref": "26:40–45",
               "note": "Calvin: The restoration promise at the end of the curse section teaches that divine judgment is always penultimate and divine mercy is always ultimate. God's anger is for a moment; his favour is for a lifetime (Ps 30:5). The exile is not God's last word; the covenant is. The NT equivalent: even in the depths of human sin, Christ is the gōʾēl who redeems and restores. The last word of the covenant is always grace."
-            },
-            {
-              "ref": "26:27",
-              "note": "Calvin: The passage on covenant blessings and curses demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "26:45",
               "note": "NET Note: \"For their sake I will remember the covenant with their ancestors whom I brought out of Egypt in the sight of the nations to be their God.\" The Exodus remains the covenant's anchor even in the depths of the exile curse. The God who brought Israel out of Egypt will bring them out of Babylon. The first Exodus grounds the promise of the second."
-            },
-            {
-              "ref": "26:27",
-              "note": "NET Note: The Hebrew vocabulary in this section on covenant blessings and curses employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/27.json
+++ b/content/leviticus/27.json
@@ -159,10 +159,6 @@
             {
               "ref": "27:30–34",
               "note": "Calvin: The tithe closes Leviticus with the reminder that covenant living is comprehensive — even the harvest's arithmetic is theological. One-tenth is the Lord's because all is the Lord's; the tithe is a visible expression of the invisible truth that the covenant community owns nothing absolutely. The closing colophon — \"at Mount Sinai\" — seals the book's authority: not human legislation, not priestly tradition, but divine command. Leviticus is God's word for God's people."
-            },
-            {
-              "ref": "27:26",
-              "note": "Calvin: The passage on vows and dedications demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "27:34",
               "note": "NET Note: The Sinaitic colophon (\"at Mount Sinai\") closes not just Lev 27 but the entire book. It distinguishes Leviticus's legislation from Sinai-period ordinances from post-Sinai legislation (which receives different introductory formulas). The colophon is an editorial claim: every regulation in this book was received at the mountain of revelation. It is the priestly writers' equivalent of \"thus says the Lord.\""
-            },
-            {
-              "ref": "27:26",
-              "note": "NET Note: The Hebrew vocabulary in this section on vows and dedications employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/3.json
+++ b/content/leviticus/3.json
@@ -157,10 +157,6 @@
             {
               "ref": "3:16–17",
               "note": "Calvin: That God reserves fat and blood for himself is a perpetual reminder that we hold nothing absolutely — our bodies, our food, our very life are held on loan from the Creator. Worship is the acknowledgement of this dependence."
-            },
-            {
-              "ref": "3:12",
-              "note": "Calvin: The passage on peace offering demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },

--- a/content/leviticus/4.json
+++ b/content/leviticus/4.json
@@ -155,10 +155,6 @@
             {
               "ref": "4:22–35",
               "note": "Calvin: God's provision of the sin offering for every level of society reveals his universal mercy. No condition of life lies beyond the reach of his forgiveness. The poorest Israelite, the most obscure individual, is not forgotten in the sacrificial system — God's grace is as available to the commonest person as to the high priest."
-            },
-            {
-              "ref": "4:22",
-              "note": "Calvin: The passage on sin offering demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },

--- a/content/leviticus/5.json
+++ b/content/leviticus/5.json
@@ -151,10 +151,6 @@
             {
               "ref": "5:14–19",
               "note": "Calvin: The guilt offering teaches that sin against God is never without cost — it must be repaired, not merely regretted. The addition of the 20% surcharge signifies that repentance involves more than the return of what was wrongly taken; it involves acknowledging the wrong through sacrificial generosity."
-            },
-            {
-              "ref": "5:14",
-              "note": "Calvin: The passage on guilt offering demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -164,10 +160,6 @@
             {
               "ref": "5:16",
               "note": "NET Note: The 20% (literally \"one-fifth,\" ḥomešô) addition appears also in Lev 22:14; 27:13, 15, 19 — always in contexts of restoring what belongs to the sacred domain. It is a standard Torah penalty for unauthorised use of consecrated property."
-            },
-            {
-              "ref": "5:14",
-              "note": "NET Note: The Hebrew vocabulary in this section on guilt offering employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/6.json
+++ b/content/leviticus/6.json
@@ -151,10 +151,6 @@
             {
               "ref": "6:12–13",
               "note": "Calvin: The perpetual fire typifies the Holy Spirit — the divine fire never extinguished in the church. As the physical fire was to be fed and maintained by human diligence, so the Spirit's fire must be fed by prayer, worship, and the means of grace. Quench not the Spirit (1 Thess 5:19)."
-            },
-            {
-              "ref": "6:8",
-              "note": "Calvin: The passage on priestly offering regulations demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -164,10 +160,6 @@
             {
               "ref": "6:13",
               "note": "NET Note: The three-fold repetition of the command in vv.9, 12, 13 uses the negated jussive with tāmîd — the strongest possible form of the prohibition: \"the fire shall not be extinguished.\" The priestly compiler marks this as foundational to the entire sacrificial system's operation."
-            },
-            {
-              "ref": "6:8",
-              "note": "NET Note: The Hebrew vocabulary in this section on priestly offering regulations employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -248,10 +240,6 @@
             {
               "ref": "6:24–30",
               "note": "Calvin: The elaborate precautions around the sin offering's residue teach the gravity of dealing with holy things. We ought not to approach the sacraments or the worship of God casually — the New Testament's warnings about unworthy communion (1 Cor 11) echo Leviticus's insistence that the most holy demands the most careful handling."
-            },
-            {
-              "ref": "6:24",
-              "note": "Calvin: The passage on priestly offering regulations demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -261,10 +249,6 @@
             {
               "ref": "6:28",
               "note": "NET Note: The earthenware pot requirement (break it) vs. bronze pot (scour and rinse it) reflects practical knowledge of material properties — porous clay absorbs liquids and cannot be fully cleansed; non-porous metal can. The priestly system integrates material science with theological principle."
-            },
-            {
-              "ref": "6:24",
-              "note": "NET Note: The Hebrew vocabulary in this section on priestly offering regulations employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/7.json
+++ b/content/leviticus/7.json
@@ -151,10 +151,6 @@
             {
               "ref": "7:22–27",
               "note": "Calvin: The fat and blood prohibitions, with their severe kārēt penalty, demonstrate that not all of God's commands carry equal weight — some strike at the foundation of the covenant itself. The Christian who treats all of God's commands as equally negotiable misunderstands the Levitical logic of graduated holiness."
-            },
-            {
-              "ref": "7:22",
-              "note": "Calvin: The passage on guilt and peace instructions demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },

--- a/content/leviticus/8.json
+++ b/content/leviticus/8.json
@@ -159,10 +159,6 @@
             {
               "ref": "8:33–36",
               "note": "Calvin: The seven-day confinement teaches that entry into sacred ministry is not instantaneous. The candidate must dwell in the threshold, separated from the common life, before assuming holy office. There is no quick path to spiritual leadership — the formation takes time, and rushing it is spiritually fatal."
-            },
-            {
-              "ref": "8:18",
-              "note": "Calvin: The passage on priestly ordination demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -172,10 +168,6 @@
             {
               "ref": "8:23",
               "note": "NET Note: The right extremities — earlobe, thumb, toe — are the most exposed points of the body, those most likely to be touched and contaminated. Consecrating these specific points claims the most vulnerable areas for holiness. The same logic governs their use in the leper's purification (Lev 14:14)."
-            },
-            {
-              "ref": "8:18",
-              "note": "NET Note: The Hebrew vocabulary in this section on priestly ordination employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/leviticus/9.json
+++ b/content/leviticus/9.json
@@ -157,10 +157,6 @@
             {
               "ref": "9:22–24",
               "note": "Calvin: The people falling facedown is the appropriate response to unveiled holiness. We are trained in our age to treat God with familiarity; Leviticus teaches the other dimension — the holy provokes awe, even terror. The fire is not comfortable but consuming; the glory is not decorative but overwhelming. Both responses — joy and prostration — are necessary for full-orbed worship."
-            },
-            {
-              "ref": "9:22",
-              "note": "Calvin: The passage on tabernacle inauguration demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -170,10 +166,6 @@
             {
               "ref": "9:23",
               "note": "NET Note: Moses and Aaron entering together then emerging together models the partnership of prophetic and priestly mediation in Israel — Moses the lawgiver and Aaron the priest together represent the two modes of God's approach to Israel: word and rite, teaching and sacrifice. Their joint blessing seals the inaugural day."
-            },
-            {
-              "ref": "9:22",
-              "note": "NET Note: The Hebrew vocabulary in this section on tabernacle inauguration employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },

--- a/content/luke/10.json
+++ b/content/luke/10.json
@@ -7,46 +7,46 @@
   "subtitle": "The Seventy-Two Sent Out; The Good Samaritan; Mary and Martha",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201124 \u2014 The Seventy-Two Sent; Their Return; I Saw Satan Fall",
+      "header": "Verses 1‑24 — The Seventy-Two Sent; Their Return; I Saw Satan Fall",
       "verse_start": 1,
       "verse_end": 24,
       "panels": {
         "heb": [
           {
             "word": "Didrachmon",
-            "transliteration": "Satan falling like lightning from heaven \u2014 Estrapsin \u2014 the aorist: I watched Satan fall",
-            "gloss": "astrapt\u014dn",
-            "paragraph": "I saw Satan fall like lightning from heaven (estrapsen) \u2014 the aorist \u201cI saw\u201d looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples\u2019 authority over demons as a disclosure of Satan\u2019s defeat \u2014 not merely future but already beginning. The kingdom\u2019s advance is simultaneously Satan\u2019s retreat."
+            "transliteration": "Satan falling like lightning from heaven — Estrapsin — the aorist: I watched Satan fall",
+            "gloss": "astraptōn",
+            "paragraph": "I saw Satan fall like lightning from heaven (estrapsen) — the aorist “I saw” looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples’ authority over demons as a disclosure of Satan’s defeat — not merely future but already beginning. The kingdom’s advance is simultaneously Satan’s retreat."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 10",
-              "note": "The table of seventy nations \u2014 the background for the number seventy-two, suggesting a mission to all peoples."
+              "note": "The table of seventy nations — the background for the number seventy-two, suggesting a mission to all peoples."
             },
             {
               "ref": "Isa 14:12",
-              "note": "How you have fallen from heaven, morning star \u2014 the Isaiah text behind the lightning-fall of Satan (10:18)."
+              "note": "How you have fallen from heaven, morning star — the Isaiah text behind the lightning-fall of Satan (10:18)."
             },
             {
               "ref": "Ps 91:13",
-              "note": "You will tread on the lion and the cobra \u2014 the text behind the promise of authority over snakes and scorpions (10:19)."
+              "note": "You will tread on the lion and the cobra — the text behind the promise of authority over snakes and scorpions (10:19)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "10:18",
-              "note": "I saw Satan fall like lightning from heaven \u2014 the disciples\u2019 successful exorcisms are evidence of a larger cosmic event: Satan\u2019s authority over the world is being dismantled. The present tense of the kingdom\u2019s advance is the aorist of Satan\u2019s fall."
+              "note": "I saw Satan fall like lightning from heaven — the disciples’ successful exorcisms are evidence of a larger cosmic event: Satan’s authority over the world is being dismantled. The present tense of the kingdom’s advance is the aorist of Satan’s fall."
             },
             {
               "ref": "10:21-22",
@@ -55,65 +55,65 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "10:22",
-              "note": "No one knows who the Father is except the Son and those to whom the Son chooses to reveal him \u2014 Calvin: the mutual knowledge of Father and Son is eternal and complete. The revelation of the Father through the Son is the sole avenue of saving knowledge. Natural theology gives knowledge of God\u2019s power and divinity (Rom 1:20); saving knowledge of the Father comes only through the Son."
+              "note": "No one knows who the Father is except the Son and those to whom the Son chooses to reveal him — Calvin: the mutual knowledge of Father and Son is eternal and complete. The revelation of the Father through the Son is the sole avenue of saving knowledge. Natural theology gives knowledge of God’s power and divinity (Rom 1:20); saving knowledge of the Father comes only through the Son."
             },
             {
               "ref": "10:24",
-              "note": "Many prophets and kings desired to see what you see \u2014 Calvin: the privileges of the NT are greater than those of the OT, not because the covenant is different but because the fulfilment has arrived. The disciples are the beneficiaries of everything the prophets hoped for and did not see."
+              "note": "Many prophets and kings desired to see what you see — Calvin: the privileges of the NT are greater than those of the OT, not because the covenant is different but because the fulfilment has arrived. The disciples are the beneficiaries of everything the prophets hoped for and did not see."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "10:1",
-              "note": "Seventy-two others \u2014 the manuscript tradition is divided between seventy and seventy-two. The NA28 prefers seventy-two; the majority tradition has seventy. Both numbers echo significant OT precedents: seventy elders in Num 11:16-17 and seventy (or seventy-two) nations in Gen 10."
+              "note": "Seventy-two others — the manuscript tradition is divided between seventy and seventy-two. The NA28 prefers seventy-two; the majority tradition has seventy. Both numbers echo significant OT precedents: seventy elders in Num 11:16-17 and seventy (or seventy-two) nations in Gen 10."
             },
             {
               "ref": "10:18",
-              "note": "I saw Satan fall like lightning from heaven \u2014 the aorist ethe\u014droun with the imperfect participle: I was watching Satan fall. The timing and reference of this vision are debated. The most natural reading relates it to the disciples\u2019 successful mission: their authority over demons is a sign of Satan\u2019s decisive defeat."
+              "note": "I saw Satan fall like lightning from heaven — the aorist etheōroun with the imperfect participle: I was watching Satan fall. The timing and reference of this vision are debated. The most natural reading relates it to the disciples’ successful mission: their authority over demons is a sign of Satan’s decisive defeat."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "10:2",
-              "note": "The harvest is plentiful, but the workers are few \u2014 therismou: the harvest metaphor frames the mission in eschatological terms. The harvest is already ripe; the workers are urgently needed. The urgency of the mission is the urgency of the harvest season."
+              "note": "The harvest is plentiful, but the workers are few — therismou: the harvest metaphor frames the mission in eschatological terms. The harvest is already ripe; the workers are urgently needed. The urgency of the mission is the urgency of the harvest season."
             },
             {
               "ref": "10:16",
-              "note": "Whoever listens to you listens to me \u2014 the apostolic authority is participatory in Jesus\u2019s own authority. To reject the sent one is to reject the sender. The chain of representation: the Father \u2192 the Son \u2192 the sent ones \u2192 those who receive them."
+              "note": "Whoever listens to you listens to me — the apostolic authority is participatory in Jesus’s own authority. To reject the sent one is to reject the sender. The chain of representation: the Father → the Son → the sent ones → those who receive them."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "10:20",
-              "note": "Rejoice that your names are written in heaven \u2014 Origen: the register of heaven is the only list that matters. The disciples have discovered that authority over demons is real; they are told that this authority is less important than their own standing before God. The greatest miracle is not exorcism but election."
+              "note": "Rejoice that your names are written in heaven — Origen: the register of heaven is the only list that matters. The disciples have discovered that authority over demons is real; they are told that this authority is less important than their own standing before God. The greatest miracle is not exorcism but election."
             },
             {
               "ref": "10:21",
-              "note": "I praise you, Father\u2026 because you have hidden these things from the wise and learned, and revealed them to little children \u2014 Chrysostom: the prayer of thanksgiving is the theological key to the whole mission: the kingdom\u2019s advance bypasses the learned and reaches the simple. This is consistent from the Magnificat (the proud scattered, the humble lifted) to the entire ministry."
+              "note": "I praise you, Father… because you have hidden these things from the wise and learned, and revealed them to little children — Chrysostom: the prayer of thanksgiving is the theological key to the whole mission: the kingdom’s advance bypasses the learned and reaches the simple. This is consistent from the Magnificat (the proud scattered, the humble lifted) to the entire ministry."
             }
           ]
         },
         "hist": {
-          "context": "The sending of the seventy-two is unique to Luke and extends the mission beyond the Twelve. The number seventy (or seventy-two) echoes the table of nations in Genesis 10 \u2014 suggesting a universal mission. The return and Jesus\u2019s prayer of thanksgiving (10:21-22) is the highest Christological passage in Luke: the mutual knowledge of Father and Son, and the sovereign revelation of the Son."
+          "context": "The sending of the seventy-two is unique to Luke and extends the mission beyond the Twelve. The number seventy (or seventy-two) echoes the table of nations in Genesis 10 — suggesting a universal mission. The return and Jesus’s prayer of thanksgiving (10:21-22) is the highest Christological passage in Luke: the mutual knowledge of Father and Son, and the sovereign revelation of the Son."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 25\u201137 \u2014 The Good Samaritan: Who Is My Neighbour?",
+      "header": "Verses 25‑37 — The Good Samaritan: Who Is My Neighbour?",
       "verse_start": 25,
       "verse_end": 37,
       "panels": {
@@ -122,192 +122,147 @@
             "word": "splangchnistheis",
             "transliteration": "splank-KNIS-theis",
             "gloss": "moved with compassion",
-            "paragraph": "But a Samaritan\u2026 when he saw him, he took pity on him (esplagchnisth\u0113) \u2014 the same visceral-compassion word used for the widow of Nain (7:13) and the father of the Prodigal (15:20). The Samaritan\u2019s compassion is divinely-quality compassion \u2014 not merely sympathy but the gut-level movement of the whole self toward the suffering of another. Luke consistently uses this word to identify the divine character in human action."
+            "paragraph": "But a Samaritan… when he saw him, he took pity on him (esplagchnisthē) — the same visceral-compassion word used for the widow of Nain (7:13) and the father of the Prodigal (15:20). The Samaritan’s compassion is divinely-quality compassion — not merely sympathy but the gut-level movement of the whole self toward the suffering of another. Luke consistently uses this word to identify the divine character in human action."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Deut 6:5",
-              "note": "Love the LORD your God with all your heart \u2014 the Shema, which the lawyer quotes."
+              "note": "Love the LORD your God with all your heart — the Shema, which the lawyer quotes."
             },
             {
               "ref": "Lev 19:18",
-              "note": "Love your neighbor as yourself \u2014 the second commandment the lawyer cites."
+              "note": "Love your neighbor as yourself — the second commandment the lawyer cites."
             },
             {
               "ref": "Isa 53:3-4",
-              "note": "He was despised and rejected\u2026 he took up our infirmities \u2014 the Samaritan\u2019s action mirrors the Servant\u2019s: he takes on the victim\u2019s condition, at his own cost."
+              "note": "He was despised and rejected… he took up our infirmities — the Samaritan’s action mirrors the Servant’s: he takes on the victim’s condition, at his own cost."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "10:30-35",
-              "note": "The Jericho road \u2014 c.27km, descending from Jerusalem (800m) to Jericho (250m below sea level). The road was notoriously dangerous. The priest and Levite may have passed by to avoid ritual defilement (the man might be dead; contact with a corpse defiled under Lev 21:1-3). The Samaritan has no such concern and spends liberally from his own resources."
+              "note": "The Jericho road — c.27km, descending from Jerusalem (800m) to Jericho (250m below sea level). The road was notoriously dangerous. The priest and Levite may have passed by to avoid ritual defilement (the man might be dead; contact with a corpse defiled under Lev 21:1-3). The Samaritan has no such concern and spends liberally from his own resources."
             },
             {
               "ref": "10:42",
-              "note": "Mary has chosen what is better \u2014 not that service is wrong but that hearing is primary. The Mary-Martha distinction is not domestic versus spiritual but the ordering of priorities: service that has not first been filled by hearing becomes anxious duty. Martha is not rebuked for working but for anxiety."
+              "note": "Mary has chosen what is better — not that service is wrong but that hearing is primary. The Mary-Martha distinction is not domestic versus spiritual but the ordering of priorities: service that has not first been filled by hearing becomes anxious duty. Martha is not rebuked for working but for anxiety."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "10:37",
-              "note": "Go and do likewise \u2014 Calvin: the parable does not answer the lawyer\u2019s question (who is my neighbor?) but replaces it with a better question (who acted like a neighbor?). The redirection is itself the teaching: the question of definition (who qualifies?) is replaced by the question of disposition (am I the kind of person who shows mercy?)"
+              "note": "Go and do likewise — Calvin: the parable does not answer the lawyer’s question (who is my neighbor?) but replaces it with a better question (who acted like a neighbor?). The redirection is itself the teaching: the question of definition (who qualifies?) is replaced by the question of disposition (am I the kind of person who shows mercy?)"
             },
             {
               "ref": "10:42",
-              "note": "Mary has chosen what is better, and it will not be taken away from her \u2014 Calvin: the present tense of the promise is important. The hearing of Christ\u2019s word is not a temporary good that will be superseded by action; it is the permanent possession that grounds and nourishes all action. Martha\u2019s anxiety shows that she has not first been filled."
+              "note": "Mary has chosen what is better, and it will not be taken away from her — Calvin: the present tense of the promise is important. The hearing of Christ’s word is not a temporary good that will be superseded by action; it is the permanent possession that grounds and nourishes all action. Martha’s anxiety shows that she has not first been filled."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "10:30",
-              "note": "Going down from Jerusalem to Jericho \u2014 the road descends 1,000 metres over 27 kilometres, through rocky desert terrain. It was notorious for bandits in antiquity (Josephus, Jewish War 4.474). The geographical detail grounds the parable in a specific and realistic setting."
+              "note": "Going down from Jerusalem to Jericho — the road descends 1,000 metres over 27 kilometres, through rocky desert terrain. It was notorious for bandits in antiquity (Josephus, Jewish War 4.474). The geographical detail grounds the parable in a specific and realistic setting."
             },
             {
               "ref": "10:42",
-              "note": "Few things are needed\u2014or indeed only one \u2014 the Greek is textually uncertain: some MSS read \"few things are needed\" (olig\u014dn); others \"one thing is needed\" (henos). The NA28 reads olig\u014dn \u0113 henos (few or one). The point is the same in either reading: contrast the many preparations with the single priority."
+              "note": "Few things are needed—or indeed only one — the Greek is textually uncertain: some MSS read \"few things are needed\" (oligōn); others \"one thing is needed\" (henos). The NA28 reads oligōn ē henos (few or one). The point is the same in either reading: contrast the many preparations with the single priority."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "10:33",
-              "note": "When he saw him, he took pity on him \u2014 the sequence is: he came to where he was, he saw him, he was moved with compassion, he went to him. The compassion is the hinge between seeing and acting. Sight without compassion produces the priest and the Levite; sight with compassion produces the Samaritan."
+              "note": "When he saw him, he took pity on him — the sequence is: he came to where he was, he saw him, he was moved with compassion, he went to him. The compassion is the hinge between seeing and acting. Sight without compassion produces the priest and the Levite; sight with compassion produces the Samaritan."
             },
             {
               "ref": "10:40",
-              "note": "Martha was distracted (periespato) \u2014 the word means pulled in different directions, scattered: the root of anxiety is division of attention. Martha\u2019s problem is not that she is working but that the many things have replaced the one thing."
+              "note": "Martha was distracted (periespato) — the word means pulled in different directions, scattered: the root of anxiety is division of attention. Martha’s problem is not that she is working but that the many things have replaced the one thing."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "10:33",
-              "note": "A Samaritan\u2026 took pity on him \u2014 Origen: the parable has an allegorical layer: the man going from Jerusalem to Jericho is Adam descending from paradise; the robbers are the devil and his agents; the priest and Levite are the law and the prophets which could not save; the Samaritan is Christ; the inn is the church; the innkeeper is the apostle Paul; the two denarii are the two commandments. The allegorical reading was the dominant interpretation for a millennium."
+              "note": "A Samaritan… took pity on him — Origen: the parable has an allegorical layer: the man going from Jerusalem to Jericho is Adam descending from paradise; the robbers are the devil and his agents; the priest and Levite are the law and the prophets which could not save; the Samaritan is Christ; the inn is the church; the innkeeper is the apostle Paul; the two denarii are the two commandments. The allegorical reading was the dominant interpretation for a millennium."
             },
             {
               "ref": "10:41-42",
-              "note": "You are worried and upset about many things, but few things are needed\u2014or indeed only one \u2014 Chrysostom: the one thing needed is the hearing of the word. All other needs can be addressed from that centre; without it, all service becomes anxiety. The one thing is not contemplation for its own sake but the hearing that makes all action arise from love rather than duty."
+              "note": "You are worried and upset about many things, but few things are needed—or indeed only one — Chrysostom: the one thing needed is the hearing of the word. All other needs can be addressed from that centre; without it, all service becomes anxiety. The one thing is not contemplation for its own sake but the hearing that makes all action arise from love rather than duty."
             }
           ]
         },
         "hist": {
-          "context": "The Good Samaritan answers two questions simultaneously: Who is my neighbor? (asked by the lawyer) and Who acts like a neighbor? (the parable\u2019s counter-question). Jesus reframes the question: instead of defining the category of those who qualify for my duty, the parable asks who demonstrates the quality of mercy. The Mary-Martha contrast addresses the same tension in personal terms: duty versus devotion, service versus hearing."
+          "context": "The Good Samaritan answers two questions simultaneously: Who is my neighbor? (asked by the lawyer) and Who acts like a neighbor? (the parable’s counter-question). Jesus reframes the question: instead of defining the category of those who qualify for my duty, the parable asks who demonstrates the quality of mercy. The Mary-Martha contrast addresses the same tension in personal terms: duty versus devotion, service versus hearing."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 38\u201142 \u2014 Mary and Martha: One Thing Is Needed",
+      "header": "Verses 38‑42 — Mary and Martha: One Thing Is Needed",
       "verse_start": 38,
       "verse_end": 42,
       "panels": {
         "heb": [
           {
             "word": "Didrachmon",
-            "transliteration": "Satan falling like lightning from heaven \u2014 Estrapsin \u2014 the aorist: I watched Satan fall",
-            "gloss": "astrapt\u014dn",
-            "paragraph": "I saw Satan fall like lightning from heaven (estrapsen) \u2014 the aorist \u201cI saw\u201d looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples\u2019 authority over demons as a disclosure of Satan\u2019s defeat \u2014 not merely future but already beginning. The kingdom\u2019s advance is simultaneously Satan\u2019s retreat."
+            "transliteration": "Satan falling like lightning from heaven — Estrapsin — the aorist: I watched Satan fall",
+            "gloss": "astraptōn",
+            "paragraph": "I saw Satan fall like lightning from heaven (estrapsen) — the aorist “I saw” looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples’ authority over demons as a disclosure of Satan’s defeat — not merely future but already beginning. The kingdom’s advance is simultaneously Satan’s retreat."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 10",
-              "note": "The table of seventy nations \u2014 the background for the number seventy-two, suggesting a mission to all peoples."
+              "note": "The table of seventy nations — the background for the number seventy-two, suggesting a mission to all peoples."
             },
             {
               "ref": "Isa 14:12",
-              "note": "How you have fallen from heaven, morning star \u2014 the Isaiah text behind the lightning-fall of Satan (10:18)."
+              "note": "How you have fallen from heaven, morning star — the Isaiah text behind the lightning-fall of Satan (10:18)."
             },
             {
               "ref": "Ps 91:13",
-              "note": "You will tread on the lion and the cobra \u2014 the text behind the promise of authority over snakes and scorpions (10:19)."
+              "note": "You will tread on the lion and the cobra — the text behind the promise of authority over snakes and scorpions (10:19)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:18",
-              "note": "I saw Satan fall like lightning from heaven \u2014 the disciples\u2019 successful exorcisms are evidence of a larger cosmic event: Satan\u2019s authority over the world is being dismantled. The present tense of the kingdom\u2019s advance is the aorist of Satan\u2019s fall."
-            },
-            {
-              "ref": "10:21-22",
-              "note": "The highest Christological passage in the Synoptic Gospels: all things have been committed to the Son by the Father; only the Son knows the Father; the Son alone reveals the Father. This is John 1:18 in Synoptic form: no one has ever seen God, but the Son has made him known."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:22",
-              "note": "No one knows who the Father is except the Son and those to whom the Son chooses to reveal him \u2014 Calvin: the mutual knowledge of Father and Son is eternal and complete. The revelation of the Father through the Son is the sole avenue of saving knowledge. Natural theology gives knowledge of God\u2019s power and divinity (Rom 1:20); saving knowledge of the Father comes only through the Son."
-            },
-            {
-              "ref": "10:24",
-              "note": "Many prophets and kings desired to see what you see \u2014 Calvin: the privileges of the NT are greater than those of the OT, not because the covenant is different but because the fulfilment has arrived. The disciples are the beneficiaries of everything the prophets hoped for and did not see."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:1",
-              "note": "Seventy-two others \u2014 the manuscript tradition is divided between seventy and seventy-two. The NA28 prefers seventy-two; the majority tradition has seventy. Both numbers echo significant OT precedents: seventy elders in Num 11:16-17 and seventy (or seventy-two) nations in Gen 10."
-            },
-            {
-              "ref": "10:18",
-              "note": "I saw Satan fall like lightning from heaven \u2014 the aorist ethe\u014droun with the imperfect participle: I was watching Satan fall. The timing and reference of this vision are debated. The most natural reading relates it to the disciples\u2019 successful mission: their authority over demons is a sign of Satan\u2019s decisive defeat."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "10:2",
-              "note": "The harvest is plentiful, but the workers are few \u2014 therismou: the harvest metaphor frames the mission in eschatological terms. The harvest is already ripe; the workers are urgently needed. The urgency of the mission is the urgency of the harvest season."
-            },
-            {
-              "ref": "10:16",
-              "note": "Whoever listens to you listens to me \u2014 the apostolic authority is participatory in Jesus\u2019s own authority. To reject the sent one is to reject the sender. The chain of representation: the Father \u2192 the Son \u2192 the sent ones \u2192 those who receive them."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "10:20",
-              "note": "Rejoice that your names are written in heaven \u2014 Origen: the register of heaven is the only list that matters. The disciples have discovered that authority over demons is real; they are told that this authority is less important than their own standing before God. The greatest miracle is not exorcism but election."
-            },
-            {
-              "ref": "10:21",
-              "note": "I praise you, Father\u2026 because you have hidden these things from the wise and learned, and revealed them to little children \u2014 Chrysostom: the prayer of thanksgiving is the theological key to the whole mission: the kingdom\u2019s advance bypasses the learned and reaches the simple. This is consistent from the Magnificat (the proud scattered, the humble lifted) to the entire ministry."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The sending of the seventy-two is unique to Luke and extends the mission beyond the Twelve. The number seventy (or seventy-two) echoes the table of nations in Genesis 10 \u2014 suggesting a universal mission. The return and Jesus\u2019s prayer of thanksgiving (10:21-22) is the highest Christological passage in Luke: the mutual knowledge of Father and Son, and the sovereign revelation of the Son."
+          "context": "The sending of the seventy-two is unique to Luke and extends the mission beyond the Twelve. The number seventy (or seventy-two) echoes the table of nations in Genesis 10 — suggesting a universal mission. The return and Jesus’s prayer of thanksgiving (10:21-22) is the highest Christological passage in Luke: the mutual knowledge of Father and Son, and the sovereign revelation of the Son."
         }
       }
     }
@@ -316,36 +271,36 @@
     "ppl": [
       {
         "name": "The Good Samaritan",
-        "role": "Unnamed; the protagonist of Jesus\u2019s counter-parable",
-        "text": "The Samaritan is not the hero of a moral tale but the answer to the question: Who acted as neighbor? His actions \u2014 compassion, immediate care, expensive commitment, promised return \u2014 define the mercy that the commandment requires."
+        "role": "Unnamed; the protagonist of Jesus’s counter-parable",
+        "text": "The Samaritan is not the hero of a moral tale but the answer to the question: Who acted as neighbor? His actions — compassion, immediate care, expensive commitment, promised return — define the mercy that the commandment requires."
       },
       {
         "name": "Mary of Bethany",
-        "role": "Disciple; chose to sit at Jesus\u2019s feet and listen",
-        "text": "The posture of sitting at the teacher\u2019s feet (10:39) was the posture of a disciple. Luke positions Mary as a disciple of Jesus \u2014 a role normally reserved for men in first-century Judaism."
+        "role": "Disciple; chose to sit at Jesus’s feet and listen",
+        "text": "The posture of sitting at the teacher’s feet (10:39) was the posture of a disciple. Luke positions Mary as a disciple of Jesus — a role normally reserved for men in first-century Judaism."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>The expert in the law replied, \"The one who had mercy on him.\" Jesus told him, \"Go and do likewise.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>He said, \"The one who showed him mercy.\" And Jesus said to him, \"You go, and do likewise.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>And he said, He that shewed mercy on him. Then said Jesus unto him, Go, and do thou likewise.</td></tr><tr><td class=\"t-label\">NASB</td><td>And he said, \"The one who showed mercy to him.\" Then Jesus said to him, \"Go and do the same.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>The man replied, \"The one who showed him mercy.\" Then Jesus said, \"Yes, now go and do the same.\"</td></tr>",
     "src": [
       {
         "title": "Josephus, Jewish War 4.474",
-        "quote": "Josephus describes the Jerusalem-Jericho road as a site of frequent banditry \u2014 confirming the realism of the parable\u2019s setting.",
-        "note": "The danger of the Jericho road was a known fact in first-century Palestine, making the parable\u2019s scenario immediately credible."
+        "quote": "Josephus describes the Jerusalem-Jericho road as a site of frequent banditry — confirming the realism of the parable’s setting.",
+        "note": "The danger of the Jericho road was a known fact in first-century Palestine, making the parable’s scenario immediately credible."
       },
       {
         "title": "Mishnah Yadayim 4:6",
-        "quote": "Rabbinic discussions about the Samaritans\u2019 status in relation to the covenant.",
+        "quote": "Rabbinic discussions about the Samaritans’ status in relation to the covenant.",
         "note": "Provides the context for the shock of the Samaritan as hero: Samaritans were considered outside the covenant by most rabbis."
       }
     ],
     "rec": [
       {
         "who": "Vincent van Gogh, The Good Samaritan (1890; after Delacroix)",
-        "text": "Van Gogh\u2019s version painted from his hospital in Saint-R\u00e9my emphasizes the physical weight of the injured man and the Samaritan\u2019s embodied effort. The painting is a meditation on compassion as physical, costly labor."
+        "text": "Van Gogh’s version painted from his hospital in Saint-Rémy emphasizes the physical weight of the injured man and the Samaritan’s embodied effort. The painting is a meditation on compassion as physical, costly labor."
       },
       {
         "who": "Martin Luther King Jr., \"I've Been to the Mountaintop\" (1968)",
-        "text": "King\u2019s final sermon, delivered the night before his assassination, used the Good Samaritan to critique the priest and Levite: they asked \"What will happen to me if I stop?\" The Samaritan asked \"What will happen to him if I don't stop?\""
+        "text": "King’s final sermon, delivered the night before his assassination, used the Good Samaritan to critique the priest and Levite: they asked \"What will happen to me if I stop?\" The Samaritan asked \"What will happen to him if I don't stop?\""
       }
     ],
     "lit": {
@@ -366,29 +321,29 @@
     "hebtext": [
       {
         "word": "Didrachmon",
-        "tlit": "Satan falling like lightning from heaven \u2014 Estrapsin \u2014 the aorist: I watched Satan fall",
-        "gloss": "astrapt\u014dn",
-        "note": "I saw Satan fall like lightning from heaven (estrapsen) \u2014 the aorist \u201cI saw\u201d looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples\u2019 authority over demons as a disclosure of Satan\u2019s defeat \u2014 not merely future but already beginning. The kingdom\u2019s advance is simultaneously Satan\u2019s retreat."
+        "tlit": "Satan falling like lightning from heaven — Estrapsin — the aorist: I watched Satan fall",
+        "gloss": "astraptōn",
+        "note": "I saw Satan fall like lightning from heaven (estrapsen) — the aorist “I saw” looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples’ authority over demons as a disclosure of Satan’s defeat — not merely future but already beginning. The kingdom’s advance is simultaneously Satan’s retreat."
       },
       {
         "word": "splangchnistheis",
         "tlit": "splank-KNIS-theis",
         "gloss": "moved with compassion",
-        "note": "But a Samaritan\u2026 when he saw him, he took pity on him (esplagchnisth\u0113) \u2014 the same visceral-compassion word used for the widow of Nain (7:13) and the father of the Prodigal (15:20). The Samaritan\u2019s compassion is divinely-quality compassion \u2014 not merely sympathy but the gut-level movement of the whole self toward the suffering of another. Luke consistently uses this word to identify the divine character in human action."
+        "note": "But a Samaritan… when he saw him, he took pity on him (esplagchnisthē) — the same visceral-compassion word used for the widow of Nain (7:13) and the father of the Prodigal (15:20). The Samaritan’s compassion is divinely-quality compassion — not merely sympathy but the gut-level movement of the whole self toward the suffering of another. Luke consistently uses this word to identify the divine character in human action."
       },
       {
         "word": "Didrachmon",
-        "tlit": "Satan falling like lightning from heaven \u2014 Estrapsin \u2014 the aorist: I watched Satan fall",
-        "gloss": "astrapt\u014dn",
-        "note": "I saw Satan fall like lightning from heaven (estrapsen) \u2014 the aorist \u201cI saw\u201d looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples\u2019 authority over demons as a disclosure of Satan\u2019s defeat \u2014 not merely future but already beginning. The kingdom\u2019s advance is simultaneously Satan\u2019s retreat."
+        "tlit": "Satan falling like lightning from heaven — Estrapsin — the aorist: I watched Satan fall",
+        "gloss": "astraptōn",
+        "note": "I saw Satan fall like lightning from heaven (estrapsen) — the aorist “I saw” looks back to a past event that Jesus witnesses. The language of the fall of the accuser is drawn from Isa 14:12 and (perhaps) Ezek 28:11-19. Jesus interprets the disciples’ authority over demons as a disclosure of Satan’s defeat — not merely future but already beginning. The kingdom’s advance is simultaneously Satan’s retreat."
       }
     ],
     "tx": [
       {
         "ref": "10:1",
         "title": "Seventy or seventy-two?",
-        "content": "NA28 reads hebdom\u0113konta duo (seventy-two); many MSS read hebdom\u0113konta (seventy). The division is between the Western (seventy-two) and Alexandrian/Byzantine (seventy) traditions.",
-        "note": "Both numbers have OT resonance: seventy elders (Num 11) and seventy nations (Gen 10). The LXX of Gen 10 has seventy-two nations, which may explain the seventy-two reading in Luke\u2019s Gospel as carrying the universalist implication."
+        "content": "NA28 reads hebdomēkonta duo (seventy-two); many MSS read hebdomēkonta (seventy). The division is between the Western (seventy-two) and Alexandrian/Byzantine (seventy) traditions.",
+        "note": "Both numbers have OT resonance: seventy elders (Num 11) and seventy nations (Gen 10). The LXX of Gen 10 has seventy-two nations, which may explain the seventy-two reading in Luke’s Gospel as carrying the universalist implication."
       }
     ],
     "debate": [
@@ -402,7 +357,7 @@
           },
           {
             "name": "Christological allegory",
-            "proponents": "Origen\u2019s reading has the Samaritan as Christ is consistent with Luke\u2019s Christology and the language of compassion used for Jesus throughout.",
+            "proponents": "Origen’s reading has the Samaritan as Christ is consistent with Luke’s Christology and the language of compassion used for Jesus throughout.",
             "argument": "Christological"
           }
         ]
@@ -435,7 +390,7 @@
           "score": 8
         }
       ],
-      "note": "Luke 10 moves from the universal mission (seventy-two to all towns) to the definition of mercy (Good Samaritan) to the priority of hearing (Mary at Jesus\u2019s feet). The chapter asks: what does it mean to love God and neighbor? The answer is: go everywhere, show compassion, and first sit and listen."
+      "note": "Luke 10 moves from the universal mission (seventy-two to all towns) to the definition of mercy (Good Samaritan) to the priority of hearing (Mary at Jesus’s feet). The chapter asks: what does it mean to love God and neighbor? The answer is: go everywhere, show compassion, and first sit and listen."
     }
   },
   "vhl_groups": [
@@ -556,7 +511,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Seventy-two sent out\u2014echoing the seventy nations of Genesis 10. The mission expands beyond Israel. 'The harvest is plentiful, but the workers are few' (v. 2). Urgency and insufficiency.",
+      "tip": "Seventy-two sent out—echoing the seventy nations of Genesis 10. The mission expands beyond Israel. 'The harvest is plentiful, but the workers are few' (v. 2). Urgency and insufficiency.",
       "genre_tag": "canonical_thread"
     },
     {

--- a/content/luke/11.json
+++ b/content/luke/11.json
@@ -10,7 +10,7 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201113 \u2014 The Lord\u2019s Prayer; The Friend at Midnight; Ask Seek Knock",
+      "header": "Verses 1‑13 — The Lord’s Prayer; The Friend at Midnight; Ask Seek Knock",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
@@ -19,13 +19,13 @@
             "word": "anaideia",
             "transliteration": "an-ai-DEI-a",
             "gloss": "shameless audacity",
-            "paragraph": "Used only here in the NT (v.8). The word commends brazen persistence before God \u2014 the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
+            "paragraph": "Used only here in the NT (v.8). The word commends brazen persistence before God — the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
           },
           {
-            "word": "daktyl\u014d theou",
-            "transliteration": "dak-TY-l\u014d the-OO",
+            "word": "daktylō theou",
+            "transliteration": "dak-TY-lō the-OO",
             "gloss": "finger of God",
-            "paragraph": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" \u2014 both assert that Jesus's exorcisms are direct divine action."
+            "paragraph": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" — both assert that Jesus's exorcisms are direct divine action."
           }
         ],
         "cross": {
@@ -36,7 +36,7 @@
             },
             {
               "ref": "Exod 8:19",
-              "note": "\"The finger of God\" \u2014 Pharaoh's magicians identify the plague as direct divine action, the same image Jesus applies to his exorcisms."
+              "note": "\"The finger of God\" — Pharaoh's magicians identify the plague as direct divine action, the same image Jesus applies to his exorcisms."
             },
             {
               "ref": "Matt 12:22-32",
@@ -45,28 +45,28 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:2-4",
-              "note": "\"Father\" \u2014 the intimate filial address was radical in its Jewish context. \"Hallowed be your name\" is a prayer that God's own character be honoured in the world, beginning with the one praying."
+              "note": "\"Father\" — the intimate filial address was radical in its Jewish context. \"Hallowed be your name\" is a prayer that God's own character be honoured in the world, beginning with the one praying."
             },
             {
               "ref": "11:9-13",
-              "note": "\"Ask, seek, knock\" \u2014 all present imperatives implying continuous action. Prayer shapes the one who prays, aligning human desire with divine provision over time."
+              "note": "\"Ask, seek, knock\" — all present imperatives implying continuous action. Prayer shapes the one who prays, aligning human desire with divine provision over time."
             },
             {
               "ref": "11:20",
-              "note": "\"Finger of God\" applied to himself claims that divine power in history works through Jesus personally. The kingdom's arrival is present-tense \u2014 in his exorcisms it has already come."
+              "note": "\"Finger of God\" applied to himself claims that divine power in history works through Jesus personally. The kingdom's arrival is present-tense — in his exorcisms it has already come."
             },
             {
               "ref": "11:24-26",
-              "note": "Moral reformation without spiritual transformation leaves a person more vulnerable. An empty, swept house invites worse occupants \u2014 the warning is against self-improvement that omits the indwelling of the Spirit."
+              "note": "Moral reformation without spiritual transformation leaves a person more vulnerable. An empty, swept house invites worse occupants — the warning is against self-improvement that omits the indwelling of the Spirit."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:5-8",
@@ -74,38 +74,38 @@
             },
             {
               "ref": "11:20",
-              "note": "When Christ says the kingdom of God \"has come upon you\" he means not that it is approaching but that it has arrived \u2014 its presence is demonstrated in the destruction of demonic power before their eyes."
+              "note": "When Christ says the kingdom of God \"has come upon you\" he means not that it is approaching but that it has arrived — its presence is demonstrated in the destruction of demonic power before their eyes."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "11:3",
-              "note": "\"Daily bread\" \u2014 epiousios is of uncertain origin. Proposed meanings: (1) necessary for subsistence; (2) for the coming day; (3) supernatural. The traditional \"daily\" captures the sense without resolving the philological debate."
+              "note": "\"Daily bread\" — epiousios is of uncertain origin. Proposed meanings: (1) necessary for subsistence; (2) for the coming day; (3) supernatural. The traditional \"daily\" captures the sense without resolving the philological debate."
             },
             {
               "ref": "11:8",
-              "note": "Anaideia (NIV \"shameless audacity\") \u2014 in a shame/honour culture, shamelessness is a vice. Jesus reconceives it as the quality that characterises effective prayer. The commendation is deliberately surprising."
+              "note": "Anaideia (NIV \"shameless audacity\") — in a shame/honour culture, shamelessness is a vice. Jesus reconceives it as the quality that characterises effective prayer. The commendation is deliberately surprising."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "11:2",
-              "note": "Pater (Father) \u2014 direct, unadorned address. Luke's version omits \"Our\" and \"in heaven,\" making it even more immediate than Matthew's. The brevity is itself the theological point."
+              "note": "Pater (Father) — direct, unadorned address. Luke's version omits \"Our\" and \"in heaven,\" making it even more immediate than Matthew's. The brevity is itself the theological point."
             },
             {
               "ref": "11:8",
-              "note": "Anaideia \u2014 LSJ: \"shamelessness, impudence.\" Hapax in the NT. The petitioner receives bread not through friendship but through brazen refusal to accept no for an answer \u2014 a striking commendation of audacious prayer."
+              "note": "Anaideia — LSJ: \"shamelessness, impudence.\" Hapax in the NT. The petitioner receives bread not through friendship but through brazen refusal to accept no for an answer — a striking commendation of audacious prayer."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "11:2",
@@ -113,40 +113,40 @@
             },
             {
               "ref": "11:9-10",
-              "note": "Chrysostom: \"Ask and seek and knock \u2014 these are not three different things but one thing pressed with increasing urgency. Knocking implies perseverance; seeking adds diligence; but asking is the beginning.\""
+              "note": "Chrysostom: \"Ask and seek and knock — these are not three different things but one thing pressed with increasing urgency. Knocking implies perseverance; seeking adds diligence; but asking is the beginning.\""
             }
           ]
         },
         "hist": {
-          "context": "Prayer in Jewish Practice\nFirst-century Jewish prayer was formal and communal \u2014 the Amidah, fixed blessing formulae. Jesus's \"Father\" address replaces elaborate doxologies with direct filial intimacy. His instruction to pray for the Holy Spirit (11:13) reorients the tradition toward eschatological expectation.\n\nLuke's Prayer Emphasis\nLuke depicts Jesus at prayer more than any other Gospel: at baptism (3:21), before choosing the Twelve (6:12), at the Transfiguration (9:29). The Lord's Prayer here is prompted by a disciple's request \u2014 Luke frames it as teaching from relationship, not formal sermon."
+          "context": "Prayer in Jewish Practice\nFirst-century Jewish prayer was formal and communal — the Amidah, fixed blessing formulae. Jesus's \"Father\" address replaces elaborate doxologies with direct filial intimacy. His instruction to pray for the Holy Spirit (11:13) reorients the tradition toward eschatological expectation.\n\nLuke's Prayer Emphasis\nLuke depicts Jesus at prayer more than any other Gospel: at baptism (3:21), before choosing the Twelve (6:12), at the Transfiguration (9:29). The Lord's Prayer here is prompted by a disciple's request — Luke frames it as teaching from relationship, not formal sermon."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201326 \u2014 Beelzebul Controversy; The Unclean Spirit\u2019s Return",
+      "header": "Verses 14–26 — Beelzebul Controversy; The Unclean Spirit’s Return",
       "verse_start": 14,
       "verse_end": 26,
       "panels": {
         "heb": [
           {
-            "word": "s\u0113meion",
+            "word": "sēmeion",
             "transliteration": "SAY-mei-on",
             "gloss": "sign / authenticating miracle",
-            "paragraph": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof \u2014 the only credential offered is the \"sign of Jonah\": his death and resurrection."
+            "paragraph": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof — the only credential offered is the \"sign of Jonah\": his death and resurrection."
           },
           {
-            "word": "haplous / pon\u0113ros",
+            "word": "haplous / ponēros",
             "transliteration": "HAP-lous / po-NAY-ros",
             "gloss": "single/healthy vs evil/diseased",
-            "paragraph": "The haplous eye is undivided, generous; the pon\u0113ros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity \u2014 what we see clearly depends on who we are."
+            "paragraph": "The haplous eye is undivided, generous; the ponēros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity — what we see clearly depends on who we are."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Jon 1:17; 2:10",
-              "note": "Jonah in the fish \u2014 the \"sign of Jonah\" points to Jesus's death and resurrection as the defining credential of his ministry."
+              "note": "Jonah in the fish — the \"sign of Jonah\" points to Jesus's death and resurrection as the defining credential of his ministry."
             },
             {
               "ref": "Matt 23:1-36",
@@ -154,24 +154,24 @@
             },
             {
               "ref": "2 Chr 24:20-21",
-              "note": "The stoning of Zechariah in the Temple court \u2014 the endpoint of Jesus's indictment of Israel's history of prophetic rejection."
+              "note": "The stoning of Zechariah in the Temple court — the endpoint of Jesus's indictment of Israel's history of prophetic rejection."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:29-30",
-              "note": "The sign of Jonah in Luke emphasises Jonah's preaching mission \u2014 his whole ministry is the sign. Matthew (12:40) focuses on the three days in the fish as resurrection type. Both are valid: Luke emphasises the preached word, Matthew the vindication."
+              "note": "The sign of Jonah in Luke emphasises Jonah's preaching mission — his whole ministry is the sign. Matthew (12:40) focuses on the three days in the fish as resurrection type. Both are valid: Luke emphasises the preached word, Matthew the vindication."
             },
             {
               "ref": "11:39-41",
-              "note": "Pharisaic hand-washing was a tradition of the elders, not a Mosaic command. Jesus attacks not Torah but tradition that substituted external compliance for internal transformation. The remedy: generosity to the poor \u2014 inside-out renewal."
+              "note": "Pharisaic hand-washing was a tradition of the elders, not a Mosaic command. Jesus attacks not Torah but tradition that substituted external compliance for internal transformation. The remedy: generosity to the poor — inside-out renewal."
             },
             {
               "ref": "11:49-51",
-              "note": "\"God in his wisdom said\" \u2014 the indictment is total: this generation bears responsibility for the entire history of prophetic rejection, from Abel (first martyr) to Zechariah (last in the canon). The scriptural record closes against them."
+              "note": "\"God in his wisdom said\" — the indictment is total: this generation bears responsibility for the entire history of prophetic rejection, from Abel (first martyr) to Zechariah (last in the canon). The scriptural record closes against them."
             },
             {
               "ref": "11:52",
@@ -180,20 +180,20 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "11:33-36",
-              "note": "The lamp passage connects perception to moral character. A healthy eye signifies a mind open to truth; an evil eye is clouded by greed or pride. The light within \u2014 conscience, reason, and the Spirit's illumination \u2014 must not become darkness through religious posturing."
+              "note": "The lamp passage connects perception to moral character. A healthy eye signifies a mind open to truth; an evil eye is clouded by greed or pride. The light within — conscience, reason, and the Spirit's illumination — must not become darkness through religious posturing."
             },
             {
               "ref": "11:47-51",
-              "note": "The builders of prophets' tombs honour the dead while persecuting the living \u2014 a universal pattern. Every age venerates its previous generation's martyrs while repeating the same crime. Jesus identifies the scribes' hostility to himself as the contemporary expression of this ancient cycle."
+              "note": "The builders of prophets' tombs honour the dead while persecuting the living — a universal pattern. Every age venerates its previous generation's martyrs while repeating the same crime. Jesus identifies the scribes' hostility to himself as the contemporary expression of this ancient cycle."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "11:29",
@@ -201,25 +201,25 @@
             },
             {
               "ref": "11:51",
-              "note": "\"Between the altar and the sanctuary\" \u2014 Zechariah was killed in the Temple precincts (2 Chr 24:21), at the holiest geographic point in Israel. The endpoint of a comprehensive scriptural indictment from first to last."
+              "note": "\"Between the altar and the sanctuary\" — Zechariah was killed in the Temple precincts (2 Chr 24:21), at the holiest geographic point in Israel. The endpoint of a comprehensive scriptural indictment from first to last."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "11:31",
-              "note": "Pleion Solom\u014dnos \u2014 \"something greater than Solomon\" (neuter), referring to the reality rather than the person. The same construction with Jonah in v.32. Jesus forces the hearer to supply the implied subject \u2014 a deliberately indirect messianic claim."
+              "note": "Pleion Solomōnos — \"something greater than Solomon\" (neuter), referring to the reality rather than the person. The same construction with Jonah in v.32. Jesus forces the hearer to supply the implied subject — a deliberately indirect messianic claim."
             },
             {
               "ref": "11:42",
-              "note": "Apodekatoute \u2014 present active indicative: you are continually tithing. The tithing of garden herbs was a rabbinic extension. Jesus does not deny its validity \u2014 \"without neglecting the former\" \u2014 but insists it cannot substitute for justice and the love of God."
+              "note": "Apodekatoute — present active indicative: you are continually tithing. The tithing of garden herbs was a rabbinic extension. Jesus does not deny its validity — \"without neglecting the former\" — but insists it cannot substitute for justice and the love of God."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "11:34",
@@ -227,18 +227,18 @@
             },
             {
               "ref": "11:42",
-              "note": "Cyril of Alexandria: \"They tithed even mint and rue \u2014 things of the smallest value \u2014 but neglected justice and the love of God. They strained at the gnat and swallowed the camel.\""
+              "note": "Cyril of Alexandria: \"They tithed even mint and rue — things of the smallest value — but neglected justice and the love of God. They strained at the gnat and swallowed the camel.\""
             }
           ]
         },
         "hist": {
-          "context": "The Six Woes\nThree woes on Pharisees (11:42-44) and three on legal experts (11:46-52) mirror the Beatitudes in reverse. The dinner-table setting is deliberately ironic \u2014 the confrontation happens in the Pharisee's own home, at his invitation.\n\n\"From Abel to Zechariah\"\nThe range spans the Hebrew canon from first book (Genesis) to last (2 Chronicles). Zechariah son of Jehoiada was stoned in the Temple court (2 Chr 24:20-21), the last recorded prophet-killing in the Hebrew Bible. The indictment is comprehensive."
+          "context": "The Six Woes\nThree woes on Pharisees (11:42-44) and three on legal experts (11:46-52) mirror the Beatitudes in reverse. The dinner-table setting is deliberately ironic — the confrontation happens in the Pharisee's own home, at his invitation.\n\n\"From Abel to Zechariah\"\nThe range spans the Hebrew canon from first book (Genesis) to last (2 Chronicles). Zechariah son of Jehoiada was stoned in the Temple court (2 Chr 24:20-21), the last recorded prophet-killing in the Hebrew Bible. The indictment is comprehensive."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 27\u201136 \u2014 Blessed Are Those Who Hear; Sign of Jonah; The Lamp",
+      "header": "Verses 27‑36 — Blessed Are Those Who Hear; Sign of Jonah; The Lamp",
       "verse_start": 27,
       "verse_end": 36,
       "panels": {
@@ -247,13 +247,13 @@
             "word": "anaideia",
             "transliteration": "an-ai-DEI-a",
             "gloss": "shameless audacity",
-            "paragraph": "Used only here in the NT (v.8). The word commends brazen persistence before God \u2014 the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
+            "paragraph": "Used only here in the NT (v.8). The word commends brazen persistence before God — the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
           },
           {
-            "word": "daktyl\u014d theou",
-            "transliteration": "dak-TY-l\u014d the-OO",
+            "word": "daktylō theou",
+            "transliteration": "dak-TY-lō the-OO",
             "gloss": "finger of God",
-            "paragraph": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" \u2014 both assert that Jesus's exorcisms are direct divine action."
+            "paragraph": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" — both assert that Jesus's exorcisms are direct divine action."
           }
         ],
         "cross": {
@@ -264,7 +264,7 @@
             },
             {
               "ref": "Exod 8:19",
-              "note": "\"The finger of God\" \u2014 Pharaoh's magicians identify the plague as direct divine action, the same image Jesus applies to his exorcisms."
+              "note": "\"The finger of God\" — Pharaoh's magicians identify the plague as direct divine action, the same image Jesus applies to his exorcisms."
             },
             {
               "ref": "Matt 12:22-32",
@@ -273,108 +273,55 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:2-4",
-              "note": "\"Father\" \u2014 the intimate filial address was radical in its Jewish context. \"Hallowed be your name\" is a prayer that God's own character be honoured in the world, beginning with the one praying."
-            },
-            {
-              "ref": "11:9-13",
-              "note": "\"Ask, seek, knock\" \u2014 all present imperatives implying continuous action. Prayer shapes the one who prays, aligning human desire with divine provision over time."
-            },
-            {
-              "ref": "11:20",
-              "note": "\"Finger of God\" applied to himself claims that divine power in history works through Jesus personally. The kingdom's arrival is present-tense \u2014 in his exorcisms it has already come."
-            },
-            {
-              "ref": "11:24-26",
-              "note": "Moral reformation without spiritual transformation leaves a person more vulnerable. An empty, swept house invites worse occupants \u2014 the warning is against self-improvement that omits the indwelling of the Spirit."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:5-8",
-              "note": "The parable argues from lesser to greater. If even human annoyance yields to persistence, how much more certainly will the Father who delights to give respond to his children's prayer? The argument is explicitly a fortiori."
-            },
-            {
-              "ref": "11:20",
-              "note": "When Christ says the kingdom of God \"has come upon you\" he means not that it is approaching but that it has arrived \u2014 its presence is demonstrated in the destruction of demonic power before their eyes."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:3",
-              "note": "\"Daily bread\" \u2014 epiousios is of uncertain origin. Proposed meanings: (1) necessary for subsistence; (2) for the coming day; (3) supernatural. The traditional \"daily\" captures the sense without resolving the philological debate."
-            },
-            {
-              "ref": "11:8",
-              "note": "Anaideia (NIV \"shameless audacity\") \u2014 in a shame/honour culture, shamelessness is a vice. Jesus reconceives it as the quality that characterises effective prayer. The commendation is deliberately surprising."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "11:2",
-              "note": "Pater (Father) \u2014 direct, unadorned address. Luke's version omits \"Our\" and \"in heaven,\" making it even more immediate than Matthew's. The brevity is itself the theological point."
-            },
-            {
-              "ref": "11:8",
-              "note": "Anaideia \u2014 LSJ: \"shamelessness, impudence.\" Hapax in the NT. The petitioner receives bread not through friendship but through brazen refusal to accept no for an answer \u2014 a striking commendation of audacious prayer."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:2",
-              "note": "Ambrose: \"He says 'Father', not 'my Father', to show that the address is common to all. When you say 'Our Father' you claim brotherhood with the Lord himself.\""
-            },
-            {
-              "ref": "11:9-10",
-              "note": "Chrysostom: \"Ask and seek and knock \u2014 these are not three different things but one thing pressed with increasing urgency. Knocking implies perseverance; seeking adds diligence; but asking is the beginning.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Prayer in Jewish Practice\nFirst-century Jewish prayer was formal and communal \u2014 the Amidah, fixed blessing formulae. Jesus's \"Father\" address replaces elaborate doxologies with direct filial intimacy. His instruction to pray for the Holy Spirit (11:13) reorients the tradition toward eschatological expectation.\n\nLuke's Prayer Emphasis\nLuke depicts Jesus at prayer more than any other Gospel: at baptism (3:21), before choosing the Twelve (6:12), at the Transfiguration (9:29). The Lord's Prayer here is prompted by a disciple's request \u2014 Luke frames it as teaching from relationship, not formal sermon."
+          "context": "Prayer in Jewish Practice\nFirst-century Jewish prayer was formal and communal — the Amidah, fixed blessing formulae. Jesus's \"Father\" address replaces elaborate doxologies with direct filial intimacy. His instruction to pray for the Holy Spirit (11:13) reorients the tradition toward eschatological expectation.\n\nLuke's Prayer Emphasis\nLuke depicts Jesus at prayer more than any other Gospel: at baptism (3:21), before choosing the Twelve (6:12), at the Transfiguration (9:29). The Lord's Prayer here is prompted by a disciple's request — Luke frames it as teaching from relationship, not formal sermon."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 37\u201154 \u2014 Woes on the Pharisees and Experts in the Law",
+      "header": "Verses 37‑54 — Woes on the Pharisees and Experts in the Law",
       "verse_start": 37,
       "verse_end": 54,
       "panels": {
         "heb": [
           {
-            "word": "s\u0113meion",
+            "word": "sēmeion",
             "transliteration": "SAY-mei-on",
             "gloss": "sign / authenticating miracle",
-            "paragraph": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof \u2014 the only credential offered is the \"sign of Jonah\": his death and resurrection."
+            "paragraph": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof — the only credential offered is the \"sign of Jonah\": his death and resurrection."
           },
           {
-            "word": "haplous / pon\u0113ros",
+            "word": "haplous / ponēros",
             "transliteration": "HAP-lous / po-NAY-ros",
             "gloss": "single/healthy vs evil/diseased",
-            "paragraph": "The haplous eye is undivided, generous; the pon\u0113ros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity \u2014 what we see clearly depends on who we are."
+            "paragraph": "The haplous eye is undivided, generous; the ponēros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity — what we see clearly depends on who we are."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Jon 1:17; 2:10",
-              "note": "Jonah in the fish \u2014 the \"sign of Jonah\" points to Jesus's death and resurrection as the defining credential of his ministry."
+              "note": "Jonah in the fish — the \"sign of Jonah\" points to Jesus's death and resurrection as the defining credential of his ministry."
             },
             {
               "ref": "Matt 23:1-36",
@@ -382,85 +329,32 @@
             },
             {
               "ref": "2 Chr 24:20-21",
-              "note": "The stoning of Zechariah in the Temple court \u2014 the endpoint of Jesus's indictment of Israel's history of prophetic rejection."
+              "note": "The stoning of Zechariah in the Temple court — the endpoint of Jesus's indictment of Israel's history of prophetic rejection."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:29-30",
-              "note": "The sign of Jonah in Luke emphasises Jonah's preaching mission \u2014 his whole ministry is the sign. Matthew (12:40) focuses on the three days in the fish as resurrection type. Both are valid: Luke emphasises the preached word, Matthew the vindication."
-            },
-            {
-              "ref": "11:39-41",
-              "note": "Pharisaic hand-washing was a tradition of the elders, not a Mosaic command. Jesus attacks not Torah but tradition that substituted external compliance for internal transformation. The remedy: generosity to the poor \u2014 inside-out renewal."
-            },
-            {
-              "ref": "11:49-51",
-              "note": "\"God in his wisdom said\" \u2014 the indictment is total: this generation bears responsibility for the entire history of prophetic rejection, from Abel (first martyr) to Zechariah (last in the canon). The scriptural record closes against them."
-            },
-            {
-              "ref": "11:52",
-              "note": "The Torah was given as the key to knowing God. The lawyers had turned it into a locked door. The guardians of revelation had become its gatekeepers against entry."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:33-36",
-              "note": "The lamp passage connects perception to moral character. A healthy eye signifies a mind open to truth; an evil eye is clouded by greed or pride. The light within \u2014 conscience, reason, and the Spirit's illumination \u2014 must not become darkness through religious posturing."
-            },
-            {
-              "ref": "11:47-51",
-              "note": "The builders of prophets' tombs honour the dead while persecuting the living \u2014 a universal pattern. Every age venerates its previous generation's martyrs while repeating the same crime. Jesus identifies the scribes' hostility to himself as the contemporary expression of this ancient cycle."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:29",
-              "note": "The demand for a sign reflects specific first-century Jewish expectation: messianic figures would authenticate themselves through cosmic signs (cf. Josephus, Ant. 20.167-168). Jesus refuses this framework while pointing to the greater sign of his own death and vindication."
-            },
-            {
-              "ref": "11:51",
-              "note": "\"Between the altar and the sanctuary\" \u2014 Zechariah was killed in the Temple precincts (2 Chr 24:21), at the holiest geographic point in Israel. The endpoint of a comprehensive scriptural indictment from first to last."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "11:31",
-              "note": "Pleion Solom\u014dnos \u2014 \"something greater than Solomon\" (neuter), referring to the reality rather than the person. The same construction with Jonah in v.32. Jesus forces the hearer to supply the implied subject \u2014 a deliberately indirect messianic claim."
-            },
-            {
-              "ref": "11:42",
-              "note": "Apodekatoute \u2014 present active indicative: you are continually tithing. The tithing of garden herbs was a rabbinic extension. Jesus does not deny its validity \u2014 \"without neglecting the former\" \u2014 but insists it cannot substitute for justice and the love of God."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:34",
-              "note": "Augustine: \"The eye of the heart is the intention. If your intention is pure and right, all your works done according to that intention will be good. But if the intention is twisted, then however good the works may seem, they are corrupt.\""
-            },
-            {
-              "ref": "11:42",
-              "note": "Cyril of Alexandria: \"They tithed even mint and rue \u2014 things of the smallest value \u2014 but neglected justice and the love of God. They strained at the gnat and swallowed the camel.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Six Woes\nThree woes on Pharisees (11:42-44) and three on legal experts (11:46-52) mirror the Beatitudes in reverse. The dinner-table setting is deliberately ironic \u2014 the confrontation happens in the Pharisee's own home, at his invitation.\n\n\"From Abel to Zechariah\"\nThe range spans the Hebrew canon from first book (Genesis) to last (2 Chronicles). Zechariah son of Jehoiada was stoned in the Temple court (2 Chr 24:20-21), the last recorded prophet-killing in the Hebrew Bible. The indictment is comprehensive."
+          "context": "The Six Woes\nThree woes on Pharisees (11:42-44) and three on legal experts (11:46-52) mirror the Beatitudes in reverse. The dinner-table setting is deliberately ironic — the confrontation happens in the Pharisee's own home, at his invitation.\n\n\"From Abel to Zechariah\"\nThe range spans the Hebrew canon from first book (Genesis) to last (2 Chronicles). Zechariah son of Jehoiada was stoned in the Temple court (2 Chr 24:20-21), the last recorded prophet-killing in the Hebrew Bible. The indictment is comprehensive."
         }
       }
     }
@@ -475,7 +369,7 @@
       {
         "name": "The Disciples",
         "role": "Learners in prayer",
-        "text": "One unnamed disciple requests prayer instruction, prompting the Lord's Prayer \u2014 Luke's relational framing places this among the most significant teaching moments of the journey narrative."
+        "text": "One unnamed disciple requests prayer instruction, prompting the Lord's Prayer — Luke's relational framing places this among the most significant teaching moments of the journey narrative."
       },
       {
         "name": "The Pharisees",
@@ -488,12 +382,12 @@
         "text": "Distinct from the Pharisees; they receive three specific accusations: burdening others with obligations, honouring dead prophets while rejecting living ones, and locking others out of knowledge."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">epiousios (11:3)</td><td>NIV/KJV/ESV/NRSV all render \"daily\" though the Greek is of uncertain origin \u2014 possibly \"necessary for subsistence\" or \"for the coming day.\"</td></tr><tr><td class=\"t-label\">anaideia (11:8)</td><td>NIV: \"shameless audacity\"; KJV: \"importunity\"; ESV: \"impudence\"; NRSV: \"persistence\". Debate reflects genuine uncertainty about whether the virtue is boldness or persistence.</td></tr><tr><td class=\"t-label\">haplous (11:34)</td><td>KJV: \"single\"; NIV/ESV: \"healthy\"; NRSV: \"sound\". \"Single\" preserves the moral dimension of undivided loyalty that \"healthy\" obscures.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">epiousios (11:3)</td><td>NIV/KJV/ESV/NRSV all render \"daily\" though the Greek is of uncertain origin — possibly \"necessary for subsistence\" or \"for the coming day.\"</td></tr><tr><td class=\"t-label\">anaideia (11:8)</td><td>NIV: \"shameless audacity\"; KJV: \"importunity\"; ESV: \"impudence\"; NRSV: \"persistence\". Debate reflects genuine uncertainty about whether the virtue is boldness or persistence.</td></tr><tr><td class=\"t-label\">haplous (11:34)</td><td>KJV: \"single\"; NIV/ESV: \"healthy\"; NRSV: \"sound\". \"Single\" preserves the moral dimension of undivided loyalty that \"healthy\" obscures.</td></tr>",
     "src": [
       {
         "title": "Sirach 35:17-19",
         "quote": "\"The prayer of the humble pierces the clouds; it will not rest until it reaches its goal.\"",
-        "note": "Deuterocanonical background for Luke's ask/seek/knock emphasis \u2014 persistent prayer is a well-established Jewish ideal."
+        "note": "Deuterocanonical background for Luke's ask/seek/knock emphasis — persistent prayer is a well-established Jewish ideal."
       },
       {
         "title": "Mishnah Berakhot",
@@ -514,13 +408,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Chiasm \u2014 vv.9-13",
-          "text": "Ask/receive \u2192 Seek/find \u2192 Knock/opened; then elaborated with father/son pairs (fish/snake, egg/scorpion). The three-part ascending structure followed by concrete illustration is a classical chiastic elaboration.",
+          "label": "Chiasm — vv.9-13",
+          "text": "Ask/receive → Seek/find → Knock/opened; then elaborated with father/son pairs (fish/snake, egg/scorpion). The three-part ascending structure followed by concrete illustration is a classical chiastic elaboration.",
           "is_key": false
         },
         {
-          "label": "Contrast \u2014 vv.37-54",
-          "text": "Dinner invitation (hospitality) frames the woe-discourse (confrontation). Luke uses the table throughout his Gospel as the site of both grace and judgment \u2014 the same meal reveals the host's heart and occasions Jesus's most direct attack on religious hypocrisy.",
+          "label": "Contrast — vv.37-54",
+          "text": "Dinner invitation (hospitality) frames the woe-discourse (confrontation). Luke uses the table throughout his Gospel as the site of both grace and judgment — the same meal reveals the host's heart and occasions Jesus's most direct attack on religious hypocrisy.",
           "is_key": false
         }
       ],
@@ -531,49 +425,49 @@
         "word": "anaideia",
         "tlit": "an-ai-DEI-a",
         "gloss": "shameless audacity",
-        "note": "Used only here in the NT (v.8). The word commends brazen persistence before God \u2014 the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
+        "note": "Used only here in the NT (v.8). The word commends brazen persistence before God — the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
       },
       {
-        "word": "daktyl\u014d theou",
-        "tlit": "dak-TY-l\u014d the-OO",
+        "word": "daktylō theou",
+        "tlit": "dak-TY-lō the-OO",
         "gloss": "finger of God",
-        "note": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" \u2014 both assert that Jesus's exorcisms are direct divine action."
+        "note": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" — both assert that Jesus's exorcisms are direct divine action."
       },
       {
-        "word": "s\u0113meion",
+        "word": "sēmeion",
         "tlit": "SAY-mei-on",
         "gloss": "sign / authenticating miracle",
-        "note": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof \u2014 the only credential offered is the \"sign of Jonah\": his death and resurrection."
+        "note": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof — the only credential offered is the \"sign of Jonah\": his death and resurrection."
       },
       {
-        "word": "haplous / pon\u0113ros",
+        "word": "haplous / ponēros",
         "tlit": "HAP-lous / po-NAY-ros",
         "gloss": "single/healthy vs evil/diseased",
-        "note": "The haplous eye is undivided, generous; the pon\u0113ros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity \u2014 what we see clearly depends on who we are."
+        "note": "The haplous eye is undivided, generous; the ponēros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity — what we see clearly depends on who we are."
       },
       {
         "word": "anaideia",
         "tlit": "an-ai-DEI-a",
         "gloss": "shameless audacity",
-        "note": "Used only here in the NT (v.8). The word commends brazen persistence before God \u2014 the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
+        "note": "Used only here in the NT (v.8). The word commends brazen persistence before God — the cultural shame of making a nuisance of yourself is reimagined as a virtue in prayer."
       },
       {
-        "word": "daktyl\u014d theou",
-        "tlit": "dak-TY-l\u014d the-OO",
+        "word": "daktylō theou",
+        "tlit": "dak-TY-lō the-OO",
         "gloss": "finger of God",
-        "note": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" \u2014 both assert that Jesus's exorcisms are direct divine action."
+        "note": "An OT theophanic image (Exod 8:19; 31:18). Luke preserves this archaic phrase where Matthew writes \"Spirit of God\" — both assert that Jesus's exorcisms are direct divine action."
       },
       {
-        "word": "s\u0113meion",
+        "word": "sēmeion",
         "tlit": "SAY-mei-on",
         "gloss": "sign / authenticating miracle",
-        "note": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof \u2014 the only credential offered is the \"sign of Jonah\": his death and resurrection."
+        "note": "The demand reflects the expectation that genuine prophets and messiahs would authenticate themselves through spectacular public acts. Jesus refuses this economy of proof — the only credential offered is the \"sign of Jonah\": his death and resurrection."
       },
       {
-        "word": "haplous / pon\u0113ros",
+        "word": "haplous / ponēros",
         "tlit": "HAP-lous / po-NAY-ros",
         "gloss": "single/healthy vs evil/diseased",
-        "note": "The haplous eye is undivided, generous; the pon\u0113ros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity \u2014 what we see clearly depends on who we are."
+        "note": "The haplous eye is undivided, generous; the ponēros eye is corrupt, stingy. The metaphor unites moral character with perceptual capacity — what we see clearly depends on who we are."
       }
     ],
     "tx": [
@@ -597,7 +491,7 @@
           {
             "name": "Luke's emphasis: the preacher",
             "proponents": "Green, Fitzmyer, Bock",
-            "argument": "Luke's version focuses on Jonah as a preacher \u2014 his whole mission to Nineveh is the sign. The Son of Man's preached word will be the sign to this generation."
+            "argument": "Luke's version focuses on Jonah as a preacher — his whole mission to Nineveh is the sign. The Son of Man's preached word will be the sign to this generation."
           },
           {
             "name": "Matthew's emphasis: the resurrection",
@@ -612,7 +506,7 @@
           {
             "name": "Luke preserves the original",
             "proponents": "Jeremias, Fitzmyer, Luz",
-            "argument": "Luke's shorter form is likely closer to the original. Matthew expanded it for liturgical use \u2014 the additions are consistent with his other expansions of Q material."
+            "argument": "Luke's shorter form is likely closer to the original. Matthew expanded it for liturgical use — the additions are consistent with his other expansions of Q material."
           },
           {
             "name": "Matthew preserves the original",
@@ -649,7 +543,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 11 frames prayer as bold filial confidence before a generous Father. The friend-at-midnight parable commends brazen persistence; the ask-seek-knock triad underlines prayer as continuous relational practice. The lamp and eye sayings (11:33-36) connect spiritual perception to moral orientation \u2014 the Pharisees' blindness is moral, not intellectual. The six woes anatomise religious dimness: external observance without internal transformation, public honour without justice, scholarship that obscures rather than opens the word of God."
+      "note": "Luke 11 frames prayer as bold filial confidence before a generous Father. The friend-at-midnight parable commends brazen persistence; the ask-seek-knock triad underlines prayer as continuous relational practice. The lamp and eye sayings (11:33-36) connect spiritual perception to moral orientation — the Pharisees' blindness is moral, not intellectual. The six woes anatomise religious dimness: external observance without internal transformation, public honour without justice, scholarship that obscures rather than opens the word of God."
     }
   },
   "vhl_groups": [
@@ -770,12 +664,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Father, hallowed be your name' (v. 2). Luke's Lord's Prayer is shorter than Matthew's\u2014economy of words. Prayer isn't verbosity; it's directed dependence. Daily bread, forgiveness, deliverance.",
+      "tip": "'Father, hallowed be your name' (v. 2). Luke's Lord's Prayer is shorter than Matthew's—economy of words. Prayer isn't verbosity; it's directed dependence. Daily bread, forgiveness, deliverance.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 3,
-      "tip": "'This is a wicked generation. It asks for a sign' (v. 29). Sign-seeking avoids commitment. Jonah preached without miracles; Nineveh repented. Something greater than Jonah is here\u2014and rejected.",
+      "tip": "'This is a wicked generation. It asks for a sign' (v. 29). Sign-seeking avoids commitment. Jonah preached without miracles; Nineveh repented. Something greater than Jonah is here—and rejected.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/luke/12.json
+++ b/content/luke/12.json
@@ -10,7 +10,7 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201121 \u2014 Hypocrisy Warned; Fear God; Greed and the Rich Fool",
+      "header": "Verses 1‑21 — Hypocrisy Warned; Fear God; Greed and the Rich Fool",
       "verse_start": 1,
       "verse_end": 21,
       "panels": {
@@ -19,7 +19,7 @@
             "word": "pleonexia",
             "transliteration": "ple-o-NEX-ia",
             "gloss": "greed / covetousness",
-            "paragraph": "The word (v.15) means literally \"wanting more\" \u2014 a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
+            "paragraph": "The word (v.15) means literally \"wanting more\" — a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
           },
           {
             "word": "merimnate",
@@ -36,76 +36,76 @@
             },
             {
               "ref": "Eccl 2:18-19",
-              "note": "Qoheleth's reflection on leaving wealth to those who did not work for it \u2014 the same theme underlying the rich fool parable."
+              "note": "Qoheleth's reflection on leaving wealth to those who did not work for it — the same theme underlying the rich fool parable."
             },
             {
               "ref": "Ps 49:10-12",
-              "note": "\"For all can see that the wise die... their wealth will remain though they called lands after their own names\" \u2014 the Psalm that provides the scriptural background for the fool's delusion."
+              "note": "\"For all can see that the wise die... their wealth will remain though they called lands after their own names\" — the Psalm that provides the scriptural background for the fool's delusion."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:5",
-              "note": "\"Fear him who has authority to throw you into hell\" \u2014 the Greek word is Gehenna, the valley of Hinnom south of Jerusalem, used as a burning rubbish dump and thus a metaphor for final judgment. Jesus commands a holy fear of God that relativises all other fears, including the fear of death."
+              "note": "\"Fear him who has authority to throw you into hell\" — the Greek word is Gehenna, the valley of Hinnom south of Jerusalem, used as a burning rubbish dump and thus a metaphor for final judgment. Jesus commands a holy fear of God that relativises all other fears, including the fear of death."
             },
             {
               "ref": "12:15",
-              "note": "\"Life does not consist in an abundance of possessions\" \u2014 this is one of Jesus's most counter-cultural statements. The entire economic assumption of antiquity (and modernity) is that security comes from accumulation. Jesus locates security in relationship with the Father who knows what his children need."
+              "note": "\"Life does not consist in an abundance of possessions\" — this is one of Jesus's most counter-cultural statements. The entire economic assumption of antiquity (and modernity) is that security comes from accumulation. Jesus locates security in relationship with the Father who knows what his children need."
             },
             {
               "ref": "12:20-21",
-              "note": "\"This very night your life will be demanded from you\" \u2014 the passive \"demanded\" suggests divine agency: God calls in the loan. Life is not owned but borrowed. The fool's error was treating a lease as ownership. \"Rich toward God\" \u2014 the opposite of the fool's self-storage is generosity that accumulates relationship with God."
+              "note": "\"This very night your life will be demanded from you\" — the passive \"demanded\" suggests divine agency: God calls in the loan. Life is not owned but borrowed. The fool's error was treating a lease as ownership. \"Rich toward God\" — the opposite of the fool's self-storage is generosity that accumulates relationship with God."
             },
             {
               "ref": "12:32",
-              "note": "\"Little flock\" \u2014 a term of great tenderness in a chapter that commands fear, urgency, and radical generosity. The Father's pleasure in giving the kingdom is unconditional; the disciples' smallness and vulnerability is not a problem to be overcome but the very condition in which the gift is received."
+              "note": "\"Little flock\" — a term of great tenderness in a chapter that commands fear, urgency, and radical generosity. The Father's pleasure in giving the kingdom is unconditional; the disciples' smallness and vulnerability is not a problem to be overcome but the very condition in which the gift is received."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:4-5",
-              "note": "The distinction between those who kill the body and Him who can destroy both soul and body is the foundation of Christian courage. All human power is limited to the mortal; God's authority extends to the eternal. True freedom from fear of men comes only through reverential fear of God \u2014 the two fears are incompatible, and one must displace the other."
+              "note": "The distinction between those who kill the body and Him who can destroy both soul and body is the foundation of Christian courage. All human power is limited to the mortal; God's authority extends to the eternal. True freedom from fear of men comes only through reverential fear of God — the two fears are incompatible, and one must displace the other."
             },
             {
               "ref": "12:22-31",
-              "note": "The ravens and flowers argument moves from the lesser to the greater. God's provision for creatures with no capacity for prayer or faith is the ground for confidence in the Father's provision for his children who do pray and do trust. The \"little faith\" of v.28 is not condemnation but encouragement \u2014 a small faith is enough when the object of faith is so great."
+              "note": "The ravens and flowers argument moves from the lesser to the greater. God's provision for creatures with no capacity for prayer or faith is the ground for confidence in the Father's provision for his children who do pray and do trust. The \"little faith\" of v.28 is not condemnation but encouragement — a small faith is enough when the object of faith is so great."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "12:5",
-              "note": "\"Throw you into hell\" \u2014 Gehenna refers to the valley of Hinnom (ge-hinnom), which became a metonym for final divine judgment in Second Temple Jewish literature (1 Enoch 27; 4 Ezra 7:36). Jesus's use of the term would have been immediately understood in its eschatological sense."
+              "note": "\"Throw you into hell\" — Gehenna refers to the valley of Hinnom (ge-hinnom), which became a metonym for final divine judgment in Second Temple Jewish literature (1 Enoch 27; 4 Ezra 7:36). Jesus's use of the term would have been immediately understood in its eschatological sense."
             },
             {
               "ref": "12:25",
-              "note": "\"Add a single hour to your life\" \u2014 the Greek p\u0113chys means \"cubit\" (a unit of length), and the word translated \"life\" can also mean \"stature/height.\" NIV and most modern translations take it temporally; some older versions translate \"add a cubit to his stature.\" The temporal reading fits the context of anxiety better."
+              "note": "\"Add a single hour to your life\" — the Greek pēchys means \"cubit\" (a unit of length), and the word translated \"life\" can also mean \"stature/height.\" NIV and most modern translations take it temporally; some older versions translate \"add a cubit to his stature.\" The temporal reading fits the context of anxiety better."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "12:1",
-              "note": "Hypokrisis \u2014 originally \"play-acting\" (stage performance), then applied to religious performance for human audience rather than God. The yeast metaphor implies that hypocrisy spreads invisibly through a community until it has leavened the whole."
+              "note": "Hypokrisis — originally \"play-acting\" (stage performance), then applied to religious performance for human audience rather than God. The yeast metaphor implies that hypocrisy spreads invisibly through a community until it has leavened the whole."
             },
             {
               "ref": "12:20",
-              "note": "Apaitousin \u2014 \"they demand back\" (plural impersonal, equivalent to divine passive). The soul is demanded back as a loan called in. Robertson notes the aorist tense: a decisive, once-for-all moment. The rich man had no time-frame in his plans; God does."
+              "note": "Apaitousin — \"they demand back\" (plural impersonal, equivalent to divine passive). The soul is demanded back as a loan called in. Robertson notes the aorist tense: a decisive, once-for-all moment. The rich man had no time-frame in his plans; God does."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "12:6-7",
@@ -118,13 +118,13 @@
           ]
         },
         "hist": {
-          "context": "Inheritance Law in First-Century Judea\nUnder Jewish law (Num 27; Deut 21:17) the eldest son received a double portion of the inheritance. Disputes over division were common and were brought to rabbis or community leaders for adjudication. The man's request treats Jesus as a legal authority \u2014 a role Jesus explicitly refuses, redirecting from the legal question to the spiritual one underneath it.\n\nThe Rich Fool in Context\nThe parable of the rich fool (12:16-21) is unique to Luke and sits at the centre of a sustained teaching on wealth that runs through chapters 12-16. The fool's problem is not industry or success but the substitution of possessions for relationship with God \u2014 storing up for himself while being \"not rich toward God\" (12:21)."
+          "context": "Inheritance Law in First-Century Judea\nUnder Jewish law (Num 27; Deut 21:17) the eldest son received a double portion of the inheritance. Disputes over division were common and were brought to rabbis or community leaders for adjudication. The man's request treats Jesus as a legal authority — a role Jesus explicitly refuses, redirecting from the legal question to the spiritual one underneath it.\n\nThe Rich Fool in Context\nThe parable of the rich fool (12:16-21) is unique to Luke and sits at the centre of a sustained teaching on wealth that runs through chapters 12-16. The fool's problem is not industry or success but the substitution of possessions for relationship with God — storing up for himself while being \"not rich toward God\" (12:21)."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 22\u201134 \u2014 Do Not Worry; Seek His Kingdom; Treasure in Heaven",
+      "header": "Verses 22‑34 — Do Not Worry; Seek His Kingdom; Treasure in Heaven",
       "verse_start": 22,
       "verse_end": 34,
       "panels": {
@@ -133,20 +133,20 @@
             "word": "kairos",
             "transliteration": "KAI-ros",
             "gloss": "appointed time / critical moment",
-            "paragraph": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) \u2014 the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
+            "paragraph": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) — the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
           },
           {
             "word": "diamerismos",
             "transliteration": "dia-me-RIS-mos",
             "gloss": "division / separation",
-            "paragraph": "The striking word in v.51 \u2014 not eir\u0113n\u0113 (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
+            "paragraph": "The striking word in v.51 — not eirēnē (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Mic 7:6",
-              "note": "\"For a son dishonors his father, a daughter rises up against her mother\" \u2014 the OT text Jesus is applying to the divisions his ministry creates."
+              "note": "\"For a son dishonors his father, a daughter rises up against her mother\" — the OT text Jesus is applying to the divisions his ministry creates."
             },
             {
               "ref": "Matt 24:43-51",
@@ -154,33 +154,33 @@
             },
             {
               "ref": "Rev 3:20",
-              "note": "\"Here I am! I stand at the door and knock\" \u2014 the Revelation image draws on the same returning-master imagery Jesus employs here."
+              "note": "\"Here I am! I stand at the door and knock\" — the Revelation image draws on the same returning-master imagery Jesus employs here."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:37",
-              "note": "\"He will dress himself to serve, will have them recline at the table and will come and wait on them\" \u2014 one of the most astonishing reversals in the Gospels. The returning Master becomes the servant. This is fulfilled in John 13 (the foot-washing) and ultimately in the cross. The faithful servant's reward is to receive service from the one they served."
+              "note": "\"He will dress himself to serve, will have them recline at the table and will come and wait on them\" — one of the most astonishing reversals in the Gospels. The returning Master becomes the servant. This is fulfilled in John 13 (the foot-washing) and ultimately in the cross. The faithful servant's reward is to receive service from the one they served."
             },
             {
               "ref": "12:47-48",
-              "note": "Graduated accountability based on knowledge is a biblical principle: greater knowledge brings greater responsibility and greater judgment. This counters the notion that ignorance protects \u2014 it reduces culpability but does not eliminate it. Those who know the Master's will and disobey bear the heavier burden."
+              "note": "Graduated accountability based on knowledge is a biblical principle: greater knowledge brings greater responsibility and greater judgment. This counters the notion that ignorance protects — it reduces culpability but does not eliminate it. Those who know the Master's will and disobey bear the heavier burden."
             },
             {
               "ref": "12:49-50",
-              "note": "\"Fire\" and \"baptism\" are both images of the passion. The fire Jesus came to bring is the purifying, dividing fire of the Spirit and judgment (Mal 3:2-3; Matt 3:11). The \"baptism\" is his imminent death \u2014 the overwhelming flood that Ps 42 and 69 describe. The tension (\"how I wish it were already kindled!\") reveals Christ's human longing for the mission to be complete."
+              "note": "\"Fire\" and \"baptism\" are both images of the passion. The fire Jesus came to bring is the purifying, dividing fire of the Spirit and judgment (Mal 3:2-3; Matt 3:11). The \"baptism\" is his imminent death — the overwhelming flood that Ps 42 and 69 describe. The tension (\"how I wish it were already kindled!\") reveals Christ's human longing for the mission to be complete."
             },
             {
               "ref": "12:56",
-              "note": "\"You don't know how to interpret this present time\" \u2014 the Pharisees and crowds are adept meteorologists but blind theologians. The signs of the kingdom are more legible than weather patterns; their refusal to read them is not ignorance but a failure of will."
+              "note": "\"You don't know how to interpret this present time\" — the Pharisees and crowds are adept meteorologists but blind theologians. The signs of the kingdom are more legible than weather patterns; their refusal to read them is not ignorance but a failure of will."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "12:35-40",
@@ -193,33 +193,33 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "12:39",
-              "note": "\"The thief\" \u2014 the image of Christ's return as a thief in the night appears also in 1 Thess 5:2, 2 Pet 3:10, and Rev 3:3; 16:15. The point is not stealth but surprise \u2014 the thief comes when not expected. The implication for watchfulness is the same: since the hour is unknown, every hour must be treated as potentially the last."
+              "note": "\"The thief\" — the image of Christ's return as a thief in the night appears also in 1 Thess 5:2, 2 Pet 3:10, and Rev 3:3; 16:15. The point is not stealth but surprise — the thief comes when not expected. The implication for watchfulness is the same: since the hour is unknown, every hour must be treated as potentially the last."
             },
             {
               "ref": "12:59",
-              "note": "\"The last penny\" \u2014 the lepton, the smallest Greek coin, worth about 1/128 of a denarius. The juridical metaphor warns of complete and final accountability: every debt must be settled. Applied to standing before God, the warning is absolute \u2014 there is no partial settlement, no statute of limitations."
+              "note": "\"The last penny\" — the lepton, the smallest Greek coin, worth about 1/128 of a denarius. The juridical metaphor warns of complete and final accountability: every debt must be settled. Applied to standing before God, the warning is absolute — there is no partial settlement, no statute of limitations."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "12:35",
-              "note": "Periz\u014dsmenai \u2014 \"girded,\" the aorist passive participle describing loins cinched for active service. Working garments were held up by a belt; letting them down indicated rest or sleep. The command is for the readiness posture, not comfort."
+              "note": "Perizōsmenai — \"girded,\" the aorist passive participle describing loins cinched for active service. Working garments were held up by a belt; letting them down indicated rest or sleep. The command is for the readiness posture, not comfort."
             },
             {
               "ref": "12:50",
-              "note": "Synechomai \u2014 \"I am under constraint/pressed.\" The verb implies being hemmed in on all sides. Jesus's awareness of the approaching passion is not resignation but urgency \u2014 the compression of time before the decisive moment."
+              "note": "Synechomai — \"I am under constraint/pressed.\" The verb implies being hemmed in on all sides. Jesus's awareness of the approaching passion is not resignation but urgency — the compression of time before the decisive moment."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "12:49",
@@ -232,13 +232,13 @@
           ]
         },
         "hist": {
-          "context": "Watchfulness Parables\nThe sequence of watchfulness parables (12:35-48) escalates through three scenarios: servants watching for the master, a householder watching for a thief, and a manager given authority in the master's absence. Peter's question in v.41 (\"is this for us or for everyone?\") sharpens the application \u2014 the greatest accountability falls on those with the greatest knowledge and responsibility.\n\nFamily Division as Mission Cost\nJesus's declaration that he brings division (12:51-53) echoes Mic 7:6, which describes the breakdown of family solidarity as a sign of the end time. In the ancient world, family loyalty was the primary social bond. Loyalty to Jesus that overrides family allegiance would have been culturally scandalous \u2014 Jesus names this explicitly and treats it not as unfortunate but as inevitable."
+          "context": "Watchfulness Parables\nThe sequence of watchfulness parables (12:35-48) escalates through three scenarios: servants watching for the master, a householder watching for a thief, and a manager given authority in the master's absence. Peter's question in v.41 (\"is this for us or for everyone?\") sharpens the application — the greatest accountability falls on those with the greatest knowledge and responsibility.\n\nFamily Division as Mission Cost\nJesus's declaration that he brings division (12:51-53) echoes Mic 7:6, which describes the breakdown of family solidarity as a sign of the end time. In the ancient world, family loyalty was the primary social bond. Loyalty to Jesus that overrides family allegiance would have been culturally scandalous — Jesus names this explicitly and treats it not as unfortunate but as inevitable."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 35\u201348 \u2014 Watchful Servants; The Faithful Steward",
+      "header": "Verses 35–48 — Watchful Servants; The Faithful Steward",
       "verse_start": 35,
       "verse_end": 48,
       "panels": {
@@ -247,7 +247,7 @@
             "word": "pleonexia",
             "transliteration": "ple-o-NEX-ia",
             "gloss": "greed / covetousness",
-            "paragraph": "The word (v.15) means literally \"wanting more\" \u2014 a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
+            "paragraph": "The word (v.15) means literally \"wanting more\" — a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
           },
           {
             "word": "merimnate",
@@ -264,95 +264,42 @@
             },
             {
               "ref": "Eccl 2:18-19",
-              "note": "Qoheleth's reflection on leaving wealth to those who did not work for it \u2014 the same theme underlying the rich fool parable."
+              "note": "Qoheleth's reflection on leaving wealth to those who did not work for it — the same theme underlying the rich fool parable."
             },
             {
               "ref": "Ps 49:10-12",
-              "note": "\"For all can see that the wise die... their wealth will remain though they called lands after their own names\" \u2014 the Psalm that provides the scriptural background for the fool's delusion."
+              "note": "\"For all can see that the wise die... their wealth will remain though they called lands after their own names\" — the Psalm that provides the scriptural background for the fool's delusion."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:5",
-              "note": "\"Fear him who has authority to throw you into hell\" \u2014 the Greek word is Gehenna, the valley of Hinnom south of Jerusalem, used as a burning rubbish dump and thus a metaphor for final judgment. Jesus commands a holy fear of God that relativises all other fears, including the fear of death."
-            },
-            {
-              "ref": "12:15",
-              "note": "\"Life does not consist in an abundance of possessions\" \u2014 this is one of Jesus's most counter-cultural statements. The entire economic assumption of antiquity (and modernity) is that security comes from accumulation. Jesus locates security in relationship with the Father who knows what his children need."
-            },
-            {
-              "ref": "12:20-21",
-              "note": "\"This very night your life will be demanded from you\" \u2014 the passive \"demanded\" suggests divine agency: God calls in the loan. Life is not owned but borrowed. The fool's error was treating a lease as ownership. \"Rich toward God\" \u2014 the opposite of the fool's self-storage is generosity that accumulates relationship with God."
-            },
-            {
-              "ref": "12:32",
-              "note": "\"Little flock\" \u2014 a term of great tenderness in a chapter that commands fear, urgency, and radical generosity. The Father's pleasure in giving the kingdom is unconditional; the disciples' smallness and vulnerability is not a problem to be overcome but the very condition in which the gift is received."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:4-5",
-              "note": "The distinction between those who kill the body and Him who can destroy both soul and body is the foundation of Christian courage. All human power is limited to the mortal; God's authority extends to the eternal. True freedom from fear of men comes only through reverential fear of God \u2014 the two fears are incompatible, and one must displace the other."
-            },
-            {
-              "ref": "12:22-31",
-              "note": "The ravens and flowers argument moves from the lesser to the greater. God's provision for creatures with no capacity for prayer or faith is the ground for confidence in the Father's provision for his children who do pray and do trust. The \"little faith\" of v.28 is not condemnation but encouragement \u2014 a small faith is enough when the object of faith is so great."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:5",
-              "note": "\"Throw you into hell\" \u2014 Gehenna refers to the valley of Hinnom (ge-hinnom), which became a metonym for final divine judgment in Second Temple Jewish literature (1 Enoch 27; 4 Ezra 7:36). Jesus's use of the term would have been immediately understood in its eschatological sense."
-            },
-            {
-              "ref": "12:25",
-              "note": "\"Add a single hour to your life\" \u2014 the Greek p\u0113chys means \"cubit\" (a unit of length), and the word translated \"life\" can also mean \"stature/height.\" NIV and most modern translations take it temporally; some older versions translate \"add a cubit to his stature.\" The temporal reading fits the context of anxiety better."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "12:1",
-              "note": "Hypokrisis \u2014 originally \"play-acting\" (stage performance), then applied to religious performance for human audience rather than God. The yeast metaphor implies that hypocrisy spreads invisibly through a community until it has leavened the whole."
-            },
-            {
-              "ref": "12:20",
-              "note": "Apaitousin \u2014 \"they demand back\" (plural impersonal, equivalent to divine passive). The soul is demanded back as a loan called in. Robertson notes the aorist tense: a decisive, once-for-all moment. The rich man had no time-frame in his plans; God does."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "12:6-7",
-              "note": "Chrysostom: \"If God numbers the very hairs of your head, can anything concerning you escape his care? He who attends to things so small will not overlook things so great as your body, your soul, your very life.\""
-            },
-            {
-              "ref": "12:33",
-              "note": "Basil of Caesarea: \"The bread you are holding back belongs to the hungry; the coat you keep locked in storage belongs to the naked; the money you have buried in the ground belongs to the poor. You are wronging as many as you might help.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Inheritance Law in First-Century Judea\nUnder Jewish law (Num 27; Deut 21:17) the eldest son received a double portion of the inheritance. Disputes over division were common and were brought to rabbis or community leaders for adjudication. The man's request treats Jesus as a legal authority \u2014 a role Jesus explicitly refuses, redirecting from the legal question to the spiritual one underneath it.\n\nThe Rich Fool in Context\nThe parable of the rich fool (12:16-21) is unique to Luke and sits at the centre of a sustained teaching on wealth that runs through chapters 12-16. The fool's problem is not industry or success but the substitution of possessions for relationship with God \u2014 storing up for himself while being \"not rich toward God\" (12:21)."
+          "context": "Inheritance Law in First-Century Judea\nUnder Jewish law (Num 27; Deut 21:17) the eldest son received a double portion of the inheritance. Disputes over division were common and were brought to rabbis or community leaders for adjudication. The man's request treats Jesus as a legal authority — a role Jesus explicitly refuses, redirecting from the legal question to the spiritual one underneath it.\n\nThe Rich Fool in Context\nThe parable of the rich fool (12:16-21) is unique to Luke and sits at the centre of a sustained teaching on wealth that runs through chapters 12-16. The fool's problem is not industry or success but the substitution of possessions for relationship with God — storing up for himself while being \"not rich toward God\" (12:21)."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 49\u201159 \u2014 Division, Not Peace; Interpreting the Times",
+      "header": "Verses 49‑59 — Division, Not Peace; Interpreting the Times",
       "verse_start": 49,
       "verse_end": 59,
       "panels": {
@@ -361,20 +308,20 @@
             "word": "kairos",
             "transliteration": "KAI-ros",
             "gloss": "appointed time / critical moment",
-            "paragraph": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) \u2014 the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
+            "paragraph": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) — the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
           },
           {
             "word": "diamerismos",
             "transliteration": "dia-me-RIS-mos",
             "gloss": "division / separation",
-            "paragraph": "The striking word in v.51 \u2014 not eir\u0113n\u0113 (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
+            "paragraph": "The striking word in v.51 — not eirēnē (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Mic 7:6",
-              "note": "\"For a son dishonors his father, a daughter rises up against her mother\" \u2014 the OT text Jesus is applying to the divisions his ministry creates."
+              "note": "\"For a son dishonors his father, a daughter rises up against her mother\" — the OT text Jesus is applying to the divisions his ministry creates."
             },
             {
               "ref": "Matt 24:43-51",
@@ -382,85 +329,32 @@
             },
             {
               "ref": "Rev 3:20",
-              "note": "\"Here I am! I stand at the door and knock\" \u2014 the Revelation image draws on the same returning-master imagery Jesus employs here."
+              "note": "\"Here I am! I stand at the door and knock\" — the Revelation image draws on the same returning-master imagery Jesus employs here."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:37",
-              "note": "\"He will dress himself to serve, will have them recline at the table and will come and wait on them\" \u2014 one of the most astonishing reversals in the Gospels. The returning Master becomes the servant. This is fulfilled in John 13 (the foot-washing) and ultimately in the cross. The faithful servant's reward is to receive service from the one they served."
-            },
-            {
-              "ref": "12:47-48",
-              "note": "Graduated accountability based on knowledge is a biblical principle: greater knowledge brings greater responsibility and greater judgment. This counters the notion that ignorance protects \u2014 it reduces culpability but does not eliminate it. Those who know the Master's will and disobey bear the heavier burden."
-            },
-            {
-              "ref": "12:49-50",
-              "note": "\"Fire\" and \"baptism\" are both images of the passion. The fire Jesus came to bring is the purifying, dividing fire of the Spirit and judgment (Mal 3:2-3; Matt 3:11). The \"baptism\" is his imminent death \u2014 the overwhelming flood that Ps 42 and 69 describe. The tension (\"how I wish it were already kindled!\") reveals Christ's human longing for the mission to be complete."
-            },
-            {
-              "ref": "12:56",
-              "note": "\"You don't know how to interpret this present time\" \u2014 the Pharisees and crowds are adept meteorologists but blind theologians. The signs of the kingdom are more legible than weather patterns; their refusal to read them is not ignorance but a failure of will."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:35-40",
-              "note": "The parable of the watching servants is not about calculating the date of Christ's return but about the disposition of perpetual readiness. No one knows the hour; therefore the only rational response is continuous preparation. Calvin notes that those who predict specific dates for the end reveal by their prediction that they have not understood the command to watch."
-            },
-            {
-              "ref": "12:51-53",
-              "note": "Christ does not say he came to bring strife, but that strife is the inevitable consequence of his mission in a divided world. Where some receive the gospel and others reject it, division is inescapable. The peace Christ brings is between God and humanity; the division he causes is between those who accept that peace and those who refuse it."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:39",
-              "note": "\"The thief\" \u2014 the image of Christ's return as a thief in the night appears also in 1 Thess 5:2, 2 Pet 3:10, and Rev 3:3; 16:15. The point is not stealth but surprise \u2014 the thief comes when not expected. The implication for watchfulness is the same: since the hour is unknown, every hour must be treated as potentially the last."
-            },
-            {
-              "ref": "12:59",
-              "note": "\"The last penny\" \u2014 the lepton, the smallest Greek coin, worth about 1/128 of a denarius. The juridical metaphor warns of complete and final accountability: every debt must be settled. Applied to standing before God, the warning is absolute \u2014 there is no partial settlement, no statute of limitations."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "12:35",
-              "note": "Periz\u014dsmenai \u2014 \"girded,\" the aorist passive participle describing loins cinched for active service. Working garments were held up by a belt; letting them down indicated rest or sleep. The command is for the readiness posture, not comfort."
-            },
-            {
-              "ref": "12:50",
-              "note": "Synechomai \u2014 \"I am under constraint/pressed.\" The verb implies being hemmed in on all sides. Jesus's awareness of the approaching passion is not resignation but urgency \u2014 the compression of time before the decisive moment."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "12:49",
-              "note": "Gregory the Great: \"The fire which Christ came to cast upon the earth is the love of God. For it warms the heart when it inflames the mind, and whatever is earthly in the soul it burns up and consumes, and whatever is heavenly it purifies and keeps.\""
-            },
-            {
-              "ref": "12:48",
-              "note": "Ambrose: \"From everyone who has been given much, much will be demanded. This is the law of divine equity: the servant who knew and did not prepare will be beaten with many blows; the one who did not know with few. The judge weighs not only the act but the knowledge behind it.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Watchfulness Parables\nThe sequence of watchfulness parables (12:35-48) escalates through three scenarios: servants watching for the master, a householder watching for a thief, and a manager given authority in the master's absence. Peter's question in v.41 (\"is this for us or for everyone?\") sharpens the application \u2014 the greatest accountability falls on those with the greatest knowledge and responsibility.\n\nFamily Division as Mission Cost\nJesus's declaration that he brings division (12:51-53) echoes Mic 7:6, which describes the breakdown of family solidarity as a sign of the end time. In the ancient world, family loyalty was the primary social bond. Loyalty to Jesus that overrides family allegiance would have been culturally scandalous \u2014 Jesus names this explicitly and treats it not as unfortunate but as inevitable."
+          "context": "Watchfulness Parables\nThe sequence of watchfulness parables (12:35-48) escalates through three scenarios: servants watching for the master, a householder watching for a thief, and a manager given authority in the master's absence. Peter's question in v.41 (\"is this for us or for everyone?\") sharpens the application — the greatest accountability falls on those with the greatest knowledge and responsibility.\n\nFamily Division as Mission Cost\nJesus's declaration that he brings division (12:51-53) echoes Mic 7:6, which describes the breakdown of family solidarity as a sign of the end time. In the ancient world, family loyalty was the primary social bond. Loyalty to Jesus that overrides family allegiance would have been culturally scandalous — Jesus names this explicitly and treats it not as unfortunate but as inevitable."
         }
       }
     }
@@ -475,24 +369,24 @@
       {
         "name": "Peter",
         "role": "Lead disciple",
-        "text": "His question in 12:41 (\"is this parable for us or for everyone?\") reveals the disciples' concern about their own accountability \u2014 Jesus's answer (12:42-48) effectively answers: those with greater knowledge and responsibility bear the greater burden."
+        "text": "His question in 12:41 (\"is this parable for us or for everyone?\") reveals the disciples' concern about their own accountability — Jesus's answer (12:42-48) effectively answers: those with greater knowledge and responsibility bear the greater burden."
       },
       {
         "name": "The Man in the Crowd",
         "role": "Anonymous inheritance disputant",
-        "text": "His request for Jesus to arbitrate an inheritance dispute occasions the rich fool parable \u2014 Jesus refuses the legal role but addresses the spiritual condition the dispute reveals."
+        "text": "His request for Jesus to arbitrate an inheritance dispute occasions the rich fool parable — Jesus refuses the legal role but addresses the spiritual condition the dispute reveals."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">apaitousin (12:20)</td><td>NIV: \"demanded\"; KJV: \"required\"; ESV: \"required\"; NRSV: \"required\". The plural impersonal (lit. \"they demand back\") is a reverential circumlocution for divine action \u2014 God calling in the loan of life.</td></tr><tr><td class=\"t-label\">p\u0113chys (12:25)</td><td>NIV: \"single hour\"; KJV: \"one cubit unto his stature\"; ESV: \"single hour\"; NRSV: \"single hour\". Most modern translations take p\u0113chys temporally (a short span of time) rather than literally (a unit of length).</td></tr><tr><td class=\"t-label\">diamerismon (12:51)</td><td>NIV: \"division\"; KJV: \"division\"; ESV: \"division\"; NRSV: \"division\". All major versions agree. The word is striking in context \u2014 the expected antonym of \"peace\" would be \"war,\" but Jesus chooses the more domestic \"division.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">apaitousin (12:20)</td><td>NIV: \"demanded\"; KJV: \"required\"; ESV: \"required\"; NRSV: \"required\". The plural impersonal (lit. \"they demand back\") is a reverential circumlocution for divine action — God calling in the loan of life.</td></tr><tr><td class=\"t-label\">pēchys (12:25)</td><td>NIV: \"single hour\"; KJV: \"one cubit unto his stature\"; ESV: \"single hour\"; NRSV: \"single hour\". Most modern translations take pēchys temporally (a short span of time) rather than literally (a unit of length).</td></tr><tr><td class=\"t-label\">diamerismon (12:51)</td><td>NIV: \"division\"; KJV: \"division\"; ESV: \"division\"; NRSV: \"division\". All major versions agree. The word is striking in context — the expected antonym of \"peace\" would be \"war,\" but Jesus chooses the more domestic \"division.\"</td></tr>",
     "src": [
       {
         "title": "Sirach 11:18-19",
         "quote": "\"One grows rich by his carefulness and frugality, and this is his reward: when he says, 'I have found rest, and now I shall enjoy my goods!' he does not know how long it will be until he leaves them to others and dies.\"",
-        "note": "The Sirach passage is the closest OT parallel to the rich fool \u2014 same self-congratulation, same sudden death, same transfer of wealth. Jesus may be consciously evoking this wisdom tradition."
+        "note": "The Sirach passage is the closest OT parallel to the rich fool — same self-congratulation, same sudden death, same transfer of wealth. Jesus may be consciously evoking this wisdom tradition."
       },
       {
         "title": "Micah 7:6",
-        "quote": "\"For a son dishonors his father, a daughter rises up against her mother, a daughter-in-law against her mother-in-law \u2014 a man's enemies are the members of his own household.\"",
+        "quote": "\"For a son dishonors his father, a daughter rises up against her mother, a daughter-in-law against her mother-in-law — a man's enemies are the members of his own household.\"",
         "note": "The exact OT text Jesus applies to the social divisions his ministry creates (12:52-53). The Micah passage described the breakdown of covenant loyalty in Israel; Jesus applies it to the divisions produced by loyalty to himself."
       }
     ],
@@ -509,12 +403,12 @@
     "lit": {
       "rows": [
         {
-          "label": "Escalation \u2014 vv.35-48",
-          "text": "Three watching scenarios in ascending order of responsibility: servants watching (low accountability) \u2192 householder watching (personal protection) \u2192 manager with authority (high accountability). Each intensifies the demand.",
+          "label": "Escalation — vv.35-48",
+          "text": "Three watching scenarios in ascending order of responsibility: servants watching (low accountability) → householder watching (personal protection) → manager with authority (high accountability). Each intensifies the demand.",
           "is_key": false
         },
         {
-          "label": "Juxtaposition \u2014 vv.16-21 / 22-34",
+          "label": "Juxtaposition — vv.16-21 / 22-34",
           "text": "The rich fool (one who accumulates for self) is immediately followed by the do-not-worry teaching (trust the Father's provision). The parable gives the negative example; the teaching gives the positive alternative.",
           "is_key": false
         }
@@ -526,7 +420,7 @@
         "word": "pleonexia",
         "tlit": "ple-o-NEX-ia",
         "gloss": "greed / covetousness",
-        "note": "The word (v.15) means literally \"wanting more\" \u2014 a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
+        "note": "The word (v.15) means literally \"wanting more\" — a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
       },
       {
         "word": "merimnate",
@@ -538,19 +432,19 @@
         "word": "kairos",
         "tlit": "KAI-ros",
         "gloss": "appointed time / critical moment",
-        "note": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) \u2014 the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
+        "note": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) — the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
       },
       {
         "word": "diamerismos",
         "tlit": "dia-me-RIS-mos",
         "gloss": "division / separation",
-        "note": "The striking word in v.51 \u2014 not eir\u0113n\u0113 (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
+        "note": "The striking word in v.51 — not eirēnē (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
       },
       {
         "word": "pleonexia",
         "tlit": "ple-o-NEX-ia",
         "gloss": "greed / covetousness",
-        "note": "The word (v.15) means literally \"wanting more\" \u2014 a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
+        "note": "The word (v.15) means literally \"wanting more\" — a disposition of insatiability. Jesus warns against it as the defining spiritual disease of the affluent. The rich fool's problem is not his wealth but his pleonexia: he has no category for generosity or mortality."
       },
       {
         "word": "merimnate",
@@ -562,19 +456,19 @@
         "word": "kairos",
         "tlit": "KAI-ros",
         "gloss": "appointed time / critical moment",
-        "note": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) \u2014 the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
+        "note": "Jesus rebukes the crowd for failing to interpret the kairos (v.56) — the critical, loaded moment in which they are living. Unlike chronos (ordinary sequential time), kairos denotes time charged with meaning and opportunity. The crowd can read weather signs but misses the far more legible signs of the messianic moment."
       },
       {
         "word": "diamerismos",
         "tlit": "dia-me-RIS-mos",
         "gloss": "division / separation",
-        "note": "The striking word in v.51 \u2014 not eir\u0113n\u0113 (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
+        "note": "The striking word in v.51 — not eirēnē (peace) but diamerismos (division, splitting). Jesus describes the inevitable social fracture that loyalty to him creates in families where allegiances are divided. Not that he desires strife, but that the kingdom's arrival forces decision, and decision divides."
       }
     ],
     "tx": [
       {
         "ref": "12:1",
-        "title": "\"Yeast of the Pharisees\" \u2014 Beware vs. guard against",
+        "title": "\"Yeast of the Pharisees\" — Beware vs. guard against",
         "content": "Minor variant: some MSS read prosechein heautois (\"pay attention to yourselves\") rather than prosechete heautois (\"be on your guard\"). NA28 follows the majority reading.",
         "note": "No impact on meaning; both formulations convey the same warning."
       },
@@ -597,7 +491,7 @@
           {
             "name": "Fire of judgment and division",
             "proponents": "Marshall, Bock",
-            "argument": "The fire is the eschatological judgment that Jesus's arrival initiates \u2014 consistent with John the Baptist's fire-and-Spirit imagery (3:16-17) and the division language of vv.51-53."
+            "argument": "The fire is the eschatological judgment that Jesus's arrival initiates — consistent with John the Baptist's fire-and-Spirit imagery (3:16-17) and the division language of vv.51-53."
           }
         ]
       },
@@ -607,7 +501,7 @@
           {
             "name": "Yes, graduated eschatological punishment",
             "proponents": "MacArthur, Bock, Calvin",
-            "argument": "The passage implies that punishment in the final judgment is proportionate to knowledge and responsibility \u2014 a teaching consistent with Rom 2:12-16 and Heb 10:29."
+            "argument": "The passage implies that punishment in the final judgment is proportionate to knowledge and responsibility — a teaching consistent with Rom 2:12-16 and Heb 10:29."
           },
           {
             "name": "Contextual hyperbole about earthly discipline",
@@ -644,7 +538,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 12 develops two interlocking themes across its sixty verses. The first is the proper relationship to possessions: life does not consist in abundance; the Father knows what his children need; sell and give. The second is eschatological urgency: the master will return at an unexpected hour; the servant who knows and fails bears greater culpability. Both themes converge on the same point: the kingdom of God relativises everything else \u2014 wealth, security, family loyalty, and the fear of death."
+      "note": "Luke 12 develops two interlocking themes across its sixty verses. The first is the proper relationship to possessions: life does not consist in abundance; the Father knows what his children need; sell and give. The second is eschatological urgency: the master will return at an unexpected hour; the servant who knows and fails bears greater culpability. Both themes converge on the same point: the kingdom of God relativises everything else — wealth, security, family loyalty, and the fear of death."
     }
   },
   "vhl_groups": [
@@ -770,7 +664,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'Life does not consist in an abundance of possessions' (v. 15). The rich fool builds bigger barns and dies that night. 'Fool!'\u2014the first time God addresses anyone directly in Luke. Wealth without wisdom.",
+      "tip": "'Life does not consist in an abundance of possessions' (v. 15). The rich fool builds bigger barns and dies that night. 'Fool!'—the first time God addresses anyone directly in Luke. Wealth without wisdom.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/luke/13.json
+++ b/content/luke/13.json
@@ -10,22 +10,22 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201317 \u2014 Repent or Perish; The Barren Fig Tree; Sabbath Healing",
+      "header": "Verses 1–17 — Repent or Perish; The Barren Fig Tree; Sabbath Healing",
       "verse_start": 1,
       "verse_end": 17,
       "panels": {
         "heb": [
           {
-            "word": "metanoe\u014d",
+            "word": "metanoeō",
             "transliteration": "me-ta-NO-eh-o",
             "gloss": "repent / change direction",
             "paragraph": "The twice-repeated call to repentance (vv.3, 5) uses the full word for a turning of mind, will, and direction. Jesus refuses to connect suffering to personal sin but insists that all mortality confronts everyone with the same demand: repent now, before the end."
           },
           {
-            "word": "thygat\u0113r Abraam",
-            "transliteration": "thy-GA-t\u0113r ab-ra-AM",
+            "word": "thygatēr Abraam",
+            "transliteration": "thy-GA-tēr ab-ra-AM",
             "gloss": "daughter of Abraham",
-            "paragraph": "Jesus's designation for the bent woman (v.16) is theologically loaded \u2014 not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
+            "paragraph": "Jesus's designation for the bent woman (v.16) is theologically loaded — not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
           }
         ],
         "cross": {
@@ -36,7 +36,7 @@
             },
             {
               "ref": "Dan 4:12, 21",
-              "note": "The great tree in whose branches birds shelter \u2014 the Danielic imagery underlying the mustard seed parable, intentionally scaling down the imperial tree metaphor to a garden plant."
+              "note": "The great tree in whose branches birds shelter — the Danielic imagery underlying the mustard seed parable, intentionally scaling down the imperial tree metaphor to a garden plant."
             },
             {
               "ref": "Mark 3:1-6",
@@ -45,7 +45,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:2-5",
@@ -53,7 +53,7 @@
             },
             {
               "ref": "13:6-9",
-              "note": "The fig tree parable is Israel in miniature \u2014 three years of fruitless expectation (corresponding roughly to Jesus's ministry), the owner's legitimate frustration, the gardener's intercession for one more year. The parable is simultaneously a warning (judgment is coming) and a grace (there is still time). The \"one more year\" is the present moment of opportunity."
+              "note": "The fig tree parable is Israel in miniature — three years of fruitless expectation (corresponding roughly to Jesus's ministry), the owner's legitimate frustration, the gardener's intercession for one more year. The parable is simultaneously a warning (judgment is coming) and a grace (there is still time). The \"one more year\" is the present moment of opportunity."
             },
             {
               "ref": "13:15-16",
@@ -66,20 +66,20 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:1-5",
-              "note": "Calvin insists that Jesus is not denying all connection between sin and suffering in the broad sense \u2014 suffering entered the world through sin \u2014 but is denying the specific inference that the degree of suffering indicates the degree of personal guilt. This is the error of Job's comforters, and Jesus corrects it directly."
+              "note": "Calvin insists that Jesus is not denying all connection between sin and suffering in the broad sense — suffering entered the world through sin — but is denying the specific inference that the degree of suffering indicates the degree of personal guilt. This is the error of Job's comforters, and Jesus corrects it directly."
             },
             {
               "ref": "13:18-21",
-              "note": "The mustard seed and yeast parables answer the same implicit objection: why is the kingdom so unimpressive in its present form? The answer is that the kingdom's greatness is already determined by its origin; its appearance will come. The yeast works invisibly until the whole lump is leavened \u2014 the kingdom's hidden work is no less real for being unseen."
+              "note": "The mustard seed and yeast parables answer the same implicit objection: why is the kingdom so unimpressive in its present form? The answer is that the kingdom's greatness is already determined by its origin; its appearance will come. The yeast works invisibly until the whole lump is leavened — the kingdom's hidden work is no less real for being unseen."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:1",
@@ -87,25 +87,25 @@
             },
             {
               "ref": "13:4",
-              "note": "\"The tower in Siloam\" \u2014 the Siloam pool (John 9:7) was in the southern part of Jerusalem. Building projects in the area were documented; the collapse of a tower there is unattested in other sources but architecturally plausible for a city under frequent construction."
+              "note": "\"The tower in Siloam\" — the Siloam pool (John 9:7) was in the southern part of Jerusalem. Building projects in the area were documented; the collapse of a tower there is unattested in other sources but architecturally plausible for a city under frequent construction."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "13:11",
-              "note": "Syggkyptousa \u2014 \"bent double,\" a word that perfectly describes the medical condition: she could not at all (pantelos) straighten herself up. The perfect passive participle suggests a long-established condition, consistent with the eighteen years specified."
+              "note": "Syggkyptousa — \"bent double,\" a word that perfectly describes the medical condition: she could not at all (pantelos) straighten herself up. The perfect passive participle suggests a long-established condition, consistent with the eighteen years specified."
             },
             {
               "ref": "13:16",
-              "note": "Edei \u2014 imperfect of the divine necessity: \"it was necessary.\" Jesus frames the healing not as a controversy but as an obligation: the Sabbath day is precisely the right day to liberate a daughter of Abraham from satanic bondage."
+              "note": "Edei — imperfect of the divine necessity: \"it was necessary.\" Jesus frames the healing not as a controversy but as an obligation: the Sabbath day is precisely the right day to liberate a daughter of Abraham from satanic bondage."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "13:3",
@@ -113,47 +113,47 @@
             },
             {
               "ref": "13:12",
-              "note": "Ambrose: \"She was bent over by a spirit of infirmity \u2014 and Jesus says 'you are set free' before he touches her. The word releases her; the touch confirms the release. Both show that healing comes by authority, not by physical means alone.\""
+              "note": "Ambrose: \"She was bent over by a spirit of infirmity — and Jesus says 'you are set free' before he touches her. The word releases her; the touch confirms the release. Both show that healing comes by authority, not by physical means alone.\""
             }
           ]
         },
         "places": [
           {
             "name": "Jerusalem",
-            "coords": "31.7767\u00b0 N, 35.2345\u00b0 E",
-            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions \u2014 the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
+            "coords": "31.7767° N, 35.2345° E",
+            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions — the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
           }
         ],
         "hist": {
-          "context": "Pilate's Massacre of Galileans\nThe incident of Galileans whose blood Pilate \"mixed with their sacrifices\" is not recorded elsewhere but is consistent with Pilate's documented brutality (Josephus, Ant. 18.3.2; 18.4.1). The victims may have been Zealots or pilgrims at the Temple. Jesus's refusal to interpret their deaths as divine punishment challenges the common theological assumption that catastrophe signals divine displeasure.\n\nThe Tower of Siloam\nThe collapse of a tower in the Siloam district (south of the Temple, near the pool of Siloam) killing eighteen people is unknown from external sources. Both incidents \u2014 human atrocity and natural disaster \u2014 are treated identically: neither implies exceptional guilt in the victims, and both serve as occasions for the general call to repentance."
+          "context": "Pilate's Massacre of Galileans\nThe incident of Galileans whose blood Pilate \"mixed with their sacrifices\" is not recorded elsewhere but is consistent with Pilate's documented brutality (Josephus, Ant. 18.3.2; 18.4.1). The victims may have been Zealots or pilgrims at the Temple. Jesus's refusal to interpret their deaths as divine punishment challenges the common theological assumption that catastrophe signals divine displeasure.\n\nThe Tower of Siloam\nThe collapse of a tower in the Siloam district (south of the Temple, near the pool of Siloam) killing eighteen people is unknown from external sources. Both incidents — human atrocity and natural disaster — are treated identically: neither implies exceptional guilt in the victims, and both serve as occasions for the general call to repentance."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 18\u201330 \u2014 Mustard Seed; Yeast; The Narrow Door",
+      "header": "Verses 18–30 — Mustard Seed; Yeast; The Narrow Door",
       "verse_start": 18,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "ag\u014dnizesthe",
-            "transliteration": "a-g\u014d-NI-zes-the",
+            "word": "agōnizesthe",
+            "transliteration": "a-gō-NI-zes-the",
             "gloss": "strive / agonise",
-            "paragraph": "The verb (v.24) is athletic \u2014 to compete in the games, to struggle with all one's effort. Entry through the narrow door is not passive; it requires the kind of total effort an athlete brings to competition. The word group gives us the English \"agony.\""
+            "paragraph": "The verb (v.24) is athletic — to compete in the games, to struggle with all one's effort. Entry through the narrow door is not passive; it requires the kind of total effort an athlete brings to competition. The word group gives us the English \"agony.\""
           },
           {
-            "word": "al\u014dp\u0113x",
+            "word": "alōpēx",
             "transliteration": "a-LO-pex",
             "gloss": "fox",
-            "paragraph": "Jesus's term for Herod Antipas (v.32) is uniquely contemptuous in all the Gospels. In Jewish idiom a fox was a cunning but small and destructive animal \u2014 the opposite of the lion (noble power). Jesus refuses to dignify Herod's threat with fear."
+            "paragraph": "Jesus's term for Herod Antipas (v.32) is uniquely contemptuous in all the Gospels. In Jewish idiom a fox was a cunning but small and destructive animal — the opposite of the lion (noble power). Jesus refuses to dignify Herod's threat with fear."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 7:13-14",
-              "note": "\"Enter through the narrow gate\" \u2014 Matthew's parallel to the narrow door, given in the Sermon on the Mount."
+              "note": "\"Enter through the narrow gate\" — Matthew's parallel to the narrow door, given in the Sermon on the Mount."
             },
             {
               "ref": "Matt 23:37-39",
@@ -161,33 +161,33 @@
             },
             {
               "ref": "Ps 118:26",
-              "note": "\"Blessed is he who comes in the name of the Lord\" \u2014 the Hallel verse Jesus quotes as the condition for Jerusalem seeing him again. It echoes the Palm Sunday acclamation (19:38)."
+              "note": "\"Blessed is he who comes in the name of the Lord\" — the Hallel verse Jesus quotes as the condition for Jerusalem seeing him again. It echoes the Palm Sunday acclamation (19:38)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:24",
-              "note": "\"Make every effort\" \u2014 ag\u014dnizesthe. Salvation is not earned by striving, but entry through the narrow door demands the full engagement of the will. The narrowness of the door is not about the difficulty of meeting God's standard but about the radical self-renunciation that comes through it. Wide doors admit everyone as they are; the narrow door requires leaving self behind."
+              "note": "\"Make every effort\" — agōnizesthe. Salvation is not earned by striving, but entry through the narrow door demands the full engagement of the will. The narrowness of the door is not about the difficulty of meeting God's standard but about the radical self-renunciation that comes through it. Wide doors admit everyone as they are; the narrow door requires leaving self behind."
             },
             {
               "ref": "13:25-27",
-              "note": "\"I don't know you\" \u2014 the most chilling words in Luke. Religious familiarity (eating and drinking with Jesus, hearing his teaching in the streets) is not the same as relationship. Many will claim acquaintance; the issue is whether they are known by the one who matters. The door closes; the moment of opportunity ends."
+              "note": "\"I don't know you\" — the most chilling words in Luke. Religious familiarity (eating and drinking with Jesus, hearing his teaching in the streets) is not the same as relationship. Many will claim acquaintance; the issue is whether they are known by the one who matters. The door closes; the moment of opportunity ends."
             },
             {
               "ref": "13:32-33",
-              "note": "\"Today and tomorrow and the third day I will reach my goal\" \u2014 the three-day pattern foreshadows the passion and resurrection. Jesus's refusal to be deflected by Herod's threat is not defiance for its own sake but the steady movement of one who knows his destination. He will not die in Galilee; he will die in Jerusalem, because that is where prophets die."
+              "note": "\"Today and tomorrow and the third day I will reach my goal\" — the three-day pattern foreshadows the passion and resurrection. Jesus's refusal to be deflected by Herod's threat is not defiance for its own sake but the steady movement of one who knows his destination. He will not die in Galilee; he will die in Jerusalem, because that is where prophets die."
             },
             {
               "ref": "13:34",
-              "note": "The maternal image of the hen is one of the most tender in all the Gospels. Christ's desire for Jerusalem is not the desire of power but of love \u2014 sheltering, vulnerable, repeatedly extended and repeatedly refused. \"You were not willing\" \u2014 the tragedy is not divine abandonment but human refusal."
+              "note": "The maternal image of the hen is one of the most tender in all the Gospels. Christ's desire for Jerusalem is not the desire of power but of love — sheltering, vulnerable, repeatedly extended and repeatedly refused. \"You were not willing\" — the tragedy is not divine abandonment but human refusal."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "13:23-24",
@@ -195,12 +195,12 @@
             },
             {
               "ref": "13:35",
-              "note": "\"Your house is left to you desolate\" \u2014 the abandonment of the Temple by the divine presence, foreshadowed here, was fulfilled in AD 70 when the Temple was destroyed. The phrase echoes Ezek 10-11, where the glory of the Lord departed from the Temple before its first destruction in 587 BC."
+              "note": "\"Your house is left to you desolate\" — the abandonment of the Temple by the divine presence, foreshadowed here, was fulfilled in AD 70 when the Temple was destroyed. The phrase echoes Ezek 10-11, where the glory of the Lord departed from the Temple before its first destruction in 587 BC."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "13:31",
@@ -208,66 +208,66 @@
             },
             {
               "ref": "13:35",
-              "note": "\"Until you say 'Blessed is he who comes in the name of the Lord'\" \u2014 this could refer to the Palm Sunday entry (19:28-40) which immediately follows in the narrative, or to a future eschatological recognition of Jesus at his return. Most scholars see a double reference: the near term (the triumphal entry) and the ultimate (the Parousia)."
+              "note": "\"Until you say 'Blessed is he who comes in the name of the Lord'\" — this could refer to the Palm Sunday entry (19:28-40) which immediately follows in the narrative, or to a future eschatological recognition of Jesus at his return. Most scholars see a double reference: the near term (the triumphal entry) and the ultimate (the Parousia)."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "13:24",
-              "note": "Ag\u014dnizesthe \u2014 present imperative: keep on striving. The word is from the athletic arena. The present tense implies continuous effort, not a single decisive act."
+              "note": "Agōnizesthe — present imperative: keep on striving. The word is from the athletic arena. The present tense implies continuous effort, not a single decisive act."
             },
             {
               "ref": "13:32",
-              "note": "Al\u014dp\u0113x \u2014 \"fox.\" A term of contempt in Jewish culture (cf. Neh 4:3, where Tobiah uses a fox as an image of insignificance). Jesus's refusal to fear Herod is expressed through dismissive description rather than confrontation."
+              "note": "Alōpēx — \"fox.\" A term of contempt in Jewish culture (cf. Neh 4:3, where Tobiah uses a fox as an image of insignificance). Jesus's refusal to fear Herod is expressed through dismissive description rather than confrontation."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "13:24",
-              "note": "Augustine: \"The narrow way is narrow for the sake of those who walk carelessly. For those who walk with care and love, it is wide enough \u2014 wide enough, I mean, not in quantity of space, but in the stretching out of the heart.\""
+              "note": "Augustine: \"The narrow way is narrow for the sake of those who walk carelessly. For those who walk with care and love, it is wide enough — wide enough, I mean, not in quantity of space, but in the stretching out of the heart.\""
             },
             {
               "ref": "13:34",
-              "note": "Cyril of Alexandria: \"He gathered the children of Israel under the wings of his divine protection through the law and the prophets. But they were not willing. And so at last he came in his own person \u2014 and they were still not willing.\""
+              "note": "Cyril of Alexandria: \"He gathered the children of Israel under the wings of his divine protection through the law and the prophets. But they were not willing. And so at last he came in his own person — and they were still not willing.\""
             }
           ]
         },
         "places": [
           {
             "name": "Jerusalem",
-            "coords": "31.7767\u00b0 N, 35.2345\u00b0 E",
-            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions \u2014 the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
+            "coords": "31.7767° N, 35.2345° E",
+            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions — the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
           }
         ],
         "hist": {
-          "context": "The Journey to Jerusalem\nLuke periodically reminds the reader that Jesus is travelling toward Jerusalem (9:51; 13:22; 17:11; 18:31; 19:28). The journey is both geographical and theological \u2014 it is the via crucis, and every teaching along the way is coloured by its destination.\n\nThe Jerusalem Lament\nThe lament over Jerusalem (13:34-35) is one of the most emotionally charged passages in Luke. The maternal image \u2014 a hen gathering chicks \u2014 is remarkable for its vulnerability: Jesus does not describe his desire to protect Jerusalem through power but through sheltering tenderness. Jerusalem's desolation is not God's preference but the consequence of her refusal."
+          "context": "The Journey to Jerusalem\nLuke periodically reminds the reader that Jesus is travelling toward Jerusalem (9:51; 13:22; 17:11; 18:31; 19:28). The journey is both geographical and theological — it is the via crucis, and every teaching along the way is coloured by its destination.\n\nThe Jerusalem Lament\nThe lament over Jerusalem (13:34-35) is one of the most emotionally charged passages in Luke. The maternal image — a hen gathering chicks — is remarkable for its vulnerability: Jesus does not describe his desire to protect Jerusalem through power but through sheltering tenderness. Jerusalem's desolation is not God's preference but the consequence of her refusal."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201335 \u2014 Herod\u2019s Threat; Lament over Jerusalem",
+      "header": "Verses 31–35 — Herod’s Threat; Lament over Jerusalem",
       "verse_start": 31,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "metanoe\u014d",
+            "word": "metanoeō",
             "transliteration": "me-ta-NO-eh-o",
             "gloss": "repent / change direction",
             "paragraph": "The twice-repeated call to repentance (vv.3, 5) uses the full word for a turning of mind, will, and direction. Jesus refuses to connect suffering to personal sin but insists that all mortality confronts everyone with the same demand: repent now, before the end."
           },
           {
-            "word": "thygat\u0113r Abraam",
-            "transliteration": "thy-GA-t\u0113r ab-ra-AM",
+            "word": "thygatēr Abraam",
+            "transliteration": "thy-GA-tēr ab-ra-AM",
             "gloss": "daughter of Abraham",
-            "paragraph": "Jesus's designation for the bent woman (v.16) is theologically loaded \u2014 not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
+            "paragraph": "Jesus's designation for the bent woman (v.16) is theologically loaded — not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
           }
         ],
         "cross": {
@@ -278,7 +278,7 @@
             },
             {
               "ref": "Dan 4:12, 21",
-              "note": "The great tree in whose branches birds shelter \u2014 the Danielic imagery underlying the mustard seed parable, intentionally scaling down the imperial tree metaphor to a garden plant."
+              "note": "The great tree in whose branches birds shelter — the Danielic imagery underlying the mustard seed parable, intentionally scaling down the imperial tree metaphor to a garden plant."
             },
             {
               "ref": "Mark 3:1-6",
@@ -287,87 +287,34 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:2-5",
-              "note": "Jesus dismantles two false theological equations: suffering = greater sinfulness, and survival = greater righteousness. Both are wrong. The only conclusion to draw from others' deaths is personal urgency: \"you too will all perish\" unless you repent. The deaths are not punishments but warnings."
-            },
-            {
-              "ref": "13:6-9",
-              "note": "The fig tree parable is Israel in miniature \u2014 three years of fruitless expectation (corresponding roughly to Jesus's ministry), the owner's legitimate frustration, the gardener's intercession for one more year. The parable is simultaneously a warning (judgment is coming) and a grace (there is still time). The \"one more year\" is the present moment of opportunity."
-            },
-            {
-              "ref": "13:15-16",
-              "note": "Jesus's Sabbath argument moves from animal to human: if you untie an animal on the Sabbath to water it, how much more should a daughter of Abraham be untied from eighteen years of satanic bondage? The logic is a fortiori and the conclusion is unanswerable. The opponents are humiliated not by force but by the irresistible coherence of the argument."
-            },
-            {
-              "ref": "13:19-21",
-              "note": "Both kingdom parables emphasise hidden, unprepossessing beginnings yielding extraordinary results. The mustard seed is proverbially tiny; the yeast is invisible in the dough. The kingdom does not arrive with observable grandeur (17:20) but permeates all things from within."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:1-5",
-              "note": "Calvin insists that Jesus is not denying all connection between sin and suffering in the broad sense \u2014 suffering entered the world through sin \u2014 but is denying the specific inference that the degree of suffering indicates the degree of personal guilt. This is the error of Job's comforters, and Jesus corrects it directly."
-            },
-            {
-              "ref": "13:18-21",
-              "note": "The mustard seed and yeast parables answer the same implicit objection: why is the kingdom so unimpressive in its present form? The answer is that the kingdom's greatness is already determined by its origin; its appearance will come. The yeast works invisibly until the whole lump is leavened \u2014 the kingdom's hidden work is no less real for being unseen."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:1",
-              "note": "The incident of Galileans killed by Pilate during their Temple sacrifices has no independent historical attestation. However, Pilate's governorship (AD 26-36) is well documented for its violations of Jewish religious sensitivities (cf. Josephus, Ant. 18.55-62; 18.85-89). The incident is historically plausible."
-            },
-            {
-              "ref": "13:4",
-              "note": "\"The tower in Siloam\" \u2014 the Siloam pool (John 9:7) was in the southern part of Jerusalem. Building projects in the area were documented; the collapse of a tower there is unattested in other sources but architecturally plausible for a city under frequent construction."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "13:11",
-              "note": "Syggkyptousa \u2014 \"bent double,\" a word that perfectly describes the medical condition: she could not at all (pantelos) straighten herself up. The perfect passive participle suggests a long-established condition, consistent with the eighteen years specified."
-            },
-            {
-              "ref": "13:16",
-              "note": "Edei \u2014 imperfect of the divine necessity: \"it was necessary.\" Jesus frames the healing not as a controversy but as an obligation: the Sabbath day is precisely the right day to liberate a daughter of Abraham from satanic bondage."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "13:3",
-              "note": "Origen: \"The word 'unless you repent' is addressed not only to those present but to all who hear it, in all generations. For all of us are subject to the same mortality, and the same call to repentance applies equally to all.\""
-            },
-            {
-              "ref": "13:12",
-              "note": "Ambrose: \"She was bent over by a spirit of infirmity \u2014 and Jesus says 'you are set free' before he touches her. The word releases her; the touch confirms the release. Both show that healing comes by authority, not by physical means alone.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
             "name": "Jerusalem",
-            "coords": "31.7767\u00b0 N, 35.2345\u00b0 E",
-            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions \u2014 the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
+            "coords": "31.7767° N, 35.2345° E",
+            "text": "The destination of the entire Lukan journey narrative (9:51-19:28). Jerusalem is simultaneously the city of the prophets' martyrdom, the site of the Temple, and the place of Jesus's own passion. The lament of 13:34-35 names all of these dimensions — the city's grandeur and its tragedy converge in the address \"Jerusalem, Jerusalem.\""
           }
         ],
         "hist": {
-          "context": "Pilate's Massacre of Galileans\nThe incident of Galileans whose blood Pilate \"mixed with their sacrifices\" is not recorded elsewhere but is consistent with Pilate's documented brutality (Josephus, Ant. 18.3.2; 18.4.1). The victims may have been Zealots or pilgrims at the Temple. Jesus's refusal to interpret their deaths as divine punishment challenges the common theological assumption that catastrophe signals divine displeasure.\n\nThe Tower of Siloam\nThe collapse of a tower in the Siloam district (south of the Temple, near the pool of Siloam) killing eighteen people is unknown from external sources. Both incidents \u2014 human atrocity and natural disaster \u2014 are treated identically: neither implies exceptional guilt in the victims, and both serve as occasions for the general call to repentance."
+          "context": "Pilate's Massacre of Galileans\nThe incident of Galileans whose blood Pilate \"mixed with their sacrifices\" is not recorded elsewhere but is consistent with Pilate's documented brutality (Josephus, Ant. 18.3.2; 18.4.1). The victims may have been Zealots or pilgrims at the Temple. Jesus's refusal to interpret their deaths as divine punishment challenges the common theological assumption that catastrophe signals divine displeasure.\n\nThe Tower of Siloam\nThe collapse of a tower in the Siloam district (south of the Temple, near the pool of Siloam) killing eighteen people is unknown from external sources. Both incidents — human atrocity and natural disaster — are treated identically: neither implies exceptional guilt in the victims, and both serve as occasions for the general call to repentance."
         }
       }
     }
@@ -387,26 +334,26 @@
       {
         "name": "The Synagogue Leader",
         "role": "Religious authority",
-        "text": "His indignation at the Sabbath healing is addressed to the crowd rather than to Jesus \u2014 a rhetorical evasion Jesus immediately exposes and answers with the animal-care argument."
+        "text": "His indignation at the Sabbath healing is addressed to the crowd rather than to Jesus — a rhetorical evasion Jesus immediately exposes and answers with the animal-care argument."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ag\u014dnizesthe (13:24)</td><td>NIV: \"make every effort\"; KJV: \"strive\"; ESV: \"strive\"; NRSV: \"strive\". All major versions agree on the athletic/effort connotation.</td></tr><tr><td class=\"t-label\">al\u014dp\u0113x (13:32)</td><td>All major versions: \"fox.\" The term of contempt is universally rendered literally.</td></tr><tr><td class=\"t-label\">er\u0113mos (13:35)</td><td>NIV: \"desolate\"; KJV: \"desolate\"; ESV: \"desolate\"; NRSV: \"abandoned\". The word refers to abandonment \u2014 the divine presence departing \u2014 rather than physical ruin, though physical ruin follows.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">agōnizesthe (13:24)</td><td>NIV: \"make every effort\"; KJV: \"strive\"; ESV: \"strive\"; NRSV: \"strive\". All major versions agree on the athletic/effort connotation.</td></tr><tr><td class=\"t-label\">alōpēx (13:32)</td><td>All major versions: \"fox.\" The term of contempt is universally rendered literally.</td></tr><tr><td class=\"t-label\">erēmos (13:35)</td><td>NIV: \"desolate\"; KJV: \"desolate\"; ESV: \"desolate\"; NRSV: \"abandoned\". The word refers to abandonment — the divine presence departing — rather than physical ruin, though physical ruin follows.</td></tr>",
     "src": [
       {
         "title": "Ezekiel 10-11",
-        "quote": "The departure of the glory (shekinah) from the Temple before its destruction in 587 BC \u2014 the OT background for Jesus's \"your house is left to you desolate\" (13:35). The Temple cannot be destroyed until the divine presence has withdrawn.",
+        "quote": "The departure of the glory (shekinah) from the Temple before its destruction in 587 BC — the OT background for Jesus's \"your house is left to you desolate\" (13:35). The Temple cannot be destroyed until the divine presence has withdrawn.",
         "note": "Jesus's lament implies that the same pattern is repeating: divine presence is being refused, and abandonment will follow."
       },
       {
         "title": "Psalm 118:26",
-        "quote": "\"Blessed is he who comes in the name of the Lord\" \u2014 the Hallel psalm sung at Passover, which becomes the acclamation of the Palm Sunday crowd. Jesus quotes it as the condition under which Jerusalem will see him again.",
+        "quote": "\"Blessed is he who comes in the name of the Lord\" — the Hallel psalm sung at Passover, which becomes the acclamation of the Palm Sunday crowd. Jesus quotes it as the condition under which Jerusalem will see him again.",
         "note": "The citation connects the lament to both the immediate triumphal entry (19:38) and the eschatological return of Christ."
       }
     ],
     "rec": [
       {
         "who": "The Narrow Door in Christian Asceticism",
-        "text": "The \"narrow door\" became a key text for monastic theology. The desert fathers quoted it as the scriptural basis for the renunciations of the ascetic life \u2014 not as earning salvation but as the form that radical self-surrender takes. John Cassian and Benedict of Nursia both invoke it in their writings on the spiritual life."
+        "text": "The \"narrow door\" became a key text for monastic theology. The desert fathers quoted it as the scriptural basis for the renunciations of the ascetic life — not as earning salvation but as the form that radical self-surrender takes. John Cassian and Benedict of Nursia both invoke it in their writings on the spiritual life."
       },
       {
         "who": "The Jerusalem Lament in Art and Theology",
@@ -416,12 +363,12 @@
     "lit": {
       "rows": [
         {
-          "label": "Inclusio \u2014 vv.22 / 33",
+          "label": "Inclusio — vv.22 / 33",
           "text": "The journey-to-Jerusalem frame brackets the section: \"as he made his way to Jerusalem\" (v.22) and \"no prophet can die outside Jerusalem\" (v.33). The geographical destination and the theological destination are the same.",
           "is_key": false
         },
         {
-          "label": "Reversal \u2014 vv.28-30",
+          "label": "Reversal — vv.28-30",
           "text": "The last will be first, the first last. Those who assumed their place at the table (the insiders, those who ate with Jesus) are excluded; those from east, west, north and south (the outsiders, the Gentiles) take their places. Luke's great reversal theme at its starkest.",
           "is_key": false
         }
@@ -430,54 +377,54 @@
     },
     "hebtext": [
       {
-        "word": "metanoe\u014d",
+        "word": "metanoeō",
         "tlit": "me-ta-NO-eh-o",
         "gloss": "repent / change direction",
         "note": "The twice-repeated call to repentance (vv.3, 5) uses the full word for a turning of mind, will, and direction. Jesus refuses to connect suffering to personal sin but insists that all mortality confronts everyone with the same demand: repent now, before the end."
       },
       {
-        "word": "thygat\u0113r Abraam",
-        "tlit": "thy-GA-t\u0113r ab-ra-AM",
+        "word": "thygatēr Abraam",
+        "tlit": "thy-GA-tēr ab-ra-AM",
         "gloss": "daughter of Abraham",
-        "note": "Jesus's designation for the bent woman (v.16) is theologically loaded \u2014 not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
+        "note": "Jesus's designation for the bent woman (v.16) is theologically loaded — not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
       },
       {
-        "word": "ag\u014dnizesthe",
-        "tlit": "a-g\u014d-NI-zes-the",
+        "word": "agōnizesthe",
+        "tlit": "a-gō-NI-zes-the",
         "gloss": "strive / agonise",
-        "note": "The verb (v.24) is athletic \u2014 to compete in the games, to struggle with all one's effort. Entry through the narrow door is not passive; it requires the kind of total effort an athlete brings to competition. The word group gives us the English \"agony.\""
+        "note": "The verb (v.24) is athletic — to compete in the games, to struggle with all one's effort. Entry through the narrow door is not passive; it requires the kind of total effort an athlete brings to competition. The word group gives us the English \"agony.\""
       },
       {
-        "word": "al\u014dp\u0113x",
+        "word": "alōpēx",
         "tlit": "a-LO-pex",
         "gloss": "fox",
-        "note": "Jesus's term for Herod Antipas (v.32) is uniquely contemptuous in all the Gospels. In Jewish idiom a fox was a cunning but small and destructive animal \u2014 the opposite of the lion (noble power). Jesus refuses to dignify Herod's threat with fear."
+        "note": "Jesus's term for Herod Antipas (v.32) is uniquely contemptuous in all the Gospels. In Jewish idiom a fox was a cunning but small and destructive animal — the opposite of the lion (noble power). Jesus refuses to dignify Herod's threat with fear."
       },
       {
-        "word": "metanoe\u014d",
+        "word": "metanoeō",
         "tlit": "me-ta-NO-eh-o",
         "gloss": "repent / change direction",
         "note": "The twice-repeated call to repentance (vv.3, 5) uses the full word for a turning of mind, will, and direction. Jesus refuses to connect suffering to personal sin but insists that all mortality confronts everyone with the same demand: repent now, before the end."
       },
       {
-        "word": "thygat\u0113r Abraam",
-        "tlit": "thy-GA-t\u0113r ab-ra-AM",
+        "word": "thygatēr Abraam",
+        "tlit": "thy-GA-tēr ab-ra-AM",
         "gloss": "daughter of Abraham",
-        "note": "Jesus's designation for the bent woman (v.16) is theologically loaded \u2014 not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
+        "note": "Jesus's designation for the bent woman (v.16) is theologically loaded — not merely a biological description but a covenantal one. She belongs to the covenant people; her liberation on the Sabbath is therefore not a violation of the day but its fulfilment."
       }
     ],
     "tx": [
       {
         "ref": "13:35",
         "title": "\"Your house is left to you desolate\"",
-        "content": "Some MSS (including several important ones) omit \"desolate\" (er\u0113mos), reading simply \"your house is left to you.\" NA28 includes er\u0113mos on the strength of multiple early witnesses.",
+        "content": "Some MSS (including several important ones) omit \"desolate\" (erēmos), reading simply \"your house is left to you.\" NA28 includes erēmos on the strength of multiple early witnesses.",
         "note": "The longer reading is well-attested and makes the OT allusion (Ezek 10-11; Jer 22:5) explicit. The shorter reading may reflect scribal haplography."
       },
       {
         "ref": "13:31",
         "title": "Pharisees' motives",
         "content": "No textual variation, but interpreters divide on whether the Pharisees are warning Jesus genuinely or attempting to move him away from Herod's territory for other reasons. The ambiguity is in the text, not a manuscript variant.",
-        "note": "Luke presents the warning without evaluating the Pharisees' motives \u2014 a characteristic Lukan restraint that leaves the reader to judge."
+        "note": "Luke presents the warning without evaluating the Pharisees' motives — a characteristic Lukan restraint that leaves the reader to judge."
       }
     ],
     "debate": [
@@ -492,7 +439,7 @@
           {
             "name": "The Parousia",
             "proponents": "Marshall, Green",
-            "argument": "The full recognition implied \u2014 Jerusalem \"seeing\" Jesus with the Hallel acclamation \u2014 was not achieved at the Palm Sunday entry, where Jesus was rejected within days. The ultimate fulfilment is eschatological."
+            "argument": "The full recognition implied — Jerusalem \"seeing\" Jesus with the Hallel acclamation — was not achieved at the Palm Sunday entry, where Jesus was rejected within days. The ultimate fulfilment is eschatological."
           }
         ]
       }
@@ -524,7 +471,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 13 presses repentance with unusual urgency: not as a response to personal guilt about specific sins but as the only appropriate response to human mortality \u2014 all die, therefore all must repent now. The chapter then demonstrates the kingdom's character in miniature: it heals on the Sabbath, grows from invisible beginnings, enters through a narrow door, and welcomes those from every direction while excluding those who assumed their own entry was guaranteed. The Jerusalem lament brings the chapter to its emotional climax: the city that kills the prophets is tenderly, repeatedly, and uselessly wooed by the one it will kill."
+      "note": "Luke 13 presses repentance with unusual urgency: not as a response to personal guilt about specific sins but as the only appropriate response to human mortality — all die, therefore all must repent now. The chapter then demonstrates the kingdom's character in miniature: it heals on the Sabbath, grows from invisible beginnings, enters through a narrow door, and welcomes those from every direction while excluding those who assumed their own entry was guaranteed. The Jerusalem lament brings the chapter to its emotional climax: the city that kills the prophets is tenderly, repeatedly, and uselessly wooed by the one it will kill."
     }
   },
   "vhl_groups": [

--- a/content/luke/14.json
+++ b/content/luke/14.json
@@ -7,25 +7,25 @@
   "subtitle": "Banquets, Humility, and the Cost of Discipleship",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201114 \u2014 Sabbath Healing; Humility at the Banquet Table",
+      "header": "Verses 1‑14 — Sabbath Healing; Humility at the Banquet Table",
       "verse_start": 1,
       "verse_end": 14,
       "panels": {
         "heb": [
           {
-            "word": "hydr\u014dpikos",
+            "word": "hydrōpikos",
             "transliteration": "hyd-RO-pi-kos",
             "gloss": "dropsy / abnormal swelling",
-            "paragraph": "The medical term (v.2) for the accumulation of fluid in the body \u2014 a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
+            "paragraph": "The medical term (v.2) for the accumulation of fluid in the body — a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
           },
           {
-            "word": "tapein\u014dsis / hyps\u014dsis",
+            "word": "tapeinōsis / hypsōsis",
             "transliteration": "ta-pei-NO-sis / hyp-SO-sis",
             "gloss": "humiliation / exaltation",
             "paragraph": "The reversal axiom (v.11: \"all who exalt themselves will be humbled; all who humble themselves will be exalted\") is a central Lukan theme that runs from the Magnificat (1:52) through the beatitudes (6:20-26) to the great banquet here. The Greek words carry weight in the LXX's wisdom tradition."
@@ -35,45 +35,45 @@
           "refs": [
             {
               "ref": "Matt 22:1-14",
-              "note": "Matthew's parallel great banquet parable, set as a king's wedding feast for his son \u2014 more explicitly allegorical and including the man without a wedding garment."
+              "note": "Matthew's parallel great banquet parable, set as a king's wedding feast for his son — more explicitly allegorical and including the man without a wedding garment."
             },
             {
               "ref": "Luke 1:52",
-              "note": "The Magnificat: \"He has brought down rulers from their thrones but has lifted up the humble\" \u2014 the reversal axiom that the seating parable (14:7-11) illustrates in miniature."
+              "note": "The Magnificat: \"He has brought down rulers from their thrones but has lifted up the humble\" — the reversal axiom that the seating parable (14:7-11) illustrates in miniature."
             },
             {
               "ref": "Prov 25:6-7",
-              "note": "\"Do not exalt yourself in the king's presence... it is better for him to say to you, 'Come up here' than for him to humiliate you before his nobles\" \u2014 the wisdom text Jesus's seating parable expands and radicalises."
+              "note": "\"Do not exalt yourself in the king's presence... it is better for him to say to you, 'Come up here' than for him to humiliate you before his nobles\" — the wisdom text Jesus's seating parable expands and radicalises."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:5",
-              "note": "\"A child or an ox that falls into a well\" \u2014 the argument escalates from Mark 3:4 (animal care on the Sabbath) to child rescue. If you would immediately rescue your own child or valuable animal, how can you object to the healing of a human being? The opponents' silence (v.6) is the only possible response to a logically unanswerable argument."
+              "note": "\"A child or an ox that falls into a well\" — the argument escalates from Mark 3:4 (animal care on the Sabbath) to child rescue. If you would immediately rescue your own child or valuable animal, how can you object to the healing of a human being? The opponents' silence (v.6) is the only possible response to a logically unanswerable argument."
             },
             {
               "ref": "14:12-14",
-              "note": "Jesus redefines generosity: true generosity gives to those who cannot repay. Social networking through dinner invitations is self-interest dressed as hospitality. Genuine hospitality invites the poor, the crippled, the lame, the blind \u2014 those who can offer nothing in return. The repayment comes at \"the resurrection of the righteous,\" not at the next dinner party."
+              "note": "Jesus redefines generosity: true generosity gives to those who cannot repay. Social networking through dinner invitations is self-interest dressed as hospitality. Genuine hospitality invites the poor, the crippled, the lame, the blind — those who can offer nothing in return. The repayment comes at \"the resurrection of the righteous,\" not at the next dinner party."
             },
             {
               "ref": "14:18-20",
-              "note": "The three excuses are not unreasonable in themselves \u2014 land purchase, livestock investment, and marriage are legitimate concerns. But their timing is the insult. The banquet was prepared; the invitation was accepted; the summons came. The excuses reveal that other priorities have displaced the invitation. The application to the Jewish establishment's response to Jesus is unmistakable."
+              "note": "The three excuses are not unreasonable in themselves — land purchase, livestock investment, and marriage are legitimate concerns. But their timing is the insult. The banquet was prepared; the invitation was accepted; the summons came. The excuses reveal that other priorities have displaced the invitation. The application to the Jewish establishment's response to Jesus is unmistakable."
             },
             {
               "ref": "14:23",
-              "note": "\"Make them come in\" \u2014 anagkason, compel. The third stage of the invitation reaches beyond the town altogether, to the roads and country lanes \u2014 Gentiles, in the parable's allegorical register. The house is to be full; the original guests' refusal does not diminish the feast but changes the guest list."
+              "note": "\"Make them come in\" — anagkason, compel. The third stage of the invitation reaches beyond the town altogether, to the roads and country lanes — Gentiles, in the parable's allegorical register. The house is to be full; the original guests' refusal does not diminish the feast but changes the guest list."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:7-11",
-              "note": "Calvin notes that Jesus is not merely giving etiquette advice \u2014 he is describing the fundamental inversion of the kingdom's social order. The posture of humility is not a strategy for getting honour but the only posture appropriate before God, who alone exalts. Those who seek honour for themselves have already taken their reward; those who seek God's honour receive it from God's hand."
+              "note": "Calvin notes that Jesus is not merely giving etiquette advice — he is describing the fundamental inversion of the kingdom's social order. The posture of humility is not a strategy for getting honour but the only posture appropriate before God, who alone exalts. Those who seek honour for themselves have already taken their reward; those who seek God's honour receive it from God's hand."
             },
             {
               "ref": "14:21-24",
@@ -82,7 +82,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "14:5",
@@ -90,139 +90,139 @@
             },
             {
               "ref": "14:23",
-              "note": "\"Make them come in\" (NIV) \u2014 the Latin compelle intrare became the most controversial phrase in the parable, used by Augustine to justify coercion of Donatist schismatics and later by medieval authorities to justify forced conversion. The context makes clear that the compulsion is the urgency of the invitation, not physical force."
+              "note": "\"Make them come in\" (NIV) — the Latin compelle intrare became the most controversial phrase in the parable, used by Augustine to justify coercion of Donatist schismatics and later by medieval authorities to justify forced conversion. The context makes clear that the compulsion is the urgency of the invitation, not physical force."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "14:2",
-              "note": "Hydr\u014dpikos \u2014 a medical technical term. Robertson notes that only Luke among the evangelists uses precise medical vocabulary consistently \u2014 the physician's hand is evident throughout."
+              "note": "Hydrōpikos — a medical technical term. Robertson notes that only Luke among the evangelists uses precise medical vocabulary consistently — the physician's hand is evident throughout."
             },
             {
               "ref": "14:18",
-              "note": "Paraitoumai \u2014 \"I beg off,\" a word used for excusing oneself from military service as well as social obligations. The urgency of the excuses is conveyed by the apo mias (all at once, unanimously) \u2014 they did not discuss it; they all refused simultaneously."
+              "note": "Paraitoumai — \"I beg off,\" a word used for excusing oneself from military service as well as social obligations. The urgency of the excuses is conveyed by the apo mias (all at once, unanimously) — they did not discuss it; they all refused simultaneously."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "14:11",
-              "note": "Gregory the Great: \"In the kingdom of God there is no pride of place by right of birth or wealth, but of merit. Therefore he who humbles himself here will be exalted there \u2014 not because humility itself merits the reward, but because humility opens the person to receive what only God can give.\""
+              "note": "Gregory the Great: \"In the kingdom of God there is no pride of place by right of birth or wealth, but of merit. Therefore he who humbles himself here will be exalted there — not because humility itself merits the reward, but because humility opens the person to receive what only God can give.\""
             },
             {
               "ref": "14:16-17",
-              "note": "Augustine: \"God prepared the banquet from before the foundation of the world. When the time came \u2014 when Christ came \u2014 he sent his servant to say: 'Come, for everything is now ready.' The readiness is perfect; the refusal is entirely on the side of those invited.\""
+              "note": "Augustine: \"God prepared the banquet from before the foundation of the world. When the time came — when Christ came — he sent his servant to say: 'Come, for everything is now ready.' The readiness is perfect; the refusal is entirely on the side of those invited.\""
             }
           ]
         },
         "hist": {
-          "context": "Dinner Party as Theological Arena\nLuke's Jesus is consistently at table \u2014 with Pharisees (7:36-50; 11:37-54; 14:1-24), with tax collectors (5:29-32; 19:1-10), and with disciples (22:7-38). The meal is Luke's preferred setting for theological controversy and reversal. The great banquet parable (14:16-24) is the climax of a sustained dinner-table meditation on who truly belongs at the eschatological feast.\n\nThe Double Invitation\nFirst-century dinner invitations worked in two stages: a prior invitation, then a summons when the food was ready. The guests who refuse the second summons (14:18-20) have committed a serious social insult \u2014 they accepted the first invitation and then refused when the time came. Their excuses (land, oxen, marriage) are all legitimate activities but none constitute an adequate reason for the insult."
+          "context": "Dinner Party as Theological Arena\nLuke's Jesus is consistently at table — with Pharisees (7:36-50; 11:37-54; 14:1-24), with tax collectors (5:29-32; 19:1-10), and with disciples (22:7-38). The meal is Luke's preferred setting for theological controversy and reversal. The great banquet parable (14:16-24) is the climax of a sustained dinner-table meditation on who truly belongs at the eschatological feast.\n\nThe Double Invitation\nFirst-century dinner invitations worked in two stages: a prior invitation, then a summons when the food was ready. The guests who refuse the second summons (14:18-20) have committed a serious social insult — they accepted the first invitation and then refused when the time came. Their excuses (land, oxen, marriage) are all legitimate activities but none constitute an adequate reason for the insult."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 15\u201124 \u2014 The Parable of the Great Banquet",
+      "header": "Verses 15‑24 — The Parable of the Great Banquet",
       "verse_start": 15,
       "verse_end": 24,
       "panels": {
         "heb": [
           {
-            "word": "mise\u014d",
+            "word": "miseō",
             "transliteration": "mi-SEH-o",
             "gloss": "hate",
-            "paragraph": "The word (v.26) is Semitic hyperbole for relative priority \u2014 \"love less by comparison\" rather than active animosity. Matt 10:37 uses the Greek for \"love more\" to express the same teaching. Jesus demands that loyalty to him supersede every other loyalty, including the deepest family bonds."
+            "paragraph": "The word (v.26) is Semitic hyperbole for relative priority — \"love less by comparison\" rather than active animosity. Matt 10:37 uses the Greek for \"love more\" to express the same teaching. Jesus demands that loyalty to him supersede every other loyalty, including the deepest family bonds."
           },
           {
-            "word": "bastaz\u014d",
+            "word": "bastazō",
             "transliteration": "bas-TA-zo",
             "gloss": "carry / bear",
-            "paragraph": "The verb (v.27) means to lift and carry as a burden \u2014 the cross as a physical object to be shouldered, not a metaphor for general difficulty. Jesus's hearers knew what crucifixion looked like: a condemned man carrying his own crossbeam through the city to his execution."
+            "paragraph": "The verb (v.27) means to lift and carry as a burden — the cross as a physical object to be shouldered, not a metaphor for general difficulty. Jesus's hearers knew what crucifixion looked like: a condemned man carrying his own crossbeam through the city to his execution."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 10:37-38",
-              "note": "\"Anyone who loves their father or mother more than me is not worthy of me\" \u2014 Matthew's less extreme formulation of the same demand, making explicit that the \"hate\" is relative priority."
+              "note": "\"Anyone who loves their father or mother more than me is not worthy of me\" — Matthew's less extreme formulation of the same demand, making explicit that the \"hate\" is relative priority."
             },
             {
               "ref": "Mark 8:34-38",
-              "note": "The cross-bearing saying in Mark, placed after Peter's confession \u2014 a slightly different context suggesting the saying circulated widely."
+              "note": "The cross-bearing saying in Mark, placed after Peter's confession — a slightly different context suggesting the saying circulated widely."
             },
             {
               "ref": "Matt 5:13",
-              "note": "\"You are the salt of the earth. But if the salt loses its saltiness, how can it be made salty again?\" \u2014 parallel salt saying in the Sermon on the Mount."
+              "note": "\"You are the salt of the earth. But if the salt loses its saltiness, how can it be made salty again?\" — parallel salt saying in the Sermon on the Mount."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:26",
-              "note": "\"Hate\" \u2014 hyperbolic Semitic idiom for relative priority. The demand is that loyalty to Christ supersede every other loyalty, including the most natural and deepest \u2014 parents, spouse, children, siblings, and even one's own life. The shock of the language is intentional: Jesus is not competing for second place in one's priorities."
+              "note": "\"Hate\" — hyperbolic Semitic idiom for relative priority. The demand is that loyalty to Christ supersede every other loyalty, including the most natural and deepest — parents, spouse, children, siblings, and even one's own life. The shock of the language is intentional: Jesus is not competing for second place in one's priorities."
             },
             {
               "ref": "14:28-32",
-              "note": "Both parables warn against superficial commitment. The builder who begins without counting the cost becomes a public embarrassment. The king who goes to war without assessing his odds faces destruction. The application: count the full cost of discipleship before committing, because incomplete discipleship is worse than no discipleship \u2014 it brings dishonour to the cause."
+              "note": "Both parables warn against superficial commitment. The builder who begins without counting the cost becomes a public embarrassment. The king who goes to war without assessing his odds faces destruction. The application: count the full cost of discipleship before committing, because incomplete discipleship is worse than no discipleship — it brings dishonour to the cause."
             },
             {
               "ref": "14:33",
-              "note": "\"Give up everything you have\" \u2014 panta ta heautou. Not merely a sentimental detachment but actual dispossession. The rich young ruler (18:18-23) illustrates the failure of this demand: he wanted Jesus plus his possessions. Jesus says the cost is total."
+              "note": "\"Give up everything you have\" — panta ta heautou. Not merely a sentimental detachment but actual dispossession. The rich young ruler (18:18-23) illustrates the failure of this demand: he wanted Jesus plus his possessions. Jesus says the cost is total."
             },
             {
               "ref": "14:34-35",
-              "note": "The salt metaphor closes the section: a disciple who abandons the radical commitment is like salt that has lost its saltiness \u2014 useless, fit for nothing, thrown out. The warning is against the gradual dilution of discipleship until the distinctive character (the saltiness) is gone."
+              "note": "The salt metaphor closes the section: a disciple who abandons the radical commitment is like salt that has lost its saltiness — useless, fit for nothing, thrown out. The warning is against the gradual dilution of discipleship until the distinctive character (the saltiness) is gone."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:26-27",
-              "note": "Calvin insists the \"hate\" language is not a literal command to despise family but a call to relative priority \u2014 Christ must be supreme. However, Calvin also insists the demand is genuinely costly: there will be moments when loyalty to Christ and loyalty to family genuinely conflict, and in those moments Christ must be chosen even at real personal cost."
+              "note": "Calvin insists the \"hate\" language is not a literal command to despise family but a call to relative priority — Christ must be supreme. However, Calvin also insists the demand is genuinely costly: there will be moments when loyalty to Christ and loyalty to family genuinely conflict, and in those moments Christ must be chosen even at real personal cost."
             },
             {
               "ref": "14:28-33",
-              "note": "The counting-the-cost parables are directed not at those outside the faith but at those already following \u2014 the large crowds of v.25. Jesus wants genuine disciples who understand what they are committing to, not a swelling crowd of fair-weather followers whose enthusiasm will evaporate at the first serious cost."
+              "note": "The counting-the-cost parables are directed not at those outside the faith but at those already following — the large crowds of v.25. Jesus wants genuine disciples who understand what they are committing to, not a swelling crowd of fair-weather followers whose enthusiasm will evaporate at the first serious cost."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "14:26",
-              "note": "The parallel in Matthew (10:37) uses \"love more/less\" language, suggesting that the Lukan \"hate\" (mise\u014d) is a Semitic idiom of relative comparison that Greek preserves literally where Matthew paraphrases. The theological demand is the same: Christ as the absolute priority over every other loyalty."
+              "note": "The parallel in Matthew (10:37) uses \"love more/less\" language, suggesting that the Lukan \"hate\" (miseō) is a Semitic idiom of relative comparison that Greek preserves literally where Matthew paraphrases. The theological demand is the same: Christ as the absolute priority over every other loyalty."
             },
             {
               "ref": "14:34",
-              "note": "Palestinian salt in the first century was often impure \u2014 mixed with gypsum and other minerals. When the sodium chloride leached out through contact with moisture, what remained was tasteless residue that looked like salt but had lost all its preserving and flavouring properties. The image is of a disciple whose distinctive character has been lost through compromise."
+              "note": "Palestinian salt in the first century was often impure — mixed with gypsum and other minerals. When the sodium chloride leached out through contact with moisture, what remained was tasteless residue that looked like salt but had lost all its preserving and flavouring properties. The image is of a disciple whose distinctive character has been lost through compromise."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "14:26",
-              "note": "Mise\u014d \u2014 the word is strong but must be read in its Semitic context. The Hebrew idiom of loving/hating means to prefer/not prefer (cf. Gen 29:30-31; Mal 1:2-3; Rom 9:13). Robertson notes Matthew's parallel (10:37) uses \"love more\" where Luke has \"hate\" \u2014 confirming the comparative sense."
+              "note": "Miseō — the word is strong but must be read in its Semitic context. The Hebrew idiom of loving/hating means to prefer/not prefer (cf. Gen 29:30-31; Mal 1:2-3; Rom 9:13). Robertson notes Matthew's parallel (10:37) uses \"love more\" where Luke has \"hate\" — confirming the comparative sense."
             },
             {
               "ref": "14:27",
-              "note": "Bastaz\u014d \u2014 present active infinitive of continuous action: \"keep on carrying his own cross.\" Not a single act but a posture maintained throughout the journey. The cross is not picked up once but carried daily."
+              "note": "Bastazō — present active infinitive of continuous action: \"keep on carrying his own cross.\" Not a single act but a posture maintained throughout the journey. The cross is not picked up once but carried daily."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "14:26",
@@ -235,25 +235,25 @@
           ]
         },
         "hist": {
-          "context": "Cross-Bearing Before the Crucifixion\nJesus speaks of cross-bearing before his own crucifixion. His hearers knew the image: condemned criminals carried their crossbeams in public procession as a final humiliation. To \"carry your cross\" was to accept public shame, loss of status, and potentially death. Jesus is not using a vague metaphor \u2014 he is describing radical identification with the rejected and condemned.\n\nThe Counting-the-Cost Parables\nThe tower-builder and king-at-war parables (14:28-32) make the same point from different angles: wise action requires calculating the full cost before committing. Applied to discipleship, the demand is not to count the cost and decide it's too high, but to count it accurately so that the commitment made is genuine and complete. Cheap discipleship that abandons the project is worse than not starting."
+          "context": "Cross-Bearing Before the Crucifixion\nJesus speaks of cross-bearing before his own crucifixion. His hearers knew the image: condemned criminals carried their crossbeams in public procession as a final humiliation. To \"carry your cross\" was to accept public shame, loss of status, and potentially death. Jesus is not using a vague metaphor — he is describing radical identification with the rejected and condemned.\n\nThe Counting-the-Cost Parables\nThe tower-builder and king-at-war parables (14:28-32) make the same point from different angles: wise action requires calculating the full cost before committing. Applied to discipleship, the demand is not to count the cost and decide it's too high, but to count it accurately so that the commitment made is genuine and complete. Cheap discipleship that abandons the project is worse than not starting."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 25\u201135 \u2014 The Cost of Discipleship; Salt and Its Saltiness",
+      "header": "Verses 25‑35 — The Cost of Discipleship; Salt and Its Saltiness",
       "verse_start": 25,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "hydr\u014dpikos",
+            "word": "hydrōpikos",
             "transliteration": "hyd-RO-pi-kos",
             "gloss": "dropsy / abnormal swelling",
-            "paragraph": "The medical term (v.2) for the accumulation of fluid in the body \u2014 a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
+            "paragraph": "The medical term (v.2) for the accumulation of fluid in the body — a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
           },
           {
-            "word": "tapein\u014dsis / hyps\u014dsis",
+            "word": "tapeinōsis / hypsōsis",
             "transliteration": "ta-pei-NO-sis / hyp-SO-sis",
             "gloss": "humiliation / exaltation",
             "paragraph": "The reversal axiom (v.11: \"all who exalt themselves will be humbled; all who humble themselves will be exalted\") is a central Lukan theme that runs from the Magnificat (1:52) through the beatitudes (6:20-26) to the great banquet here. The Greek words carry weight in the LXX's wisdom tradition."
@@ -263,93 +263,40 @@
           "refs": [
             {
               "ref": "Matt 22:1-14",
-              "note": "Matthew's parallel great banquet parable, set as a king's wedding feast for his son \u2014 more explicitly allegorical and including the man without a wedding garment."
+              "note": "Matthew's parallel great banquet parable, set as a king's wedding feast for his son — more explicitly allegorical and including the man without a wedding garment."
             },
             {
               "ref": "Luke 1:52",
-              "note": "The Magnificat: \"He has brought down rulers from their thrones but has lifted up the humble\" \u2014 the reversal axiom that the seating parable (14:7-11) illustrates in miniature."
+              "note": "The Magnificat: \"He has brought down rulers from their thrones but has lifted up the humble\" — the reversal axiom that the seating parable (14:7-11) illustrates in miniature."
             },
             {
               "ref": "Prov 25:6-7",
-              "note": "\"Do not exalt yourself in the king's presence... it is better for him to say to you, 'Come up here' than for him to humiliate you before his nobles\" \u2014 the wisdom text Jesus's seating parable expands and radicalises."
+              "note": "\"Do not exalt yourself in the king's presence... it is better for him to say to you, 'Come up here' than for him to humiliate you before his nobles\" — the wisdom text Jesus's seating parable expands and radicalises."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:5",
-              "note": "\"A child or an ox that falls into a well\" \u2014 the argument escalates from Mark 3:4 (animal care on the Sabbath) to child rescue. If you would immediately rescue your own child or valuable animal, how can you object to the healing of a human being? The opponents' silence (v.6) is the only possible response to a logically unanswerable argument."
-            },
-            {
-              "ref": "14:12-14",
-              "note": "Jesus redefines generosity: true generosity gives to those who cannot repay. Social networking through dinner invitations is self-interest dressed as hospitality. Genuine hospitality invites the poor, the crippled, the lame, the blind \u2014 those who can offer nothing in return. The repayment comes at \"the resurrection of the righteous,\" not at the next dinner party."
-            },
-            {
-              "ref": "14:18-20",
-              "note": "The three excuses are not unreasonable in themselves \u2014 land purchase, livestock investment, and marriage are legitimate concerns. But their timing is the insult. The banquet was prepared; the invitation was accepted; the summons came. The excuses reveal that other priorities have displaced the invitation. The application to the Jewish establishment's response to Jesus is unmistakable."
-            },
-            {
-              "ref": "14:23",
-              "note": "\"Make them come in\" \u2014 anagkason, compel. The third stage of the invitation reaches beyond the town altogether, to the roads and country lanes \u2014 Gentiles, in the parable's allegorical register. The house is to be full; the original guests' refusal does not diminish the feast but changes the guest list."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:7-11",
-              "note": "Calvin notes that Jesus is not merely giving etiquette advice \u2014 he is describing the fundamental inversion of the kingdom's social order. The posture of humility is not a strategy for getting honour but the only posture appropriate before God, who alone exalts. Those who seek honour for themselves have already taken their reward; those who seek God's honour receive it from God's hand."
-            },
-            {
-              "ref": "14:21-24",
-              "note": "The parable's allegorical transparency to Israel's situation is deliberate. Those who had the prior invitation (Israel, the covenant people) refused when the summons came. Those brought in from the streets and alleys (tax collectors, sinners, the marginalized in Israel) and from the roads and country lanes (Gentiles) are the recipients of the kingdom by default of those who refused."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:5",
-              "note": "The manuscripts vary between \"son\" (huios) and \"donkey\" (onos) in v.5. NA28 reads \"son\" (huios); some important witnesses read \"donkey.\" If \"donkey,\" the argument moves from animal (lower) to human (higher); if \"son,\" it moves from child (high concern) to livestock (lower) to human patient (equal or higher). Either reading supports the a fortiori argument."
-            },
-            {
-              "ref": "14:23",
-              "note": "\"Make them come in\" (NIV) \u2014 the Latin compelle intrare became the most controversial phrase in the parable, used by Augustine to justify coercion of Donatist schismatics and later by medieval authorities to justify forced conversion. The context makes clear that the compulsion is the urgency of the invitation, not physical force."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "14:2",
-              "note": "Hydr\u014dpikos \u2014 a medical technical term. Robertson notes that only Luke among the evangelists uses precise medical vocabulary consistently \u2014 the physician's hand is evident throughout."
-            },
-            {
-              "ref": "14:18",
-              "note": "Paraitoumai \u2014 \"I beg off,\" a word used for excusing oneself from military service as well as social obligations. The urgency of the excuses is conveyed by the apo mias (all at once, unanimously) \u2014 they did not discuss it; they all refused simultaneously."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "14:11",
-              "note": "Gregory the Great: \"In the kingdom of God there is no pride of place by right of birth or wealth, but of merit. Therefore he who humbles himself here will be exalted there \u2014 not because humility itself merits the reward, but because humility opens the person to receive what only God can give.\""
-            },
-            {
-              "ref": "14:16-17",
-              "note": "Augustine: \"God prepared the banquet from before the foundation of the world. When the time came \u2014 when Christ came \u2014 he sent his servant to say: 'Come, for everything is now ready.' The readiness is perfect; the refusal is entirely on the side of those invited.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Dinner Party as Theological Arena\nLuke's Jesus is consistently at table \u2014 with Pharisees (7:36-50; 11:37-54; 14:1-24), with tax collectors (5:29-32; 19:1-10), and with disciples (22:7-38). The meal is Luke's preferred setting for theological controversy and reversal. The great banquet parable (14:16-24) is the climax of a sustained dinner-table meditation on who truly belongs at the eschatological feast.\n\nThe Double Invitation\nFirst-century dinner invitations worked in two stages: a prior invitation, then a summons when the food was ready. The guests who refuse the second summons (14:18-20) have committed a serious social insult \u2014 they accepted the first invitation and then refused when the time came. Their excuses (land, oxen, marriage) are all legitimate activities but none constitute an adequate reason for the insult."
+          "context": "Dinner Party as Theological Arena\nLuke's Jesus is consistently at table — with Pharisees (7:36-50; 11:37-54; 14:1-24), with tax collectors (5:29-32; 19:1-10), and with disciples (22:7-38). The meal is Luke's preferred setting for theological controversy and reversal. The great banquet parable (14:16-24) is the climax of a sustained dinner-table meditation on who truly belongs at the eschatological feast.\n\nThe Double Invitation\nFirst-century dinner invitations worked in two stages: a prior invitation, then a summons when the food was ready. The guests who refuse the second summons (14:18-20) have committed a serious social insult — they accepted the first invitation and then refused when the time came. Their excuses (land, oxen, marriage) are all legitimate activities but none constitute an adequate reason for the insult."
         }
       }
     }
@@ -359,36 +306,36 @@
       {
         "name": "Jesus",
         "role": "Host and Teacher",
-        "text": "Luke 14's Jesus is simultaneously guest (at the Pharisee's table) and host (of the eschatological banquet). His teaching inverts the social logic of every gathering \u2014 the first will be last, the excluded will be included, the cost is total."
+        "text": "Luke 14's Jesus is simultaneously guest (at the Pharisee's table) and host (of the eschatological banquet). His teaching inverts the social logic of every gathering — the first will be last, the excluded will be included, the cost is total."
       },
       {
         "name": "The Man with Dropsy",
         "role": "Silent recipient",
-        "text": "Healed without a word spoken by him \u2014 he appears, Jesus acts, he is dismissed. His presence at a Pharisee's Sabbath dinner is itself curious; he may have been placed there as a test."
+        "text": "Healed without a word spoken by him — he appears, Jesus acts, he is dismissed. His presence at a Pharisee's Sabbath dinner is itself curious; he may have been placed there as a test."
       },
       {
         "name": "The Host (Prominent Pharisee)",
         "role": "Wealthy host",
-        "text": "The setting of the chapter. Jesus accepts his invitation but immediately subverts the social conventions of the occasion \u2014 instructing the guests on seating, the host on invitation policy, and then telling a parable that allegorically indicts the host's class."
+        "text": "The setting of the chapter. Jesus accepts his invitation but immediately subverts the social conventions of the occasion — instructing the guests on seating, the host on invitation policy, and then telling a parable that allegorically indicts the host's class."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">huios / onos (14:5)</td><td>NIV: \"a son or ox\"; many MSS: \"a donkey or ox.\" The manuscript variation affects whether the first case is a child or an animal, but not the force of the argument.</td></tr><tr><td class=\"t-label\">anagkason (14:23)</td><td>NIV: \"make them come in\"; KJV: \"compel them\"; ESV: \"compel people to come in\". The Latin compelle intrare has a troubled history of misuse for coercion. The Greek means urgent persuasion, not physical force.</td></tr><tr><td class=\"t-label\">mise\u014d (14:26)</td><td>NIV: \"does not hate\"; KJV: \"hate not\"; ESV: \"does not hate\"; NRSV: \"does not hate\". All versions translate literally, relying on context and the Matt 10:37 parallel to show the comparative meaning.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">huios / onos (14:5)</td><td>NIV: \"a son or ox\"; many MSS: \"a donkey or ox.\" The manuscript variation affects whether the first case is a child or an animal, but not the force of the argument.</td></tr><tr><td class=\"t-label\">anagkason (14:23)</td><td>NIV: \"make them come in\"; KJV: \"compel them\"; ESV: \"compel people to come in\". The Latin compelle intrare has a troubled history of misuse for coercion. The Greek means urgent persuasion, not physical force.</td></tr><tr><td class=\"t-label\">miseō (14:26)</td><td>NIV: \"does not hate\"; KJV: \"hate not\"; ESV: \"does not hate\"; NRSV: \"does not hate\". All versions translate literally, relying on context and the Matt 10:37 parallel to show the comparative meaning.</td></tr>",
     "src": [
       {
         "title": "Proverbs 25:6-7",
         "quote": "\"Do not exalt yourself in the king's presence... it is better for him to say to you, 'Come up here' than for him to humiliate you.\"",
-        "note": "The wisdom text Jesus radicalises in the seating parable \u2014 the same wisdom principle of voluntary humility leading to honour, but Jesus locates the ultimate honour at the resurrection rather than at the next banquet."
+        "note": "The wisdom text Jesus radicalises in the seating parable — the same wisdom principle of voluntary humility leading to honour, but Jesus locates the ultimate honour at the resurrection rather than at the next banquet."
       },
       {
         "title": "Isaiah 25:6",
-        "quote": "\"On this mountain the Lord Almighty will prepare a feast of rich food for all peoples\" \u2014 the eschatological banquet that provides the biblical background for Jesus's great banquet parable and for the table fellowship that characterises his ministry.",
-        "note": "The Isaianic vision of a universal feast is the horizon against which the great banquet parable plays \u2014 the kingdom feast is being prepared; the question is who will be present."
+        "quote": "\"On this mountain the Lord Almighty will prepare a feast of rich food for all peoples\" — the eschatological banquet that provides the biblical background for Jesus's great banquet parable and for the table fellowship that characterises his ministry.",
+        "note": "The Isaianic vision of a universal feast is the horizon against which the great banquet parable plays — the kingdom feast is being prepared; the question is who will be present."
       }
     ],
     "rec": [
       {
         "who": "The Great Banquet in Mission Theology",
-        "text": "The third stage of the invitation \u2014 \"go out to the roads and country lanes\" (14:23) \u2014 became a key text for Gentile mission theology. Origen, Chrysostom, and later Protestant missionaries used it to argue for the universal scope of the gospel invitation. The \"compel them to come in\" phrase, however, was controversially deployed by Augustine to justify coercive policies toward Donatists, establishing a lasting exegetical controversy."
+        "text": "The third stage of the invitation — \"go out to the roads and country lanes\" (14:23) — became a key text for Gentile mission theology. Origen, Chrysostom, and later Protestant missionaries used it to argue for the universal scope of the gospel invitation. The \"compel them to come in\" phrase, however, was controversially deployed by Augustine to justify coercive policies toward Donatists, establishing a lasting exegetical controversy."
       },
       {
         "who": "Cost of Discipleship in Reformation and Modern Theology",
@@ -398,12 +345,12 @@
     "lit": {
       "rows": [
         {
-          "label": "Escalation \u2014 vv.16-23",
-          "text": "Three stages of invitation: the original guests refuse \u2192 the town's poor and marginalised are invited \u2192 roads and country lanes are swept for guests. The scope expands as the refusals multiply; the feast will be full regardless.",
+          "label": "Escalation — vv.16-23",
+          "text": "Three stages of invitation: the original guests refuse → the town's poor and marginalised are invited → roads and country lanes are swept for guests. The scope expands as the refusals multiply; the feast will be full regardless.",
           "is_key": false
         },
         {
-          "label": "Double Parable \u2014 vv.28-32",
+          "label": "Double Parable — vv.28-32",
           "text": "The tower-builder and the king at war make the same point from civilian and military angles. Luke frequently pairs parables to reinforce a single truth from two perspectives (cf. 15:4-10; 18:1-14).",
           "is_key": false
         }
@@ -412,37 +359,37 @@
     },
     "hebtext": [
       {
-        "word": "hydr\u014dpikos",
+        "word": "hydrōpikos",
         "tlit": "hyd-RO-pi-kos",
         "gloss": "dropsy / abnormal swelling",
-        "note": "The medical term (v.2) for the accumulation of fluid in the body \u2014 a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
+        "note": "The medical term (v.2) for the accumulation of fluid in the body — a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
       },
       {
-        "word": "tapein\u014dsis / hyps\u014dsis",
+        "word": "tapeinōsis / hypsōsis",
         "tlit": "ta-pei-NO-sis / hyp-SO-sis",
         "gloss": "humiliation / exaltation",
         "note": "The reversal axiom (v.11: \"all who exalt themselves will be humbled; all who humble themselves will be exalted\") is a central Lukan theme that runs from the Magnificat (1:52) through the beatitudes (6:20-26) to the great banquet here. The Greek words carry weight in the LXX's wisdom tradition."
       },
       {
-        "word": "mise\u014d",
+        "word": "miseō",
         "tlit": "mi-SEH-o",
         "gloss": "hate",
-        "note": "The word (v.26) is Semitic hyperbole for relative priority \u2014 \"love less by comparison\" rather than active animosity. Matt 10:37 uses the Greek for \"love more\" to express the same teaching. Jesus demands that loyalty to him supersede every other loyalty, including the deepest family bonds."
+        "note": "The word (v.26) is Semitic hyperbole for relative priority — \"love less by comparison\" rather than active animosity. Matt 10:37 uses the Greek for \"love more\" to express the same teaching. Jesus demands that loyalty to him supersede every other loyalty, including the deepest family bonds."
       },
       {
-        "word": "bastaz\u014d",
+        "word": "bastazō",
         "tlit": "bas-TA-zo",
         "gloss": "carry / bear",
-        "note": "The verb (v.27) means to lift and carry as a burden \u2014 the cross as a physical object to be shouldered, not a metaphor for general difficulty. Jesus's hearers knew what crucifixion looked like: a condemned man carrying his own crossbeam through the city to his execution."
+        "note": "The verb (v.27) means to lift and carry as a burden — the cross as a physical object to be shouldered, not a metaphor for general difficulty. Jesus's hearers knew what crucifixion looked like: a condemned man carrying his own crossbeam through the city to his execution."
       },
       {
-        "word": "hydr\u014dpikos",
+        "word": "hydrōpikos",
         "tlit": "hyd-RO-pi-kos",
         "gloss": "dropsy / abnormal swelling",
-        "note": "The medical term (v.2) for the accumulation of fluid in the body \u2014 a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
+        "note": "The medical term (v.2) for the accumulation of fluid in the body — a condition associated with liver or kidney disease. Luke, the physician (Col 4:14), uses the precise medical vocabulary. The condition was visible, probably severe, and would have been considered ritually problematic."
       },
       {
-        "word": "tapein\u014dsis / hyps\u014dsis",
+        "word": "tapeinōsis / hypsōsis",
         "tlit": "ta-pei-NO-sis / hyp-SO-sis",
         "gloss": "humiliation / exaltation",
         "note": "The reversal axiom (v.11: \"all who exalt themselves will be humbled; all who humble themselves will be exalted\") is a central Lukan theme that runs from the Magnificat (1:52) through the beatitudes (6:20-26) to the great banquet here. The Greek words carry weight in the LXX's wisdom tradition."
@@ -506,7 +453,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 14 is structured around the theology of the table. The Sabbath healing, the seating parable, the invitation policy, and the great banquet all develop a single argument: the kingdom of God reverses every social hierarchy, operates on a logic of generosity without reciprocity, and welcomes those the world excludes. The chapter's second half is equally radical: the same kingdom that includes the marginalised demands total commitment from those who would follow \u2014 there is no comfortable middle position between the feast and the road."
+      "note": "Luke 14 is structured around the theology of the table. The Sabbath healing, the seating parable, the invitation policy, and the great banquet all develop a single argument: the kingdom of God reverses every social hierarchy, operates on a logic of generosity without reciprocity, and welcomes those the world excludes. The chapter's second half is equally radical: the same kingdom that includes the marginalised demands total commitment from those who would follow — there is no comfortable middle position between the feast and the road."
     }
   },
   "vhl_groups": [
@@ -627,7 +574,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'When you give a banquet, invite the poor, the crippled, the lame, the blind' (v. 13). Hospitality without reciprocity\u2014those who can't repay. Kingdom generosity expects nothing back.",
+      "tip": "'When you give a banquet, invite the poor, the crippled, the lame, the blind' (v. 13). Hospitality without reciprocity—those who can't repay. Kingdom generosity expects nothing back.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/luke/15.json
+++ b/content/luke/15.json
@@ -7,69 +7,69 @@
   "subtitle": "The Lost Sheep, Lost Coin, and Prodigal Son",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201110 \u2014 The Lost Sheep and the Lost Coin",
+      "header": "Verses 1‑10 — The Lost Sheep and the Lost Coin",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
         "heb": [
           {
-            "word": "apol\u014dlos",
+            "word": "apolōlos",
             "transliteration": "a-po-LO-los",
             "gloss": "lost",
-            "paragraph": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 \u2014 apol\u014dl\u014ds). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist \u2014 it has become separated from its proper place and owner."
+            "paragraph": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 — apolōlōs). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist — it has become separated from its proper place and owner."
           },
           {
             "word": "chairete",
             "transliteration": "CHAI-re-te",
             "gloss": "rejoice / share in the joy",
-            "paragraph": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal \u2014 as is the joy of heaven over one repentant sinner."
+            "paragraph": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal — as is the joy of heaven over one repentant sinner."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 18:12-14",
-              "note": "Matthew's parallel lost sheep parable, placed in the discourse on community care \u2014 the application is slightly different (care for straying community members) but the parable is the same."
+              "note": "Matthew's parallel lost sheep parable, placed in the discourse on community care — the application is slightly different (care for straying community members) but the parable is the same."
             },
             {
               "ref": "Ezek 34:11-16",
-              "note": "\"For this is what the Sovereign Lord says: I myself will search for my sheep and look after them\" \u2014 the OT background. Jesus's seeking of the lost is the fulfilment of YHWH's promise to be the shepherd Israel's leaders failed to be."
+              "note": "\"For this is what the Sovereign Lord says: I myself will search for my sheep and look after them\" — the OT background. Jesus's seeking of the lost is the fulfilment of YHWH's promise to be the shepherd Israel's leaders failed to be."
             },
             {
               "ref": "Ps 119:176",
-              "note": "\"I have strayed like a lost sheep\" \u2014 the Psalmist's self-description that provides the scriptural image of the lost condition."
+              "note": "\"I have strayed like a lost sheep\" — the Psalmist's self-description that provides the scriptural image of the lost condition."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:4",
-              "note": "\"Leave the ninety-nine in the open country\" \u2014 the shocking element of the parable. A responsible shepherd does not abandon 99 sheep for 1. But the parable describes God's priorities, not sound animal husbandry. The 99 are left \u2014 entrusted to each other, perhaps, or to other shepherds \u2014 because one lost sheep is worth the full expenditure of the shepherd's energy."
+              "note": "\"Leave the ninety-nine in the open country\" — the shocking element of the parable. A responsible shepherd does not abandon 99 sheep for 1. But the parable describes God's priorities, not sound animal husbandry. The 99 are left — entrusted to each other, perhaps, or to other shepherds — because one lost sheep is worth the full expenditure of the shepherd's energy."
             },
             {
               "ref": "15:7",
-              "note": "\"More rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent\" \u2014 the comparative is not a slight on the righteous but an expression of the intensity of joy over recovery. The ninety-nine are safe; the one was lost. Joy tracks the movement from danger to safety, from separation to reunion."
+              "note": "\"More rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent\" — the comparative is not a slight on the righteous but an expression of the intensity of joy over recovery. The ninety-nine are safe; the one was lost. Joy tracks the movement from danger to safety, from separation to reunion."
             },
             {
               "ref": "15:8-9",
-              "note": "The woman's lamp, sweep, and search describe God's diligence in seeking the lost. The coin cannot cooperate \u2014 unlike the sheep which can be called and the son who must \"come to his senses.\" God's seeking precedes and enables human response."
+              "note": "The woman's lamp, sweep, and search describe God's diligence in seeking the lost. The coin cannot cooperate — unlike the sheep which can be called and the son who must \"come to his senses.\" God's seeking precedes and enables human response."
             },
             {
               "ref": "15:10",
-              "note": "\"Rejoicing in the presence of the angels of God\" \u2014 not merely that angels rejoice but that there is rejoicing in the divine assembly at the news of one repentant sinner. Heaven's emotional economy is oriented toward recovery and return; what moves heaven is what should move the Pharisees."
+              "note": "\"Rejoicing in the presence of the angels of God\" — not merely that angels rejoice but that there is rejoicing in the divine assembly at the news of one repentant sinner. Heaven's emotional economy is oriented toward recovery and return; what moves heaven is what should move the Pharisees."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:1-3",
@@ -77,126 +77,126 @@
             },
             {
               "ref": "15:7",
-              "note": "The \"ninety-nine righteous persons who do not need to repent\" is ironic: no one falls into that category. Jesus uses the Pharisees' self-description against them. If they think they do not need to repent, they are precisely the ninety-nine who are already safe in the fold \u2014 and therefore need not be the object of extraordinary seeking joy."
+              "note": "The \"ninety-nine righteous persons who do not need to repent\" is ironic: no one falls into that category. Jesus uses the Pharisees' self-description against them. If they think they do not need to repent, they are precisely the ninety-nine who are already safe in the fold — and therefore need not be the object of extraordinary seeking joy."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "15:4",
-              "note": "\"Leave the ninety-nine in the open country\" \u2014 unlike Matthew's version (\"on the hills\"), Luke's \"open country\" (en t\u0113 er\u0113m\u014d) could mean wilderness or uninhabited country, suggesting a less safe situation for the remaining sheep and therefore a greater recklessness in the seeking."
+              "note": "\"Leave the ninety-nine in the open country\" — unlike Matthew's version (\"on the hills\"), Luke's \"open country\" (en tē erēmō) could mean wilderness or uninhabited country, suggesting a less safe situation for the remaining sheep and therefore a greater recklessness in the seeking."
             },
             {
               "ref": "15:8",
-              "note": "Ten drachmas \u2014 equivalent to roughly ten days' wages. As a wedding dowry or family savings, this would be a significant sum. The coin's loss is not trivial; the diligence of the search is proportionate."
+              "note": "Ten drachmas — equivalent to roughly ten days' wages. As a wedding dowry or family savings, this would be a significant sum. The coin's loss is not trivial; the diligence of the search is proportionate."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:4",
-              "note": "Kataleip\u014d \u2014 \"leaves behind\" with full knowledge; not abandons. The present active participle poreuetai describes the going as a continuous search. The shepherd does not give up; he searches \"until he finds it\" \u2014 the goal-oriented persistence is the point."
+              "note": "Kataleipō — \"leaves behind\" with full knowledge; not abandons. The present active participle poreuetai describes the going as a continuous search. The shepherd does not give up; he searches \"until he finds it\" — the goal-oriented persistence is the point."
             },
             {
               "ref": "15:8",
-              "note": "Drachma \u2014 a Greek silver coin roughly equivalent to a Roman denarius (a day's wage). Ten such coins might represent a significant portion of a family's savings. The woman's diligent search (light, sweep, search carefully) is proportionate to the real value of what is lost."
+              "note": "Drachma — a Greek silver coin roughly equivalent to a Roman denarius (a day's wage). Ten such coins might represent a significant portion of a family's savings. The woman's diligent search (light, sweep, search carefully) is proportionate to the real value of what is lost."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "15:4-5",
-              "note": "Gregory the Great: \"He who left the ninety-nine in the mountains to seek one lost sheep is our Lord, who left the angels in heaven to seek fallen humanity. And when he found it, he laid it on his shoulders \u2014 that is, he took our nature upon himself and carried our sins.\""
+              "note": "Gregory the Great: \"He who left the ninety-nine in the mountains to seek one lost sheep is our Lord, who left the angels in heaven to seek fallen humanity. And when he found it, he laid it on his shoulders — that is, he took our nature upon himself and carried our sins.\""
             },
             {
               "ref": "15:8",
-              "note": "Ambrose: \"The woman is the church. The ten coins are the ten commandments, or the ten nations of the world. The one lost coin is the sinner. She lights a lamp \u2014 the light of the gospel \u2014 and sweeps the house \u2014 that is, she searches everywhere within herself \u2014 until she finds what was lost.\""
+              "note": "Ambrose: \"The woman is the church. The ten coins are the ten commandments, or the ten nations of the world. The one lost coin is the sinner. She lights a lamp — the light of the gospel — and sweeps the house — that is, she searches everywhere within herself — until she finds what was lost.\""
             }
           ]
         },
         "hist": {
-          "context": "The Setting: Tax Collectors and Sinners\nLuke grounds the three parables in a specific social confrontation: tax collectors and sinners are gathering around Jesus; Pharisees and teachers are muttering. All three parables are Jesus's answer to the same objection \u2014 \"This man welcomes sinners and eats with them.\" The parables do not defend Jesus's practice; they expose the muttering as a failure to understand God's character.\n\nThe Female Image of God\nThe woman in the coin parable (15:8-10) is one of several passages in Luke where God's action is imaged through a female figure (cf. 13:20-21, the woman with yeast). Luke's Jesus is unusual in the ancient world for using women as positive exemplars and images of divine activity without any qualification."
+          "context": "The Setting: Tax Collectors and Sinners\nLuke grounds the three parables in a specific social confrontation: tax collectors and sinners are gathering around Jesus; Pharisees and teachers are muttering. All three parables are Jesus's answer to the same objection — \"This man welcomes sinners and eats with them.\" The parables do not defend Jesus's practice; they expose the muttering as a failure to understand God's character.\n\nThe Female Image of God\nThe woman in the coin parable (15:8-10) is one of several passages in Luke where God's action is imaged through a female figure (cf. 13:20-21, the woman with yeast). Luke's Jesus is unusual in the ancient world for using women as positive exemplars and images of divine activity without any qualification."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201124 \u2014 The Prodigal Son Returns: This Son of Mine Was Dead",
+      "header": "Verses 11‑24 — The Prodigal Son Returns: This Son of Mine Was Dead",
       "verse_start": 11,
       "verse_end": 24,
       "panels": {
         "heb": [
           {
-            "word": "eis heauton de elth\u014dn",
+            "word": "eis heauton de elthōn",
             "transliteration": "eis heau-TON de el-THON",
             "gloss": "coming to himself / when he came to his senses",
-            "paragraph": "The idiom (v.17) is Greek for regaining one's right mind \u2014 the moment of moral clarity that precedes repentance. The prodigal does not immediately repent; he first perceives his situation clearly. The movement is: see reality clearly \u2192 formulate a plan \u2192 act. Repentance begins with seeing."
+            "paragraph": "The idiom (v.17) is Greek for regaining one's right mind — the moment of moral clarity that precedes repentance. The prodigal does not immediately repent; he first perceives his situation clearly. The movement is: see reality clearly → formulate a plan → act. Repentance begins with seeing."
           },
           {
             "word": "splanchnistheis",
             "transliteration": "splan-ch-NIS-theis",
             "gloss": "filled with compassion / moved in his gut",
-            "paragraph": "The father's response (v.20) uses the most visceral Greek word for compassion \u2014 a stirring of the intestines, the seat of emotion in antiquity. The same word is used for Jesus's own compassion at healings (7:13; 10:33). The father's love is not cool benevolence but gut-wrenching tenderness."
+            "paragraph": "The father's response (v.20) uses the most visceral Greek word for compassion — a stirring of the intestines, the seat of emotion in antiquity. The same word is used for Jesus's own compassion at healings (7:13; 10:33). The father's love is not cool benevolence but gut-wrenching tenderness."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Deut 21:17",
-              "note": "The double portion for the eldest son in Jewish inheritance law \u2014 the context for the younger son's request. By asking for his portion early, he effectively claims what is not yet legally his and dishonours his father."
+              "note": "The double portion for the eldest son in Jewish inheritance law — the context for the younger son's request. By asking for his portion early, he effectively claims what is not yet legally his and dishonours his father."
             },
             {
               "ref": "2 Cor 5:17",
-              "note": "\"If anyone is in Christ, the new creation has come; the old has gone, the new is here!\" \u2014 Paul's theological formulation of the same movement the prodigal embodies: death to the old life, new creation in the father's house."
+              "note": "\"If anyone is in Christ, the new creation has come; the old has gone, the new is here!\" — Paul's theological formulation of the same movement the prodigal embodies: death to the old life, new creation in the father's house."
             },
             {
               "ref": "Ps 103:13",
-              "note": "\"As a father has compassion on his children, so the Lord has compassion on those who fear him\" \u2014 the Psalm that provides the OT background for the father's compassion in the parable."
+              "note": "\"As a father has compassion on his children, so the Lord has compassion on those who fear him\" — the Psalm that provides the OT background for the father's compassion in the parable."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:20",
-              "note": "\"While he was still a long way off, his father saw him\" \u2014 the father is watching, waiting, looking. He has not written off the son. The \"still a long way off\" is the most grace-saturated detail in the parable: the father runs before the son has spoken a word of repentance. Grace precedes confession."
+              "note": "\"While he was still a long way off, his father saw him\" — the father is watching, waiting, looking. He has not written off the son. The \"still a long way off\" is the most grace-saturated detail in the parable: the father runs before the son has spoken a word of repentance. Grace precedes confession."
             },
             {
               "ref": "15:22-24",
-              "note": "The three gifts \u2014 robe, ring, sandals \u2014 are restorations of status. The best robe replaces the rags; the ring restores legal authority (a signet ring could authenticate documents); the sandals distinguish son from slave (slaves went barefoot). The fatted calf signals a feast of maximum celebration. Nothing is held back; the restoration is total."
+              "note": "The three gifts — robe, ring, sandals — are restorations of status. The best robe replaces the rags; the ring restores legal authority (a signet ring could authenticate documents); the sandals distinguish son from slave (slaves went barefoot). The fatted calf signals a feast of maximum celebration. Nothing is held back; the restoration is total."
             },
             {
               "ref": "15:28-30",
-              "note": "The elder brother's accusation is revealing: \"this son of yours who has squandered your property with prostitutes\" \u2014 he adds detail not in the narrative (prostitutes), showing that his imagination has been working overtime on his brother's behaviour. His complaint is not about the son's sin but about the differential treatment."
+              "note": "The elder brother's accusation is revealing: \"this son of yours who has squandered your property with prostitutes\" — he adds detail not in the narrative (prostitutes), showing that his imagination has been working overtime on his brother's behaviour. His complaint is not about the son's sin but about the differential treatment."
             },
             {
               "ref": "15:31-32",
-              "note": "\"You are always with me, and everything I have is yours\" \u2014 the elder's inheritance is intact; the father has not given away his portion. The elder has been living in the father's house all this time without enjoying it. His obedience has been servile, not filial \u2014 he has been slaving (douleu\u014d, v.29), not sonning. The parable ends without his decision: will he go in?"
+              "note": "\"You are always with me, and everything I have is yours\" — the elder's inheritance is intact; the father has not given away his portion. The elder has been living in the father's house all this time without enjoying it. His obedience has been servile, not filial — he has been slaving (douleuō, v.29), not sonning. The parable ends without his decision: will he go in?"
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:17",
-              "note": "\"He came to himself\" \u2014 Calvin sees in this phrase the beginnings of the work of the Holy Spirit, who illuminates the mind to see its own condition clearly. Repentance begins with clear-eyed acknowledgment of reality. The prodigal's calculation (my father's servants have bread; I am starving) is the beginning of wisdom."
+              "note": "\"He came to himself\" — Calvin sees in this phrase the beginnings of the work of the Holy Spirit, who illuminates the mind to see its own condition clearly. Repentance begins with clear-eyed acknowledgment of reality. The prodigal's calculation (my father's servants have bread; I am starving) is the beginning of wisdom."
             },
             {
               "ref": "15:28-32",
-              "note": "Calvin notes that the parable ends without the elder son's decision \u2014 deliberately. Luke leaves the Pharisees in the position of the elder son: they have been in the father's house all along; the question is whether they will enter the feast or remain outside in their resentment. The parable is still open; their response is still possible."
+              "note": "Calvin notes that the parable ends without the elder son's decision — deliberately. Luke leaves the Pharisees in the position of the elder son: they have been in the father's house all along; the question is whether they will enter the feast or remain outside in their resentment. The parable is still open; their response is still possible."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "15:12",
@@ -204,25 +204,25 @@
             },
             {
               "ref": "15:21",
-              "note": "The prodigal's confession in v.21 is shorter than his rehearsed speech in vv.18-19 \u2014 he never gets to say \"make me like one of your hired servants.\" The father interrupts with the restoration before the full confession is complete. The parable insists that God's grace outpaces human contrition."
+              "note": "The prodigal's confession in v.21 is shorter than his rehearsed speech in vv.18-19 — he never gets to say \"make me like one of your hired servants.\" The father interrupts with the restoration before the full confession is complete. The parable insists that God's grace outpaces human contrition."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:20",
-              "note": "Edramen \u2014 aorist of trech\u014d: \"he ran.\" A dignified Middle Eastern patriarch did not run; running required gathering one's robes and was considered undignified. The father's running is itself a statement of his character \u2014 he abandons dignity to reach the son."
+              "note": "Edramen — aorist of trechō: \"he ran.\" A dignified Middle Eastern patriarch did not run; running required gathering one's robes and was considered undignified. The father's running is itself a statement of his character — he abandons dignity to reach the son."
             },
             {
               "ref": "15:29",
-              "note": "Douleu\u014d \u2014 \"I have been slaving for you.\" The elder uses the word for a slave's service, not a son's relationship. His self-description reveals that he has never understood the relationship he was in. He has lived in his father's house as a slave rather than a son."
+              "note": "Douleuō — \"I have been slaving for you.\" The elder uses the word for a slave's service, not a son's relationship. His self-description reveals that he has never understood the relationship he was in. He has lived in his father's house as a slave rather than a son."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "15:20",
@@ -235,121 +235,68 @@
           ]
         },
         "hist": {
-          "context": "The Younger Son's Request\nIn first-century Jewish culture, requesting the inheritance while the father was still alive was equivalent to wishing the father dead \u2014 a supreme act of dishonour. The father's compliance is equally scandalous: he divides the property (including the elder's share) without the family consultation that honour culture demanded. From the parable's first sentence, everything is upside-down.\n\nFeeding Pigs\nFor a Jewish audience, feeding pigs was the ultimate humiliation: pigs were unclean animals, and caring for them in a Gentile country placed the prodigal in a state of maximum ritual impurity. \"No one gave him anything\" \u2014 even his Gentile employer offered nothing. He is at the bottom of every social, ritual, and economic ladder simultaneously."
+          "context": "The Younger Son's Request\nIn first-century Jewish culture, requesting the inheritance while the father was still alive was equivalent to wishing the father dead — a supreme act of dishonour. The father's compliance is equally scandalous: he divides the property (including the elder's share) without the family consultation that honour culture demanded. From the parable's first sentence, everything is upside-down.\n\nFeeding Pigs\nFor a Jewish audience, feeding pigs was the ultimate humiliation: pigs were unclean animals, and caring for them in a Gentile country placed the prodigal in a state of maximum ritual impurity. \"No one gave him anything\" — even his Gentile employer offered nothing. He is at the bottom of every social, ritual, and economic ladder simultaneously."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 25\u201132 \u2014 The Elder Brother\u2019s Anger",
+      "header": "Verses 25‑32 — The Elder Brother’s Anger",
       "verse_start": 25,
       "verse_end": 32,
       "panels": {
         "heb": [
           {
-            "word": "apol\u014dlos",
+            "word": "apolōlos",
             "transliteration": "a-po-LO-los",
             "gloss": "lost",
-            "paragraph": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 \u2014 apol\u014dl\u014ds). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist \u2014 it has become separated from its proper place and owner."
+            "paragraph": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 — apolōlōs). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist — it has become separated from its proper place and owner."
           },
           {
             "word": "chairete",
             "transliteration": "CHAI-re-te",
             "gloss": "rejoice / share in the joy",
-            "paragraph": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal \u2014 as is the joy of heaven over one repentant sinner."
+            "paragraph": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal — as is the joy of heaven over one repentant sinner."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 18:12-14",
-              "note": "Matthew's parallel lost sheep parable, placed in the discourse on community care \u2014 the application is slightly different (care for straying community members) but the parable is the same."
+              "note": "Matthew's parallel lost sheep parable, placed in the discourse on community care — the application is slightly different (care for straying community members) but the parable is the same."
             },
             {
               "ref": "Ezek 34:11-16",
-              "note": "\"For this is what the Sovereign Lord says: I myself will search for my sheep and look after them\" \u2014 the OT background. Jesus's seeking of the lost is the fulfilment of YHWH's promise to be the shepherd Israel's leaders failed to be."
+              "note": "\"For this is what the Sovereign Lord says: I myself will search for my sheep and look after them\" — the OT background. Jesus's seeking of the lost is the fulfilment of YHWH's promise to be the shepherd Israel's leaders failed to be."
             },
             {
               "ref": "Ps 119:176",
-              "note": "\"I have strayed like a lost sheep\" \u2014 the Psalmist's self-description that provides the scriptural image of the lost condition."
+              "note": "\"I have strayed like a lost sheep\" — the Psalmist's self-description that provides the scriptural image of the lost condition."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:4",
-              "note": "\"Leave the ninety-nine in the open country\" \u2014 the shocking element of the parable. A responsible shepherd does not abandon 99 sheep for 1. But the parable describes God's priorities, not sound animal husbandry. The 99 are left \u2014 entrusted to each other, perhaps, or to other shepherds \u2014 because one lost sheep is worth the full expenditure of the shepherd's energy."
-            },
-            {
-              "ref": "15:7",
-              "note": "\"More rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent\" \u2014 the comparative is not a slight on the righteous but an expression of the intensity of joy over recovery. The ninety-nine are safe; the one was lost. Joy tracks the movement from danger to safety, from separation to reunion."
-            },
-            {
-              "ref": "15:8-9",
-              "note": "The woman's lamp, sweep, and search describe God's diligence in seeking the lost. The coin cannot cooperate \u2014 unlike the sheep which can be called and the son who must \"come to his senses.\" God's seeking precedes and enables human response."
-            },
-            {
-              "ref": "15:10",
-              "note": "\"Rejoicing in the presence of the angels of God\" \u2014 not merely that angels rejoice but that there is rejoicing in the divine assembly at the news of one repentant sinner. Heaven's emotional economy is oriented toward recovery and return; what moves heaven is what should move the Pharisees."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:1-3",
-              "note": "Calvin notes that the three parables are not abstract theology but a direct answer to the Pharisees' complaint. Jesus defends his table fellowship with sinners by arguing that this is precisely how God operates. The Pharisees have confused holiness (separation from the defiled) with the character of God (who seeks the defiled)."
-            },
-            {
-              "ref": "15:7",
-              "note": "The \"ninety-nine righteous persons who do not need to repent\" is ironic: no one falls into that category. Jesus uses the Pharisees' self-description against them. If they think they do not need to repent, they are precisely the ninety-nine who are already safe in the fold \u2014 and therefore need not be the object of extraordinary seeking joy."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:4",
-              "note": "\"Leave the ninety-nine in the open country\" \u2014 unlike Matthew's version (\"on the hills\"), Luke's \"open country\" (en t\u0113 er\u0113m\u014d) could mean wilderness or uninhabited country, suggesting a less safe situation for the remaining sheep and therefore a greater recklessness in the seeking."
-            },
-            {
-              "ref": "15:8",
-              "note": "Ten drachmas \u2014 equivalent to roughly ten days' wages. As a wedding dowry or family savings, this would be a significant sum. The coin's loss is not trivial; the diligence of the search is proportionate."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "15:4",
-              "note": "Kataleip\u014d \u2014 \"leaves behind\" with full knowledge; not abandons. The present active participle poreuetai describes the going as a continuous search. The shepherd does not give up; he searches \"until he finds it\" \u2014 the goal-oriented persistence is the point."
-            },
-            {
-              "ref": "15:8",
-              "note": "Drachma \u2014 a Greek silver coin roughly equivalent to a Roman denarius (a day's wage). Ten such coins might represent a significant portion of a family's savings. The woman's diligent search (light, sweep, search carefully) is proportionate to the real value of what is lost."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "15:4-5",
-              "note": "Gregory the Great: \"He who left the ninety-nine in the mountains to seek one lost sheep is our Lord, who left the angels in heaven to seek fallen humanity. And when he found it, he laid it on his shoulders \u2014 that is, he took our nature upon himself and carried our sins.\""
-            },
-            {
-              "ref": "15:8",
-              "note": "Ambrose: \"The woman is the church. The ten coins are the ten commandments, or the ten nations of the world. The one lost coin is the sinner. She lights a lamp \u2014 the light of the gospel \u2014 and sweeps the house \u2014 that is, she searches everywhere within herself \u2014 until she finds what was lost.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Setting: Tax Collectors and Sinners\nLuke grounds the three parables in a specific social confrontation: tax collectors and sinners are gathering around Jesus; Pharisees and teachers are muttering. All three parables are Jesus's answer to the same objection \u2014 \"This man welcomes sinners and eats with them.\" The parables do not defend Jesus's practice; they expose the muttering as a failure to understand God's character.\n\nThe Female Image of God\nThe woman in the coin parable (15:8-10) is one of several passages in Luke where God's action is imaged through a female figure (cf. 13:20-21, the woman with yeast). Luke's Jesus is unusual in the ancient world for using women as positive exemplars and images of divine activity without any qualification."
+          "context": "The Setting: Tax Collectors and Sinners\nLuke grounds the three parables in a specific social confrontation: tax collectors and sinners are gathering around Jesus; Pharisees and teachers are muttering. All three parables are Jesus's answer to the same objection — \"This man welcomes sinners and eats with them.\" The parables do not defend Jesus's practice; they expose the muttering as a failure to understand God's character.\n\nThe Female Image of God\nThe woman in the coin parable (15:8-10) is one of several passages in Luke where God's action is imaged through a female figure (cf. 13:20-21, the woman with yeast). Luke's Jesus is unusual in the ancient world for using women as positive exemplars and images of divine activity without any qualification."
         }
       }
     }
@@ -364,15 +311,15 @@
       {
         "name": "The Younger Son",
         "role": "The Prodigal",
-        "text": "His journey traces the arc of sin and repentance: demand \u2192 departure \u2192 destitution \u2192 clarity \u2192 return \u2192 restoration. His repentance is genuine but his restored sonship comes faster than he expected \u2014 the father interrupts his confession."
+        "text": "His journey traces the arc of sin and repentance: demand → departure → destitution → clarity → return → restoration. His repentance is genuine but his restored sonship comes faster than he expected — the father interrupts his confession."
       },
       {
         "name": "The Elder Son",
         "role": "The Resentful Obedient",
-        "text": "The Pharisees' stand-in. His complaint is not theologically wrong \u2014 the younger son did wrong, the father's response seems disproportionate \u2014 but his resentment reveals that he has never understood what it means to live in the father's house as a son. He has been obedient but not loving."
+        "text": "The Pharisees' stand-in. His complaint is not theologically wrong — the younger son did wrong, the father's response seems disproportionate — but his resentment reveals that he has never understood what it means to live in the father's house as a son. He has been obedient but not loving."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eis heauton de elth\u014dn (15:17)</td><td>NIV: \"he came to his senses\"; KJV: \"he came to himself\"; ESV: \"he came to himself\"; NRSV: \"he came to himself\". The Greek is idiomatic \u2014 literally \"coming into himself\" \u2014 and all major versions render the idiom appropriately.</td></tr><tr><td class=\"t-label\">splanchnistheis (15:20)</td><td>NIV: \"filled with compassion\"; KJV: \"had compassion\"; ESV: \"felt compassion\"; NRSV: \"filled with compassion\". The visceral force (literally: moved in his intestines) is softened in all translations.</td></tr><tr><td class=\"t-label\">douleu\u014d (15:29)</td><td>NIV: \"slaving\"; KJV: \"do I serve\"; ESV: \"slaving\"; NRSV: \"working like a slave\". NIV and ESV capture the slave-language the elder uses of his own service.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eis heauton de elthōn (15:17)</td><td>NIV: \"he came to his senses\"; KJV: \"he came to himself\"; ESV: \"he came to himself\"; NRSV: \"he came to himself\". The Greek is idiomatic — literally \"coming into himself\" — and all major versions render the idiom appropriately.</td></tr><tr><td class=\"t-label\">splanchnistheis (15:20)</td><td>NIV: \"filled with compassion\"; KJV: \"had compassion\"; ESV: \"felt compassion\"; NRSV: \"filled with compassion\". The visceral force (literally: moved in his intestines) is softened in all translations.</td></tr><tr><td class=\"t-label\">douleuō (15:29)</td><td>NIV: \"slaving\"; KJV: \"do I serve\"; ESV: \"slaving\"; NRSV: \"working like a slave\". NIV and ESV capture the slave-language the elder uses of his own service.</td></tr>",
     "src": [
       {
         "title": "Ezekiel 34:11-16",
@@ -388,79 +335,79 @@
     "rec": [
       {
         "who": "The Prodigal Son in Art and Literature",
-        "text": "No parable has inspired more art than the story of the prodigal son. Rembrandt's The Return of the Prodigal Son (c. 1669) \u2014 depicting the father's hands (one masculine, one feminine) resting on the kneeling son's back \u2014 is widely considered the most theologically profound painting in Western art. Henri Nouwen's meditation on the painting, The Return of the Prodigal Son (1992), has become a modern classic of spiritual reflection."
+        "text": "No parable has inspired more art than the story of the prodigal son. Rembrandt's The Return of the Prodigal Son (c. 1669) — depicting the father's hands (one masculine, one feminine) resting on the kneeling son's back — is widely considered the most theologically profound painting in Western art. Henri Nouwen's meditation on the painting, The Return of the Prodigal Son (1992), has become a modern classic of spiritual reflection."
       },
       {
         "who": "The Waiting Father in Christian Theology",
-        "text": "The image of the father who \"while he was still a long way off... saw him and ran\" has shaped Christian understandings of prevenient grace \u2014 the doctrine that God's love and seeking precede human repentance. Tertullian, Augustine, and Wesley all return to this passage as the clearest narrative expression of divine initiative in salvation."
+        "text": "The image of the father who \"while he was still a long way off... saw him and ran\" has shaped Christian understandings of prevenient grace — the doctrine that God's love and seeking precede human repentance. Tertullian, Augustine, and Wesley all return to this passage as the clearest narrative expression of divine initiative in salvation."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Triptych \u2014 chs.15",
-          "text": "Three parables of the lost, escalating in stakes and elaboration: one sheep from a hundred (1%) \u2192 one coin from ten (10%) \u2192 one son from two (50%). The percentage rises; the narrative detail expands; the emotional weight increases.",
+          "label": "Triptych — chs.15",
+          "text": "Three parables of the lost, escalating in stakes and elaboration: one sheep from a hundred (1%) → one coin from ten (10%) → one son from two (50%). The percentage rises; the narrative detail expands; the emotional weight increases.",
           "is_key": false
         },
         {
           "label": "Joy as Refrain",
-          "text": "Each parable climaxes in communal rejoicing: \"Rejoice with me\" (v.6, 9); the father's feast (v.24, 32). The three-fold repetition of joy is the chapter's heartbeat \u2014 heaven's response to repentance is not relief but celebration. The lost sheep chapter (15) is itself framed by a joy that the Pharisees' grumbling (v.2) conspicuously lacks.",
+          "text": "Each parable climaxes in communal rejoicing: \"Rejoice with me\" (v.6, 9); the father's feast (v.24, 32). The three-fold repetition of joy is the chapter's heartbeat — heaven's response to repentance is not relief but celebration. The lost sheep chapter (15) is itself framed by a joy that the Pharisees' grumbling (v.2) conspicuously lacks.",
           "is_key": false
         }
       ],
       "note": "",
       "chiasm": {
-        "title": "Luke 15 \u2014 The Three Parables of the Lost",
+        "title": "Luke 15 — The Three Parables of the Lost",
         "pairs": [
           {
             "label": "A",
-            "top": "The Lost Sheep: a man with a hundred sheep loses one, leaves the ninety-nine, searches until he finds it, carries it home on his shoulders, and calls his friends to rejoice (vv.3\u20137)",
-            "bottom": "The Lost Coin: a woman with ten coins loses one, lights a lamp, sweeps the house, searches carefully until she finds it, and calls her friends to rejoice (vv.8\u201310)",
+            "top": "The Lost Sheep: a man with a hundred sheep loses one, leaves the ninety-nine, searches until he finds it, carries it home on his shoulders, and calls his friends to rejoice (vv.3–7)",
+            "bottom": "The Lost Coin: a woman with ten coins loses one, lights a lamp, sweeps the house, searches carefully until she finds it, and calls her friends to rejoice (vv.8–10)",
             "color": "#8B7CB8"
           }
         ],
         "center": {
           "label": "X",
-          "text": "The Lost Son (vv.11\u201332): the longest and most complex of the three, with its own internal structure. The younger son\u2019s departure, degradation, and return mirrors the elder son\u2019s revelation as equally lost. The father\u2019s response to each son is identical in character \u2014 extravagant, undignified love. The sheep and coin parables bracket the prodigal to establish the pattern (search \u2192 find \u2192 rejoice), then the center explodes the pattern: the father does not search \u2014 he waits, watches, and runs."
+          "text": "The Lost Son (vv.11–32): the longest and most complex of the three, with its own internal structure. The younger son’s departure, degradation, and return mirrors the elder son’s revelation as equally lost. The father’s response to each son is identical in character — extravagant, undignified love. The sheep and coin parables bracket the prodigal to establish the pattern (search → find → rejoice), then the center explodes the pattern: the father does not search — he waits, watches, and runs."
         }
       }
     },
     "hebtext": [
       {
-        "word": "apol\u014dlos",
+        "word": "apolōlos",
         "tlit": "a-po-LO-los",
         "gloss": "lost",
-        "note": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 \u2014 apol\u014dl\u014ds). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist \u2014 it has become separated from its proper place and owner."
+        "note": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 — apolōlōs). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist — it has become separated from its proper place and owner."
       },
       {
         "word": "chairete",
         "tlit": "CHAI-re-te",
         "gloss": "rejoice / share in the joy",
-        "note": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal \u2014 as is the joy of heaven over one repentant sinner."
+        "note": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal — as is the joy of heaven over one repentant sinner."
       },
       {
-        "word": "eis heauton de elth\u014dn",
+        "word": "eis heauton de elthōn",
         "tlit": "eis heau-TON de el-THON",
         "gloss": "coming to himself / when he came to his senses",
-        "note": "The idiom (v.17) is Greek for regaining one's right mind \u2014 the moment of moral clarity that precedes repentance. The prodigal does not immediately repent; he first perceives his situation clearly. The movement is: see reality clearly \u2192 formulate a plan \u2192 act. Repentance begins with seeing."
+        "note": "The idiom (v.17) is Greek for regaining one's right mind — the moment of moral clarity that precedes repentance. The prodigal does not immediately repent; he first perceives his situation clearly. The movement is: see reality clearly → formulate a plan → act. Repentance begins with seeing."
       },
       {
         "word": "splanchnistheis",
         "tlit": "splan-ch-NIS-theis",
         "gloss": "filled with compassion / moved in his gut",
-        "note": "The father's response (v.20) uses the most visceral Greek word for compassion \u2014 a stirring of the intestines, the seat of emotion in antiquity. The same word is used for Jesus's own compassion at healings (7:13; 10:33). The father's love is not cool benevolence but gut-wrenching tenderness."
+        "note": "The father's response (v.20) uses the most visceral Greek word for compassion — a stirring of the intestines, the seat of emotion in antiquity. The same word is used for Jesus's own compassion at healings (7:13; 10:33). The father's love is not cool benevolence but gut-wrenching tenderness."
       },
       {
-        "word": "apol\u014dlos",
+        "word": "apolōlos",
         "tlit": "a-po-LO-los",
         "gloss": "lost",
-        "note": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 \u2014 apol\u014dl\u014ds). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist \u2014 it has become separated from its proper place and owner."
+        "note": "The same adjective describes the sheep (v.4), the coin (v.8), and the son (v.24, 32 — apolōlōs). Luke uses a single word to link the three parables into a triptych. What is lost has not ceased to exist — it has become separated from its proper place and owner."
       },
       {
         "word": "chairete",
         "tlit": "CHAI-re-te",
         "gloss": "rejoice / share in the joy",
-        "note": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal \u2014 as is the joy of heaven over one repentant sinner."
+        "note": "The command in both parables (vv.6, 9) is not merely \"be happy\" but \"join in the joy.\" The finding creates a social event of celebration. The point is not just that the lost is found but that the joy is communal — as is the joy of heaven over one repentant sinner."
       }
     ],
     "tx": [
@@ -468,13 +415,13 @@
         "ref": "15:21",
         "title": "Prodigal's truncated confession",
         "content": "The prodigal's rehearsed speech in vv.18-19 includes \"make me like one of your hired servants\"; v.21 omits this phrase. Some MSS include it in v.21, harmonising with the rehearsed version. NA28 follows the shorter form.",
-        "note": "The shorter form is almost certainly original \u2014 the father interrupts before the full confession is complete. This is theologically significant: grace precedes the completion of contrition. The longer harmonising reading removes this point."
+        "note": "The shorter form is almost certainly original — the father interrupts before the full confession is complete. This is theologically significant: grace precedes the completion of contrition. The longer harmonising reading removes this point."
       },
       {
         "ref": "15:16",
         "title": "The pods / carob pods",
         "content": "Some MSS read \"husks\" (KJV); NA28 reads keratia (carob pods, the seed pods of the carob tree used as animal fodder). The carob reading is original; the vaguer \"husks\" is a later simplification.",
-        "note": "The carob detail grounds the parable in Palestinian agricultural reality and underlines the depth of the son's degradation \u2014 feeding pigs on food unfit for human consumption."
+        "note": "The carob detail grounds the parable in Palestinian agricultural reality and underlines the depth of the son's degradation — feeding pigs on food unfit for human consumption."
       }
     ],
     "debate": [
@@ -489,7 +436,7 @@
           {
             "name": "Elder son invited, not condemned",
             "proponents": "Bailey, Green, Fitzmyer",
-            "argument": "The parable does not end with the elder son refusing. The father goes out and pleads \u2014 as he went out to the younger. The open ending is an invitation: the Pharisees can still enter. The parable is evangelistic toward the elder son, not merely critical."
+            "argument": "The parable does not end with the elder son refusing. The father goes out and pleads — as he went out to the younger. The open ending is an invitation: the Pharisees can still enter. The parable is evangelistic toward the elder son, not merely critical."
           }
         ]
       }
@@ -521,7 +468,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 15 is the theological centre of the travel narrative and perhaps of the entire Gospel. The three parables answer a single accusation \u2014 \"this man welcomes sinners and eats with them\" \u2014 by revealing the character of God: a God who seeks, who finds, who celebrates. The lost sheep, the lost coin, and the lost son are progressively more personal; the father's love in the third parable is the fullest portrait of divine grace in the Synoptic Gospels. The elder son's resentment is the parable's unresolved challenge: can the self-righteous enter the same feast?"
+      "note": "Luke 15 is the theological centre of the travel narrative and perhaps of the entire Gospel. The three parables answer a single accusation — \"this man welcomes sinners and eats with them\" — by revealing the character of God: a God who seeks, who finds, who celebrates. The lost sheep, the lost coin, and the lost son are progressively more personal; the father's love in the third parable is the fullest portrait of divine grace in the Synoptic Gospels. The elder son's resentment is the parable's unresolved challenge: can the self-righteous enter the same feast?"
     }
   },
   "vhl_groups": [
@@ -647,7 +594,7 @@
     },
     {
       "after_section": 2,
-      "tip": "The older brother refuses the party: 'This son of yours...' (v. 30)\u2014not 'my brother.' The father pleads with both sons: one lost in the far country, one lost in the field. Self-righteousness is its own far country.",
+      "tip": "The older brother refuses the party: 'This son of yours...' (v. 30)—not 'my brother.' The father pleads with both sons: one lost in the far country, one lost in the field. Self-righteousness is its own far country.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/luke/16.json
+++ b/content/luke/16.json
@@ -10,33 +10,33 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201113 \u2014 The Shrewd Manager; You Cannot Serve Both God and Money",
+      "header": "Verses 1‑13 — The Shrewd Manager; You Cannot Serve Both God and Money",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
         "heb": [
           {
-            "word": "phronim\u014ds",
+            "word": "phronimōs",
             "transliteration": "phro-NI-mos",
             "gloss": "shrewdly / wisely / with practical wisdom",
-            "paragraph": "The manager is commended not for dishonesty but for phronim\u014ds (v.8) \u2014 practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
+            "paragraph": "The manager is commended not for dishonesty but for phronimōs (v.8) — practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
           },
           {
-            "word": "mam\u014dnas",
+            "word": "mamōnas",
             "transliteration": "ma-MO-nas",
             "gloss": "mammon / money / wealth",
-            "paragraph": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master \u2014 it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
+            "paragraph": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master — it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 6:24",
-              "note": "\"No one can serve two masters... You cannot serve both God and money\" \u2014 the parallel saying in the Sermon on the Mount."
+              "note": "\"No one can serve two masters... You cannot serve both God and money\" — the parallel saying in the Sermon on the Mount."
             },
             {
               "ref": "Matt 11:12-13",
-              "note": "Matthew's parallel to the Law-and-Prophets saying in 16:16 \u2014 the same epochal transition, slightly differently expressed."
+              "note": "Matthew's parallel to the Law-and-Prophets saying in 16:16 — the same epochal transition, slightly differently expressed."
             },
             {
               "ref": "Matt 5:32",
@@ -45,28 +45,28 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:8",
-              "note": "\"The master commended the dishonest manager because he had acted shrewdly\" \u2014 the commendation is for shrewdness, not ethics. Jesus is using a negative example positively: if a scoundrel can act with decisive creativity to secure his future, how much more should disciples act with at least equal shrewdness in securing their eternal future."
+              "note": "\"The master commended the dishonest manager because he had acted shrewdly\" — the commendation is for shrewdness, not ethics. Jesus is using a negative example positively: if a scoundrel can act with decisive creativity to secure his future, how much more should disciples act with at least equal shrewdness in securing their eternal future."
             },
             {
               "ref": "16:9",
-              "note": "\"Use worldly wealth to gain friends for yourselves\" \u2014 give generously now, so that when earthly wealth ends at death, you will have laid up relational and spiritual capital in heaven. The \"friends\" are the poor who have been served; the \"eternal dwellings\" are the heavenly welcome awaiting those who used wealth as a servant rather than serving it as a master."
+              "note": "\"Use worldly wealth to gain friends for yourselves\" — give generously now, so that when earthly wealth ends at death, you will have laid up relational and spiritual capital in heaven. The \"friends\" are the poor who have been served; the \"eternal dwellings\" are the heavenly welcome awaiting those who used wealth as a servant rather than serving it as a master."
             },
             {
               "ref": "16:13",
-              "note": "\"You cannot serve both God and money\" \u2014 this is one of Jesus's most absolute statements. Money is not merely a tool; it is a master with its own demands, its own claim on loyalty, its own logic that subtly displaces God. The Pharisees' money-love (v.14) is the practical demonstration of what serving mammon looks like in a religious person."
+              "note": "\"You cannot serve both God and money\" — this is one of Jesus's most absolute statements. Money is not merely a tool; it is a master with its own demands, its own claim on loyalty, its own logic that subtly displaces God. The Pharisees' money-love (v.14) is the practical demonstration of what serving mammon looks like in a religious person."
             },
             {
               "ref": "16:17",
-              "note": "\"Easier for heaven and earth to disappear than for the least stroke of a pen to drop out of the Law\" \u2014 the new epoch of the kingdom does not abrogate Torah but fulfils it. Jesus is the Law's completion, not its cancellation. The divorce saying that follows (v.18) is an example: Jesus intensifies the Law's original intent rather than relaxing it."
+              "note": "\"Easier for heaven and earth to disappear than for the least stroke of a pen to drop out of the Law\" — the new epoch of the kingdom does not abrogate Torah but fulfils it. Jesus is the Law's completion, not its cancellation. The divorce saying that follows (v.18) is an example: Jesus intensifies the Law's original intent rather than relaxing it."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:9",
@@ -79,37 +79,37 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:8",
-              "note": "The \"master\" who commends the manager could be the landowner in the parable or Jesus himself (\"the Lord\"). If Jesus is the one commending, the commendation is even more pointed. NA28's ambiguity is probably deliberate \u2014 the narrative keeps the layers of meaning open."
+              "note": "The \"master\" who commends the manager could be the landowner in the parable or Jesus himself (\"the Lord\"). If Jesus is the one commending, the commendation is even more pointed. NA28's ambiguity is probably deliberate — the narrative keeps the layers of meaning open."
             },
             {
               "ref": "16:16",
-              "note": "\"Everyone is forcing their way into it\" (NIV) \u2014 biazetai is middle or passive and can mean \"everyone presses urgently into it\" (positive) or \"everyone is violently entering it\" (negative, suggesting opposition). The ambiguity has generated extensive scholarly debate; most modern translations follow the active/positive reading."
+              "note": "\"Everyone is forcing their way into it\" (NIV) — biazetai is middle or passive and can mean \"everyone presses urgently into it\" (positive) or \"everyone is violently entering it\" (negative, suggesting opposition). The ambiguity has generated extensive scholarly debate; most modern translations follow the active/positive reading."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "16:8",
-              "note": "Phronim\u014dteros \u2014 \"more shrewd\" (comparative). The children of this age are comparatively more shrewd than the children of light in dealing with their own affairs. Robertson notes the painful concession Jesus makes to the superior practical cleverness of the worldly person."
+              "note": "Phronimōteros — \"more shrewd\" (comparative). The children of this age are comparatively more shrewd than the children of light in dealing with their own affairs. Robertson notes the painful concession Jesus makes to the superior practical cleverness of the worldly person."
             },
             {
               "ref": "16:9",
-              "note": "Ekleip\u0113 \u2014 aorist subjunctive: \"when it fails/runs out.\" Worldly wealth has a built-in expiry date \u2014 it ends at death if not before. The prudent use of it before it expires is the parable's practical application."
+              "note": "Ekleipē — aorist subjunctive: \"when it fails/runs out.\" Worldly wealth has a built-in expiry date — it ends at death if not before. The prudent use of it before it expires is the parable's practical application."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "16:8",
-              "note": "Augustine: \"He does not praise the dishonesty \u2014 God forbid. He praises the shrewdness. The lord of that unjust steward praised the steward's cleverness, not his injustice. In the same way, Christ uses this as an example, not endorsing the unjust action but praising the foresight.\""
+              "note": "Augustine: \"He does not praise the dishonesty — God forbid. He praises the shrewdness. The lord of that unjust steward praised the steward's cleverness, not his injustice. In the same way, Christ uses this as an example, not endorsing the unjust action but praising the foresight.\""
             },
             {
               "ref": "16:13",
@@ -118,13 +118,13 @@
           ]
         },
         "hist": {
-          "context": "The Steward's Debt Reduction\nThe manager's reduction of debts may have involved removing his own commission from the bills (commissions on agricultural transactions were standard in antiquity). If so, the \"dishonesty\" may lie in how he originally inflated the bills, not in the reduction. Alternatively, the reduction is straightforwardly fraudulent. Either way, Jesus commends not the ethics but the shrewdness \u2014 the decisive use of available resources before the window closes.\n\nThe Transition of Epochs (16:16)\nVerse 16 is among the most debated in Luke: \"The Law and the Prophets were proclaimed until John. Since that time, the good news of the kingdom of God is being preached.\" The epoch of preparation has ended; the epoch of fulfilment has begun. This does not abolish the Law (v.17 insists the opposite) but establishes Jesus's ministry as the hinge of redemptive history."
+          "context": "The Steward's Debt Reduction\nThe manager's reduction of debts may have involved removing his own commission from the bills (commissions on agricultural transactions were standard in antiquity). If so, the \"dishonesty\" may lie in how he originally inflated the bills, not in the reduction. Alternatively, the reduction is straightforwardly fraudulent. Either way, Jesus commends not the ethics but the shrewdness — the decisive use of available resources before the window closes.\n\nThe Transition of Epochs (16:16)\nVerse 16 is among the most debated in Luke: \"The Law and the Prophets were proclaimed until John. Since that time, the good news of the kingdom of God is being preached.\" The epoch of preparation has ended; the epoch of fulfilment has begun. This does not abolish the Law (v.17 insists the opposite) but establishes Jesus's ministry as the hinge of redemptive history."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201118 \u2014 The Pharisees Ridiculed; The Law and the Kingdom",
+      "header": "Verses 14‑18 — The Pharisees Ridiculed; The Law and the Kingdom",
       "verse_start": 14,
       "verse_end": 18,
       "panels": {
@@ -133,20 +133,20 @@
             "word": "porphyran",
             "transliteration": "por-PHY-ran",
             "gloss": "purple",
-            "paragraph": "The colour of imperial and priestly garments \u2014 extravagant luxury. Only the very wealthy could afford purple dye (extracted from murex shellfish). The detail places the rich man at the apex of economic privilege."
+            "paragraph": "The colour of imperial and priestly garments — extravagant luxury. Only the very wealthy could afford purple dye (extracted from murex shellfish). The detail places the rich man at the apex of economic privilege."
           },
           {
             "word": "kolpon Abraam",
             "transliteration": "kol-PON ab-ra-AM",
             "gloss": "Abraham's bosom / Abraham's side",
-            "paragraph": "The metaphor (v.22) is of reclining at a banquet in the place of honour next to the host \u2014 the position of the most honoured guest. Lazarus, who had no place at any table in his lifetime, now reclines in the most honoured place at the eternal feast."
+            "paragraph": "The metaphor (v.22) is of reclining at a banquet in the place of honour next to the host — the position of the most honoured guest. Lazarus, who had no place at any table in his lifetime, now reclines in the most honoured place at the eternal feast."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Amos 6:1-7",
-              "note": "\"Woe to you who are complacent in Zion... you feast and lounge... but you do not grieve over the ruin of Joseph\" \u2014 the OT prophetic indictment of wealthy indifference that the rich man embodies."
+              "note": "\"Woe to you who are complacent in Zion... you feast and lounge... but you do not grieve over the ruin of Joseph\" — the OT prophetic indictment of wealthy indifference that the rich man embodies."
             },
             {
               "ref": "1 Enoch 22",
@@ -154,50 +154,50 @@
             },
             {
               "ref": "John 11:1-44",
-              "note": "The raising of Lazarus of Bethany \u2014 a different Lazarus but the same name. Luke may be playing on the irony: a man named Lazarus did rise from the dead, and many still did not believe."
+              "note": "The raising of Lazarus of Bethany — a different Lazarus but the same name. Luke may be playing on the irony: a man named Lazarus did rise from the dead, and many still did not believe."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:19-21",
-              "note": "The contrast is not between a good poor man and a bad rich man but between a man who had everything and a man who had nothing, at the same gate every day. The rich man's sin is not enumerated \u2014 it is the sin of not seeing. Lazarus was at his gate; the dogs noticed him. The rich man apparently did not."
+              "note": "The contrast is not between a good poor man and a bad rich man but between a man who had everything and a man who had nothing, at the same gate every day. The rich man's sin is not enumerated — it is the sin of not seeing. Lazarus was at his gate; the dogs noticed him. The rich man apparently did not."
             },
             {
               "ref": "16:25",
-              "note": "\"Son, remember\" \u2014 Abraham calls him \"son,\" recognising his covenant heritage. The rich man is not excluded from the covenant family; he is excluded by his own choices. The \"good things\" received in lifetime were not themselves the sin \u2014 their possession without compassionate use was."
+              "note": "\"Son, remember\" — Abraham calls him \"son,\" recognising his covenant heritage. The rich man is not excluded from the covenant family; he is excluded by his own choices. The \"good things\" received in lifetime were not themselves the sin — their possession without compassionate use was."
             },
             {
               "ref": "16:26",
-              "note": "\"A great chasm has been set in place\" \u2014 the permanence of the division after death is the parable's most sobering element. There is no purgatorial crossing, no second chance, no late repentance. The time of decision is the present life; the separation at death is final."
+              "note": "\"A great chasm has been set in place\" — the permanence of the division after death is the parable's most sobering element. There is no purgatorial crossing, no second chance, no late repentance. The time of decision is the present life; the separation at death is final."
             },
             {
               "ref": "16:31",
-              "note": "\"They will not be convinced even if someone rises from the dead\" \u2014 this is the parable's most transparent reference to the resurrection. The Pharisees who demanded signs (11:16), who had Moses and the Prophets and rejected them, would not be convinced by the resurrection either. And they were not."
+              "note": "\"They will not be convinced even if someone rises from the dead\" — this is the parable's most transparent reference to the resurrection. The Pharisees who demanded signs (11:16), who had Moses and the Prophets and rejected them, would not be convinced by the resurrection either. And they were not."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:22-23",
-              "note": "Calvin insists that the parable teaches the reality of the soul's conscious existence between death and resurrection \u2014 against the doctrine of \"soul sleep.\" Lazarus is comforted; the rich man is in agony. Both are conscious, both remember, both can converse. The intermediate state is a real state, not a condition of unconscious waiting."
+              "note": "Calvin insists that the parable teaches the reality of the soul's conscious existence between death and resurrection — against the doctrine of \"soul sleep.\" Lazarus is comforted; the rich man is in agony. Both are conscious, both remember, both can converse. The intermediate state is a real state, not a condition of unconscious waiting."
             },
             {
               "ref": "16:29-31",
-              "note": "\"They have Moses and the Prophets\" \u2014 Scripture is sufficient. The demand for miraculous confirmation of what Scripture already teaches is a sign of unbelief, not of genuine inquiry. If the word of God does not persuade, no miracle will. This is Calvin's foundational epistemology: the Spirit who inspired Scripture illumines the reading of Scripture; no additional external confirmation is required."
+              "note": "\"They have Moses and the Prophets\" — Scripture is sufficient. The demand for miraculous confirmation of what Scripture already teaches is a sign of unbelief, not of genuine inquiry. If the word of God does not persuade, no miracle will. This is Calvin's foundational epistemology: the Spirit who inspired Scripture illumines the reading of Scripture; no additional external confirmation is required."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:22",
-              "note": "\"Angels carried him to Abraham's side\" \u2014 the image of angels escorting the righteous dead is attested in Jewish literature (T. Asher 6:4-6; T. Abraham 20:12). Luke's Jesus uses the image without necessarily endorsing all the apocalyptic detail that surrounds it in the Jewish sources."
+              "note": "\"Angels carried him to Abraham's side\" — the image of angels escorting the righteous dead is attested in Jewish literature (T. Asher 6:4-6; T. Abraham 20:12). Luke's Jesus uses the image without necessarily endorsing all the apocalyptic detail that surrounds it in the Jewish sources."
             },
             {
               "ref": "16:19",
@@ -206,20 +206,20 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "16:23",
-              "note": "Hades \u2014 not Gehenna (the place of final punishment) but the intermediate state of the dead. The distinction matters: the parable describes the period between death and final judgment, not the eternal state. However, the chasm suggests that the categories are already fixed."
+              "note": "Hades — not Gehenna (the place of final punishment) but the intermediate state of the dead. The distinction matters: the parable describes the period between death and final judgment, not the eternal state. However, the chasm suggests that the categories are already fixed."
             },
             {
               "ref": "16:26",
-              "note": "Chasma mega est\u0113raktai \u2014 \"a great chasm has been fixed/established\" (perfect passive). The perfect tense indicates a completed, settled action. The chasm is not being set; it has been set. The arrangement is permanent."
+              "note": "Chasma mega estēraktai — \"a great chasm has been fixed/established\" (perfect passive). The perfect tense indicates a completed, settled action. The chasm is not being set; it has been set. The arrangement is permanent."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "16:20-21",
@@ -227,44 +227,44 @@
             },
             {
               "ref": "16:31",
-              "note": "Augustine: \"Even if one rose from the dead, they would not believe \u2014 and so it proved. Christ rose, and many did not believe. The resurrection does not produce faith in those who have hardened themselves against the scriptures. Faith comes by hearing the word of God.\""
+              "note": "Augustine: \"Even if one rose from the dead, they would not believe — and so it proved. Christ rose, and many did not believe. The resurrection does not produce faith in those who have hardened themselves against the scriptures. Faith comes by hearing the word of God.\""
             }
           ]
         },
         "hist": {
-          "context": "Hades in Jewish Thought\nFirst-century Jewish understanding of the afterlife was varied. The Pharisees believed in resurrection; the Sadducees did not. The parable's picture of Hades \u2014 a place of the dead with different compartments for the righteous and the wicked, separated by an impassable chasm \u2014 draws on the apocalyptic tradition visible in 1 Enoch 22. Jesus uses the categories his audience recognised without necessarily making ontological claims about the precise geography of the afterlife.\n\n\"Someone Rising from the Dead\"\nThe parable's closing punch \u2014 \"they will not be convinced even if someone rises from the dead\" (v.31) \u2014 is both Jesus's commentary on the unresponsive heart and Luke's retrospective commentary on the resurrection. The Pharisees who refused to believe in Jesus were not convinced even when he rose. The parable ends as both prediction and indictment."
+          "context": "Hades in Jewish Thought\nFirst-century Jewish understanding of the afterlife was varied. The Pharisees believed in resurrection; the Sadducees did not. The parable's picture of Hades — a place of the dead with different compartments for the righteous and the wicked, separated by an impassable chasm — draws on the apocalyptic tradition visible in 1 Enoch 22. Jesus uses the categories his audience recognised without necessarily making ontological claims about the precise geography of the afterlife.\n\n\"Someone Rising from the Dead\"\nThe parable's closing punch — \"they will not be convinced even if someone rises from the dead\" (v.31) — is both Jesus's commentary on the unresponsive heart and Luke's retrospective commentary on the resurrection. The Pharisees who refused to believe in Jesus were not convinced even when he rose. The parable ends as both prediction and indictment."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 19\u201131 \u2014 The Rich Man and Lazarus",
+      "header": "Verses 19‑31 — The Rich Man and Lazarus",
       "verse_start": 19,
       "verse_end": 31,
       "panels": {
         "heb": [
           {
-            "word": "phronim\u014ds",
+            "word": "phronimōs",
             "transliteration": "phro-NI-mos",
             "gloss": "shrewdly / wisely / with practical wisdom",
-            "paragraph": "The manager is commended not for dishonesty but for phronim\u014ds (v.8) \u2014 practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
+            "paragraph": "The manager is commended not for dishonesty but for phronimōs (v.8) — practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
           },
           {
-            "word": "mam\u014dnas",
+            "word": "mamōnas",
             "transliteration": "ma-MO-nas",
             "gloss": "mammon / money / wealth",
-            "paragraph": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master \u2014 it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
+            "paragraph": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master — it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 6:24",
-              "note": "\"No one can serve two masters... You cannot serve both God and money\" \u2014 the parallel saying in the Sermon on the Mount."
+              "note": "\"No one can serve two masters... You cannot serve both God and money\" — the parallel saying in the Sermon on the Mount."
             },
             {
               "ref": "Matt 11:12-13",
-              "note": "Matthew's parallel to the Law-and-Prophets saying in 16:16 \u2014 the same epochal transition, slightly differently expressed."
+              "note": "Matthew's parallel to the Law-and-Prophets saying in 16:16 — the same epochal transition, slightly differently expressed."
             },
             {
               "ref": "Matt 5:32",
@@ -273,80 +273,27 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:8",
-              "note": "\"The master commended the dishonest manager because he had acted shrewdly\" \u2014 the commendation is for shrewdness, not ethics. Jesus is using a negative example positively: if a scoundrel can act with decisive creativity to secure his future, how much more should disciples act with at least equal shrewdness in securing their eternal future."
-            },
-            {
-              "ref": "16:9",
-              "note": "\"Use worldly wealth to gain friends for yourselves\" \u2014 give generously now, so that when earthly wealth ends at death, you will have laid up relational and spiritual capital in heaven. The \"friends\" are the poor who have been served; the \"eternal dwellings\" are the heavenly welcome awaiting those who used wealth as a servant rather than serving it as a master."
-            },
-            {
-              "ref": "16:13",
-              "note": "\"You cannot serve both God and money\" \u2014 this is one of Jesus's most absolute statements. Money is not merely a tool; it is a master with its own demands, its own claim on loyalty, its own logic that subtly displaces God. The Pharisees' money-love (v.14) is the practical demonstration of what serving mammon looks like in a religious person."
-            },
-            {
-              "ref": "16:17",
-              "note": "\"Easier for heaven and earth to disappear than for the least stroke of a pen to drop out of the Law\" \u2014 the new epoch of the kingdom does not abrogate Torah but fulfils it. Jesus is the Law's completion, not its cancellation. The divorce saying that follows (v.18) is an example: Jesus intensifies the Law's original intent rather than relaxing it."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:9",
-              "note": "Calvin insists that Jesus is not advising the purchase of heaven with money. The \"friends\" who welcome us are not God and the angels who owe us for our generosity, but the poor whose intercessions on our behalf, whose testimony to our character, rises before God. Generosity does not purchase salvation; it demonstrates the transformed heart that salvation produces."
-            },
-            {
-              "ref": "16:16-17",
-              "note": "The two verses in sequence (the kingdom epoch has arrived / not one stroke of the Law will fail) correct two opposite misunderstandings: (1) the kingdom has nothing to do with the Law (wrong: the Law's deepest intentions are fulfilled in the kingdom); (2) the Law continues in its letter as before (wrong: the epoch has changed, though not the moral substance of the Law)."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:8",
-              "note": "The \"master\" who commends the manager could be the landowner in the parable or Jesus himself (\"the Lord\"). If Jesus is the one commending, the commendation is even more pointed. NA28's ambiguity is probably deliberate \u2014 the narrative keeps the layers of meaning open."
-            },
-            {
-              "ref": "16:16",
-              "note": "\"Everyone is forcing their way into it\" (NIV) \u2014 biazetai is middle or passive and can mean \"everyone presses urgently into it\" (positive) or \"everyone is violently entering it\" (negative, suggesting opposition). The ambiguity has generated extensive scholarly debate; most modern translations follow the active/positive reading."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "16:8",
-              "note": "Phronim\u014dteros \u2014 \"more shrewd\" (comparative). The children of this age are comparatively more shrewd than the children of light in dealing with their own affairs. Robertson notes the painful concession Jesus makes to the superior practical cleverness of the worldly person."
-            },
-            {
-              "ref": "16:9",
-              "note": "Ekleip\u0113 \u2014 aorist subjunctive: \"when it fails/runs out.\" Worldly wealth has a built-in expiry date \u2014 it ends at death if not before. The prudent use of it before it expires is the parable's practical application."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "16:8",
-              "note": "Augustine: \"He does not praise the dishonesty \u2014 God forbid. He praises the shrewdness. The lord of that unjust steward praised the steward's cleverness, not his injustice. In the same way, Christ uses this as an example, not endorsing the unjust action but praising the foresight.\""
-            },
-            {
-              "ref": "16:13",
-              "note": "Basil of Caesarea: \"It is not possible to serve two masters whose commands are in direct opposition. God commands: despise earthly things, seek eternal ones. Money commands: seek earthly things, despise eternal ones. Where money rules, the love of God finds no place.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Steward's Debt Reduction\nThe manager's reduction of debts may have involved removing his own commission from the bills (commissions on agricultural transactions were standard in antiquity). If so, the \"dishonesty\" may lie in how he originally inflated the bills, not in the reduction. Alternatively, the reduction is straightforwardly fraudulent. Either way, Jesus commends not the ethics but the shrewdness \u2014 the decisive use of available resources before the window closes.\n\nThe Transition of Epochs (16:16)\nVerse 16 is among the most debated in Luke: \"The Law and the Prophets were proclaimed until John. Since that time, the good news of the kingdom of God is being preached.\" The epoch of preparation has ended; the epoch of fulfilment has begun. This does not abolish the Law (v.17 insists the opposite) but establishes Jesus's ministry as the hinge of redemptive history."
+          "context": "The Steward's Debt Reduction\nThe manager's reduction of debts may have involved removing his own commission from the bills (commissions on agricultural transactions were standard in antiquity). If so, the \"dishonesty\" may lie in how he originally inflated the bills, not in the reduction. Alternatively, the reduction is straightforwardly fraudulent. Either way, Jesus commends not the ethics but the shrewdness — the decisive use of available resources before the window closes.\n\nThe Transition of Epochs (16:16)\nVerse 16 is among the most debated in Luke: \"The Law and the Prophets were proclaimed until John. Since that time, the good news of the kingdom of God is being preached.\" The epoch of preparation has ended; the epoch of fulfilment has begun. This does not abolish the Law (v.17 insists the opposite) but establishes Jesus's ministry as the hinge of redemptive history."
         }
       }
     }
@@ -356,24 +303,24 @@
       {
         "name": "The Rich Man",
         "role": "Unnamed wealthy man",
-        "text": "Named by tradition as \"Dives\" (Latin: rich man). His sin is absence of compassion rather than explicit wickedness \u2014 he was at his gate every day, but Lazarus was invisible to him. In Hades he still treats Lazarus as a servant to be sent on errands."
+        "text": "Named by tradition as \"Dives\" (Latin: rich man). His sin is absence of compassion rather than explicit wickedness — he was at his gate every day, but Lazarus was invisible to him. In Hades he still treats Lazarus as a servant to be sent on errands."
       },
       {
         "name": "Lazarus",
         "role": "The named poor man",
-        "text": "The only named character in any of Jesus's parables \u2014 his name (Greek form of Hebrew Eleazar: \"God helps\") is the parable's first theological statement. The man the world overlooked was named before God."
+        "text": "The only named character in any of Jesus's parables — his name (Greek form of Hebrew Eleazar: \"God helps\") is the parable's first theological statement. The man the world overlooked was named before God."
       },
       {
         "name": "Abraham",
         "role": "Patriarch and judge",
-        "text": "Abraham's role in the afterlife reflects Jewish apocalyptic tradition. He addresses the rich man as \"son\" \u2014 recognising his covenant identity \u2014 while maintaining the finality of the separation."
+        "text": "Abraham's role in the afterlife reflects Jewish apocalyptic tradition. He addresses the rich man as \"son\" — recognising his covenant identity — while maintaining the finality of the separation."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">phronim\u014dteros (16:8)</td><td>NIV: \"more shrewd\"; KJV: \"wiser\"; ESV: \"more shrewd\"; NRSV: \"more shrewd\". The comparative (\"more shrewd than\") is preserved in most versions.</td></tr><tr><td class=\"t-label\">biazetai (16:16)</td><td>NIV: \"is being preached, and everyone is forcing their way into it\"; KJV: \"is preached, and every man presseth into it\"; ESV: \"is preached, and everyone forces his way into it\". The verb's voice and meaning are disputed; the urgency is clear.</td></tr><tr><td class=\"t-label\">kolpon (16:22)</td><td>NIV: \"Abraham's side\"; KJV: \"Abraham's bosom\"; ESV: \"Abraham's side\"; NRSV: \"Abraham's bosom\". KJV preserves the literal image of reclining at a feast; NIV and ESV use the more accessible \"side.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">phronimōteros (16:8)</td><td>NIV: \"more shrewd\"; KJV: \"wiser\"; ESV: \"more shrewd\"; NRSV: \"more shrewd\". The comparative (\"more shrewd than\") is preserved in most versions.</td></tr><tr><td class=\"t-label\">biazetai (16:16)</td><td>NIV: \"is being preached, and everyone is forcing their way into it\"; KJV: \"is preached, and every man presseth into it\"; ESV: \"is preached, and everyone forces his way into it\". The verb's voice and meaning are disputed; the urgency is clear.</td></tr><tr><td class=\"t-label\">kolpon (16:22)</td><td>NIV: \"Abraham's side\"; KJV: \"Abraham's bosom\"; ESV: \"Abraham's side\"; NRSV: \"Abraham's bosom\". KJV preserves the literal image of reclining at a feast; NIV and ESV use the more accessible \"side.\"</td></tr>",
     "src": [
       {
         "title": "1 Enoch 22",
-        "quote": "The apocalyptic text describes Sheol divided into chambers for different categories of the dead \u2014 a righteous chamber and a wicked chamber, with those awaiting judgment in intermediate states.",
+        "quote": "The apocalyptic text describes Sheol divided into chambers for different categories of the dead — a righteous chamber and a wicked chamber, with those awaiting judgment in intermediate states.",
         "note": "The closest Jewish parallel to the parable's geography of Hades. Jesus uses categories familiar to his audience without necessarily endorsing every detail of the apocalyptic picture."
       },
       {
@@ -395,13 +342,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Reversal \u2014 vv.19-25",
+          "label": "Reversal — vv.19-25",
           "text": "The parable's entire structure is built on reversal: the rich man's daily luxury becomes post-mortem agony; Lazarus's daily suffering becomes post-mortem comfort. The reversal is not mechanical (poverty does not automatically produce heaven) but reflects the logic of the beatitudes (6:20-26).",
           "is_key": false
         },
         {
-          "label": "Irony \u2014 v.31",
-          "text": "The final line \u2014 \"they will not be convinced even if someone rises from the dead\" \u2014 is retrospective irony. Luke's reader knows that someone did rise from the dead, and many were not convinced. The parable's ending is both prediction and post-resurrection commentary.",
+          "label": "Irony — v.31",
+          "text": "The final line — \"they will not be convinced even if someone rises from the dead\" — is retrospective irony. Luke's reader knows that someone did rise from the dead, and many were not convinced. The parable's ending is both prediction and post-resurrection commentary.",
           "is_key": false
         }
       ],
@@ -409,54 +356,54 @@
     },
     "hebtext": [
       {
-        "word": "phronim\u014ds",
+        "word": "phronimōs",
         "tlit": "phro-NI-mos",
         "gloss": "shrewdly / wisely / with practical wisdom",
-        "note": "The manager is commended not for dishonesty but for phronim\u014ds (v.8) \u2014 practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
+        "note": "The manager is commended not for dishonesty but for phronimōs (v.8) — practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
       },
       {
-        "word": "mam\u014dnas",
+        "word": "mamōnas",
         "tlit": "ma-MO-nas",
         "gloss": "mammon / money / wealth",
-        "note": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master \u2014 it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
+        "note": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master — it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
       },
       {
         "word": "porphyran",
         "tlit": "por-PHY-ran",
         "gloss": "purple",
-        "note": "The colour of imperial and priestly garments \u2014 extravagant luxury. Only the very wealthy could afford purple dye (extracted from murex shellfish). The detail places the rich man at the apex of economic privilege."
+        "note": "The colour of imperial and priestly garments — extravagant luxury. Only the very wealthy could afford purple dye (extracted from murex shellfish). The detail places the rich man at the apex of economic privilege."
       },
       {
         "word": "kolpon Abraam",
         "tlit": "kol-PON ab-ra-AM",
         "gloss": "Abraham's bosom / Abraham's side",
-        "note": "The metaphor (v.22) is of reclining at a banquet in the place of honour next to the host \u2014 the position of the most honoured guest. Lazarus, who had no place at any table in his lifetime, now reclines in the most honoured place at the eternal feast."
+        "note": "The metaphor (v.22) is of reclining at a banquet in the place of honour next to the host — the position of the most honoured guest. Lazarus, who had no place at any table in his lifetime, now reclines in the most honoured place at the eternal feast."
       },
       {
-        "word": "phronim\u014ds",
+        "word": "phronimōs",
         "tlit": "phro-NI-mos",
         "gloss": "shrewdly / wisely / with practical wisdom",
-        "note": "The manager is commended not for dishonesty but for phronim\u014ds (v.8) \u2014 practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
+        "note": "The manager is commended not for dishonesty but for phronimōs (v.8) — practical cleverness, the capacity to assess a situation and act decisively. Jesus points to this worldly trait as something the \"children of light\" conspicuously lack in managing their own affairs."
       },
       {
-        "word": "mam\u014dnas",
+        "word": "mamōnas",
         "tlit": "ma-MO-nas",
         "gloss": "mammon / money / wealth",
-        "note": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master \u2014 it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
+        "note": "The Aramaic loanword (vv.9, 11, 13) personifies wealth as a rival lord. Jesus does not say money is evil in itself but that it has the character of a master — it demands loyalty, shapes priorities, and competes with God for the allegiance of the heart."
       }
     ],
     "tx": [
       {
         "ref": "16:9",
         "title": "\"When it is gone\" vs \"when you fail\"",
-        "content": "The Greek hotan eklip\u0113 can mean \"when it [worldly wealth] runs out/is gone\" or \"when you fail/die.\" NA28 follows the majority reading; some MSS and commentators read it as referring to the disciple's death rather than wealth's expiry.",
+        "content": "The Greek hotan eklipē can mean \"when it [worldly wealth] runs out/is gone\" or \"when you fail/die.\" NA28 follows the majority reading; some MSS and commentators read it as referring to the disciple's death rather than wealth's expiry.",
         "note": "Both readings make theological sense. The temporal reading (when wealth runs out) fits the immediate context of the steward parable; the personal reading (when you die) fits the broader context of 16:19-31."
       },
       {
         "ref": "16:19",
         "title": "The rich man unnamed",
         "content": "Earliest MSS give no name; later traditions supply \"Nineue,\" \"Fineas,\" or (via the Latin tradition) \"Dives.\" NA28 follows the unnamed form.",
-        "note": "The unnamed form is almost certainly original. The tradition of naming the rich man developed to balance the named Lazarus; the unnamed form is more pointed \u2014 he who had everything has no name in eternity."
+        "note": "The unnamed form is almost certainly original. The tradition of naming the rich man developed to balance the named Lazarus; the unnamed form is more pointed — he who had everything has no name in eternity."
       }
     ],
     "debate": [
@@ -503,7 +450,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 16 develops the chapter's wealth theology in two directions. The shrewd manager parable argues for the wise use of wealth before it expires \u2014 use what you have now to lay up eternal capital. The rich man and Lazarus illustrates the consequence of failing to do so: wealth enjoyed without compassion for the visible poor produces a post-mortem reversal of devastating completeness. Both parables converge on the same point: money is a master that competes with God, and how we use it now shapes what awaits us then. The chapter's closing twist \u2014 \"if they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" \u2014 indicts the Pharisees who have Scripture but refuse its demand."
+      "note": "Luke 16 develops the chapter's wealth theology in two directions. The shrewd manager parable argues for the wise use of wealth before it expires — use what you have now to lay up eternal capital. The rich man and Lazarus illustrates the consequence of failing to do so: wealth enjoyed without compassion for the visible poor produces a post-mortem reversal of devastating completeness. Both parables converge on the same point: money is a master that competes with God, and how we use it now shapes what awaits us then. The chapter's closing twist — \"if they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\" — indicts the Pharisees who have Scripture but refuse its demand."
     }
   },
   "vhl_groups": [
@@ -624,7 +571,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "The shrewd manager, about to be fired, cuts debts to make friends. Jesus commends his shrewdness, not his ethics. 'Use worldly wealth to gain friends' (v. 9)\u2014generosity creates eternal welcomes.",
+      "tip": "The shrewd manager, about to be fired, cuts debts to make friends. Jesus commends his shrewdness, not his ethics. 'Use worldly wealth to gain friends' (v. 9)—generosity creates eternal welcomes.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/luke/17.json
+++ b/content/luke/17.json
@@ -10,7 +10,7 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201310 \u2014 Causes of Stumbling; Forgiveness; Faith Like a Mustard Seed",
+      "header": "Verses 1–10 — Causes of Stumbling; Forgiveness; Faith Like a Mustard Seed",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
@@ -19,61 +19,61 @@
             "word": "skandalon",
             "transliteration": "SKAN-da-lon",
             "gloss": "stumbling block / cause of sin",
-            "paragraph": "The word (v.1) originally described the trigger of a trap \u2014 the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
+            "paragraph": "The word (v.1) originally described the trigger of a trap — the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
           },
           {
             "word": "pistis sinapiou",
             "transliteration": "PIS-tis si-NA-pi-ou",
             "gloss": "faith the size of a mustard seed",
-            "paragraph": "The comparative (v.6) is not about quantity of faith but quality \u2014 the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
+            "paragraph": "The comparative (v.6) is not about quantity of faith but quality — the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
           }
         ],
         "places": [
           {
             "name": "Samaria-Galilee Border",
-            "coords": "32.3\u00b0 N, 35.2\u00b0 E",
-            "text": "The frontier between the territories of Samaria and Galilee in the first century \u2014 a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
+            "coords": "32.3° N, 35.2° E",
+            "text": "The frontier between the territories of Samaria and Galilee in the first century — a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 18:6-7",
-              "note": "Millstone and stumbling blocks \u2014 parallel warning in Matthew's community discourse."
+              "note": "Millstone and stumbling blocks — parallel warning in Matthew's community discourse."
             },
             {
               "ref": "Matt 17:20",
-              "note": "\"Truly I tell you, if you have faith as small as a mustard seed, you can say to this mountain, 'Move from here to there,' and it will move\" \u2014 Matthew's version uses a mountain rather than a mulberry tree."
+              "note": "\"Truly I tell you, if you have faith as small as a mustard seed, you can say to this mountain, 'Move from here to there,' and it will move\" — Matthew's version uses a mountain rather than a mulberry tree."
             },
             {
               "ref": "2 Kgs 5:1-19",
-              "note": "Naaman the Syrian healed of leprosy by Elisha \u2014 the OT precedent for a foreigner receiving cleansing that Israelites failed to seek, which Jesus references in 4:27."
+              "note": "Naaman the Syrian healed of leprosy by Elisha — the OT precedent for a foreigner receiving cleansing that Israelites failed to seek, which Jesus references in 4:27."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:3-4",
-              "note": "\"If they repent, forgive them. Even if they sin against you seven times in a day...\" \u2014 the repetition is the point. Forgiveness is not a one-time act but a continuous disposition. Seven times in a day makes the command feel impossible \u2014 which is precisely why the apostles immediately respond \"Increase our faith!\" The demand for repeated forgiveness is the context for the faith request."
+              "note": "\"If they repent, forgive them. Even if they sin against you seven times in a day...\" — the repetition is the point. Forgiveness is not a one-time act but a continuous disposition. Seven times in a day makes the command feel impossible — which is precisely why the apostles immediately respond \"Increase our faith!\" The demand for repeated forgiveness is the context for the faith request."
             },
             {
               "ref": "17:6",
-              "note": "The mustard-seed faith saying is not an invitation to attempt botanical miracles but an assurance that even tiny genuine faith is sufficient for the demands Jesus places on his disciples \u2014 including the demand for repeated forgiveness just stated. The \"mulberry tree\" (sykaminon) is specifically a deep-rooted tree, making the transplantation image even more striking."
+              "note": "The mustard-seed faith saying is not an invitation to attempt botanical miracles but an assurance that even tiny genuine faith is sufficient for the demands Jesus places on his disciples — including the demand for repeated forgiveness just stated. The \"mulberry tree\" (sykaminon) is specifically a deep-rooted tree, making the transplantation image even more striking."
             },
             {
               "ref": "17:10",
-              "note": "\"Unworthy servants; we have only done our duty\" \u2014 this corrects any theology of merit. Obedience does not put God in our debt; it simply fulfils what was expected. Grace cannot be earned by obedience because obedience is already owed. The servant who has done everything commanded has done nothing extraordinary; he has simply done what the relationship required."
+              "note": "\"Unworthy servants; we have only done our duty\" — this corrects any theology of merit. Obedience does not put God in our debt; it simply fulfils what was expected. Grace cannot be earned by obedience because obedience is already owed. The servant who has done everything commanded has done nothing extraordinary; he has simply done what the relationship required."
             },
             {
               "ref": "17:15-18",
-              "note": "The nine who did not return are not condemned \u2014 they followed Jesus's instruction to go to the priests. The Samaritan's return is extraordinary, not normative. But Jesus's question (\"Where are the other nine? Has no one returned to give praise to God except this foreigner?\") makes the contrast stark: the one who had least reason to return, by the standards of covenant belonging, was the one who returned."
+              "note": "The nine who did not return are not condemned — they followed Jesus's instruction to go to the priests. The Samaritan's return is extraordinary, not normative. But Jesus's question (\"Where are the other nine? Has no one returned to give praise to God except this foreigner?\") makes the contrast stark: the one who had least reason to return, by the standards of covenant belonging, was the one who returned."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:7-10",
@@ -81,69 +81,69 @@
             },
             {
               "ref": "17:19",
-              "note": "\"Your faith has made you well\" \u2014 the same formula used at other healings (7:50; 8:48). The nine were healed by the same power; the Samaritan received something more \u2014 not just physical cleansing but the pronouncement of wholeness that Jesus alone could give. Faith here is not the mechanism of healing but the relationship that opens to the fuller gift."
+              "note": "\"Your faith has made you well\" — the same formula used at other healings (7:50; 8:48). The nine were healed by the same power; the Samaritan received something more — not just physical cleansing but the pronouncement of wholeness that Jesus alone could give. Faith here is not the mechanism of healing but the relationship that opens to the fuller gift."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:6",
-              "note": "The mulberry tree (sykaminos) was proverbially deep-rooted in antiquity \u2014 rabbinic sources mention it as lasting 600 years. The image of uprooting such a tree and planting it in the sea combines deep-rootedness with the impossibility of growing in saltwater. The point is not botany but the impossible made possible by genuine faith."
+              "note": "The mulberry tree (sykaminos) was proverbially deep-rooted in antiquity — rabbinic sources mention it as lasting 600 years. The image of uprooting such a tree and planting it in the sea combines deep-rootedness with the impossibility of growing in saltwater. The point is not botany but the impossible made possible by genuine faith."
             },
             {
               "ref": "17:14",
-              "note": "\"As they went, they were cleansed\" \u2014 the healing occurs during the journey of obedience, not at the moment of the command. This pattern \u2014 healing in the act of obedient response \u2014 appears also in the blind man at Siloam (John 9:7). Faith acts before the evidence is complete."
+              "note": "\"As they went, they were cleansed\" — the healing occurs during the journey of obedience, not at the moment of the command. This pattern — healing in the act of obedient response — appears also in the blind man at Siloam (John 9:7). Faith acts before the evidence is complete."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "17:1",
-              "note": "Anendekton \u2014 \"impossible that\" (literally \"unable to be received/accepted\"). The strongest possible expression of impossibility: skandala are inevitable because of human sinfulness, but woe to the one who provides them. The inevitability does not excuse the agent."
+              "note": "Anendekton — \"impossible that\" (literally \"unable to be received/accepted\"). The strongest possible expression of impossibility: skandala are inevitable because of human sinfulness, but woe to the one who provides them. The inevitability does not excuse the agent."
             },
             {
               "ref": "17:6",
-              "note": "Sykamin\u014d \u2014 a mulberry tree (not the black mulberry, which was also called sykaminos, but the white mulberry or possibly the sycamore-fig). Distinguished from the sykom\u014drea (sycamore) of 19:4. Whatever the tree, it is deep-rooted and therefore a striking image for the impossible."
+              "note": "Sykaminō — a mulberry tree (not the black mulberry, which was also called sykaminos, but the white mulberry or possibly the sycamore-fig). Distinguished from the sykomōrea (sycamore) of 19:4. Whatever the tree, it is deep-rooted and therefore a striking image for the impossible."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:4",
-              "note": "Chrysostom: \"If you forgive seven times, you have gone beyond ordinary human patience. But Christ says: and again, and yet again. For it is not the number of times that matters but the disposition \u2014 to be always ready to receive the repentant, however many times they return.\""
+              "note": "Chrysostom: \"If you forgive seven times, you have gone beyond ordinary human patience. But Christ says: and again, and yet again. For it is not the number of times that matters but the disposition — to be always ready to receive the repentant, however many times they return.\""
             },
             {
               "ref": "17:16",
-              "note": "Bede: \"He was a Samaritan \u2014 that is, a foreigner and one rejected by the Jews. Yet he alone returned to give thanks. So often those who are far from the chosen community give back to God what the chosen keep for themselves.\""
+              "note": "Bede: \"He was a Samaritan — that is, a foreigner and one rejected by the Jews. Yet he alone returned to give thanks. So often those who are far from the chosen community give back to God what the chosen keep for themselves.\""
             }
           ]
         },
         "hist": {
-          "context": "Boundary Between Samaria and Galilee\nJesus's route (v.11) through the border region between Samaria and Galilee is geographically specific and theologically significant. The border was a social and religious boundary \u2014 Jewish-Samaritan relations were hostile. The ten lepers' mixed company (nine Jews, presumably, and one Samaritan) suggests that shared suffering crossed the usual boundaries.\n\nLeprosy and Social Exclusion\nBiblical \"leprosy\" (tsara'at) covered a range of skin conditions requiring Levitical examination and social isolation (Lev 13-14). The requirement to \"stand at a distance\" (v.12) and the command to \"show yourselves to the priests\" (v.14) both reflect the Levitical purity system. The Samaritan's return to Jesus rather than a Jewish priest is itself an implicit theological statement."
+          "context": "Boundary Between Samaria and Galilee\nJesus's route (v.11) through the border region between Samaria and Galilee is geographically specific and theologically significant. The border was a social and religious boundary — Jewish-Samaritan relations were hostile. The ten lepers' mixed company (nine Jews, presumably, and one Samaritan) suggests that shared suffering crossed the usual boundaries.\n\nLeprosy and Social Exclusion\nBiblical \"leprosy\" (tsara'at) covered a range of skin conditions requiring Levitical examination and social isolation (Lev 13-14). The requirement to \"stand at a distance\" (v.12) and the command to \"show yourselves to the priests\" (v.14) both reflect the Levitical purity system. The Samaritan's return to Jesus rather than a Jewish priest is itself an implicit theological statement."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201319 \u2014 The Ten Lepers: Where Are the Other Nine?",
+      "header": "Verses 11–19 — The Ten Lepers: Where Are the Other Nine?",
       "verse_start": 11,
       "verse_end": 19,
       "panels": {
         "heb": [
           {
-            "word": "entos hym\u014dn",
+            "word": "entos hymōn",
             "transliteration": "EN-tos hy-MON",
             "gloss": "in your midst / within you",
-            "paragraph": "The debated phrase (v.21) is either \"within you\" (the kingdom is an interior spiritual reality) or \"in your midst / among you\" (the kingdom is present in Jesus's person and ministry). The latter is more consistent with Luke's usage elsewhere \u2014 the kingdom arrives in events and persons, not primarily as an interior state."
+            "paragraph": "The debated phrase (v.21) is either \"within you\" (the kingdom is an interior spiritual reality) or \"in your midst / among you\" (the kingdom is present in Jesus's person and ministry). The latter is more consistent with Luke's usage elsewhere — the kingdom arrives in events and persons, not primarily as an interior state."
           },
           {
-            "word": "h\u014dsper astrap\u0113",
+            "word": "hōsper astrapē",
             "transliteration": "HO-sper as-tra-PE",
             "gloss": "like lightning",
             "paragraph": "The comparison (v.24) emphasises simultaneity and universality: lightning lights up the whole sky at once; the Son of Man's day will be equally instantaneous and unmissable. No local announcement (\"here he is!\") will be needed; the event will be self-evident to all."
@@ -152,8 +152,8 @@
         "places": [
           {
             "name": "Samaria-Galilee Border",
-            "coords": "32.3\u00b0 N, 35.2\u00b0 E",
-            "text": "The frontier between the territories of Samaria and Galilee in the first century \u2014 a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
+            "coords": "32.3° N, 35.2° E",
+            "text": "The frontier between the territories of Samaria and Galilee in the first century — a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
           }
         ],
         "cross": {
@@ -164,20 +164,20 @@
             },
             {
               "ref": "Gen 6:5-8",
-              "note": "The days of Noah \u2014 the setting of the flood narrative that Jesus invokes as a type of the final judgment."
+              "note": "The days of Noah — the setting of the flood narrative that Jesus invokes as a type of the final judgment."
             },
             {
               "ref": "Gen 19:1-29",
-              "note": "The destruction of Sodom and the escape of Lot \u2014 the second OT type Jesus uses, with the specific warning to remember Lot's wife (Gen 19:26)."
+              "note": "The destruction of Sodom and the escape of Lot — the second OT type Jesus uses, with the specific warning to remember Lot's wife (Gen 19:26)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:20-21",
-              "note": "\"The kingdom of God is in your midst\" \u2014 the Pharisees are asking the wrong question. They want a calendar; Jesus offers a reality. The kingdom is already present in the one they are questioning. Their inability to see this is itself evidence of the kingdom's hiddenness from the self-sufficient."
+              "note": "\"The kingdom of God is in your midst\" — the Pharisees are asking the wrong question. They want a calendar; Jesus offers a reality. The kingdom is already present in the one they are questioning. Their inability to see this is itself evidence of the kingdom's hiddenness from the self-sufficient."
             },
             {
               "ref": "17:24",
@@ -185,7 +185,7 @@
             },
             {
               "ref": "17:32",
-              "note": "\"Remember Lot's wife\" \u2014 the shortest command in Luke, and one of the most ominous. Her sin was not curiosity but attachment: looking back at what she was leaving, she was destroyed by the very judgment she was escaping. Jesus applies it directly: when the day comes, do not go back for possessions (v.31). Attachment to the old life is incompatible with rescue."
+              "note": "\"Remember Lot's wife\" — the shortest command in Luke, and one of the most ominous. Her sin was not curiosity but attachment: looking back at what she was leaving, she was destroyed by the very judgment she was escaping. Jesus applies it directly: when the day comes, do not go back for possessions (v.31). Attachment to the old life is incompatible with rescue."
             },
             {
               "ref": "17:33",
@@ -194,11 +194,11 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:20-21",
-              "note": "Calvin takes entos hym\u014dn as \"among you\" rather than \"within you\" \u2014 the kingdom is present in Christ himself, not in an inner spiritual experience. The Pharisees' error is demanding an external visible sign of what is already standing before them. Calvin uses this to argue against all attempts to locate the kingdom geographically or chronologically."
+              "note": "Calvin takes entos hymōn as \"among you\" rather than \"within you\" — the kingdom is present in Christ himself, not in an inner spiritual experience. The Pharisees' error is demanding an external visible sign of what is already standing before them. Calvin uses this to argue against all attempts to locate the kingdom geographically or chronologically."
             },
             {
               "ref": "17:26-30",
@@ -207,7 +207,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:21",
@@ -220,24 +220,24 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "17:21",
-              "note": "Entos \u2014 the lexical debate is genuine. LSJ gives both \"within\" and \"among\" as valid meanings. Robertson himself favours \"in the midst of you\" (among you, in your presence) as more consistent with Luke's kingdom theology. The present tense (estin) suggests a current reality, not a future interior state."
+              "note": "Entos — the lexical debate is genuine. LSJ gives both \"within\" and \"among\" as valid meanings. Robertson himself favours \"in the midst of you\" (among you, in your presence) as more consistent with Luke's kingdom theology. The present tense (estin) suggests a current reality, not a future interior state."
             },
             {
               "ref": "17:37",
-              "note": "\"Where the body is, there the vultures will gather\" \u2014 a proverb of inevitable consequence. Just as carrion attracts vultures without announcement, the coming of the Son of Man will be attracted by the moral condition of the earth. Robertson notes that the \"eagles\" of KJV is better rendered \"vultures\" (aetoi can mean either, but the context requires scavengers)."
+              "note": "\"Where the body is, there the vultures will gather\" — a proverb of inevitable consequence. Just as carrion attracts vultures without announcement, the coming of the Son of Man will be attracted by the moral condition of the earth. Robertson notes that the \"eagles\" of KJV is better rendered \"vultures\" (aetoi can mean either, but the context requires scavengers)."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:21",
-              "note": "Origen: \"The kingdom of God is within us \u2014 that is, in our intellect and our soul \u2014 when we make progress and it advances in us. For the kingdom is not a place but a spiritual condition, and it grows in those who grow toward it.\""
+              "note": "Origen: \"The kingdom of God is within us — that is, in our intellect and our soul — when we make progress and it advances in us. For the kingdom is not a place but a spiritual condition, and it grows in those who grow toward it.\""
             },
             {
               "ref": "17:26-27",
@@ -246,13 +246,13 @@
           ]
         },
         "hist": {
-          "context": "When Does the Kingdom Come?\nThe Pharisees' question about the timing of the kingdom reflects a common apocalyptic expectation \u2014 a datable, observable arrival of the divine reign. Jesus rejects both the calculability (it is not something that can be observed, 17:20) and the locality (not \"here\" or \"there,\" 17:21). The kingdom's presence is not a future event to be calculated but a present reality to be discerned in Jesus himself.\n\nNoah and Lot as Eschatological Types\nBoth Noah (Gen 6-9) and Lot (Gen 18-19) are OT figures of divine rescue preceding divine judgment. In both cases, ordinary life continued up to the moment of catastrophe \u2014 eating, drinking, marrying, buying, selling. The lesson is not that these activities are wrong but that they created a false sense of security that blinded people to the crisis."
+          "context": "When Does the Kingdom Come?\nThe Pharisees' question about the timing of the kingdom reflects a common apocalyptic expectation — a datable, observable arrival of the divine reign. Jesus rejects both the calculability (it is not something that can be observed, 17:20) and the locality (not \"here\" or \"there,\" 17:21). The kingdom's presence is not a future event to be calculated but a present reality to be discerned in Jesus himself.\n\nNoah and Lot as Eschatological Types\nBoth Noah (Gen 6-9) and Lot (Gen 18-19) are OT figures of divine rescue preceding divine judgment. In both cases, ordinary life continued up to the moment of catastrophe — eating, drinking, marrying, buying, selling. The lesson is not that these activities are wrong but that they created a false sense of security that blinded people to the crisis."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 20\u201337 \u2014 The Coming of the Kingdom; The Days of the Son of Man",
+      "header": "Verses 20–37 — The Coming of the Kingdom; The Days of the Son of Man",
       "verse_start": 20,
       "verse_end": 37,
       "panels": {
@@ -261,113 +261,60 @@
             "word": "skandalon",
             "transliteration": "SKAN-da-lon",
             "gloss": "stumbling block / cause of sin",
-            "paragraph": "The word (v.1) originally described the trigger of a trap \u2014 the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
+            "paragraph": "The word (v.1) originally described the trigger of a trap — the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
           },
           {
             "word": "pistis sinapiou",
             "transliteration": "PIS-tis si-NA-pi-ou",
             "gloss": "faith the size of a mustard seed",
-            "paragraph": "The comparative (v.6) is not about quantity of faith but quality \u2014 the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
+            "paragraph": "The comparative (v.6) is not about quantity of faith but quality — the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
           }
         ],
         "places": [
           {
             "name": "Samaria-Galilee Border",
-            "coords": "32.3\u00b0 N, 35.2\u00b0 E",
-            "text": "The frontier between the territories of Samaria and Galilee in the first century \u2014 a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
+            "coords": "32.3° N, 35.2° E",
+            "text": "The frontier between the territories of Samaria and Galilee in the first century — a social as well as geographic boundary. Jesus's route through this region on his way to Jerusalem (9:51) is one of Luke's periodic geographical reminders that the journey continues. The border setting makes the Samaritan leper's presence in the group of ten plausible."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 18:6-7",
-              "note": "Millstone and stumbling blocks \u2014 parallel warning in Matthew's community discourse."
+              "note": "Millstone and stumbling blocks — parallel warning in Matthew's community discourse."
             },
             {
               "ref": "Matt 17:20",
-              "note": "\"Truly I tell you, if you have faith as small as a mustard seed, you can say to this mountain, 'Move from here to there,' and it will move\" \u2014 Matthew's version uses a mountain rather than a mulberry tree."
+              "note": "\"Truly I tell you, if you have faith as small as a mustard seed, you can say to this mountain, 'Move from here to there,' and it will move\" — Matthew's version uses a mountain rather than a mulberry tree."
             },
             {
               "ref": "2 Kgs 5:1-19",
-              "note": "Naaman the Syrian healed of leprosy by Elisha \u2014 the OT precedent for a foreigner receiving cleansing that Israelites failed to seek, which Jesus references in 4:27."
+              "note": "Naaman the Syrian healed of leprosy by Elisha — the OT precedent for a foreigner receiving cleansing that Israelites failed to seek, which Jesus references in 4:27."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:3-4",
-              "note": "\"If they repent, forgive them. Even if they sin against you seven times in a day...\" \u2014 the repetition is the point. Forgiveness is not a one-time act but a continuous disposition. Seven times in a day makes the command feel impossible \u2014 which is precisely why the apostles immediately respond \"Increase our faith!\" The demand for repeated forgiveness is the context for the faith request."
-            },
-            {
-              "ref": "17:6",
-              "note": "The mustard-seed faith saying is not an invitation to attempt botanical miracles but an assurance that even tiny genuine faith is sufficient for the demands Jesus places on his disciples \u2014 including the demand for repeated forgiveness just stated. The \"mulberry tree\" (sykaminon) is specifically a deep-rooted tree, making the transplantation image even more striking."
-            },
-            {
-              "ref": "17:10",
-              "note": "\"Unworthy servants; we have only done our duty\" \u2014 this corrects any theology of merit. Obedience does not put God in our debt; it simply fulfils what was expected. Grace cannot be earned by obedience because obedience is already owed. The servant who has done everything commanded has done nothing extraordinary; he has simply done what the relationship required."
-            },
-            {
-              "ref": "17:15-18",
-              "note": "The nine who did not return are not condemned \u2014 they followed Jesus's instruction to go to the priests. The Samaritan's return is extraordinary, not normative. But Jesus's question (\"Where are the other nine? Has no one returned to give praise to God except this foreigner?\") makes the contrast stark: the one who had least reason to return, by the standards of covenant belonging, was the one who returned."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:7-10",
-              "note": "Calvin uses the duty parable to counter any doctrine of merit or supererogation (works beyond what is required). If we obey completely, we have done only what the master was owed. There is no surplus of obedience that can be stored up or transferred. This is directed against both Protestant pride in good works and the Catholic doctrine that saints' surplus merits can be distributed to others."
-            },
-            {
-              "ref": "17:19",
-              "note": "\"Your faith has made you well\" \u2014 the same formula used at other healings (7:50; 8:48). The nine were healed by the same power; the Samaritan received something more \u2014 not just physical cleansing but the pronouncement of wholeness that Jesus alone could give. Faith here is not the mechanism of healing but the relationship that opens to the fuller gift."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:6",
-              "note": "The mulberry tree (sykaminos) was proverbially deep-rooted in antiquity \u2014 rabbinic sources mention it as lasting 600 years. The image of uprooting such a tree and planting it in the sea combines deep-rootedness with the impossibility of growing in saltwater. The point is not botany but the impossible made possible by genuine faith."
-            },
-            {
-              "ref": "17:14",
-              "note": "\"As they went, they were cleansed\" \u2014 the healing occurs during the journey of obedience, not at the moment of the command. This pattern \u2014 healing in the act of obedient response \u2014 appears also in the blind man at Siloam (John 9:7). Faith acts before the evidence is complete."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "17:1",
-              "note": "Anendekton \u2014 \"impossible that\" (literally \"unable to be received/accepted\"). The strongest possible expression of impossibility: skandala are inevitable because of human sinfulness, but woe to the one who provides them. The inevitability does not excuse the agent."
-            },
-            {
-              "ref": "17:6",
-              "note": "Sykamin\u014d \u2014 a mulberry tree (not the black mulberry, which was also called sykaminos, but the white mulberry or possibly the sycamore-fig). Distinguished from the sykom\u014drea (sycamore) of 19:4. Whatever the tree, it is deep-rooted and therefore a striking image for the impossible."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "17:4",
-              "note": "Chrysostom: \"If you forgive seven times, you have gone beyond ordinary human patience. But Christ says: and again, and yet again. For it is not the number of times that matters but the disposition \u2014 to be always ready to receive the repentant, however many times they return.\""
-            },
-            {
-              "ref": "17:16",
-              "note": "Bede: \"He was a Samaritan \u2014 that is, a foreigner and one rejected by the Jews. Yet he alone returned to give thanks. So often those who are far from the chosen community give back to God what the chosen keep for themselves.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Boundary Between Samaria and Galilee\nJesus's route (v.11) through the border region between Samaria and Galilee is geographically specific and theologically significant. The border was a social and religious boundary \u2014 Jewish-Samaritan relations were hostile. The ten lepers' mixed company (nine Jews, presumably, and one Samaritan) suggests that shared suffering crossed the usual boundaries.\n\nLeprosy and Social Exclusion\nBiblical \"leprosy\" (tsara'at) covered a range of skin conditions requiring Levitical examination and social isolation (Lev 13-14). The requirement to \"stand at a distance\" (v.12) and the command to \"show yourselves to the priests\" (v.14) both reflect the Levitical purity system. The Samaritan's return to Jesus rather than a Jewish priest is itself an implicit theological statement."
+          "context": "Boundary Between Samaria and Galilee\nJesus's route (v.11) through the border region between Samaria and Galilee is geographically specific and theologically significant. The border was a social and religious boundary — Jewish-Samaritan relations were hostile. The ten lepers' mixed company (nine Jews, presumably, and one Samaritan) suggests that shared suffering crossed the usual boundaries.\n\nLeprosy and Social Exclusion\nBiblical \"leprosy\" (tsara'at) covered a range of skin conditions requiring Levitical examination and social isolation (Lev 13-14). The requirement to \"stand at a distance\" (v.12) and the command to \"show yourselves to the priests\" (v.14) both reflect the Levitical purity system. The Samaritan's return to Jesus rather than a Jewish priest is itself an implicit theological statement."
         }
       }
     }
@@ -377,12 +324,12 @@
       {
         "name": "Jesus",
         "role": "Teacher on the journey",
-        "text": "Luke 17 spans from community ethics (forgiveness, faith, duty) to miraculous healing to eschatological teaching \u2014 the range of Luke's Jesus in a single chapter."
+        "text": "Luke 17 spans from community ethics (forgiveness, faith, duty) to miraculous healing to eschatological teaching — the range of Luke's Jesus in a single chapter."
       },
       {
         "name": "The Ten Lepers",
         "role": "Mixed group of the excluded",
-        "text": "Nine Jews and one Samaritan, united by their condition and separated by their response. The nine fulfill the legal requirement (showing themselves to priests); the one returns with something beyond legal compliance \u2014 gratitude and faith."
+        "text": "Nine Jews and one Samaritan, united by their condition and separated by their response. The nine fulfill the legal requirement (showing themselves to priests); the one returns with something beyond legal compliance — gratitude and faith."
       },
       {
         "name": "The Samaritan Leper",
@@ -390,38 +337,38 @@
         "text": "Fourth Samaritan in Luke's positive portraits (cf. 10:33-37; 17:16; and implicitly Acts 8). The pattern is consistent: the outsider models what the insider should have been."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">entos hym\u014dn (17:21)</td><td>KJV: \"within you\"; NIV: \"in your midst\"; ESV: \"in the midst of you\"; NRSV: \"among you\". Modern translations generally favour \"among/in your midst\" against KJV's \"within.\"</td></tr><tr><td class=\"t-label\">aetoi (17:37)</td><td>KJV: \"eagles\"; NIV/ESV/NRSV: \"vultures\". The Greek can mean either; context requires scavenging birds, making \"vultures\" correct.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">entos hymōn (17:21)</td><td>KJV: \"within you\"; NIV: \"in your midst\"; ESV: \"in the midst of you\"; NRSV: \"among you\". Modern translations generally favour \"among/in your midst\" against KJV's \"within.\"</td></tr><tr><td class=\"t-label\">aetoi (17:37)</td><td>KJV: \"eagles\"; NIV/ESV/NRSV: \"vultures\". The Greek can mean either; context requires scavenging birds, making \"vultures\" correct.</td></tr>",
     "src": [
       {
         "title": "Genesis 6-9",
-        "quote": "The flood narrative \u2014 Noah's world continued in ordinary life until the rain began. Jesus uses it as a type of the sudden, unmissable arrival of the Son of Man's day.",
+        "quote": "The flood narrative — Noah's world continued in ordinary life until the rain began. Jesus uses it as a type of the sudden, unmissable arrival of the Son of Man's day.",
         "note": "The comparison is not about Noah's generation being peculiarly wicked but about their absorption in ordinary life to the exclusion of divine warning."
       },
       {
         "title": "Genesis 19",
-        "quote": "The destruction of Sodom and Lot's rescue \u2014 with the specific detail of Lot's wife looking back (19:26). Jesus's \"Remember Lot's wife\" (17:32) is the shortest eschatological warning in the Gospels.",
-        "note": "Lot's wife represents attachment to the life being left behind \u2014 the same attachment Jesus warns against in 17:31 (going back for possessions)."
+        "quote": "The destruction of Sodom and Lot's rescue — with the specific detail of Lot's wife looking back (19:26). Jesus's \"Remember Lot's wife\" (17:32) is the shortest eschatological warning in the Gospels.",
+        "note": "Lot's wife represents attachment to the life being left behind — the same attachment Jesus warns against in 17:31 (going back for possessions)."
       }
     ],
     "rec": [
       {
         "who": "The Kingdom \"Within You\" in Mystical Theology",
-        "text": "The KJV rendering \"the kingdom of God is within you\" became the foundational text for Christian mystical and interior spirituality \u2014 from Meister Eckhart and Thomas \u00e0 Kempis through Quaker inwardness to Tolstoy's The Kingdom of God Is Within You (1894). The \"among you\" reading, now favoured by most scholars, has been a corrective, but the interior reading has proved remarkably generative in the tradition."
+        "text": "The KJV rendering \"the kingdom of God is within you\" became the foundational text for Christian mystical and interior spirituality — from Meister Eckhart and Thomas à Kempis through Quaker inwardness to Tolstoy's The Kingdom of God Is Within You (1894). The \"among you\" reading, now favoured by most scholars, has been a corrective, but the interior reading has proved remarkably generative in the tradition."
       },
       {
         "who": "Remember Lot's Wife",
-        "text": "The three words of 17:32 (\"Remember Lot's wife\") have echoed through Christian reflection on detachment, worldliness, and the cost of discipleship. They appear in monastic literature as a warning against nostalgia for the life renounced, and in Puritan writing as an example of the danger of half-conversion \u2014 those who begin the journey but look back at what they are leaving."
+        "text": "The three words of 17:32 (\"Remember Lot's wife\") have echoed through Christian reflection on detachment, worldliness, and the cost of discipleship. They appear in monastic literature as a warning against nostalgia for the life renounced, and in Puritan writing as an example of the danger of half-conversion — those who begin the journey but look back at what they are leaving."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Two Audiences \u2014 vv.20-21 / 22-37",
-          "text": "The chapter's eschatological teaching is addressed to two audiences: the Pharisees (17:20-21, about the observable kingdom) and the disciples (17:22-37, about the Son of Man's day). The teaching differs in both content and emphasis \u2014 the Pharisees get a present-tense statement; the disciples get future-tense warnings.",
+          "label": "Two Audiences — vv.20-21 / 22-37",
+          "text": "The chapter's eschatological teaching is addressed to two audiences: the Pharisees (17:20-21, about the observable kingdom) and the disciples (17:22-37, about the Son of Man's day). The teaching differs in both content and emphasis — the Pharisees get a present-tense statement; the disciples get future-tense warnings.",
           "is_key": false
         },
         {
-          "label": "Noah and Lot Parallelism \u2014 vv.26-29",
+          "label": "Noah and Lot Parallelism — vv.26-29",
           "text": "Two OT catastrophes presented in parallel construction: \"just as it was in the days of Noah / it was the same in the days of Lot.\" Both list ordinary activities; both end with sudden destruction. The parallelism intensifies the warning through repetition.",
           "is_key": false
         }
@@ -433,22 +380,22 @@
         "word": "skandalon",
         "tlit": "SKAN-da-lon",
         "gloss": "stumbling block / cause of sin",
-        "note": "The word (v.1) originally described the trigger of a trap \u2014 the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
+        "note": "The word (v.1) originally described the trigger of a trap — the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
       },
       {
         "word": "pistis sinapiou",
         "tlit": "PIS-tis si-NA-pi-ou",
         "gloss": "faith the size of a mustard seed",
-        "note": "The comparative (v.6) is not about quantity of faith but quality \u2014 the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
+        "note": "The comparative (v.6) is not about quantity of faith but quality — the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
       },
       {
-        "word": "entos hym\u014dn",
+        "word": "entos hymōn",
         "tlit": "EN-tos hy-MON",
         "gloss": "in your midst / within you",
-        "note": "The debated phrase (v.21) is either \"within you\" (the kingdom is an interior spiritual reality) or \"in your midst / among you\" (the kingdom is present in Jesus's person and ministry). The latter is more consistent with Luke's usage elsewhere \u2014 the kingdom arrives in events and persons, not primarily as an interior state."
+        "note": "The debated phrase (v.21) is either \"within you\" (the kingdom is an interior spiritual reality) or \"in your midst / among you\" (the kingdom is present in Jesus's person and ministry). The latter is more consistent with Luke's usage elsewhere — the kingdom arrives in events and persons, not primarily as an interior state."
       },
       {
-        "word": "h\u014dsper astrap\u0113",
+        "word": "hōsper astrapē",
         "tlit": "HO-sper as-tra-PE",
         "gloss": "like lightning",
         "note": "The comparison (v.24) emphasises simultaneity and universality: lightning lights up the whole sky at once; the Son of Man's day will be equally instantaneous and unmissable. No local announcement (\"here he is!\") will be needed; the event will be self-evident to all."
@@ -457,26 +404,26 @@
         "word": "skandalon",
         "tlit": "SKAN-da-lon",
         "gloss": "stumbling block / cause of sin",
-        "note": "The word (v.1) originally described the trigger of a trap \u2014 the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
+        "note": "The word (v.1) originally described the trigger of a trap — the stick that, when touched, snapped the snare shut. Applied to human behaviour, it describes anything that trips another person into sin. Jesus treats causing another to stumble as a capital offence worthy of millstone-and-sea."
       },
       {
         "word": "pistis sinapiou",
         "tlit": "PIS-tis si-NA-pi-ou",
         "gloss": "faith the size of a mustard seed",
-        "note": "The comparative (v.6) is not about quantity of faith but quality \u2014 the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
+        "note": "The comparative (v.6) is not about quantity of faith but quality — the genuine article, however small. The mustard seed was proverbially the smallest agricultural seed. The point: even the tiniest genuine faith can do the impossible, because faith connects the one who has it to the God who does the impossible."
       }
     ],
     "tx": [
       {
         "ref": "17:36",
         "title": "Verse 36 omitted",
-        "content": "NA28 omits \"Two men will be in the field; one will be taken and the other left\" \u2014 absent from the best early witnesses (p75, Sinaiticus, Vaticanus) and almost certainly a scribal addition harmonising with Matt 24:40.",
+        "content": "NA28 omits \"Two men will be in the field; one will be taken and the other left\" — absent from the best early witnesses (p75, Sinaiticus, Vaticanus) and almost certainly a scribal addition harmonising with Matt 24:40.",
         "note": "The omission preserves the original: Luke has the bed and the grinding mill; Matthew has the field. Both are authentic tradition; Luke's version did not originally include the field."
       },
       {
         "ref": "17:21",
-        "title": "entos \u2014 no textual variant",
-        "content": "The manuscript tradition is uniform on entos; the debate is purely interpretive. The NRSV and NIV translate \"among you\"; KJV \"within you.\" No manuscript supports one reading over the other \u2014 this is a question of lexicography and context, not textual criticism.",
+        "title": "entos — no textual variant",
+        "content": "The manuscript tradition is uniform on entos; the debate is purely interpretive. The NRSV and NIV translate \"among you\"; KJV \"within you.\" No manuscript supports one reading over the other — this is a question of lexicography and context, not textual criticism.",
         "note": "Context and Lukan usage strongly favour \"among you.\" The lexical evidence for \"within\" in this context is weaker than the contextual evidence for \"among.\""
       }
     ],
@@ -650,7 +597,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'One of them, when he saw he was healed, came back, praising God... and he was a Samaritan' (vv. 15-16). Ten lepers healed; one returns\u2014the outsider. 'Where are the other nine?' Gratitude is rare.",
+      "tip": "'One of them, when he saw he was healed, came back, praising God... and he was a Samaritan' (vv. 15-16). Ten lepers healed; one returns—the outsider. 'Where are the other nine?' Gratitude is rare.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/luke/18.json
+++ b/content/luke/18.json
@@ -10,7 +10,7 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201117 \u2014 The Persistent Widow; The Pharisee and Tax Collector; Children",
+      "header": "Verses 1‑17 — The Persistent Widow; The Pharisee and Tax Collector; Children",
       "verse_start": 1,
       "verse_end": 17,
       "panels": {
@@ -22,10 +22,10 @@
             "paragraph": "The verb (v.1) means to grow tired, to lose the energy of persistence. The parable's primary application is stated before the story begins: pray and do not lose heart. The widow's persistence is the positive model; ekkakein is what the disciples are to refuse."
           },
           {
-            "word": "hilasth\u0113ti moi",
-            "transliteration": "hi-LAS-th\u0113-ti moi",
+            "word": "hilasthēti moi",
+            "transliteration": "hi-LAS-thē-ti moi",
             "gloss": "have mercy on me / be propitiated toward me",
-            "paragraph": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably \u2014 he asks for mercy from a God whose holiness his life has violated."
+            "paragraph": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably — he asks for mercy from a God whose holiness his life has violated."
           }
         ],
         "cross": {
@@ -40,12 +40,12 @@
             },
             {
               "ref": "Ps 17:1-2",
-              "note": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer\" \u2014 the Psalm of the persisting righteous sufferer that provides the OT background for the widow's persistence."
+              "note": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer\" — the Psalm of the persisting righteous sufferer that provides the OT background for the widow's persistence."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:7-8",
@@ -53,37 +53,37 @@
             },
             {
               "ref": "18:11-12",
-              "note": "The Pharisee's prayer is not prayer at all \u2014 it is self-congratulation addressed to God. He compares himself favourably to others, lists his religious achievements, and asks for nothing. The form is prayer; the content is a r\u00e9sum\u00e9. He leaves exactly as he arrived \u2014 \"justified in his own eyes\" but not before God."
+              "note": "The Pharisee's prayer is not prayer at all — it is self-congratulation addressed to God. He compares himself favourably to others, lists his religious achievements, and asks for nothing. The form is prayer; the content is a résumé. He leaves exactly as he arrived — \"justified in his own eyes\" but not before God."
             },
             {
               "ref": "18:13",
-              "note": "\"God, have mercy on me, a sinner\" \u2014 in Greek: ho hamart\u014dlos, with the definite article: \"the sinner\" \u2014 as if he is the only one in the category, or at least the representative of the category. The tax collector does not say \"a sinner among many\" but \"the sinner\" \u2014 total self-assessment without mitigation."
+              "note": "\"God, have mercy on me, a sinner\" — in Greek: ho hamartōlos, with the definite article: \"the sinner\" — as if he is the only one in the category, or at least the representative of the category. The tax collector does not say \"a sinner among many\" but \"the sinner\" — total self-assessment without mitigation."
             },
             {
               "ref": "18:22-23",
-              "note": "\"Sell everything you have and give to the poor, and you will have treasure in heaven. Then come, follow me.\" \u2014 \"When he heard this, he became very sad.\" The ruler's sadness is not anger or defiance but genuine grief \u2014 he wants the eternal life, he cannot pay the price. The encounter is one of the most poignant in the Gospels: a sincere man who cannot do the one necessary thing."
+              "note": "\"Sell everything you have and give to the poor, and you will have treasure in heaven. Then come, follow me.\" — \"When he heard this, he became very sad.\" The ruler's sadness is not anger or defiance but genuine grief — he wants the eternal life, he cannot pay the price. The encounter is one of the most poignant in the Gospels: a sincere man who cannot do the one necessary thing."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:9",
-              "note": "Calvin notes that the parable's target is specifically \"those who were confident of their own righteousness and looked down on everyone else\" \u2014 not the openly wicked but the religiously self-satisfied. The Pharisee's prayer is a case study in the most dangerous form of irreligion: the religion that makes its practitioners worse, not better, by filling them with self-congratulation in the very act of appearing to worship God."
+              "note": "Calvin notes that the parable's target is specifically \"those who were confident of their own righteousness and looked down on everyone else\" — not the openly wicked but the religiously self-satisfied. The Pharisee's prayer is a case study in the most dangerous form of irreligion: the religion that makes its practitioners worse, not better, by filling them with self-congratulation in the very act of appearing to worship God."
             },
             {
               "ref": "18:27",
-              "note": "\"What is impossible with man is possible with God\" \u2014 Calvin uses this as a statement about the nature of salvation itself, not merely about exceptional conversions of the wealthy. Salvation is impossible with man in every case; it is possible with God in every case. The camel-needle image is a universal statement about human inability that the divine response reverses."
+              "note": "\"What is impossible with man is possible with God\" — Calvin uses this as a statement about the nature of salvation itself, not merely about exceptional conversions of the wealthy. Salvation is impossible with man in every case; it is possible with God in every case. The camel-needle image is a universal statement about human inability that the divine response reverses."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:12",
-              "note": "\"I fast twice a week and give a tenth of all I get\" \u2014 fasting twice a week (Monday and Thursday) was a supererogatory practice of particularly devout Jews, beyond the single annual fast of Yom Kippur required by Torah. Tithing \"all I get\" may mean tithing even what he purchased from others in case they had not already tithed it \u2014 extreme religious conscientiousness. The Pharisee's religious practice is genuine and extraordinary, which makes his self-justification all the more tragic."
+              "note": "\"I fast twice a week and give a tenth of all I get\" — fasting twice a week (Monday and Thursday) was a supererogatory practice of particularly devout Jews, beyond the single annual fast of Yom Kippur required by Torah. Tithing \"all I get\" may mean tithing even what he purchased from others in case they had not already tithed it — extreme religious conscientiousness. The Pharisee's religious practice is genuine and extraordinary, which makes his self-justification all the more tragic."
             },
             {
               "ref": "18:25",
@@ -92,24 +92,24 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "18:2",
-              "note": "Ton theon m\u0113 phoboumenos \u2014 \"not fearing God\" (present participle). The negative is me with the participle: a continuous state of not-fearing. The judge is characterised by two negatives: no fear of God, no care about people. He is the opposite of every quality that makes a just judge."
+              "note": "Ton theon mē phoboumenos — \"not fearing God\" (present participle). The negative is me with the participle: a continuous state of not-fearing. The judge is characterised by two negatives: no fear of God, no care about people. He is the opposite of every quality that makes a just judge."
             },
             {
               "ref": "18:25",
-              "note": "Tryp\u0113matos belon\u0113s \u2014 \"eye of a needle.\" The same image appears in rabbinic literature (b. Berachoth 55b) with \"elephant through the eye of a needle\" as a common hyperbole for impossibility. Jesus is using a standard rhetorical form, not coining a new phrase."
+              "note": "Trypēmatos belonēs — \"eye of a needle.\" The same image appears in rabbinic literature (b. Berachoth 55b) with \"elephant through the eye of a needle\" as a common hyperbole for impossibility. Jesus is using a standard rhetorical form, not coining a new phrase."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:13",
-              "note": "Augustine: \"He did not say 'Forgive me my sins' but 'Be merciful to me' \u2014 as if he could not even name his sins for shame, but cast himself entirely on divine mercy. And this is the right posture: not to enumerate but to abandon oneself to the one who is merciful.\""
+              "note": "Augustine: \"He did not say 'Forgive me my sins' but 'Be merciful to me' — as if he could not even name his sins for shame, but cast himself entirely on divine mercy. And this is the right posture: not to enumerate but to abandon oneself to the one who is merciful.\""
             },
             {
               "ref": "18:16",
@@ -120,18 +120,18 @@
         "places": [
           {
             "name": "Jericho",
-            "coords": "31.8561\u00b0 N, 35.4614\u00b0 E",
-            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase \u2014 the next stop after Jericho is Jerusalem."
+            "coords": "31.8561° N, 35.4614° E",
+            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase — the next stop after Jericho is Jerusalem."
           }
         ],
         "hist": {
-          "context": "The Widow and the Unjust Judge\nWidows in the ancient world had no independent legal standing \u2014 they depended on male relatives or public advocates to press their legal cases. The unjust judge had no interest in justice; the widow had no leverage. Her only resource was persistence. The parable argues from the lesser to the greater: if even a corrupt, godless judge eventually yields to persistence, how much more certainly will the God who loves his people respond to their persistent prayer?\n\nCamel and Needle\nThe camel-through-a-needle's-eye saying (v.25) is one of Jesus's most debated images. There is no evidence for the theory that \"needle's gate\" was a small gate in Jerusalem's walls (this explanation first appears in medieval sources). The saying uses deliberate hyperbole \u2014 the largest animal in Palestine through the smallest opening \u2014 to express genuine impossibility: rich people do not enter the kingdom through their own resources."
+          "context": "The Widow and the Unjust Judge\nWidows in the ancient world had no independent legal standing — they depended on male relatives or public advocates to press their legal cases. The unjust judge had no interest in justice; the widow had no leverage. Her only resource was persistence. The parable argues from the lesser to the greater: if even a corrupt, godless judge eventually yields to persistence, how much more certainly will the God who loves his people respond to their persistent prayer?\n\nCamel and Needle\nThe camel-through-a-needle's-eye saying (v.25) is one of Jesus's most debated images. There is no evidence for the theory that \"needle's gate\" was a small gate in Jerusalem's walls (this explanation first appears in medieval sources). The saying uses deliberate hyperbole — the largest animal in Palestine through the smallest opening — to express genuine impossibility: rich people do not enter the kingdom through their own resources."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 18\u201130 \u2014 The Rich Ruler; Camel Through a Needle\u2019s Eye",
+      "header": "Verses 18‑30 — The Rich Ruler; Camel Through a Needle’s Eye",
       "verse_start": 18,
       "verse_end": 30,
       "panels": {
@@ -140,13 +140,13 @@
             "word": "huios Dauid",
             "transliteration": "HY-os Da-UID",
             "gloss": "Son of David",
-            "paragraph": "The messianic title (vv.38-39) is significant on the lips of a blind man. He cannot see Jesus but has heard enough to know the Davidic claim \u2014 and to press it with increasing urgency against the crowd's attempts to silence him. The blind man's insight is the chapter's final irony: those who can see do not recognise Jesus; the blind man sees him correctly."
+            "paragraph": "The messianic title (vv.38-39) is significant on the lips of a blind man. He cannot see Jesus but has heard enough to know the Davidic claim — and to press it with increasing urgency against the crowd's attempts to silence him. The blind man's insight is the chapter's final irony: those who can see do not recognise Jesus; the blind man sees him correctly."
           },
           {
-            "word": "anablep\u014d",
+            "word": "anablepō",
             "transliteration": "a-na-BLE-po",
             "gloss": "receive sight / look up",
-            "paragraph": "The verb (v.41) means both to recover sight and to look up \u2014 it is the same word used for Jesus looking up at the tax collectors and sinners who gathered around him. The physical recovery of sight is a transparent image of the spiritual sight that the chapter's first half described: the tax collector who saw himself clearly, the children who received with clear simplicity."
+            "paragraph": "The verb (v.41) means both to recover sight and to look up — it is the same word used for Jesus looking up at the tax collectors and sinners who gathered around him. The physical recovery of sight is a transparent image of the spiritual sight that the chapter's first half described: the tax collector who saw himself clearly, the children who received with clear simplicity."
           }
         ],
         "cross": {
@@ -157,76 +157,76 @@
             },
             {
               "ref": "Isa 35:5",
-              "note": "\"Then will the eyes of the blind be opened\" \u2014 the eschatological promise that Jesus's healings fulfil, consistent with 7:22's answer to John the Baptist."
+              "note": "\"Then will the eyes of the blind be opened\" — the eschatological promise that Jesus's healings fulfil, consistent with 7:22's answer to John the Baptist."
             },
             {
               "ref": "Ps 2:7; Isa 11:1-5",
-              "note": "The Davidic messianic promises that the \"Son of David\" title invokes \u2014 the expected king who would restore justice and judge the poor with equity."
+              "note": "The Davidic messianic promises that the \"Son of David\" title invokes — the expected king who would restore justice and judge the poor with equity."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:31-33",
-              "note": "The third passion prediction is the most specific and the disciples understand nothing. This is not a failure of intelligence but of theological category \u2014 they could not integrate the messianic expectation with suffering and death. No one in first-century Judaism expected the Messiah to be crucified. The disciples' incomprehension is historically plausible and theologically important: the cross was genuinely unexpected."
+              "note": "The third passion prediction is the most specific and the disciples understand nothing. This is not a failure of intelligence but of theological category — they could not integrate the messianic expectation with suffering and death. No one in first-century Judaism expected the Messiah to be crucified. The disciples' incomprehension is historically plausible and theologically important: the cross was genuinely unexpected."
             },
             {
               "ref": "18:38-39",
-              "note": "\"Son of David, have mercy on me!\" \u2014 the blind man uses the most explicitly messianic address in the Gospel and will not be silenced. The crowd's attempts to shut him up parallel the disciples' attempts to shut out the children (18:15). In both cases, Jesus overrules the gatekeepers. Those who should be guardians of access to Jesus become obstacles to it."
+              "note": "\"Son of David, have mercy on me!\" — the blind man uses the most explicitly messianic address in the Gospel and will not be silenced. The crowd's attempts to shut him up parallel the disciples' attempts to shut out the children (18:15). In both cases, Jesus overrules the gatekeepers. Those who should be guardians of access to Jesus become obstacles to it."
             },
             {
               "ref": "18:42",
-              "note": "\"Your faith has healed you\" (ses\u014dken se) \u2014 the same word as \"saved.\" Physical healing and spiritual salvation use the same vocabulary throughout Luke. The blind man's faith \u2014 his persistent, insistent, unreasoned trust in Jesus's capacity and willingness to heal \u2014 is the model the chapter's first half sought to describe."
+              "note": "\"Your faith has healed you\" (sesōken se) — the same word as \"saved.\" Physical healing and spiritual salvation use the same vocabulary throughout Luke. The blind man's faith — his persistent, insistent, unreasoned trust in Jesus's capacity and willingness to heal — is the model the chapter's first half sought to describe."
             },
             {
               "ref": "18:43",
-              "note": "\"He followed Jesus, praising God\" \u2014 the healing's aftermath is described in two verbs: followed and praised. These are the marks of genuine healing in Luke: not just restored function but a new direction (following) and a new orientation (praise). The crowd's response mirrors the individual's: they also praised God."
+              "note": "\"He followed Jesus, praising God\" — the healing's aftermath is described in two verbs: followed and praised. These are the marks of genuine healing in Luke: not just restored function but a new direction (following) and a new orientation (praise). The crowd's response mirrors the individual's: they also praised God."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:34",
-              "note": "Calvin notes that the disciples' incomprehension was providentially ordered \u2014 they were not ready to receive what the passion prediction announced. Full understanding came after the resurrection (24:44-45) when Jesus himself opened their minds to understand the scriptures. The hiddenness is not a failure of teaching but a preparation for a later illumination."
+              "note": "Calvin notes that the disciples' incomprehension was providentially ordered — they were not ready to receive what the passion prediction announced. Full understanding came after the resurrection (24:44-45) when Jesus himself opened their minds to understand the scriptures. The hiddenness is not a failure of teaching but a preparation for a later illumination."
             },
             {
               "ref": "18:41",
-              "note": "\"What do you want me to do for you?\" \u2014 Jesus asks the obvious question. Calvin sees in this question a pattern of prayer: God already knows what we need, yet he invites us to express it. The asking is not for God's information but for ours \u2014 to articulate our need is to acknowledge our dependence, which is itself the beginning of faith."
+              "note": "\"What do you want me to do for you?\" — Jesus asks the obvious question. Calvin sees in this question a pattern of prayer: God already knows what we need, yet he invites us to express it. The asking is not for God's information but for ours — to articulate our need is to acknowledge our dependence, which is itself the beginning of faith."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:35",
-              "note": "\"As Jesus approached Jericho\" \u2014 Mark 10:46 says \"as Jesus and his disciples were leaving Jericho.\" Luke says approaching. The discrepancy has generated extensive harmonisation attempts: two Jerichos (old and new), two blind men, the healing happening between them. Most likely Luke and Mark drew on slightly different traditions, or Luke's approach/depart is imprecise. No textual variant resolves the difference."
+              "note": "\"As Jesus approached Jericho\" — Mark 10:46 says \"as Jesus and his disciples were leaving Jericho.\" Luke says approaching. The discrepancy has generated extensive harmonisation attempts: two Jerichos (old and new), two blind men, the healing happening between them. Most likely Luke and Mark drew on slightly different traditions, or Luke's approach/depart is imprecise. No textual variant resolves the difference."
             },
             {
               "ref": "18:38",
-              "note": "\"Son of David, have mercy on me\" \u2014 this is the earliest use in Luke's Gospel of \"Son of David\" as an address to Jesus. The title is implicitly rejected by Jesus in 20:41-44, not because it is wrong but because it is insufficient. The Messiah is more than David's son; he is David's Lord."
+              "note": "\"Son of David, have mercy on me\" — this is the earliest use in Luke's Gospel of \"Son of David\" as an address to Jesus. The title is implicitly rejected by Jesus in 20:41-44, not because it is wrong but because it is insufficient. The Messiah is more than David's son; he is David's Lord."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "18:34",
-              "note": "Synekan \u2014 imperfect active of syni\u0113mi: they were not understanding, continuously. The three-fold description of incomprehension (did not understand / its meaning was hidden from them / they did not know what he was talking about) is unusually emphatic. Luke piles up the vocabulary of non-understanding to make the point unmistakeable."
+              "note": "Synekan — imperfect active of syniēmi: they were not understanding, continuously. The three-fold description of incomprehension (did not understand / its meaning was hidden from them / they did not know what he was talking about) is unusually emphatic. Luke piles up the vocabulary of non-understanding to make the point unmistakeable."
             },
             {
               "ref": "18:39",
-              "note": "Ekrazen \u2014 imperfect active: \"he was crying out\" continuously. The crowd tried to silence him; he kept on shouting. The imperfect tenses in vv.38-39 create a picture of sustained, escalating insistence \u2014 the exact quality the persistent widow parable commended."
+              "note": "Ekrazen — imperfect active: \"he was crying out\" continuously. The crowd tried to silence him; he kept on shouting. The imperfect tenses in vv.38-39 create a picture of sustained, escalating insistence — the exact quality the persistent widow parable commended."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:38",
@@ -241,18 +241,18 @@
         "places": [
           {
             "name": "Jericho",
-            "coords": "31.8561\u00b0 N, 35.4614\u00b0 E",
-            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase \u2014 the next stop after Jericho is Jerusalem."
+            "coords": "31.8561° N, 35.4614° E",
+            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase — the next stop after Jericho is Jerusalem."
           }
         ],
         "hist": {
-          "context": "Third Passion Prediction\nLuke's third explicit passion prediction (after 9:22 and 9:44) is the most detailed: delivered to Gentiles, mocked, insulted, spit on, flogged, killed, raised on the third day. The disciples understand nothing (18:34) \u2014 a compressed Lukan note that Luke will later explain as divinely ordained hiddenness (24:25-27, 44-45) rather than simple obtuseness.\n\nJericho on the Journey\nJesus approaches Jericho (18:35) \u2014 the last major city before Jerusalem, about 15 miles from the capital and 800 feet below sea level. The blind beggar at Jericho and then Zacchaeus in Jericho (19:1-10) are the final healing and call stories before the Jerusalem entry. The location signals that the journey narrative is reaching its climax."
+          "context": "Third Passion Prediction\nLuke's third explicit passion prediction (after 9:22 and 9:44) is the most detailed: delivered to Gentiles, mocked, insulted, spit on, flogged, killed, raised on the third day. The disciples understand nothing (18:34) — a compressed Lukan note that Luke will later explain as divinely ordained hiddenness (24:25-27, 44-45) rather than simple obtuseness.\n\nJericho on the Journey\nJesus approaches Jericho (18:35) — the last major city before Jerusalem, about 15 miles from the capital and 800 feet below sea level. The blind beggar at Jericho and then Zacchaeus in Jericho (19:1-10) are the final healing and call stories before the Jerusalem entry. The location signals that the journey narrative is reaching its climax."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201143 \u2014 Third Passion Prediction; The Blind Beggar at Jericho",
+      "header": "Verses 31‑43 — Third Passion Prediction; The Blind Beggar at Jericho",
       "verse_start": 31,
       "verse_end": 43,
       "panels": {
@@ -264,10 +264,10 @@
             "paragraph": "The verb (v.1) means to grow tired, to lose the energy of persistence. The parable's primary application is stated before the story begins: pray and do not lose heart. The widow's persistence is the positive model; ekkakein is what the disciples are to refuse."
           },
           {
-            "word": "hilasth\u0113ti moi",
-            "transliteration": "hi-LAS-th\u0113-ti moi",
+            "word": "hilasthēti moi",
+            "transliteration": "hi-LAS-thē-ti moi",
             "gloss": "have mercy on me / be propitiated toward me",
-            "paragraph": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably \u2014 he asks for mercy from a God whose holiness his life has violated."
+            "paragraph": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably — he asks for mercy from a God whose holiness his life has violated."
           }
         ],
         "cross": {
@@ -282,92 +282,39 @@
             },
             {
               "ref": "Ps 17:1-2",
-              "note": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer\" \u2014 the Psalm of the persisting righteous sufferer that provides the OT background for the widow's persistence."
+              "note": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer\" — the Psalm of the persisting righteous sufferer that provides the OT background for the widow's persistence."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:7-8",
-              "note": "\"Will not God bring about justice for his chosen ones, who cry out to him day and night? Will he keep putting them off? I tell you, he will see that they get justice, and quickly.\" The argument is a fortiori: the unjust judge eventually yields; God is not unjust and not reluctant. The question at the end (\"when the Son of Man comes, will he find faith on the earth?\") reframes the parable: the issue is not whether God will answer but whether anyone will still be praying when he does."
-            },
-            {
-              "ref": "18:11-12",
-              "note": "The Pharisee's prayer is not prayer at all \u2014 it is self-congratulation addressed to God. He compares himself favourably to others, lists his religious achievements, and asks for nothing. The form is prayer; the content is a r\u00e9sum\u00e9. He leaves exactly as he arrived \u2014 \"justified in his own eyes\" but not before God."
-            },
-            {
-              "ref": "18:13",
-              "note": "\"God, have mercy on me, a sinner\" \u2014 in Greek: ho hamart\u014dlos, with the definite article: \"the sinner\" \u2014 as if he is the only one in the category, or at least the representative of the category. The tax collector does not say \"a sinner among many\" but \"the sinner\" \u2014 total self-assessment without mitigation."
-            },
-            {
-              "ref": "18:22-23",
-              "note": "\"Sell everything you have and give to the poor, and you will have treasure in heaven. Then come, follow me.\" \u2014 \"When he heard this, he became very sad.\" The ruler's sadness is not anger or defiance but genuine grief \u2014 he wants the eternal life, he cannot pay the price. The encounter is one of the most poignant in the Gospels: a sincere man who cannot do the one necessary thing."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:9",
-              "note": "Calvin notes that the parable's target is specifically \"those who were confident of their own righteousness and looked down on everyone else\" \u2014 not the openly wicked but the religiously self-satisfied. The Pharisee's prayer is a case study in the most dangerous form of irreligion: the religion that makes its practitioners worse, not better, by filling them with self-congratulation in the very act of appearing to worship God."
-            },
-            {
-              "ref": "18:27",
-              "note": "\"What is impossible with man is possible with God\" \u2014 Calvin uses this as a statement about the nature of salvation itself, not merely about exceptional conversions of the wealthy. Salvation is impossible with man in every case; it is possible with God in every case. The camel-needle image is a universal statement about human inability that the divine response reverses."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:12",
-              "note": "\"I fast twice a week and give a tenth of all I get\" \u2014 fasting twice a week (Monday and Thursday) was a supererogatory practice of particularly devout Jews, beyond the single annual fast of Yom Kippur required by Torah. Tithing \"all I get\" may mean tithing even what he purchased from others in case they had not already tithed it \u2014 extreme religious conscientiousness. The Pharisee's religious practice is genuine and extraordinary, which makes his self-justification all the more tragic."
-            },
-            {
-              "ref": "18:25",
-              "note": "The camel-through-a-needle saying has a rabbinic parallel (b. Berachot 55b: \"A man is shown in a dream only what is suggested by his own thoughts... a man is not shown a golden palm tree or an elephant going through the eye of a needle, except...\"). The rabbinic use confirms that \"impossibility through the eye of a needle\" was a standard hyperbolic idiom in first-century Judaism."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "18:2",
-              "note": "Ton theon m\u0113 phoboumenos \u2014 \"not fearing God\" (present participle). The negative is me with the participle: a continuous state of not-fearing. The judge is characterised by two negatives: no fear of God, no care about people. He is the opposite of every quality that makes a just judge."
-            },
-            {
-              "ref": "18:25",
-              "note": "Tryp\u0113matos belon\u0113s \u2014 \"eye of a needle.\" The same image appears in rabbinic literature (b. Berachoth 55b) with \"elephant through the eye of a needle\" as a common hyperbole for impossibility. Jesus is using a standard rhetorical form, not coining a new phrase."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "18:13",
-              "note": "Augustine: \"He did not say 'Forgive me my sins' but 'Be merciful to me' \u2014 as if he could not even name his sins for shame, but cast himself entirely on divine mercy. And this is the right posture: not to enumerate but to abandon oneself to the one who is merciful.\""
-            },
-            {
-              "ref": "18:16",
-              "note": "Jerome: \"Children are held up as models because they do not persist in anger, they do not remember injuries, they do not lust after beautiful women at the sight of them. They take no pleasure in money; they do not strive for glory. They receive the kingdom without calculation.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
             "name": "Jericho",
-            "coords": "31.8561\u00b0 N, 35.4614\u00b0 E",
-            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase \u2014 the next stop after Jericho is Jerusalem."
+            "coords": "31.8561° N, 35.4614° E",
+            "text": "One of the world's oldest cities, located in the Jordan Valley about 15 miles northeast of Jerusalem and 800 feet below sea level. The final major city before Jerusalem on the pilgrim route from Galilee through the Jordan Valley. Jesus's approach to Jericho marks the journey narrative's final phase — the next stop after Jericho is Jerusalem."
           }
         ],
         "hist": {
-          "context": "The Widow and the Unjust Judge\nWidows in the ancient world had no independent legal standing \u2014 they depended on male relatives or public advocates to press their legal cases. The unjust judge had no interest in justice; the widow had no leverage. Her only resource was persistence. The parable argues from the lesser to the greater: if even a corrupt, godless judge eventually yields to persistence, how much more certainly will the God who loves his people respond to their persistent prayer?\n\nCamel and Needle\nThe camel-through-a-needle's-eye saying (v.25) is one of Jesus's most debated images. There is no evidence for the theory that \"needle's gate\" was a small gate in Jerusalem's walls (this explanation first appears in medieval sources). The saying uses deliberate hyperbole \u2014 the largest animal in Palestine through the smallest opening \u2014 to express genuine impossibility: rich people do not enter the kingdom through their own resources."
+          "context": "The Widow and the Unjust Judge\nWidows in the ancient world had no independent legal standing — they depended on male relatives or public advocates to press their legal cases. The unjust judge had no interest in justice; the widow had no leverage. Her only resource was persistence. The parable argues from the lesser to the greater: if even a corrupt, godless judge eventually yields to persistence, how much more certainly will the God who loves his people respond to their persistent prayer?\n\nCamel and Needle\nThe camel-through-a-needle's-eye saying (v.25) is one of Jesus's most debated images. There is no evidence for the theory that \"needle's gate\" was a small gate in Jerusalem's walls (this explanation first appears in medieval sources). The saying uses deliberate hyperbole — the largest animal in Palestine through the smallest opening — to express genuine impossibility: rich people do not enter the kingdom through their own resources."
         }
       }
     }
@@ -377,57 +324,57 @@
       {
         "name": "The Persistent Widow",
         "role": "Model of prayer",
-        "text": "Unnamed, voiceless except for her repeated plea. Her persistence in the face of the unjust judge's repeated refusals is the parable's virtue \u2014 not her cause (which may or may not be just) but her refusal to give up."
+        "text": "Unnamed, voiceless except for her repeated plea. Her persistence in the face of the unjust judge's repeated refusals is the parable's virtue — not her cause (which may or may not be just) but her refusal to give up."
       },
       {
         "name": "The Tax Collector",
         "role": "Model of humility",
-        "text": "Unnamed, standing at a distance, not lifting his eyes. His four-word prayer (in Greek: hilasth\u0113ti moi t\u014d hamart\u014dl\u014d) is the model petition \u2014 asking for mercy, nothing else, on the basis of need, not merit."
+        "text": "Unnamed, standing at a distance, not lifting his eyes. His four-word prayer (in Greek: hilasthēti moi tō hamartōlō) is the model petition — asking for mercy, nothing else, on the basis of need, not merit."
       },
       {
         "name": "The Rich Ruler",
         "role": "The almost-disciple",
-        "text": "A leading figure (arch\u014dn) who has kept the commandments, comes to Jesus with a genuine question, and leaves very sad. His departure is the chapter's most poignant moment \u2014 sincere, observant, unable."
+        "text": "A leading figure (archōn) who has kept the commandments, comes to Jesus with a genuine question, and leaves very sad. His departure is the chapter's most poignant moment — sincere, observant, unable."
       },
       {
         "name": "The Blind Beggar",
         "role": "Model of persistent faith",
-        "text": "His shouting through the crowd's opposition embodies the persistent widow's quality \u2014 he will not be silenced. His request is simple and direct; his response to healing is immediate following and praise."
+        "text": "His shouting through the crowd's opposition embodies the persistent widow's quality — he will not be silenced. His request is simple and direct; his response to healing is immediate following and praise."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ho hamart\u014dlos (18:13)</td><td>NIV: \"a sinner\"; KJV: \"a sinner\"; ESV: \"a sinner\"; NRSV: \"a sinner\". All versions omit the definite article (\"the sinner\"). The Greek article intensifies the self-assessment.</td></tr><tr><td class=\"t-label\">tryp\u0113matos belon\u0113s (18:25)</td><td>NIV: \"eye of a needle\"; KJV: \"eye of a needle\"; ESV: \"eye of a needle\"; NRSV: \"eye of a needle\". Universal agreement; no translation controversy.</td></tr><tr><td class=\"t-label\">ses\u014dken se (18:42)</td><td>NIV: \"healed you\"; KJV: \"made thee whole\"; ESV: \"recovered your sight\"; NRSV: \"made you well\". NIV and ESV split the semantic range of s\u014dz\u014d between healing and saving; KJV captures the wholeness; NRSV focuses on the specific physical healing.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">ho hamartōlos (18:13)</td><td>NIV: \"a sinner\"; KJV: \"a sinner\"; ESV: \"a sinner\"; NRSV: \"a sinner\". All versions omit the definite article (\"the sinner\"). The Greek article intensifies the self-assessment.</td></tr><tr><td class=\"t-label\">trypēmatos belonēs (18:25)</td><td>NIV: \"eye of a needle\"; KJV: \"eye of a needle\"; ESV: \"eye of a needle\"; NRSV: \"eye of a needle\". Universal agreement; no translation controversy.</td></tr><tr><td class=\"t-label\">sesōken se (18:42)</td><td>NIV: \"healed you\"; KJV: \"made thee whole\"; ESV: \"recovered your sight\"; NRSV: \"made you well\". NIV and ESV split the semantic range of sōzō between healing and saving; KJV captures the wholeness; NRSV focuses on the specific physical healing.</td></tr>",
     "src": [
       {
         "title": "Psalm 17:1-2",
-        "quote": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer \u2014 it does not rise from deceitful lips.\"",
-        "note": "The persistent righteous sufferer who appeals to God's justice \u2014 the Psalm that provides the OT background for the widow's persistent appeal to the unjust judge."
+        "quote": "\"Hear me, Lord, my plea is just; listen to my cry. Hear my prayer — it does not rise from deceitful lips.\"",
+        "note": "The persistent righteous sufferer who appeals to God's justice — the Psalm that provides the OT background for the widow's persistent appeal to the unjust judge."
       },
       {
         "title": "Isaiah 35:5",
         "quote": "\"Then will the eyes of the blind be opened and the ears of the deaf unstopped.\"",
-        "note": "The eschatological promise of healing that Jesus's ministry fulfils \u2014 cited in 7:22 as evidence for John the Baptist and enacted repeatedly, here at the journey's end."
+        "note": "The eschatological promise of healing that Jesus's ministry fulfils — cited in 7:22 as evidence for John the Baptist and enacted repeatedly, here at the journey's end."
       }
     ],
     "rec": [
       {
         "who": "The Tax Collector's Prayer in Christian Spirituality",
-        "text": "The tax collector's four-word prayer became the basis of the Jesus Prayer of Eastern Orthodox spirituality: \"Lord Jesus Christ, Son of God, have mercy on me, a sinner.\" The Philokalia and the anonymous Russian spiritual memoir The Way of a Pilgrim (19th century) trace the practice of repeating this prayer in rhythm with breathing \u2014 a contemplative tradition rooted in Luke 18:13."
+        "text": "The tax collector's four-word prayer became the basis of the Jesus Prayer of Eastern Orthodox spirituality: \"Lord Jesus Christ, Son of God, have mercy on me, a sinner.\" The Philokalia and the anonymous Russian spiritual memoir The Way of a Pilgrim (19th century) trace the practice of repeating this prayer in rhythm with breathing — a contemplative tradition rooted in Luke 18:13."
       },
       {
         "who": "\"Camel Through the Eye of a Needle\": Interpretation History",
-        "text": "The saying's difficulty prompted creative interpretation throughout church history. Origen interpreted it allegorically; medieval commentators invented the \"Needle's Gate\" to soften it. Luther and Calvin insisted on its literal force, using it to argue that rich Christians can be saved only by the same miraculous divine intervention that saves all sinners \u2014 the camel-needle image is a statement about human inability universalised, not merely applied to the wealthy."
+        "text": "The saying's difficulty prompted creative interpretation throughout church history. Origen interpreted it allegorically; medieval commentators invented the \"Needle's Gate\" to soften it. Luther and Calvin insisted on its literal force, using it to argue that rich Christians can be saved only by the same miraculous divine intervention that saves all sinners — the camel-needle image is a statement about human inability universalised, not merely applied to the wealthy."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Double Parable \u2014 vv.2-14",
+          "label": "Double Parable — vv.2-14",
           "text": "Two parables of prayer back to back: the persistent widow (model of persistence) and the Pharisee/tax collector (model of posture). Both involve coming before a judge/God; both contrast two figures; both teach something essential about prayer.",
           "is_key": false
         },
         {
-          "label": "Bracket \u2014 vv.15-17 / 35-43",
-          "text": "Children receive the kingdom; the blind man receives sight. Both are about reception \u2014 receptive simplicity and receptive persistence. The chapter's central section (rich ruler, camel-needle) is bracketed by two images of those who receive what the self-sufficient cannot obtain.",
+          "label": "Bracket — vv.15-17 / 35-43",
+          "text": "Children receive the kingdom; the blind man receives sight. Both are about reception — receptive simplicity and receptive persistence. The chapter's central section (rich ruler, camel-needle) is bracketed by two images of those who receive what the self-sufficient cannot obtain.",
           "is_key": false
         }
       ],
@@ -441,22 +388,22 @@
         "note": "The verb (v.1) means to grow tired, to lose the energy of persistence. The parable's primary application is stated before the story begins: pray and do not lose heart. The widow's persistence is the positive model; ekkakein is what the disciples are to refuse."
       },
       {
-        "word": "hilasth\u0113ti moi",
-        "tlit": "hi-LAS-th\u0113-ti moi",
+        "word": "hilasthēti moi",
+        "tlit": "hi-LAS-thē-ti moi",
         "gloss": "have mercy on me / be propitiated toward me",
-        "note": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably \u2014 he asks for mercy from a God whose holiness his life has violated."
+        "note": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably — he asks for mercy from a God whose holiness his life has violated."
       },
       {
         "word": "huios Dauid",
         "tlit": "HY-os Da-UID",
         "gloss": "Son of David",
-        "note": "The messianic title (vv.38-39) is significant on the lips of a blind man. He cannot see Jesus but has heard enough to know the Davidic claim \u2014 and to press it with increasing urgency against the crowd's attempts to silence him. The blind man's insight is the chapter's final irony: those who can see do not recognise Jesus; the blind man sees him correctly."
+        "note": "The messianic title (vv.38-39) is significant on the lips of a blind man. He cannot see Jesus but has heard enough to know the Davidic claim — and to press it with increasing urgency against the crowd's attempts to silence him. The blind man's insight is the chapter's final irony: those who can see do not recognise Jesus; the blind man sees him correctly."
       },
       {
-        "word": "anablep\u014d",
+        "word": "anablepō",
         "tlit": "a-na-BLE-po",
         "gloss": "receive sight / look up",
-        "note": "The verb (v.41) means both to recover sight and to look up \u2014 it is the same word used for Jesus looking up at the tax collectors and sinners who gathered around him. The physical recovery of sight is a transparent image of the spiritual sight that the chapter's first half described: the tax collector who saw himself clearly, the children who received with clear simplicity."
+        "note": "The verb (v.41) means both to recover sight and to look up — it is the same word used for Jesus looking up at the tax collectors and sinners who gathered around him. The physical recovery of sight is a transparent image of the spiritual sight that the chapter's first half described: the tax collector who saw himself clearly, the children who received with clear simplicity."
       },
       {
         "word": "ekkakein",
@@ -465,10 +412,10 @@
         "note": "The verb (v.1) means to grow tired, to lose the energy of persistence. The parable's primary application is stated before the story begins: pray and do not lose heart. The widow's persistence is the positive model; ekkakein is what the disciples are to refuse."
       },
       {
-        "word": "hilasth\u0113ti moi",
-        "tlit": "hi-LAS-th\u0113-ti moi",
+        "word": "hilasthēti moi",
+        "tlit": "hi-LAS-thē-ti moi",
         "gloss": "have mercy on me / be propitiated toward me",
-        "note": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably \u2014 he asks for mercy from a God whose holiness his life has violated."
+        "note": "The tax collector's prayer (v.13) uses a word from the Temple's sacrificial vocabulary: be propitiated, be turned toward me in mercy. He does not ask to be understood, excused, or compared favourably — he asks for mercy from a God whose holiness his life has violated."
       }
     ],
     "tx": [
@@ -481,7 +428,7 @@
       {
         "ref": "18:24",
         "title": "\"How hard it is for the rich\"",
-        "content": "Some MSS (including early ones) add \"those who have riches\" after \"how hard it is\" \u2014 a clarifying expansion. NA28 follows the shorter reading.",
+        "content": "Some MSS (including early ones) add \"those who have riches\" after \"how hard it is\" — a clarifying expansion. NA28 follows the shorter reading.",
         "note": "The shorter form is original; the expansion makes explicit what is already clear from context."
       }
     ],
@@ -497,7 +444,7 @@
           {
             "name": "Jesus is testing the ruler's theology",
             "proponents": "MacArthur, Calvin, most evangelicals",
-            "argument": "Jesus is not denying his own goodness but pressing the ruler: do you understand what you're saying? \"Good\" belongs to God alone \u2014 so who do you think I am? The question is an invitation to Christological recognition, not a denial of divinity."
+            "argument": "Jesus is not denying his own goodness but pressing the ruler: do you understand what you're saying? \"Good\" belongs to God alone — so who do you think I am? The question is an invitation to Christological recognition, not a denial of divinity."
           },
           {
             "name": "Jesus is correcting flattery",
@@ -534,7 +481,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 18 is a sustained meditation on who enters the kingdom. The persistent widow enters through patient prayer; the tax collector enters through humble honesty; children enter by simple reception; the rich ruler fails to enter because of attachment; the blind beggar enters through persistent faith. The chapter's pattern is the beatitudes in narrative form: the poor in spirit, those who mourn for their condition, those who cannot secure entry on their own terms \u2014 these are the ones who receive the kingdom. The self-sufficient, the self-congratulatory, and the self-protected cannot enter."
+      "note": "Luke 18 is a sustained meditation on who enters the kingdom. The persistent widow enters through patient prayer; the tax collector enters through humble honesty; children enter by simple reception; the rich ruler fails to enter because of attachment; the blind beggar enters through persistent faith. The chapter's pattern is the beatitudes in narrative form: the poor in spirit, those who mourn for their condition, those who cannot secure entry on their own terms — these are the ones who receive the kingdom. The self-sufficient, the self-congratulatory, and the self-protected cannot enter."
     }
   },
   "vhl_groups": [
@@ -655,7 +602,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "The persistent widow wears down the unjust judge. Jesus argues from lesser to greater: if an unjust judge yields, 'will not God bring about justice for his chosen ones?' (v. 7). Persistence in prayer isn't pestering\u2014it's faith.",
+      "tip": "The persistent widow wears down the unjust judge. Jesus argues from lesser to greater: if an unjust judge yields, 'will not God bring about justice for his chosen ones?' (v. 7). Persistence in prayer isn't pestering—it's faith.",
       "genre_tag": "theological_insight"
     },
     {

--- a/content/luke/19.json
+++ b/content/luke/19.json
@@ -7,118 +7,118 @@
   "subtitle": "Zacchaeus, the Minas, and the Triumphal Entry",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": {
     "story_id": "final-week",
-    "text": "See on Map \u2014 Passion Week"
+    "text": "See on Map — Passion Week"
   },
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201110 \u2014 Zacchaeus: The Son of Man Came to Seek and Save the Lost",
+      "header": "Verses 1‑10 — Zacchaeus: The Son of Man Came to Seek and Save the Lost",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
         "heb": [
           {
-            "word": "s\u014dt\u0113ria",
+            "word": "sōtēria",
             "transliteration": "so-TE-ri-a",
             "gloss": "salvation",
-            "paragraph": "The word (v.9) appears rarely in Luke's narrative sections \u2014 mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
+            "paragraph": "The word (v.9) appears rarely in Luke's narrative sections — mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
           },
           {
-            "word": "architel\u014dn\u0113s",
-            "transliteration": "ar-chi-te-LO-n\u0113s",
+            "word": "architelōnēs",
+            "transliteration": "ar-chi-te-LO-nēs",
             "gloss": "chief tax collector",
-            "paragraph": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau \u2014 a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
+            "paragraph": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau — a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
           }
         ],
         "places": [
           {
             "name": "Jericho",
-            "coords": "31.8561\u00b0 N, 35.4614\u00b0 E",
-            "text": "Jesus enters Jericho proper for the Zacchaeus encounter after the blind beggar on the approach (18:35). Jericho was a major trading city and tax collection centre \u2014 an ideal location for a chief tax collector. The sycamore-fig tree Zacchaeus climbed would have been a common street tree in this warm Jordan Valley city."
+            "coords": "31.8561° N, 35.4614° E",
+            "text": "Jesus enters Jericho proper for the Zacchaeus encounter after the blind beggar on the approach (18:35). Jericho was a major trading city and tax collection centre — an ideal location for a chief tax collector. The sycamore-fig tree Zacchaeus climbed would have been a common street tree in this warm Jordan Valley city."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 25:14-30",
-              "note": "The parallel parable of the talents in Matthew \u2014 three servants, larger sums, the same basic structure. The minas (one each to ten servants) and talents (different amounts to three servants) present the same truth differently."
+              "note": "The parallel parable of the talents in Matthew — three servants, larger sums, the same basic structure. The minas (one each to ten servants) and talents (different amounts to three servants) present the same truth differently."
             },
             {
               "ref": "Luke 15:4-7",
-              "note": "The lost sheep \u2014 \"the Son of Man came to seek and save the lost\" (19:10) is the theological statement that connects Zacchaeus to Luke 15's searching parables."
+              "note": "The lost sheep — \"the Son of Man came to seek and save the lost\" (19:10) is the theological statement that connects Zacchaeus to Luke 15's searching parables."
             },
             {
               "ref": "Josephus, Ant. 17.299-314",
-              "note": "The historical account of Archelaus's journey to Rome and the Jewish delegation opposing his kingship \u2014 the political event underlying the minas parable."
+              "note": "The historical account of Archelaus's journey to Rome and the Jewish delegation opposing his kingship — the political event underlying the minas parable."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:5",
-              "note": "\"I must stay at your house today\" \u2014 dei, the divine necessity that drives Jesus's entire ministry (cf. 4:43; 9:22; 13:33; 17:25; 22:37). Jesus does not negotiate or accept an invitation; he announces. Zacchaeus had climbed a tree to see Jesus; Jesus had already seen Zacchaeus and knew his name."
+              "note": "\"I must stay at your house today\" — dei, the divine necessity that drives Jesus's entire ministry (cf. 4:43; 9:22; 13:33; 17:25; 22:37). Jesus does not negotiate or accept an invitation; he announces. Zacchaeus had climbed a tree to see Jesus; Jesus had already seen Zacchaeus and knew his name."
             },
             {
               "ref": "19:8",
-              "note": "Zacchaeus's response is dramatic and voluntary \u2014 no command to sell everything, no direct demand from Jesus. The encounter with Jesus produces spontaneous generosity: half of possessions to the poor, fourfold restitution to those cheated. Under Jewish law, fourfold restitution was required for theft of sheep (Exod 22:1); Zacchaeus applies the highest standard voluntarily."
+              "note": "Zacchaeus's response is dramatic and voluntary — no command to sell everything, no direct demand from Jesus. The encounter with Jesus produces spontaneous generosity: half of possessions to the poor, fourfold restitution to those cheated. Under Jewish law, fourfold restitution was required for theft of sheep (Exod 22:1); Zacchaeus applies the highest standard voluntarily."
             },
             {
               "ref": "19:9-10",
-              "note": "\"Today salvation has come to this house\" \u2014 s\u014dt\u0113ria, the great word of Luke's infancy narratives, now entering a Jericho tax-collector's home. \"Son of Abraham\" \u2014 the covenant belonging that the Pharisees claimed as their exclusive territory extends to this despised man. The final statement of Jesus's mission: \"to seek and to save the lost.\""
+              "note": "\"Today salvation has come to this house\" — sōtēria, the great word of Luke's infancy narratives, now entering a Jericho tax-collector's home. \"Son of Abraham\" — the covenant belonging that the Pharisees claimed as their exclusive territory extends to this despised man. The final statement of Jesus's mission: \"to seek and to save the lost.\""
             },
             {
               "ref": "19:22",
-              "note": "\"I will judge you by your own words\" \u2014 the servant's fear-based inaction is judged on its own terms. If he believed the master to be harsh and exacting, the least he could have done was deposit the money with interest. His own description of the master condemns his inaction. Fear that produces no action is not humility but paralysis."
+              "note": "\"I will judge you by your own words\" — the servant's fear-based inaction is judged on its own terms. If he believed the master to be harsh and exacting, the least he could have done was deposit the money with interest. His own description of the master condemns his inaction. Fear that produces no action is not humility but paralysis."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:8",
-              "note": "Calvin uses Zacchaeus's response to argue against any understanding of repentance as merely a change of feeling. Genuine repentance demonstrates itself in concrete restitution: half to the poor (generosity going forward) and fourfold repayment (justice for the past). The two movements \u2014 restitution and generosity \u2014 are the external marks of an internal transformation."
+              "note": "Calvin uses Zacchaeus's response to argue against any understanding of repentance as merely a change of feeling. Genuine repentance demonstrates itself in concrete restitution: half to the poor (generosity going forward) and fourfold repayment (justice for the past). The two movements — restitution and generosity — are the external marks of an internal transformation."
             },
             {
               "ref": "19:11",
-              "note": "The crowd's expectation that the kingdom would \"appear at once\" reflects the standard Jewish expectation that the Messiah's entry into Jerusalem would trigger an immediate divine intervention. Jesus corrects this not by denying the kingdom's coming but by insisting on the delay \u2014 the king must go away first, entrust resources to servants, and then return to judge. The passion is the going-away; the Parousia is the return."
+              "note": "The crowd's expectation that the kingdom would \"appear at once\" reflects the standard Jewish expectation that the Messiah's entry into Jerusalem would trigger an immediate divine intervention. Jesus corrects this not by denying the kingdom's coming but by insisting on the delay — the king must go away first, entrust resources to servants, and then return to judge. The passion is the going-away; the Parousia is the return."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:9",
-              "note": "\"This man, too, is a son of Abraham\" \u2014 the phrase echoes 13:16 (\"daughter of Abraham\") where Jesus used covenant language to claim the bent woman's healing as a Sabbath right. Zacchaeus, despite his profession, has never ceased to be within the covenant. Jesus claims him as a covenant member, not a convert from outside."
+              "note": "\"This man, too, is a son of Abraham\" — the phrase echoes 13:16 (\"daughter of Abraham\") where Jesus used covenant language to claim the bent woman's healing as a Sabbath right. Zacchaeus, despite his profession, has never ceased to be within the covenant. Jesus claims him as a covenant member, not a convert from outside."
             },
             {
               "ref": "19:13",
-              "note": "\"Put this money to work\" \u2014 pragmateusasthe, do business with it. The command is active and entrepreneurial. The servant who simply preserves the capital has not fulfilled the command; he has actively disobeyed by not trading."
+              "note": "\"Put this money to work\" — pragmateusasthe, do business with it. The command is active and entrepreneurial. The servant who simply preserves the capital has not fulfilled the command; he has actively disobeyed by not trading."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "19:4",
-              "note": "Sykomorean \u2014 the sycamore-fig (Ficus sycomorus), a large tree with wide branches and low, easy-to-climb limbs. Not the sycamine (17:6). The specificity is consistent with Luke's general precision about geographical and botanical detail."
+              "note": "Sykomorean — the sycamore-fig (Ficus sycomorus), a large tree with wide branches and low, easy-to-climb limbs. Not the sycamine (17:6). The specificity is consistent with Luke's general precision about geographical and botanical detail."
             },
             {
               "ref": "19:8",
-              "note": "Sykophanteo \u2014 \"cheated / extorted.\" The word literally means \"to shake figs\" but became a technical term for false accusation or extortion. Zacchaeus admits the possibility that he has used such methods in his tax collection."
+              "note": "Sykophanteo — \"cheated / extorted.\" The word literally means \"to shake figs\" but became a technical term for false accusation or extortion. Zacchaeus admits the possibility that he has used such methods in his tax collection."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:5",
@@ -126,49 +126,49 @@
             },
             {
               "ref": "19:8",
-              "note": "Augustine: \"Look how quickly Zacchaeus was transformed! A short time ago he was climbing the tree to see Jesus; now he is giving half his goods to the poor and repaying fourfold those he had cheated. The presence of Christ was enough: no long instruction, no gradual reformation \u2014 the encounter itself was the transformation.\""
+              "note": "Augustine: \"Look how quickly Zacchaeus was transformed! A short time ago he was climbing the tree to see Jesus; now he is giving half his goods to the poor and repaying fourfold those he had cheated. The presence of Christ was enough: no long instruction, no gradual reformation — the encounter itself was the transformation.\""
             }
           ]
         },
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem from the Mount of Olives on a colt, acclaimed by the crowd with Psalm 118. He weeps over the city, enters the Temple, and surveys it. Luke 19:28-48.",
             "current": true
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Fig Tree; Temple Cleansing",
             "text": "Jesus returns to Jerusalem, drives out the sellers from the Temple, and teaches daily in the courts.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies; Olivet Discourse",
             "text": "Authority questioned; wicked tenants; taxes; resurrection; the great commandment; the Olivet Discourse.",
             "current": false
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Jesus anointed at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane; Arrest",
             "text": "The Passover meal with the Twelve; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion; Death; Burial",
             "text": "Before Pilate and Herod; sentenced; crucified at Golgotha; buried in Joseph's tomb.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "The empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
@@ -181,7 +181,7 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201127 \u2014 The Parable of the Ten Minas",
+      "header": "Verses 11‑27 — The Parable of the Ten Minas",
       "verse_start": 11,
       "verse_end": 27,
       "panels": {
@@ -190,75 +190,75 @@
             "word": "eklausen",
             "transliteration": "ek-LAU-sen",
             "gloss": "he wept",
-            "paragraph": "The verb (v.41) is the stronger Greek word for weeping \u2014 not dakry\u014d (to shed tears quietly) but klai\u014d (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
+            "paragraph": "The verb (v.41) is the stronger Greek word for weeping — not dakryō (to shed tears quietly) but klaiō (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
           },
           {
-            "word": "epegn\u014ds",
+            "word": "epegnōs",
             "transliteration": "e-PEG-nos",
             "gloss": "if you had known / recognised",
-            "paragraph": "The conditional (v.42) \u2014 \"if you, even you, had only known\" \u2014 uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkop\u0113n, v.44), the moment of kairos \u2014 the time when salvation was on offer."
+            "paragraph": "The conditional (v.42) — \"if you, even you, had only known\" — uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkopēn, v.44), the moment of kairos — the time when salvation was on offer."
           }
         ],
         "places": [
           {
             "name": "Mount of Olives",
-            "coords": "31.7781\u00b0 N, 35.2437\u00b0 E",
+            "coords": "31.7781° N, 35.2437° E",
             "text": "The ridge east of Jerusalem across the Kidron Valley, from which the city is dramatically visible. Zechariah 14:4 associated the Mount of Olives with the final divine intervention. Jesus's weeping over Jerusalem (19:41) was triggered by seeing the city from this vantage point."
           },
           {
             "name": "Bethphage and Bethany",
-            "coords": "31.7764\u00b0 N, 35.2590\u00b0 E",
+            "coords": "31.7764° N, 35.2590° E",
             "text": "Two villages on the eastern slope of the Mount of Olives, approximately 2km from Jerusalem. Bethany was the home of Mary, Martha, and Lazarus (John 11). The colt was found in these villages; the entry procession began from here."
           },
           {
             "name": "Jerusalem Temple Mount",
-            "coords": "31.7781\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Herodian Temple complex \u2014 massive, gleaming, and recently completed (begun 20 BC, still under construction in AD 70). Jesus's weeping anticipates its destruction; his cleansing claims it as his own. \"Every day he was teaching at the temple\" (v.47) makes the Temple Jesus's base of operations for the Jerusalem ministry."
+            "coords": "31.7781° N, 35.2354° E",
+            "text": "The Herodian Temple complex — massive, gleaming, and recently completed (begun 20 BC, still under construction in AD 70). Jesus's weeping anticipates its destruction; his cleansing claims it as his own. \"Every day he was teaching at the temple\" (v.47) makes the Temple Jesus's base of operations for the Jerusalem ministry."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" \u2014 the prophetic text the entry enacts, though Luke does not cite it explicitly."
+              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" — the prophetic text the entry enacts, though Luke does not cite it explicitly."
             },
             {
               "ref": "Isa 56:7",
-              "note": "\"My house will be called a house of prayer for all nations\" \u2014 the Temple cleansing citation, combined with Jer 7:11 (\"den of robbers\")."
+              "note": "\"My house will be called a house of prayer for all nations\" — the Temple cleansing citation, combined with Jer 7:11 (\"den of robbers\")."
             },
             {
               "ref": "Jer 7:11",
-              "note": "\"Has this house, which bears my Name, become a den of robbers to you?\" \u2014 Jeremiah's Temple sermon preceding the Babylonian destruction, which Jesus applies to the Temple of his own day."
+              "note": "\"Has this house, which bears my Name, become a den of robbers to you?\" — Jeremiah's Temple sermon preceding the Babylonian destruction, which Jesus applies to the Temple of his own day."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:38",
-              "note": "\"Blessed is the king who comes in the name of the Lord!\" \u2014 the Psalm 118 acclamation adapted: Luke adds \"the king,\" making the Christological identification explicit. \"Peace in heaven and glory in the highest\" echoes the angels' song at the nativity (2:14), but inverted: the angels sang \"peace on earth\"; the crowd sings \"peace in heaven.\" The peace Christ brings is first vertical (God reconciled to humanity) before it is horizontal."
+              "note": "\"Blessed is the king who comes in the name of the Lord!\" — the Psalm 118 acclamation adapted: Luke adds \"the king,\" making the Christological identification explicit. \"Peace in heaven and glory in the highest\" echoes the angels' song at the nativity (2:14), but inverted: the angels sang \"peace on earth\"; the crowd sings \"peace in heaven.\" The peace Christ brings is first vertical (God reconciled to humanity) before it is horizontal."
             },
             {
               "ref": "19:41-44",
-              "note": "The weeping over Jerusalem is unique to Luke and is one of the most theologically significant passages in the Gospel. Jesus weeps not from frustration or defeat but from genuine grief over what Jerusalem's refusal will bring upon itself. The destruction described in vv.43-44 is not punishment imposed from outside but the consequence of having rejected the one who would have given peace. \"Because you did not recognize the time of God's coming to you\" \u2014 kairos again (cf. 12:56)."
+              "note": "The weeping over Jerusalem is unique to Luke and is one of the most theologically significant passages in the Gospel. Jesus weeps not from frustration or defeat but from genuine grief over what Jerusalem's refusal will bring upon itself. The destruction described in vv.43-44 is not punishment imposed from outside but the consequence of having rejected the one who would have given peace. \"Because you did not recognize the time of God's coming to you\" — kairos again (cf. 12:56)."
             },
             {
               "ref": "19:45-46",
-              "note": "The Temple cleansing in Luke is brief (two verses versus Mark's fuller account). Luke emphasises the teaching that follows: \"every day he was teaching at the temple\" (v.47). The cleansing is preparatory \u2014 removing the obstruction to make space for what the Temple was built for: the word of God, now taught by the one who is the Word."
+              "note": "The Temple cleansing in Luke is brief (two verses versus Mark's fuller account). Luke emphasises the teaching that follows: \"every day he was teaching at the temple\" (v.47). The cleansing is preparatory — removing the obstruction to make space for what the Temple was built for: the word of God, now taught by the one who is the Word."
             },
             {
               "ref": "19:48",
-              "note": "\"All the people hung on his words\" \u2014 the Greek is literally \"were hanging on him listening.\" The establishment wants to kill him; the people cannot stop listening. This tension \u2014 popular support providing temporary protection \u2014 runs through the passion narrative until the crowd's mood shifts."
+              "note": "\"All the people hung on his words\" — the Greek is literally \"were hanging on him listening.\" The establishment wants to kill him; the people cannot stop listening. This tension — popular support providing temporary protection — runs through the passion narrative until the crowd's mood shifts."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:41-44",
-              "note": "Calvin reads the weeping over Jerusalem as a revelation of the divine will \u2014 God genuinely desires the salvation of those who refuse it. The tears are not theatrical; they are the outward expression of what is real in the divine heart. Calvin uses this passage against the view that God's predestination is cold and indifferent to human choices: God weeps over the city's refusal even while sovereignly directing history toward its end."
+              "note": "Calvin reads the weeping over Jerusalem as a revelation of the divine will — God genuinely desires the salvation of those who refuse it. The tears are not theatrical; they are the outward expression of what is real in the divine heart. Calvin uses this passage against the view that God's predestination is cold and indifferent to human choices: God weeps over the city's refusal even while sovereignly directing history toward its end."
             },
             {
               "ref": "19:46",
@@ -267,248 +267,195 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:38",
-              "note": "\"Peace in heaven and glory in the highest\" \u2014 a remarkable adaptation of the angels' nativity song (2:14). The crowd unconsciously reverses the direction: the angels announced peace on earth; the crowd announces peace in heaven. Both are true: the peace Christ brings reconciles heaven and earth simultaneously, though Luke's crowd understands only part of what they are saying."
+              "note": "\"Peace in heaven and glory in the highest\" — a remarkable adaptation of the angels' nativity song (2:14). The crowd unconsciously reverses the direction: the angels announced peace on earth; the crowd announces peace in heaven. Both are true: the peace Christ brings reconciles heaven and earth simultaneously, though Luke's crowd understands only part of what they are saying."
             },
             {
               "ref": "19:44",
-              "note": "\"The time of God's coming to you\" \u2014 episkop\u0113n, \"visitation.\" This technical term for divine intervention appears in the LXX for YHWH's decisive arrivals in history (Exod 3:16; Gen 50:24). Luke is claiming that Jesus's entry into Jerusalem is the defining episkop\u0113 of Israel's history \u2014 the moment of God's personal arrival \u2014 and that Jerusalem failed to recognise it."
+              "note": "\"The time of God's coming to you\" — episkopēn, \"visitation.\" This technical term for divine intervention appears in the LXX for YHWH's decisive arrivals in history (Exod 3:16; Gen 50:24). Luke is claiming that Jesus's entry into Jerusalem is the defining episkopē of Israel's history — the moment of God's personal arrival — and that Jerusalem failed to recognise it."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "19:41",
-              "note": "Eklausen \u2014 aorist active: he wept. Not a sustained weeping but a definitive act of grief at the moment of seeing the city. The aorist captures the moment; the sight of Jerusalem across the Kidron Valley triggered it."
+              "note": "Eklausen — aorist active: he wept. Not a sustained weeping but a definitive act of grief at the moment of seeing the city. The aorist captures the moment; the sight of Jerusalem across the Kidron Valley triggered it."
             },
             {
               "ref": "19:44",
-              "note": "Episkop\u0113n \u2014 \"visitation.\" The same word used in 1:68 for God's visitation to his people in the infancy narrative. Jerusalem has failed to recognise its episkop\u0113 \u2014 the moment when God visited in person. The connection to the birth narrative is deliberate and devastating."
+              "note": "Episkopēn — \"visitation.\" The same word used in 1:68 for God's visitation to his people in the infancy narrative. Jerusalem has failed to recognise its episkopē — the moment when God visited in person. The connection to the birth narrative is deliberate and devastating."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:41",
-              "note": "Ambrose: \"He wept over the city that would not receive him. He weeps even now over those who reject him. For the tears of Christ are the tears of divine compassion \u2014 they do not diminish his joy over those who are saved, but they reveal that he desires the salvation of all.\""
+              "note": "Ambrose: \"He wept over the city that would not receive him. He weeps even now over those who reject him. For the tears of Christ are the tears of divine compassion — they do not diminish his joy over those who are saved, but they reveal that he desires the salvation of all.\""
             },
             {
               "ref": "19:46",
-              "note": "Chrysostom: \"He says 'my house' \u2014 not 'the house of the law' or 'the house of sacrifice' but my house. He is claiming the Temple as his own possession. And then he says what it has become: a den of robbers. The contrast is total: what was meant for prayer has been turned into a market.\""
+              "note": "Chrysostom: \"He says 'my house' — not 'the house of the law' or 'the house of sacrifice' but my house. He is claiming the Temple as his own possession. And then he says what it has become: a den of robbers. The contrast is total: what was meant for prayer has been turned into a market.\""
             }
           ]
         },
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem from the Mount of Olives on a colt, acclaimed by the crowd with Psalm 118. He weeps over the city, enters the Temple, and surveys it. Luke 19:28-48.",
             "current": true
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Fig Tree; Temple Cleansing",
             "text": "Jesus returns to Jerusalem, drives out the sellers from the Temple, and teaches daily in the courts.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies; Olivet Discourse",
             "text": "Authority questioned; wicked tenants; taxes; resurrection; the great commandment; the Olivet Discourse.",
             "current": false
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Jesus anointed at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane; Arrest",
             "text": "The Passover meal with the Twelve; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion; Death; Burial",
             "text": "Before Pilate and Herod; sentenced; crucified at Golgotha; buried in Joseph's tomb.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "The empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
           }
         ],
         "hist": {
-          "context": "The Triumphal Entry as Staged Fulfilment\nJesus's arrangements for the colt (19:30-31) show the same precise foreknowledge as the upper room preparation (22:10-12) \u2014 a pattern of deliberately staged symbolic action. The choice of a colt on which no one had sat recalls Zech 9:9 (\"your king comes to you, gentle and riding on a donkey, on a colt\") without explicit citation. The action interprets itself for those who know the scripture.\n\nJesus Weeps\nOnly Luke records Jesus weeping over Jerusalem (19:41-44). The prophetic lament is specific: a siege (19:43-44 describes the Roman siege of AD 70 with remarkable precision \u2014 embankment, encirclement, children dashed to the ground). The weeping is not resignation but grief: \"if you had only known\" \u2014 the possibility of a different outcome was real."
+          "context": "The Triumphal Entry as Staged Fulfilment\nJesus's arrangements for the colt (19:30-31) show the same precise foreknowledge as the upper room preparation (22:10-12) — a pattern of deliberately staged symbolic action. The choice of a colt on which no one had sat recalls Zech 9:9 (\"your king comes to you, gentle and riding on a donkey, on a colt\") without explicit citation. The action interprets itself for those who know the scripture.\n\nJesus Weeps\nOnly Luke records Jesus weeping over Jerusalem (19:41-44). The prophetic lament is specific: a siege (19:43-44 describes the Roman siege of AD 70 with remarkable precision — embankment, encirclement, children dashed to the ground). The weeping is not resignation but grief: \"if you had only known\" — the possibility of a different outcome was real."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 28\u201144 \u2014 The Triumphal Entry; Jesus Weeps over Jerusalem",
+      "header": "Verses 28‑44 — The Triumphal Entry; Jesus Weeps over Jerusalem",
       "verse_start": 28,
       "verse_end": 44,
       "panels": {
         "heb": [
           {
-            "word": "s\u014dt\u0113ria",
+            "word": "sōtēria",
             "transliteration": "so-TE-ri-a",
             "gloss": "salvation",
-            "paragraph": "The word (v.9) appears rarely in Luke's narrative sections \u2014 mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
+            "paragraph": "The word (v.9) appears rarely in Luke's narrative sections — mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
           },
           {
-            "word": "architel\u014dn\u0113s",
-            "transliteration": "ar-chi-te-LO-n\u0113s",
+            "word": "architelōnēs",
+            "transliteration": "ar-chi-te-LO-nēs",
             "gloss": "chief tax collector",
-            "paragraph": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau \u2014 a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
+            "paragraph": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau — a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
           }
         ],
         "places": [
           {
             "name": "Jericho",
-            "coords": "31.8561\u00b0 N, 35.4614\u00b0 E",
-            "text": "Jesus enters Jericho proper for the Zacchaeus encounter after the blind beggar on the approach (18:35). Jericho was a major trading city and tax collection centre \u2014 an ideal location for a chief tax collector. The sycamore-fig tree Zacchaeus climbed would have been a common street tree in this warm Jordan Valley city."
+            "coords": "31.8561° N, 35.4614° E",
+            "text": "Jesus enters Jericho proper for the Zacchaeus encounter after the blind beggar on the approach (18:35). Jericho was a major trading city and tax collection centre — an ideal location for a chief tax collector. The sycamore-fig tree Zacchaeus climbed would have been a common street tree in this warm Jordan Valley city."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Matt 25:14-30",
-              "note": "The parallel parable of the talents in Matthew \u2014 three servants, larger sums, the same basic structure. The minas (one each to ten servants) and talents (different amounts to three servants) present the same truth differently."
+              "note": "The parallel parable of the talents in Matthew — three servants, larger sums, the same basic structure. The minas (one each to ten servants) and talents (different amounts to three servants) present the same truth differently."
             },
             {
               "ref": "Luke 15:4-7",
-              "note": "The lost sheep \u2014 \"the Son of Man came to seek and save the lost\" (19:10) is the theological statement that connects Zacchaeus to Luke 15's searching parables."
+              "note": "The lost sheep — \"the Son of Man came to seek and save the lost\" (19:10) is the theological statement that connects Zacchaeus to Luke 15's searching parables."
             },
             {
               "ref": "Josephus, Ant. 17.299-314",
-              "note": "The historical account of Archelaus's journey to Rome and the Jewish delegation opposing his kingship \u2014 the political event underlying the minas parable."
+              "note": "The historical account of Archelaus's journey to Rome and the Jewish delegation opposing his kingship — the political event underlying the minas parable."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:5",
-              "note": "\"I must stay at your house today\" \u2014 dei, the divine necessity that drives Jesus's entire ministry (cf. 4:43; 9:22; 13:33; 17:25; 22:37). Jesus does not negotiate or accept an invitation; he announces. Zacchaeus had climbed a tree to see Jesus; Jesus had already seen Zacchaeus and knew his name."
-            },
-            {
-              "ref": "19:8",
-              "note": "Zacchaeus's response is dramatic and voluntary \u2014 no command to sell everything, no direct demand from Jesus. The encounter with Jesus produces spontaneous generosity: half of possessions to the poor, fourfold restitution to those cheated. Under Jewish law, fourfold restitution was required for theft of sheep (Exod 22:1); Zacchaeus applies the highest standard voluntarily."
-            },
-            {
-              "ref": "19:9-10",
-              "note": "\"Today salvation has come to this house\" \u2014 s\u014dt\u0113ria, the great word of Luke's infancy narratives, now entering a Jericho tax-collector's home. \"Son of Abraham\" \u2014 the covenant belonging that the Pharisees claimed as their exclusive territory extends to this despised man. The final statement of Jesus's mission: \"to seek and to save the lost.\""
-            },
-            {
-              "ref": "19:22",
-              "note": "\"I will judge you by your own words\" \u2014 the servant's fear-based inaction is judged on its own terms. If he believed the master to be harsh and exacting, the least he could have done was deposit the money with interest. His own description of the master condemns his inaction. Fear that produces no action is not humility but paralysis."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:8",
-              "note": "Calvin uses Zacchaeus's response to argue against any understanding of repentance as merely a change of feeling. Genuine repentance demonstrates itself in concrete restitution: half to the poor (generosity going forward) and fourfold repayment (justice for the past). The two movements \u2014 restitution and generosity \u2014 are the external marks of an internal transformation."
-            },
-            {
-              "ref": "19:11",
-              "note": "The crowd's expectation that the kingdom would \"appear at once\" reflects the standard Jewish expectation that the Messiah's entry into Jerusalem would trigger an immediate divine intervention. Jesus corrects this not by denying the kingdom's coming but by insisting on the delay \u2014 the king must go away first, entrust resources to servants, and then return to judge. The passion is the going-away; the Parousia is the return."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "\"This man, too, is a son of Abraham\" \u2014 the phrase echoes 13:16 (\"daughter of Abraham\") where Jesus used covenant language to claim the bent woman's healing as a Sabbath right. Zacchaeus, despite his profession, has never ceased to be within the covenant. Jesus claims him as a covenant member, not a convert from outside."
-            },
-            {
-              "ref": "19:13",
-              "note": "\"Put this money to work\" \u2014 pragmateusasthe, do business with it. The command is active and entrepreneurial. The servant who simply preserves the capital has not fulfilled the command; he has actively disobeyed by not trading."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "19:4",
-              "note": "Sykomorean \u2014 the sycamore-fig (Ficus sycomorus), a large tree with wide branches and low, easy-to-climb limbs. Not the sycamine (17:6). The specificity is consistent with Luke's general precision about geographical and botanical detail."
-            },
-            {
-              "ref": "19:8",
-              "note": "Sykophanteo \u2014 \"cheated / extorted.\" The word literally means \"to shake figs\" but became a technical term for false accusation or extortion. Zacchaeus admits the possibility that he has used such methods in his tax collection."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "19:5",
-              "note": "Chrysostom: \"He says 'come down quickly.' He does not wait for Zacchaeus to invite him; he invites himself. This is the nature of divine grace: it does not wait to be sought. It seeks, it calls, it comes before it is invited.\""
-            },
-            {
-              "ref": "19:8",
-              "note": "Augustine: \"Look how quickly Zacchaeus was transformed! A short time ago he was climbing the tree to see Jesus; now he is giving half his goods to the poor and repaying fourfold those he had cheated. The presence of Christ was enough: no long instruction, no gradual reformation \u2014 the encounter itself was the transformation.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem from the Mount of Olives on a colt, acclaimed by the crowd with Psalm 118. He weeps over the city, enters the Temple, and surveys it. Luke 19:28-48.",
             "current": true
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Fig Tree; Temple Cleansing",
             "text": "Jesus returns to Jerusalem, drives out the sellers from the Temple, and teaches daily in the courts.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies; Olivet Discourse",
             "text": "Authority questioned; wicked tenants; taxes; resurrection; the great commandment; the Olivet Discourse.",
             "current": false
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Jesus anointed at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane; Arrest",
             "text": "The Passover meal with the Twelve; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion; Death; Burial",
             "text": "Before Pilate and Herod; sentenced; crucified at Golgotha; buried in Joseph's tomb.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "The empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
@@ -521,7 +468,7 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 45\u201148 \u2014 Cleansing the Temple",
+      "header": "Verses 45‑48 — Cleansing the Temple",
       "verse_start": 45,
       "verse_end": 48,
       "panels": {
@@ -530,167 +477,114 @@
             "word": "eklausen",
             "transliteration": "ek-LAU-sen",
             "gloss": "he wept",
-            "paragraph": "The verb (v.41) is the stronger Greek word for weeping \u2014 not dakry\u014d (to shed tears quietly) but klai\u014d (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
+            "paragraph": "The verb (v.41) is the stronger Greek word for weeping — not dakryō (to shed tears quietly) but klaiō (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
           },
           {
-            "word": "epegn\u014ds",
+            "word": "epegnōs",
             "transliteration": "e-PEG-nos",
             "gloss": "if you had known / recognised",
-            "paragraph": "The conditional (v.42) \u2014 \"if you, even you, had only known\" \u2014 uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkop\u0113n, v.44), the moment of kairos \u2014 the time when salvation was on offer."
+            "paragraph": "The conditional (v.42) — \"if you, even you, had only known\" — uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkopēn, v.44), the moment of kairos — the time when salvation was on offer."
           }
         ],
         "places": [
           {
             "name": "Mount of Olives",
-            "coords": "31.7781\u00b0 N, 35.2437\u00b0 E",
+            "coords": "31.7781° N, 35.2437° E",
             "text": "The ridge east of Jerusalem across the Kidron Valley, from which the city is dramatically visible. Zechariah 14:4 associated the Mount of Olives with the final divine intervention. Jesus's weeping over Jerusalem (19:41) was triggered by seeing the city from this vantage point."
           },
           {
             "name": "Bethphage and Bethany",
-            "coords": "31.7764\u00b0 N, 35.2590\u00b0 E",
+            "coords": "31.7764° N, 35.2590° E",
             "text": "Two villages on the eastern slope of the Mount of Olives, approximately 2km from Jerusalem. Bethany was the home of Mary, Martha, and Lazarus (John 11). The colt was found in these villages; the entry procession began from here."
           },
           {
             "name": "Jerusalem Temple Mount",
-            "coords": "31.7781\u00b0 N, 35.2354\u00b0 E",
-            "text": "The Herodian Temple complex \u2014 massive, gleaming, and recently completed (begun 20 BC, still under construction in AD 70). Jesus's weeping anticipates its destruction; his cleansing claims it as his own. \"Every day he was teaching at the temple\" (v.47) makes the Temple Jesus's base of operations for the Jerusalem ministry."
+            "coords": "31.7781° N, 35.2354° E",
+            "text": "The Herodian Temple complex — massive, gleaming, and recently completed (begun 20 BC, still under construction in AD 70). Jesus's weeping anticipates its destruction; his cleansing claims it as his own. \"Every day he was teaching at the temple\" (v.47) makes the Temple Jesus's base of operations for the Jerusalem ministry."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" \u2014 the prophetic text the entry enacts, though Luke does not cite it explicitly."
+              "note": "\"See, your king comes to you, righteous and victorious, lowly and riding on a donkey, on a colt, the foal of a donkey\" — the prophetic text the entry enacts, though Luke does not cite it explicitly."
             },
             {
               "ref": "Isa 56:7",
-              "note": "\"My house will be called a house of prayer for all nations\" \u2014 the Temple cleansing citation, combined with Jer 7:11 (\"den of robbers\")."
+              "note": "\"My house will be called a house of prayer for all nations\" — the Temple cleansing citation, combined with Jer 7:11 (\"den of robbers\")."
             },
             {
               "ref": "Jer 7:11",
-              "note": "\"Has this house, which bears my Name, become a den of robbers to you?\" \u2014 Jeremiah's Temple sermon preceding the Babylonian destruction, which Jesus applies to the Temple of his own day."
+              "note": "\"Has this house, which bears my Name, become a den of robbers to you?\" — Jeremiah's Temple sermon preceding the Babylonian destruction, which Jesus applies to the Temple of his own day."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:38",
-              "note": "\"Blessed is the king who comes in the name of the Lord!\" \u2014 the Psalm 118 acclamation adapted: Luke adds \"the king,\" making the Christological identification explicit. \"Peace in heaven and glory in the highest\" echoes the angels' song at the nativity (2:14), but inverted: the angels sang \"peace on earth\"; the crowd sings \"peace in heaven.\" The peace Christ brings is first vertical (God reconciled to humanity) before it is horizontal."
-            },
-            {
-              "ref": "19:41-44",
-              "note": "The weeping over Jerusalem is unique to Luke and is one of the most theologically significant passages in the Gospel. Jesus weeps not from frustration or defeat but from genuine grief over what Jerusalem's refusal will bring upon itself. The destruction described in vv.43-44 is not punishment imposed from outside but the consequence of having rejected the one who would have given peace. \"Because you did not recognize the time of God's coming to you\" \u2014 kairos again (cf. 12:56)."
-            },
-            {
-              "ref": "19:45-46",
-              "note": "The Temple cleansing in Luke is brief (two verses versus Mark's fuller account). Luke emphasises the teaching that follows: \"every day he was teaching at the temple\" (v.47). The cleansing is preparatory \u2014 removing the obstruction to make space for what the Temple was built for: the word of God, now taught by the one who is the Word."
-            },
-            {
-              "ref": "19:48",
-              "note": "\"All the people hung on his words\" \u2014 the Greek is literally \"were hanging on him listening.\" The establishment wants to kill him; the people cannot stop listening. This tension \u2014 popular support providing temporary protection \u2014 runs through the passion narrative until the crowd's mood shifts."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:41-44",
-              "note": "Calvin reads the weeping over Jerusalem as a revelation of the divine will \u2014 God genuinely desires the salvation of those who refuse it. The tears are not theatrical; they are the outward expression of what is real in the divine heart. Calvin uses this passage against the view that God's predestination is cold and indifferent to human choices: God weeps over the city's refusal even while sovereignly directing history toward its end."
-            },
-            {
-              "ref": "19:46",
-              "note": "The Temple cleansing enacts the prophetic tradition of religious reform through dramatic action (cf. Jeremiah's Temple sermon, Ezekiel's symbolic acts). By citing Isa 56:7 and Jer 7:11, Jesus places himself in the prophetic tradition and implies the same judgment: as the Temple was destroyed after Jeremiah's warning, so it will be destroyed after his."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:38",
-              "note": "\"Peace in heaven and glory in the highest\" \u2014 a remarkable adaptation of the angels' nativity song (2:14). The crowd unconsciously reverses the direction: the angels announced peace on earth; the crowd announces peace in heaven. Both are true: the peace Christ brings reconciles heaven and earth simultaneously, though Luke's crowd understands only part of what they are saying."
-            },
-            {
-              "ref": "19:44",
-              "note": "\"The time of God's coming to you\" \u2014 episkop\u0113n, \"visitation.\" This technical term for divine intervention appears in the LXX for YHWH's decisive arrivals in history (Exod 3:16; Gen 50:24). Luke is claiming that Jesus's entry into Jerusalem is the defining episkop\u0113 of Israel's history \u2014 the moment of God's personal arrival \u2014 and that Jerusalem failed to recognise it."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "19:41",
-              "note": "Eklausen \u2014 aorist active: he wept. Not a sustained weeping but a definitive act of grief at the moment of seeing the city. The aorist captures the moment; the sight of Jerusalem across the Kidron Valley triggered it."
-            },
-            {
-              "ref": "19:44",
-              "note": "Episkop\u0113n \u2014 \"visitation.\" The same word used in 1:68 for God's visitation to his people in the infancy narrative. Jerusalem has failed to recognise its episkop\u0113 \u2014 the moment when God visited in person. The connection to the birth narrative is deliberate and devastating."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "19:41",
-              "note": "Ambrose: \"He wept over the city that would not receive him. He weeps even now over those who reject him. For the tears of Christ are the tears of divine compassion \u2014 they do not diminish his joy over those who are saved, but they reveal that he desires the salvation of all.\""
-            },
-            {
-              "ref": "19:46",
-              "note": "Chrysostom: \"He says 'my house' \u2014 not 'the house of the law' or 'the house of sacrifice' but my house. He is claiming the Temple as his own possession. And then he says what it has become: a den of robbers. The contrast is total: what was meant for prayer has been turned into a market.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem from the Mount of Olives on a colt, acclaimed by the crowd with Psalm 118. He weeps over the city, enters the Temple, and surveys it. Luke 19:28-48.",
             "current": true
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Fig Tree; Temple Cleansing",
             "text": "Jesus returns to Jerusalem, drives out the sellers from the Temple, and teaches daily in the courts.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies; Olivet Discourse",
             "text": "Authority questioned; wicked tenants; taxes; resurrection; the great commandment; the Olivet Discourse.",
             "current": false
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Jesus anointed at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane; Arrest",
             "text": "The Passover meal with the Twelve; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion; Death; Burial",
             "text": "Before Pilate and Herod; sentenced; crucified at Golgotha; buried in Joseph's tomb.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "The empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
           }
         ],
         "hist": {
-          "context": "The Triumphal Entry as Staged Fulfilment\nJesus's arrangements for the colt (19:30-31) show the same precise foreknowledge as the upper room preparation (22:10-12) \u2014 a pattern of deliberately staged symbolic action. The choice of a colt on which no one had sat recalls Zech 9:9 (\"your king comes to you, gentle and riding on a donkey, on a colt\") without explicit citation. The action interprets itself for those who know the scripture.\n\nJesus Weeps\nOnly Luke records Jesus weeping over Jerusalem (19:41-44). The prophetic lament is specific: a siege (19:43-44 describes the Roman siege of AD 70 with remarkable precision \u2014 embankment, encirclement, children dashed to the ground). The weeping is not resignation but grief: \"if you had only known\" \u2014 the possibility of a different outcome was real."
+          "context": "The Triumphal Entry as Staged Fulfilment\nJesus's arrangements for the colt (19:30-31) show the same precise foreknowledge as the upper room preparation (22:10-12) — a pattern of deliberately staged symbolic action. The choice of a colt on which no one had sat recalls Zech 9:9 (\"your king comes to you, gentle and riding on a donkey, on a colt\") without explicit citation. The action interprets itself for those who know the scripture.\n\nJesus Weeps\nOnly Luke records Jesus weeping over Jerusalem (19:41-44). The prophetic lament is specific: a siege (19:43-44 describes the Roman siege of AD 70 with remarkable precision — embankment, encirclement, children dashed to the ground). The weeping is not resignation but grief: \"if you had only known\" — the possibility of a different outcome was real."
         }
       }
     }
@@ -700,15 +594,15 @@
       {
         "name": "Zacchaeus",
         "role": "Chief tax collector",
-        "text": "The only named convert in Luke's journey narrative. His transformation \u2014 spontaneous, complete, restitutionary \u2014 is the clearest narrative demonstration of what salvation produces. Jesus seeks him; he responds; the whole house is transformed."
+        "text": "The only named convert in Luke's journey narrative. His transformation — spontaneous, complete, restitutionary — is the clearest narrative demonstration of what salvation produces. Jesus seeks him; he responds; the whole house is transformed."
       },
       {
         "name": "Jesus",
         "role": "Seeker and King",
-        "text": "Luke 19 presents two aspects of Jesus simultaneously: the one who seeks the lost (19:10) and the king who will return to judge (19:12-27). Both are present at the entry \u2014 the crowd acclaims a king; Jesus weeps as a prophet."
+        "text": "Luke 19 presents two aspects of Jesus simultaneously: the one who seeks the lost (19:10) and the king who will return to judge (19:12-27). Both are present at the entry — the crowd acclaims a king; Jesus weeps as a prophet."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">dei (19:5)</td><td>NIV: \"I must\"; KJV: \"I must\"; ESV: \"I must\"; NRSV: \"I must\". Universal agreement on the divine necessity.</td></tr><tr><td class=\"t-label\">s\u014dt\u0113ria (19:9)</td><td>NIV: \"salvation\"; KJV: \"salvation\"; ESV: \"salvation\"; NRSV: \"salvation\". Universal agreement; s\u014dt\u0113ria's appearance in the narrative (rare outside the infancy hymns) is significant.</td></tr><tr><td class=\"t-label\">episkop\u0113n (19:44)</td><td>NIV: \"God's coming to you\"; KJV: \"thy visitation\"; ESV: \"the time of your visitation\"; NRSV: \"the time of your visitation from God\". KJV/ESV/NRSV preserve \"visitation\" and its LXX resonance; NIV paraphrases.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">dei (19:5)</td><td>NIV: \"I must\"; KJV: \"I must\"; ESV: \"I must\"; NRSV: \"I must\". Universal agreement on the divine necessity.</td></tr><tr><td class=\"t-label\">sōtēria (19:9)</td><td>NIV: \"salvation\"; KJV: \"salvation\"; ESV: \"salvation\"; NRSV: \"salvation\". Universal agreement; sōtēria's appearance in the narrative (rare outside the infancy hymns) is significant.</td></tr><tr><td class=\"t-label\">episkopēn (19:44)</td><td>NIV: \"God's coming to you\"; KJV: \"thy visitation\"; ESV: \"the time of your visitation\"; NRSV: \"the time of your visitation from God\". KJV/ESV/NRSV preserve \"visitation\" and its LXX resonance; NIV paraphrases.</td></tr>",
     "src": [
       {
         "title": "Zechariah 9:9",
@@ -717,8 +611,8 @@
       },
       {
         "title": "Josephus, Antiquities 17.299-314",
-        "quote": "The account of Archelaus's journey to Rome to receive royal appointment and the Jewish delegation that opposed him \u2014 the political event behind the minas parable, providing the parable's \"historical\" frame.",
-        "note": "The parable's uncomfortable correspondence between the king-figure and Archelaus would not have been lost on Jesus's Palestinian audience \u2014 and neither would the identification of the king with Jesus."
+        "quote": "The account of Archelaus's journey to Rome to receive royal appointment and the Jewish delegation that opposed him — the political event behind the minas parable, providing the parable's \"historical\" frame.",
+        "note": "The parable's uncomfortable correspondence between the king-figure and Archelaus would not have been lost on Jesus's Palestinian audience — and neither would the identification of the king with Jesus."
       }
     ],
     "rec": [
@@ -734,12 +628,12 @@
     "lit": {
       "rows": [
         {
-          "label": "Contrast \u2014 vv.8-9 / 14, 27",
+          "label": "Contrast — vv.8-9 / 14, 27",
           "text": "Zacchaeus's willing submission to the king who comes to seek him contrasts with the citizens who \"hated him and sent a delegation after him to say, 'We don't want this man to be our king'\" (v.14). Two responses to the same king-figure are presented simultaneously, with the parable providing the eschatological consequences of each.",
           "is_key": false
         },
         {
-          "label": "Inclusio \u2014 vv.10 / 41-44",
+          "label": "Inclusio — vv.10 / 41-44",
           "text": "\"The Son of Man came to seek and to save the lost\" (v.10) is the mission statement. The weeping over Jerusalem (vv.41-44) is its tragic counterpart: the one who came to save weeps because the lost refuses to be found. The chapter begins with successful seeking and ends with grief over the city that rejected what it was offered.",
           "is_key": false
         }
@@ -748,59 +642,59 @@
     },
     "hebtext": [
       {
-        "word": "s\u014dt\u0113ria",
+        "word": "sōtēria",
         "tlit": "so-TE-ri-a",
         "gloss": "salvation",
-        "note": "The word (v.9) appears rarely in Luke's narrative sections \u2014 mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
+        "note": "The word (v.9) appears rarely in Luke's narrative sections — mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
       },
       {
-        "word": "architel\u014dn\u0113s",
-        "tlit": "ar-chi-te-LO-n\u0113s",
+        "word": "architelōnēs",
+        "tlit": "ar-chi-te-LO-nēs",
         "gloss": "chief tax collector",
-        "note": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau \u2014 a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
+        "note": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau — a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
       },
       {
         "word": "eklausen",
         "tlit": "ek-LAU-sen",
         "gloss": "he wept",
-        "note": "The verb (v.41) is the stronger Greek word for weeping \u2014 not dakry\u014d (to shed tears quietly) but klai\u014d (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
+        "note": "The verb (v.41) is the stronger Greek word for weeping — not dakryō (to shed tears quietly) but klaiō (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
       },
       {
-        "word": "epegn\u014ds",
+        "word": "epegnōs",
         "tlit": "e-PEG-nos",
         "gloss": "if you had known / recognised",
-        "note": "The conditional (v.42) \u2014 \"if you, even you, had only known\" \u2014 uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkop\u0113n, v.44), the moment of kairos \u2014 the time when salvation was on offer."
+        "note": "The conditional (v.42) — \"if you, even you, had only known\" — uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkopēn, v.44), the moment of kairos — the time when salvation was on offer."
       },
       {
-        "word": "s\u014dt\u0113ria",
+        "word": "sōtēria",
         "tlit": "so-TE-ri-a",
         "gloss": "salvation",
-        "note": "The word (v.9) appears rarely in Luke's narrative sections \u2014 mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
+        "note": "The word (v.9) appears rarely in Luke's narrative sections — mostly in the Benedictus (1:69, 71, 77) and Simeon's song (2:30). Its appearance here, as the result of Jesus's visit to Zacchaeus's house, frames the encounter as the fulfilment of the infancy narrative's promises: the salvation of Israel is entering houses one by one."
       },
       {
-        "word": "architel\u014dn\u0113s",
-        "tlit": "ar-chi-te-LO-n\u0113s",
+        "word": "architelōnēs",
+        "tlit": "ar-chi-te-LO-nēs",
         "gloss": "chief tax collector",
-        "note": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau \u2014 a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
+        "note": "Unique in the NT (v.2). Zacchaeus was not merely a tax collector but the head of the local tax-collection bureau — a contractor who subcontracted collection to others, taking a percentage at each level. He was wealthy because others were paying his commission as well as Rome's demands. His wealth was built on a system of extraction."
       },
       {
         "word": "eklausen",
         "tlit": "ek-LAU-sen",
         "gloss": "he wept",
-        "note": "The verb (v.41) is the stronger Greek word for weeping \u2014 not dakry\u014d (to shed tears quietly) but klai\u014d (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
+        "note": "The verb (v.41) is the stronger Greek word for weeping — not dakryō (to shed tears quietly) but klaiō (to weep aloud, sob). Luke is the only evangelist who records Jesus weeping over Jerusalem at the entry. The word connects with the weeping of the exiles in Psalm 137 and the prophetic lament tradition."
       },
       {
-        "word": "epegn\u014ds",
+        "word": "epegnōs",
         "tlit": "e-PEG-nos",
         "gloss": "if you had known / recognised",
-        "note": "The conditional (v.42) \u2014 \"if you, even you, had only known\" \u2014 uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkop\u0113n, v.44), the moment of kairos \u2014 the time when salvation was on offer."
+        "note": "The conditional (v.42) — \"if you, even you, had only known\" — uses a second-person singular address to the city as a person. The knowing that Jerusalem failed is not intellectual information but the recognition of God's visitation (episkopēn, v.44), the moment of kairos — the time when salvation was on offer."
       }
     ],
     "tx": [
       {
         "ref": "19:25",
         "title": "The crowd's interruption",
-        "content": "Some interpreters treat v.25 (\"Sir, they said, he already has ten!\") as a parenthetical aside by Luke rather than part of the parable's dialogue. NA28 treats it as part of the parable. No textual variant exists \u2014 the question is literary, not manuscript.",
+        "content": "Some interpreters treat v.25 (\"Sir, they said, he already has ten!\") as a parenthetical aside by Luke rather than part of the parable's dialogue. NA28 treats it as part of the parable. No textual variant exists — the question is literary, not manuscript.",
         "note": "The parable's realism is enhanced by the bystanders' objection. The master's reply (v.26) directly answers their concern. Both readings are defensible; including it within the parable gives it more dramatic force."
       },
       {
@@ -817,7 +711,7 @@
           {
             "name": "A promise: present conversion",
             "proponents": "Fitzmyer, Green, most modern scholars",
-            "argument": "Zacchaeus's present tense (\"I give\" / \"I will pay back\") represents a declaration of immediate intent \u2014 his spontaneous response to Jesus's presence. This reading makes the story a conversion narrative."
+            "argument": "Zacchaeus's present tense (\"I give\" / \"I will pay back\") represents a declaration of immediate intent — his spontaneous response to Jesus's presence. This reading makes the story a conversion narrative."
           },
           {
             "name": "A defence: describing current practice",
@@ -854,7 +748,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 19 brings the long journey narrative to its destination in four movements: Zacchaeus (salvation entering a sinner's house), the minas (the king's departure, servants' accountability, and return), the triumphal entry (the king arriving in his city), and the weeping and cleansing (the prophet's grief and action in the Temple). The chapter holds together the joyful (\"Blessed is the king!\") and the sorrowful (\"he wept over it\") \u2014 the same city that receives the king with palms will crucify him within the week. Luke does not let the reader forget either dimension."
+      "note": "Luke 19 brings the long journey narrative to its destination in four movements: Zacchaeus (salvation entering a sinner's house), the minas (the king's departure, servants' accountability, and return), the triumphal entry (the king arriving in his city), and the weeping and cleansing (the prophet's grief and action in the Temple). The chapter holds together the joyful (\"Blessed is the king!\") and the sorrowful (\"he wept over it\") — the same city that receives the king with palms will crucify him within the week. Luke does not let the reader forget either dimension."
     }
   },
   "vhl_groups": [

--- a/content/luke/2.json
+++ b/content/luke/2.json
@@ -7,116 +7,116 @@
   "subtitle": "The Birth of Jesus; Simeon and Anna; The Boy Jesus in the Temple",
   "timeline_link": {
     "event_id": "jesus-born",
-    "text": "See on Timeline \u2014 Jesus Born"
+    "text": "See on Timeline — Jesus Born"
   },
   "map_story_link": {
     "story_id": "nativity",
-    "text": "See on Map \u2014 The Nativity"
+    "text": "See on Map — The Nativity"
   },
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201320 \u2014 The Birth of Jesus; The Shepherds and the Angels",
+      "header": "Verses 1–20 — The Birth of Jesus; The Shepherds and the Angels",
       "verse_start": 1,
       "verse_end": 20,
       "panels": {
         "heb": [
           {
-            "word": "s\u014dt\u0113r",
+            "word": "sōtēr",
             "transliteration": "so-TARE",
             "gloss": "Savior",
-            "paragraph": "Today in the town of David a Savior has been born to you \u2014 the angel\u2019s announcement uses all three great titles simultaneously: Savior (s\u014dt\u0113r), Messiah (Christos), Lord (Kyrios). S\u014dt\u0113r was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke\u2019s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
+            "paragraph": "Today in the town of David a Savior has been born to you — the angel’s announcement uses all three great titles simultaneously: Savior (sōtēr), Messiah (Christos), Lord (Kyrios). Sōtēr was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke’s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Mic 5:2",
-              "note": "But you, Bethlehem Ephrathah\u2026out of you will come for me one who will be ruler over Israel \u2014 the prophecy Luke fulfils by the census mechanism without citing it."
+              "note": "But you, Bethlehem Ephrathah…out of you will come for me one who will be ruler over Israel — the prophecy Luke fulfils by the census mechanism without citing it."
             },
             {
               "ref": "Isa 9:6",
-              "note": "For to us a child is born, to us a son is given\u2026 his name will be called Wonderful Counselor, Mighty God, Everlasting Father, Prince of Peace \u2014 the messianic birth announcement Isaiah prefigured."
+              "note": "For to us a child is born, to us a son is given… his name will be called Wonderful Counselor, Mighty God, Everlasting Father, Prince of Peace — the messianic birth announcement Isaiah prefigured."
             },
             {
               "ref": "Ps 72:7-8",
-              "note": "In his days may the righteous flourish and prosperity abound till the moon is no more. May he rule from sea to sea \u2014 the universal Davidic peace the angels announce."
+              "note": "In his days may the righteous flourish and prosperity abound till the moon is no more. May he rule from sea to sea — the universal Davidic peace the angels announce."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:7",
-              "note": "She wrapped him in cloths and placed him in a manger, because there was no guest room available \u2014 the three details together communicate the totality of his condescension. Swaddling cloths: the ordinary care given any newborn. Manger: an animal feeding trough. No room: the rejection begins at birth. John 1:11 \u2014 he came to his own, and his own did not receive him \u2014 is already true in Bethlehem."
+              "note": "She wrapped him in cloths and placed him in a manger, because there was no guest room available — the three details together communicate the totality of his condescension. Swaddling cloths: the ordinary care given any newborn. Manger: an animal feeding trough. No room: the rejection begins at birth. John 1:11 — he came to his own, and his own did not receive him — is already true in Bethlehem."
             },
             {
               "ref": "2:10-11",
-              "note": "Good news that will cause great joy for all the people \u2014 the announcement is universal in scope. The Savior is not born for a sect or a class but for all the people \u2014 and ultimately, as Luke\u2019s infancy narrative has insisted from the Magnificat onward, for all nations."
+              "note": "Good news that will cause great joy for all the people — the announcement is universal in scope. The Savior is not born for a sect or a class but for all the people — and ultimately, as Luke’s infancy narrative has insisted from the Magnificat onward, for all nations."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:7",
-              "note": "No room available \u2014 Calvin: the poverty and rejection of the nativity are not misfortunes that attend the Incarnation but are the Incarnation\u2019s meaning. God chose to come this way \u2014 without privilege, without comfort, without recognition \u2014 so that no human being could claim their poverty or obscurity placed them beyond the reach of this salvation."
+              "note": "No room available — Calvin: the poverty and rejection of the nativity are not misfortunes that attend the Incarnation but are the Incarnation’s meaning. God chose to come this way — without privilege, without comfort, without recognition — so that no human being could claim their poverty or obscurity placed them beyond the reach of this salvation."
             },
             {
               "ref": "2:8-12",
-              "note": "The shepherds are the first witnesses \u2014 Calvin: God\u2019s choice of shepherds as the first human recipients of the angelic announcement is consistent with his whole pattern: the things of this world that are foolish and weak and low (1 Cor 1:27-28). The message is given to those the world overlooks."
+              "note": "The shepherds are the first witnesses — Calvin: God’s choice of shepherds as the first human recipients of the angelic announcement is consistent with his whole pattern: the things of this world that are foolish and weak and low (1 Cor 1:27-28). The message is given to those the world overlooks."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:2",
-              "note": "The first census that took place while Quirinius was governor of Syria \u2014 one of the most debated historical notes in Luke. Josephus places a Quirinius census in AD 6, which is too late for Herod the Great\u2019s reign (who died c. 4 BC). Proposed solutions include: an earlier governorship of Quirinius, a different official, or Luke\u2019s reference to a different census occasion. The historical problem is real; the theological point is clear."
+              "note": "The first census that took place while Quirinius was governor of Syria — one of the most debated historical notes in Luke. Josephus places a Quirinius census in AD 6, which is too late for Herod the Great’s reign (who died c. 4 BC). Proposed solutions include: an earlier governorship of Quirinius, a different official, or Luke’s reference to a different census occasion. The historical problem is real; the theological point is clear."
             },
             {
               "ref": "2:11",
-              "note": "He is the Messiah, the Lord (Christos Kyrios) \u2014 the combination of these two titles in a single proclamation is unique. Christos identifies him as the anointed Davidic king; Kyrios is the Septuagint\u2019s word for YHWH. The angel collapses the messianic and the divine into one announcement."
+              "note": "He is the Messiah, the Lord (Christos Kyrios) — the combination of these two titles in a single proclamation is unique. Christos identifies him as the anointed Davidic king; Kyrios is the Septuagint’s word for YHWH. The angel collapses the messianic and the divine into one announcement."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "2:1",
-              "note": "Caesar Augustus issued a decree \u2014 the Greek edogma exelthen places the narrative inside Roman imperial time. Augustus (the divine, the revered) is named with his title \u2014 a title that will eventually be claimed by the church for Jesus alone."
+              "note": "Caesar Augustus issued a decree — the Greek edogma exelthen places the narrative inside Roman imperial time. Augustus (the divine, the revered) is named with his title — a title that will eventually be claimed by the church for Jesus alone."
             },
             {
               "ref": "2:19",
-              "note": "Mary treasured up all these things and pondered them in her heart \u2014 the imperfect tense of both verbs (was keeping, was pondering) indicates ongoing, continuous reflection. This is a characteristic Lukan detail suggesting Mary as one of Luke\u2019s eyewitness sources."
+              "note": "Mary treasured up all these things and pondered them in her heart — the imperfect tense of both verbs (was keeping, was pondering) indicates ongoing, continuous reflection. This is a characteristic Lukan detail suggesting Mary as one of Luke’s eyewitness sources."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "2:7",
-              "note": "Placed him in a manger \u2014 Origen: the manger is a prophecy. Isaiah 1:3 says \u201cthe ox knows his master, the donkey his owner\u2019s manger; but Israel does not know, my people do not understand.\u201d The one the animals recognize in their manger is the Lord Israel fails to recognize."
+              "note": "Placed him in a manger — Origen: the manger is a prophecy. Isaiah 1:3 says “the ox knows his master, the donkey his owner’s manger; but Israel does not know, my people do not understand.” The one the animals recognize in their manger is the Lord Israel fails to recognize."
             },
             {
               "ref": "2:14",
-              "note": "Glory to God in the highest, and peace on earth \u2014 Augustine: the two movements of the angelic song define the whole pattern of redemption: the upward movement of glory to God, and the downward gift of peace to earth. These are not separate transactions but the same act viewed from two directions."
+              "note": "Glory to God in the highest, and peace on earth — Augustine: the two movements of the angelic song define the whole pattern of redemption: the upward movement of glory to God, and the downward gift of peace to earth. These are not separate transactions but the same act viewed from two directions."
             }
           ]
         },
         "hist": {
-          "context": "Luke anchors the birth of Jesus in the largest political reality of the first-century world: Caesar Augustus\u2019s census. The universal decree creates the geographical necessity that brings Joseph and Mary from Nazareth to Bethlehem \u2014 fulfilling Micah 5:2 without Luke citing it. The manger and the shepherds are the Gospel\u2019s first great reversal: the one the angels announce as Savior, Messiah, and Lord is found in an animal feeding trough by working-class field workers."
+          "context": "Luke anchors the birth of Jesus in the largest political reality of the first-century world: Caesar Augustus’s census. The universal decree creates the geographical necessity that brings Joseph and Mary from Nazareth to Bethlehem — fulfilling Micah 5:2 without Luke citing it. The manger and the shepherds are the Gospel’s first great reversal: the one the angels announce as Savior, Messiah, and Lord is found in an animal feeding trough by working-class field workers."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 21\u201338 \u2014 Presentation at the Temple; Simeon and Anna",
+      "header": "Verses 21–38 — Presentation at the Temple; Simeon and Anna",
       "verse_start": 21,
       "verse_end": 38,
       "panels": {
@@ -125,192 +125,147 @@
             "word": "Nyn apolysis",
             "transliteration": "NOON a-pol-Y-sis",
             "gloss": "Now you are releasing/dismissing",
-            "paragraph": "Sovereign Lord, now you may dismiss your servant in peace \u2014 the opening of the Nunc Dimittis. Apolysis (release/dismissal) is the word used for releasing a slave or a watchman from duty. Simeon has been standing watch, waiting for the consolation of Israel. Now that his eyes have seen the salvation, the watch is over. He can be released."
+            "paragraph": "Sovereign Lord, now you may dismiss your servant in peace — the opening of the Nunc Dimittis. Apolysis (release/dismissal) is the word used for releasing a slave or a watchman from duty. Simeon has been standing watch, waiting for the consolation of Israel. Now that his eyes have seen the salvation, the watch is over. He can be released."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 42:6; 49:6",
-              "note": "I will make you a light for the Gentiles \u2014 the Servant Song texts that Simeon quotes in 2:32. Jesus is identified as the Servant of YHWH from his infancy."
+              "note": "I will make you a light for the Gentiles — the Servant Song texts that Simeon quotes in 2:32. Jesus is identified as the Servant of YHWH from his infancy."
             },
             {
               "ref": "Lev 12:6-8",
-              "note": "The purification offering after childbirth \u2014 the pair of doves or two pigeons was the offering of the poor (2:24), indicating the family\u2019s economic status."
+              "note": "The purification offering after childbirth — the pair of doves or two pigeons was the offering of the poor (2:24), indicating the family’s economic status."
             },
             {
               "ref": "Mal 3:1",
-              "note": "The Lord you are seeking will come to his temple suddenly \u2014 the presentation is the literal first coming of the Lord to his Temple."
+              "note": "The Lord you are seeking will come to his temple suddenly — the presentation is the literal first coming of the Lord to his Temple."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:29-32",
-              "note": "Now you may dismiss your servant in peace \u2014 the Nunc Dimittis is the third great canticle of Luke\u2019s infancy narrative and its most universally scoped: salvation prepared for all nations, light for Gentiles, glory for Israel. Simeon holds the one who answers every hope Israel has been carrying."
+              "note": "Now you may dismiss your servant in peace — the Nunc Dimittis is the third great canticle of Luke’s infancy narrative and its most universally scoped: salvation prepared for all nations, light for Gentiles, glory for Israel. Simeon holds the one who answers every hope Israel has been carrying."
             },
             {
               "ref": "2:34-35",
-              "note": "This child is destined to cause the falling and rising of many in Israel \u2014 Simeon\u2019s prophecy is the first dark note of the infancy narrative. The sword through Mary\u2019s soul is the cross, not merely grief. The falling and rising reverses the expected direction: in Israel\u2019s expectation the nations fall and Israel rises; here even Israel is divided by this child."
+              "note": "This child is destined to cause the falling and rising of many in Israel — Simeon’s prophecy is the first dark note of the infancy narrative. The sword through Mary’s soul is the cross, not merely grief. The falling and rising reverses the expected direction: in Israel’s expectation the nations fall and Israel rises; here even Israel is divided by this child."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "2:34-35",
-              "note": "Destined to cause the falling and rising of many in Israel \u2014 Calvin: the child\u2019s arrival does not bring universal harmony but division. Simeon\u2019s prophecy corrects the triumphal reading of the Magnificat and Benedictus: the Messiah\u2019s coming divides between those who fall before him in faith and those who fall against him in rejection."
+              "note": "Destined to cause the falling and rising of many in Israel — Calvin: the child’s arrival does not bring universal harmony but division. Simeon’s prophecy corrects the triumphal reading of the Magnificat and Benedictus: the Messiah’s coming divides between those who fall before him in faith and those who fall against him in rejection."
             },
             {
               "ref": "2:49",
-              "note": "Didn\u2019t you know I had to be in my Father\u2019s house? \u2014 Calvin: the \u201cmust\u201d (dei) is the language of divine necessity. Jesus\u2019s orientation toward his Father\u2019s will is prior to his relationship with his earthly parents. He is obedient to them (2:51), but his primary obedience is higher."
+              "note": "Didn’t you know I had to be in my Father’s house? — Calvin: the “must” (dei) is the language of divine necessity. Jesus’s orientation toward his Father’s will is prior to his relationship with his earthly parents. He is obedient to them (2:51), but his primary obedience is higher."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "2:22",
-              "note": "Purification rites required by the Law of Moses \u2014 Luke says \u201ctheir purification\u201d (not just Mary\u2019s), though the Mosaic law only required purification for the mother (Lev 12). Luke may be extending the rite to indicate the whole family\u2019s covenant participation, or he may be treating it loosely."
+              "note": "Purification rites required by the Law of Moses — Luke says “their purification” (not just Mary’s), though the Mosaic law only required purification for the mother (Lev 12). Luke may be extending the rite to indicate the whole family’s covenant participation, or he may be treating it loosely."
             },
             {
               "ref": "2:52",
-              "note": "Grew in wisdom and stature \u2014 the statement that Jesus grew in wisdom is theologically significant: it affirms the genuine development of the incarnate Son in his human nature. The Chalcedonian understanding is that he possessed full divine wisdom in his divine nature while genuinely growing in wisdom in his human formation."
+              "note": "Grew in wisdom and stature — the statement that Jesus grew in wisdom is theologically significant: it affirms the genuine development of the incarnate Son in his human nature. The Chalcedonian understanding is that he possessed full divine wisdom in his divine nature while genuinely growing in wisdom in his human formation."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "2:49",
-              "note": "\"Didn\u2019t you know I had to be in my Father\u2019s house?\" \u2014 the Greek is literally \"in the things of my Father\" \u2014 a deliberately ambiguous phrase that could mean my Father\u2019s house, my Father\u2019s affairs, or my Father\u2019s presence. The ambiguity is Lukan: the twelve-year-old Jesus is claiming a primary relationship that supersedes the earthly parental relationship."
+              "note": "\"Didn’t you know I had to be in my Father’s house?\" — the Greek is literally \"in the things of my Father\" — a deliberately ambiguous phrase that could mean my Father’s house, my Father’s affairs, or my Father’s presence. The ambiguity is Lukan: the twelve-year-old Jesus is claiming a primary relationship that supersedes the earthly parental relationship."
             },
             {
               "ref": "2:52",
-              "note": "Jesus grew in wisdom and stature, and in favor with God and man \u2014 the fourfold growth mirrors 1 Sam 2:26 (Samuel). Luke is positioning Jesus within the pattern of Israel\u2019s great servant-figures who were formed before their public ministry."
+              "note": "Jesus grew in wisdom and stature, and in favor with God and man — the fourfold growth mirrors 1 Sam 2:26 (Samuel). Luke is positioning Jesus within the pattern of Israel’s great servant-figures who were formed before their public ministry."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "2:25-35",
-              "note": "Simeon\u2019s recognition \u2014 Origen: Simeon embodies Israel at its best: righteous, devout, Spirit-filled, waiting with patient faith. His immediate recognition of the child as the consolation of Israel answers the question the whole OT has been asking. He is the covenant\u2019s most faithful last witness."
+              "note": "Simeon’s recognition — Origen: Simeon embodies Israel at its best: righteous, devout, Spirit-filled, waiting with patient faith. His immediate recognition of the child as the consolation of Israel answers the question the whole OT has been asking. He is the covenant’s most faithful last witness."
             },
             {
               "ref": "2:36-38",
-              "note": "Anna the prophet \u2014 Chrysostom: Luke names Anna\u2019s tribe (Asher), her years (84 in widowhood), and her practice (fasting and prayer night and day). This is not decoration but theological testimony: the one who first proclaims Jesus to the public is an elderly widow \u2014 the social category least likely to be taken seriously in the first century. God\u2019s pattern of choosing the overlooked continues."
+              "note": "Anna the prophet — Chrysostom: Luke names Anna’s tribe (Asher), her years (84 in widowhood), and her practice (fasting and prayer night and day). This is not decoration but theological testimony: the one who first proclaims Jesus to the public is an elderly widow — the social category least likely to be taken seriously in the first century. God’s pattern of choosing the overlooked continues."
             }
           ]
         },
         "hist": {
-          "context": "The Presentation in the Temple brings the infant Jesus to Jerusalem for the first time \u2014 the city that will receive and reject and finally be judged by him. Simeon\u2019s Nunc Dimittis is the third canticle of Luke\u2019s infancy narrative and its most universally scoped: light for the Gentiles and glory for Israel. His prophecy to Mary (2:34-35) is the first shadow of the cross \u2014 a sword through her soul. The boy Jesus in the Temple at twelve is Luke\u2019s only childhood story and his first direct speech."
+          "context": "The Presentation in the Temple brings the infant Jesus to Jerusalem for the first time — the city that will receive and reject and finally be judged by him. Simeon’s Nunc Dimittis is the third canticle of Luke’s infancy narrative and its most universally scoped: light for the Gentiles and glory for Israel. His prophecy to Mary (2:34-35) is the first shadow of the cross — a sword through her soul. The boy Jesus in the Temple at twelve is Luke’s only childhood story and his first direct speech."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 39\u201352 \u2014 Return to Nazareth; The Boy Jesus in the Temple",
+      "header": "Verses 39–52 — Return to Nazareth; The Boy Jesus in the Temple",
       "verse_start": 39,
       "verse_end": 52,
       "panels": {
         "heb": [
           {
-            "word": "s\u014dt\u0113r",
+            "word": "sōtēr",
             "transliteration": "so-TARE",
             "gloss": "Savior",
-            "paragraph": "Today in the town of David a Savior has been born to you \u2014 the angel\u2019s announcement uses all three great titles simultaneously: Savior (s\u014dt\u0113r), Messiah (Christos), Lord (Kyrios). S\u014dt\u0113r was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke\u2019s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
+            "paragraph": "Today in the town of David a Savior has been born to you — the angel’s announcement uses all three great titles simultaneously: Savior (sōtēr), Messiah (Christos), Lord (Kyrios). Sōtēr was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke’s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Mic 5:2",
-              "note": "But you, Bethlehem Ephrathah\u2026out of you will come for me one who will be ruler over Israel \u2014 the prophecy Luke fulfils by the census mechanism without citing it."
+              "note": "But you, Bethlehem Ephrathah…out of you will come for me one who will be ruler over Israel — the prophecy Luke fulfils by the census mechanism without citing it."
             },
             {
               "ref": "Isa 9:6",
-              "note": "For to us a child is born, to us a son is given\u2026 his name will be called Wonderful Counselor, Mighty God, Everlasting Father, Prince of Peace \u2014 the messianic birth announcement Isaiah prefigured."
+              "note": "For to us a child is born, to us a son is given… his name will be called Wonderful Counselor, Mighty God, Everlasting Father, Prince of Peace — the messianic birth announcement Isaiah prefigured."
             },
             {
               "ref": "Ps 72:7-8",
-              "note": "In his days may the righteous flourish and prosperity abound till the moon is no more. May he rule from sea to sea \u2014 the universal Davidic peace the angels announce."
+              "note": "In his days may the righteous flourish and prosperity abound till the moon is no more. May he rule from sea to sea — the universal Davidic peace the angels announce."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:7",
-              "note": "She wrapped him in cloths and placed him in a manger, because there was no guest room available \u2014 the three details together communicate the totality of his condescension. Swaddling cloths: the ordinary care given any newborn. Manger: an animal feeding trough. No room: the rejection begins at birth. John 1:11 \u2014 he came to his own, and his own did not receive him \u2014 is already true in Bethlehem."
-            },
-            {
-              "ref": "2:10-11",
-              "note": "Good news that will cause great joy for all the people \u2014 the announcement is universal in scope. The Savior is not born for a sect or a class but for all the people \u2014 and ultimately, as Luke\u2019s infancy narrative has insisted from the Magnificat onward, for all nations."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:7",
-              "note": "No room available \u2014 Calvin: the poverty and rejection of the nativity are not misfortunes that attend the Incarnation but are the Incarnation\u2019s meaning. God chose to come this way \u2014 without privilege, without comfort, without recognition \u2014 so that no human being could claim their poverty or obscurity placed them beyond the reach of this salvation."
-            },
-            {
-              "ref": "2:8-12",
-              "note": "The shepherds are the first witnesses \u2014 Calvin: God\u2019s choice of shepherds as the first human recipients of the angelic announcement is consistent with his whole pattern: the things of this world that are foolish and weak and low (1 Cor 1:27-28). The message is given to those the world overlooks."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:2",
-              "note": "The first census that took place while Quirinius was governor of Syria \u2014 one of the most debated historical notes in Luke. Josephus places a Quirinius census in AD 6, which is too late for Herod the Great\u2019s reign (who died c. 4 BC). Proposed solutions include: an earlier governorship of Quirinius, a different official, or Luke\u2019s reference to a different census occasion. The historical problem is real; the theological point is clear."
-            },
-            {
-              "ref": "2:11",
-              "note": "He is the Messiah, the Lord (Christos Kyrios) \u2014 the combination of these two titles in a single proclamation is unique. Christos identifies him as the anointed Davidic king; Kyrios is the Septuagint\u2019s word for YHWH. The angel collapses the messianic and the divine into one announcement."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "2:1",
-              "note": "Caesar Augustus issued a decree \u2014 the Greek edogma exelthen places the narrative inside Roman imperial time. Augustus (the divine, the revered) is named with his title \u2014 a title that will eventually be claimed by the church for Jesus alone."
-            },
-            {
-              "ref": "2:19",
-              "note": "Mary treasured up all these things and pondered them in her heart \u2014 the imperfect tense of both verbs (was keeping, was pondering) indicates ongoing, continuous reflection. This is a characteristic Lukan detail suggesting Mary as one of Luke\u2019s eyewitness sources."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "2:7",
-              "note": "Placed him in a manger \u2014 Origen: the manger is a prophecy. Isaiah 1:3 says \u201cthe ox knows his master, the donkey his owner\u2019s manger; but Israel does not know, my people do not understand.\u201d The one the animals recognize in their manger is the Lord Israel fails to recognize."
-            },
-            {
-              "ref": "2:14",
-              "note": "Glory to God in the highest, and peace on earth \u2014 Augustine: the two movements of the angelic song define the whole pattern of redemption: the upward movement of glory to God, and the downward gift of peace to earth. These are not separate transactions but the same act viewed from two directions."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke anchors the birth of Jesus in the largest political reality of the first-century world: Caesar Augustus\u2019s census. The universal decree creates the geographical necessity that brings Joseph and Mary from Nazareth to Bethlehem \u2014 fulfilling Micah 5:2 without Luke citing it. The manger and the shepherds are the Gospel\u2019s first great reversal: the one the angels announce as Savior, Messiah, and Lord is found in an animal feeding trough by working-class field workers."
+          "context": "Luke anchors the birth of Jesus in the largest political reality of the first-century world: Caesar Augustus’s census. The universal decree creates the geographical necessity that brings Joseph and Mary from Nazareth to Bethlehem — fulfilling Micah 5:2 without Luke citing it. The manger and the shepherds are the Gospel’s first great reversal: the one the angels announce as Savior, Messiah, and Lord is found in an animal feeding trough by working-class field workers."
         }
       }
     }
@@ -320,12 +275,12 @@
       {
         "name": "Simeon",
         "role": "Righteous and devout; waiting for the consolation of Israel",
-        "text": "He holds the infant Jesus and delivers the Nunc Dimittis \u2014 the Gospel\u2019s third great canticle. His prophecy about the sword piercing Mary\u2019s soul is the first passion shadow in Luke."
+        "text": "He holds the infant Jesus and delivers the Nunc Dimittis — the Gospel’s third great canticle. His prophecy about the sword piercing Mary’s soul is the first passion shadow in Luke."
       },
       {
         "name": "Anna",
         "role": "Prophet; daughter of Penuel; tribe of Asher; 84 years in widowhood",
-        "text": "Luke\u2019s most detailed female character in the infancy narrative. She is the first person in Luke who publicly proclaims Jesus to others \u2014 the first evangelist in the narrative."
+        "text": "Luke’s most detailed female character in the infancy narrative. She is the first person in Luke who publicly proclaims Jesus to others — the first evangelist in the narrative."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Glory to God in the highest heaven, and on earth peace to those on whom his favor rests.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Glory to God in the highest, and on earth peace among those with whom he is pleased!\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"Glory to God in the highest, and on earth peace, good will toward men.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"Glory to God in the highest, And on earth peace among people with whom He is pleased.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"Glory to God in highest heaven, and peace on earth to those with whom God is pleased.\"</td></tr>",
@@ -333,22 +288,22 @@
       {
         "title": "Josephus, Antiquities 17.42; Jewish War 1.648",
         "quote": "Josephus describes the political situation in Judea under Herod the Great and Augustus, confirming the historical setting of Luke 2.",
-        "note": "Provides the historical matrix for the census narrative and Herod\u2019s reign within which Luke places the birth of Jesus."
+        "note": "Provides the historical matrix for the census narrative and Herod’s reign within which Luke places the birth of Jesus."
       },
       {
         "title": "Virgil, Aeneid 1.278-279",
-        "quote": "Caesar Augustus brings world peace \u2014 the Roman imperial ideology that the angels\u2019 \u201cpeace on earth\u201d announcement deliberately counters.",
+        "quote": "Caesar Augustus brings world peace — the Roman imperial ideology that the angels’ “peace on earth” announcement deliberately counters.",
         "note": "The counter-imperial dimension of the angelic proclamation: Augustus claims to bring peace; Luke 2:14 claims peace comes through a different Lord."
       }
     ],
     "rec": [
       {
         "who": "Karl Barth, Church Dogmatics I/2",
-        "text": "Barth used the Presentation scene to argue that the Incarnation is the covenant\u2019s completion: God\u2019s promise to Abraham finds its fulfilment in this child who is brought to the Temple on the eighth day, placed in Simeon\u2019s arms, and recognized as the salvation prepared for all nations."
+        "text": "Barth used the Presentation scene to argue that the Incarnation is the covenant’s completion: God’s promise to Abraham finds its fulfilment in this child who is brought to the Temple on the eighth day, placed in Simeon’s arms, and recognized as the salvation prepared for all nations."
       },
       {
         "who": "Origen, Homilies on Luke 15",
-        "text": "Origen\u2019s meditation on Simeon became the foundation of the Western liturgical tradition of the Nunc Dimittis at Compline (night prayer). The monk ends the day holding Christ, as Simeon did, before being released into the peace of sleep/death."
+        "text": "Origen’s meditation on Simeon became the foundation of the Western liturgical tradition of the Nunc Dimittis at Compline (night prayer). The monk ends the day holding Christ, as Simeon did, before being released into the peace of sleep/death."
       }
     ],
     "lit": {
@@ -368,30 +323,30 @@
     },
     "hebtext": [
       {
-        "word": "s\u014dt\u0113r",
+        "word": "sōtēr",
         "tlit": "so-TARE",
         "gloss": "Savior",
-        "note": "Today in the town of David a Savior has been born to you \u2014 the angel\u2019s announcement uses all three great titles simultaneously: Savior (s\u014dt\u0113r), Messiah (Christos), Lord (Kyrios). S\u014dt\u0113r was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke\u2019s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
+        "note": "Today in the town of David a Savior has been born to you — the angel’s announcement uses all three great titles simultaneously: Savior (sōtēr), Messiah (Christos), Lord (Kyrios). Sōtēr was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke’s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
       },
       {
         "word": "Nyn apolysis",
         "tlit": "NOON a-pol-Y-sis",
         "gloss": "Now you are releasing/dismissing",
-        "note": "Sovereign Lord, now you may dismiss your servant in peace \u2014 the opening of the Nunc Dimittis. Apolysis (release/dismissal) is the word used for releasing a slave or a watchman from duty. Simeon has been standing watch, waiting for the consolation of Israel. Now that his eyes have seen the salvation, the watch is over. He can be released."
+        "note": "Sovereign Lord, now you may dismiss your servant in peace — the opening of the Nunc Dimittis. Apolysis (release/dismissal) is the word used for releasing a slave or a watchman from duty. Simeon has been standing watch, waiting for the consolation of Israel. Now that his eyes have seen the salvation, the watch is over. He can be released."
       },
       {
-        "word": "s\u014dt\u0113r",
+        "word": "sōtēr",
         "tlit": "so-TARE",
         "gloss": "Savior",
-        "note": "Today in the town of David a Savior has been born to you \u2014 the angel\u2019s announcement uses all three great titles simultaneously: Savior (s\u014dt\u0113r), Messiah (Christos), Lord (Kyrios). S\u014dt\u0113r was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke\u2019s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
+        "note": "Today in the town of David a Savior has been born to you — the angel’s announcement uses all three great titles simultaneously: Savior (sōtēr), Messiah (Christos), Lord (Kyrios). Sōtēr was also a title of the Roman emperor and of the gods Asclepius and Zeus. Luke’s proclamation is a deliberate counter-claim: Caesar is not the savior; the child in the manger is."
       }
     ],
     "tx": [
       {
         "ref": "2:14",
         "title": "\"Peace among men of good will\" vs \"peace to those on whom his favor rests\"",
-        "content": "The Greek manuscript tradition is divided: eudokias (genitive: \u201cof good will\u201d \u2014 qualifying men) vs eudokia (nominative: \u201cgood will\u201d \u2014 a third parallel noun). The genitive (supported by Sinaiticus, Vaticanus) is harder and almost certainly original. The KJV\u201cs \u201cgood will toward men\u201d follows the nominative reading of later MSS.",
-        "note": "The genitive reading \u2014 \u201cmembers of [God\u2019s] good pleasure\u201d \u2014 means peace flows to those whom God has chosen, not to all humanity universally. This is the preferred critical reading."
+        "content": "The Greek manuscript tradition is divided: eudokias (genitive: “of good will” — qualifying men) vs eudokia (nominative: “good will” — a third parallel noun). The genitive (supported by Sinaiticus, Vaticanus) is harder and almost certainly original. The KJV“s “good will toward men” follows the nominative reading of later MSS.",
+        "note": "The genitive reading — “members of [God’s] good pleasure” — means peace flows to those whom God has chosen, not to all humanity universally. This is the preferred critical reading."
       }
     ],
     "debate": [
@@ -400,12 +355,12 @@
         "positions": [
           {
             "name": "Historical view",
-            "proponents": "Luke\u2019s census fits within the Augustan census programme (documented by Josephus and papyri). An earlier Quirinius census or a different official is possible.",
+            "proponents": "Luke’s census fits within the Augustan census programme (documented by Josephus and papyri). An earlier Quirinius census or a different official is possible.",
             "argument": "Historical"
           },
           {
             "name": "Anachronistic view",
-            "proponents": "Luke may have confused a later AD 6 Quirinius census with Herod\u2019s reign. The historical difficulty is acknowledged even among conservative scholars.",
+            "proponents": "Luke may have confused a later AD 6 Quirinius census with Herod’s reign. The historical difficulty is acknowledged even among conservative scholars.",
             "argument": "Possible error in attribution"
           }
         ]
@@ -564,7 +519,7 @@
     },
     {
       "after_section": 3,
-      "tip": "Simeon and Anna\u2014aged prophets recognizing the infant Messiah. 'A sword will pierce your own soul' (v. 35): Mary's joy will become grief. Luke foreshadows the cross from the cradle.",
+      "tip": "Simeon and Anna—aged prophets recognizing the infant Messiah. 'A sword will pierce your own soul' (v. 35): Mary's joy will become grief. Luke foreshadows the cross from the cradle.",
       "genre_tag": "canonical_thread"
     }
   ]

--- a/content/luke/20.json
+++ b/content/luke/20.json
@@ -7,13 +7,13 @@
   "subtitle": "Authority, Parables, and Controversies in the Temple",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201119 \u2014 By What Authority?; The Parable of the Wicked Tenants",
+      "header": "Verses 1‑19 — By What Authority?; The Parable of the Wicked Tenants",
       "verse_start": 1,
       "verse_end": 19,
       "panels": {
@@ -25,51 +25,51 @@
             "paragraph": "The word (vv.2, 8) denotes both power (capacity to act) and right (legitimate authorization). The authorities challenge Jesus on both: who gave him the right, and what power does he have? Jesus refuses the question not from evasion but because their question presupposes a framework (human authorization) that cannot contain the answer."
           },
           {
-            "word": "eik\u014dn",
+            "word": "eikōn",
             "transliteration": "EI-kon",
             "gloss": "image / likeness",
-            "paragraph": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eik\u014dn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eik\u014dn; humans bear God's eik\u014dn. The implication: render yourself \u2014 entirely \u2014 to God."
+            "paragraph": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eikōn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eikōn; humans bear God's eikōn. The implication: render yourself — entirely — to God."
           }
         ],
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem on a colt, acclaimed by the crowd. He weeps over the city and surveys the Temple.",
             "current": false
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Temple Cleansing",
             "text": "Jesus drives out the merchants; begins daily Temple teaching.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies",
             "text": "Authority challenged; wicked tenants; taxes to Caesar; resurrection question; scribes and the widow. Luke 20-21.",
             "current": true
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Anointing at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane",
             "text": "Passover meal; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion",
             "text": "Trials before Pilate and Herod; crucifixion at Golgotha; burial.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "Empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
@@ -91,11 +91,11 @@
           "refs": [
             {
               "ref": "Isa 5:1-7",
-              "note": "The Song of the Vineyard \u2014 God's vineyard (Israel) that produced only wild grapes and faces destruction. The OT text that Jesus's parable is deliberately invoking."
+              "note": "The Song of the Vineyard — God's vineyard (Israel) that produced only wild grapes and faces destruction. The OT text that Jesus's parable is deliberately invoking."
             },
             {
               "ref": "Ps 118:22",
-              "note": "\"The stone the builders rejected has become the cornerstone\" \u2014 the psalm Jesus quotes after the parable, applying the rejected stone to himself."
+              "note": "\"The stone the builders rejected has become the cornerstone\" — the psalm Jesus quotes after the parable, applying the rejected stone to himself."
             },
             {
               "ref": "Matt 22:15-22; Mark 12:13-17",
@@ -104,7 +104,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:4",
@@ -112,20 +112,20 @@
             },
             {
               "ref": "20:13-15",
-              "note": "\"This is the heir \u2014 let us kill him, and the inheritance will be ours.\" The tenants' logic is nakedly acquisitive: eliminate the rightful owner's representative and seize the property. This is the establishment's actual motivation, dramatised in the parable. They want to occupy the covenant's benefits without submission to the covenant's Lord."
+              "note": "\"This is the heir — let us kill him, and the inheritance will be ours.\" The tenants' logic is nakedly acquisitive: eliminate the rightful owner's representative and seize the property. This is the establishment's actual motivation, dramatised in the parable. They want to occupy the covenant's benefits without submission to the covenant's Lord."
             },
             {
               "ref": "20:25",
-              "note": "\"Give back to Caesar what is Caesar's, and to God what is God's\" \u2014 the answer is perfectly balanced and perfectly devastating to both sides of the trap. If they say pay taxes, Jewish nationalists hate them. If they say don't, Rome arrests them. Jesus escapes both horns while delivering a principle of breathtaking scope: there are two spheres of obligation, and they are not identical, but both are real."
+              "note": "\"Give back to Caesar what is Caesar's, and to God what is God's\" — the answer is perfectly balanced and perfectly devastating to both sides of the trap. If they say pay taxes, Jewish nationalists hate them. If they say don't, Rome arrests them. Jesus escapes both horns while delivering a principle of breathtaking scope: there are two spheres of obligation, and they are not identical, but both are real."
             },
             {
               "ref": "20:18",
-              "note": "\"Everyone who falls on that stone will be broken to pieces; anyone on whom it falls will be crushed\" \u2014 the stone that saves (the cornerstone) is also the stone that destroys (the crushing stone). Encounter with Jesus is unavoidable; the only variable is the posture of the encounter. Fall on the stone in humility, or be fallen on in judgment."
+              "note": "\"Everyone who falls on that stone will be broken to pieces; anyone on whom it falls will be crushed\" — the stone that saves (the cornerstone) is also the stone that destroys (the crushing stone). Encounter with Jesus is unavoidable; the only variable is the posture of the encounter. Fall on the stone in humility, or be fallen on in judgment."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:9-16",
@@ -133,38 +133,38 @@
             },
             {
               "ref": "20:25",
-              "note": "The taxes-to-Caesar answer does not establish a doctrine of complete separation of church and state. It establishes that both Caesar and God have legitimate claims, that these claims are distinguishable, and that neither cancels the other. The deeper point \u2014 that God's claim extends to everything that bears his image \u2014 means that in practice, God's claim is total."
+              "note": "The taxes-to-Caesar answer does not establish a doctrine of complete separation of church and state. It establishes that both Caesar and God have legitimate claims, that these claims are distinguishable, and that neither cancels the other. The deeper point — that God's claim extends to everything that bears his image — means that in practice, God's claim is total."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:17",
-              "note": "The cornerstone (kephal\u0113n g\u014dnias) could refer to the capstone of an arch or the foundation cornerstone. Either way, the rejected stone has become the most critical structural element. Acts 4:11, 1 Pet 2:7, and Eph 2:20 all use this image for Christ \u2014 it became a foundational early church Christological text."
+              "note": "The cornerstone (kephalēn gōnias) could refer to the capstone of an arch or the foundation cornerstone. Either way, the rejected stone has become the most critical structural element. Acts 4:11, 1 Pet 2:7, and Eph 2:20 all use this image for Christ — it became a foundational early church Christological text."
             },
             {
               "ref": "20:25",
-              "note": "The denarius bore the image of Tiberius Caesar with the inscription \"Tiberius Caesar, son of the divine Augustus\" \u2014 a claim to divine sonship that many Jews found offensive. Jesus takes this coin, points to its image, and turns the question back: whose image do you bear? The theological stakes are much higher than the tax question."
+              "note": "The denarius bore the image of Tiberius Caesar with the inscription \"Tiberius Caesar, son of the divine Augustus\" — a claim to divine sonship that many Jews found offensive. Jesus takes this coin, points to its image, and turns the question back: whose image do you bear? The theological stakes are much higher than the tax question."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "20:7",
-              "note": "Ouk oidamen \u2014 \"we do not know.\" The present tense with ou (rather than m\u0113) is the negative of actual fact: they genuinely do not know, or claim not to. The irony is thick: the religious authorities charged with discerning authentic prophecy confess inability to evaluate John."
+              "note": "Ouk oidamen — \"we do not know.\" The present tense with ou (rather than mē) is the negative of actual fact: they genuinely do not know, or claim not to. The irony is thick: the religious authorities charged with discerning authentic prophecy confess inability to evaluate John."
             },
             {
               "ref": "20:24",
-              "note": "Eikona \u2014 the accusative of eik\u014dn. Jesus asks them to look at the coin and name what they see. Their answer (\"Caesar's\") gives him his premise. The argument from image is entirely his own construction, not a trap-escape."
+              "note": "Eikona — the accusative of eikōn. Jesus asks them to look at the coin and name what they see. Their answer (\"Caesar's\") gives him his premise. The argument from image is entirely his own construction, not a trap-escape."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:17",
@@ -172,18 +172,18 @@
             },
             {
               "ref": "20:25",
-              "note": "Ambrose: \"Render to Caesar the things that are Caesar's \u2014 taxes, tribute, civil obedience. Render to God the things that are God's \u2014 faith, service, and above all yourself, for you are made in his image. The coin bears Caesar's face; the soul bears God's.\""
+              "note": "Ambrose: \"Render to Caesar the things that are Caesar's — taxes, tribute, civil obedience. Render to God the things that are God's — faith, service, and above all yourself, for you are made in his image. The coin bears Caesar's face; the soul bears God's.\""
             }
           ]
         },
         "hist": {
-          "context": "Temple as Battleground\nLuke 20 takes place entirely in the Temple courts (19:47-20:1), where Jesus has been teaching daily. The establishment's challenge is public and formal \u2014 a delegation of chief priests, scribes, and elders confronting a Galilean teacher who has disrupted Temple commerce. The authority question is the opening move in a series of escalating attempts to discredit or entrap Jesus before the crowd.\n\nThe Vineyard Parable's Allegory\nThe wicked tenants parable (20:9-18) is one of Luke's most transparently allegorical: the vineyard is Israel (cf. Isa 5:1-7); the owner is God; the servants are the prophets; the son is Jesus. The tenants' reasoning (\"the inheritance will be ours,\" v.14) gives the theological diagnosis of the establishment's hostility: they want to possess what belongs to the son."
+          "context": "Temple as Battleground\nLuke 20 takes place entirely in the Temple courts (19:47-20:1), where Jesus has been teaching daily. The establishment's challenge is public and formal — a delegation of chief priests, scribes, and elders confronting a Galilean teacher who has disrupted Temple commerce. The authority question is the opening move in a series of escalating attempts to discredit or entrap Jesus before the crowd.\n\nThe Vineyard Parable's Allegory\nThe wicked tenants parable (20:9-18) is one of Luke's most transparently allegorical: the vineyard is Israel (cf. Isa 5:1-7); the owner is God; the servants are the prophets; the son is Jesus. The tenants' reasoning (\"the inheritance will be ours,\" v.14) gives the theological diagnosis of the establishment's hostility: they want to possess what belongs to the son."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 20\u201140 \u2014 Taxes to Caesar; Marriage at the Resurrection",
+      "header": "Verses 20‑40 — Taxes to Caesar; Marriage at the Resurrection",
       "verse_start": 20,
       "verse_end": 40,
       "panels": {
@@ -192,54 +192,54 @@
             "word": "anastasis",
             "transliteration": "a-NAS-ta-sis",
             "gloss": "resurrection",
-            "paragraph": "The Sadducees deny the anastasis (v.27) \u2014 a word that literally means \"standing up again.\" Their reductio ad absurdum (the seven-brothers scenario) assumes resurrection simply restores earthly conditions. Jesus denies the premise: resurrection life is qualitatively different from earthly life, not merely a continuation of it."
+            "paragraph": "The Sadducees deny the anastasis (v.27) — a word that literally means \"standing up again.\" Their reductio ad absurdum (the seven-brothers scenario) assumes resurrection simply restores earthly conditions. Jesus denies the premise: resurrection life is qualitatively different from earthly life, not merely a continuation of it."
           },
           {
             "word": "huioi theou",
             "transliteration": "HY-oi the-OU",
             "gloss": "sons/children of God",
-            "paragraph": "The designation for the resurrected (v.36) \u2014 they are \"God's children\" (huioi theou) by virtue of being \"children of the resurrection.\" The resurrection is not merely a restoration of life but an adoption into a new mode of existence that shares the angels' immortality."
+            "paragraph": "The designation for the resurrected (v.36) — they are \"God's children\" (huioi theou) by virtue of being \"children of the resurrection.\" The resurrection is not merely a restoration of life but an adoption into a new mode of existence that shares the angels' immortality."
           }
         ],
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem on a colt, acclaimed by the crowd. He weeps over the city and surveys the Temple.",
             "current": false
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Temple Cleansing",
             "text": "Jesus drives out the merchants; begins daily Temple teaching.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies",
             "text": "Authority challenged; wicked tenants; taxes to Caesar; resurrection question; scribes and the widow. Luke 20-21.",
             "current": true
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Anointing at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane",
             "text": "Passover meal; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion",
             "text": "Trials before Pilate and Herod; crucifixion at Golgotha; burial.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "Empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
@@ -261,28 +261,28 @@
           "refs": [
             {
               "ref": "Exod 3:6",
-              "note": "\"I am the God of Abraham, the God of Isaac, and the God of Jacob\" \u2014 the burning bush text Jesus uses to prove resurrection from the Pentateuch. If God is the God of the patriarchs in the present tense, they must still be alive in some sense."
+              "note": "\"I am the God of Abraham, the God of Isaac, and the God of Jacob\" — the burning bush text Jesus uses to prove resurrection from the Pentateuch. If God is the God of the patriarchs in the present tense, they must still be alive in some sense."
             },
             {
               "ref": "Ps 110:1",
-              "note": "\"The Lord said to my Lord: Sit at my right hand until I make your enemies a footstool for your feet\" \u2014 the most-cited OT verse in the NT, used here to press the Christological question beyond Davidic descent."
+              "note": "\"The Lord said to my Lord: Sit at my right hand until I make your enemies a footstool for your feet\" — the most-cited OT verse in the NT, used here to press the Christological question beyond Davidic descent."
             },
             {
               "ref": "Deut 25:5-6",
-              "note": "Levirate marriage law \u2014 the Sadducees' question's legal foundation."
+              "note": "Levirate marriage law — the Sadducees' question's legal foundation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:35-36",
-              "note": "Resurrection life is neither a restoration of earthly conditions nor a mere immortality of the soul. It is a new mode of existence: no death, no marriage (marriage's function \u2014 procreation and family continuity \u2014 is unnecessary when death is eliminated), and the quality of angelic existence. The Sadducees' question was based on a category error about what resurrection is."
+              "note": "Resurrection life is neither a restoration of earthly conditions nor a mere immortality of the soul. It is a new mode of existence: no death, no marriage (marriage's function — procreation and family continuity — is unnecessary when death is eliminated), and the quality of angelic existence. The Sadducees' question was based on a category error about what resurrection is."
             },
             {
               "ref": "20:37-38",
-              "note": "The argument from Exod 3:6 is characteristically rabbinic in form: God uses the present tense of \"I am the God of Abraham\" after Abraham's death. This implies that Abraham is alive to God \u2014 that the covenant relationship persists beyond physical death. The argument is not about what \"I am\" means grammatically but about what it means theologically for God to be in covenant with the patriarchs."
+              "note": "The argument from Exod 3:6 is characteristically rabbinic in form: God uses the present tense of \"I am the God of Abraham\" after Abraham's death. This implies that Abraham is alive to God — that the covenant relationship persists beyond physical death. The argument is not about what \"I am\" means grammatically but about what it means theologically for God to be in covenant with the patriarchs."
             },
             {
               "ref": "20:41-44",
@@ -290,70 +290,70 @@
             },
             {
               "ref": "20:47",
-              "note": "\"They devour widows' houses\" \u2014 the scribes' wealth management of widows' estates, enriching themselves while ostensibly serving as trustees, is the practical expression of the spiritual corruption the woes in Luke 11 described. The widow who gives two coins (21:1-4) is the narrative contrast \u2014 she is one of those whose house has been devoured."
+              "note": "\"They devour widows' houses\" — the scribes' wealth management of widows' estates, enriching themselves while ostensibly serving as trustees, is the practical expression of the spiritual corruption the woes in Luke 11 described. The widow who gives two coins (21:1-4) is the narrative contrast — she is one of those whose house has been devoured."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:37-38",
-              "note": "Calvin uses the burning bush argument to establish a key principle: the covenant relationship between God and his people is eternal, not temporal. If God says \"I am the God of Abraham\" after Abraham's death, the covenant persists beyond death \u2014 and therefore the person must persist to be in covenant. The covenant's eternity guarantees the covenant partner's continuation."
+              "note": "Calvin uses the burning bush argument to establish a key principle: the covenant relationship between God and his people is eternal, not temporal. If God says \"I am the God of Abraham\" after Abraham's death, the covenant persists beyond death — and therefore the person must persist to be in covenant. The covenant's eternity guarantees the covenant partner's continuation."
             },
             {
               "ref": "20:46-47",
-              "note": "The warning about the scribes closes the Temple controversies where they began \u2014 with the religious establishment. The scribes' public religious performance (robes, greetings, seats, prayers) is the veneer over a predatory practice (devouring widows' estates). Jesus ends his public teaching in the Temple with a comprehensive indictment of the very people who had tried to discredit him."
+              "note": "The warning about the scribes closes the Temple controversies where they began — with the religious establishment. The scribes' public religious performance (robes, greetings, seats, prayers) is the veneer over a predatory practice (devouring widows' estates). Jesus ends his public teaching in the Temple with a comprehensive indictment of the very people who had tried to discredit him."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:27",
-              "note": "The Sadducees are identified specifically as those \"who say there is no resurrection\" \u2014 a Lukan editorial note that explains their question for readers unfamiliar with intra-Jewish theological debates. The Pharisees believed in resurrection; the Sadducees did not. The question is therefore not a sincere inquiry but a theological challenge from a hostile party."
+              "note": "The Sadducees are identified specifically as those \"who say there is no resurrection\" — a Lukan editorial note that explains their question for readers unfamiliar with intra-Jewish theological debates. The Pharisees believed in resurrection; the Sadducees did not. The question is therefore not a sincere inquiry but a theological challenge from a hostile party."
             },
             {
               "ref": "20:42-43",
-              "note": "Psalm 110 is attributed to David in the title. Jesus uses this attribution as his premise: if David wrote it, and David calls the Messiah \"my Lord,\" then the Messiah cannot merely be David's descendant \u2014 he must be David's superior. Early Christianity used Ps 110:1 to describe the resurrection and exaltation of Christ (Acts 2:34-35; Heb 1:13; 1 Cor 15:25)."
+              "note": "Psalm 110 is attributed to David in the title. Jesus uses this attribution as his premise: if David wrote it, and David calls the Messiah \"my Lord,\" then the Messiah cannot merely be David's descendant — he must be David's superior. Early Christianity used Ps 110:1 to describe the resurrection and exaltation of Christ (Acts 2:34-35; Heb 1:13; 1 Cor 15:25)."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "20:38",
-              "note": "Pantes gar auto z\u014dsin \u2014 \"for to him all are alive.\" The present tense: all (including the long-dead patriarchs) are alive to God now. Robertson notes this is a present-tense claim about the current condition of the dead \u2014 they are not in a state of non-existence but of life in God's presence."
+              "note": "Pantes gar auto zōsin — \"for to him all are alive.\" The present tense: all (including the long-dead patriarchs) are alive to God now. Robertson notes this is a present-tense claim about the current condition of the dead — they are not in a state of non-existence but of life in God's presence."
             },
             {
               "ref": "20:44",
-              "note": "Kai p\u014ds huios autou estin \u2014 \"and how is he his son?\" The question is not a denial of Davidic descent (Jesus was himself of David's line) but a challenge to the sufficiency of \"Son of David\" as a complete description. The more-than category needs to be supplied."
+              "note": "Kai pōs huios autou estin — \"and how is he his son?\" The question is not a denial of Davidic descent (Jesus was himself of David's line) but a challenge to the sufficiency of \"Son of David\" as a complete description. The more-than category needs to be supplied."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:38",
-              "note": "Origen: \"God is not the God of the dead but of the living. He who is the God of Abraham is the God of one who lives and is blessed in him. Therefore Abraham lives \u2014 and Isaac lives, and Jacob lives. The patriarchs are not dead to God; they live before him, even now.\""
+              "note": "Origen: \"God is not the God of the dead but of the living. He who is the God of Abraham is the God of one who lives and is blessed in him. Therefore Abraham lives — and Isaac lives, and Jacob lives. The patriarchs are not dead to God; they live before him, even now.\""
             },
             {
               "ref": "20:44",
-              "note": "Augustine: \"David calls him Lord; how can he be his son? Because he is Lord as God, and son as man. He is David's son according to the flesh; he is David's Lord according to his divinity. Both are true \u2014 and neither is enough without the other.\""
+              "note": "Augustine: \"David calls him Lord; how can he be his son? Because he is Lord as God, and son as man. He is David's son according to the flesh; he is David's Lord according to his divinity. Both are true — and neither is enough without the other.\""
             }
           ]
         },
         "hist": {
-          "context": "Sadducees and Resurrection\nThe Sadducees (priestly aristocracy, controlling the Temple establishment) accepted only the Pentateuch (Torah) as authoritative and found no clear teaching of resurrection there. Their scenario is a classic reductio ad absurdum: levirate marriage (Deut 25:5-6) + resurrection = impossible social complexity. Jesus answers on their own terms \u2014 from the Pentateuch, specifically Exod 3:6.\n\nPsalm 110 and Davidic Sonship\nPsalm 110:1 is the most-cited OT text in the NT. Jesus uses it to press a question that exposes the inadequacy of \"Son of David\" as a complete Christological description. David calls the Messiah \"my Lord\" \u2014 how can a son be his father's Lord? The answer Jesus implies: because the Messiah is more than David's son. He is David's Lord."
+          "context": "Sadducees and Resurrection\nThe Sadducees (priestly aristocracy, controlling the Temple establishment) accepted only the Pentateuch (Torah) as authoritative and found no clear teaching of resurrection there. Their scenario is a classic reductio ad absurdum: levirate marriage (Deut 25:5-6) + resurrection = impossible social complexity. Jesus answers on their own terms — from the Pentateuch, specifically Exod 3:6.\n\nPsalm 110 and Davidic Sonship\nPsalm 110:1 is the most-cited OT text in the NT. Jesus uses it to press a question that exposes the inadequacy of \"Son of David\" as a complete Christological description. David calls the Messiah \"my Lord\" — how can a son be his father's Lord? The answer Jesus implies: because the Messiah is more than David's son. He is David's Lord."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 41\u201147 \u2014 David\u2019s Son; Beware of the Teachers of the Law",
+      "header": "Verses 41‑47 — David’s Son; Beware of the Teachers of the Law",
       "verse_start": 41,
       "verse_end": 47,
       "panels": {
@@ -365,51 +365,51 @@
             "paragraph": "The word (vv.2, 8) denotes both power (capacity to act) and right (legitimate authorization). The authorities challenge Jesus on both: who gave him the right, and what power does he have? Jesus refuses the question not from evasion but because their question presupposes a framework (human authorization) that cannot contain the answer."
           },
           {
-            "word": "eik\u014dn",
+            "word": "eikōn",
             "transliteration": "EI-kon",
             "gloss": "image / likeness",
-            "paragraph": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eik\u014dn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eik\u014dn; humans bear God's eik\u014dn. The implication: render yourself \u2014 entirely \u2014 to God."
+            "paragraph": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eikōn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eikōn; humans bear God's eikōn. The implication: render yourself — entirely — to God."
           }
         ],
         "tl": [
           {
-            "date": "Sun \u2014 Palm Sunday",
+            "date": "Sun — Palm Sunday",
             "name": "Triumphal Entry",
             "text": "Jesus enters Jerusalem on a colt, acclaimed by the crowd. He weeps over the city and surveys the Temple.",
             "current": false
           },
           {
-            "date": "Mon \u2014 Monday",
+            "date": "Mon — Monday",
             "name": "Temple Cleansing",
             "text": "Jesus drives out the merchants; begins daily Temple teaching.",
             "current": false
           },
           {
-            "date": "Tue \u2014 Tuesday",
+            "date": "Tue — Tuesday",
             "name": "Temple Controversies",
             "text": "Authority challenged; wicked tenants; taxes to Caesar; resurrection question; scribes and the widow. Luke 20-21.",
             "current": true
           },
           {
-            "date": "Wed \u2014 Wednesday",
+            "date": "Wed — Wednesday",
             "name": "Anointing; Judas's Deal",
             "text": "Anointing at Bethany; Judas bargains with the chief priests.",
             "current": false
           },
           {
-            "date": "Thu \u2014 Thursday",
+            "date": "Thu — Thursday",
             "name": "Last Supper; Gethsemane",
             "text": "Passover meal; prayer in Gethsemane; betrayal and arrest.",
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion",
             "text": "Trials before Pilate and Herod; crucifixion at Golgotha; burial.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Resurrection",
             "text": "Empty tomb; road to Emmaus; appearances to the disciples.",
             "current": false
@@ -431,11 +431,11 @@
           "refs": [
             {
               "ref": "Isa 5:1-7",
-              "note": "The Song of the Vineyard \u2014 God's vineyard (Israel) that produced only wild grapes and faces destruction. The OT text that Jesus's parable is deliberately invoking."
+              "note": "The Song of the Vineyard — God's vineyard (Israel) that produced only wild grapes and faces destruction. The OT text that Jesus's parable is deliberately invoking."
             },
             {
               "ref": "Ps 118:22",
-              "note": "\"The stone the builders rejected has become the cornerstone\" \u2014 the psalm Jesus quotes after the parable, applying the rejected stone to himself."
+              "note": "\"The stone the builders rejected has become the cornerstone\" — the psalm Jesus quotes after the parable, applying the rejected stone to himself."
             },
             {
               "ref": "Matt 22:15-22; Mark 12:13-17",
@@ -444,80 +444,27 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:4",
-              "note": "The counter-question about John's baptism is not evasion but a principled challenge. If they could not answer a simpler question about a recently deceased prophet whose authority was publicly demonstrated, they have no standing to evaluate Jesus's authority. Their silence is a concession of their own disqualification."
-            },
-            {
-              "ref": "20:13-15",
-              "note": "\"This is the heir \u2014 let us kill him, and the inheritance will be ours.\" The tenants' logic is nakedly acquisitive: eliminate the rightful owner's representative and seize the property. This is the establishment's actual motivation, dramatised in the parable. They want to occupy the covenant's benefits without submission to the covenant's Lord."
-            },
-            {
-              "ref": "20:25",
-              "note": "\"Give back to Caesar what is Caesar's, and to God what is God's\" \u2014 the answer is perfectly balanced and perfectly devastating to both sides of the trap. If they say pay taxes, Jewish nationalists hate them. If they say don't, Rome arrests them. Jesus escapes both horns while delivering a principle of breathtaking scope: there are two spheres of obligation, and they are not identical, but both are real."
-            },
-            {
-              "ref": "20:18",
-              "note": "\"Everyone who falls on that stone will be broken to pieces; anyone on whom it falls will be crushed\" \u2014 the stone that saves (the cornerstone) is also the stone that destroys (the crushing stone). Encounter with Jesus is unavoidable; the only variable is the posture of the encounter. Fall on the stone in humility, or be fallen on in judgment."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:9-16",
-              "note": "Calvin notes that the parable's allegory is self-interpreting to anyone who knows Isaiah 5. Jesus is not being subtle: he is publicly accusing the establishment of planning the same murder that the wicked tenants committed. Their desire to arrest him immediately (v.19) confirms that they understood the accusation perfectly."
-            },
-            {
-              "ref": "20:25",
-              "note": "The taxes-to-Caesar answer does not establish a doctrine of complete separation of church and state. It establishes that both Caesar and God have legitimate claims, that these claims are distinguishable, and that neither cancels the other. The deeper point \u2014 that God's claim extends to everything that bears his image \u2014 means that in practice, God's claim is total."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:17",
-              "note": "The cornerstone (kephal\u0113n g\u014dnias) could refer to the capstone of an arch or the foundation cornerstone. Either way, the rejected stone has become the most critical structural element. Acts 4:11, 1 Pet 2:7, and Eph 2:20 all use this image for Christ \u2014 it became a foundational early church Christological text."
-            },
-            {
-              "ref": "20:25",
-              "note": "The denarius bore the image of Tiberius Caesar with the inscription \"Tiberius Caesar, son of the divine Augustus\" \u2014 a claim to divine sonship that many Jews found offensive. Jesus takes this coin, points to its image, and turns the question back: whose image do you bear? The theological stakes are much higher than the tax question."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "20:7",
-              "note": "Ouk oidamen \u2014 \"we do not know.\" The present tense with ou (rather than m\u0113) is the negative of actual fact: they genuinely do not know, or claim not to. The irony is thick: the religious authorities charged with discerning authentic prophecy confess inability to evaluate John."
-            },
-            {
-              "ref": "20:24",
-              "note": "Eikona \u2014 the accusative of eik\u014dn. Jesus asks them to look at the coin and name what they see. Their answer (\"Caesar's\") gives him his premise. The argument from image is entirely his own construction, not a trap-escape."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "20:17",
-              "note": "Augustine: \"The stone the builders rejected has become the cornerstone. They rejected him by crucifying him; God made him the cornerstone by raising him. The very act of rejection became the act of establishment. This is the logic of the resurrection: what men destroy, God builds.\""
-            },
-            {
-              "ref": "20:25",
-              "note": "Ambrose: \"Render to Caesar the things that are Caesar's \u2014 taxes, tribute, civil obedience. Render to God the things that are God's \u2014 faith, service, and above all yourself, for you are made in his image. The coin bears Caesar's face; the soul bears God's.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Temple as Battleground\nLuke 20 takes place entirely in the Temple courts (19:47-20:1), where Jesus has been teaching daily. The establishment's challenge is public and formal \u2014 a delegation of chief priests, scribes, and elders confronting a Galilean teacher who has disrupted Temple commerce. The authority question is the opening move in a series of escalating attempts to discredit or entrap Jesus before the crowd.\n\nThe Vineyard Parable's Allegory\nThe wicked tenants parable (20:9-18) is one of Luke's most transparently allegorical: the vineyard is Israel (cf. Isa 5:1-7); the owner is God; the servants are the prophets; the son is Jesus. The tenants' reasoning (\"the inheritance will be ours,\" v.14) gives the theological diagnosis of the establishment's hostility: they want to possess what belongs to the son."
+          "context": "Temple as Battleground\nLuke 20 takes place entirely in the Temple courts (19:47-20:1), where Jesus has been teaching daily. The establishment's challenge is public and formal — a delegation of chief priests, scribes, and elders confronting a Galilean teacher who has disrupted Temple commerce. The authority question is the opening move in a series of escalating attempts to discredit or entrap Jesus before the crowd.\n\nThe Vineyard Parable's Allegory\nThe wicked tenants parable (20:9-18) is one of Luke's most transparently allegorical: the vineyard is Israel (cf. Isa 5:1-7); the owner is God; the servants are the prophets; the son is Jesus. The tenants' reasoning (\"the inheritance will be ours,\" v.14) gives the theological diagnosis of the establishment's hostility: they want to possess what belongs to the son."
         }
       }
     }
@@ -537,15 +484,15 @@
       {
         "name": "Jesus",
         "role": "Teacher and Lord",
-        "text": "The chapter shows Jesus systematically defeating every attempt to discredit him \u2014 by evasion (authority), parable (wicked tenants), precision (taxes), scripture (resurrection), and counter-question (David's son). He is the questioner who cannot be trapped."
+        "text": "The chapter shows Jesus systematically defeating every attempt to discredit him — by evasion (authority), parable (wicked tenants), precision (taxes), scripture (resurrection), and counter-question (David's son). He is the questioner who cannot be trapped."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eikona (20:24)</td><td>All versions: \"image.\" The connection to Gen 1:26-27 (humans as image of God) is not always made explicit in translation but underlies Jesus's reply.</td></tr><tr><td class=\"t-label\">ta Kaisaros / ta tou theou (20:25)</td><td>NIV: \"Caesar's / God's\"; KJV: \"Caesar's / God's\"; ESV: \"Caesar's / God's\"; NRSV: \"emperor's / God's\". Universal agreement except NRSV's \"emperor\" for Caesar.</td></tr><tr><td class=\"t-label\">z\u014dsin (20:38)</td><td>NIV: \"he is not the God of the dead, but of the living, for to him all are alive\"; KJV: \"for all live unto him\". The present tense \"are alive\" / \"live\" is theologically significant \u2014 a present-tense claim about the current state of the dead.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">eikona (20:24)</td><td>All versions: \"image.\" The connection to Gen 1:26-27 (humans as image of God) is not always made explicit in translation but underlies Jesus's reply.</td></tr><tr><td class=\"t-label\">ta Kaisaros / ta tou theou (20:25)</td><td>NIV: \"Caesar's / God's\"; KJV: \"Caesar's / God's\"; ESV: \"Caesar's / God's\"; NRSV: \"emperor's / God's\". Universal agreement except NRSV's \"emperor\" for Caesar.</td></tr><tr><td class=\"t-label\">zōsin (20:38)</td><td>NIV: \"he is not the God of the dead, but of the living, for to him all are alive\"; KJV: \"for all live unto him\". The present tense \"are alive\" / \"live\" is theologically significant — a present-tense claim about the current state of the dead.</td></tr>",
     "src": [
       {
         "title": "Isaiah 5:1-7",
         "quote": "\"My loved one had a vineyard on a fertile hillside... he looked for a crop of good grapes, but it yielded only bad fruit.\"",
-        "note": "The Song of the Vineyard that provides the OT framework for the wicked tenants parable. Jesus's audience would have recognised the allusion immediately \u2014 the vineyard-as-Israel metaphor was well established."
+        "note": "The Song of the Vineyard that provides the OT framework for the wicked tenants parable. Jesus's audience would have recognised the allusion immediately — the vineyard-as-Israel metaphor was well established."
       },
       {
         "title": "Exodus 3:6",
@@ -566,12 +513,12 @@
     "lit": {
       "rows": [
         {
-          "label": "Debate Structure \u2014 vv.1-44",
-          "text": "Five exchanges in sequence: authority (vv.1-8) \u2192 parable (vv.9-19) \u2192 taxes (vv.20-26) \u2192 resurrection (vv.27-40) \u2192 David's son (vv.41-44). Each round is initiated by Jesus's opponents; each ends in silence, astonishment, or a counter-question from Jesus. The structure documents Jesus's total rhetorical mastery.",
+          "label": "Debate Structure — vv.1-44",
+          "text": "Five exchanges in sequence: authority (vv.1-8) → parable (vv.9-19) → taxes (vv.20-26) → resurrection (vv.27-40) → David's son (vv.41-44). Each round is initiated by Jesus's opponents; each ends in silence, astonishment, or a counter-question from Jesus. The structure documents Jesus's total rhetorical mastery.",
           "is_key": false
         },
         {
-          "label": "Inclusio \u2014 vv.1-2 / 45-47",
+          "label": "Inclusio — vv.1-2 / 45-47",
           "text": "The chapter opens with the establishment challenging Jesus's authority to teach (vv.1-2) and closes with Jesus warning about teachers of the law who use their authority for self-enrichment (vv.46-47). The contrast is total: contested authority versus abused authority.",
           "is_key": false
         }
@@ -586,22 +533,22 @@
         "note": "The word (vv.2, 8) denotes both power (capacity to act) and right (legitimate authorization). The authorities challenge Jesus on both: who gave him the right, and what power does he have? Jesus refuses the question not from evasion but because their question presupposes a framework (human authorization) that cannot contain the answer."
       },
       {
-        "word": "eik\u014dn",
+        "word": "eikōn",
         "tlit": "EI-kon",
         "gloss": "image / likeness",
-        "note": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eik\u014dn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eik\u014dn; humans bear God's eik\u014dn. The implication: render yourself \u2014 entirely \u2014 to God."
+        "note": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eikōn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eikōn; humans bear God's eikōn. The implication: render yourself — entirely — to God."
       },
       {
         "word": "anastasis",
         "tlit": "a-NAS-ta-sis",
         "gloss": "resurrection",
-        "note": "The Sadducees deny the anastasis (v.27) \u2014 a word that literally means \"standing up again.\" Their reductio ad absurdum (the seven-brothers scenario) assumes resurrection simply restores earthly conditions. Jesus denies the premise: resurrection life is qualitatively different from earthly life, not merely a continuation of it."
+        "note": "The Sadducees deny the anastasis (v.27) — a word that literally means \"standing up again.\" Their reductio ad absurdum (the seven-brothers scenario) assumes resurrection simply restores earthly conditions. Jesus denies the premise: resurrection life is qualitatively different from earthly life, not merely a continuation of it."
       },
       {
         "word": "huioi theou",
         "tlit": "HY-oi the-OU",
         "gloss": "sons/children of God",
-        "note": "The designation for the resurrected (v.36) \u2014 they are \"God's children\" (huioi theou) by virtue of being \"children of the resurrection.\" The resurrection is not merely a restoration of life but an adoption into a new mode of existence that shares the angels' immortality."
+        "note": "The designation for the resurrected (v.36) — they are \"God's children\" (huioi theou) by virtue of being \"children of the resurrection.\" The resurrection is not merely a restoration of life but an adoption into a new mode of existence that shares the angels' immortality."
       },
       {
         "word": "exousia",
@@ -610,24 +557,24 @@
         "note": "The word (vv.2, 8) denotes both power (capacity to act) and right (legitimate authorization). The authorities challenge Jesus on both: who gave him the right, and what power does he have? Jesus refuses the question not from evasion but because their question presupposes a framework (human authorization) that cannot contain the answer."
       },
       {
-        "word": "eik\u014dn",
+        "word": "eikōn",
         "tlit": "EI-kon",
         "gloss": "image / likeness",
-        "note": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eik\u014dn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eik\u014dn; humans bear God's eik\u014dn. The implication: render yourself \u2014 entirely \u2014 to God."
+        "note": "The word (v.24) is the same used in Gen 1:26-27: humans made in the image (eikōn) of God. When Jesus says \"give back to Caesar what is Caesar's, and to God what is God's,\" the coin bears Caesar's eikōn; humans bear God's eikōn. The implication: render yourself — entirely — to God."
       }
     ],
     "tx": [
       {
         "ref": "20:30-31",
         "title": "The second and third brothers",
-        "content": "The manuscript tradition shows some variation in how the second and third brothers' marriages are described \u2014 some MSS elaborate, some abbreviate. NA28 follows a compact form. No theological significance; the legal point requires only that all seven married her.",
+        "content": "The manuscript tradition shows some variation in how the second and third brothers' marriages are described — some MSS elaborate, some abbreviate. NA28 follows a compact form. No theological significance; the legal point requires only that all seven married her.",
         "note": "The scenario is legally constructed to be maximally problematic for resurrection belief; the specific narrative detail of each marriage matters less than the cumulative number seven."
       },
       {
         "ref": "20:36",
         "title": "\"like the angels\"",
-        "content": "Isanggeloi \u2014 a rare compound (\"equal to angels\") appearing only here in the NT. Some later MSS substitute the more common h\u014ds angeloi (\"as angels\"). NA28 reads the compound.",
-        "note": "The compound isanggeloi (equal to angels) is the harder and more original reading; the simpler h\u014ds angeloi is a scribal simplification."
+        "content": "Isanggeloi — a rare compound (\"equal to angels\") appearing only here in the NT. Some later MSS substitute the more common hōs angeloi (\"as angels\"). NA28 reads the compound.",
+        "note": "The compound isanggeloi (equal to angels) is the harder and more original reading; the simpler hōs angeloi is a scribal simplification."
       }
     ],
     "debate": [
@@ -642,7 +589,7 @@
           {
             "name": "Humans as God's image",
             "proponents": "Tertullian, Calvin, many patristics",
-            "argument": "Since humans bear God's image (Gen 1:26), the full answer to \"give to God what is God's\" is: give yourself \u2014 totally \u2014 to God. The eik\u014dn wordplay is intentional and subversive: Caesar gets his coins; God gets everything that bears his image, which is you."
+            "argument": "Since humans bear God's image (Gen 1:26), the full answer to \"give to God what is God's\" is: give yourself — totally — to God. The eikōn wordplay is intentional and subversive: Caesar gets his coins; God gets everything that bears his image, which is you."
           }
         ]
       }
@@ -674,7 +621,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 20 is the most sustained theological debate sequence in the Gospel. The establishment tries three approaches \u2014 direct challenge (authority), legal trap (taxes), and doctrinal puzzle (resurrection) \u2014 and fails at each. Jesus then takes the initiative with his own question (David's son) that exposes the inadequacy of every Christological category the questioners have been using. The chapter ends where it began: the religious establishment exposed as lacking the insight to recognise the authority they are challenging."
+      "note": "Luke 20 is the most sustained theological debate sequence in the Gospel. The establishment tries three approaches — direct challenge (authority), legal trap (taxes), and doctrinal puzzle (resurrection) — and fails at each. Jesus then takes the initiative with his own question (David's son) that exposes the inadequacy of every Christological category the questioners have been using. The chapter ends where it began: the religious establishment exposed as lacking the insight to recognise the authority they are challenging."
     }
   },
   "vhl_groups": [

--- a/content/luke/21.json
+++ b/content/luke/21.json
@@ -7,13 +7,13 @@
   "subtitle": "The Widow's Gift, Signs of the End, and the Son of Man",
   "timeline_link": {
     "event_id": "temple-destruction-detail",
-    "text": "See on Timeline \u2014 Destruction of Jerusalem"
+    "text": "See on Timeline — Destruction of Jerusalem"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20134 \u2014 The Widow\u2019s Offering: All She Had to Live On",
+      "header": "Verses 1–4 — The Widow’s Offering: All She Had to Live On",
       "verse_start": 1,
       "verse_end": 4,
       "panels": {
@@ -22,13 +22,13 @@
             "word": "lepta duo",
             "transliteration": "LEP-ta DY-o",
             "gloss": "two very small copper coins",
-            "paragraph": "The lepton (v.2) was the smallest coin in circulation \u2014 worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible \u2014 which was everything she had."
+            "paragraph": "The lepton (v.2) was the smallest coin in circulation — worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible — which was everything she had."
           },
           {
-            "word": "hypomon\u0113",
+            "word": "hypomonē",
             "transliteration": "hy-po-mo-NE",
             "gloss": "patient endurance / standing firm",
-            "paragraph": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure \u2014 the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
+            "paragraph": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure — the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
           }
         ],
         "places": [
@@ -47,20 +47,20 @@
           "refs": [
             {
               "ref": "Mark 12:41-44",
-              "note": "Mark's parallel widow's offering, essentially identical \u2014 one of the few passages where Luke and Mark are nearly verbatim."
+              "note": "Mark's parallel widow's offering, essentially identical — one of the few passages where Luke and Mark are nearly verbatim."
             },
             {
               "ref": "Matt 24:1-14",
-              "note": "Matthew's parallel Olivet Discourse beginning \u2014 nations, earthquakes, persecutions, endurance."
+              "note": "Matthew's parallel Olivet Discourse beginning — nations, earthquakes, persecutions, endurance."
             },
             {
               "ref": "Dan 7:13-14",
-              "note": "\"Son of Man coming in the clouds\" \u2014 the Danielic vision that provides the background for the Son of Man coming in Luke 21:27."
+              "note": "\"Son of Man coming in the clouds\" — the Danielic vision that provides the background for the Son of Man coming in Luke 21:27."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:3-4",
@@ -68,11 +68,11 @@
             },
             {
               "ref": "21:8",
-              "note": "\"Do not follow them\" \u2014 false Christs and false timetables are the first danger. The instruction is not about distant eschatological events but about the susceptibility of every generation to prophetic pretenders who claim to have decoded the schedule. Jesus's first command in the discourse is: do not be deceived."
+              "note": "\"Do not follow them\" — false Christs and false timetables are the first danger. The instruction is not about distant eschatological events but about the susceptibility of every generation to prophetic pretenders who claim to have decoded the schedule. Jesus's first command in the discourse is: do not be deceived."
             },
             {
               "ref": "21:14-15",
-              "note": "\"Make up your mind not to worry beforehand how you will defend yourselves\" \u2014 prostithesthe is a deliberate decision: pre-decide not to pre-plan. The assurance is extraordinary: \"I will give you words and wisdom that none of your adversaries will be able to resist.\" This is not advice to be unprepared; it is confidence in the promise that the Spirit will supply what is needed."
+              "note": "\"Make up your mind not to worry beforehand how you will defend yourselves\" — prostithesthe is a deliberate decision: pre-decide not to pre-plan. The assurance is extraordinary: \"I will give you words and wisdom that none of your adversaries will be able to resist.\" This is not advice to be unprepared; it is confidence in the promise that the Spirit will supply what is needed."
             },
             {
               "ref": "21:18-19",
@@ -81,7 +81,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:3-4",
@@ -94,41 +94,41 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:2",
-              "note": "Two lepta \u2014 about 1/64 of a denarius, which was one day's wage for a labourer. The lepton was so small that it could not be further subdivided. The widow could have kept one coin and given one; instead she gave both. The voluntariness of total giving, not merely its extent, is part of Jesus's commendation."
+              "note": "Two lepta — about 1/64 of a denarius, which was one day's wage for a labourer. The lepton was so small that it could not be further subdivided. The widow could have kept one coin and given one; instead she gave both. The voluntariness of total giving, not merely its extent, is part of Jesus's commendation."
             },
             {
               "ref": "21:12",
-              "note": "\"Before all this\" \u2014 Luke's Olivet Discourse is notable for its temporal markers: the persecution of disciples (vv.12-19) comes before the cosmic signs (vv.9-11), which themselves precede the destruction of Jerusalem (vv.20-24). The sequencing is more explicit in Luke than in Matthew or Mark, contributing to Luke's reputation for chronological precision."
+              "note": "\"Before all this\" — Luke's Olivet Discourse is notable for its temporal markers: the persecution of disciples (vv.12-19) comes before the cosmic signs (vv.9-11), which themselves precede the destruction of Jerusalem (vv.20-24). The sequencing is more explicit in Luke than in Matthew or Mark, contributing to Luke's reputation for chronological precision."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:2",
-              "note": "Penichran ch\u0113ran \u2014 \"a poor widow\" (both adjective and noun emphasising poverty). The only time penichros appears in the Gospels. Luke compounds the description to maximise the contrast with the wealthy donors."
+              "note": "Penichran chēran — \"a poor widow\" (both adjective and noun emphasising poverty). The only time penichros appears in the Gospels. Luke compounds the description to maximise the contrast with the wealthy donors."
             },
             {
               "ref": "21:19",
-              "note": "Kt\u0113sasthe \u2014 aorist middle imperative: \"you will gain/acquire\" life. The aorist implies a decisive acquisition, not a gradual accumulation. Patient endurance results in a definitive winning of life."
+              "note": "Ktēsasthe — aorist middle imperative: \"you will gain/acquire\" life. The aorist implies a decisive acquisition, not a gradual accumulation. Patient endurance results in a definitive winning of life."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "21:3-4",
-              "note": "Chrysostom: \"She gave all she had \u2014 not a tenth, not a tithe, but her entire substance. The wealthy gave from their abundance; this woman gave from her need. In the arithmetic of heaven, the surplus of the rich is worth less than the poverty of the poor woman who trusts God with everything.\""
+              "note": "Chrysostom: \"She gave all she had — not a tenth, not a tithe, but her entire substance. The wealthy gave from their abundance; this woman gave from her need. In the arithmetic of heaven, the surplus of the rich is worth less than the poverty of the poor woman who trusts God with everything.\""
             },
             {
               "ref": "21:15",
-              "note": "Augustine: \"I will give you a mouth and wisdom. Not your own words \u2014 my words in your mouth. The martyrs did not prepare speeches; they received them. The promise is not that the Spirit will help you remember what you studied, but that the Spirit will give you what you could not have studied.\""
+              "note": "Augustine: \"I will give you a mouth and wisdom. Not your own words — my words in your mouth. The martyrs did not prepare speeches; they received them. The promise is not that the Spirit will help you remember what you studied, but that the Spirit will give you what you could not have studied.\""
             }
           ]
         },
@@ -153,25 +153,25 @@
           }
         ],
         "hist": {
-          "context": "The Widow's Two Coins\nThe widow's offering (21:1-4) is the last act of ministry Jesus observes before the Olivet Discourse \u2014 and it is an act that condemns the Temple establishment even as it praises the widow. The scribes who \"devour widows' houses\" (20:47) are at work; this widow has been reduced to her last two coins. Her gift is an act of total trust and total surrender, which Jesus commends without intervening to restore her funds.\n\nThe Olivet Discourse: Jerusalem and the End\nLuke's Olivet Discourse (21:5-38) addresses two distinct events: the destruction of Jerusalem (21:20-24, with specific historical language) and the coming of the Son of Man (21:25-28, with cosmic language). Luke's version is more clearly differentiated than Matthew's or Mark's parallel \u2014 a feature that has shaped its distinctive reception in Christian eschatology."
+          "context": "The Widow's Two Coins\nThe widow's offering (21:1-4) is the last act of ministry Jesus observes before the Olivet Discourse — and it is an act that condemns the Temple establishment even as it praises the widow. The scribes who \"devour widows' houses\" (20:47) are at work; this widow has been reduced to her last two coins. Her gift is an act of total trust and total surrender, which Jesus commends without intervening to restore her funds.\n\nThe Olivet Discourse: Jerusalem and the End\nLuke's Olivet Discourse (21:5-38) addresses two distinct events: the destruction of Jerusalem (21:20-24, with specific historical language) and the coming of the Son of Man (21:25-28, with cosmic language). Luke's version is more clearly differentiated than Matthew's or Mark's parallel — a feature that has shaped its distinctive reception in Christian eschatology."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 5\u201119 \u2014 Signs of the End; Temple Destruction; Persecution Predicted",
+      "header": "Verses 5‑19 — Signs of the End; Temple Destruction; Persecution Predicted",
       "verse_start": 5,
       "verse_end": 19,
       "panels": {
         "heb": [
           {
-            "word": "kairoi ethn\u014dn",
+            "word": "kairoi ethnōn",
             "transliteration": "kai-ROI ETH-non",
             "gloss": "times of the Gentiles",
-            "paragraph": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem \u2014 a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
+            "paragraph": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem — a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
           },
           {
-            "word": "apolytr\u014dsis",
+            "word": "apolytrōsis",
             "transliteration": "a-po-ly-TRO-sis",
             "gloss": "redemption / liberation",
             "paragraph": "The word (v.28) appears only here in Luke's narrative sections (it occurs in the infancy hymns). When the cosmic signs appear, disciples are not to be terrified but to \"lift up your heads, because your redemption is drawing near.\" The end of the age is not primarily a moment of judgment for the faithful but a moment of liberation."
@@ -188,41 +188,41 @@
           "refs": [
             {
               "ref": "Dan 7:13",
-              "note": "\"In my vision at night I looked, and there before me was one like a son of man, coming with the clouds of heaven\" \u2014 the Danielic vision that 21:27 directly invokes."
+              "note": "\"In my vision at night I looked, and there before me was one like a son of man, coming with the clouds of heaven\" — the Danielic vision that 21:27 directly invokes."
             },
             {
               "ref": "Isa 13:10",
-              "note": "\"The stars of heaven and their constellations will not show their light... the moon will not give its light\" \u2014 the OT cosmic-dissolution language that Jesus uses for the end-time signs."
+              "note": "\"The stars of heaven and their constellations will not show their light... the moon will not give its light\" — the OT cosmic-dissolution language that Jesus uses for the end-time signs."
             },
             {
               "ref": "Matt 24:29-31",
-              "note": "Matthew's parallel cosmic signs and Son of Man coming \u2014 Luke's version is briefer but uses the same Danielic language."
+              "note": "Matthew's parallel cosmic signs and Son of Man coming — Luke's version is briefer but uses the same Danielic language."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:20",
-              "note": "Luke's version of the abomination-of-desolation saying (Matt 24:15 / Mark 13:14) is strikingly different: \"When you see Jerusalem being surrounded by armies, you will know that its desolation is near.\" Luke replaces the Danielic \"abomination of desolation\" with a concrete military description \u2014 armies surrounding Jerusalem. This is either a clarification for Gentile readers, a specifically different saying, or (on the preterist reading) an accurate prediction of the Roman siege."
+              "note": "Luke's version of the abomination-of-desolation saying (Matt 24:15 / Mark 13:14) is strikingly different: \"When you see Jerusalem being surrounded by armies, you will know that its desolation is near.\" Luke replaces the Danielic \"abomination of desolation\" with a concrete military description — armies surrounding Jerusalem. This is either a clarification for Gentile readers, a specifically different saying, or (on the preterist reading) an accurate prediction of the Roman siege."
             },
             {
               "ref": "21:24",
-              "note": "\"Jerusalem will be trampled on by the Gentiles until the times of the Gentiles are fulfilled\" \u2014 the phrase \"times of the Gentiles\" suggests a specific, divinely limited period. Paul's mystery of Israel's partial hardening \"until the full number of the Gentiles has come in\" (Rom 11:25) appears to refer to the same period."
+              "note": "\"Jerusalem will be trampled on by the Gentiles until the times of the Gentiles are fulfilled\" — the phrase \"times of the Gentiles\" suggests a specific, divinely limited period. Paul's mystery of Israel's partial hardening \"until the full number of the Gentiles has come in\" (Rom 11:25) appears to refer to the same period."
             },
             {
               "ref": "21:28",
-              "note": "\"Stand up and lift up your heads, because your redemption is drawing near\" \u2014 the cosmic signs that produce terror in \"the nations\" (v.25) are the signal for disciples to lift their heads in expectation. The same events are simultaneously a judgment on the resistant world and a liberation for the faithful. The same Son of Man who comes in judgment is the redeemer of those who have been watching and praying."
+              "note": "\"Stand up and lift up your heads, because your redemption is drawing near\" — the cosmic signs that produce terror in \"the nations\" (v.25) are the signal for disciples to lift their heads in expectation. The same events are simultaneously a judgment on the resistant world and a liberation for the faithful. The same Son of Man who comes in judgment is the redeemer of those who have been watching and praying."
             },
             {
               "ref": "21:33",
-              "note": "\"Heaven and earth will pass away, but my words will never pass away\" \u2014 this is one of the most absolute claims Jesus makes. The universe is more temporary than his words. The implication is not merely that he is a reliable prophet but that his words have the character of divine utterance \u2014 sharing the permanence of the one who spoke the creation into existence."
+              "note": "\"Heaven and earth will pass away, but my words will never pass away\" — this is one of the most absolute claims Jesus makes. The universe is more temporary than his words. The implication is not merely that he is a reliable prophet but that his words have the character of divine utterance — sharing the permanence of the one who spoke the creation into existence."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:20-24",
@@ -230,46 +230,46 @@
             },
             {
               "ref": "21:32",
-              "note": "Calvin takes \"this generation\" as referring to the Jewish people as an enduring ethnic and religious community \u2014 not the individual generation alive in AD 30. The \"all these things\" that will happen before this generation passes include the entire eschatological sequence, which requires Israel's persistence as a people throughout the age."
+              "note": "Calvin takes \"this generation\" as referring to the Jewish people as an enduring ethnic and religious community — not the individual generation alive in AD 30. The \"all these things\" that will happen before this generation passes include the entire eschatological sequence, which requires Israel's persistence as a people throughout the age."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:20",
-              "note": "Luke's substitution of \"armies surrounding Jerusalem\" for \"the abomination of desolation\" (Matt 24:15 / Mark 13:14) has been used to argue that Luke was written after AD 70 (vaticinium ex eventu \u2014 prophecy after the fact). Most evangelical scholars maintain a pre-70 date and see Luke's version as a clarification of the Danielic phrase for non-Jewish readers, not as post-event writing."
+              "note": "Luke's substitution of \"armies surrounding Jerusalem\" for \"the abomination of desolation\" (Matt 24:15 / Mark 13:14) has been used to argue that Luke was written after AD 70 (vaticinium ex eventu — prophecy after the fact). Most evangelical scholars maintain a pre-70 date and see Luke's version as a clarification of the Danielic phrase for non-Jewish readers, not as post-event writing."
             },
             {
               "ref": "21:24",
-              "note": "\"Times of the Gentiles\" \u2014 this phrase occurs only here in the NT. Its connection to Rom 11:25 (\"the full number of the Gentiles\") and to the broader Pauline theology of Israel's place in God's plan has made it a central text in both covenant theology and dispensationalism, each reading it differently within their respective frameworks."
+              "note": "\"Times of the Gentiles\" — this phrase occurs only here in the NT. Its connection to Rom 11:25 (\"the full number of the Gentiles\") and to the broader Pauline theology of Israel's place in God's plan has made it a central text in both covenant theology and dispensationalism, each reading it differently within their respective frameworks."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:24",
-              "note": "Kairoi ethn\u014dn \u2014 the \"times\" (kairoi, the appointed, significant times rather than ordinary chronos time) of the Gentiles. The phrase implies a divinely scheduled period with a beginning and an end. Robertson notes the connection to Paul's \"fullness of the Gentiles\" in Rom 11:25."
+              "note": "Kairoi ethnōn — the \"times\" (kairoi, the appointed, significant times rather than ordinary chronos time) of the Gentiles. The phrase implies a divinely scheduled period with a beginning and an end. Robertson notes the connection to Paul's \"fullness of the Gentiles\" in Rom 11:25."
             },
             {
               "ref": "21:32",
-              "note": "Genea aut\u0113 \u2014 \"this generation.\" The demonstrative aut\u0113 (this one, here) normally points to the immediately present group. The natural reading is the generation alive in Jesus's day. If the reference is entirely to AD 70, the saying was fulfilled on schedule; if it includes the Parousia, further interpretation is required."
+              "note": "Genea autē — \"this generation.\" The demonstrative autē (this one, here) normally points to the immediately present group. The natural reading is the generation alive in Jesus's day. If the reference is entirely to AD 70, the saying was fulfilled on schedule; if it includes the Parousia, further interpretation is required."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "21:28",
-              "note": "Chrysostom: \"When you see these things beginning to happen \u2014 lift up your heads. For when others are cast down in terror, the faithful are to look up in expectation. The very things that terrify the world are the signals of the believer's liberation.\""
+              "note": "Chrysostom: \"When you see these things beginning to happen — lift up your heads. For when others are cast down in terror, the faithful are to look up in expectation. The very things that terrify the world are the signals of the believer's liberation.\""
             },
             {
               "ref": "21:33",
-              "note": "Augustine: \"Heaven and earth will pass away, but my words will not pass away. O the stability of that word! The things that seem most permanent \u2014 the heavens, the earth \u2014 are less permanent than the words of Christ. For they are the words of the one who made heaven and earth.\""
+              "note": "Augustine: \"Heaven and earth will pass away, but my words will not pass away. O the stability of that word! The things that seem most permanent — the heavens, the earth — are less permanent than the words of Christ. For they are the words of the one who made heaven and earth.\""
             }
           ]
         },
@@ -300,7 +300,7 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 20\u201133 \u2014 Jerusalem Surrounded; The Son of Man Coming in a Cloud",
+      "header": "Verses 20‑33 — Jerusalem Surrounded; The Son of Man Coming in a Cloud",
       "verse_start": 20,
       "verse_end": 33,
       "panels": {
@@ -309,13 +309,13 @@
             "word": "lepta duo",
             "transliteration": "LEP-ta DY-o",
             "gloss": "two very small copper coins",
-            "paragraph": "The lepton (v.2) was the smallest coin in circulation \u2014 worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible \u2014 which was everything she had."
+            "paragraph": "The lepton (v.2) was the smallest coin in circulation — worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible — which was everything she had."
           },
           {
-            "word": "hypomon\u0113",
+            "word": "hypomonē",
             "transliteration": "hy-po-mo-NE",
             "gloss": "patient endurance / standing firm",
-            "paragraph": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure \u2014 the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
+            "paragraph": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure — the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
           }
         ],
         "places": [
@@ -334,90 +334,37 @@
           "refs": [
             {
               "ref": "Mark 12:41-44",
-              "note": "Mark's parallel widow's offering, essentially identical \u2014 one of the few passages where Luke and Mark are nearly verbatim."
+              "note": "Mark's parallel widow's offering, essentially identical — one of the few passages where Luke and Mark are nearly verbatim."
             },
             {
               "ref": "Matt 24:1-14",
-              "note": "Matthew's parallel Olivet Discourse beginning \u2014 nations, earthquakes, persecutions, endurance."
+              "note": "Matthew's parallel Olivet Discourse beginning — nations, earthquakes, persecutions, endurance."
             },
             {
               "ref": "Dan 7:13-14",
-              "note": "\"Son of Man coming in the clouds\" \u2014 the Danielic vision that provides the background for the Son of Man coming in Luke 21:27."
+              "note": "\"Son of Man coming in the clouds\" — the Danielic vision that provides the background for the Son of Man coming in Luke 21:27."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:3-4",
-              "note": "Jesus evaluates giving by what remains, not what is given. The rich gave from their surplus; the widow gave her whole living (bios). The percentage is 100%. The contrast is not between large and small amounts but between giving that costs nothing and giving that costs everything. The widow's giving is costly discipleship in miniature."
-            },
-            {
-              "ref": "21:8",
-              "note": "\"Do not follow them\" \u2014 false Christs and false timetables are the first danger. The instruction is not about distant eschatological events but about the susceptibility of every generation to prophetic pretenders who claim to have decoded the schedule. Jesus's first command in the discourse is: do not be deceived."
-            },
-            {
-              "ref": "21:14-15",
-              "note": "\"Make up your mind not to worry beforehand how you will defend yourselves\" \u2014 prostithesthe is a deliberate decision: pre-decide not to pre-plan. The assurance is extraordinary: \"I will give you words and wisdom that none of your adversaries will be able to resist.\" This is not advice to be unprepared; it is confidence in the promise that the Spirit will supply what is needed."
-            },
-            {
-              "ref": "21:18-19",
-              "note": "\"Not a hair of your head will perish\" (v.18) appears to contradict \"they will put some of you to death\" (v.16). The contradiction is deliberately paradoxical: physical death does not constitute \"perishing\" in the ultimate sense. The life gained by standing firm (v.19) is the life that cannot be taken by those who kill the body (12:4)."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:3-4",
-              "note": "Calvin uses the widow's two coins to critique both external and internal forms of religious assessment. External: we measure by size of gift; God measures by ratio of sacrifice. Internal: we measure by emotional generosity; God measures by actual cost. The widow's gift is the model because it is both total (100%) and genuine (not from surplus)."
-            },
-            {
-              "ref": "21:8",
-              "note": "Calvin insists that the warning against false prophets claiming to know the schedule is addressed to every generation, not merely the first. The instruction \"do not follow them\" is an implicit instruction not to try to calculate what Jesus says is not calculable. Every generation produces its own false timetables; Jesus's response to all of them is the same: do not follow."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:2",
-              "note": "Two lepta \u2014 about 1/64 of a denarius, which was one day's wage for a labourer. The lepton was so small that it could not be further subdivided. The widow could have kept one coin and given one; instead she gave both. The voluntariness of total giving, not merely its extent, is part of Jesus's commendation."
-            },
-            {
-              "ref": "21:12",
-              "note": "\"Before all this\" \u2014 Luke's Olivet Discourse is notable for its temporal markers: the persecution of disciples (vv.12-19) comes before the cosmic signs (vv.9-11), which themselves precede the destruction of Jerusalem (vv.20-24). The sequencing is more explicit in Luke than in Matthew or Mark, contributing to Luke's reputation for chronological precision."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "21:2",
-              "note": "Penichran ch\u0113ran \u2014 \"a poor widow\" (both adjective and noun emphasising poverty). The only time penichros appears in the Gospels. Luke compounds the description to maximise the contrast with the wealthy donors."
-            },
-            {
-              "ref": "21:19",
-              "note": "Kt\u0113sasthe \u2014 aorist middle imperative: \"you will gain/acquire\" life. The aorist implies a decisive acquisition, not a gradual accumulation. Patient endurance results in a definitive winning of life."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "21:3-4",
-              "note": "Chrysostom: \"She gave all she had \u2014 not a tenth, not a tithe, but her entire substance. The wealthy gave from their abundance; this woman gave from her need. In the arithmetic of heaven, the surplus of the rich is worth less than the poverty of the poor woman who trusts God with everything.\""
-            },
-            {
-              "ref": "21:15",
-              "note": "Augustine: \"I will give you a mouth and wisdom. Not your own words \u2014 my words in your mouth. The martyrs did not prepare speeches; they received them. The promise is not that the Spirit will help you remember what you studied, but that the Spirit will give you what you could not have studied.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
@@ -440,25 +387,25 @@
           }
         ],
         "hist": {
-          "context": "The Widow's Two Coins\nThe widow's offering (21:1-4) is the last act of ministry Jesus observes before the Olivet Discourse \u2014 and it is an act that condemns the Temple establishment even as it praises the widow. The scribes who \"devour widows' houses\" (20:47) are at work; this widow has been reduced to her last two coins. Her gift is an act of total trust and total surrender, which Jesus commends without intervening to restore her funds.\n\nThe Olivet Discourse: Jerusalem and the End\nLuke's Olivet Discourse (21:5-38) addresses two distinct events: the destruction of Jerusalem (21:20-24, with specific historical language) and the coming of the Son of Man (21:25-28, with cosmic language). Luke's version is more clearly differentiated than Matthew's or Mark's parallel \u2014 a feature that has shaped its distinctive reception in Christian eschatology."
+          "context": "The Widow's Two Coins\nThe widow's offering (21:1-4) is the last act of ministry Jesus observes before the Olivet Discourse — and it is an act that condemns the Temple establishment even as it praises the widow. The scribes who \"devour widows' houses\" (20:47) are at work; this widow has been reduced to her last two coins. Her gift is an act of total trust and total surrender, which Jesus commends without intervening to restore her funds.\n\nThe Olivet Discourse: Jerusalem and the End\nLuke's Olivet Discourse (21:5-38) addresses two distinct events: the destruction of Jerusalem (21:20-24, with specific historical language) and the coming of the Son of Man (21:25-28, with cosmic language). Luke's version is more clearly differentiated than Matthew's or Mark's parallel — a feature that has shaped its distinctive reception in Christian eschatology."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 34\u201138 \u2014 Be Always on the Watch",
+      "header": "Verses 34‑38 — Be Always on the Watch",
       "verse_start": 34,
       "verse_end": 38,
       "panels": {
         "heb": [
           {
-            "word": "kairoi ethn\u014dn",
+            "word": "kairoi ethnōn",
             "transliteration": "kai-ROI ETH-non",
             "gloss": "times of the Gentiles",
-            "paragraph": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem \u2014 a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
+            "paragraph": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem — a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
           },
           {
-            "word": "apolytr\u014dsis",
+            "word": "apolytrōsis",
             "transliteration": "a-po-ly-TRO-sis",
             "gloss": "redemption / liberation",
             "paragraph": "The word (v.28) appears only here in Luke's narrative sections (it occurs in the infancy hymns). When the cosmic signs appear, disciples are not to be terrified but to \"lift up your heads, because your redemption is drawing near.\" The end of the age is not primarily a moment of judgment for the faithful but a moment of liberation."
@@ -475,90 +422,37 @@
           "refs": [
             {
               "ref": "Dan 7:13",
-              "note": "\"In my vision at night I looked, and there before me was one like a son of man, coming with the clouds of heaven\" \u2014 the Danielic vision that 21:27 directly invokes."
+              "note": "\"In my vision at night I looked, and there before me was one like a son of man, coming with the clouds of heaven\" — the Danielic vision that 21:27 directly invokes."
             },
             {
               "ref": "Isa 13:10",
-              "note": "\"The stars of heaven and their constellations will not show their light... the moon will not give its light\" \u2014 the OT cosmic-dissolution language that Jesus uses for the end-time signs."
+              "note": "\"The stars of heaven and their constellations will not show their light... the moon will not give its light\" — the OT cosmic-dissolution language that Jesus uses for the end-time signs."
             },
             {
               "ref": "Matt 24:29-31",
-              "note": "Matthew's parallel cosmic signs and Son of Man coming \u2014 Luke's version is briefer but uses the same Danielic language."
+              "note": "Matthew's parallel cosmic signs and Son of Man coming — Luke's version is briefer but uses the same Danielic language."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:20",
-              "note": "Luke's version of the abomination-of-desolation saying (Matt 24:15 / Mark 13:14) is strikingly different: \"When you see Jerusalem being surrounded by armies, you will know that its desolation is near.\" Luke replaces the Danielic \"abomination of desolation\" with a concrete military description \u2014 armies surrounding Jerusalem. This is either a clarification for Gentile readers, a specifically different saying, or (on the preterist reading) an accurate prediction of the Roman siege."
-            },
-            {
-              "ref": "21:24",
-              "note": "\"Jerusalem will be trampled on by the Gentiles until the times of the Gentiles are fulfilled\" \u2014 the phrase \"times of the Gentiles\" suggests a specific, divinely limited period. Paul's mystery of Israel's partial hardening \"until the full number of the Gentiles has come in\" (Rom 11:25) appears to refer to the same period."
-            },
-            {
-              "ref": "21:28",
-              "note": "\"Stand up and lift up your heads, because your redemption is drawing near\" \u2014 the cosmic signs that produce terror in \"the nations\" (v.25) are the signal for disciples to lift their heads in expectation. The same events are simultaneously a judgment on the resistant world and a liberation for the faithful. The same Son of Man who comes in judgment is the redeemer of those who have been watching and praying."
-            },
-            {
-              "ref": "21:33",
-              "note": "\"Heaven and earth will pass away, but my words will never pass away\" \u2014 this is one of the most absolute claims Jesus makes. The universe is more temporary than his words. The implication is not merely that he is a reliable prophet but that his words have the character of divine utterance \u2014 sharing the permanence of the one who spoke the creation into existence."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:20-24",
-              "note": "Calvin treats vv.20-24 as a specific prediction of the Jerusalem destruction of AD 70, fulfilled with remarkable accuracy by the Roman siege under Vespasian and Titus. The \"desolation\" described in v.22 is the literal physical desolation of the city and Temple. Calvin uses this as evidence of Jesus's prophetic authority: the accuracy of the near prediction validates the far ones."
-            },
-            {
-              "ref": "21:32",
-              "note": "Calvin takes \"this generation\" as referring to the Jewish people as an enduring ethnic and religious community \u2014 not the individual generation alive in AD 30. The \"all these things\" that will happen before this generation passes include the entire eschatological sequence, which requires Israel's persistence as a people throughout the age."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:20",
-              "note": "Luke's substitution of \"armies surrounding Jerusalem\" for \"the abomination of desolation\" (Matt 24:15 / Mark 13:14) has been used to argue that Luke was written after AD 70 (vaticinium ex eventu \u2014 prophecy after the fact). Most evangelical scholars maintain a pre-70 date and see Luke's version as a clarification of the Danielic phrase for non-Jewish readers, not as post-event writing."
-            },
-            {
-              "ref": "21:24",
-              "note": "\"Times of the Gentiles\" \u2014 this phrase occurs only here in the NT. Its connection to Rom 11:25 (\"the full number of the Gentiles\") and to the broader Pauline theology of Israel's place in God's plan has made it a central text in both covenant theology and dispensationalism, each reading it differently within their respective frameworks."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "21:24",
-              "note": "Kairoi ethn\u014dn \u2014 the \"times\" (kairoi, the appointed, significant times rather than ordinary chronos time) of the Gentiles. The phrase implies a divinely scheduled period with a beginning and an end. Robertson notes the connection to Paul's \"fullness of the Gentiles\" in Rom 11:25."
-            },
-            {
-              "ref": "21:32",
-              "note": "Genea aut\u0113 \u2014 \"this generation.\" The demonstrative aut\u0113 (this one, here) normally points to the immediately present group. The natural reading is the generation alive in Jesus's day. If the reference is entirely to AD 70, the saying was fulfilled on schedule; if it includes the Parousia, further interpretation is required."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "21:28",
-              "note": "Chrysostom: \"When you see these things beginning to happen \u2014 lift up your heads. For when others are cast down in terror, the faithful are to look up in expectation. The very things that terrify the world are the signals of the believer's liberation.\""
-            },
-            {
-              "ref": "21:33",
-              "note": "Augustine: \"Heaven and earth will pass away, but my words will not pass away. O the stability of that word! The things that seem most permanent \u2014 the heavens, the earth \u2014 are less permanent than the words of Christ. For they are the words of the one who made heaven and earth.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
@@ -599,7 +493,7 @@
         "text": "The Olivet Discourse is addressed to the disciples who will face arrest, trials, persecution, and death. The promise of Spirit-given words (21:15) and indestructible life (21:18-19) are addressed directly to them and to every generation of disciples facing the same pressures."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">bios (21:4)</td><td>NIV: \"all she had to live on\"; KJV: \"all the living that she had\"; ESV: \"all the living she had\"; NRSV: \"all she had to live on\". Bios means both \"life\" and \"livelihood/means of living.\" The widow gave not just her savings but her means of survival.</td></tr><tr><td class=\"t-label\">hypomon\u0113 (21:19)</td><td>NIV: \"stand firm\"; KJV: \"in your patience\"; ESV: \"by your endurance\"; NRSV: \"by your endurance\". All major versions capture the active quality of patient persistence.</td></tr><tr><td class=\"t-label\">kairoi ethn\u014dn (21:24)</td><td>NIV: \"times of the Gentiles\"; KJV: \"times of the Gentiles\"; ESV: \"times of the Gentiles\"; NRSV: \"times of the Gentiles\". Universal agreement; the phrase is a hapax legomenon in the NT.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">bios (21:4)</td><td>NIV: \"all she had to live on\"; KJV: \"all the living that she had\"; ESV: \"all the living she had\"; NRSV: \"all she had to live on\". Bios means both \"life\" and \"livelihood/means of living.\" The widow gave not just her savings but her means of survival.</td></tr><tr><td class=\"t-label\">hypomonē (21:19)</td><td>NIV: \"stand firm\"; KJV: \"in your patience\"; ESV: \"by your endurance\"; NRSV: \"by your endurance\". All major versions capture the active quality of patient persistence.</td></tr><tr><td class=\"t-label\">kairoi ethnōn (21:24)</td><td>NIV: \"times of the Gentiles\"; KJV: \"times of the Gentiles\"; ESV: \"times of the Gentiles\"; NRSV: \"times of the Gentiles\". Universal agreement; the phrase is a hapax legomenon in the NT.</td></tr>",
     "src": [
       {
         "title": "Daniel 7:13-14",
@@ -615,7 +509,7 @@
     "rec": [
       {
         "who": "The Widow's Offering and Christian Stewardship",
-        "text": "The widow's two coins has shaped Christian theology of stewardship more than almost any other passage. The principle that God measures giving by sacrifice rather than amount \u2014 by what remains rather than what is given \u2014 has been standard in Christian teaching on giving from the earliest centuries. Ambrose, Chrysostom, and countless later preachers have used it to argue against using the logic of comfortable giving."
+        "text": "The widow's two coins has shaped Christian theology of stewardship more than almost any other passage. The principle that God measures giving by sacrifice rather than amount — by what remains rather than what is given — has been standard in Christian teaching on giving from the earliest centuries. Ambrose, Chrysostom, and countless later preachers have used it to argue against using the logic of comfortable giving."
       },
       {
         "who": "\"This Generation\" in Eschatological Debate",
@@ -625,13 +519,13 @@
     "lit": {
       "rows": [
         {
-          "label": "Contrast \u2014 vv.1-4 / 5-6",
+          "label": "Contrast — vv.1-4 / 5-6",
           "text": "The widow who gives everything contrasts with the Temple that will lose everything. The stones that impress the disciples will be thrown down; the two coins that nobody noticed will be remembered. Luke places these two episodes in direct sequence to create a deliberate contrast: genuine devotion versus impressive religion.",
           "is_key": false
         },
         {
-          "label": "Frame \u2014 vv.37-38",
-          "text": "The closing note \u2014 Jesus teaching daily in the Temple, sleeping on the Mount of Olives, crowds arriving early \u2014 provides a serene pastoral frame for the chapter's apocalyptic content. The Olivet Discourse is delivered and then life continues; the urgency of the teaching is set within an ordinary teaching rhythm.",
+          "label": "Frame — vv.37-38",
+          "text": "The closing note — Jesus teaching daily in the Temple, sleeping on the Mount of Olives, crowds arriving early — provides a serene pastoral frame for the chapter's apocalyptic content. The Olivet Discourse is delivered and then life continues; the urgency of the teaching is set within an ordinary teaching rhythm.",
           "is_key": false
         }
       ],
@@ -642,22 +536,22 @@
         "word": "lepta duo",
         "tlit": "LEP-ta DY-o",
         "gloss": "two very small copper coins",
-        "note": "The lepton (v.2) was the smallest coin in circulation \u2014 worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible \u2014 which was everything she had."
+        "note": "The lepton (v.2) was the smallest coin in circulation — worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible — which was everything she had."
       },
       {
-        "word": "hypomon\u0113",
+        "word": "hypomonē",
         "tlit": "hy-po-mo-NE",
         "gloss": "patient endurance / standing firm",
-        "note": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure \u2014 the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
+        "note": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure — the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
       },
       {
-        "word": "kairoi ethn\u014dn",
+        "word": "kairoi ethnōn",
         "tlit": "kai-ROI ETH-non",
         "gloss": "times of the Gentiles",
-        "note": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem \u2014 a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
+        "note": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem — a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
       },
       {
-        "word": "apolytr\u014dsis",
+        "word": "apolytrōsis",
         "tlit": "a-po-ly-TRO-sis",
         "gloss": "redemption / liberation",
         "note": "The word (v.28) appears only here in Luke's narrative sections (it occurs in the infancy hymns). When the cosmic signs appear, disciples are not to be terrified but to \"lift up your heads, because your redemption is drawing near.\" The end of the age is not primarily a moment of judgment for the faithful but a moment of liberation."
@@ -666,22 +560,22 @@
         "word": "lepta duo",
         "tlit": "LEP-ta DY-o",
         "gloss": "two very small copper coins",
-        "note": "The lepton (v.2) was the smallest coin in circulation \u2014 worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible \u2014 which was everything she had."
+        "note": "The lepton (v.2) was the smallest coin in circulation — worth 1/128 of a denarius (roughly 6 minutes of a labourer's wages). Two leptons were the minimum legally acceptable Temple offering. The widow gave the minimum possible — which was everything she had."
       },
       {
-        "word": "hypomon\u0113",
+        "word": "hypomonē",
         "tlit": "hy-po-mo-NE",
         "gloss": "patient endurance / standing firm",
-        "note": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure \u2014 the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
+        "note": "The command (v.19) is not simply \"be patient\" but to stand firm under sustained pressure — the endurance of one who holds a position against assault. The same word appears in the Revelation letters (Rev 2-3) as the characteristic virtue of persecuted churches."
       },
       {
-        "word": "kairoi ethn\u014dn",
+        "word": "kairoi ethnōn",
         "tlit": "kai-ROI ETH-non",
         "gloss": "times of the Gentiles",
-        "note": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem \u2014 a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
+        "note": "The phrase (v.24) is unique to Luke's Olivet Discourse and has generated extensive debate. It refers to a period during which Gentile nations exercise dominion over Jerusalem — a period that began in 587 BC, resumed in AD 70, and (in some interpretations) will last until a specific future moment."
       },
       {
-        "word": "apolytr\u014dsis",
+        "word": "apolytrōsis",
         "tlit": "a-po-ly-TRO-sis",
         "gloss": "redemption / liberation",
         "note": "The word (v.28) appears only here in Luke's narrative sections (it occurs in the infancy hymns). When the cosmic signs appear, disciples are not to be terrified but to \"lift up your heads, because your redemption is drawing near.\" The end of the age is not primarily a moment of judgment for the faithful but a moment of liberation."
@@ -691,8 +585,8 @@
       {
         "ref": "21:19",
         "title": "\"Win life\" vs \"gain your souls\"",
-        "content": "NA28 reads kt\u0113sasthe tas psychas hym\u014dn (\"you will gain your lives/souls\"). KJV: \"In your patience possess ye your souls\"; NIV: \"stand firm, and you will win life for yourselves.\" The Greek psychas can mean \"souls,\" \"lives,\" or \"selves.\"",
-        "note": "The word psych\u0113 (life/soul) connects to the paradox of 17:33: whoever tries to save their psych\u0113 will lose it; whoever loses it will preserve it. Endurance \"gains\" life in the ultimate sense while risking it in the temporal sense."
+        "content": "NA28 reads ktēsasthe tas psychas hymōn (\"you will gain your lives/souls\"). KJV: \"In your patience possess ye your souls\"; NIV: \"stand firm, and you will win life for yourselves.\" The Greek psychas can mean \"souls,\" \"lives,\" or \"selves.\"",
+        "note": "The word psychē (life/soul) connects to the paradox of 17:33: whoever tries to save their psychē will lose it; whoever loses it will preserve it. Endurance \"gains\" life in the ultimate sense while risking it in the temporal sense."
       },
       {
         "ref": "21:36",
@@ -718,7 +612,7 @@
           {
             "name": "\"Generation\" = the Jewish people",
             "proponents": "Calvin, some Reformed interpreters",
-            "argument": "\"This generation\" (genea) means the Jewish people as an enduring race \u2014 they will persist until the final eschatological fulfilment."
+            "argument": "\"This generation\" (genea) means the Jewish people as an enduring race — they will persist until the final eschatological fulfilment."
           }
         ]
       }
@@ -871,7 +765,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "The widow's two small coins: 'She out of her poverty put in all she had to live on' (v. 4). Proportional giving\u2014the rich gave from surplus; she gave subsistence. Jesus measures differently.",
+      "tip": "The widow's two small coins: 'She out of her poverty put in all she had to live on' (v. 4). Proportional giving—the rich gave from surplus; she gave subsistence. Jesus measures differently.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/luke/22.json
+++ b/content/luke/22.json
@@ -7,33 +7,33 @@
   "subtitle": "The Last Supper, Gethsemane, Arrest, and Trial",
   "timeline_link": {
     "event_id": "last-supper",
-    "text": "See on Timeline \u2014 The Last Supper"
+    "text": "See on Timeline — The Last Supper"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201123 \u2014 The Plot; Judas; The Last Supper",
+      "header": "Verses 1‑23 — The Plot; Judas; The Last Supper",
       "verse_start": 1,
       "verse_end": 23,
       "panels": {
         "heb": [
           {
-            "word": "diath\u0113k\u0113",
-            "transliteration": "dia-THE-k\u0113",
+            "word": "diathēkē",
+            "transliteration": "dia-THE-kē",
             "gloss": "covenant",
-            "paragraph": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" \u2014 the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
+            "paragraph": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" — the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
           },
           {
-            "word": "to hyper hym\u014dn ekchynnomenon",
+            "word": "to hyper hymōn ekchynnomenon",
             "transliteration": "to hy-per hy-MON ek-chyn-NO-me-non",
             "gloss": "which is poured out for you",
-            "paragraph": "The present passive participle (v.20) is significant: \"being poured out\" \u2014 the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
+            "paragraph": "The present passive participle (v.20) is significant: \"being poured out\" — the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
           }
         ],
         "tl": [
           {
-            "date": "Thu \u2014 Passover",
+            "date": "Thu — Passover",
             "name": "Last Supper",
             "text": "Jesus eats the Passover with the Twelve in an upper room. He institutes the Lord's Supper, predicts his betrayal, disputes about greatness, predicts Peter's denial, and prepares the disciples for what is coming.",
             "current": true
@@ -45,7 +45,7 @@
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion",
             "text": "Peter's denial; trial before the Sanhedrin; Pilate; Herod; Pilate again; crucifixion and death.",
             "current": false
@@ -55,15 +55,15 @@
           "refs": [
             {
               "ref": "Jer 31:31-34",
-              "note": "\"The days are coming... when I will make a new covenant with the people of Israel and with the people of Judah\" \u2014 the foundational OT promise that Jesus's words of institution fulfil: \"This cup is the new covenant in my blood.\""
+              "note": "\"The days are coming... when I will make a new covenant with the people of Israel and with the people of Judah\" — the foundational OT promise that Jesus's words of institution fulfil: \"This cup is the new covenant in my blood.\""
             },
             {
               "ref": "Exod 24:8",
-              "note": "\"Moses then took the blood, sprinkled it on the people and said, 'This is the blood of the covenant'\" \u2014 the Sinai covenant inauguration that the Last Supper supersedes and fulfils."
+              "note": "\"Moses then took the blood, sprinkled it on the people and said, 'This is the blood of the covenant'\" — the Sinai covenant inauguration that the Last Supper supersedes and fulfils."
             },
             {
               "ref": "Isa 53:12",
-              "note": "\"He was numbered with the transgressors\" \u2014 the Isaiah servant text Jesus quotes as he prepares to be arrested (22:37)."
+              "note": "\"He was numbered with the transgressors\" — the Isaiah servant text Jesus quotes as he prepares to be arrested (22:37)."
             }
           ],
           "echoes": [
@@ -71,13 +71,13 @@
               "source_ref": "Isaiah 53:12",
               "target_ref": "Luke 22:37",
               "type": "direct_quote",
-              "source_context": "The Servant is numbered with transgressors \u2014 he dies among criminals, treated as one of them, though he is innocent.",
+              "source_context": "The Servant is numbered with transgressors — he dies among criminals, treated as one of them, though he is innocent.",
               "connection": "At the Last Supper, Jesus quotes this verse and says it must be fulfilled in him. He anticipates his crucifixion between two criminals as Servant Song fulfillment.",
               "significance": "Jesus explicitly identifies himself as Isaiah's Servant on the night of his arrest. The fulfillment formula shows he understood his death as scripted in Israel's prophetic tradition."
             },
             {
-              "source_ref": "Exodus 12:1\u201328",
-              "target_ref": "Luke 22:15\u201320",
+              "source_ref": "Exodus 12:1–28",
+              "target_ref": "Luke 22:15–20",
               "type": "typological",
               "source_context": "The Passover lamb's blood on the doorposts protected Israel from the destroyer. The meal was to be eaten in haste, with unleavened bread, commemorating the night of deliverance from Egypt.",
               "connection": "Jesus reinterprets the Passover meal: the bread becomes his body given for them; the cup becomes the new covenant in his blood. The exodus meal points forward to a greater deliverance.",
@@ -86,28 +86,28 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:15",
-              "note": "\"I have eagerly desired to eat this Passover with you before I suffer\" \u2014 the language of intense longing. Jesus desires the Last Supper not as a duty but as the moment toward which his entire ministry has been moving. This is the meal that will interpret his death; he has longed to eat it."
+              "note": "\"I have eagerly desired to eat this Passover with you before I suffer\" — the language of intense longing. Jesus desires the Last Supper not as a duty but as the moment toward which his entire ministry has been moving. This is the meal that will interpret his death; he has longed to eat it."
             },
             {
               "ref": "22:19-20",
-              "note": "\"This is my body given for you... This cup is the new covenant in my blood\" \u2014 the words of institution. The bread is his body; the cup is the new covenant sealed in blood. Luke's version is close to Paul's in 1 Cor 11:24-25 (and different from Mark's), suggesting a common liturgical tradition. \"Do this in remembrance of me\" \u2014 not merely intellectual recall but a participatory re-presentation."
+              "note": "\"This is my body given for you... This cup is the new covenant in my blood\" — the words of institution. The bread is his body; the cup is the new covenant sealed in blood. Luke's version is close to Paul's in 1 Cor 11:24-25 (and different from Mark's), suggesting a common liturgical tradition. \"Do this in remembrance of me\" — not merely intellectual recall but a participatory re-presentation."
             },
             {
               "ref": "22:27",
-              "note": "\"I am among you as one who serves\" \u2014 the climactic statement of Luke 22's service theme. Jesus does not say \"I will serve\" or \"I came to serve\" but \"I am\" \u2014 present tense, ongoing reality. The one at whom the disciples are reclining has been serving them all along. He is the table's host and its servant simultaneously."
+              "note": "\"I am among you as one who serves\" — the climactic statement of Luke 22's service theme. Jesus does not say \"I will serve\" or \"I came to serve\" but \"I am\" — present tense, ongoing reality. The one at whom the disciples are reclining has been serving them all along. He is the table's host and its servant simultaneously."
             },
             {
               "ref": "22:31-32",
-              "note": "\"Simon, Simon, Satan has asked to sift all of you as wheat. But I have prayed for you, Simon, that your faith may not fail.\" The double address (Simon, Simon) signals solemnity. Satan's request echoes Job 1:6-12 \u2014 the adversary seeking permission to test. Jesus does not pray that Peter will not fail (he knows he will); he prays that Peter's faith will not ultimately fail. The distinction is between a temporary lapse and a permanent apostasy."
+              "note": "\"Simon, Simon, Satan has asked to sift all of you as wheat. But I have prayed for you, Simon, that your faith may not fail.\" The double address (Simon, Simon) signals solemnity. Satan's request echoes Job 1:6-12 — the adversary seeking permission to test. Jesus does not pray that Peter will not fail (he knows he will); he prays that Peter's faith will not ultimately fail. The distinction is between a temporary lapse and a permanent apostasy."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:19-20",
@@ -115,12 +115,12 @@
             },
             {
               "ref": "22:31-32",
-              "note": "Calvin uses the sifting-as-wheat image to argue that Satan's activity in the world is bounded by divine permission and overruled by divine intercession. Satan can test but not ultimately destroy. Christ's prayer for Peter is the guarantee of all believers' perseverance \u2014 not that they will not fall, but that their faith will not ultimately fail."
+              "note": "Calvin uses the sifting-as-wheat image to argue that Satan's activity in the world is bounded by divine permission and overruled by divine intercession. Satan can test but not ultimately destroy. Christ's prayer for Peter is the guarantee of all believers' perseverance — not that they will not fall, but that their faith will not ultimately fail."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "22:19b-20",
@@ -128,33 +128,33 @@
             },
             {
               "ref": "22:36",
-              "note": "\"If you don't have a sword, sell your cloak and buy one\" \u2014 the command has generated extensive debate. Options: (1) literal instruction to arm for self-defence; (2) symbolic language for spiritual readiness; (3) fulfilment of Isa 53:12 (numbered with transgressors) by ensuring the disciples appeared armed. The \"two swords are enough\" response (v.38) suggests Jesus is not expecting literal military resistance."
+              "note": "\"If you don't have a sword, sell your cloak and buy one\" — the command has generated extensive debate. Options: (1) literal instruction to arm for self-defence; (2) symbolic language for spiritual readiness; (3) fulfilment of Isa 53:12 (numbered with transgressors) by ensuring the disciples appeared armed. The \"two swords are enough\" response (v.38) suggests Jesus is not expecting literal military resistance."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "22:3",
-              "note": "Eis\u0113lthen de Satanas \u2014 \"Satan entered into Judas.\" Luke is direct about the supernatural dimension of the betrayal in a way the other Gospels also note (John 13:2, 27). This is not an excuse for Judas \u2014 he \"consented\" (synetheto, v.6, a deliberate agreement) \u2014 but an acknowledgement that the passion involves cosmic as well as human agents."
+              "note": "Eisēlthen de Satanas — \"Satan entered into Judas.\" Luke is direct about the supernatural dimension of the betrayal in a way the other Gospels also note (John 13:2, 27). This is not an excuse for Judas — he \"consented\" (synetheto, v.6, a deliberate agreement) — but an acknowledgement that the passion involves cosmic as well as human agents."
             },
             {
               "ref": "22:20",
-              "note": "Kain\u0113 diath\u0113k\u0113 \u2014 \"new covenant.\" The adjective kain\u0113 means not merely \"another\" but qualitatively new, fresh, superior to what came before. The Sinai covenant is not merely renewed; it is superseded and fulfilled in a covenant of a different order."
+              "note": "Kainē diathēkē — \"new covenant.\" The adjective kainē means not merely \"another\" but qualitatively new, fresh, superior to what came before. The Sinai covenant is not merely renewed; it is superseded and fulfilled in a covenant of a different order."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "22:19",
-              "note": "Chrysostom: \"He said 'Do this in remembrance of me' \u2014 not merely as a memorial of his death in the abstract, but so that we might think of all that he has done for us, and what he was, and what he became on our account, and how he suffered. This is the anamnesis he commands: a total remembrance of the whole Christ.\""
+              "note": "Chrysostom: \"He said 'Do this in remembrance of me' — not merely as a memorial of his death in the abstract, but so that we might think of all that he has done for us, and what he was, and what he became on our account, and how he suffered. This is the anamnesis he commands: a total remembrance of the whole Christ.\""
             },
             {
               "ref": "22:27",
-              "note": "Augustine: \"I am among you as one who serves. The Lord of all, in whose sight the angels stand in awe \u2014 among his own disciples, at his own table, on the eve of his own death, he describes himself as a servant. This is not condescension; it is revelation. The Lord's glory is the glory of self-giving love.\""
+              "note": "Augustine: \"I am among you as one who serves. The Lord of all, in whose sight the angels stand in awe — among his own disciples, at his own table, on the eve of his own death, he describes himself as a servant. This is not condescension; it is revelation. The Lord's glory is the glory of self-giving love.\""
             }
           ]
         },
@@ -171,25 +171,25 @@
           }
         ],
         "hist": {
-          "context": "Passover and the Last Supper\nThe Last Supper is a Passover meal (22:15) \u2014 the annual commemoration of the Exodus liberation. Jesus deliberately sets his own death within the Passover framework: as the Passover lamb's blood protected Israel from the death angel and inaugurated the covenant at Sinai, so his blood establishes the new covenant. The four cups of the Passover seder provide the liturgical structure within which the words of institution are spoken.\n\nDispute about Greatness at the Table\nThat the disciples argue about greatness (22:24) at the Last Supper is one of Luke's most jarring juxtapositions. Jesus has just spoken of his body given and blood poured out; the Twelve are debating their relative rank. The juxtaposition is not accidental \u2014 it displays the gap between the self-giving of the one who serves and the self-seeking of those who should follow him."
+          "context": "Passover and the Last Supper\nThe Last Supper is a Passover meal (22:15) — the annual commemoration of the Exodus liberation. Jesus deliberately sets his own death within the Passover framework: as the Passover lamb's blood protected Israel from the death angel and inaugurated the covenant at Sinai, so his blood establishes the new covenant. The four cups of the Passover seder provide the liturgical structure within which the words of institution are spoken.\n\nDispute about Greatness at the Table\nThat the disciples argue about greatness (22:24) at the Last Supper is one of Luke's most jarring juxtapositions. Jesus has just spoken of his body given and blood poured out; the Twelve are debating their relative rank. The juxtaposition is not accidental — it displays the gap between the self-giving of the one who serves and the self-seeking of those who should follow him."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 24\u201138 \u2014 Dispute about Greatness; Thrones; Peter\u2019s Denial Predicted",
+      "header": "Verses 24‑38 — Dispute about Greatness; Thrones; Peter’s Denial Predicted",
       "verse_start": 24,
       "verse_end": 38,
       "panels": {
         "heb": [
           {
-            "word": "thel\u0113ma",
+            "word": "thelēma",
             "transliteration": "the-LE-ma",
             "gloss": "will",
-            "paragraph": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome \u2014 will the cup be taken away? \u2014 but about alignment: his human will surrendered to the Father's. The thel\u0113ma of the Son perfectly mirrors the thel\u0113ma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
+            "paragraph": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome — will the cup be taken away? — but about alignment: his human will surrendered to the Father's. The thelēma of the Son perfectly mirrors the thelēma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
           },
           {
-            "word": "ho huios tou anthr\u014dpou",
+            "word": "ho huios tou anthrōpou",
             "transliteration": "ho hy-IOS tou an-THRO-pou",
             "gloss": "the Son of Man",
             "paragraph": "At the trial (v.69) Jesus uses the Son of Man title with its Daniel 7 resonance: \"from now on, the Son of Man will be seated at the right hand of the mighty God.\" The precise moment of his greatest apparent humiliation is when he claims the most exalted position. The trial produces the clearest Christological statement in Luke."
@@ -197,7 +197,7 @@
         ],
         "tl": [
           {
-            "date": "Thu \u2014 Passover",
+            "date": "Thu — Passover",
             "name": "Last Supper",
             "text": "Jesus eats the Passover with the Twelve in an upper room. He institutes the Lord's Supper, predicts his betrayal, disputes about greatness, predicts Peter's denial, and prepares the disciples for what is coming.",
             "current": true
@@ -209,7 +209,7 @@
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion",
             "text": "Peter's denial; trial before the Sanhedrin; Pilate; Herod; Pilate again; crucifixion and death.",
             "current": false
@@ -219,45 +219,45 @@
           "refs": [
             {
               "ref": "Ps 22:1-18",
-              "note": "The Psalm of the suffering righteous one \u2014 \"My God, my God, why have you forsaken me?\" \u2014 which Matthew and Mark cite at the cross and which underlies the passion narrative throughout."
+              "note": "The Psalm of the suffering righteous one — \"My God, my God, why have you forsaken me?\" — which Matthew and Mark cite at the cross and which underlies the passion narrative throughout."
             },
             {
               "ref": "Dan 7:13-14",
-              "note": "\"There before me was one like a son of man, coming with the clouds of heaven... He was given authority, glory and sovereign power\" \u2014 the text Jesus quotes at his trial (22:69)."
+              "note": "\"There before me was one like a son of man, coming with the clouds of heaven... He was given authority, glory and sovereign power\" — the text Jesus quotes at his trial (22:69)."
             },
             {
               "ref": "Isa 53:3-12",
-              "note": "The Suffering Servant \u2014 mocked, beaten, numbered with transgressors \u2014 whose profile maps exactly onto the passion narrative Luke is narrating."
+              "note": "The Suffering Servant — mocked, beaten, numbered with transgressors — whose profile maps exactly onto the passion narrative Luke is narrating."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:42",
-              "note": "\"Father, if you are willing, take this cup from me; yet not my will, but yours be done.\" The prayer is the fullest expression of Christ's humanity in the Gospel: genuine reluctance, genuine anguish, genuine submission. It is not performance. The eternal Son of God, in his humanity, shrinks from what the Father asks \u2014 and freely chooses to embrace it. This is the moment the atonement is won in the will before it is enacted in the body."
+              "note": "\"Father, if you are willing, take this cup from me; yet not my will, but yours be done.\" The prayer is the fullest expression of Christ's humanity in the Gospel: genuine reluctance, genuine anguish, genuine submission. It is not performance. The eternal Son of God, in his humanity, shrinks from what the Father asks — and freely chooses to embrace it. This is the moment the atonement is won in the will before it is enacted in the body."
             },
             {
               "ref": "22:44",
-              "note": "\"His sweat was like drops of blood\" \u2014 the phenomenon of hematidrosis, where extreme stress causes capillaries beneath the skin to rupture, producing blood-tinged sweat. Luke the physician (Col 4:14) is the only evangelist to record this detail. It confirms the genuine physiological reality of Jesus's agony."
+              "note": "\"His sweat was like drops of blood\" — the phenomenon of hematidrosis, where extreme stress causes capillaries beneath the skin to rupture, producing blood-tinged sweat. Luke the physician (Col 4:14) is the only evangelist to record this detail. It confirms the genuine physiological reality of Jesus's agony."
             },
             {
               "ref": "22:61",
-              "note": "\"The Lord turned and looked straight at Peter\" \u2014 one of the most poignant moments in all the Gospels. Jesus, newly arrested and in the high priest's courtyard, turns at the sound of the rooster's crow. His eyes meet Peter's. No word is spoken. Peter goes out and weeps bitterly. The look is not condemnation but the fulfilment of a prediction \u2014 and perhaps also the look that would hold Peter through his restoration."
+              "note": "\"The Lord turned and looked straight at Peter\" — one of the most poignant moments in all the Gospels. Jesus, newly arrested and in the high priest's courtyard, turns at the sound of the rooster's crow. His eyes meet Peter's. No word is spoken. Peter goes out and weeps bitterly. The look is not condemnation but the fulfilment of a prediction — and perhaps also the look that would hold Peter through his restoration."
             },
             {
               "ref": "22:69",
-              "note": "\"From now on, the Son of Man will be seated at the right hand of the mighty God\" \u2014 Jesus's answer at the trial is a claim to Ps 110:1 and Dan 7:13 simultaneously. He is telling his judges that they are looking at the one who will be their judge. The moment of his lowest humiliation is the occasion for his highest claim. The council has heard enough; they need no other evidence."
+              "note": "\"From now on, the Son of Man will be seated at the right hand of the mighty God\" — Jesus's answer at the trial is a claim to Ps 110:1 and Dan 7:13 simultaneously. He is telling his judges that they are looking at the one who will be their judge. The moment of his lowest humiliation is the occasion for his highest claim. The council has heard enough; they need no other evidence."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:42",
-              "note": "Calvin insists that the prayer \"if you are willing, take this cup\" is not a prayer that failed \u2014 as if God was unwilling and Jesus resigned himself to rejection. Rather, the conditional \"if you are willing\" is itself the content of the submission: Jesus is not pressing an alternative agenda but handing the outcome entirely to the Father. The prayer is heard; the submission is the hearing."
+              "note": "Calvin insists that the prayer \"if you are willing, take this cup\" is not a prayer that failed — as if God was unwilling and Jesus resigned himself to rejection. Rather, the conditional \"if you are willing\" is itself the content of the submission: Jesus is not pressing an alternative agenda but handing the outcome entirely to the Father. The prayer is heard; the submission is the hearing."
             },
             {
               "ref": "22:67-70",
@@ -266,7 +266,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "22:43-44",
@@ -274,33 +274,33 @@
             },
             {
               "ref": "22:70",
-              "note": "\"You say that I am\" \u2014 the Greek sy legeis hoti eg\u014d eimi is ambiguous: it could mean \"you say so\" (a deflection) or \"yes, that is what I am\" (an affirmation in their words). The council clearly takes it as an affirmation \u2014 \"we have heard it from his own lips.\" Most scholars read it as a qualified affirmation: \"yes, though not quite in the terms you use.\""
+              "note": "\"You say that I am\" — the Greek sy legeis hoti egō eimi is ambiguous: it could mean \"you say so\" (a deflection) or \"yes, that is what I am\" (an affirmation in their words). The council clearly takes it as an affirmation — \"we have heard it from his own lips.\" Most scholars read it as a qualified affirmation: \"yes, though not quite in the terms you use.\""
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "22:44",
-              "note": "Thromboi haimatos \u2014 \"drops of blood\" or \"clots of blood.\" Robertson notes that Luke alone records this detail and that the hematidrosis phenomenon was known in ancient medicine (Aristotle mentions it). The detail is medically precise."
+              "note": "Thromboi haimatos — \"drops of blood\" or \"clots of blood.\" Robertson notes that Luke alone records this detail and that the hematidrosis phenomenon was known in ancient medicine (Aristotle mentions it). The detail is medically precise."
             },
             {
               "ref": "22:61",
-              "note": "Emblepsas \u2014 aorist participle of emblep\u014d: \"having looked at.\" The compound suggests a focused, intent look \u2014 not a glance but a fixed gaze. Combined with the turning of Jesus's head (strapheis), the moment is described with maximum emotional precision."
+              "note": "Emblepsas — aorist participle of emblepō: \"having looked at.\" The compound suggests a focused, intent look — not a glance but a fixed gaze. Combined with the turning of Jesus's head (strapheis), the moment is described with maximum emotional precision."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "22:42",
-              "note": "Ambrose: \"He prays that the cup may pass not because he fears death, but to show us that he truly took human nature upon himself \u2014 the nature that shrinks from death. And then he shows us what we must do: not my will, but yours. This is the prayer for every tribulation: not my will, but yours.\""
+              "note": "Ambrose: \"He prays that the cup may pass not because he fears death, but to show us that he truly took human nature upon himself — the nature that shrinks from death. And then he shows us what we must do: not my will, but yours. This is the prayer for every tribulation: not my will, but yours.\""
             },
             {
               "ref": "22:61",
-              "note": "Chrysostom: \"Jesus turned and looked at Peter. He did not upbraid him; he did not reproach him; he only looked. And that look was enough. For the memory of the words he had spoken came flooding back \u2014 and Peter went out and wept. The tears of Peter are the tears of one who has been both warned and loved.\""
+              "note": "Chrysostom: \"Jesus turned and looked at Peter. He did not upbraid him; he did not reproach him; he only looked. And that look was enough. For the memory of the words he had spoken came flooding back — and Peter went out and wept. The tears of Peter are the tears of one who has been both warned and loved.\""
             }
           ]
         },
@@ -317,33 +317,33 @@
           }
         ],
         "hist": {
-          "context": "Gethsemane and the Human Will of Christ\nThe Gethsemane prayer (\"not my will, but yours be done\") is the sharpest expression in the Gospels of the distinction between Christ's divine and human wills. The human will shrinks from the cup; the divine will embraces it; the submission of the human to the divine is the act of perfect obedience that is itself redemptive. The angel's strengthening (22:43) and the sweat like drops of blood (22:44) underline the genuine agony of the human experience.\n\nThe Sanhedrin Trial\nLuke's Sanhedrin trial (22:66-71) occurs at daybreak \u2014 technically conforming to Jewish law that capital trials must be held during the day. Matthew and Mark describe a night trial followed by a morning ratification; Luke compresses the procedure. The key exchange is the same: they ask about messiahship; Jesus answers with the Son of Man at the right hand; they interpret it as blasphemy."
+          "context": "Gethsemane and the Human Will of Christ\nThe Gethsemane prayer (\"not my will, but yours be done\") is the sharpest expression in the Gospels of the distinction between Christ's divine and human wills. The human will shrinks from the cup; the divine will embraces it; the submission of the human to the divine is the act of perfect obedience that is itself redemptive. The angel's strengthening (22:43) and the sweat like drops of blood (22:44) underline the genuine agony of the human experience.\n\nThe Sanhedrin Trial\nLuke's Sanhedrin trial (22:66-71) occurs at daybreak — technically conforming to Jewish law that capital trials must be held during the day. Matthew and Mark describe a night trial followed by a morning ratification; Luke compresses the procedure. The key exchange is the same: they ask about messiahship; Jesus answers with the Son of Man at the right hand; they interpret it as blasphemy."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 39\u201153 \u2014 Gethsemane; The Arrest; An Ear Restored",
+      "header": "Verses 39‑53 — Gethsemane; The Arrest; An Ear Restored",
       "verse_start": 39,
       "verse_end": 53,
       "panels": {
         "heb": [
           {
-            "word": "diath\u0113k\u0113",
-            "transliteration": "dia-THE-k\u0113",
+            "word": "diathēkē",
+            "transliteration": "dia-THE-kē",
             "gloss": "covenant",
-            "paragraph": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" \u2014 the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
+            "paragraph": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" — the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
           },
           {
-            "word": "to hyper hym\u014dn ekchynnomenon",
+            "word": "to hyper hymōn ekchynnomenon",
             "transliteration": "to hy-per hy-MON ek-chyn-NO-me-non",
             "gloss": "which is poured out for you",
-            "paragraph": "The present passive participle (v.20) is significant: \"being poured out\" \u2014 the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
+            "paragraph": "The present passive participle (v.20) is significant: \"being poured out\" — the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
           }
         ],
         "tl": [
           {
-            "date": "Thu \u2014 Passover",
+            "date": "Thu — Passover",
             "name": "Last Supper",
             "text": "Jesus eats the Passover with the Twelve in an upper room. He institutes the Lord's Supper, predicts his betrayal, disputes about greatness, predicts Peter's denial, and prepares the disciples for what is coming.",
             "current": true
@@ -355,7 +355,7 @@
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion",
             "text": "Peter's denial; trial before the Sanhedrin; Pilate; Herod; Pilate again; crucifixion and death.",
             "current": false
@@ -365,90 +365,37 @@
           "refs": [
             {
               "ref": "Jer 31:31-34",
-              "note": "\"The days are coming... when I will make a new covenant with the people of Israel and with the people of Judah\" \u2014 the foundational OT promise that Jesus's words of institution fulfil: \"This cup is the new covenant in my blood.\""
+              "note": "\"The days are coming... when I will make a new covenant with the people of Israel and with the people of Judah\" — the foundational OT promise that Jesus's words of institution fulfil: \"This cup is the new covenant in my blood.\""
             },
             {
               "ref": "Exod 24:8",
-              "note": "\"Moses then took the blood, sprinkled it on the people and said, 'This is the blood of the covenant'\" \u2014 the Sinai covenant inauguration that the Last Supper supersedes and fulfils."
+              "note": "\"Moses then took the blood, sprinkled it on the people and said, 'This is the blood of the covenant'\" — the Sinai covenant inauguration that the Last Supper supersedes and fulfils."
             },
             {
               "ref": "Isa 53:12",
-              "note": "\"He was numbered with the transgressors\" \u2014 the Isaiah servant text Jesus quotes as he prepares to be arrested (22:37)."
+              "note": "\"He was numbered with the transgressors\" — the Isaiah servant text Jesus quotes as he prepares to be arrested (22:37)."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:15",
-              "note": "\"I have eagerly desired to eat this Passover with you before I suffer\" \u2014 the language of intense longing. Jesus desires the Last Supper not as a duty but as the moment toward which his entire ministry has been moving. This is the meal that will interpret his death; he has longed to eat it."
-            },
-            {
-              "ref": "22:19-20",
-              "note": "\"This is my body given for you... This cup is the new covenant in my blood\" \u2014 the words of institution. The bread is his body; the cup is the new covenant sealed in blood. Luke's version is close to Paul's in 1 Cor 11:24-25 (and different from Mark's), suggesting a common liturgical tradition. \"Do this in remembrance of me\" \u2014 not merely intellectual recall but a participatory re-presentation."
-            },
-            {
-              "ref": "22:27",
-              "note": "\"I am among you as one who serves\" \u2014 the climactic statement of Luke 22's service theme. Jesus does not say \"I will serve\" or \"I came to serve\" but \"I am\" \u2014 present tense, ongoing reality. The one at whom the disciples are reclining has been serving them all along. He is the table's host and its servant simultaneously."
-            },
-            {
-              "ref": "22:31-32",
-              "note": "\"Simon, Simon, Satan has asked to sift all of you as wheat. But I have prayed for you, Simon, that your faith may not fail.\" The double address (Simon, Simon) signals solemnity. Satan's request echoes Job 1:6-12 \u2014 the adversary seeking permission to test. Jesus does not pray that Peter will not fail (he knows he will); he prays that Peter's faith will not ultimately fail. The distinction is between a temporary lapse and a permanent apostasy."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:19-20",
-              "note": "Calvin insists that \"This is my body\" and \"this cup is the new covenant in my blood\" are not identities of substance (Rome) nor mere memorial symbols (Zwingli) but a sacramental union: the bread and cup are genuine means by which Christ offers himself to those who receive them in faith. The sign and the thing signified are distinct but inseparable in the sacrament."
-            },
-            {
-              "ref": "22:31-32",
-              "note": "Calvin uses the sifting-as-wheat image to argue that Satan's activity in the world is bounded by divine permission and overruled by divine intercession. Satan can test but not ultimately destroy. Christ's prayer for Peter is the guarantee of all believers' perseverance \u2014 not that they will not fall, but that their faith will not ultimately fail."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:19b-20",
-              "note": "The longer text of the words of institution (including \"given for you; do this in remembrance of me\" and the full cup saying) is absent from some Western manuscripts (notably D and some Old Latin versions). NA28 includes the longer text on the strength of the overwhelming manuscript evidence. The shorter text was probably produced by scribal oversight or a desire to avoid a perceived repetition."
-            },
-            {
-              "ref": "22:36",
-              "note": "\"If you don't have a sword, sell your cloak and buy one\" \u2014 the command has generated extensive debate. Options: (1) literal instruction to arm for self-defence; (2) symbolic language for spiritual readiness; (3) fulfilment of Isa 53:12 (numbered with transgressors) by ensuring the disciples appeared armed. The \"two swords are enough\" response (v.38) suggests Jesus is not expecting literal military resistance."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "22:3",
-              "note": "Eis\u0113lthen de Satanas \u2014 \"Satan entered into Judas.\" Luke is direct about the supernatural dimension of the betrayal in a way the other Gospels also note (John 13:2, 27). This is not an excuse for Judas \u2014 he \"consented\" (synetheto, v.6, a deliberate agreement) \u2014 but an acknowledgement that the passion involves cosmic as well as human agents."
-            },
-            {
-              "ref": "22:20",
-              "note": "Kain\u0113 diath\u0113k\u0113 \u2014 \"new covenant.\" The adjective kain\u0113 means not merely \"another\" but qualitatively new, fresh, superior to what came before. The Sinai covenant is not merely renewed; it is superseded and fulfilled in a covenant of a different order."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "22:19",
-              "note": "Chrysostom: \"He said 'Do this in remembrance of me' \u2014 not merely as a memorial of his death in the abstract, but so that we might think of all that he has done for us, and what he was, and what he became on our account, and how he suffered. This is the anamnesis he commands: a total remembrance of the whole Christ.\""
-            },
-            {
-              "ref": "22:27",
-              "note": "Augustine: \"I am among you as one who serves. The Lord of all, in whose sight the angels stand in awe \u2014 among his own disciples, at his own table, on the eve of his own death, he describes himself as a servant. This is not condescension; it is revelation. The Lord's glory is the glory of self-giving love.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
@@ -463,25 +410,25 @@
           }
         ],
         "hist": {
-          "context": "Passover and the Last Supper\nThe Last Supper is a Passover meal (22:15) \u2014 the annual commemoration of the Exodus liberation. Jesus deliberately sets his own death within the Passover framework: as the Passover lamb's blood protected Israel from the death angel and inaugurated the covenant at Sinai, so his blood establishes the new covenant. The four cups of the Passover seder provide the liturgical structure within which the words of institution are spoken.\n\nDispute about Greatness at the Table\nThat the disciples argue about greatness (22:24) at the Last Supper is one of Luke's most jarring juxtapositions. Jesus has just spoken of his body given and blood poured out; the Twelve are debating their relative rank. The juxtaposition is not accidental \u2014 it displays the gap between the self-giving of the one who serves and the self-seeking of those who should follow him."
+          "context": "Passover and the Last Supper\nThe Last Supper is a Passover meal (22:15) — the annual commemoration of the Exodus liberation. Jesus deliberately sets his own death within the Passover framework: as the Passover lamb's blood protected Israel from the death angel and inaugurated the covenant at Sinai, so his blood establishes the new covenant. The four cups of the Passover seder provide the liturgical structure within which the words of institution are spoken.\n\nDispute about Greatness at the Table\nThat the disciples argue about greatness (22:24) at the Last Supper is one of Luke's most jarring juxtapositions. Jesus has just spoken of his body given and blood poured out; the Twelve are debating their relative rank. The juxtaposition is not accidental — it displays the gap between the self-giving of the one who serves and the self-seeking of those who should follow him."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 54\u201171 \u2014 Peter\u2019s Denials; Jesus Mocked; Before the Council",
+      "header": "Verses 54‑71 — Peter’s Denials; Jesus Mocked; Before the Council",
       "verse_start": 54,
       "verse_end": 71,
       "panels": {
         "heb": [
           {
-            "word": "thel\u0113ma",
+            "word": "thelēma",
             "transliteration": "the-LE-ma",
             "gloss": "will",
-            "paragraph": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome \u2014 will the cup be taken away? \u2014 but about alignment: his human will surrendered to the Father's. The thel\u0113ma of the Son perfectly mirrors the thel\u0113ma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
+            "paragraph": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome — will the cup be taken away? — but about alignment: his human will surrendered to the Father's. The thelēma of the Son perfectly mirrors the thelēma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
           },
           {
-            "word": "ho huios tou anthr\u014dpou",
+            "word": "ho huios tou anthrōpou",
             "transliteration": "ho hy-IOS tou an-THRO-pou",
             "gloss": "the Son of Man",
             "paragraph": "At the trial (v.69) Jesus uses the Son of Man title with its Daniel 7 resonance: \"from now on, the Son of Man will be seated at the right hand of the mighty God.\" The precise moment of his greatest apparent humiliation is when he claims the most exalted position. The trial produces the clearest Christological statement in Luke."
@@ -489,7 +436,7 @@
         ],
         "tl": [
           {
-            "date": "Thu \u2014 Passover",
+            "date": "Thu — Passover",
             "name": "Last Supper",
             "text": "Jesus eats the Passover with the Twelve in an upper room. He institutes the Lord's Supper, predicts his betrayal, disputes about greatness, predicts Peter's denial, and prepares the disciples for what is coming.",
             "current": true
@@ -501,7 +448,7 @@
             "current": false
           },
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Trials; Crucifixion",
             "text": "Peter's denial; trial before the Sanhedrin; Pilate; Herod; Pilate again; crucifixion and death.",
             "current": false
@@ -511,90 +458,37 @@
           "refs": [
             {
               "ref": "Ps 22:1-18",
-              "note": "The Psalm of the suffering righteous one \u2014 \"My God, my God, why have you forsaken me?\" \u2014 which Matthew and Mark cite at the cross and which underlies the passion narrative throughout."
+              "note": "The Psalm of the suffering righteous one — \"My God, my God, why have you forsaken me?\" — which Matthew and Mark cite at the cross and which underlies the passion narrative throughout."
             },
             {
               "ref": "Dan 7:13-14",
-              "note": "\"There before me was one like a son of man, coming with the clouds of heaven... He was given authority, glory and sovereign power\" \u2014 the text Jesus quotes at his trial (22:69)."
+              "note": "\"There before me was one like a son of man, coming with the clouds of heaven... He was given authority, glory and sovereign power\" — the text Jesus quotes at his trial (22:69)."
             },
             {
               "ref": "Isa 53:3-12",
-              "note": "The Suffering Servant \u2014 mocked, beaten, numbered with transgressors \u2014 whose profile maps exactly onto the passion narrative Luke is narrating."
+              "note": "The Suffering Servant — mocked, beaten, numbered with transgressors — whose profile maps exactly onto the passion narrative Luke is narrating."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:42",
-              "note": "\"Father, if you are willing, take this cup from me; yet not my will, but yours be done.\" The prayer is the fullest expression of Christ's humanity in the Gospel: genuine reluctance, genuine anguish, genuine submission. It is not performance. The eternal Son of God, in his humanity, shrinks from what the Father asks \u2014 and freely chooses to embrace it. This is the moment the atonement is won in the will before it is enacted in the body."
-            },
-            {
-              "ref": "22:44",
-              "note": "\"His sweat was like drops of blood\" \u2014 the phenomenon of hematidrosis, where extreme stress causes capillaries beneath the skin to rupture, producing blood-tinged sweat. Luke the physician (Col 4:14) is the only evangelist to record this detail. It confirms the genuine physiological reality of Jesus's agony."
-            },
-            {
-              "ref": "22:61",
-              "note": "\"The Lord turned and looked straight at Peter\" \u2014 one of the most poignant moments in all the Gospels. Jesus, newly arrested and in the high priest's courtyard, turns at the sound of the rooster's crow. His eyes meet Peter's. No word is spoken. Peter goes out and weeps bitterly. The look is not condemnation but the fulfilment of a prediction \u2014 and perhaps also the look that would hold Peter through his restoration."
-            },
-            {
-              "ref": "22:69",
-              "note": "\"From now on, the Son of Man will be seated at the right hand of the mighty God\" \u2014 Jesus's answer at the trial is a claim to Ps 110:1 and Dan 7:13 simultaneously. He is telling his judges that they are looking at the one who will be their judge. The moment of his lowest humiliation is the occasion for his highest claim. The council has heard enough; they need no other evidence."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:42",
-              "note": "Calvin insists that the prayer \"if you are willing, take this cup\" is not a prayer that failed \u2014 as if God was unwilling and Jesus resigned himself to rejection. Rather, the conditional \"if you are willing\" is itself the content of the submission: Jesus is not pressing an alternative agenda but handing the outcome entirely to the Father. The prayer is heard; the submission is the hearing."
-            },
-            {
-              "ref": "22:67-70",
-              "note": "The council's two questions (Are you the Messiah? Are you the Son of God?) and Jesus's answers constitute a Christological declaration under oath at the most dangerous possible moment. Calvin notes that Jesus does not deny either claim; he refuses the framing of the first (they will not believe) and accepts the second in their own words (\"You say that I am\"). The confession under trial is the most costly confession in the Gospel."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:43-44",
-              "note": "The angel strengthening Jesus and the sweat like blood are absent from some important manuscripts (p69vid, p75, Codex Alexandrinus, and others). They are present in Sinaiticus, Vaticanus, and many others. NA28 includes them with brackets. Most textual critics consider them original, perhaps omitted early because they seemed to compromise Christ's divinity."
-            },
-            {
-              "ref": "22:70",
-              "note": "\"You say that I am\" \u2014 the Greek sy legeis hoti eg\u014d eimi is ambiguous: it could mean \"you say so\" (a deflection) or \"yes, that is what I am\" (an affirmation in their words). The council clearly takes it as an affirmation \u2014 \"we have heard it from his own lips.\" Most scholars read it as a qualified affirmation: \"yes, though not quite in the terms you use.\""
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "22:44",
-              "note": "Thromboi haimatos \u2014 \"drops of blood\" or \"clots of blood.\" Robertson notes that Luke alone records this detail and that the hematidrosis phenomenon was known in ancient medicine (Aristotle mentions it). The detail is medically precise."
-            },
-            {
-              "ref": "22:61",
-              "note": "Emblepsas \u2014 aorist participle of emblep\u014d: \"having looked at.\" The compound suggests a focused, intent look \u2014 not a glance but a fixed gaze. Combined with the turning of Jesus's head (strapheis), the moment is described with maximum emotional precision."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "22:42",
-              "note": "Ambrose: \"He prays that the cup may pass not because he fears death, but to show us that he truly took human nature upon himself \u2014 the nature that shrinks from death. And then he shows us what we must do: not my will, but yours. This is the prayer for every tribulation: not my will, but yours.\""
-            },
-            {
-              "ref": "22:61",
-              "note": "Chrysostom: \"Jesus turned and looked at Peter. He did not upbraid him; he did not reproach him; he only looked. And that look was enough. For the memory of the words he had spoken came flooding back \u2014 and Peter went out and wept. The tears of Peter are the tears of one who has been both warned and loved.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
@@ -609,7 +503,7 @@
           }
         ],
         "hist": {
-          "context": "Gethsemane and the Human Will of Christ\nThe Gethsemane prayer (\"not my will, but yours be done\") is the sharpest expression in the Gospels of the distinction between Christ's divine and human wills. The human will shrinks from the cup; the divine will embraces it; the submission of the human to the divine is the act of perfect obedience that is itself redemptive. The angel's strengthening (22:43) and the sweat like drops of blood (22:44) underline the genuine agony of the human experience.\n\nThe Sanhedrin Trial\nLuke's Sanhedrin trial (22:66-71) occurs at daybreak \u2014 technically conforming to Jewish law that capital trials must be held during the day. Matthew and Mark describe a night trial followed by a morning ratification; Luke compresses the procedure. The key exchange is the same: they ask about messiahship; Jesus answers with the Son of Man at the right hand; they interpret it as blasphemy."
+          "context": "Gethsemane and the Human Will of Christ\nThe Gethsemane prayer (\"not my will, but yours be done\") is the sharpest expression in the Gospels of the distinction between Christ's divine and human wills. The human will shrinks from the cup; the divine will embraces it; the submission of the human to the divine is the act of perfect obedience that is itself redemptive. The angel's strengthening (22:43) and the sweat like drops of blood (22:44) underline the genuine agony of the human experience.\n\nThe Sanhedrin Trial\nLuke's Sanhedrin trial (22:66-71) occurs at daybreak — technically conforming to Jewish law that capital trials must be held during the day. Matthew and Mark describe a night trial followed by a morning ratification; Luke compresses the procedure. The key exchange is the same: they ask about messiahship; Jesus answers with the Son of Man at the right hand; they interpret it as blasphemy."
         }
       }
     }
@@ -624,7 +518,7 @@
       {
         "name": "Judas",
         "role": "The betrayer",
-        "text": "His betrayal is described with unusual restraint in Luke \u2014 no extended explanation, no psychological analysis. \"Satan entered Judas\" (22:3) and \"he consented\" (22:6) are together the full account."
+        "text": "His betrayal is described with unusual restraint in Luke — no extended explanation, no psychological analysis. \"Satan entered Judas\" (22:3) and \"he consented\" (22:6) are together the full account."
       },
       {
         "name": "Peter",
@@ -637,7 +531,7 @@
         "text": "The assembly of chief priests and teachers of the law that constitutes the Jewish ruling body. Their trial of Jesus is conducted at daybreak (technically legal) and produces the confession that becomes the basis of the capital charge."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anamn\u0113sin (22:19)</td><td>NIV: \"remembrance\"; KJV: \"remembrance\"; ESV: \"remembrance\"; NRSV: \"remembrance\". Universal agreement. Anamn\u0113sis is not mere intellectual recall but participatory memorial \u2014 making present the past event.</td></tr><tr><td class=\"t-label\">diath\u0113k\u0113 (22:20)</td><td>NIV: \"covenant\"; KJV: \"testament\"; ESV: \"covenant\"; NRSV: \"covenant\". Modern versions prefer \"covenant\" (the covenantal, relational sense); KJV's \"testament\" (the legal/inheritance sense) preserves a different but not incorrect nuance.</td></tr><tr><td class=\"t-label\">thel\u0113ma (22:42)</td><td>NIV: \"will\"; KJV: \"will\"; ESV: \"will\"; NRSV: \"will\". Universal agreement on the central word of the Gethsemane prayer.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">anamnēsin (22:19)</td><td>NIV: \"remembrance\"; KJV: \"remembrance\"; ESV: \"remembrance\"; NRSV: \"remembrance\". Universal agreement. Anamnēsis is not mere intellectual recall but participatory memorial — making present the past event.</td></tr><tr><td class=\"t-label\">diathēkē (22:20)</td><td>NIV: \"covenant\"; KJV: \"testament\"; ESV: \"covenant\"; NRSV: \"covenant\". Modern versions prefer \"covenant\" (the covenantal, relational sense); KJV's \"testament\" (the legal/inheritance sense) preserves a different but not incorrect nuance.</td></tr><tr><td class=\"t-label\">thelēma (22:42)</td><td>NIV: \"will\"; KJV: \"will\"; ESV: \"will\"; NRSV: \"will\". Universal agreement on the central word of the Gethsemane prayer.</td></tr>",
     "src": [
       {
         "title": "Jeremiah 31:31-34",
@@ -653,7 +547,7 @@
     "rec": [
       {
         "who": "Gethsemane in Christian Spiritual Direction",
-        "text": "\"Not my will, but yours be done\" has been the foundation of the Christian tradition of conformity to divine will. Ignatius of Loyola placed it at the centre of the Spiritual Exercises; Thomas \u00e0 Kempis built the Imitation of Christ around it; Luther's Heidelberg Disputation used it to argue for the theology of the cross over the theology of glory. The prayer is simultaneously the most human moment in the Gospels and its most redemptively significant."
+        "text": "\"Not my will, but yours be done\" has been the foundation of the Christian tradition of conformity to divine will. Ignatius of Loyola placed it at the centre of the Spiritual Exercises; Thomas à Kempis built the Imitation of Christ around it; Luther's Heidelberg Disputation used it to argue for the theology of the cross over the theology of glory. The prayer is simultaneously the most human moment in the Gospels and its most redemptively significant."
       },
       {
         "who": "The Lord's Supper in Christian Worship",
@@ -663,13 +557,13 @@
     "lit": {
       "rows": [
         {
-          "label": "The Servant King \u2014 vv.14-27",
-          "text": "The Last Supper discourse holds together two realities that the world considers opposites: king (he confers a kingdom, v.29) and servant (I am among you as one who serves, v.27). The meal is the place where this paradox is most fully displayed \u2014 he serves them bread and wine that are himself, seated at the table they will soon abandon.",
+          "label": "The Servant King — vv.14-27",
+          "text": "The Last Supper discourse holds together two realities that the world considers opposites: king (he confers a kingdom, v.29) and servant (I am among you as one who serves, v.27). The meal is the place where this paradox is most fully displayed — he serves them bread and wine that are himself, seated at the table they will soon abandon.",
           "is_key": false
         },
         {
-          "label": "Prophecy and Fulfilment \u2014 vv.21-22 / 47-48; vv.31-34 / 54-62",
-          "text": "The betrayal (foretold v.21-22, enacted v.47-48) and Peter's denial (foretold v.31-34, enacted v.54-62) both follow the same pattern: Jesus speaks with precise foreknowledge; the event unfolds exactly as described. The double fulfilment within the same chapter emphasises that nothing in the passion is accidental \u2014 it follows a predetermined pattern.",
+          "label": "Prophecy and Fulfilment — vv.21-22 / 47-48; vv.31-34 / 54-62",
+          "text": "The betrayal (foretold v.21-22, enacted v.47-48) and Peter's denial (foretold v.31-34, enacted v.54-62) both follow the same pattern: Jesus speaks with precise foreknowledge; the event unfolds exactly as described. The double fulfilment within the same chapter emphasises that nothing in the passion is accidental — it follows a predetermined pattern.",
           "is_key": false
         }
       ],
@@ -677,49 +571,49 @@
     },
     "hebtext": [
       {
-        "word": "diath\u0113k\u0113",
-        "tlit": "dia-THE-k\u0113",
+        "word": "diathēkē",
+        "tlit": "dia-THE-kē",
         "gloss": "covenant",
-        "note": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" \u2014 the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
+        "note": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" — the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
       },
       {
-        "word": "to hyper hym\u014dn ekchynnomenon",
+        "word": "to hyper hymōn ekchynnomenon",
         "tlit": "to hy-per hy-MON ek-chyn-NO-me-non",
         "gloss": "which is poured out for you",
-        "note": "The present passive participle (v.20) is significant: \"being poured out\" \u2014 the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
+        "note": "The present passive participle (v.20) is significant: \"being poured out\" — the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
       },
       {
-        "word": "thel\u0113ma",
+        "word": "thelēma",
         "tlit": "the-LE-ma",
         "gloss": "will",
-        "note": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome \u2014 will the cup be taken away? \u2014 but about alignment: his human will surrendered to the Father's. The thel\u0113ma of the Son perfectly mirrors the thel\u0113ma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
+        "note": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome — will the cup be taken away? — but about alignment: his human will surrendered to the Father's. The thelēma of the Son perfectly mirrors the thelēma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
       },
       {
-        "word": "ho huios tou anthr\u014dpou",
+        "word": "ho huios tou anthrōpou",
         "tlit": "ho hy-IOS tou an-THRO-pou",
         "gloss": "the Son of Man",
         "note": "At the trial (v.69) Jesus uses the Son of Man title with its Daniel 7 resonance: \"from now on, the Son of Man will be seated at the right hand of the mighty God.\" The precise moment of his greatest apparent humiliation is when he claims the most exalted position. The trial produces the clearest Christological statement in Luke."
       },
       {
-        "word": "diath\u0113k\u0113",
-        "tlit": "dia-THE-k\u0113",
+        "word": "diathēkē",
+        "tlit": "dia-THE-kē",
         "gloss": "covenant",
-        "note": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" \u2014 the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
+        "note": "The word (v.20) that interprets the Last Supper. The cup is the \"new covenant in my blood\" — the language of Jeremiah 31:31-34 fulfilled. A covenant is a binding agreement sealed in blood; Jesus is establishing the new covenant by his own death. Every subsequent Eucharist re-presents this covenant inauguration."
       },
       {
-        "word": "to hyper hym\u014dn ekchynnomenon",
+        "word": "to hyper hymōn ekchynnomenon",
         "tlit": "to hy-per hy-MON ek-chyn-NO-me-non",
         "gloss": "which is poured out for you",
-        "note": "The present passive participle (v.20) is significant: \"being poured out\" \u2014 the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
+        "note": "The present passive participle (v.20) is significant: \"being poured out\" — the shedding of blood is described as ongoing (liturgical present), not merely future. In the Supper, the disciples participate proleptically in what is about to happen at Golgotha."
       },
       {
-        "word": "thel\u0113ma",
+        "word": "thelēma",
         "tlit": "the-LE-ma",
         "gloss": "will",
-        "note": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome \u2014 will the cup be taken away? \u2014 but about alignment: his human will surrendered to the Father's. The thel\u0113ma of the Son perfectly mirrors the thel\u0113ma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
+        "note": "The word at the centre of Gethsemane (v.42): \"not my will, but yours be done.\" Jesus's prayer is not merely about outcome — will the cup be taken away? — but about alignment: his human will surrendered to the Father's. The thelēma of the Son perfectly mirrors the thelēma of the Father, and the submission of one to the other is the moment at which the atonement is sealed in the garden before it is enacted at the cross."
       },
       {
-        "word": "ho huios tou anthr\u014dpou",
+        "word": "ho huios tou anthrōpou",
         "tlit": "ho hy-IOS tou an-THRO-pou",
         "gloss": "the Son of Man",
         "note": "At the trial (v.69) Jesus uses the Son of Man title with its Daniel 7 resonance: \"from now on, the Son of Man will be seated at the right hand of the mighty God.\" The precise moment of his greatest apparent humiliation is when he claims the most exalted position. The trial produces the clearest Christological statement in Luke."
@@ -828,7 +722,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 22 is the theological hinge of the Gospel \u2014 the night on which everything converges. At the table, Jesus gives himself in bread and wine and establishes the new covenant in his blood. In the garden, he surrenders his human will to the Father's. At the arrest, he heals the last person he will heal before the resurrection. In the courtyard, Peter denies him. Before the council, Jesus claims his exaltation at the precise moment of his humiliation. The chapter holds together the deepest contradiction of the Gospel: the Son of Man served, suffered, and was condemned \u2014 and by this became the eternal king."
+      "note": "Luke 22 is the theological hinge of the Gospel — the night on which everything converges. At the table, Jesus gives himself in bread and wine and establishes the new covenant in his blood. In the garden, he surrenders his human will to the Father's. At the arrest, he heals the last person he will heal before the resurrection. In the courtyard, Peter denies him. Before the council, Jesus claims his exaltation at the precise moment of his humiliation. The chapter holds together the deepest contradiction of the Gospel: the Son of Man served, suffered, and was condemned — and by this became the eternal king."
     }
   },
   "vhl_groups": [
@@ -954,7 +848,7 @@
     },
     {
       "after_section": 4,
-      "tip": "'Father, forgive them, for they do not know what they are doing' (v. 34). Only Luke records this prayer. Crucified by ignorance\u2014the executioners don't grasp whom they're killing. Jesus intercedes for his murderers.",
+      "tip": "'Father, forgive them, for they do not know what they are doing' (v. 34). Only Luke records this prayer. Crucified by ignorance—the executioners don't grasp whom they're killing. Jesus intercedes for his murderers.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/luke/23.json
+++ b/content/luke/23.json
@@ -7,13 +7,13 @@
   "subtitle": "The Crucifixion and Death of Jesus",
   "timeline_link": {
     "event_id": "crucifixion",
-    "text": "See on Timeline \u2014 Crucifixion"
+    "text": "See on Timeline — Crucifixion"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201325 \u2014 Before Pilate and Herod; Barabbas Released",
+      "header": "Verses 1–25 — Before Pilate and Herod; Barabbas Released",
       "verse_start": 1,
       "verse_end": 25,
       "panels": {
@@ -22,13 +22,13 @@
             "word": "aithios",
             "transliteration": "AI-ti-os",
             "gloss": "cause / basis for a charge",
-            "paragraph": "Pilate's repeated verdict (vv.4, 14, 22) \u2014 \"I find no basis for a charge\" \u2014 uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
+            "paragraph": "Pilate's repeated verdict (vv.4, 14, 22) — \"I find no basis for a charge\" — uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
           },
           {
-            "word": "paradid\u014dmi",
+            "word": "paradidōmi",
             "transliteration": "pa-ra-DI-do-mi",
             "gloss": "handed over / surrendered",
-            "paragraph": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) \u2014 God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
+            "paragraph": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) — God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
           }
         ],
         "places": [
@@ -52,28 +52,28 @@
           "refs": [
             {
               "ref": "Isa 53:7",
-              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" \u2014 Jesus's silence before Herod (23:9) fulfils the Servant's silence."
+              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" — Jesus's silence before Herod (23:9) fulfils the Servant's silence."
             },
             {
               "ref": "Hos 10:8",
-              "note": "\"They will say to the mountains, 'Cover us!' and to the hills, 'Fall on us!'\" \u2014 Jesus quotes Hosea as the OT description of the extremity of judgment on unfaithful Israel, applying it to Jerusalem's coming fate."
+              "note": "\"They will say to the mountains, 'Cover us!' and to the hills, 'Fall on us!'\" — Jesus quotes Hosea as the OT description of the extremity of judgment on unfaithful Israel, applying it to Jerusalem's coming fate."
             },
             {
               "ref": "Acts 4:27-28",
-              "note": "\"Herod and Pontius Pilate met together with the Gentiles and the people of Israel in this city to conspire against your holy servant Jesus\" \u2014 the early church's theological reading of the trial narrative, recognising the fulfilment of Psalm 2."
+              "note": "\"Herod and Pontius Pilate met together with the Gentiles and the people of Israel in this city to conspire against your holy servant Jesus\" — the early church's theological reading of the trial narrative, recognising the fulfilment of Psalm 2."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:2",
-              "note": "The charges against Jesus \u2014 subverting the nation, opposing taxation, claiming to be a king \u2014 are all deliberate distortions of his actual teaching. He had not opposed taxation (20:25: \"give back to Caesar what is Caesar's\"). He had not subverted the nation in any way Rome would recognise. The charges reveal the accusers' bad faith; the reader of Luke's Gospel knows they are false."
+              "note": "The charges against Jesus — subverting the nation, opposing taxation, claiming to be a king — are all deliberate distortions of his actual teaching. He had not opposed taxation (20:25: \"give back to Caesar what is Caesar's\"). He had not subverted the nation in any way Rome would recognise. The charges reveal the accusers' bad faith; the reader of Luke's Gospel knows they are false."
             },
             {
               "ref": "23:8-9",
-              "note": "Jesus's silence before Herod is one of the most striking moments in the passion narrative. He had refused to perform signs throughout his ministry when demanded as proof; he refuses to perform for Herod now. The silence is not impotence but dignity \u2014 the refusal to play the entertainer for a man who has no interest in truth."
+              "note": "Jesus's silence before Herod is one of the most striking moments in the passion narrative. He had refused to perform signs throughout his ministry when demanded as proof; he refuses to perform for Herod now. The silence is not impotence but dignity — the refusal to play the entertainer for a man who has no interest in truth."
             },
             {
               "ref": "23:14-15, 22",
@@ -86,54 +86,54 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:13-24",
-              "note": "Calvin argues that Pilate's condemnation, despite his personal conviction of Jesus's innocence, is a representative act of human injustice \u2014 the acquittal of the guilty and the condemnation of the righteous, which was the universal condition of humanity before God. Jesus is condemned in the place of those who deserved condemnation; Barabbas's release is the earliest typological enactment of the substitution the cross effects."
+              "note": "Calvin argues that Pilate's condemnation, despite his personal conviction of Jesus's innocence, is a representative act of human injustice — the acquittal of the guilty and the condemnation of the righteous, which was the universal condition of humanity before God. Jesus is condemned in the place of those who deserved condemnation; Barabbas's release is the earliest typological enactment of the substitution the cross effects."
             },
             {
               "ref": "23:31",
-              "note": "\"If people do these things when the tree is green, what will happen when it is dry?\" \u2014 Calvin reads this as a saying about the correlation between the treatment of Christ and the subsequent fate of the nation. If God allows the innocent to suffer this, how will he treat the guilty? The logic is unanswerable."
+              "note": "\"If people do these things when the tree is green, what will happen when it is dry?\" — Calvin reads this as a saying about the correlation between the treatment of Christ and the subsequent fate of the nation. If God allows the innocent to suffer this, how will he treat the guilty? The logic is unanswerable."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "23:17",
-              "note": "Verse 17 \u2014 \"Now he was obligated to release one man to them at the feast\" \u2014 is absent from the best manuscripts (p75, Sinaiticus, Vaticanus) and is almost certainly a scribal addition from Mark 15:6. NA28 omits it."
+              "note": "Verse 17 — \"Now he was obligated to release one man to them at the feast\" — is absent from the best manuscripts (p75, Sinaiticus, Vaticanus) and is almost certainly a scribal addition from Mark 15:6. NA28 omits it."
             },
             {
               "ref": "23:26",
-              "note": "Simon of Cyrene \u2014 Cyrene was in modern Libya; its Jewish population is well attested. Simon was \"on his way in from the country\" \u2014 probably coming in for the Passover festival. Mark 15:21 names him as the father of Alexander and Rufus, suggesting he was known to the early church community."
+              "note": "Simon of Cyrene — Cyrene was in modern Libya; its Jewish population is well attested. Simon was \"on his way in from the country\" — probably coming in for the Passover festival. Mark 15:21 names him as the father of Alexander and Rufus, suggesting he was known to the early church community."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "23:4",
-              "note": "Aition \u2014 \"charge, cause, reason.\" The legal technical term for a formal accusation in Roman law. Pilate uses it precisely: he cannot identify a legally actionable charge. The verdict is not merely personal sympathy but a formal judicial finding."
+              "note": "Aition — \"charge, cause, reason.\" The legal technical term for a formal accusation in Roman law. Pilate uses it precisely: he cannot identify a legally actionable charge. The verdict is not merely personal sympathy but a formal judicial finding."
             },
             {
               "ref": "23:12",
-              "note": "Philoi \u2014 \"friends.\" The irony is sharp: the trial of the innocent creates a friendship between two corrupt men. Their previous enmity is resolved by their shared complicity in the condemnation of Jesus."
+              "note": "Philoi — \"friends.\" The irony is sharp: the trial of the innocent creates a friendship between two corrupt men. Their previous enmity is resolved by their shared complicity in the condemnation of Jesus."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "23:3",
-              "note": "Chrysostom: \"You say that I am \u2014 he does not say simply yes, because his kingship is not of the kind Pilate means. He is king, but not in the way Roman governors understand kingship. He answers truly without being understood truly.\""
+              "note": "Chrysostom: \"You say that I am — he does not say simply yes, because his kingship is not of the kind Pilate means. He is king, but not in the way Roman governors understand kingship. He answers truly without being understood truly.\""
             },
             {
               "ref": "23:28",
-              "note": "Augustine: \"Weep for yourselves, he says. Not because I do not need your tears \u2014 but because you need them more than I do. I go to my glory; you remain in your danger. The tears appropriate here are not tears of grief for me but tears of repentance for you.\""
+              "note": "Augustine: \"Weep for yourselves, he says. Not because I do not need your tears — but because you need them more than I do. I go to my glory; you remain in your danger. The tears appropriate here are not tears of grief for me but tears of repentance for you.\""
             }
           ]
         },
@@ -164,13 +164,13 @@
           }
         ],
         "hist": {
-          "context": "Pilate's Triple Declaration\nPilate declares Jesus innocent three times (23:4, 14, 22) \u2014 a literary emphasis unique to Luke. The triple declaration mirrors Peter's triple denial and creates a legal framework for the passion: the one condemned to death was declared innocent by the highest Roman authority in the region. Luke's passion narrative is simultaneously a theological document and a legal one.\n\nThe Daughters of Jerusalem\nJesus's address to the women (23:28-31) as he carries the cross is unique to Luke. He redirects their mourning from himself to themselves and their children \u2014 a prophetic warning of the coming destruction of Jerusalem (21:20-24). The mourning is not wrong, but its object should be redirected. The green tree/dry tree metaphor: if this is what happens to the innocent (Jesus, the green tree), what will happen to the guilty (Jerusalem, the dry tree)?"
+          "context": "Pilate's Triple Declaration\nPilate declares Jesus innocent three times (23:4, 14, 22) — a literary emphasis unique to Luke. The triple declaration mirrors Peter's triple denial and creates a legal framework for the passion: the one condemned to death was declared innocent by the highest Roman authority in the region. Luke's passion narrative is simultaneously a theological document and a legal one.\n\nThe Daughters of Jerusalem\nJesus's address to the women (23:28-31) as he carries the cross is unique to Luke. He redirects their mourning from himself to themselves and their children — a prophetic warning of the coming destruction of Jerusalem (21:20-24). The mourning is not wrong, but its object should be redirected. The green tree/dry tree metaphor: if this is what happens to the innocent (Jesus, the green tree), what will happen to the guilty (Jerusalem, the dry tree)?"
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 26\u201343 \u2014 The Crucifixion; The Two Criminals; Today in Paradise",
+      "header": "Verses 26–43 — The Crucifixion; The Two Criminals; Today in Paradise",
       "verse_start": 26,
       "verse_end": 43,
       "panels": {
@@ -179,7 +179,7 @@
             "word": "Kranion",
             "transliteration": "kra-NI-on",
             "gloss": "the Skull / Cranium",
-            "paragraph": "The transliteration into Greek of the Hebrew \"Golgotha\" (Aramaic gulgalta, \"skull\"). The location outside Jerusalem was probably a rocky outcrop resembling a skull \u2014 a place of public execution where the condemned were visible to passers-by as a deterrent."
+            "paragraph": "The transliteration into Greek of the Hebrew \"Golgotha\" (Aramaic gulgalta, \"skull\"). The location outside Jerusalem was probably a rocky outcrop resembling a skull — a place of public execution where the condemned were visible to passers-by as a deterrent."
           },
           {
             "word": "paradeisos",
@@ -204,88 +204,88 @@
           "refs": [
             {
               "ref": "Ps 22:18",
-              "note": "\"They divide my clothes among them and cast lots for my garment\" \u2014 fulfilled in 23:34."
+              "note": "\"They divide my clothes among them and cast lots for my garment\" — fulfilled in 23:34."
             },
             {
               "ref": "Ps 31:5",
-              "note": "\"Into your hands I commit my spirit\" \u2014 the Psalm verse Jesus quotes as his final word. He dies praying the Psalms."
+              "note": "\"Into your hands I commit my spirit\" — the Psalm verse Jesus quotes as his final word. He dies praying the Psalms."
             },
             {
               "ref": "Isa 53:9",
-              "note": "\"He was assigned a grave with the wicked, and with the rich in his death\" \u2014 Joseph of Arimathea's wealthy tomb and the criminals on either side fulfil the double servant text simultaneously."
+              "note": "\"He was assigned a grave with the wicked, and with the rich in his death\" — Joseph of Arimathea's wealthy tomb and the criminals on either side fulfil the double servant text simultaneously."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:34",
-              "note": "\"Father, forgive them, for they do not know what they are doing\" \u2014 the first word from the cross is intercession for those who are crucifying him. \"They do not know what they are doing\" is not an excuse (the Romans knew perfectly well they were executing a man) but an identification of the deeper ignorance: they do not know who they are crucifying, what they are accomplishing, or what they are against. The prayer is universal in its implication \u2014 the forgiveness for which Jesus prays encompasses all human sin against the divine."
+              "note": "\"Father, forgive them, for they do not know what they are doing\" — the first word from the cross is intercession for those who are crucifying him. \"They do not know what they are doing\" is not an excuse (the Romans knew perfectly well they were executing a man) but an identification of the deeper ignorance: they do not know who they are crucifying, what they are accomplishing, or what they are against. The prayer is universal in its implication — the forgiveness for which Jesus prays encompasses all human sin against the divine."
             },
             {
               "ref": "23:42-43",
-              "note": "\"Jesus, remember me when you come into your kingdom\" \u2014 the most extraordinary expression of faith in the Gospels, spoken from a cross by a dying criminal who has minutes to live and nothing to offer. He asks only to be remembered; Jesus gives him immediate presence. \"Today you will be with me in paradise\" \u2014 not eventually, not after a waiting period, not contingent on anything: today."
+              "note": "\"Jesus, remember me when you come into your kingdom\" — the most extraordinary expression of faith in the Gospels, spoken from a cross by a dying criminal who has minutes to live and nothing to offer. He asks only to be remembered; Jesus gives him immediate presence. \"Today you will be with me in paradise\" — not eventually, not after a waiting period, not contingent on anything: today."
             },
             {
               "ref": "23:45",
-              "note": "\"The curtain of the temple was torn in two\" \u2014 the heavy curtain separating the Holy of Holies from the rest of the Temple. Its tearing at the moment of Jesus's death signifies the end of the old sacrificial order and the opening of direct access to God through the one true sacrifice. The veil that kept God hidden is gone; what was hidden is now accessible through Christ."
+              "note": "\"The curtain of the temple was torn in two\" — the heavy curtain separating the Holy of Holies from the rest of the Temple. Its tearing at the moment of Jesus's death signifies the end of the old sacrificial order and the opening of direct access to God through the one true sacrifice. The veil that kept God hidden is gone; what was hidden is now accessible through Christ."
             },
             {
               "ref": "23:46",
-              "note": "\"Father, into your hands I commit my spirit\" \u2014 Luke's last word from the cross (Ps 31:5) contrasts with Mark's \"My God, my God, why have you forsaken me?\" (Ps 22:1). Luke presents a dying Jesus in perfect trust and communion with the Father \u2014 the one who in Gethsemane surrendered his will to the Father now surrenders his spirit to the Father's hands."
+              "note": "\"Father, into your hands I commit my spirit\" — Luke's last word from the cross (Ps 31:5) contrasts with Mark's \"My God, my God, why have you forsaken me?\" (Ps 22:1). Luke presents a dying Jesus in perfect trust and communion with the Father — the one who in Gethsemane surrendered his will to the Father now surrenders his spirit to the Father's hands."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:34",
-              "note": "Calvin insists that the prayer \"Father, forgive them\" was genuinely answered \u2014 the mass conversion in Acts 2-4, especially among Jerusalem Jews and priests, represents the partial fulfilment of this intercessory prayer. The prayer models the Christian disposition toward persecutors and establishes that forgiveness, not vengeance, is the response of the crucified community to its crucifiers."
+              "note": "Calvin insists that the prayer \"Father, forgive them\" was genuinely answered — the mass conversion in Acts 2-4, especially among Jerusalem Jews and priests, represents the partial fulfilment of this intercessory prayer. The prayer models the Christian disposition toward persecutors and establishes that forgiveness, not vengeance, is the response of the crucified community to its crucifiers."
             },
             {
               "ref": "23:45",
-              "note": "Calvin reads the Temple veil's tearing as the abolition of the Levitical economy. The system of priests, sacrifices, and spatial barriers to God was a preparation for Christ; with his sacrifice, the preparation ends and the substance arrives. There is no longer a veil because there is no longer a need for mediated, partial, obscured access to God \u2014 the one perfect sacrifice has opened the way entirely."
+              "note": "Calvin reads the Temple veil's tearing as the abolition of the Levitical economy. The system of priests, sacrifices, and spatial barriers to God was a preparation for Christ; with his sacrifice, the preparation ends and the substance arrives. There is no longer a veil because there is no longer a need for mediated, partial, obscured access to God — the one perfect sacrifice has opened the way entirely."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "23:34",
-              "note": "\"Father, forgive them\" \u2014 this prayer is absent from some important manuscripts (p75, Codex Bezae, and others). NA28 includes it. If original, its omission may reflect anti-Jewish sentiment in some early communities who found it difficult to pray for those responsible for the crucifixion. The prayer is stylistically consistent with Luke's emphasis on forgiveness and prayer."
+              "note": "\"Father, forgive them\" — this prayer is absent from some important manuscripts (p75, Codex Bezae, and others). NA28 includes it. If original, its omission may reflect anti-Jewish sentiment in some early communities who found it difficult to pray for those responsible for the crucifixion. The prayer is stylistically consistent with Luke's emphasis on forgiveness and prayer."
             },
             {
               "ref": "23:47",
-              "note": "\"This was a righteous man\" (Luke) vs. \"Son of God\" (Matt 27:54; Mark 15:39) \u2014 Luke's centurion gives a judicial verdict (dikaios, righteous/innocent); Matthew's and Mark's give a theological confession. Either both traditions preserve different dimensions of the same event, or Luke has adapted the tradition for his theological purposes."
+              "note": "\"This was a righteous man\" (Luke) vs. \"Son of God\" (Matt 27:54; Mark 15:39) — Luke's centurion gives a judicial verdict (dikaios, righteous/innocent); Matthew's and Mark's give a theological confession. Either both traditions preserve different dimensions of the same event, or Luke has adapted the tradition for his theological purposes."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "23:43",
-              "note": "S\u0113meron \u2014 \"today.\" The adverb is emphatic and unambiguous. The thief will be with Jesus in paradise on this same day \u2014 not after a period of waiting or purification. The promise is immediate. Robertson notes that the word cannot be grammatically attached to \"truly I tell you\" (as some have argued) without violating the normal Greek construction."
+              "note": "Sēmeron — \"today.\" The adverb is emphatic and unambiguous. The thief will be with Jesus in paradise on this same day — not after a period of waiting or purification. The promise is immediate. Robertson notes that the word cannot be grammatically attached to \"truly I tell you\" (as some have argued) without violating the normal Greek construction."
             },
             {
               "ref": "23:46",
-              "note": "Paratithemai \u2014 \"I commit/entrust/deposit.\" The verb is used for depositing valuables with a trusted person. Jesus deposits his spirit with the Father as a man deposits a treasure with a trusted friend. The act is voluntary, confident, and relational."
+              "note": "Paratithemai — \"I commit/entrust/deposit.\" The verb is used for depositing valuables with a trusted person. Jesus deposits his spirit with the Father as a man deposits a treasure with a trusted friend. The act is voluntary, confident, and relational."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "23:34",
-              "note": "Augustine: \"Father, forgive them, for they do not know what they are doing. What ignorance! They see him hanging on the cross, and they do not see the one who is on the cross. Could we too say they do not know what they are doing? They do not know \u2014 but the one who forgives knows. And he offers prayer rather than punishment.\""
+              "note": "Augustine: \"Father, forgive them, for they do not know what they are doing. What ignorance! They see him hanging on the cross, and they do not see the one who is on the cross. Could we too say they do not know what they are doing? They do not know — but the one who forgives knows. And he offers prayer rather than punishment.\""
             },
             {
               "ref": "23:43",
-              "note": "Chrysostom: \"He did not say 'I will remember you' or 'I will save you' but 'you will be with me' \u2014 not merely remembered from a distance but present, with the one who remembers. This is the fullness of salvation: to be with Christ, where he is.\""
+              "note": "Chrysostom: \"He did not say 'I will remember you' or 'I will save you' but 'you will be with me' — not merely remembered from a distance but present, with the one who remembers. This is the fullness of salvation: to be with Christ, where he is.\""
             }
           ]
         },
@@ -316,13 +316,13 @@
           }
         ],
         "hist": {
-          "context": "The Three Words from the Cross\nLuke records three distinct words of Jesus from the cross: (1) \"Father, forgive them\" (23:34); (2) \"Today you will be with me in paradise\" (23:43); (3) \"Father, into your hands I commit my spirit\" (23:46). These three are unique to Luke among the Gospels. Together they present a dying Jesus who intercedes, promises, and entrusts \u2014 wholly oriented toward others and toward the Father, not toward himself.\n\nThe Centurion's Verdict\nThe Roman centurion's response \u2014 \"Surely this was a righteous man\" (23:47) \u2014 is the third external declaration of innocence in Luke's passion narrative (after Pilate's three declarations and Herod's implicit one). In Matthew and Mark, the centurion says \"Son of God\"; in Luke, \"righteous man\" (dikaios). The Lukan verdict is more judicial \u2014 confirming the legal innocence \u2014 while the Matthean/Markan version is more Christological."
+          "context": "The Three Words from the Cross\nLuke records three distinct words of Jesus from the cross: (1) \"Father, forgive them\" (23:34); (2) \"Today you will be with me in paradise\" (23:43); (3) \"Father, into your hands I commit my spirit\" (23:46). These three are unique to Luke among the Gospels. Together they present a dying Jesus who intercedes, promises, and entrusts — wholly oriented toward others and toward the Father, not toward himself.\n\nThe Centurion's Verdict\nThe Roman centurion's response — \"Surely this was a righteous man\" (23:47) — is the third external declaration of innocence in Luke's passion narrative (after Pilate's three declarations and Herod's implicit one). In Matthew and Mark, the centurion says \"Son of God\"; in Luke, \"righteous man\" (dikaios). The Lukan verdict is more judicial — confirming the legal innocence — while the Matthean/Markan version is more Christological."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 44\u201356 \u2014 The Death of Jesus; The Burial",
+      "header": "Verses 44–56 — The Death of Jesus; The Burial",
       "verse_start": 44,
       "verse_end": 56,
       "panels": {
@@ -331,13 +331,13 @@
             "word": "aithios",
             "transliteration": "AI-ti-os",
             "gloss": "cause / basis for a charge",
-            "paragraph": "Pilate's repeated verdict (vv.4, 14, 22) \u2014 \"I find no basis for a charge\" \u2014 uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
+            "paragraph": "Pilate's repeated verdict (vv.4, 14, 22) — \"I find no basis for a charge\" — uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
           },
           {
-            "word": "paradid\u014dmi",
+            "word": "paradidōmi",
             "transliteration": "pa-ra-DI-do-mi",
             "gloss": "handed over / surrendered",
-            "paragraph": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) \u2014 God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
+            "paragraph": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) — God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
           }
         ],
         "places": [
@@ -361,90 +361,37 @@
           "refs": [
             {
               "ref": "Isa 53:7",
-              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" \u2014 Jesus's silence before Herod (23:9) fulfils the Servant's silence."
+              "note": "\"He was oppressed and afflicted, yet he did not open his mouth; he was led like a lamb to the slaughter\" — Jesus's silence before Herod (23:9) fulfils the Servant's silence."
             },
             {
               "ref": "Hos 10:8",
-              "note": "\"They will say to the mountains, 'Cover us!' and to the hills, 'Fall on us!'\" \u2014 Jesus quotes Hosea as the OT description of the extremity of judgment on unfaithful Israel, applying it to Jerusalem's coming fate."
+              "note": "\"They will say to the mountains, 'Cover us!' and to the hills, 'Fall on us!'\" — Jesus quotes Hosea as the OT description of the extremity of judgment on unfaithful Israel, applying it to Jerusalem's coming fate."
             },
             {
               "ref": "Acts 4:27-28",
-              "note": "\"Herod and Pontius Pilate met together with the Gentiles and the people of Israel in this city to conspire against your holy servant Jesus\" \u2014 the early church's theological reading of the trial narrative, recognising the fulfilment of Psalm 2."
+              "note": "\"Herod and Pontius Pilate met together with the Gentiles and the people of Israel in this city to conspire against your holy servant Jesus\" — the early church's theological reading of the trial narrative, recognising the fulfilment of Psalm 2."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:2",
-              "note": "The charges against Jesus \u2014 subverting the nation, opposing taxation, claiming to be a king \u2014 are all deliberate distortions of his actual teaching. He had not opposed taxation (20:25: \"give back to Caesar what is Caesar's\"). He had not subverted the nation in any way Rome would recognise. The charges reveal the accusers' bad faith; the reader of Luke's Gospel knows they are false."
-            },
-            {
-              "ref": "23:8-9",
-              "note": "Jesus's silence before Herod is one of the most striking moments in the passion narrative. He had refused to perform signs throughout his ministry when demanded as proof; he refuses to perform for Herod now. The silence is not impotence but dignity \u2014 the refusal to play the entertainer for a man who has no interest in truth."
-            },
-            {
-              "ref": "23:14-15, 22",
-              "note": "Pilate's three declarations of innocence are the passion narrative's legal framework. Whatever the crowd does, the Roman governor has placed his official verdict on record: this man deserves no death. This is important for Luke's purposes: the condemnation of Jesus is not an act of Roman justice but of Roman capitulation to Jewish mob pressure. The innocent are condemned; the guilty (Barabbas) are released."
-            },
-            {
-              "ref": "23:28-31",
-              "note": "\"Do not weep for me; weep for yourselves and for your children.\" This is not callousness but prophecy. The destruction of Jerusalem that Jesus predicted throughout the Gospel is imminent; these women and their children will live to experience it. Jesus's concern, even on the road to his own execution, is for the welfare of those who mourn for him."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:13-24",
-              "note": "Calvin argues that Pilate's condemnation, despite his personal conviction of Jesus's innocence, is a representative act of human injustice \u2014 the acquittal of the guilty and the condemnation of the righteous, which was the universal condition of humanity before God. Jesus is condemned in the place of those who deserved condemnation; Barabbas's release is the earliest typological enactment of the substitution the cross effects."
-            },
-            {
-              "ref": "23:31",
-              "note": "\"If people do these things when the tree is green, what will happen when it is dry?\" \u2014 Calvin reads this as a saying about the correlation between the treatment of Christ and the subsequent fate of the nation. If God allows the innocent to suffer this, how will he treat the guilty? The logic is unanswerable."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:17",
-              "note": "Verse 17 \u2014 \"Now he was obligated to release one man to them at the feast\" \u2014 is absent from the best manuscripts (p75, Sinaiticus, Vaticanus) and is almost certainly a scribal addition from Mark 15:6. NA28 omits it."
-            },
-            {
-              "ref": "23:26",
-              "note": "Simon of Cyrene \u2014 Cyrene was in modern Libya; its Jewish population is well attested. Simon was \"on his way in from the country\" \u2014 probably coming in for the Passover festival. Mark 15:21 names him as the father of Alexander and Rufus, suggesting he was known to the early church community."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "23:4",
-              "note": "Aition \u2014 \"charge, cause, reason.\" The legal technical term for a formal accusation in Roman law. Pilate uses it precisely: he cannot identify a legally actionable charge. The verdict is not merely personal sympathy but a formal judicial finding."
-            },
-            {
-              "ref": "23:12",
-              "note": "Philoi \u2014 \"friends.\" The irony is sharp: the trial of the innocent creates a friendship between two corrupt men. Their previous enmity is resolved by their shared complicity in the condemnation of Jesus."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "23:3",
-              "note": "Chrysostom: \"You say that I am \u2014 he does not say simply yes, because his kingship is not of the kind Pilate means. He is king, but not in the way Roman governors understand kingship. He answers truly without being understood truly.\""
-            },
-            {
-              "ref": "23:28",
-              "note": "Augustine: \"Weep for yourselves, he says. Not because I do not need your tears \u2014 but because you need them more than I do. I go to my glory; you remain in your danger. The tears appropriate here are not tears of grief for me but tears of repentance for you.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
@@ -473,7 +420,7 @@
           }
         ],
         "hist": {
-          "context": "Pilate's Triple Declaration\nPilate declares Jesus innocent three times (23:4, 14, 22) \u2014 a literary emphasis unique to Luke. The triple declaration mirrors Peter's triple denial and creates a legal framework for the passion: the one condemned to death was declared innocent by the highest Roman authority in the region. Luke's passion narrative is simultaneously a theological document and a legal one.\n\nThe Daughters of Jerusalem\nJesus's address to the women (23:28-31) as he carries the cross is unique to Luke. He redirects their mourning from himself to themselves and their children \u2014 a prophetic warning of the coming destruction of Jerusalem (21:20-24). The mourning is not wrong, but its object should be redirected. The green tree/dry tree metaphor: if this is what happens to the innocent (Jesus, the green tree), what will happen to the guilty (Jerusalem, the dry tree)?"
+          "context": "Pilate's Triple Declaration\nPilate declares Jesus innocent three times (23:4, 14, 22) — a literary emphasis unique to Luke. The triple declaration mirrors Peter's triple denial and creates a legal framework for the passion: the one condemned to death was declared innocent by the highest Roman authority in the region. Luke's passion narrative is simultaneously a theological document and a legal one.\n\nThe Daughters of Jerusalem\nJesus's address to the women (23:28-31) as he carries the cross is unique to Luke. He redirects their mourning from himself to themselves and their children — a prophetic warning of the coming destruction of Jerusalem (21:20-24). The mourning is not wrong, but its object should be redirected. The green tree/dry tree metaphor: if this is what happens to the innocent (Jesus, the green tree), what will happen to the guilty (Jerusalem, the dry tree)?"
         }
       }
     }
@@ -483,7 +430,7 @@
       {
         "name": "Pilate",
         "role": "Roman governor",
-        "text": "Three times he declares Jesus innocent; three times he yields to crowd pressure. His triple acquittal makes him the passion narrative's ironic witness \u2014 the one who establishes Jesus's innocence in the very act of condemning him."
+        "text": "Three times he declares Jesus innocent; three times he yields to crowd pressure. His triple acquittal makes him the passion narrative's ironic witness — the one who establishes Jesus's innocence in the very act of condemning him."
       },
       {
         "name": "Herod Antipas",
@@ -493,12 +440,12 @@
       {
         "name": "The Penitent Criminal",
         "role": "The dying convert",
-        "text": "No name, no history, no preparation \u2014 only a dying recognition of justice and a request for remembrance. He receives the most explicit promise of immediate paradise in all the Gospels."
+        "text": "No name, no history, no preparation — only a dying recognition of justice and a request for remembrance. He receives the most explicit promise of immediate paradise in all the Gospels."
       },
       {
         "name": "Joseph of Arimathea",
         "role": "The dissenting councillor",
-        "text": "Luke carefully notes that he \"had not consented to their decision and action\" \u2014 distinguishing him from the Sanhedrin majority. His provision of a new tomb fulfils Isa 53:9 and ensures the body's proper burial before the resurrection."
+        "text": "Luke carefully notes that he \"had not consented to their decision and action\" — distinguishing him from the Sanhedrin majority. His provision of a new tomb fulfils Isa 53:9 and ensures the body's proper burial before the resurrection."
       },
       {
         "name": "The Women from Galilee",
@@ -511,7 +458,7 @@
       {
         "title": "Psalm 31:5",
         "quote": "\"Into your hands I commit my spirit; deliver me, Lord, my faithful God.\"",
-        "note": "The Psalm verse Jesus prays as his last word from the cross. He dies as the suffering righteous one of the Psalter \u2014 not merely quoting a prayer but embodying it."
+        "note": "The Psalm verse Jesus prays as his last word from the cross. He dies as the suffering righteous one of the Psalter — not merely quoting a prayer but embodying it."
       },
       {
         "title": "Isaiah 53:7-12",
@@ -526,19 +473,19 @@
       },
       {
         "who": "The Penitent Thief in Christian Teaching on Last-Minute Salvation",
-        "text": "The conversation between Jesus and the penitent criminal (23:40-43) became the standard evidence for death-bed conversion in Christian theology. Augustine used it to argue against Pelagianism: the thief contributes nothing \u2014 no works, no preparation, no religious history \u2014 and receives everything by grace alone. It has also been used in Christian ministry to dying criminals, most notably in the tradition of prison chaplaincy."
+        "text": "The conversation between Jesus and the penitent criminal (23:40-43) became the standard evidence for death-bed conversion in Christian theology. Augustine used it to argue against Pelagianism: the thief contributes nothing — no works, no preparation, no religious history — and receives everything by grace alone. It has also been used in Christian ministry to dying criminals, most notably in the tradition of prison chaplaincy."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "The Three Words \u2014 vv.34, 43, 46",
-          "text": "Luke's three passion words form a structural triad: forgiveness for others (v.34) \u2192 promise to another (v.43) \u2192 self-surrender to the Father (v.46). The movement is outward (others), then lateral (alongside the dying), then upward (the Father). Jesus dies facing outward, not inward.",
+          "label": "The Three Words — vv.34, 43, 46",
+          "text": "Luke's three passion words form a structural triad: forgiveness for others (v.34) → promise to another (v.43) → self-surrender to the Father (v.46). The movement is outward (others), then lateral (alongside the dying), then upward (the Father). Jesus dies facing outward, not inward.",
           "is_key": false
         },
         {
-          "label": "Legal Innocence Framework \u2014 vv.4, 14-15, 22, 47",
-          "text": "Four declarations of innocence \u2014 Pilate three times, the centurion once \u2014 surround the crucifixion. The innocent one is condemned; the guilty (Barabbas) is released. The legal framework makes the substitutionary pattern structurally visible in Luke's narrative.",
+          "label": "Legal Innocence Framework — vv.4, 14-15, 22, 47",
+          "text": "Four declarations of innocence — Pilate three times, the centurion once — surround the crucifixion. The innocent one is condemned; the guilty (Barabbas) is released. The legal framework makes the substitutionary pattern structurally visible in Luke's narrative.",
           "is_key": false
         }
       ],
@@ -549,19 +496,19 @@
         "word": "aithios",
         "tlit": "AI-ti-os",
         "gloss": "cause / basis for a charge",
-        "note": "Pilate's repeated verdict (vv.4, 14, 22) \u2014 \"I find no basis for a charge\" \u2014 uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
+        "note": "Pilate's repeated verdict (vv.4, 14, 22) — \"I find no basis for a charge\" — uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
       },
       {
-        "word": "paradid\u014dmi",
+        "word": "paradidōmi",
         "tlit": "pa-ra-DI-do-mi",
         "gloss": "handed over / surrendered",
-        "note": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) \u2014 God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
+        "note": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) — God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
       },
       {
         "word": "Kranion",
         "tlit": "kra-NI-on",
         "gloss": "the Skull / Cranium",
-        "note": "The transliteration into Greek of the Hebrew \"Golgotha\" (Aramaic gulgalta, \"skull\"). The location outside Jerusalem was probably a rocky outcrop resembling a skull \u2014 a place of public execution where the condemned were visible to passers-by as a deterrent."
+        "note": "The transliteration into Greek of the Hebrew \"Golgotha\" (Aramaic gulgalta, \"skull\"). The location outside Jerusalem was probably a rocky outcrop resembling a skull — a place of public execution where the condemned were visible to passers-by as a deterrent."
       },
       {
         "word": "paradeisos",
@@ -573,13 +520,13 @@
         "word": "aithios",
         "tlit": "AI-ti-os",
         "gloss": "cause / basis for a charge",
-        "note": "Pilate's repeated verdict (vv.4, 14, 22) \u2014 \"I find no basis for a charge\" \u2014 uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
+        "note": "Pilate's repeated verdict (vv.4, 14, 22) — \"I find no basis for a charge\" — uses the legal term for a cause or ground of accusation. Three times he declares the formal verdict of innocence, making Luke's passion narrative a legal document that establishes the juridical innocence of the one being crucified."
       },
       {
-        "word": "paradid\u014dmi",
+        "word": "paradidōmi",
         "tlit": "pa-ra-DI-do-mi",
         "gloss": "handed over / surrendered",
-        "note": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) \u2014 God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
+        "note": "The word (v.25) that summarises the passion: Pilate \"surrendered Jesus to their will.\" The same word is used of divine handing-over in Paul (Rom 4:25; 8:32) — God handed him over for us. The human handing-over by Pilate is simultaneously the divine handing-over for redemption."
       }
     ],
     "tx": {
@@ -601,7 +548,7 @@
         {
           "title": "Father, Forgive Them",
           "passage": "Luke 23:34a",
-          "summary": "The first of the Seven Last Words \u2014 'Father, forgive them, for they do not know what they do' \u2014 is absent from several early and important manuscripts. Some scholars have proposed it was removed by copyists who doubted that divine forgiveness extended to those responsible for the crucifixion.",
+          "summary": "The first of the Seven Last Words — 'Father, forgive them, for they do not know what they do' — is absent from several early and important manuscripts. Some scholars have proposed it was removed by copyists who doubted that divine forgiveness extended to those responsible for the crucifixion.",
           "evidence": [
             {
               "manuscript": "Papyrus 75 (c. 175-225)",
@@ -798,7 +745,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'I find no basis for a charge against this man' (v. 4). Pilate's verdict\u2014repeated three times\u2014confirms Jesus' innocence. He dies not for his crimes but for ours.",
+      "tip": "'I find no basis for a charge against this man' (v. 4). Pilate's verdict—repeated three times—confirms Jesus' innocence. He dies not for his crimes but for ours.",
       "genre_tag": "theological_insight"
     },
     {

--- a/content/luke/24.json
+++ b/content/luke/24.json
@@ -7,22 +7,22 @@
   "subtitle": "The Resurrection: Empty Tomb, Emmaus, and Ascension",
   "timeline_link": {
     "event_id": "resurrection",
-    "text": "See on Timeline \u2014 The Resurrection"
+    "text": "See on Timeline — The Resurrection"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201112 \u2014 The Empty Tomb; The Women\u2019s Report",
+      "header": "Verses 1‑12 — The Empty Tomb; The Women’s Report",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
         "heb": [
           {
-            "word": "apokalypt\u014d / dianoig\u014d",
+            "word": "apokalyptō / dianoigō",
             "transliteration": "a-po-ka-LYP-to / di-a-NOI-go",
             "gloss": "revealed / opened",
-            "paragraph": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (di\u0113noichth\u0113san, v.31) and \"he opened their minds\" (di\u0113noixen, v.45). The resurrection does not merely remove an obstacle to sight \u2014 it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
+            "paragraph": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (diēnoichthēsan, v.31) and \"he opened their minds\" (diēnoixen, v.45). The resurrection does not merely remove an obstacle to sight — it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
           },
           {
             "word": "dei",
@@ -34,25 +34,25 @@
         "places": [
           {
             "name": "Emmaus",
-            "coords": "31.8347\u00b0 N, 35.1078\u00b0 E",
+            "coords": "31.8347° N, 35.1078° E",
             "text": "The exact location of Emmaus is disputed; the strongest candidate for the 60-stadia tradition is Moza (Qoloniyya), about 4 miles (60 stadia) west-northwest of Jerusalem. The road from Jerusalem to Emmaus passed through the Judean foothills, a beautiful route for a conversation that changed the history of Christian interpretation."
           }
         ],
         "tl": [
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion & Burial",
             "text": "Jesus crucified at Golgotha; dies at 3pm; buried in Joseph's tomb before the Sabbath.",
             "current": false
           },
           {
-            "date": "Sat \u2014 Sabbath",
+            "date": "Sat — Sabbath",
             "name": "The Silent Day",
             "text": "The women rest on the Sabbath, spices prepared. The tomb is sealed.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Empty Tomb; Emmaus; Appearances",
             "text": "Women find the stone rolled away; angels announce the resurrection; Jesus appears on the road to Emmaus and to the assembled disciples.",
             "current": true
@@ -62,11 +62,11 @@
           "refs": [
             {
               "ref": "Ps 16:10",
-              "note": "\"You will not abandon me to the realm of the dead, nor will you let your faithful one see decay\" \u2014 the resurrection psalm Peter cites in Acts 2:27, which Jesus's resurrection fulfils."
+              "note": "\"You will not abandon me to the realm of the dead, nor will you let your faithful one see decay\" — the resurrection psalm Peter cites in Acts 2:27, which Jesus's resurrection fulfils."
             },
             {
               "ref": "Gen 18:1-8",
-              "note": "Abraham's hospitality to the three visitors \u2014 the OT prototype of table hospitality that reveals the divine guest, which the Emmaus meal echoes."
+              "note": "Abraham's hospitality to the three visitors — the OT prototype of table hospitality that reveals the divine guest, which the Emmaus meal echoes."
             },
             {
               "ref": "1 Cor 15:3-8",
@@ -75,67 +75,67 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:5",
-              "note": "\"Why do you look for the living among the dead?\" \u2014 the angels' question is the chapter's hermeneutical key. The tomb is the wrong place to look for the risen Christ. The disciples' confusion throughout Luke 24 stems from looking in wrong places: in the tomb (where he is not), in the category of \"failed prophet\" (24:19-21), in the class of ghost or spirit (24:37). Jesus himself re-educates them through Scripture and through meals."
+              "note": "\"Why do you look for the living among the dead?\" — the angels' question is the chapter's hermeneutical key. The tomb is the wrong place to look for the risen Christ. The disciples' confusion throughout Luke 24 stems from looking in wrong places: in the tomb (where he is not), in the category of \"failed prophet\" (24:19-21), in the class of ghost or spirit (24:37). Jesus himself re-educates them through Scripture and through meals."
             },
             {
               "ref": "24:21",
-              "note": "\"We had hoped that he was the one who was going to redeem Israel\" \u2014 the most poignant confession of dashed hope in the Gospels. The disciples had expected a political messiah who would liberate Israel from Rome. The crucifixion had destroyed that hope. Their reconstruction of what happened \u2014 \"it is the third day since all this took place\" \u2014 shows they know the resurrection tradition but cannot connect it to their experience. The hope was correct; the category of fulfilment was wrong."
+              "note": "\"We had hoped that he was the one who was going to redeem Israel\" — the most poignant confession of dashed hope in the Gospels. The disciples had expected a political messiah who would liberate Israel from Rome. The crucifixion had destroyed that hope. Their reconstruction of what happened — \"it is the third day since all this took place\" — shows they know the resurrection tradition but cannot connect it to their experience. The hope was correct; the category of fulfilment was wrong."
             },
             {
               "ref": "24:30-31",
-              "note": "\"He took bread, gave thanks, broke it and began to give it to them. Then their eyes were opened and they recognized him, and he disappeared from their sight.\" The recognition comes at the moment of eucharistic action \u2014 not during the Scripture exposition, not during conversation, but in the meal. Luke connects the risen Christ to the broken bread in a way that has shaped Christian eucharistic theology ever since: the Table is where he is known."
+              "note": "\"He took bread, gave thanks, broke it and began to give it to them. Then their eyes were opened and they recognized him, and he disappeared from their sight.\" The recognition comes at the moment of eucharistic action — not during the Scripture exposition, not during conversation, but in the meal. Luke connects the risen Christ to the broken bread in a way that has shaped Christian eucharistic theology ever since: the Table is where he is known."
             },
             {
               "ref": "24:32",
-              "note": "\"Were not our hearts burning within us while he talked with us on the road and opened the Scriptures to us?\" \u2014 the retrospective confirmation that the Scripture exposition was itself a resurrection experience. The burning heart is the mark of divine encounter in Scripture, even when the one speaking is not yet recognised. Christian preaching participates in this same dynamic."
+              "note": "\"Were not our hearts burning within us while he talked with us on the road and opened the Scriptures to us?\" — the retrospective confirmation that the Scripture exposition was itself a resurrection experience. The burning heart is the mark of divine encounter in Scripture, even when the one speaking is not yet recognised. Christian preaching participates in this same dynamic."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:25-27",
-              "note": "Calvin emphasises that Jesus rebukes their slowness to believe \"all that the prophets have spoken\" \u2014 not some of it, not the easy parts, but all of it. The passion was predicted; they had refused to hear it. The resurrection now forces the full reading of all the prophets, including the parts about suffering and rejection. The Scripture that they thought contradicted the messianic expectation was actually its clearest prediction."
+              "note": "Calvin emphasises that Jesus rebukes their slowness to believe \"all that the prophets have spoken\" — not some of it, not the easy parts, but all of it. The passion was predicted; they had refused to hear it. The resurrection now forces the full reading of all the prophets, including the parts about suffering and rejection. The Scripture that they thought contradicted the messianic expectation was actually its clearest prediction."
             },
             {
               "ref": "24:30-31",
-              "note": "Calvin connects the breaking of bread to both the Last Supper and to the ordinary meal of hospitality, deliberately avoiding an exclusively sacramental reading. The recognition of Christ at the table is a pattern for all meals that are received in faith and gratitude \u2014 the risen Christ is present wherever bread is broken with thankfulness and where Scripture has been opened."
+              "note": "Calvin connects the breaking of bread to both the Last Supper and to the ordinary meal of hospitality, deliberately avoiding an exclusively sacramental reading. The recognition of Christ at the table is a pattern for all meals that are received in faith and gratitude — the risen Christ is present wherever bread is broken with thankfulness and where Scripture has been opened."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "24:13",
-              "note": "\"About seven miles from Jerusalem\" \u2014 literally sixty stadia (about 7 miles or 11 km). The location of Emmaus is disputed: candidates include Moza (4 miles), Nicopolis/Emmaus Nicopolis (20 miles), and Qaloniyya (4 miles). The 60-stadia measurement (present in the majority of manuscripts) fits Moza or Qaloniyya; some MSS read 160 stadia, matching Nicopolis."
+              "note": "\"About seven miles from Jerusalem\" — literally sixty stadia (about 7 miles or 11 km). The location of Emmaus is disputed: candidates include Moza (4 miles), Nicopolis/Emmaus Nicopolis (20 miles), and Qaloniyya (4 miles). The 60-stadia measurement (present in the majority of manuscripts) fits Moza or Qaloniyya; some MSS read 160 stadia, matching Nicopolis."
             },
             {
               "ref": "24:34",
-              "note": "\"The Lord has risen and has appeared to Simon\" \u2014 this appearance to Peter alone is mentioned but not narrated in Luke. Paul lists it first among the resurrection appearances (1 Cor 15:5 \u2014 \"he appeared to Cephas\"). Its mention in 24:34 suggests Luke's readers were familiar with the tradition even without a full account."
+              "note": "\"The Lord has risen and has appeared to Simon\" — this appearance to Peter alone is mentioned but not narrated in Luke. Paul lists it first among the resurrection appearances (1 Cor 15:5 — \"he appeared to Cephas\"). Its mention in 24:34 suggests Luke's readers were familiar with the tradition even without a full account."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "24:11",
-              "note": "L\u0113ros \u2014 \"nonsense, foolishness, idle tale.\" A strong word implying contempt or dismissal. The medical vocabulary of Luke-Acts uses l\u0113ros for hallucination or delirious speech. The disciples' initial response to the resurrection report is dismissal, not merely scepticism."
+              "note": "Lēros — \"nonsense, foolishness, idle tale.\" A strong word implying contempt or dismissal. The medical vocabulary of Luke-Acts uses lēros for hallucination or delirious speech. The disciples' initial response to the resurrection report is dismissal, not merely scepticism."
             },
             {
               "ref": "24:34",
-              "note": "\u014cphth\u0113 Sim\u014dni \u2014 \"appeared to Simon.\" The aorist passive of hora\u014d \u2014 \"was seen by\" or \"appeared to.\" The same passive is used throughout Paul's list in 1 Cor 15:5. The passive form suggests that the appearances are initiated by Christ, not by the disciples' seeing."
+              "note": "Ōphthē Simōni — \"appeared to Simon.\" The aorist passive of horaō — \"was seen by\" or \"appeared to.\" The same passive is used throughout Paul's list in 1 Cor 15:5. The passive form suggests that the appearances are initiated by Christ, not by the disciples' seeing."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "24:27",
@@ -148,13 +148,13 @@
           ]
         },
         "hist": {
-          "context": "The Emmaus Road\nThe road to Emmaus (24:13-35) is the longest resurrection appearance narrative in the Gospels and unique to Luke. The two disciples embody the confusion and grief of the broader disciple community: they had hoped Jesus was the redeemer of Israel, and now they are leaving Jerusalem. Jesus joins them as an unknown companion, walks with them through their misunderstanding, interprets the Scriptures, and reveals himself in the breaking of bread \u2014 then vanishes. The recognition comes through a meal, not through seeing.\n\nScripture Interpretation in Luke 24\nThree times in Luke 24, Jesus opens Scripture: to the two disciples on the Emmaus road (24:27), to the assembled disciples in Jerusalem (24:44-47), and implicitly through the angels' \"remember what he told you\" (24:6-7). The entire chapter is a hermeneutical event: the resurrection is the key that unlocks all of Moses, the Prophets, and the Psalms. The disciples' previous inability to understand the passion predictions is resolved not by more explanation but by the event itself."
+          "context": "The Emmaus Road\nThe road to Emmaus (24:13-35) is the longest resurrection appearance narrative in the Gospels and unique to Luke. The two disciples embody the confusion and grief of the broader disciple community: they had hoped Jesus was the redeemer of Israel, and now they are leaving Jerusalem. Jesus joins them as an unknown companion, walks with them through their misunderstanding, interprets the Scriptures, and reveals himself in the breaking of bread — then vanishes. The recognition comes through a meal, not through seeing.\n\nScripture Interpretation in Luke 24\nThree times in Luke 24, Jesus opens Scripture: to the two disciples on the Emmaus road (24:27), to the assembled disciples in Jerusalem (24:44-47), and implicitly through the angels' \"remember what he told you\" (24:6-7). The entire chapter is a hermeneutical event: the resurrection is the key that unlocks all of Moses, the Prophets, and the Psalms. The disciples' previous inability to understand the passion predictions is resolved not by more explanation but by the event itself."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201135 \u2014 The Road to Emmaus: Our Hearts Were Burning",
+      "header": "Verses 13‑35 — The Road to Emmaus: Our Hearts Were Burning",
       "verse_start": 13,
       "verse_end": 35,
       "panels": {
@@ -163,13 +163,13 @@
             "word": "martyres",
             "transliteration": "mar-TY-res",
             "gloss": "witnesses",
-            "paragraph": "The final commission (v.48) uses the Greek word from which \"martyr\" derives \u2014 originally \"witness\" in a legal sense. The disciples are appointed as legal witnesses to the resurrection: they have seen, touched, and eaten with the risen Jesus. Their testimony is not opinion or interpretation; it is eyewitness evidence. The Acts narrative will show what witness costs in practice."
+            "paragraph": "The final commission (v.48) uses the Greek word from which \"martyr\" derives — originally \"witness\" in a legal sense. The disciples are appointed as legal witnesses to the resurrection: they have seen, touched, and eaten with the risen Jesus. Their testimony is not opinion or interpretation; it is eyewitness evidence. The Acts narrative will show what witness costs in practice."
           },
           {
-            "word": "eparch\u0113",
+            "word": "eparchē",
             "transliteration": "ep-ar-CHE",
             "gloss": "promise / what was promised",
-            "paragraph": "The \"promise\" of the Father (v.49) that the disciples are to wait for is the Holy Spirit \u2014 explicitly identified in Acts 1:4-5 as the content of this promise. Luke ends his Gospel pointing toward the Spirit; Acts begins with the Spirit's arrival (Pentecost). The ascension is the pivot between the two volumes."
+            "paragraph": "The \"promise\" of the Father (v.49) that the disciples are to wait for is the Holy Spirit — explicitly identified in Acts 1:4-5 as the content of this promise. Luke ends his Gospel pointing toward the Spirit; Acts begins with the Spirit's arrival (Pentecost). The ascension is the pivot between the two volumes."
           }
         ],
         "places": [
@@ -191,19 +191,19 @@
         ],
         "tl": [
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion & Burial",
             "text": "Jesus crucified at Golgotha; dies at 3pm; buried in Joseph's tomb before the Sabbath.",
             "current": false
           },
           {
-            "date": "Sat \u2014 Sabbath",
+            "date": "Sat — Sabbath",
             "name": "The Silent Day",
             "text": "The women rest on the Sabbath, spices prepared. The tomb is sealed.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Empty Tomb; Emmaus; Appearances",
             "text": "Women find the stone rolled away; angels announce the resurrection; Jesus appears on the road to Emmaus and to the assembled disciples.",
             "current": true
@@ -213,24 +213,24 @@
           "refs": [
             {
               "ref": "Num 6:24-26",
-              "note": "\"The Lord bless you and keep you... the Lord turn his face toward you and give you peace\" \u2014 the Aaronic blessing whose posture Jesus adopts at the Ascension: hands lifted in blessing as he is taken up."
+              "note": "\"The Lord bless you and keep you... the Lord turn his face toward you and give you peace\" — the Aaronic blessing whose posture Jesus adopts at the Ascension: hands lifted in blessing as he is taken up."
             },
             {
               "ref": "Acts 1:9-11",
-              "note": "Luke's own expansion of the Ascension in his second volume \u2014 the cloud, the two men in white, the promise of return."
+              "note": "Luke's own expansion of the Ascension in his second volume — the cloud, the two men in white, the promise of return."
             },
             {
               "ref": "Ps 110:1",
-              "note": "\"Sit at my right hand\" \u2014 the Ascension is the fulfilment of Psalm 110:1, which Jesus had cited as a riddle in 20:42-44 and claimed for himself at his trial (22:69). The journey from the cross to the right hand of power is now complete."
+              "note": "\"Sit at my right hand\" — the Ascension is the fulfilment of Psalm 110:1, which Jesus had cited as a riddle in 20:42-44 and claimed for himself at his trial (22:69). The journey from the cross to the right hand of power is now complete."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:39",
-              "note": "\"It is I myself! Touch me and see; a ghost does not have flesh and bones, as you see I have.\" \u2014 the resurrection is physical. Not a spiritual vision, not a subjective experience, not a metaphor for the disciples' continued community or inspiration \u2014 flesh and bones, capable of being touched, visible to multiple witnesses simultaneously. Luke's anti-docetic emphasis here is consistent with 1 John 4:2 and the early church's insistence on bodily resurrection against Gnostic spiritualisation."
+              "note": "\"It is I myself! Touch me and see; a ghost does not have flesh and bones, as you see I have.\" — the resurrection is physical. Not a spiritual vision, not a subjective experience, not a metaphor for the disciples' continued community or inspiration — flesh and bones, capable of being touched, visible to multiple witnesses simultaneously. Luke's anti-docetic emphasis here is consistent with 1 John 4:2 and the early church's insistence on bodily resurrection against Gnostic spiritualisation."
             },
             {
               "ref": "24:44-47",
@@ -238,59 +238,59 @@
             },
             {
               "ref": "24:47",
-              "note": "\"Repentance for the forgiveness of sins will be preached in his name to all nations, beginning at Jerusalem\" \u2014 the resurrection is not the conclusion of Jesus's story but its launch-pad. The death and resurrection that the disciples had hoped would \"redeem Israel\" now turns out to be the means of redeeming all nations. The mission that begins in Jerusalem will reach Rome and beyond \u2014 the theme of Acts."
+              "note": "\"Repentance for the forgiveness of sins will be preached in his name to all nations, beginning at Jerusalem\" — the resurrection is not the conclusion of Jesus's story but its launch-pad. The death and resurrection that the disciples had hoped would \"redeem Israel\" now turns out to be the means of redeeming all nations. The mission that begins in Jerusalem will reach Rome and beyond — the theme of Acts."
             },
             {
               "ref": "24:51-53",
-              "note": "\"He left them and was taken up into heaven. Then they worshiped him and returned to Jerusalem with great joy.\" The disciples who scattered at the arrest, who hid behind locked doors, who dismissed the women's testimony as nonsense \u2014 these same disciples now worship the risen, ascended Jesus and return to Jerusalem with great joy. The resurrection has not merely consoled them; it has transformed them."
+              "note": "\"He left them and was taken up into heaven. Then they worshiped him and returned to Jerusalem with great joy.\" The disciples who scattered at the arrest, who hid behind locked doors, who dismissed the women's testimony as nonsense — these same disciples now worship the risen, ascended Jesus and return to Jerusalem with great joy. The resurrection has not merely consoled them; it has transformed them."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:44-45",
-              "note": "Calvin insists that the opening of minds (24:45) is the subjective correlate of the objective resurrection. The same event that is externally attested by the empty tomb and the appearances requires an internal illumination before it can be truly received. This illumination is the work of the Holy Spirit \u2014 the \"promise of the Father\" (24:49) for which the disciples are told to wait. Easter and Pentecost belong together."
+              "note": "Calvin insists that the opening of minds (24:45) is the subjective correlate of the objective resurrection. The same event that is externally attested by the empty tomb and the appearances requires an internal illumination before it can be truly received. This illumination is the work of the Holy Spirit — the \"promise of the Father\" (24:49) for which the disciples are told to wait. Easter and Pentecost belong together."
             },
             {
               "ref": "24:50-53",
-              "note": "The Ascension and the disciples' joy: Calvin notes that the disciples' joy at the departure of Jesus is paradoxical \u2014 one would expect grief at his leaving, as they grieved at the prospect of his departure in John 14. But the Ascension produces joy because it is not a removal but an enthronement. The one who was rejected and crucified is now seated at the right hand of power, from which position he rules, intercedes, and will return."
+              "note": "The Ascension and the disciples' joy: Calvin notes that the disciples' joy at the departure of Jesus is paradoxical — one would expect grief at his leaving, as they grieved at the prospect of his departure in John 14. But the Ascension produces joy because it is not a removal but an enthronement. The one who was rejected and crucified is now seated at the right hand of power, from which position he rules, intercedes, and will return."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "24:51",
-              "note": "\"Was taken up into heaven\" \u2014 some manuscripts (p75, Sinaiticus, Alexandrinus) include this phrase; others (Codex Bezae, some Latin versions) omit it, reading simply \"he left them.\" NA28 includes it. The phrase is almost certainly original to Luke; the omission may reflect early harmonisation with accounts that did not narrate the Ascension in the resurrection chapter."
+              "note": "\"Was taken up into heaven\" — some manuscripts (p75, Sinaiticus, Alexandrinus) include this phrase; others (Codex Bezae, some Latin versions) omit it, reading simply \"he left them.\" NA28 includes it. The phrase is almost certainly original to Luke; the omission may reflect early harmonisation with accounts that did not narrate the Ascension in the resurrection chapter."
             },
             {
               "ref": "24:47",
-              "note": "\"Beginning at Jerusalem\" \u2014 Acts 1:8 expands this: \"you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\" The geographical progression of Acts is already encoded in Luke 24:47. The Gospel that followed Jesus from Galilee to Jerusalem now sends the disciples from Jerusalem to the world."
+              "note": "\"Beginning at Jerusalem\" — Acts 1:8 expands this: \"you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\" The geographical progression of Acts is already encoded in Luke 24:47. The Gospel that followed Jesus from Galilee to Jerusalem now sends the disciples from Jerusalem to the world."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "24:39",
-              "note": "Sarx kai ostea \u2014 \"flesh and bones.\" Not merely sarx (flesh) but the compound \u2014 the full physicality of bone-and-muscle embodiment. Robertson notes that John's Gospel (20:20, 27) emphasises the wounds in hands and side; Luke emphasises the physical substance of the body."
+              "note": "Sarx kai ostea — \"flesh and bones.\" Not merely sarx (flesh) but the compound — the full physicality of bone-and-muscle embodiment. Robertson notes that John's Gospel (20:20, 27) emphasises the wounds in hands and side; Luke emphasises the physical substance of the body."
             },
             {
               "ref": "24:51",
-              "note": "Anephereto eis ton ouranon \u2014 \"was carried up into heaven.\" The compound verb (ana + pher\u014d) and the prepositional phrase specify both the direction and the destination. The passive suggests divine action \u2014 Christ is taken up by the Father's power into the Father's presence."
+              "note": "Anephereto eis ton ouranon — \"was carried up into heaven.\" The compound verb (ana + pherō) and the prepositional phrase specify both the direction and the destination. The passive suggests divine action — Christ is taken up by the Father's power into the Father's presence."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "24:39",
-              "note": "Gregory the Great: \"He showed them his hands and feet \u2014 the same marks that he had received in our redemption. He kept the scars of his wounds not from necessity but from glory. For those wounds of our healing he showed to his disciples as trophies of his victory over death.\""
+              "note": "Gregory the Great: \"He showed them his hands and feet — the same marks that he had received in our redemption. He kept the scars of his wounds not from necessity but from glory. For those wounds of our healing he showed to his disciples as trophies of his victory over death.\""
             },
             {
               "ref": "24:45",
@@ -299,22 +299,22 @@
           ]
         },
         "hist": {
-          "context": "Physical Resurrection Evidence\nJesus's proof of bodily resurrection to the frightened disciples in Luke 24:36-43 is the most explicit anti-docetic material in the Gospels. Three types of evidence are offered: (1) visual \u2014 \"look at my hands and feet\"; (2) tactile \u2014 \"touch me and see\"; (3) eating broiled fish in their presence. A ghost cannot eat fish. Luke's Jesus provides three sensory witnesses to his physical resurrection before opening the Scriptures.\n\nThe Ascension as Narrative Climax\nLuke is the only Gospel to narrate the Ascension (24:50-53; expanded in Acts 1:9-11). The Ascension is simultaneously the conclusion of the Gospel and the beginning of the church's mission. Jesus departs with hands raised in blessing \u2014 the posture of the Aaronic blessing (Num 6:24-26) \u2014 and the disciples worship, return to Jerusalem with great joy, and remain continually in the Temple praising God. The Gospel that began in the Temple (Zechariah's vision, 1:5-23) ends in the Temple."
+          "context": "Physical Resurrection Evidence\nJesus's proof of bodily resurrection to the frightened disciples in Luke 24:36-43 is the most explicit anti-docetic material in the Gospels. Three types of evidence are offered: (1) visual — \"look at my hands and feet\"; (2) tactile — \"touch me and see\"; (3) eating broiled fish in their presence. A ghost cannot eat fish. Luke's Jesus provides three sensory witnesses to his physical resurrection before opening the Scriptures.\n\nThe Ascension as Narrative Climax\nLuke is the only Gospel to narrate the Ascension (24:50-53; expanded in Acts 1:9-11). The Ascension is simultaneously the conclusion of the Gospel and the beginning of the church's mission. Jesus departs with hands raised in blessing — the posture of the Aaronic blessing (Num 6:24-26) — and the disciples worship, return to Jerusalem with great joy, and remain continually in the Temple praising God. The Gospel that began in the Temple (Zechariah's vision, 1:5-23) ends in the Temple."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 36\u201153 \u2014 Jesus Appears; The Great Commission; The Ascension",
+      "header": "Verses 36‑53 — Jesus Appears; The Great Commission; The Ascension",
       "verse_start": 36,
       "verse_end": 53,
       "panels": {
         "heb": [
           {
-            "word": "apokalypt\u014d / dianoig\u014d",
+            "word": "apokalyptō / dianoigō",
             "transliteration": "a-po-ka-LYP-to / di-a-NOI-go",
             "gloss": "revealed / opened",
-            "paragraph": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (di\u0113noichth\u0113san, v.31) and \"he opened their minds\" (di\u0113noixen, v.45). The resurrection does not merely remove an obstacle to sight \u2014 it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
+            "paragraph": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (diēnoichthēsan, v.31) and \"he opened their minds\" (diēnoixen, v.45). The resurrection does not merely remove an obstacle to sight — it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
           },
           {
             "word": "dei",
@@ -326,25 +326,25 @@
         "places": [
           {
             "name": "Emmaus",
-            "coords": "31.8347\u00b0 N, 35.1078\u00b0 E",
+            "coords": "31.8347° N, 35.1078° E",
             "text": "The exact location of Emmaus is disputed; the strongest candidate for the 60-stadia tradition is Moza (Qoloniyya), about 4 miles (60 stadia) west-northwest of Jerusalem. The road from Jerusalem to Emmaus passed through the Judean foothills, a beautiful route for a conversation that changed the history of Christian interpretation."
           }
         ],
         "tl": [
           {
-            "date": "Fri \u2014 Good Friday",
+            "date": "Fri — Good Friday",
             "name": "Crucifixion & Burial",
             "text": "Jesus crucified at Golgotha; dies at 3pm; buried in Joseph's tomb before the Sabbath.",
             "current": false
           },
           {
-            "date": "Sat \u2014 Sabbath",
+            "date": "Sat — Sabbath",
             "name": "The Silent Day",
             "text": "The women rest on the Sabbath, spices prepared. The tomb is sealed.",
             "current": false
           },
           {
-            "date": "Sun \u2014 Easter",
+            "date": "Sun — Easter",
             "name": "Empty Tomb; Emmaus; Appearances",
             "text": "Women find the stone rolled away; angels announce the resurrection; Jesus appears on the road to Emmaus and to the assembled disciples.",
             "current": true
@@ -354,11 +354,11 @@
           "refs": [
             {
               "ref": "Ps 16:10",
-              "note": "\"You will not abandon me to the realm of the dead, nor will you let your faithful one see decay\" \u2014 the resurrection psalm Peter cites in Acts 2:27, which Jesus's resurrection fulfils."
+              "note": "\"You will not abandon me to the realm of the dead, nor will you let your faithful one see decay\" — the resurrection psalm Peter cites in Acts 2:27, which Jesus's resurrection fulfils."
             },
             {
               "ref": "Gen 18:1-8",
-              "note": "Abraham's hospitality to the three visitors \u2014 the OT prototype of table hospitality that reveals the divine guest, which the Emmaus meal echoes."
+              "note": "Abraham's hospitality to the three visitors — the OT prototype of table hospitality that reveals the divine guest, which the Emmaus meal echoes."
             },
             {
               "ref": "1 Cor 15:3-8",
@@ -367,80 +367,27 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:5",
-              "note": "\"Why do you look for the living among the dead?\" \u2014 the angels' question is the chapter's hermeneutical key. The tomb is the wrong place to look for the risen Christ. The disciples' confusion throughout Luke 24 stems from looking in wrong places: in the tomb (where he is not), in the category of \"failed prophet\" (24:19-21), in the class of ghost or spirit (24:37). Jesus himself re-educates them through Scripture and through meals."
-            },
-            {
-              "ref": "24:21",
-              "note": "\"We had hoped that he was the one who was going to redeem Israel\" \u2014 the most poignant confession of dashed hope in the Gospels. The disciples had expected a political messiah who would liberate Israel from Rome. The crucifixion had destroyed that hope. Their reconstruction of what happened \u2014 \"it is the third day since all this took place\" \u2014 shows they know the resurrection tradition but cannot connect it to their experience. The hope was correct; the category of fulfilment was wrong."
-            },
-            {
-              "ref": "24:30-31",
-              "note": "\"He took bread, gave thanks, broke it and began to give it to them. Then their eyes were opened and they recognized him, and he disappeared from their sight.\" The recognition comes at the moment of eucharistic action \u2014 not during the Scripture exposition, not during conversation, but in the meal. Luke connects the risen Christ to the broken bread in a way that has shaped Christian eucharistic theology ever since: the Table is where he is known."
-            },
-            {
-              "ref": "24:32",
-              "note": "\"Were not our hearts burning within us while he talked with us on the road and opened the Scriptures to us?\" \u2014 the retrospective confirmation that the Scripture exposition was itself a resurrection experience. The burning heart is the mark of divine encounter in Scripture, even when the one speaking is not yet recognised. Christian preaching participates in this same dynamic."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:25-27",
-              "note": "Calvin emphasises that Jesus rebukes their slowness to believe \"all that the prophets have spoken\" \u2014 not some of it, not the easy parts, but all of it. The passion was predicted; they had refused to hear it. The resurrection now forces the full reading of all the prophets, including the parts about suffering and rejection. The Scripture that they thought contradicted the messianic expectation was actually its clearest prediction."
-            },
-            {
-              "ref": "24:30-31",
-              "note": "Calvin connects the breaking of bread to both the Last Supper and to the ordinary meal of hospitality, deliberately avoiding an exclusively sacramental reading. The recognition of Christ at the table is a pattern for all meals that are received in faith and gratitude \u2014 the risen Christ is present wherever bread is broken with thankfulness and where Scripture has been opened."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:13",
-              "note": "\"About seven miles from Jerusalem\" \u2014 literally sixty stadia (about 7 miles or 11 km). The location of Emmaus is disputed: candidates include Moza (4 miles), Nicopolis/Emmaus Nicopolis (20 miles), and Qaloniyya (4 miles). The 60-stadia measurement (present in the majority of manuscripts) fits Moza or Qaloniyya; some MSS read 160 stadia, matching Nicopolis."
-            },
-            {
-              "ref": "24:34",
-              "note": "\"The Lord has risen and has appeared to Simon\" \u2014 this appearance to Peter alone is mentioned but not narrated in Luke. Paul lists it first among the resurrection appearances (1 Cor 15:5 \u2014 \"he appeared to Cephas\"). Its mention in 24:34 suggests Luke's readers were familiar with the tradition even without a full account."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "24:11",
-              "note": "L\u0113ros \u2014 \"nonsense, foolishness, idle tale.\" A strong word implying contempt or dismissal. The medical vocabulary of Luke-Acts uses l\u0113ros for hallucination or delirious speech. The disciples' initial response to the resurrection report is dismissal, not merely scepticism."
-            },
-            {
-              "ref": "24:34",
-              "note": "\u014cphth\u0113 Sim\u014dni \u2014 \"appeared to Simon.\" The aorist passive of hora\u014d \u2014 \"was seen by\" or \"appeared to.\" The same passive is used throughout Paul's list in 1 Cor 15:5. The passive form suggests that the appearances are initiated by Christ, not by the disciples' seeing."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "24:27",
-              "note": "Gregory the Great: \"Beginning with Moses and all the Prophets, he explained to them what was said in all the Scriptures concerning himself. What a school was the road to Emmaus! The Master himself was the teacher; the subject was himself; the method was exposition of his own scriptures. And even then, they did not recognise him until he broke the bread.\""
-            },
-            {
-              "ref": "24:32",
-              "note": "Augustine: \"Did not our heart burn within us? This burning is the sign of the Holy Spirit's work in the reading of Scripture. Where the Scriptures are opened and the living Christ speaks through them, the heart burns. This is the mark of true preaching: not eloquence, but the fire that the word carries from the one who is the Word.\""
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The Emmaus Road\nThe road to Emmaus (24:13-35) is the longest resurrection appearance narrative in the Gospels and unique to Luke. The two disciples embody the confusion and grief of the broader disciple community: they had hoped Jesus was the redeemer of Israel, and now they are leaving Jerusalem. Jesus joins them as an unknown companion, walks with them through their misunderstanding, interprets the Scriptures, and reveals himself in the breaking of bread \u2014 then vanishes. The recognition comes through a meal, not through seeing.\n\nScripture Interpretation in Luke 24\nThree times in Luke 24, Jesus opens Scripture: to the two disciples on the Emmaus road (24:27), to the assembled disciples in Jerusalem (24:44-47), and implicitly through the angels' \"remember what he told you\" (24:6-7). The entire chapter is a hermeneutical event: the resurrection is the key that unlocks all of Moses, the Prophets, and the Psalms. The disciples' previous inability to understand the passion predictions is resolved not by more explanation but by the event itself."
+          "context": "The Emmaus Road\nThe road to Emmaus (24:13-35) is the longest resurrection appearance narrative in the Gospels and unique to Luke. The two disciples embody the confusion and grief of the broader disciple community: they had hoped Jesus was the redeemer of Israel, and now they are leaving Jerusalem. Jesus joins them as an unknown companion, walks with them through their misunderstanding, interprets the Scriptures, and reveals himself in the breaking of bread — then vanishes. The recognition comes through a meal, not through seeing.\n\nScripture Interpretation in Luke 24\nThree times in Luke 24, Jesus opens Scripture: to the two disciples on the Emmaus road (24:27), to the assembled disciples in Jerusalem (24:44-47), and implicitly through the angels' \"remember what he told you\" (24:6-7). The entire chapter is a hermeneutical event: the resurrection is the key that unlocks all of Moses, the Prophets, and the Psalms. The disciples' previous inability to understand the passion predictions is resolved not by more explanation but by the event itself."
         }
       }
     }
@@ -450,7 +397,7 @@
       {
         "name": "The Women",
         "role": "First witnesses of the resurrection",
-        "text": "Mary Magdalene, Joanna, Mary the mother of James (24:10). Luke names them after the fact \u2014 their testimony was dismissed as nonsense (24:11) and yet they were correct. The resurrection's first witnesses are women whose testimony was legally inadmissible in first-century Jewish courts."
+        "text": "Mary Magdalene, Joanna, Mary the mother of James (24:10). Luke names them after the fact — their testimony was dismissed as nonsense (24:11) and yet they were correct. The resurrection's first witnesses are women whose testimony was legally inadmissible in first-century Jewish courts."
       },
       {
         "name": "The Two Emmaus Disciples",
@@ -460,10 +407,10 @@
       {
         "name": "Peter",
         "role": "Restored witness",
-        "text": "He ran to the tomb first (24:12) and received the first individual resurrection appearance (24:34) \u2014 restoring him to a central role after his triple denial. The appearance to Simon is mentioned but not narrated: a gap that John 21 fills."
+        "text": "He ran to the tomb first (24:12) and received the first individual resurrection appearance (24:34) — restoring him to a central role after his triple denial. The appearance to Simon is mentioned but not narrated: a gap that John 21 fills."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">l\u0113ros (24:11)</td><td>NIV: \"nonsense\"; KJV: \"idle tales\"; ESV: \"idle tale\"; NRSV: \"idle tale\". NIV's \"nonsense\" is the strongest rendering and closest to the Greek's force.</td></tr><tr><td class=\"t-label\">\u014dphth\u0113 (24:34)</td><td>NIV: \"appeared\"; KJV: \"appeared\"; ESV: \"appeared\"; NRSV: \"appeared\". Universal agreement. The passive construction is significant \u2014 Christ appears; the disciples do not produce the vision.</td></tr><tr><td class=\"t-label\">aparch\u0113n (24:49)</td><td>NIV: \"what my Father has promised\"; KJV: \"the promise of my Father\"; ESV: \"the promise of my Father\"; NRSV: \"what my Father promised\". All major versions agree; the referent (the Holy Spirit) is made explicit in Acts 1:4-5.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">lēros (24:11)</td><td>NIV: \"nonsense\"; KJV: \"idle tales\"; ESV: \"idle tale\"; NRSV: \"idle tale\". NIV's \"nonsense\" is the strongest rendering and closest to the Greek's force.</td></tr><tr><td class=\"t-label\">ōphthē (24:34)</td><td>NIV: \"appeared\"; KJV: \"appeared\"; ESV: \"appeared\"; NRSV: \"appeared\". Universal agreement. The passive construction is significant — Christ appears; the disciples do not produce the vision.</td></tr><tr><td class=\"t-label\">aparchēn (24:49)</td><td>NIV: \"what my Father has promised\"; KJV: \"the promise of my Father\"; ESV: \"the promise of my Father\"; NRSV: \"what my Father promised\". All major versions agree; the referent (the Holy Spirit) is made explicit in Acts 1:4-5.</td></tr>",
     "src": [
       {
         "title": "Psalm 16:10",
@@ -483,19 +430,19 @@
       },
       {
         "who": "The Ascension in Christian Theology and Art",
-        "text": "The Ascension \u2014 Luke's unique contribution to the resurrection narrative \u2014 has generated sustained theological reflection on Christ's heavenly session (Heb 1:3; 4:14-16), his intercession (Rom 8:34), and his Lordship over all creation (Eph 1:20-23). In art, the Ascension became one of the standard scenes of the Christian iconographic programme, particularly in Byzantine and medieval Western traditions. The departing Christ with raised, blessing hands has entered permanent visual vocabulary."
+        "text": "The Ascension — Luke's unique contribution to the resurrection narrative — has generated sustained theological reflection on Christ's heavenly session (Heb 1:3; 4:14-16), his intercession (Rom 8:34), and his Lordship over all creation (Eph 1:20-23). In art, the Ascension became one of the standard scenes of the Christian iconographic programme, particularly in Byzantine and medieval Western traditions. The departing Christ with raised, blessing hands has entered permanent visual vocabulary."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Inclusio: Temple to Temple \u2014 chs.1-2 / 24:52-53",
+          "label": "Inclusio: Temple to Temple — chs.1-2 / 24:52-53",
           "text": "Luke's Gospel begins in the Temple (Zechariah's vision, 1:5-23) and ends in the Temple (disciples praising God continually, 24:52-53). The Temple frames the entire narrative: the place of God's presence is the beginning and end of the story. Between these brackets, Jesus has replaced the Temple as the locus of divine presence.",
           "is_key": false
         },
         {
-          "label": "Opened/Closed Eyes \u2014 vv.16, 31, 45",
-          "text": "Eyes kept from recognising (v.16) \u2192 eyes opened (v.31) \u2192 minds opened (v.45). The chapter's structure is a progressive opening: first physical recognition at the table, then full scriptural understanding. Both openings are divine acts, not human achievements.",
+          "label": "Opened/Closed Eyes — vv.16, 31, 45",
+          "text": "Eyes kept from recognising (v.16) → eyes opened (v.31) → minds opened (v.45). The chapter's structure is a progressive opening: first physical recognition at the table, then full scriptural understanding. Both openings are divine acts, not human achievements.",
           "is_key": false
         }
       ],
@@ -503,10 +450,10 @@
     },
     "hebtext": [
       {
-        "word": "apokalypt\u014d / dianoig\u014d",
+        "word": "apokalyptō / dianoigō",
         "tlit": "a-po-ka-LYP-to / di-a-NOI-go",
         "gloss": "revealed / opened",
-        "note": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (di\u0113noichth\u0113san, v.31) and \"he opened their minds\" (di\u0113noixen, v.45). The resurrection does not merely remove an obstacle to sight \u2014 it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
+        "note": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (diēnoichthēsan, v.31) and \"he opened their minds\" (diēnoixen, v.45). The resurrection does not merely remove an obstacle to sight — it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
       },
       {
         "word": "dei",
@@ -518,19 +465,19 @@
         "word": "martyres",
         "tlit": "mar-TY-res",
         "gloss": "witnesses",
-        "note": "The final commission (v.48) uses the Greek word from which \"martyr\" derives \u2014 originally \"witness\" in a legal sense. The disciples are appointed as legal witnesses to the resurrection: they have seen, touched, and eaten with the risen Jesus. Their testimony is not opinion or interpretation; it is eyewitness evidence. The Acts narrative will show what witness costs in practice."
+        "note": "The final commission (v.48) uses the Greek word from which \"martyr\" derives — originally \"witness\" in a legal sense. The disciples are appointed as legal witnesses to the resurrection: they have seen, touched, and eaten with the risen Jesus. Their testimony is not opinion or interpretation; it is eyewitness evidence. The Acts narrative will show what witness costs in practice."
       },
       {
-        "word": "eparch\u0113",
+        "word": "eparchē",
         "tlit": "ep-ar-CHE",
         "gloss": "promise / what was promised",
-        "note": "The \"promise\" of the Father (v.49) that the disciples are to wait for is the Holy Spirit \u2014 explicitly identified in Acts 1:4-5 as the content of this promise. Luke ends his Gospel pointing toward the Spirit; Acts begins with the Spirit's arrival (Pentecost). The ascension is the pivot between the two volumes."
+        "note": "The \"promise\" of the Father (v.49) that the disciples are to wait for is the Holy Spirit — explicitly identified in Acts 1:4-5 as the content of this promise. Luke ends his Gospel pointing toward the Spirit; Acts begins with the Spirit's arrival (Pentecost). The ascension is the pivot between the two volumes."
       },
       {
-        "word": "apokalypt\u014d / dianoig\u014d",
+        "word": "apokalyptō / dianoigō",
         "tlit": "a-po-ka-LYP-to / di-a-NOI-go",
         "gloss": "revealed / opened",
-        "note": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (di\u0113noichth\u0113san, v.31) and \"he opened their minds\" (di\u0113noixen, v.45). The resurrection does not merely remove an obstacle to sight \u2014 it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
+        "note": "Two verbs of opening that frame the chapter: \"their eyes were opened\" (diēnoichthēsan, v.31) and \"he opened their minds\" (diēnoixen, v.45). The resurrection does not merely remove an obstacle to sight — it actively opens what was closed. The same verb is used in Acts 16:14 for Lydia's heart opened by the Lord. Understanding Scripture and recognising the risen Christ require a divine opening."
       },
       {
         "word": "dei",
@@ -560,7 +507,7 @@
           {
             "name": "Yes, eucharistic allusion is deliberate",
             "proponents": "Fitzmyer, Green, most Catholic and many Protestant scholars",
-            "argument": "The sequence \u2014 took bread, gave thanks, broke it, gave it (24:30) \u2014 exactly parallels the Last Supper (22:19) and the feeding of the five thousand (9:16). Luke uses this four-verb pattern consistently for the Eucharist. The recognition at the breaking of bread is a model for Eucharistic presence of the risen Christ."
+            "argument": "The sequence — took bread, gave thanks, broke it, gave it (24:30) — exactly parallels the Last Supper (22:19) and the feeding of the five thousand (9:16). Luke uses this four-verb pattern consistently for the Eucharist. The recognition at the breaking of bread is a model for Eucharistic presence of the risen Christ."
           },
           {
             "name": "Ordinary hospitality, not eucharistic",
@@ -597,7 +544,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 24 is the Gospel's resolution in every sense: narrative, theological, and emotional. The empty tomb (the absence that means presence), the road to Emmaus (the presence that is not yet recognised), the meal (the recognition in breaking bread), the opened minds (understanding Scripture), and the Ascension (departure that is enthronement) \u2014 each movement deepens the chapter's central claim: the one who was crucified is alive, present, and Lord. The disciples who ended chapter 23 preparing spices for a dead body end chapter 24 in the Temple with great joy, praising God. The Gospel ends where it began \u2014 in the Temple, in praise \u2014 but everything has changed."
+      "note": "Luke 24 is the Gospel's resolution in every sense: narrative, theological, and emotional. The empty tomb (the absence that means presence), the road to Emmaus (the presence that is not yet recognised), the meal (the recognition in breaking bread), the opened minds (understanding Scripture), and the Ascension (departure that is enthronement) — each movement deepens the chapter's central claim: the one who was crucified is alive, present, and Lord. The disciples who ended chapter 23 preparing spices for a dead body end chapter 24 in the Temple with great joy, praising God. The Gospel ends where it began — in the Temple, in praise — but everything has changed."
     }
   },
   "vhl_groups": [

--- a/content/luke/3.json
+++ b/content/luke/3.json
@@ -7,13 +7,13 @@
   "subtitle": "John the Baptist; Baptism of Jesus; Genealogy",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201318 \u2014 John the Baptist\u2019s Ministry; The Baptism of Jesus",
+      "header": "Verses 1–18 — John the Baptist’s Ministry; The Baptism of Jesus",
       "verse_start": 1,
       "verse_end": 18,
       "panels": {
@@ -22,136 +22,136 @@
             "word": "metanoia",
             "transliteration": "me-TAN-oi-a",
             "gloss": "repentance/change of mind and direction",
-            "paragraph": "A baptism of repentance for the forgiveness of sins \u2014 metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John\u2019s baptism is an enacted declaration of this turn \u2014 a public covenant of allegiance to the coming kingdom. The pairing with \u201cforgiveness of sins\u201d (aphesin hamarti\u014dn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
+            "paragraph": "A baptism of repentance for the forgiveness of sins — metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John’s baptism is an enacted declaration of this turn — a public covenant of allegiance to the coming kingdom. The pairing with “forgiveness of sins” (aphesin hamartiōn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 40:3-5",
-              "note": "A voice of one calling in the wilderness \u2014 Luke quotes more of Isaiah 40 than either Matthew or Mark, extending to v.5: \u201call people will see God\u2019s salvation.\u201d The universal scope is Luke\u2019s editorial addition."
+              "note": "A voice of one calling in the wilderness — Luke quotes more of Isaiah 40 than either Matthew or Mark, extending to v.5: “all people will see God’s salvation.” The universal scope is Luke’s editorial addition."
             },
             {
               "ref": "Mal 3:1-2",
-              "note": "Who can endure the day of his coming? For he will be like a refiner\u2019s fire \u2014 the winnowing and burning imagery of 3:17."
+              "note": "Who can endure the day of his coming? For he will be like a refiner’s fire — the winnowing and burning imagery of 3:17."
             },
             {
               "ref": "Amos 5:18-20",
-              "note": "The Day of the LORD will be darkness, not light \u2014 the OT prophetic tradition behind John\u2019s wrath-warning."
+              "note": "The Day of the LORD will be darkness, not light — the OT prophetic tradition behind John’s wrath-warning."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:8",
-              "note": "Do not say, \u201cWe have Abraham as our father\u201d \u2014 the most radical element of John\u2019s message. He dismantles the foundation of Jewish national confidence: ethnic descent from Abraham does not guarantee covenant standing. God can raise up children for Abraham from the stones. Covenant membership is redefined by repentance and fruit, not by birth."
+              "note": "Do not say, “We have Abraham as our father” — the most radical element of John’s message. He dismantles the foundation of Jewish national confidence: ethnic descent from Abraham does not guarantee covenant standing. God can raise up children for Abraham from the stones. Covenant membership is redefined by repentance and fruit, not by birth."
             },
             {
               "ref": "3:16-17",
-              "note": "He will baptize you with the Holy Spirit and fire \u2014 the dual baptism announcement. Fire in the context of the threshing floor (3:17) is the fire of judgment. The same Spirit-and-fire arrival will separate the wheat from the chaff. Pentecost is one face of this coming; judgment is the other."
+              "note": "He will baptize you with the Holy Spirit and fire — the dual baptism announcement. Fire in the context of the threshing floor (3:17) is the fire of judgment. The same Spirit-and-fire arrival will separate the wheat from the chaff. Pentecost is one face of this coming; judgment is the other."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:3",
-              "note": "Preaching a baptism of repentance for the forgiveness of sins \u2014 Calvin: John\u2019s baptism is the same in substance as Christian baptism \u2014 both are signs of repentance and forgiveness. The difference is in what they signify: John\u2019s looks forward to the coming Messiah; Christian baptism looks back to the accomplished cross."
+              "note": "Preaching a baptism of repentance for the forgiveness of sins — Calvin: John’s baptism is the same in substance as Christian baptism — both are signs of repentance and forgiveness. The difference is in what they signify: John’s looks forward to the coming Messiah; Christian baptism looks back to the accomplished cross."
             },
             {
               "ref": "3:16",
-              "note": "He will baptize you with the Holy Spirit and fire \u2014 Calvin: the Spirit and fire are not two baptisms but one. The Spirit purges and refines as fire does. The Pentecostal tongues of fire are the enacted sign of this promised baptism: purification and empowerment in a single event."
+              "note": "He will baptize you with the Holy Spirit and fire — Calvin: the Spirit and fire are not two baptisms but one. The Spirit purges and refines as fire does. The Pentecostal tongues of fire are the enacted sign of this promised baptism: purification and empowerment in a single event."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:1",
-              "note": "Pontius Pilate was governor of Judea \u2014 Luke introduces Pilate here, fourteen chapters before his role in the Passion. The same imperial machinery that cannot understand Jesus\u2019s kingdom has been named at the beginning of his public life."
+              "note": "Pontius Pilate was governor of Judea — Luke introduces Pilate here, fourteen chapters before his role in the Passion. The same imperial machinery that cannot understand Jesus’s kingdom has been named at the beginning of his public life."
             },
             {
               "ref": "3:15",
-              "note": "The people were wondering if John might be the Messiah \u2014 Luke\u2019s explicit statement of this popular speculation is unique to his Gospel. John\u2019s response redefines his own role: he is not the Messiah but the one who announces and prepares for the one whose sandals he cannot untie."
+              "note": "The people were wondering if John might be the Messiah — Luke’s explicit statement of this popular speculation is unique to his Gospel. John’s response redefines his own role: he is not the Messiah but the one who announces and prepares for the one whose sandals he cannot untie."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "3:1",
-              "note": "In the fifteenth year of the reign of Tiberius Caesar \u2014 the most precisely anchored date in the NT. If calculated from Augustus\u2019s death (August AD 14), Tiberius\u2019s fifteenth year is AD 28-29. This is the only place in the Gospels where an absolute historical date is given for the beginning of the gospel events."
+              "note": "In the fifteenth year of the reign of Tiberius Caesar — the most precisely anchored date in the NT. If calculated from Augustus’s death (August AD 14), Tiberius’s fifteenth year is AD 28-29. This is the only place in the Gospels where an absolute historical date is given for the beginning of the gospel events."
             },
             {
               "ref": "3:9",
-              "note": "The ax is already at the root of the trees \u2014 the perfect tense: the ax has been laid and is currently there. John\u2019s eschatology is urgent and immediate. The tree-cutting is not a distant future event but an imminent one \u2014 the crisis is already at hand."
+              "note": "The ax is already at the root of the trees — the perfect tense: the ax has been laid and is currently there. John’s eschatology is urgent and immediate. The tree-cutting is not a distant future event but an imminent one — the crisis is already at hand."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "3:7",
-              "note": "Brood of vipers \u2014 Origen: John\u2019s rebuke is addressed to the crowds coming to be baptized \u2014 not to Pharisees, as in Matthew\u2019s parallel (Matt 3:7). Luke\u2019s John rebukes everyone, not just the religious leaders. The sharp edge of repentance is not reserved for obvious sinners."
+              "note": "Brood of vipers — Origen: John’s rebuke is addressed to the crowds coming to be baptized — not to Pharisees, as in Matthew’s parallel (Matt 3:7). Luke’s John rebukes everyone, not just the religious leaders. The sharp edge of repentance is not reserved for obvious sinners."
             },
             {
               "ref": "3:10-14",
-              "note": "What should we do? \u2014 Chrysostom: John\u2019s answers are not calls to asceticism or separation from the world but to radical integrity within ordinary vocations. Share your shirt. Don\u2019t extort. Be content. The kingdom\u2019s ethics are embedded in daily economic and social life."
+              "note": "What should we do? — Chrysostom: John’s answers are not calls to asceticism or separation from the world but to radical integrity within ordinary vocations. Share your shirt. Don’t extort. Be content. The kingdom’s ethics are embedded in daily economic and social life."
             }
           ]
         },
         "tl": [
           {
             "date": "c. 4000 BC (trad.)",
-            "name": "Adam \u2014 son of God",
-            "text": "Luke traces Jesus\u2019s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
+            "name": "Adam — son of God",
+            "text": "Luke traces Jesus’s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
             "current": false
           },
           {
             "date": "c. 2100 BC",
-            "name": "Abraham \u2014 the covenant promise",
+            "name": "Abraham — the covenant promise",
             "text": "",
             "current": false
           },
           {
             "date": "c. 1000 BC",
-            "name": "David \u2014 the Davidic throne",
+            "name": "David — the Davidic throne",
             "text": "",
             "current": false
           },
           {
             "date": "c. 586 BC",
-            "name": "Zerubbabel \u2014 the return from exile",
+            "name": "Zerubbabel — the return from exile",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 6",
-            "name": "Joseph \u2014 the legal father",
+            "name": "Joseph — the legal father",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 28",
             "name": "Jesus begins his ministry",
-            "text": "The baptism inaugurates Jesus\u2019s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
+            "text": "The baptism inaugurates Jesus’s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
             "current": true
           }
         ],
         "hist": {
-          "context": "Luke\u2019s dating of John\u2019s ministry (3:1-2) is the most precise historical synchronization in the Gospels: six Roman and Jewish officials are named to anchor the story within secular history. The word of God came to John in the wilderness \u2014 echoing the OT prophetic commissioning formula. John\u2019s ethical demands are distinctively Luke\u2019s: the crowd, tax collectors, and soldiers each ask \u201cwhat should we do?\u201d \u2014 a question Luke\u2019s Jesus will answer throughout the Gospel."
+          "context": "Luke’s dating of John’s ministry (3:1-2) is the most precise historical synchronization in the Gospels: six Roman and Jewish officials are named to anchor the story within secular history. The word of God came to John in the wilderness — echoing the OT prophetic commissioning formula. John’s ethical demands are distinctively Luke’s: the crowd, tax collectors, and soldiers each ask “what should we do?” — a question Luke’s Jesus will answer throughout the Gospel."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 19\u201322 \u2014 Herod Imprisons John; Jesus Baptised; The Voice from Heaven",
+      "header": "Verses 19–22 — Herod Imprisons John; Jesus Baptised; The Voice from Heaven",
       "verse_start": 19,
       "verse_end": 22,
       "panels": {
@@ -160,136 +160,136 @@
             "word": "huios tou Theou",
             "transliteration": "hwi-OS too the-OO",
             "gloss": "Son of God",
-            "paragraph": "The genealogy ends: the son of Adam, the son of God (3:38). Luke traces Jesus\u2019s lineage not just to Abraham (as Matthew does) but to Adam \u2014 and then to God. The endpoint is theological: Jesus is the Son of God, the second Adam (cf. Rom 5:12-19; 1 Cor 15:45). His solidarity is not merely with Israel but with all humanity from creation."
+            "paragraph": "The genealogy ends: the son of Adam, the son of God (3:38). Luke traces Jesus’s lineage not just to Abraham (as Matthew does) but to Adam — and then to God. The endpoint is theological: Jesus is the Son of God, the second Adam (cf. Rom 5:12-19; 1 Cor 15:45). His solidarity is not merely with Israel but with all humanity from creation."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ps 2:7",
-              "note": "You are my Son; today I have become your Father \u2014 the royal coronation psalm behind the voice at the baptism."
+              "note": "You are my Son; today I have become your Father — the royal coronation psalm behind the voice at the baptism."
             },
             {
               "ref": "Isa 42:1",
-              "note": "Here is my servant, whom I uphold, my chosen one in whom I delight \u2014 the Servant Song behind the \u201cwell pleased\u201d declaration."
+              "note": "Here is my servant, whom I uphold, my chosen one in whom I delight — the Servant Song behind the “well pleased” declaration."
             },
             {
               "ref": "Gen 5:1-32",
-              "note": "The genealogy from Adam \u2014 Luke\u2019s genealogy reverses Genesis\u2019s forward genealogical movement, retracing human lineage back to its origin in God."
+              "note": "The genealogy from Adam — Luke’s genealogy reverses Genesis’s forward genealogical movement, retracing human lineage back to its origin in God."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:21-22",
-              "note": "Jesus was baptized too \u2014 Luke\u2019s baptism account uniquely frames it while Jesus was praying. The divine disclosure (heaven opening, Spirit descending, voice speaking) happens in the context of prayer. Prayer is consistently the occasion of divine action in Luke: the Transfiguration, Gethsemane, Pentecost."
+              "note": "Jesus was baptized too — Luke’s baptism account uniquely frames it while Jesus was praying. The divine disclosure (heaven opening, Spirit descending, voice speaking) happens in the context of prayer. Prayer is consistently the occasion of divine action in Luke: the Transfiguration, Gethsemane, Pentecost."
             },
             {
               "ref": "3:38",
-              "note": "The son of Adam, the son of God \u2014 Luke\u2019s genealogy is a theological statement as much as a historical record. By tracing to Adam rather than stopping at Abraham, Luke positions Jesus as the savior of all humanity, not merely of Israel."
+              "note": "The son of Adam, the son of God — Luke’s genealogy is a theological statement as much as a historical record. By tracing to Adam rather than stopping at Abraham, Luke positions Jesus as the savior of all humanity, not merely of Israel."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "3:21",
-              "note": "While he was praying \u2014 Calvin: Luke\u2019s distinctive emphasis on Jesus at prayer before every major event \u2014 baptism, Transfiguration, Gethsemane, cross \u2014 teaches that the Incarnate Son\u2019s relationship with the Father is continuously maintained through prayer. This is not mere piety but the expression of his human nature\u2019s dependence."
+              "note": "While he was praying — Calvin: Luke’s distinctive emphasis on Jesus at prayer before every major event — baptism, Transfiguration, Gethsemane, cross — teaches that the Incarnate Son’s relationship with the Father is continuously maintained through prayer. This is not mere piety but the expression of his human nature’s dependence."
             },
             {
               "ref": "3:38",
-              "note": "The son of Adam, the son of God \u2014 Calvin: the genealogy\u2019s endpoint answers the question: who is the Redeemer? He must be both Son of God (to have divine power to redeem) and son of Adam (to represent humanity as its substitute). Luke\u2019s ending at both simultaneously is the theological answer to the soteriological requirement."
+              "note": "The son of Adam, the son of God — Calvin: the genealogy’s endpoint answers the question: who is the Redeemer? He must be both Son of God (to have divine power to redeem) and son of Adam (to represent humanity as its substitute). Luke’s ending at both simultaneously is the theological answer to the soteriological requirement."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "3:22",
-              "note": "With you I am well pleased (en soi eudok\u0113sa) \u2014 the aorist eudok\u0113sa points to a specific moment of divine choice: God\u2019s prior election of the Son for this mission is declared publicly at the baptism. The declaration is both ontological (you are my Son) and vocational (in whom I delight for this task)."
+              "note": "With you I am well pleased (en soi eudokēsa) — the aorist eudokēsa points to a specific moment of divine choice: God’s prior election of the Son for this mission is declared publicly at the baptism. The declaration is both ontological (you are my Son) and vocational (in whom I delight for this task)."
             },
             {
               "ref": "3:23-38",
-              "note": "Luke\u2019s genealogy differs from Matthew\u2019s at many points. Matthew runs from Abraham to Joseph through Solomon; Luke runs from Joseph backward through Nathan to Adam. The differences may reflect legal vs biological lineage, or two branches of the family. The discrepancies have generated extensive discussion since the early church; no solution has won universal acceptance."
+              "note": "Luke’s genealogy differs from Matthew’s at many points. Matthew runs from Abraham to Joseph through Solomon; Luke runs from Joseph backward through Nathan to Adam. The differences may reflect legal vs biological lineage, or two branches of the family. The discrepancies have generated extensive discussion since the early church; no solution has won universal acceptance."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "3:22",
-              "note": "The Holy Spirit descended in bodily form like a dove \u2014 Luke\u2019s s\u014dmatik\u014d eidei (bodily form) is unique. Matthew and Mark say \u201clike a dove\u201d \u2014 leaving whether this was visible uncertain. Luke insists on the visibility and physicality of the Spirit\u2019s descent."
+              "note": "The Holy Spirit descended in bodily form like a dove — Luke’s sōmatikō eidei (bodily form) is unique. Matthew and Mark say “like a dove” — leaving whether this was visible uncertain. Luke insists on the visibility and physicality of the Spirit’s descent."
             },
             {
               "ref": "3:23",
-              "note": "About thirty years old \u2014 the approximate age (h\u014dsei et\u014dn triakonta) echoes the age at which Levites began Temple service (Num 4:3) and at which Joseph began his public role (Gen 41:46). Thirty was the conventional age of public authority."
+              "note": "About thirty years old — the approximate age (hōsei etōn triakonta) echoes the age at which Levites began Temple service (Num 4:3) and at which Joseph began his public role (Gen 41:46). Thirty was the conventional age of public authority."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "3:21-22",
-              "note": "The baptism is Trinitarian \u2014 Hilary of Poitiers: the Father speaks, the Son is baptized, the Spirit descends. The Trinity is present at the inauguration of the Son\u2019s public ministry. The three persons are distinguished without being separated; they cooperate in a single divine act of installation and endorsement."
+              "note": "The baptism is Trinitarian — Hilary of Poitiers: the Father speaks, the Son is baptized, the Spirit descends. The Trinity is present at the inauguration of the Son’s public ministry. The three persons are distinguished without being separated; they cooperate in a single divine act of installation and endorsement."
             },
             {
               "ref": "3:38",
-              "note": "Son of Adam, son of God \u2014 Irenaeus: Luke\u2019s genealogy establishes the foundation for his recapitulation theology: Jesus sums up and restores all that Adam was and lost. By ending at God, Luke insists that the human nature Jesus takes on is created nature \u2014 belonging to God by origin and destined to return to him through redemption."
+              "note": "Son of Adam, son of God — Irenaeus: Luke’s genealogy establishes the foundation for his recapitulation theology: Jesus sums up and restores all that Adam was and lost. By ending at God, Luke insists that the human nature Jesus takes on is created nature — belonging to God by origin and destined to return to him through redemption."
             }
           ]
         },
         "tl": [
           {
             "date": "c. 4000 BC (trad.)",
-            "name": "Adam \u2014 son of God",
-            "text": "Luke traces Jesus\u2019s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
+            "name": "Adam — son of God",
+            "text": "Luke traces Jesus’s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
             "current": false
           },
           {
             "date": "c. 2100 BC",
-            "name": "Abraham \u2014 the covenant promise",
+            "name": "Abraham — the covenant promise",
             "text": "",
             "current": false
           },
           {
             "date": "c. 1000 BC",
-            "name": "David \u2014 the Davidic throne",
+            "name": "David — the Davidic throne",
             "text": "",
             "current": false
           },
           {
             "date": "c. 586 BC",
-            "name": "Zerubbabel \u2014 the return from exile",
+            "name": "Zerubbabel — the return from exile",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 6",
-            "name": "Joseph \u2014 the legal father",
+            "name": "Joseph — the legal father",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 28",
             "name": "Jesus begins his ministry",
-            "text": "The baptism inaugurates Jesus\u2019s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
+            "text": "The baptism inaugurates Jesus’s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
             "current": true
           }
         ],
         "hist": {
-          "context": "Luke\u2019s baptism account uniquely notes that the heaven opened while Jesus was praying \u2014 prayer is the context for divine disclosure throughout Luke. The genealogy follows the baptism, not (as in Matthew) the birth. Luke\u2019s genealogy runs backward from Jesus to Adam, rather than forward from Abraham to Jesus \u2014 a Gentile-audience choice that emphasizes Jesus\u2019s solidarity with all humanity rather than his Jewish particularity."
+          "context": "Luke’s baptism account uniquely notes that the heaven opened while Jesus was praying — prayer is the context for divine disclosure throughout Luke. The genealogy follows the baptism, not (as in Matthew) the birth. Luke’s genealogy runs backward from Jesus to Adam, rather than forward from Abraham to Jesus — a Gentile-audience choice that emphasizes Jesus’s solidarity with all humanity rather than his Jewish particularity."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201338 \u2014 The Genealogy of Jesus: Son of Adam, Son of God",
+      "header": "Verses 23–38 — The Genealogy of Jesus: Son of Adam, Son of God",
       "verse_start": 23,
       "verse_end": 38,
       "panels": {
@@ -298,130 +298,85 @@
             "word": "metanoia",
             "transliteration": "me-TAN-oi-a",
             "gloss": "repentance/change of mind and direction",
-            "paragraph": "A baptism of repentance for the forgiveness of sins \u2014 metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John\u2019s baptism is an enacted declaration of this turn \u2014 a public covenant of allegiance to the coming kingdom. The pairing with \u201cforgiveness of sins\u201d (aphesin hamarti\u014dn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
+            "paragraph": "A baptism of repentance for the forgiveness of sins — metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John’s baptism is an enacted declaration of this turn — a public covenant of allegiance to the coming kingdom. The pairing with “forgiveness of sins” (aphesin hamartiōn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 40:3-5",
-              "note": "A voice of one calling in the wilderness \u2014 Luke quotes more of Isaiah 40 than either Matthew or Mark, extending to v.5: \u201call people will see God\u2019s salvation.\u201d The universal scope is Luke\u2019s editorial addition."
+              "note": "A voice of one calling in the wilderness — Luke quotes more of Isaiah 40 than either Matthew or Mark, extending to v.5: “all people will see God’s salvation.” The universal scope is Luke’s editorial addition."
             },
             {
               "ref": "Mal 3:1-2",
-              "note": "Who can endure the day of his coming? For he will be like a refiner\u2019s fire \u2014 the winnowing and burning imagery of 3:17."
+              "note": "Who can endure the day of his coming? For he will be like a refiner’s fire — the winnowing and burning imagery of 3:17."
             },
             {
               "ref": "Amos 5:18-20",
-              "note": "The Day of the LORD will be darkness, not light \u2014 the OT prophetic tradition behind John\u2019s wrath-warning."
+              "note": "The Day of the LORD will be darkness, not light — the OT prophetic tradition behind John’s wrath-warning."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:8",
-              "note": "Do not say, \u201cWe have Abraham as our father\u201d \u2014 the most radical element of John\u2019s message. He dismantles the foundation of Jewish national confidence: ethnic descent from Abraham does not guarantee covenant standing. God can raise up children for Abraham from the stones. Covenant membership is redefined by repentance and fruit, not by birth."
-            },
-            {
-              "ref": "3:16-17",
-              "note": "He will baptize you with the Holy Spirit and fire \u2014 the dual baptism announcement. Fire in the context of the threshing floor (3:17) is the fire of judgment. The same Spirit-and-fire arrival will separate the wheat from the chaff. Pentecost is one face of this coming; judgment is the other."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:3",
-              "note": "Preaching a baptism of repentance for the forgiveness of sins \u2014 Calvin: John\u2019s baptism is the same in substance as Christian baptism \u2014 both are signs of repentance and forgiveness. The difference is in what they signify: John\u2019s looks forward to the coming Messiah; Christian baptism looks back to the accomplished cross."
-            },
-            {
-              "ref": "3:16",
-              "note": "He will baptize you with the Holy Spirit and fire \u2014 Calvin: the Spirit and fire are not two baptisms but one. The Spirit purges and refines as fire does. The Pentecostal tongues of fire are the enacted sign of this promised baptism: purification and empowerment in a single event."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:1",
-              "note": "Pontius Pilate was governor of Judea \u2014 Luke introduces Pilate here, fourteen chapters before his role in the Passion. The same imperial machinery that cannot understand Jesus\u2019s kingdom has been named at the beginning of his public life."
-            },
-            {
-              "ref": "3:15",
-              "note": "The people were wondering if John might be the Messiah \u2014 Luke\u2019s explicit statement of this popular speculation is unique to his Gospel. John\u2019s response redefines his own role: he is not the Messiah but the one who announces and prepares for the one whose sandals he cannot untie."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "3:1",
-              "note": "In the fifteenth year of the reign of Tiberius Caesar \u2014 the most precisely anchored date in the NT. If calculated from Augustus\u2019s death (August AD 14), Tiberius\u2019s fifteenth year is AD 28-29. This is the only place in the Gospels where an absolute historical date is given for the beginning of the gospel events."
-            },
-            {
-              "ref": "3:9",
-              "note": "The ax is already at the root of the trees \u2014 the perfect tense: the ax has been laid and is currently there. John\u2019s eschatology is urgent and immediate. The tree-cutting is not a distant future event but an imminent one \u2014 the crisis is already at hand."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "3:7",
-              "note": "Brood of vipers \u2014 Origen: John\u2019s rebuke is addressed to the crowds coming to be baptized \u2014 not to Pharisees, as in Matthew\u2019s parallel (Matt 3:7). Luke\u2019s John rebukes everyone, not just the religious leaders. The sharp edge of repentance is not reserved for obvious sinners."
-            },
-            {
-              "ref": "3:10-14",
-              "note": "What should we do? \u2014 Chrysostom: John\u2019s answers are not calls to asceticism or separation from the world but to radical integrity within ordinary vocations. Share your shirt. Don\u2019t extort. Be content. The kingdom\u2019s ethics are embedded in daily economic and social life."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
             "date": "c. 4000 BC (trad.)",
-            "name": "Adam \u2014 son of God",
-            "text": "Luke traces Jesus\u2019s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
+            "name": "Adam — son of God",
+            "text": "Luke traces Jesus’s genealogy to Adam and through Adam to God. Jesus is the second Adam, the new humanity.",
             "current": false
           },
           {
             "date": "c. 2100 BC",
-            "name": "Abraham \u2014 the covenant promise",
+            "name": "Abraham — the covenant promise",
             "text": "",
             "current": false
           },
           {
             "date": "c. 1000 BC",
-            "name": "David \u2014 the Davidic throne",
+            "name": "David — the Davidic throne",
             "text": "",
             "current": false
           },
           {
             "date": "c. 586 BC",
-            "name": "Zerubbabel \u2014 the return from exile",
+            "name": "Zerubbabel — the return from exile",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 6",
-            "name": "Joseph \u2014 the legal father",
+            "name": "Joseph — the legal father",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 28",
             "name": "Jesus begins his ministry",
-            "text": "The baptism inaugurates Jesus\u2019s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
+            "text": "The baptism inaugurates Jesus’s public ministry. Luke notes he was about thirty years old. The genealogy establishes his credentials: Son of Adam, Son of God.",
             "current": true
           }
         ],
         "hist": {
-          "context": "Luke\u2019s dating of John\u2019s ministry (3:1-2) is the most precise historical synchronization in the Gospels: six Roman and Jewish officials are named to anchor the story within secular history. The word of God came to John in the wilderness \u2014 echoing the OT prophetic commissioning formula. John\u2019s ethical demands are distinctively Luke\u2019s: the crowd, tax collectors, and soldiers each ask \u201cwhat should we do?\u201d \u2014 a question Luke\u2019s Jesus will answer throughout the Gospel."
+          "context": "Luke’s dating of John’s ministry (3:1-2) is the most precise historical synchronization in the Gospels: six Roman and Jewish officials are named to anchor the story within secular history. The word of God came to John in the wilderness — echoing the OT prophetic commissioning formula. John’s ethical demands are distinctively Luke’s: the crowd, tax collectors, and soldiers each ask “what should we do?” — a question Luke’s Jesus will answer throughout the Gospel."
         }
       }
     }
@@ -431,30 +386,30 @@
       {
         "name": "John the Baptist",
         "role": "Prophet and forerunner in the wilderness tradition",
-        "text": "Luke gives the most detailed account of John\u2019s ethical preaching (3:10-14), unique to his Gospel. John\u2019s message about the coming one (3:16-17) frames Jesus\u2019s entire ministry before it begins."
+        "text": "Luke gives the most detailed account of John’s ethical preaching (3:10-14), unique to his Gospel. John’s message about the coming one (3:16-17) frames Jesus’s entire ministry before it begins."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>And the Holy Spirit descended on him in bodily form like a dove. And a voice came from heaven: \"You are my Son, whom I love; with you I am well pleased.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>And the Holy Spirit descended on him in bodily form, like a dove; and a voice came from heaven, \"You are my beloved Son; with you I am well pleased.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>And the Holy Spirit descended in a bodily shape like a dove upon him, and a voice came from heaven, which said, Thou art my beloved Son; in thee I am well pleased.</td></tr><tr><td class=\"t-label\">NASB</td><td>And the Holy Spirit descended upon Him in bodily form like a dove, and a voice came out of heaven, \"You are My beloved Son, in You I am well-pleased.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>And the Holy Spirit, in bodily form, descended on him like a dove. And a voice from heaven said, \"You are my dearly loved Son, and you bring me great joy.\"</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities 18.116-119",
-        "quote": "Josephus\u2019s description of John the Baptist confirms his historical existence, his baptismal ministry, and his execution by Herod Antipas.",
-        "note": "The most important non-Christian source for John, corroborating Luke\u2019s placement of him as a historical prophet whose ministry preceded Jesus\u2019s."
+        "quote": "Josephus’s description of John the Baptist confirms his historical existence, his baptismal ministry, and his execution by Herod Antipas.",
+        "note": "The most important non-Christian source for John, corroborating Luke’s placement of him as a historical prophet whose ministry preceded Jesus’s."
       },
       {
         "title": "Josephus, Jewish War 2.168",
-        "quote": "Josephus names Pontius Pilate as governor of Judea, confirming Luke\u2019s dating formula in 3:1.",
-        "note": "External confirmation of the historical accuracy of Luke\u2019s six-official synchronization."
+        "quote": "Josephus names Pontius Pilate as governor of Judea, confirming Luke’s dating formula in 3:1.",
+        "note": "External confirmation of the historical accuracy of Luke’s six-official synchronization."
       }
     ],
     "rec": [
       {
         "who": "Karl Barth, Church Dogmatics IV/4",
-        "text": "Barth\u2019s treatment of baptism begins with the baptism of Jesus. He argues that Jesus\u2019s baptism is the act in which he identifies himself with sinners he has come to redeem \u2014 not because he needs repentance but because he stands in the place of those who do."
+        "text": "Barth’s treatment of baptism begins with the baptism of Jesus. He argues that Jesus’s baptism is the act in which he identifies himself with sinners he has come to redeem — not because he needs repentance but because he stands in the place of those who do."
       },
       {
         "who": "C.H. Dodd, The Apostolic Preaching (1936)",
-        "text": "Dodd identified Luke 3:1-2\u2019s historical synchronization as evidence of Luke\u2019s historiographical seriousness \u2014 the Gospel is anchored in verifiable secular history by deliberate authorial choice."
+        "text": "Dodd identified Luke 3:1-2’s historical synchronization as evidence of Luke’s historiographical seriousness — the Gospel is anchored in verifiable secular history by deliberate authorial choice."
       }
     ],
     "lit": {
@@ -465,7 +420,7 @@
           "is_key": false
         },
         {
-          "label": "Luke\u2019s Genealogy as Universal Scope: Adam to God",
+          "label": "Luke’s Genealogy as Universal Scope: Adam to God",
           "text": "3:23-38",
           "is_key": false
         }
@@ -477,42 +432,42 @@
         "word": "metanoia",
         "tlit": "me-TAN-oi-a",
         "gloss": "repentance/change of mind and direction",
-        "note": "A baptism of repentance for the forgiveness of sins \u2014 metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John\u2019s baptism is an enacted declaration of this turn \u2014 a public covenant of allegiance to the coming kingdom. The pairing with \u201cforgiveness of sins\u201d (aphesin hamarti\u014dn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
+        "note": "A baptism of repentance for the forgiveness of sins — metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John’s baptism is an enacted declaration of this turn — a public covenant of allegiance to the coming kingdom. The pairing with “forgiveness of sins” (aphesin hamartiōn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
       },
       {
         "word": "huios tou Theou",
         "tlit": "hwi-OS too the-OO",
         "gloss": "Son of God",
-        "note": "The genealogy ends: the son of Adam, the son of God (3:38). Luke traces Jesus\u2019s lineage not just to Abraham (as Matthew does) but to Adam \u2014 and then to God. The endpoint is theological: Jesus is the Son of God, the second Adam (cf. Rom 5:12-19; 1 Cor 15:45). His solidarity is not merely with Israel but with all humanity from creation."
+        "note": "The genealogy ends: the son of Adam, the son of God (3:38). Luke traces Jesus’s lineage not just to Abraham (as Matthew does) but to Adam — and then to God. The endpoint is theological: Jesus is the Son of God, the second Adam (cf. Rom 5:12-19; 1 Cor 15:45). His solidarity is not merely with Israel but with all humanity from creation."
       },
       {
         "word": "metanoia",
         "tlit": "me-TAN-oi-a",
         "gloss": "repentance/change of mind and direction",
-        "note": "A baptism of repentance for the forgiveness of sins \u2014 metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John\u2019s baptism is an enacted declaration of this turn \u2014 a public covenant of allegiance to the coming kingdom. The pairing with \u201cforgiveness of sins\u201d (aphesin hamarti\u014dn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
+        "note": "A baptism of repentance for the forgiveness of sins — metanoia is not merely remorse but a fundamental reorientation of direction. The Greek root means to turn the mind around. John’s baptism is an enacted declaration of this turn — a public covenant of allegiance to the coming kingdom. The pairing with “forgiveness of sins” (aphesin hamartiōn) makes it clear that the turn is also a transaction: the forgiveness is real, not merely symbolic."
       }
     ],
     "tx": [
       {
         "ref": "3:22",
         "title": "The voice at the baptism: \"You are my Son, whom I love\" vs \"Today I have become your Father\"",
-        "content": "Most MSS read the synoptic formula \u201cYou are my Son, whom I love; with you I am well pleased\u201d. Some Western MSS (D, Old Latin, Justin Martyr) read Ps 2:7: \u201cYou are my Son; today I have become your Father.\u201d",
+        "content": "Most MSS read the synoptic formula “You are my Son, whom I love; with you I am well pleased”. Some Western MSS (D, Old Latin, Justin Martyr) read Ps 2:7: “You are my Son; today I have become your Father.”",
         "note": "The Ps 2:7 reading was probably introduced by copyists to make the OT allusion explicit; the standard synoptic formula is almost certainly original to Luke."
       }
     ],
     "debate": [
       {
-        "title": "Does Luke\u2019s genealogy represent Mary\u2019s or Joseph\u2019s lineage?",
+        "title": "Does Luke’s genealogy represent Mary’s or Joseph’s lineage?",
         "positions": [
           {
-            "name": "Joseph\u2019s legal lineage",
-            "proponents": "Luke traces Joseph\u2019s legal ancestry through Nathan; Matthew traces his biological ancestry through Solomon. Both are true of Joseph simultaneously.",
-            "argument": "Both genealogies are Joseph\u2019s"
+            "name": "Joseph’s legal lineage",
+            "proponents": "Luke traces Joseph’s legal ancestry through Nathan; Matthew traces his biological ancestry through Solomon. Both are true of Joseph simultaneously.",
+            "argument": "Both genealogies are Joseph’s"
           },
           {
-            "name": "Mary\u2019s biological lineage",
-            "proponents": "Some propose that Luke\u2019s \u201cHeli\u201d was Mary\u2019s father, making this her lineage transmitted through Joseph\u2019s legal adoption.",
-            "argument": "Mary\u2019s lineage"
+            "name": "Mary’s biological lineage",
+            "proponents": "Some propose that Luke’s “Heli” was Mary’s father, making this her lineage transmitted through Joseph’s legal adoption.",
+            "argument": "Mary’s lineage"
           }
         ]
       }
@@ -544,7 +499,7 @@
           "score": 8
         }
       ],
-      "note": "Luke 3 is the public inauguration chapter: John\u2019s preaching of repentance, the Trinitarian baptism of Jesus, and a genealogy that anchors him in all humanity. The universal scope Luke has been building since the Magnificat reaches its structural statement."
+      "note": "Luke 3 is the public inauguration chapter: John’s preaching of repentance, the Trinitarian baptism of Jesus, and a genealogy that anchors him in all humanity. The universal scope Luke has been building since the Magnificat reaches its structural statement."
     }
   },
   "vhl_groups": [
@@ -665,7 +620,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Produce fruit in keeping with repentance' (v. 8). John demands evidence: tax collectors must stop extorting; soldiers must stop abusing power. Repentance isn't sentiment\u2014it's visible change.",
+      "tip": "'Produce fruit in keeping with repentance' (v. 8). John demands evidence: tax collectors must stop extorting; soldiers must stop abusing power. Repentance isn't sentiment—it's visible change.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/luke/4.json
+++ b/content/luke/4.json
@@ -7,13 +7,13 @@
   "subtitle": "Temptation in the Wilderness; Rejection at Nazareth; Ministry Begins",
   "timeline_link": {
     "event_id": "jesus-temptation",
-    "text": "See on Timeline \u2014 Temptation in the Wilderness"
+    "text": "See on Timeline — Temptation in the Wilderness"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201313 \u2014 The Temptation of Jesus in the Desert",
+      "header": "Verses 1–13 — The Temptation of Jesus in the Desert",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
@@ -22,110 +22,110 @@
             "word": "diabolos",
             "transliteration": "di-AB-o-los",
             "gloss": "slanderer/accuser/devil",
-            "paragraph": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke\u2019s sequence is Spirit-filled (3:22) \u2192 Spirit-led into trial (4:1) \u2192 returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil\u2019s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
+            "paragraph": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke’s sequence is Spirit-filled (3:22) → Spirit-led into trial (4:1) → returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil’s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
           }
         ],
         "places": [
           {
             "name": "Wilderness of Judea",
-            "coords": "Barren terrain west and south of the Jordan; forty days\u2019 trial",
-            "text": "The wilderness is Israel\u2019s formation-ground: Moses\u2019 forty years, Elijah\u2019s forty days, Israel\u2019s forty years. Jesus\u2019 forty days recapitulates and fulfils this tradition."
+            "coords": "Barren terrain west and south of the Jordan; forty days’ trial",
+            "text": "The wilderness is Israel’s formation-ground: Moses’ forty years, Elijah’s forty days, Israel’s forty years. Jesus’ forty days recapitulates and fulfils this tradition."
           },
           {
-            "name": "Jerusalem \u2014 the Temple pinnacle",
+            "name": "Jerusalem — the Temple pinnacle",
             "coords": "The highest point of the Temple complex, overlooking the Kidron Valley",
-            "text": "Luke\u2019s climax temptation is located at the Temple in Jerusalem \u2014 the city that is Luke\u2019s narrative destination throughout the Gospel. The devil\u2019s final offer is a shortcut to the acclaim that the cross is the real path to."
+            "text": "Luke’s climax temptation is located at the Temple in Jerusalem — the city that is Luke’s narrative destination throughout the Gospel. The devil’s final offer is a shortcut to the acclaim that the cross is the real path to."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Deut 8:3",
-              "note": "Man does not live on bread alone but on every word that comes from God \u2014 Jesus\u2019s first response, from Israel\u2019s wilderness."
+              "note": "Man does not live on bread alone but on every word that comes from God — Jesus’s first response, from Israel’s wilderness."
             },
             {
               "ref": "Deut 6:13",
-              "note": "Fear the LORD your God, serve him only \u2014 his second response."
+              "note": "Fear the LORD your God, serve him only — his second response."
             },
             {
               "ref": "Deut 6:16",
-              "note": "Do not put the LORD your God to the test \u2014 his third response. All three quotations are from Deuteronomy 6-8, Israel\u2019s wilderness instruction. Jesus succeeds where Israel failed."
+              "note": "Do not put the LORD your God to the test — his third response. All three quotations are from Deuteronomy 6-8, Israel’s wilderness instruction. Jesus succeeds where Israel failed."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:3, 9",
-              "note": "If you are the Son of God \u2014 the two conditional clauses frame the devil\u2019s strategy: he attacks the identity declared at the baptism. Each temptation is a proposal to be the Son of God on terms other than the Father\u2019s. The temptations are not crude enticements but subtle theological alternatives to the cross."
+              "note": "If you are the Son of God — the two conditional clauses frame the devil’s strategy: he attacks the identity declared at the baptism. Each temptation is a proposal to be the Son of God on terms other than the Father’s. The temptations are not crude enticements but subtle theological alternatives to the cross."
             },
             {
               "ref": "4:13",
-              "note": "He left him until an opportune time \u2014 the temptation does not end at the wilderness. Luke\u2019s \u201cuntil an opportune time\u201d (achri kairou) looks forward to Gethsemane and the cross (22:53: \u201cthis is your hour, and the power of darkness\u201d). The wilderness is the first skirmish; the cross is the decisive battle."
+              "note": "He left him until an opportune time — the temptation does not end at the wilderness. Luke’s “until an opportune time” (achri kairou) looks forward to Gethsemane and the cross (22:53: “this is your hour, and the power of darkness”). The wilderness is the first skirmish; the cross is the decisive battle."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:1-13",
-              "note": "Calvin: The threefold temptation tests Jesus\u2019s sonship in three dimensions: provision (bread), authority (kingdoms), and protection (angels). Each is a test of whether he trusts the Father\u2019s timing and method or will shortcut to the result through a means the Father has not ordained. His three Deuteronomy answers show that the Son of God lives by the same rule as Israel: the word of God."
+              "note": "Calvin: The threefold temptation tests Jesus’s sonship in three dimensions: provision (bread), authority (kingdoms), and protection (angels). Each is a test of whether he trusts the Father’s timing and method or will shortcut to the result through a means the Father has not ordained. His three Deuteronomy answers show that the Son of God lives by the same rule as Israel: the word of God."
             },
             {
               "ref": "4:13",
-              "note": "He left him until an opportune time \u2014 Calvin: the temptation\u2019s cessation is not a victory over the devil but a strategic withdrawal. The devil yields temporarily because the direct assault has failed. He will return through agents: the Pharisees, Judas, the cross."
+              "note": "He left him until an opportune time — Calvin: the temptation’s cessation is not a victory over the devil but a strategic withdrawal. The devil yields temporarily because the direct assault has failed. He will return through agents: the Pharisees, Judas, the cross."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "4:5",
-              "note": "Showed him in an instant all the kingdoms of the world \u2014 the Greek en stigm\u0113 chronou (in a moment of time) is unique to Luke. The instant vision may be a spiritual experience rather than a physical panorama, since no physical location offers a view of all kingdoms simultaneously."
+              "note": "Showed him in an instant all the kingdoms of the world — the Greek en stigmē chronou (in a moment of time) is unique to Luke. The instant vision may be a spiritual experience rather than a physical panorama, since no physical location offers a view of all kingdoms simultaneously."
             },
             {
               "ref": "4:13",
-              "note": "Until an opportune time (achri kairou) \u2014 Luke\u2019s unique phrase connects the temptation to its return in the Passion: 22:3 (Satan enters Judas), 22:31 (Satan asks to sift Simon), 22:53 (your hour and the power of darkness). The narrative arc from 4:13 to the cross is Luke\u2019s sustained temptation story."
+              "note": "Until an opportune time (achri kairou) — Luke’s unique phrase connects the temptation to its return in the Passion: 22:3 (Satan enters Judas), 22:31 (Satan asks to sift Simon), 22:53 (your hour and the power of darkness). The narrative arc from 4:13 to the cross is Luke’s sustained temptation story."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "4:1",
-              "note": "Led by the Spirit into the wilderness \u2014 the Spirit who descended at the baptism now leads Jesus into direct confrontation with the devil. The Spirit\u2019s leading is not always into comfort; it leads where the Father\u2019s purpose requires."
+              "note": "Led by the Spirit into the wilderness — the Spirit who descended at the baptism now leads Jesus into direct confrontation with the devil. The Spirit’s leading is not always into comfort; it leads where the Father’s purpose requires."
             },
             {
               "ref": "4:5-6",
-              "note": "In an instant all the kingdoms of the world \u2014 the offer is real, not illusory. Luke\u2019s devil claims genuine authority over the kingdoms (it has been given to me). This is not self-deception: the NT consistently presents the present age as under fallen spiritual governance (2 Cor 4:4; Eph 2:2)."
+              "note": "In an instant all the kingdoms of the world — the offer is real, not illusory. Luke’s devil claims genuine authority over the kingdoms (it has been given to me). This is not self-deception: the NT consistently presents the present age as under fallen spiritual governance (2 Cor 4:4; Eph 2:2)."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "4:4",
-              "note": "Man shall not live on bread alone \u2014 Origen: Jesus\u2019s first response teaches the priority of the divine word over physical need. Every stone-to-bread miracle-on-demand would make physical provision the criterion of the Messiah\u2019s legitimacy. Jesus refuses to reduce his mission to the satisfaction of bodily hunger."
+              "note": "Man shall not live on bread alone — Origen: Jesus’s first response teaches the priority of the divine word over physical need. Every stone-to-bread miracle-on-demand would make physical provision the criterion of the Messiah’s legitimacy. Jesus refuses to reduce his mission to the satisfaction of bodily hunger."
             },
             {
               "ref": "4:9-12",
-              "note": "The devil quotes Scripture \u2014 Chrysostom: the third temptation\u2019s distinctive feature is the devil\u2019s use of Ps 91:11-12. The Scripture is quoted accurately; it is the application that is satanic. False teachers have always used Scripture in the service of wrong ends. The discernment required is not textual but theological."
+              "note": "The devil quotes Scripture — Chrysostom: the third temptation’s distinctive feature is the devil’s use of Ps 91:11-12. The Scripture is quoted accurately; it is the application that is satanic. False teachers have always used Scripture in the service of wrong ends. The discernment required is not textual but theological."
             }
           ]
         },
         "hist": {
-          "context": "Luke\u2019s temptation account reorders Matthew\u2019s sequence: the pinnacle of the Temple (Luke\u2019s climax) comes last rather than second. Jerusalem is Luke\u2019s narrative destination \u2014 the city toward which the entire Gospel moves. By placing the Temple temptation last, Luke makes Jerusalem the devil\u2019s final ground and frames the whole Passion narrative as the answer to this temptation: Jesus goes to Jerusalem not to be acclaimed but to die."
+          "context": "Luke’s temptation account reorders Matthew’s sequence: the pinnacle of the Temple (Luke’s climax) comes last rather than second. Jerusalem is Luke’s narrative destination — the city toward which the entire Gospel moves. By placing the Temple temptation last, Luke makes Jerusalem the devil’s final ground and frames the whole Passion narrative as the answer to this temptation: Jesus goes to Jerusalem not to be acclaimed but to die."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201330 \u2014 Jesus Rejected at Nazareth: Today This Scripture Is Fulfilled",
+      "header": "Verses 14–30 — Jesus Rejected at Nazareth: Today This Scripture Is Fulfilled",
       "verse_start": 14,
       "verse_end": 30,
       "panels": {
@@ -134,136 +134,136 @@
             "word": "pneuma Kyriou",
             "transliteration": "PNYOO-ma koo-REE-oo",
             "gloss": "the Spirit of the Lord",
-            "paragraph": "The Spirit of the Lord is on me because he has anointed me \u2014 Jesus reads Isa 61:1-2 and then declares: Today this scripture is fulfilled in your hearing (4:21). The word today (s\u0113meron) is a Lukan signature \u2014 it appears at the decisive moment of salvation (2:11; 19:9; 23:43). The Isa 61 programme \u2014 good news to the poor, freedom for prisoners, sight for the blind, release for the oppressed \u2014 is Luke\u2019s definition of Jesus\u2019s entire mission."
+            "paragraph": "The Spirit of the Lord is on me because he has anointed me — Jesus reads Isa 61:1-2 and then declares: Today this scripture is fulfilled in your hearing (4:21). The word today (sēmeron) is a Lukan signature — it appears at the decisive moment of salvation (2:11; 19:9; 23:43). The Isa 61 programme — good news to the poor, freedom for prisoners, sight for the blind, release for the oppressed — is Luke’s definition of Jesus’s entire mission."
           }
         ],
         "places": [
           {
             "name": "Nazareth",
-            "coords": "Lower Galilee; Jesus\u2019s hometown; the site of the programmatic rejection",
-            "text": "Nazareth is the launching point and the first rejection. Luke\u2019s placement here (before Capernaum) makes Nazareth the mission\u2019s thematic context: rejected by his own, sent to others."
+            "coords": "Lower Galilee; Jesus’s hometown; the site of the programmatic rejection",
+            "text": "Nazareth is the launching point and the first rejection. Luke’s placement here (before Capernaum) makes Nazareth the mission’s thematic context: rejected by his own, sent to others."
           },
           {
             "name": "Capernaum",
             "coords": "Northwest shore of the Sea of Galilee; ministry base",
-            "text": "Capernaum receives what Nazareth rejects. The Capernaum synagogue is the scene of the first exorcism and Peter\u2019s mother-in-law\u2019s healing. The contrast between the two towns maps the Lukan theology of reception and rejection."
+            "text": "Capernaum receives what Nazareth rejects. The Capernaum synagogue is the scene of the first exorcism and Peter’s mother-in-law’s healing. The contrast between the two towns maps the Lukan theology of reception and rejection."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 61:1-2",
-              "note": "The Spirit of the Lord is on me, because he has anointed me to proclaim good news to the poor \u2014 the programme Jesus claims as his own in the Nazareth synagogue."
+              "note": "The Spirit of the Lord is on me, because he has anointed me to proclaim good news to the poor — the programme Jesus claims as his own in the Nazareth synagogue."
             },
             {
               "ref": "1 Kings 17:9",
-              "note": "Elijah was sent to a widow in Zarephath in Sidon \u2014 the Gentile precedent Jesus cites."
+              "note": "Elijah was sent to a widow in Zarephath in Sidon — the Gentile precedent Jesus cites."
             },
             {
               "ref": "2 Kings 5:14",
-              "note": "Naaman the Syrian was cleansed \u2014 the second Gentile precedent. The prophets\u2019 mission to Gentiles is the precedent for Jesus\u2019s universal scope."
+              "note": "Naaman the Syrian was cleansed — the second Gentile precedent. The prophets’ mission to Gentiles is the precedent for Jesus’s universal scope."
             }
           ],
           "echoes": [
             {
-              "source_ref": "Isaiah 61:1\u20132",
-              "target_ref": "Luke 4:18\u201319",
+              "source_ref": "Isaiah 61:1–2",
+              "target_ref": "Luke 4:18–19",
               "type": "direct_quote",
               "source_context": "The Spirit of the Lord is upon me, anointing to preach good news to the poor, proclaim freedom for prisoners, recovery of sight for the blind, release for the oppressed, the year of the Lord's favor.",
               "connection": "Jesus reads this in the Nazareth synagogue and declares: 'Today this Scripture is fulfilled in your hearing.' He claims to be Isaiah's anointed herald of jubilee.",
-              "significance": "Jesus' public ministry opens with self-identification as the fulfillment of Isaiah 61. The year of the Lord's favor \u2014 the ultimate jubilee \u2014 arrives in his person and work."
+              "significance": "Jesus' public ministry opens with self-identification as the fulfillment of Isaiah 61. The year of the Lord's favor — the ultimate jubilee — arrives in his person and work."
             },
             {
-              "source_ref": "1 Kings 17:8\u201324",
-              "target_ref": "Luke 4:25\u201326",
+              "source_ref": "1 Kings 17:8–24",
+              "target_ref": "Luke 4:25–26",
               "type": "allusion",
               "source_context": "During the famine, God sent Elijah not to any Israelite widow but to a Gentile widow in Zarephath of Sidon. She received the prophet, and her household was sustained and her son restored to life.",
-              "connection": "Jesus cites this in the Nazareth synagogue to explain why a prophet finds no honor in his hometown. God's blessing went to outsiders when Israel rejected the prophet \u2014 a pattern Jesus' ministry will repeat.",
+              "connection": "Jesus cites this in the Nazareth synagogue to explain why a prophet finds no honor in his hometown. God's blessing went to outsiders when Israel rejected the prophet — a pattern Jesus' ministry will repeat.",
               "significance": "This is programmatic for Luke-Acts: Israel's rejection opens blessing to Gentiles. The pattern established in Elijah's ministry anticipates the church's Gentile mission."
             },
             {
-              "source_ref": "2 Kings 5:1\u201314",
+              "source_ref": "2 Kings 5:1–14",
               "target_ref": "Luke 4:27",
               "type": "allusion",
-              "source_context": "Many lepers were in Israel during Elisha's time, but only Naaman the Syrian was cleansed. The enemy general received what Israelites did not \u2014 healing came to the outsider who humbled himself.",
+              "source_context": "Many lepers were in Israel during Elisha's time, but only Naaman the Syrian was cleansed. The enemy general received what Israelites did not — healing came to the outsider who humbled himself.",
               "connection": "Jesus' second example from the prophets makes the same point: God's grace extended beyond Israel's boundaries even in the old covenant. Nazareth's fury at this message leads to attempted murder.",
               "significance": "The violent rejection proves Jesus' point: Israel's hardness to God's inclusive grace is not new. The Gentile mission is not plan B but the ancient pattern of divine mercy."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:21",
-              "note": "Today this scripture is fulfilled in your hearing \u2014 the most compressed sermon in the Gospels. Jesus reads the text, sits down, and declares its fulfilment in a single sentence. The Isaiah programme is not aspirational; it is declarative. The kingdom has arrived in the speaker."
+              "note": "Today this scripture is fulfilled in your hearing — the most compressed sermon in the Gospels. Jesus reads the text, sits down, and declares its fulfilment in a single sentence. The Isaiah programme is not aspirational; it is declarative. The kingdom has arrived in the speaker."
             },
             {
               "ref": "4:25-27",
-              "note": "Elijah to Zarephath; Elisha to Naaman \u2014 the two precedents that enrage the synagogue. Jesus is claiming that God\u2019s sovereign grace has always moved beyond ethnic Israel when Israel refused it. This is the Gentile mission\u2019s theological justification stated in Luke\u2019s first chapter of public ministry."
+              "note": "Elijah to Zarephath; Elisha to Naaman — the two precedents that enrage the synagogue. Jesus is claiming that God’s sovereign grace has always moved beyond ethnic Israel when Israel refused it. This is the Gentile mission’s theological justification stated in Luke’s first chapter of public ministry."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "4:18-19",
-              "note": "Good news to the poor\u2026 freedom for prisoners \u2014 Calvin: the poor and imprisoned are not only spiritually metaphorical categories but real social ones. Calvin insists that the Jubilee programme has both spiritual and material dimensions: the gospel transforms economics as well as souls."
+              "note": "Good news to the poor… freedom for prisoners — Calvin: the poor and imprisoned are not only spiritually metaphorical categories but real social ones. Calvin insists that the Jubilee programme has both spiritual and material dimensions: the gospel transforms economics as well as souls."
             },
             {
               "ref": "4:24",
-              "note": "No prophet is accepted in his hometown \u2014 Calvin: familiarity breeds contempt only when familiarity has replaced hearing. The Nazarenes know Joseph\u2019s son; they do not hear the one who reads Isaiah. The scandal of the Incarnation is that God came in a form too ordinary for those who expected something spectacular."
+              "note": "No prophet is accepted in his hometown — Calvin: familiarity breeds contempt only when familiarity has replaced hearing. The Nazarenes know Joseph’s son; they do not hear the one who reads Isaiah. The scandal of the Incarnation is that God came in a form too ordinary for those who expected something spectacular."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "4:18",
-              "note": "He has anointed me \u2014 echrisin me: the word chrism (anointing) is cognate with Christos (the Anointed). Jesus is reading the passage about himself. The Spirit\u2019s anointing at the baptism (3:22) is the event Isaiah was predicting."
+              "note": "He has anointed me — echrisin me: the word chrism (anointing) is cognate with Christos (the Anointed). Jesus is reading the passage about himself. The Spirit’s anointing at the baptism (3:22) is the event Isaiah was predicting."
             },
             {
               "ref": "4:19",
-              "note": "To proclaim the year of the Lord\u2019s favor \u2014 Jesus stops mid-verse: Isaiah 61:2 continues \u201cand the day of vengeance of our God.\u201d The omission of the vengeance clause is deliberate: this is the time of grace, not yet the time of judgment. The full Isaiah text will be appropriate when judgment comes."
+              "note": "To proclaim the year of the Lord’s favor — Jesus stops mid-verse: Isaiah 61:2 continues “and the day of vengeance of our God.” The omission of the vengeance clause is deliberate: this is the time of grace, not yet the time of judgment. The full Isaiah text will be appropriate when judgment comes."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "4:20",
-              "note": "He sat down \u2014 the teacher\u2019s authoritative posture for interpretation. The reading was done standing; the interpretation was given seated. The eyes of everyone were fastened on him \u2014 atenizontes: fixed, intense, concentrated gaze. The silence before the one-sentence sermon is palpable."
+              "note": "He sat down — the teacher’s authoritative posture for interpretation. The reading was done standing; the interpretation was given seated. The eyes of everyone were fastened on him — atenizontes: fixed, intense, concentrated gaze. The silence before the one-sentence sermon is palpable."
             },
             {
               "ref": "4:30",
-              "note": "He walked right through the crowd and went on his way \u2014 Luke does not explain how. The crowd\u2019s murderous intent is simply overridden by Jesus\u2019s authoritative passage through them. His hour has not come."
+              "note": "He walked right through the crowd and went on his way — Luke does not explain how. The crowd’s murderous intent is simply overridden by Jesus’s authoritative passage through them. His hour has not come."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "4:18",
-              "note": "To proclaim the year of the Lord\u2019s favor \u2014 Origen: the year of favor is the Year of Jubilee (Lev 25) \u2014 the year of release, cancellation of debts, return of property, freedom for slaves. Jesus declares that his whole ministry is a permanent, extended Jubilee: the debts of sin cancelled, the enslaved freed, the dispossessed restored."
+              "note": "To proclaim the year of the Lord’s favor — Origen: the year of favor is the Year of Jubilee (Lev 25) — the year of release, cancellation of debts, return of property, freedom for slaves. Jesus declares that his whole ministry is a permanent, extended Jubilee: the debts of sin cancelled, the enslaved freed, the dispossessed restored."
             },
             {
               "ref": "4:41",
-              "note": "The demons knew he was the Messiah \u2014 Chrysostom: the demonic confession is theologically accurate but morally hostile. The demons know who Jesus is; the synagogue at Nazareth refuses to accept who he is. Accurate knowledge of Christ\u2019s identity is not saving faith."
+              "note": "The demons knew he was the Messiah — Chrysostom: the demonic confession is theologically accurate but morally hostile. The demons know who Jesus is; the synagogue at Nazareth refuses to accept who he is. Accurate knowledge of Christ’s identity is not saving faith."
             }
           ]
         },
         "hist": {
-          "context": "Luke places the Nazareth sermon at the very beginning of Jesus\u2019s public ministry (contrast Mark 6:1-6, which places it later). This is programmatic: the Isaiah 61 quotation is Luke\u2019s mission statement. The rejection that follows \u2014 including the appeal to Elijah and Elisha\u2019s Gentile missions \u2014 prefigures both the rejection of Israel\u2019s establishment and the Gentile mission."
+          "context": "Luke places the Nazareth sermon at the very beginning of Jesus’s public ministry (contrast Mark 6:1-6, which places it later). This is programmatic: the Isaiah 61 quotation is Luke’s mission statement. The rejection that follows — including the appeal to Elijah and Elisha’s Gentile missions — prefigures both the rejection of Israel’s establishment and the Gentile mission."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201344 \u2014 Capernaum: Exorcism, Peter\u2019s Mother-in-Law, Many Healed",
+      "header": "Verses 31–44 — Capernaum: Exorcism, Peter’s Mother-in-Law, Many Healed",
       "verse_start": 31,
       "verse_end": 44,
       "panels": {
@@ -272,104 +272,59 @@
             "word": "diabolos",
             "transliteration": "di-AB-o-los",
             "gloss": "slanderer/accuser/devil",
-            "paragraph": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke\u2019s sequence is Spirit-filled (3:22) \u2192 Spirit-led into trial (4:1) \u2192 returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil\u2019s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
+            "paragraph": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke’s sequence is Spirit-filled (3:22) → Spirit-led into trial (4:1) → returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil’s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
           }
         ],
         "places": [
           {
             "name": "Wilderness of Judea",
-            "coords": "Barren terrain west and south of the Jordan; forty days\u2019 trial",
-            "text": "The wilderness is Israel\u2019s formation-ground: Moses\u2019 forty years, Elijah\u2019s forty days, Israel\u2019s forty years. Jesus\u2019 forty days recapitulates and fulfils this tradition."
+            "coords": "Barren terrain west and south of the Jordan; forty days’ trial",
+            "text": "The wilderness is Israel’s formation-ground: Moses’ forty years, Elijah’s forty days, Israel’s forty years. Jesus’ forty days recapitulates and fulfils this tradition."
           },
           {
-            "name": "Jerusalem \u2014 the Temple pinnacle",
+            "name": "Jerusalem — the Temple pinnacle",
             "coords": "The highest point of the Temple complex, overlooking the Kidron Valley",
-            "text": "Luke\u2019s climax temptation is located at the Temple in Jerusalem \u2014 the city that is Luke\u2019s narrative destination throughout the Gospel. The devil\u2019s final offer is a shortcut to the acclaim that the cross is the real path to."
+            "text": "Luke’s climax temptation is located at the Temple in Jerusalem — the city that is Luke’s narrative destination throughout the Gospel. The devil’s final offer is a shortcut to the acclaim that the cross is the real path to."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Deut 8:3",
-              "note": "Man does not live on bread alone but on every word that comes from God \u2014 Jesus\u2019s first response, from Israel\u2019s wilderness."
+              "note": "Man does not live on bread alone but on every word that comes from God — Jesus’s first response, from Israel’s wilderness."
             },
             {
               "ref": "Deut 6:13",
-              "note": "Fear the LORD your God, serve him only \u2014 his second response."
+              "note": "Fear the LORD your God, serve him only — his second response."
             },
             {
               "ref": "Deut 6:16",
-              "note": "Do not put the LORD your God to the test \u2014 his third response. All three quotations are from Deuteronomy 6-8, Israel\u2019s wilderness instruction. Jesus succeeds where Israel failed."
+              "note": "Do not put the LORD your God to the test — his third response. All three quotations are from Deuteronomy 6-8, Israel’s wilderness instruction. Jesus succeeds where Israel failed."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:3, 9",
-              "note": "If you are the Son of God \u2014 the two conditional clauses frame the devil\u2019s strategy: he attacks the identity declared at the baptism. Each temptation is a proposal to be the Son of God on terms other than the Father\u2019s. The temptations are not crude enticements but subtle theological alternatives to the cross."
-            },
-            {
-              "ref": "4:13",
-              "note": "He left him until an opportune time \u2014 the temptation does not end at the wilderness. Luke\u2019s \u201cuntil an opportune time\u201d (achri kairou) looks forward to Gethsemane and the cross (22:53: \u201cthis is your hour, and the power of darkness\u201d). The wilderness is the first skirmish; the cross is the decisive battle."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "4:1-13",
-              "note": "Calvin: The threefold temptation tests Jesus\u2019s sonship in three dimensions: provision (bread), authority (kingdoms), and protection (angels). Each is a test of whether he trusts the Father\u2019s timing and method or will shortcut to the result through a means the Father has not ordained. His three Deuteronomy answers show that the Son of God lives by the same rule as Israel: the word of God."
-            },
-            {
-              "ref": "4:13",
-              "note": "He left him until an opportune time \u2014 Calvin: the temptation\u2019s cessation is not a victory over the devil but a strategic withdrawal. The devil yields temporarily because the direct assault has failed. He will return through agents: the Pharisees, Judas, the cross."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "4:5",
-              "note": "Showed him in an instant all the kingdoms of the world \u2014 the Greek en stigm\u0113 chronou (in a moment of time) is unique to Luke. The instant vision may be a spiritual experience rather than a physical panorama, since no physical location offers a view of all kingdoms simultaneously."
-            },
-            {
-              "ref": "4:13",
-              "note": "Until an opportune time (achri kairou) \u2014 Luke\u2019s unique phrase connects the temptation to its return in the Passion: 22:3 (Satan enters Judas), 22:31 (Satan asks to sift Simon), 22:53 (your hour and the power of darkness). The narrative arc from 4:13 to the cross is Luke\u2019s sustained temptation story."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "4:1",
-              "note": "Led by the Spirit into the wilderness \u2014 the Spirit who descended at the baptism now leads Jesus into direct confrontation with the devil. The Spirit\u2019s leading is not always into comfort; it leads where the Father\u2019s purpose requires."
-            },
-            {
-              "ref": "4:5-6",
-              "note": "In an instant all the kingdoms of the world \u2014 the offer is real, not illusory. Luke\u2019s devil claims genuine authority over the kingdoms (it has been given to me). This is not self-deception: the NT consistently presents the present age as under fallen spiritual governance (2 Cor 4:4; Eph 2:2)."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "4:4",
-              "note": "Man shall not live on bread alone \u2014 Origen: Jesus\u2019s first response teaches the priority of the divine word over physical need. Every stone-to-bread miracle-on-demand would make physical provision the criterion of the Messiah\u2019s legitimacy. Jesus refuses to reduce his mission to the satisfaction of bodily hunger."
-            },
-            {
-              "ref": "4:9-12",
-              "note": "The devil quotes Scripture \u2014 Chrysostom: the third temptation\u2019s distinctive feature is the devil\u2019s use of Ps 91:11-12. The Scripture is quoted accurately; it is the application that is satanic. False teachers have always used Scripture in the service of wrong ends. The discernment required is not textual but theological."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke\u2019s temptation account reorders Matthew\u2019s sequence: the pinnacle of the Temple (Luke\u2019s climax) comes last rather than second. Jerusalem is Luke\u2019s narrative destination \u2014 the city toward which the entire Gospel moves. By placing the Temple temptation last, Luke makes Jerusalem the devil\u2019s final ground and frames the whole Passion narrative as the answer to this temptation: Jesus goes to Jerusalem not to be acclaimed but to die."
+          "context": "Luke’s temptation account reorders Matthew’s sequence: the pinnacle of the Temple (Luke’s climax) comes last rather than second. Jerusalem is Luke’s narrative destination — the city toward which the entire Gospel moves. By placing the Temple temptation last, Luke makes Jerusalem the devil’s final ground and frames the whole Passion narrative as the answer to this temptation: Jesus goes to Jerusalem not to be acclaimed but to die."
         }
       }
     }
@@ -378,31 +333,31 @@
     "ppl": [
       {
         "name": "The people of Nazareth",
-        "role": "Jesus\u2019s hometown community; first to reject him",
-        "text": "Their trajectory \u2014 initial wonder (4:22) \u2192 murderous rage (4:28-29) \u2014 prefigures Jerusalem\u2019s arc: Palm Sunday to Good Friday. The hometown is the Gospel in miniature."
+        "role": "Jesus’s hometown community; first to reject him",
+        "text": "Their trajectory — initial wonder (4:22) → murderous rage (4:28-29) — prefigures Jerusalem’s arc: Palm Sunday to Good Friday. The hometown is the Gospel in miniature."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"The Spirit of the Lord is on me, because he has anointed me to proclaim good news to the poor. He has sent me to proclaim freedom for the prisoners and recovery of sight for the blind, to set the oppressed free, to proclaim the year of the Lord's favor.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"The Spirit of the Lord is upon me, because he has anointed me to proclaim good news to the poor. He has sent me to proclaim liberty to the captives and recovering of sight to the blind, to set at liberty those who are oppressed, to proclaim the year of the Lord's favor.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"The Spirit of the Lord is upon me, because he hath anointed me to preach the gospel to the poor; he hath sent me to heal the brokenhearted, to preach deliverance to the captives, and recovering of sight to the blind, to set at liberty them that are bruised, to preach the acceptable year of the Lord.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"The Spirit of the Lord is upon Me, because He anointed Me to bring good news to the poor. He has sent Me to proclaim release to the captives, and recovery of sight to the blind, to set free those who are oppressed, to proclaim the favorable year of the Lord.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"The Spirit of the Lord is upon me, for he has anointed me to bring Good News to the poor. He has sent me to proclaim that captives will be released, that the blind will see, that the oppressed will be set free, and that the time of the Lord's favor has come.\"</td></tr>",
     "src": [
       {
-        "title": "Qumran \u2014 4Q521 (Messianic Apocalypse)",
-        "quote": "A pre-Christian fragment from Qumran describes a coming messianic figure who heals the blind, raises the dead, and proclaims good news to the poor \u2014 closely parallel to the Isaiah 61 programme Jesus reads in Nazareth.",
-        "note": "Confirms that Luke 4\u2019s mission programme was a recognized messianic description in Second Temple Judaism."
+        "title": "Qumran — 4Q521 (Messianic Apocalypse)",
+        "quote": "A pre-Christian fragment from Qumran describes a coming messianic figure who heals the blind, raises the dead, and proclaims good news to the poor — closely parallel to the Isaiah 61 programme Jesus reads in Nazareth.",
+        "note": "Confirms that Luke 4’s mission programme was a recognized messianic description in Second Temple Judaism."
       },
       {
         "title": "Josephus, Life 45",
         "quote": "Josephus describes Nazareth as a small, undistinguished Galilean village.",
-        "note": "Confirms the social insignificance of Nazareth, explaining the crowd\u2019s reaction: \u201cIsn\u2019t this Joseph\u2019s son?\u201d"
+        "note": "Confirms the social insignificance of Nazareth, explaining the crowd’s reaction: “Isn’t this Joseph’s son?”"
       }
     ],
     "rec": [
       {
         "who": "John Howard Yoder, The Politics of Jesus (1972)",
-        "text": "Yoder argued that Jesus\u2019s Nazareth sermon announces a genuine Jubilee programme \u2014 not merely spiritual metaphor but the literal socio-economic politics of the kingdom."
+        "text": "Yoder argued that Jesus’s Nazareth sermon announces a genuine Jubilee programme — not merely spiritual metaphor but the literal socio-economic politics of the kingdom."
       },
       {
         "who": "N.T. Wright, Jesus and the Victory of God (1996)",
-        "text": "Wright reads the Nazareth sermon as Jesus\u2019s claim to embody the return from exile and the inauguration of the new creation \u2014 the year of the Lord\u2019s favour being the eschatological Jubilee the prophets had anticipated."
+        "text": "Wright reads the Nazareth sermon as Jesus’s claim to embody the return from exile and the inauguration of the new creation — the year of the Lord’s favour being the eschatological Jubilee the prophets had anticipated."
       }
     ],
     "lit": {
@@ -413,7 +368,7 @@
           "is_key": false
         },
         {
-          "label": "Today (s\u0113meron): Luke\u2019s Signature Word of Realized Eschatology",
+          "label": "Today (sēmeron): Luke’s Signature Word of Realized Eschatology",
           "text": "4:21",
           "is_key": false
         }
@@ -425,27 +380,27 @@
         "word": "diabolos",
         "tlit": "di-AB-o-los",
         "gloss": "slanderer/accuser/devil",
-        "note": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke\u2019s sequence is Spirit-filled (3:22) \u2192 Spirit-led into trial (4:1) \u2192 returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil\u2019s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
+        "note": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke’s sequence is Spirit-filled (3:22) → Spirit-led into trial (4:1) → returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil’s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
       },
       {
         "word": "pneuma Kyriou",
         "tlit": "PNYOO-ma koo-REE-oo",
         "gloss": "the Spirit of the Lord",
-        "note": "The Spirit of the Lord is on me because he has anointed me \u2014 Jesus reads Isa 61:1-2 and then declares: Today this scripture is fulfilled in your hearing (4:21). The word today (s\u0113meron) is a Lukan signature \u2014 it appears at the decisive moment of salvation (2:11; 19:9; 23:43). The Isa 61 programme \u2014 good news to the poor, freedom for prisoners, sight for the blind, release for the oppressed \u2014 is Luke\u2019s definition of Jesus\u2019s entire mission."
+        "note": "The Spirit of the Lord is on me because he has anointed me — Jesus reads Isa 61:1-2 and then declares: Today this scripture is fulfilled in your hearing (4:21). The word today (sēmeron) is a Lukan signature — it appears at the decisive moment of salvation (2:11; 19:9; 23:43). The Isa 61 programme — good news to the poor, freedom for prisoners, sight for the blind, release for the oppressed — is Luke’s definition of Jesus’s entire mission."
       },
       {
         "word": "diabolos",
         "tlit": "di-AB-o-los",
         "gloss": "slanderer/accuser/devil",
-        "note": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke\u2019s sequence is Spirit-filled (3:22) \u2192 Spirit-led into trial (4:1) \u2192 returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil\u2019s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
+        "note": "Full of the Holy Spirit, Jesus was led by the Spirit into the wilderness where for forty days he was tempted by the devil (diabolos). Luke’s sequence is Spirit-filled (3:22) → Spirit-led into trial (4:1) → returning in the power of the Spirit (4:14). The Spirit does not protect from testing but leads through it. The devil’s three temptations test the three things declared at the baptism: sonship, mission method, and relationship to the Father."
       }
     ],
     "tx": [
       {
         "ref": "4:44",
-        "title": "Preaching in the synagogues of Judea \u2014 Judea or Galilee?",
-        "content": "Some MSS read Galilaia (Galilee); the Majority Text and NA28 read t\u0113s Ioudaias (of Judea). Luke uses Judea sometimes for the whole Jewish homeland (1:5) and sometimes for the southern region.",
-        "note": "The Judea reading may be original, reflecting Luke\u2019s tendency to frame Jesus\u2019s ministry in terms of the broader Jewish homeland; or it may be an error for Galilee."
+        "title": "Preaching in the synagogues of Judea — Judea or Galilee?",
+        "content": "Some MSS read Galilaia (Galilee); the Majority Text and NA28 read tēs Ioudaias (of Judea). Luke uses Judea sometimes for the whole Jewish homeland (1:5) and sometimes for the southern region.",
+        "note": "The Judea reading may be original, reflecting Luke’s tendency to frame Jesus’s ministry in terms of the broader Jewish homeland; or it may be an error for Galilee."
       }
     ],
     "debate": [
@@ -453,7 +408,7 @@
         "title": "Did the Nazareth rejection precede or follow early Galilean ministry?",
         "positions": [
           {
-            "name": "Luke\u2019s order original",
+            "name": "Luke’s order original",
             "proponents": "Luke is following a topical arrangement, placing the Nazareth scene first as a programmatic statement of the mission.",
             "argument": "Programmatic placement"
           },
@@ -613,12 +568,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Man shall not live on bread alone' (v. 4). Jesus answers temptation with Deuteronomy\u2014Israel's wilderness failures reversed. Where Adam fell and Israel failed, Jesus stands.",
+      "tip": "'Man shall not live on bread alone' (v. 4). Jesus answers temptation with Deuteronomy—Israel's wilderness failures reversed. Where Adam fell and Israel failed, Jesus stands.",
       "genre_tag": "canonical_thread"
     },
     {
       "after_section": 2,
-      "tip": "'Today this scripture is fulfilled in your hearing' (v. 21). Jesus reads Isaiah 61 and claims it. Hometown audience marvels\u2014then rages when he mentions Gentiles receiving blessing. Nazareth rejects its own.",
+      "tip": "'Today this scripture is fulfilled in your hearing' (v. 21). Jesus reads Isaiah 61 and claims it. Hometown audience marvels—then rages when he mentions Gentiles receiving blessing. Nazareth rejects its own.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/luke/5.json
+++ b/content/luke/5.json
@@ -7,113 +7,113 @@
   "subtitle": "The Miraculous Catch; Levi Called; Paralytic Healed; New Wine",
   "timeline_link": {
     "event_id": "jesus-baptism",
-    "text": "See on Timeline \u2014 Baptism of Jesus"
+    "text": "See on Timeline — Baptism of Jesus"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 The Miraculous Catch of Fish; The First Disciples",
+      "header": "Verses 1–11 — The Miraculous Catch of Fish; The First Disciples",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
         "heb": [
           {
-            "word": "epistat\u0113s",
-            "transliteration": "e-pis-TA-t\u0113s",
+            "word": "epistatēs",
+            "transliteration": "e-pis-TA-tēs",
             "gloss": "Master/Superintendent",
-            "paragraph": "Simon answered, \"Master (epistat\u0113s), we've worked hard all night.\" Luke uses epistat\u0113s \u2014 a term of authority equivalent to a commanding officer \u2014 exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen\u2019s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
+            "paragraph": "Simon answered, \"Master (epistatēs), we've worked hard all night.\" Luke uses epistatēs — a term of authority equivalent to a commanding officer — exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen’s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 6:5",
-              "note": "Woe to me! I am ruined! For I am a man of unclean lips \u2014 the Isaiah pattern that Simon's response echoes."
+              "note": "Woe to me! I am ruined! For I am a man of unclean lips — the Isaiah pattern that Simon's response echoes."
             },
             {
               "ref": "Ezek 47:9-10",
-              "note": "The eschatological river teeming with fish \u2014 the background for the miraculous catch as a sign of the kingdom's abundance."
+              "note": "The eschatological river teeming with fish — the background for the miraculous catch as a sign of the kingdom's abundance."
             },
             {
               "ref": "Lev 14:2-32",
-              "note": "The cleansing ritual for leprosy \u2014 what Jesus sends the healed man to fulfil as testimony."
+              "note": "The cleansing ritual for leprosy — what Jesus sends the healed man to fulfil as testimony."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:8",
-              "note": "Go away from me, Lord; I am a sinful man \u2014 the miracle produces not pride but self-knowledge. Peter sees himself in the light of the one who commands the lake's fish. This is the proper response to the holy: not comfort but clarity about the distance between the divine and the human."
+              "note": "Go away from me, Lord; I am a sinful man — the miracle produces not pride but self-knowledge. Peter sees himself in the light of the one who commands the lake's fish. This is the proper response to the holy: not comfort but clarity about the distance between the divine and the human."
             },
             {
               "ref": "5:20",
-              "note": "When Jesus saw their faith, he said, \"Friend, your sins are forgiven\" \u2014 Jesus addresses the presenting condition that underlies the physical symptom. The Pharisees\u2019 outrage is theologically accurate: only God can forgive sins. Their error is not the premise but the conclusion."
+              "note": "When Jesus saw their faith, he said, \"Friend, your sins are forgiven\" — Jesus addresses the presenting condition that underlies the physical symptom. The Pharisees’ outrage is theologically accurate: only God can forgive sins. Their error is not the premise but the conclusion."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:10",
-              "note": "From now on you will fish for people \u2014 Calvin: the metaphor of fishing is chosen deliberately. The fisherman does not create the fish; he finds them and brings them in. The evangelist does not create faith; he casts the net of the gospel into the sea of humanity and draws in those whom God has ordained."
+              "note": "From now on you will fish for people — Calvin: the metaphor of fishing is chosen deliberately. The fisherman does not create the fish; he finds them and brings them in. The evangelist does not create faith; he casts the net of the gospel into the sea of humanity and draws in those whom God has ordained."
             },
             {
               "ref": "5:24",
-              "note": "That the Son of Man has authority on earth to forgive sins \u2014 Calvin: the forgiveness is the greater miracle. The paralytic\u2019s walking is visible proof of the invisible forgiveness. Jesus works the lesser miracle to establish credibility for the greater one."
+              "note": "That the Son of Man has authority on earth to forgive sins — Calvin: the forgiveness is the greater miracle. The paralytic’s walking is visible proof of the invisible forgiveness. Jesus works the lesser miracle to establish credibility for the greater one."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:17",
-              "note": "Pharisees and teachers of the law from every village of Galilee and from Judea and Jerusalem \u2014 the religious establishment is formally assembled for the first time to observe Jesus. Luke marks this as a significant escalation: this is no longer a local matter."
+              "note": "Pharisees and teachers of the law from every village of Galilee and from Judea and Jerusalem — the religious establishment is formally assembled for the first time to observe Jesus. Luke marks this as a significant escalation: this is no longer a local matter."
             },
             {
               "ref": "5:24",
-              "note": "Son of Man has authority on earth to forgive sins \u2014 the Son of Man title (from Dan 7:13-14) carries both human solidarity (bar enasha \u2014 a human being) and divine prerogative (the one who receives eternal dominion). Jesus uses it at precisely the moment when his divine prerogative is challenged."
+              "note": "Son of Man has authority on earth to forgive sins — the Son of Man title (from Dan 7:13-14) carries both human solidarity (bar enasha — a human being) and divine prerogative (the one who receives eternal dominion). Jesus uses it at precisely the moment when his divine prerogative is challenged."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "5:5",
-              "note": "\"But because you say so (epi de t\u014d rh\u0113mati sou)\" \u2014 the single phrase that defines Petrine obedience: not because the conditions are favourable, not because experience suggests it, but because you say so. This is the grammar of faith."
+              "note": "\"But because you say so (epi de tō rhēmati sou)\" — the single phrase that defines Petrine obedience: not because the conditions are favourable, not because experience suggests it, but because you say so. This is the grammar of faith."
             },
             {
               "ref": "5:17",
-              "note": "And the power of the Lord was with Jesus to heal \u2014 Luke uniquely adds this explanatory clause. The power (dynamis) is present as a discrete, active force \u2014 not an abstract capacity but an operative reality in the room."
+              "note": "And the power of the Lord was with Jesus to heal — Luke uniquely adds this explanatory clause. The power (dynamis) is present as a discrete, active force — not an abstract capacity but an operative reality in the room."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "5:13",
-              "note": "Jesus reached out his hand and touched him \u2014 Origen: the touch is legally defiling under Mosaic law (Lev 5:3; 13:45-46). Jesus becomes ritually unclean to cleanse the unclean man. The movement is opposite to contagion: the leper\u2019s uncleanness does not infect Jesus; Jesus\u2019s cleanness flows into the leper. This is the logic of the Incarnation."
+              "note": "Jesus reached out his hand and touched him — Origen: the touch is legally defiling under Mosaic law (Lev 5:3; 13:45-46). Jesus becomes ritually unclean to cleanse the unclean man. The movement is opposite to contagion: the leper’s uncleanness does not infect Jesus; Jesus’s cleanness flows into the leper. This is the logic of the Incarnation."
             },
             {
               "ref": "5:20",
-              "note": "Your sins are forgiven \u2014 Ambrose: notice that Jesus does not first heal the body. He addresses the deeper wound. The paralysis of sin precedes the paralysis of limbs; its cure precedes and guarantees the other."
+              "note": "Your sins are forgiven — Ambrose: notice that Jesus does not first heal the body. He addresses the deeper wound. The paralysis of sin precedes the paralysis of limbs; its cure precedes and guarantees the other."
             }
           ]
         },
         "hist": {
-          "context": "Luke\u2019s calling of Simon follows a miracle that demonstrates Jesus\u2019s authority over Simon\u2019s own domain \u2014 the lake. The sequence is invitation (teach from my boat) \u2192 miraculous demonstration \u2192 call. Simon\u2019s response \u2014 \"Go away from me, Lord; I am a sinful man\" \u2014 is the same pattern as Isaiah at the throne (Isa 6:5) and Job before the whirlwind (Job 40:4): the holy presence of God exposes human sinfulness before it commissions for service."
+          "context": "Luke’s calling of Simon follows a miracle that demonstrates Jesus’s authority over Simon’s own domain — the lake. The sequence is invitation (teach from my boat) → miraculous demonstration → call. Simon’s response — \"Go away from me, Lord; I am a sinful man\" — is the same pattern as Isaiah at the throne (Isa 6:5) and Job before the whirlwind (Job 40:4): the holy presence of God exposes human sinfulness before it commissions for service."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201326 \u2014 The Leper Healed; The Paralytic Lowered Through the Roof",
+      "header": "Verses 12–26 — The Leper Healed; The Paralytic Lowered Through the Roof",
       "verse_start": 12,
       "verse_end": 26,
       "panels": {
@@ -122,192 +122,147 @@
             "word": "nymphios",
             "transliteration": "nym-FEE-os",
             "gloss": "bridegroom",
-            "paragraph": "Can you make the friends of the bridegroom (nymphios) fast while he is with them? The bridegroom is the OT image for YHWH\u2019s relationship to Israel (Isa 54:5; 62:5; Hos 2:19-20). Jesus applies it to himself: his presence constitutes a wedding banquet. Fasting is inappropriate because the bridegroom is here. The first shadow of the cross comes in v.35: when the bridegroom is taken away \u2014 then they will fast."
+            "paragraph": "Can you make the friends of the bridegroom (nymphios) fast while he is with them? The bridegroom is the OT image for YHWH’s relationship to Israel (Isa 54:5; 62:5; Hos 2:19-20). Jesus applies it to himself: his presence constitutes a wedding banquet. Fasting is inappropriate because the bridegroom is here. The first shadow of the cross comes in v.35: when the bridegroom is taken away — then they will fast."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Hos 6:6",
-              "note": "I desire mercy, not sacrifice \u2014 the principle behind Jesus\u2019s table fellowship with sinners."
+              "note": "I desire mercy, not sacrifice — the principle behind Jesus’s table fellowship with sinners."
             },
             {
               "ref": "Isa 25:6",
-              "note": "A banquet of rich food for all peoples \u2014 the messianic banquet that Jesus\u2019s table fellowship anticipates."
+              "note": "A banquet of rich food for all peoples — the messianic banquet that Jesus’s table fellowship anticipates."
             },
             {
               "ref": "Isa 62:5",
-              "note": "As a bridegroom rejoices over his bride, so will your God rejoice over you \u2014 the OT background for the bridegroom image."
+              "note": "As a bridegroom rejoices over his bride, so will your God rejoice over you — the OT background for the bridegroom image."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:31-32",
-              "note": "It is not the healthy who need a doctor, but the sick \u2014 the physician metaphor defines Jesus\u2019s mission precisely. He has come not to affirm the self-sufficient but to rescue the acknowledged failure. The Pharisees\u2019 complaint reveals their self-diagnosis: they believe themselves to be the healthy who have no need of him."
+              "note": "It is not the healthy who need a doctor, but the sick — the physician metaphor defines Jesus’s mission precisely. He has come not to affirm the self-sufficient but to rescue the acknowledged failure. The Pharisees’ complaint reveals their self-diagnosis: they believe themselves to be the healthy who have no need of him."
             },
             {
               "ref": "5:36-39",
-              "note": "New wine into new wineskins \u2014 the three parables (garment, wine, taste-preference) together argue that the new cannot be safely contained in the forms of the old. The Pharisaic system is not evil; it is simply not designed for what the kingdom brings. Jesus is not patching Judaism; he is fulfilling it."
+              "note": "New wine into new wineskins — the three parables (garment, wine, taste-preference) together argue that the new cannot be safely contained in the forms of the old. The Pharisaic system is not evil; it is simply not designed for what the kingdom brings. Jesus is not patching Judaism; he is fulfilling it."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "5:27-28",
-              "note": "Levi got up, left everything and followed him \u2014 Calvin: the immediacy and totality of Levi\u2019s response is grace made visible. He does not deliberate, negotiate, or phase out. The call of grace produces total response. This is Calvin\u2019s doctrine of effectual calling in narrative form."
+              "note": "Levi got up, left everything and followed him — Calvin: the immediacy and totality of Levi’s response is grace made visible. He does not deliberate, negotiate, or phase out. The call of grace produces total response. This is Calvin’s doctrine of effectual calling in narrative form."
             },
             {
               "ref": "5:38",
-              "note": "New wine must be poured into new wineskins \u2014 Calvin: the new wineskins are not a new religion but a renewed covenant community. The form of the old covenant (Temple, priesthood, sacrifice) was always a container for the wine of divine grace that would burst its limits when the fulfilment arrived."
+              "note": "New wine must be poured into new wineskins — Calvin: the new wineskins are not a new religion but a renewed covenant community. The form of the old covenant (Temple, priesthood, sacrifice) was always a container for the wine of divine grace that would burst its limits when the fulfilment arrived."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "5:30",
-              "note": "Pharisees and teachers of the law who belonged to their sect (hoi grammateis aut\u014dn) \u2014 literally \"their scribes\" \u2014 suggesting that the Pharisees had their own scholarly class. Luke distinguishes between the Pharisaic scribes and the broader scribal establishment, anticipating the nuanced characterization of these groups throughout his Gospel."
+              "note": "Pharisees and teachers of the law who belonged to their sect (hoi grammateis autōn) — literally \"their scribes\" — suggesting that the Pharisees had their own scholarly class. Luke distinguishes between the Pharisaic scribes and the broader scribal establishment, anticipating the nuanced characterization of these groups throughout his Gospel."
             },
             {
               "ref": "5:36-38",
-              "note": "The parable of the garments and wineskins appears in all three Synoptics. Luke alone adds v.39 (the preference for old wine), which may reflect his Gentile audience\u2019s cultural context where wine-preference was a recognized saying about conservative taste."
+              "note": "The parable of the garments and wineskins appears in all three Synoptics. Luke alone adds v.39 (the preference for old wine), which may reflect his Gentile audience’s cultural context where wine-preference was a recognized saying about conservative taste."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "5:29",
-              "note": "A large crowd of tax collectors and others \u2014 the Greek all\u014dn is deliberately vague: and others. Luke does not specify who the others are. The banquet is deliberately inclusive \u2014 its guest list is defined by need, not status."
+              "note": "A large crowd of tax collectors and others — the Greek allōn is deliberately vague: and others. Luke does not specify who the others are. The banquet is deliberately inclusive — its guest list is defined by need, not status."
             },
             {
               "ref": "5:39",
-              "note": "The old is better \u2014 a unique Lukan addition. The saying has irony: those who prefer the old wine will not want the new. Jesus is not mocking the Torah; he is describing the psychological resistance to the kingdom that the old covenant has, paradoxically, produced in those most devoted to it."
+              "note": "The old is better — a unique Lukan addition. The saying has irony: those who prefer the old wine will not want the new. Jesus is not mocking the Torah; he is describing the psychological resistance to the kingdom that the old covenant has, paradoxically, produced in those most devoted to it."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "5:32",
-              "note": "I have not come to call the righteous, but sinners to repentance \u2014 Augustine: the righteous Jesus does not come to call are those who are righteous in their own eyes. There are no genuinely righteous persons; there are only those who know their need and those who refuse to know it. The call is available to all; only those who accept the diagnosis can receive the cure."
+              "note": "I have not come to call the righteous, but sinners to repentance — Augustine: the righteous Jesus does not come to call are those who are righteous in their own eyes. There are no genuinely righteous persons; there are only those who know their need and those who refuse to know it. The call is available to all; only those who accept the diagnosis can receive the cure."
             },
             {
               "ref": "5:34-35",
-              "note": "The bridegroom will be taken from them \u2014 the first passion reference in Luke. It is embedded in a discussion about fasting and appears almost casually. The cross is present from the beginning, not merely as the narrative\u2019s eventual destination but as the interpretive key to the whole ministry."
+              "note": "The bridegroom will be taken from them — the first passion reference in Luke. It is embedded in a discussion about fasting and appears almost casually. The cross is present from the beginning, not merely as the narrative’s eventual destination but as the interpretive key to the whole ministry."
             }
           ]
         },
         "hist": {
-          "context": "The call of Levi and the banquet that follows is Luke\u2019s first extended encounter between Jesus and the tax-collector class. Tax collectors were despised as collaborators with Rome and as ritual transgressors. Jesus\u2019s table fellowship with them is not incidental to his mission but central to it \u2014 the banquet is the kingdom in enacted form. The Pharisees\u2019 complaint opens the controversy section (5:30-6:11) that will define the opposition to Jesus\u2019s ministry."
+          "context": "The call of Levi and the banquet that follows is Luke’s first extended encounter between Jesus and the tax-collector class. Tax collectors were despised as collaborators with Rome and as ritual transgressors. Jesus’s table fellowship with them is not incidental to his mission but central to it — the banquet is the kingdom in enacted form. The Pharisees’ complaint opens the controversy section (5:30-6:11) that will define the opposition to Jesus’s ministry."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 27\u201339 \u2014 Levi Called; Eating with Sinners; New Wine, New Wineskins",
+      "header": "Verses 27–39 — Levi Called; Eating with Sinners; New Wine, New Wineskins",
       "verse_start": 27,
       "verse_end": 39,
       "panels": {
         "heb": [
           {
-            "word": "epistat\u0113s",
-            "transliteration": "e-pis-TA-t\u0113s",
+            "word": "epistatēs",
+            "transliteration": "e-pis-TA-tēs",
             "gloss": "Master/Superintendent",
-            "paragraph": "Simon answered, \"Master (epistat\u0113s), we've worked hard all night.\" Luke uses epistat\u0113s \u2014 a term of authority equivalent to a commanding officer \u2014 exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen\u2019s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
+            "paragraph": "Simon answered, \"Master (epistatēs), we've worked hard all night.\" Luke uses epistatēs — a term of authority equivalent to a commanding officer — exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen’s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 6:5",
-              "note": "Woe to me! I am ruined! For I am a man of unclean lips \u2014 the Isaiah pattern that Simon's response echoes."
+              "note": "Woe to me! I am ruined! For I am a man of unclean lips — the Isaiah pattern that Simon's response echoes."
             },
             {
               "ref": "Ezek 47:9-10",
-              "note": "The eschatological river teeming with fish \u2014 the background for the miraculous catch as a sign of the kingdom's abundance."
+              "note": "The eschatological river teeming with fish — the background for the miraculous catch as a sign of the kingdom's abundance."
             },
             {
               "ref": "Lev 14:2-32",
-              "note": "The cleansing ritual for leprosy \u2014 what Jesus sends the healed man to fulfil as testimony."
+              "note": "The cleansing ritual for leprosy — what Jesus sends the healed man to fulfil as testimony."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:8",
-              "note": "Go away from me, Lord; I am a sinful man \u2014 the miracle produces not pride but self-knowledge. Peter sees himself in the light of the one who commands the lake's fish. This is the proper response to the holy: not comfort but clarity about the distance between the divine and the human."
-            },
-            {
-              "ref": "5:20",
-              "note": "When Jesus saw their faith, he said, \"Friend, your sins are forgiven\" \u2014 Jesus addresses the presenting condition that underlies the physical symptom. The Pharisees\u2019 outrage is theologically accurate: only God can forgive sins. Their error is not the premise but the conclusion."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:10",
-              "note": "From now on you will fish for people \u2014 Calvin: the metaphor of fishing is chosen deliberately. The fisherman does not create the fish; he finds them and brings them in. The evangelist does not create faith; he casts the net of the gospel into the sea of humanity and draws in those whom God has ordained."
-            },
-            {
-              "ref": "5:24",
-              "note": "That the Son of Man has authority on earth to forgive sins \u2014 Calvin: the forgiveness is the greater miracle. The paralytic\u2019s walking is visible proof of the invisible forgiveness. Jesus works the lesser miracle to establish credibility for the greater one."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:17",
-              "note": "Pharisees and teachers of the law from every village of Galilee and from Judea and Jerusalem \u2014 the religious establishment is formally assembled for the first time to observe Jesus. Luke marks this as a significant escalation: this is no longer a local matter."
-            },
-            {
-              "ref": "5:24",
-              "note": "Son of Man has authority on earth to forgive sins \u2014 the Son of Man title (from Dan 7:13-14) carries both human solidarity (bar enasha \u2014 a human being) and divine prerogative (the one who receives eternal dominion). Jesus uses it at precisely the moment when his divine prerogative is challenged."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "5:5",
-              "note": "\"But because you say so (epi de t\u014d rh\u0113mati sou)\" \u2014 the single phrase that defines Petrine obedience: not because the conditions are favourable, not because experience suggests it, but because you say so. This is the grammar of faith."
-            },
-            {
-              "ref": "5:17",
-              "note": "And the power of the Lord was with Jesus to heal \u2014 Luke uniquely adds this explanatory clause. The power (dynamis) is present as a discrete, active force \u2014 not an abstract capacity but an operative reality in the room."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "Jesus reached out his hand and touched him \u2014 Origen: the touch is legally defiling under Mosaic law (Lev 5:3; 13:45-46). Jesus becomes ritually unclean to cleanse the unclean man. The movement is opposite to contagion: the leper\u2019s uncleanness does not infect Jesus; Jesus\u2019s cleanness flows into the leper. This is the logic of the Incarnation."
-            },
-            {
-              "ref": "5:20",
-              "note": "Your sins are forgiven \u2014 Ambrose: notice that Jesus does not first heal the body. He addresses the deeper wound. The paralysis of sin precedes the paralysis of limbs; its cure precedes and guarantees the other."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke\u2019s calling of Simon follows a miracle that demonstrates Jesus\u2019s authority over Simon\u2019s own domain \u2014 the lake. The sequence is invitation (teach from my boat) \u2192 miraculous demonstration \u2192 call. Simon\u2019s response \u2014 \"Go away from me, Lord; I am a sinful man\" \u2014 is the same pattern as Isaiah at the throne (Isa 6:5) and Job before the whirlwind (Job 40:4): the holy presence of God exposes human sinfulness before it commissions for service."
+          "context": "Luke’s calling of Simon follows a miracle that demonstrates Jesus’s authority over Simon’s own domain — the lake. The sequence is invitation (teach from my boat) → miraculous demonstration → call. Simon’s response — \"Go away from me, Lord; I am a sinful man\" — is the same pattern as Isaiah at the throne (Isa 6:5) and Job before the whirlwind (Job 40:4): the holy presence of God exposes human sinfulness before it commissions for service."
         }
       }
     }
@@ -317,26 +272,26 @@
       {
         "name": "Levi (Matthew)",
         "role": "Tax collector; called by Jesus; hosts the great banquet",
-        "text": "His call is identical in structure to Simon\u2019s (follow me \u2192 left everything \u2192 followed), but the social context is more charged: Levi is a ritually compromised collaborator. His banquet is the first enacted parable of the kingdom\u2019s inclusive welcome."
+        "text": "His call is identical in structure to Simon’s (follow me → left everything → followed), but the social context is more charged: Levi is a ritually compromised collaborator. His banquet is the first enacted parable of the kingdom’s inclusive welcome."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"It is not the healthy who need a doctor, but the sick. I have not come to call the righteous, but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Those who are well have no need of a physician, but those who are sick. I have not come to call the righteous but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"They that are whole need not a physician; but they that are sick. I came not to call the righteous, but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"It is not those who are well who need a physician, but those who are sick. I have not come to call the righteous but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"Healthy people don't need a doctor\u2014sick people do. I have come to call not those who think they are righteous, but those who know they are sinners and need to repent.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"It is not the healthy who need a doctor, but the sick. I have not come to call the righteous, but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Those who are well have no need of a physician, but those who are sick. I have not come to call the righteous but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"They that are whole need not a physician; but they that are sick. I came not to call the righteous, but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"It is not those who are well who need a physician, but those who are sick. I have not come to call the righteous but sinners to repentance.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"Healthy people don't need a doctor—sick people do. I have come to call not those who think they are righteous, but those who know they are sinners and need to repent.\"</td></tr>",
     "src": [
       {
         "title": "Mishnah Demai 2:3",
-        "quote": "Restrictions on eating with Am ha\u2019aretz (people of the land) \u2014 the Pharisaic table-fellowship rules that Jesus\u2019s practice violated.",
-        "note": "Provides the legal context for the Pharisees\u2019 complaint: eating with tax collectors and sinners was not merely socially awkward but ritually transgressive."
+        "quote": "Restrictions on eating with Am ha’aretz (people of the land) — the Pharisaic table-fellowship rules that Jesus’s practice violated.",
+        "note": "Provides the legal context for the Pharisees’ complaint: eating with tax collectors and sinners was not merely socially awkward but ritually transgressive."
       },
       {
         "title": "Josephus, Jewish War 2.287",
-        "quote": "Josephus describes the tax collection system under Roman client rulers \u2014 the economic context of Levi\u2019s booth.",
-        "note": "Confirms the social and political associations of tax collection that made Levi\u2019s call so shocking."
+        "quote": "Josephus describes the tax collection system under Roman client rulers — the economic context of Levi’s booth.",
+        "note": "Confirms the social and political associations of tax collection that made Levi’s call so shocking."
       }
     ],
     "rec": [
       {
         "who": "Caravaggio, The Calling of Saint Matthew (1600)",
-        "text": "Caravaggio painted the moment of Levi\u2019s call with a shaft of light crossing the darkness of the tax collector\u2019s table, Jesus\u2019s hand extended in the gesture of Michelangelo\u2019s creation. The painting made Levi recognizable as every person caught in the moment between the old life and the call."
+        "text": "Caravaggio painted the moment of Levi’s call with a shaft of light crossing the darkness of the tax collector’s table, Jesus’s hand extended in the gesture of Michelangelo’s creation. The painting made Levi recognizable as every person caught in the moment between the old life and the call."
       },
       {
         "who": "John Calvin, Institutes III.ii.7",
@@ -360,29 +315,29 @@
     },
     "hebtext": [
       {
-        "word": "epistat\u0113s",
-        "tlit": "e-pis-TA-t\u0113s",
+        "word": "epistatēs",
+        "tlit": "e-pis-TA-tēs",
         "gloss": "Master/Superintendent",
-        "note": "Simon answered, \"Master (epistat\u0113s), we've worked hard all night.\" Luke uses epistat\u0113s \u2014 a term of authority equivalent to a commanding officer \u2014 exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen\u2019s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
+        "note": "Simon answered, \"Master (epistatēs), we've worked hard all night.\" Luke uses epistatēs — a term of authority equivalent to a commanding officer — exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen’s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
       },
       {
         "word": "nymphios",
         "tlit": "nym-FEE-os",
         "gloss": "bridegroom",
-        "note": "Can you make the friends of the bridegroom (nymphios) fast while he is with them? The bridegroom is the OT image for YHWH\u2019s relationship to Israel (Isa 54:5; 62:5; Hos 2:19-20). Jesus applies it to himself: his presence constitutes a wedding banquet. Fasting is inappropriate because the bridegroom is here. The first shadow of the cross comes in v.35: when the bridegroom is taken away \u2014 then they will fast."
+        "note": "Can you make the friends of the bridegroom (nymphios) fast while he is with them? The bridegroom is the OT image for YHWH’s relationship to Israel (Isa 54:5; 62:5; Hos 2:19-20). Jesus applies it to himself: his presence constitutes a wedding banquet. Fasting is inappropriate because the bridegroom is here. The first shadow of the cross comes in v.35: when the bridegroom is taken away — then they will fast."
       },
       {
-        "word": "epistat\u0113s",
-        "tlit": "e-pis-TA-t\u0113s",
+        "word": "epistatēs",
+        "tlit": "e-pis-TA-tēs",
         "gloss": "Master/Superintendent",
-        "note": "Simon answered, \"Master (epistat\u0113s), we've worked hard all night.\" Luke uses epistat\u0113s \u2014 a term of authority equivalent to a commanding officer \u2014 exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen\u2019s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
+        "note": "Simon answered, \"Master (epistatēs), we've worked hard all night.\" Luke uses epistatēs — a term of authority equivalent to a commanding officer — exclusively for Jesus in his Gospel (5:5; 8:24, 45; 9:33, 49; 17:13). Simon addresses Jesus not as rabbi (the Synoptic norm) but as one who has authority to direct even the fishermen’s professional work. His compliance despite exhaustion and failed experience is the first act of Petrine obedience in Luke."
       }
     ],
     "tx": [
       {
         "ref": "5:39",
-        "title": "\"The old is better\" \u2014 unique Lukan addition",
-        "content": "\"No one after drinking old wine wants the new, for they say the old is better\" \u2014 this verse is absent from Mark and Matthew. It is almost certainly an authentic Jesus-saying that Luke alone preserves.",
+        "title": "\"The old is better\" — unique Lukan addition",
+        "content": "\"No one after drinking old wine wants the new, for they say the old is better\" — this verse is absent from Mark and Matthew. It is almost certainly an authentic Jesus-saying that Luke alone preserves.",
         "note": "The verse acknowledges the genuine preference for the familiar over the new and explains (with irony) why the religious establishment would not embrace the kingdom: the old has become the measure of the good."
       }
     ],
@@ -392,7 +347,7 @@
         "positions": [
           {
             "name": "Two different events",
-            "proponents": "Luke 5 occurs at the beginning of Jesus\u2019s ministry; John 21 occurs after the resurrection. Though structurally parallel, they are different events with different theological functions.",
+            "proponents": "Luke 5 occurs at the beginning of Jesus’s ministry; John 21 occurs after the resurrection. Though structurally parallel, they are different events with different theological functions.",
             "argument": "Two events"
           },
           {
@@ -556,7 +511,7 @@
     },
     {
       "after_section": 3,
-      "tip": "'New wine must be poured into new wineskins' (v. 38). Jesus' ministry doesn't patch the old\u2014it requires new containers. The religious establishment can't contain what's coming.",
+      "tip": "'New wine must be poured into new wineskins' (v. 38). Jesus' ministry doesn't patch the old—it requires new containers. The religious establishment can't contain what's coming.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/luke/6.json
+++ b/content/luke/6.json
@@ -7,13 +7,13 @@
   "subtitle": "Sabbath Controversies; The Twelve Appointed; The Sermon on the Plain",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 Lord of the Sabbath; Healing on the Sabbath",
+      "header": "Verses 1–11 — Lord of the Sabbath; Healing on the Sabbath",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
@@ -22,98 +22,98 @@
             "word": "makarios",
             "transliteration": "ma-KAR-ee-os",
             "gloss": "blessed/happy/favoured",
-            "paragraph": "Blessed (makarios) are you who are poor. Unlike Matthew\u2019s \"poor in spirit\" (Matt 5:3), Luke\u2019s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour \u2014 the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat\u2019s theology (1:52-53) is here given its programmatic ethical form."
+            "paragraph": "Blessed (makarios) are you who are poor. Unlike Matthew’s \"poor in spirit\" (Matt 5:3), Luke’s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour — the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat’s theology (1:52-53) is here given its programmatic ethical form."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "1 Sam 21:1-6",
-              "note": "David eating the consecrated bread \u2014 the precedent Jesus cites against Sabbath legalism."
+              "note": "David eating the consecrated bread — the precedent Jesus cites against Sabbath legalism."
             },
             {
               "ref": "Isa 61:1-2",
-              "note": "The poor, the hungry, and the oppressed \u2014 the Isaiah programme Jesus claimed in Nazareth, now enacted in the beatitudes."
+              "note": "The poor, the hungry, and the oppressed — the Isaiah programme Jesus claimed in Nazareth, now enacted in the beatitudes."
             },
             {
               "ref": "Jer 17:5-8",
-              "note": "Cursed is the one who trusts in man\u2026 blessed is the one who trusts in the LORD \u2014 the OT structure of blessing-and-curse that the beatitudes and woes echo."
+              "note": "Cursed is the one who trusts in man… blessed is the one who trusts in the LORD — the OT structure of blessing-and-curse that the beatitudes and woes echo."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:5",
-              "note": "The Son of Man is Lord of the Sabbath \u2014 the most sweeping authority claim in the controversy section. The Sabbath was instituted by God (Gen 2:2-3). To claim lordship over it is to claim divine authority over the order of creation."
+              "note": "The Son of Man is Lord of the Sabbath — the most sweeping authority claim in the controversy section. The Sabbath was instituted by God (Gen 2:2-3). To claim lordship over it is to claim divine authority over the order of creation."
             },
             {
               "ref": "6:20-26",
-              "note": "The four beatitudes are addressed to the literally poor, hungry, weeping, and persecuted disciples. The four woes address their opposites. Luke\u2019s version is not a spiritualized version of Matthew\u2019s but the same core teaching applied without qualification to the material conditions of the disciple community."
+              "note": "The four beatitudes are addressed to the literally poor, hungry, weeping, and persecuted disciples. The four woes address their opposites. Luke’s version is not a spiritualized version of Matthew’s but the same core teaching applied without qualification to the material conditions of the disciple community."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:12-13",
-              "note": "He spent the night in prayer, then chose the Twelve \u2014 Calvin: the sequence is not incidental. Every major act of the Son of God is preceded by communion with the Father. The appointment of the apostles is not an administrative decision but a covenant act emerging from the Father\u2019s will, disclosed through prayer."
+              "note": "He spent the night in prayer, then chose the Twelve — Calvin: the sequence is not incidental. Every major act of the Son of God is preceded by communion with the Father. The appointment of the apostles is not an administrative decision but a covenant act emerging from the Father’s will, disclosed through prayer."
             },
             {
               "ref": "6:24",
-              "note": "Woe to you who are rich, for you have already received your comfort \u2014 Calvin: the woes are not directed against wealth as such but against those who have made wealth their comfort and found in it a substitute for God. To have received one\u2019s comfort in this world is to have spent the currency of hope."
+              "note": "Woe to you who are rich, for you have already received your comfort — Calvin: the woes are not directed against wealth as such but against those who have made wealth their comfort and found in it a substitute for God. To have received one’s comfort in this world is to have spent the currency of hope."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "6:13",
-              "note": "Whom he also designated apostles \u2014 Luke is the only Synoptic evangelist to use apostolos (apostle) for the Twelve at their appointment. The term means sent one \u2014 their identity is defined by their commissioning and sending, not by their social status or prior qualifications."
+              "note": "Whom he also designated apostles — Luke is the only Synoptic evangelist to use apostolos (apostle) for the Twelve at their appointment. The term means sent one — their identity is defined by their commissioning and sending, not by their social status or prior qualifications."
             },
             {
               "ref": "6:17",
-              "note": "A level place \u2014 Matthew has a mountain (5:1); Luke has a level place (topou pedinou). The difference is theologically significant for Luke: Jesus descends from the mountain of prayer (6:12) to stand on the level ground among the people. The teacher comes down to where the people are."
+              "note": "A level place — Matthew has a mountain (5:1); Luke has a level place (topou pedinou). The difference is theologically significant for Luke: Jesus descends from the mountain of prayer (6:12) to stand on the level ground among the people. The teacher comes down to where the people are."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "6:12",
-              "note": "He spent the night praying to God \u2014 the longest prayer reference in Luke before Gethsemane. The appointment of the Twelve is preceded by an entire night of prayer. Luke consistently places the major decisions and disclosures of the ministry in the context of prayer."
+              "note": "He spent the night praying to God — the longest prayer reference in Luke before Gethsemane. The appointment of the Twelve is preceded by an entire night of prayer. Luke consistently places the major decisions and disclosures of the ministry in the context of prayer."
             },
             {
               "ref": "6:19",
-              "note": "Power was coming from him and healing them all \u2014 the Greek dynamis ex\u0113rcheto: power was going out from him. The healing is not a performance but an emanation \u2014 the overflow of divine power present in his person."
+              "note": "Power was coming from him and healing them all — the Greek dynamis exērcheto: power was going out from him. The healing is not a performance but an emanation — the overflow of divine power present in his person."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "6:20",
-              "note": "Blessed are you who are poor, for yours is the kingdom of God \u2014 Basil of Caesarea: the kingdom belongs to the poor not because poverty is virtuous in itself but because the poor have been stripped of every false security and are positioned to receive what God alone gives. The rich have already received their comfort and have no room for more."
+              "note": "Blessed are you who are poor, for yours is the kingdom of God — Basil of Caesarea: the kingdom belongs to the poor not because poverty is virtuous in itself but because the poor have been stripped of every false security and are positioned to receive what God alone gives. The rich have already received their comfort and have no room for more."
             },
             {
               "ref": "6:27",
-              "note": "Love your enemies \u2014 Origen: this command is the most radical in the gospel and the most universally violated. It cannot be fulfilled by natural human strength. Its fulfilment requires the same love that led Jesus to the cross for his enemies."
+              "note": "Love your enemies — Origen: this command is the most radical in the gospel and the most universally violated. It cannot be fulfilled by natural human strength. Its fulfilment requires the same love that led Jesus to the cross for his enemies."
             }
           ]
         },
         "hist": {
-          "context": "Luke\u2019s Sermon on the Plain (6:20-49) parallels Matthew\u2019s Sermon on the Mount but is shorter, more direct, and set on level ground \u2014 among the people rather than above them. The beatitudes and woes are addressed to \"you\" (the disciples) in second person, making them declarations about the disciples\u2019 present situation and future reversal, not general wisdom principles."
+          "context": "Luke’s Sermon on the Plain (6:20-49) parallels Matthew’s Sermon on the Mount but is shorter, more direct, and set on level ground — among the people rather than above them. The beatitudes and woes are addressed to \"you\" (the disciples) in second person, making them declarations about the disciples’ present situation and future reversal, not general wisdom principles."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201326 \u2014 The Twelve Chosen; Blessings and Woes",
+      "header": "Verses 12–26 — The Twelve Chosen; Blessings and Woes",
       "verse_start": 12,
       "verse_end": 26,
       "panels": {
@@ -122,98 +122,98 @@
             "word": "agapate tous echthrous",
             "transliteration": "a-GA-pa-te toos ek-THROUS",
             "gloss": "love your enemies",
-            "paragraph": "Love (agapate) your enemies \u2014 the verb is agapa\u014d, the word for deliberate, willed, self-giving love \u2014 not philos (friendship love) or eros (romantic love). The command is not to feel warmly toward enemies but to act toward them with the same intentional goodwill that God shows the ungrateful and wicked (6:35). The theological grounding makes the command both comprehensible and executable: it is an extension of the divine character, not a superhuman emotional achievement."
+            "paragraph": "Love (agapate) your enemies — the verb is agapaō, the word for deliberate, willed, self-giving love — not philos (friendship love) or eros (romantic love). The command is not to feel warmly toward enemies but to act toward them with the same intentional goodwill that God shows the ungrateful and wicked (6:35). The theological grounding makes the command both comprehensible and executable: it is an extension of the divine character, not a superhuman emotional achievement."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Lev 19:18",
-              "note": "Love your neighbor as yourself \u2014 the love command Jesus radicalizes: not just the neighbor but the enemy."
+              "note": "Love your neighbor as yourself — the love command Jesus radicalizes: not just the neighbor but the enemy."
             },
             {
               "ref": "Prov 25:21-22",
-              "note": "If your enemy is hungry, give him food to eat \u2014 the OT precedent for enemy-love."
+              "note": "If your enemy is hungry, give him food to eat — the OT precedent for enemy-love."
             },
             {
               "ref": "Deut 15:7-8",
-              "note": "Be openhanded toward the poor and needy \u2014 the generosity principle behind 6:30."
+              "note": "Be openhanded toward the poor and needy — the generosity principle behind 6:30."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:35",
-              "note": "Be children of the Most High, because he is kind to the ungrateful and wicked \u2014 the theological foundation of enemy-love. God loves his enemies \u2014 which is what every human being is before grace. The command to love enemies is the command to imitate God\u2019s actual conduct toward humanity."
+              "note": "Be children of the Most High, because he is kind to the ungrateful and wicked — the theological foundation of enemy-love. God loves his enemies — which is what every human being is before grace. The command to love enemies is the command to imitate God’s actual conduct toward humanity."
             },
             {
               "ref": "6:46-49",
-              "note": "Why do you call me Lord, Lord, and do not do what I say? \u2014 The sermon ends with the sharpest possible diagnostic: obedience, not confession, is the criterion of kingdom membership. The two builders are not differentiated by their confession but by their construction."
+              "note": "Why do you call me Lord, Lord, and do not do what I say? — The sermon ends with the sharpest possible diagnostic: obedience, not confession, is the criterion of kingdom membership. The two builders are not differentiated by their confession but by their construction."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "6:27",
-              "note": "Love your enemies \u2014 Calvin: the command is not abrogated by the natural distinction between friends and enemies. It is precisely the enemy who tests whether love is genuine or merely conditional. The Christian\u2019s love is to be modelled on the divine love that sends rain on the righteous and the unrighteous alike (Matt 5:45)."
+              "note": "Love your enemies — Calvin: the command is not abrogated by the natural distinction between friends and enemies. It is precisely the enemy who tests whether love is genuine or merely conditional. The Christian’s love is to be modelled on the divine love that sends rain on the righteous and the unrighteous alike (Matt 5:45)."
             },
             {
               "ref": "6:47-48",
-              "note": "Who digs down deep and lays the foundation on rock \u2014 Calvin: the deep digging is the work of self-examination \u2014 going beneath the surface of comfortable religion to find the bedrock of genuine faith. The storm tests the foundation; the flood reveals what the foundation actually is."
+              "note": "Who digs down deep and lays the foundation on rock — Calvin: the deep digging is the work of self-examination — going beneath the surface of comfortable religion to find the bedrock of genuine faith. The storm tests the foundation; the flood reveals what the foundation actually is."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "6:35",
-              "note": "Without expecting to get anything back (m\u0113den apelpiz\u014dntes) \u2014 the Greek is unusual and debated: it can mean without despairing of anyone (i.e., not giving up on the enemy) or without expecting repayment. The context strongly favours the repayment reading: the contrast is with lending that expects return (6:34)."
+              "note": "Without expecting to get anything back (mēden apelpizōntes) — the Greek is unusual and debated: it can mean without despairing of anyone (i.e., not giving up on the enemy) or without expecting repayment. The context strongly favours the repayment reading: the contrast is with lending that expects return (6:34)."
             },
             {
               "ref": "6:46",
-              "note": "Lord, Lord \u2014 the double address (Kyrie, Kyrie) in the vocative signals urgency and familiarity. It is the address of someone who has been using the title frequently. The irony: the most confessionally active person may be the furthest from obedience."
+              "note": "Lord, Lord — the double address (Kyrie, Kyrie) in the vocative signals urgency and familiarity. It is the address of someone who has been using the title frequently. The irony: the most confessionally active person may be the furthest from obedience."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "6:38",
-              "note": "A good measure, pressed down, shaken together and running over, will be poured into your lap \u2014 the grain-merchant\u2019s imagery: every step in the process is used to maximize the measure. The generosity of God toward the generous is described in the commercial terms of first-century market practice."
+              "note": "A good measure, pressed down, shaken together and running over, will be poured into your lap — the grain-merchant’s imagery: every step in the process is used to maximize the measure. The generosity of God toward the generous is described in the commercial terms of first-century market practice."
             },
             {
               "ref": "6:40",
-              "note": "Everyone who is fully trained will be like their teacher \u2014 kat\u0113rtismenos (fully trained/equipped): the word used for mending nets (Mark 1:19) and restoring a sinner (Gal 6:1). The disciple\u2019s goal is not to surpass the teacher but to be formed into the teacher\u2019s image."
+              "note": "Everyone who is fully trained will be like their teacher — katērtismenos (fully trained/equipped): the word used for mending nets (Mark 1:19) and restoring a sinner (Gal 6:1). The disciple’s goal is not to surpass the teacher but to be formed into the teacher’s image."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "6:36",
-              "note": "Be merciful, just as your Father is merciful \u2014 Chrysostom: Matthew says \"perfect\" (5:48); Luke says \"merciful.\" The two terms are interpretively linked: God\u2019s perfection is expressed as mercy. To be conformed to God\u2019s perfection is to practise his mercy. Mercy is not weakness but the defining characteristic of divine perfection."
+              "note": "Be merciful, just as your Father is merciful — Chrysostom: Matthew says \"perfect\" (5:48); Luke says \"merciful.\" The two terms are interpretively linked: God’s perfection is expressed as mercy. To be conformed to God’s perfection is to practise his mercy. Mercy is not weakness but the defining characteristic of divine perfection."
             },
             {
               "ref": "6:41-42",
-              "note": "The plank and the speck \u2014 Augustine: the plank in the eye is pride \u2014 the sin that prevents us from seeing our own sins. Pride does not merely blind us to our own faults; it magnifies the faults of others in inverse proportion to its blindness to our own."
+              "note": "The plank and the speck — Augustine: the plank in the eye is pride — the sin that prevents us from seeing our own sins. Pride does not merely blind us to our own faults; it magnifies the faults of others in inverse proportion to its blindness to our own."
             }
           ]
         },
         "hist": {
-          "context": "The second half of the Sermon on the Plain moves from beatitudes (declarations about the disciples\u2019 status) to commands (instructions for their conduct). The hinge is 6:35-36: be children of the Most High, be merciful as your Father is merciful. The commands are grounded in character \u2014 who God is defines what his children do. The sermon closes with the builders parable, which makes hearing and doing the criterion of the kingdom life."
+          "context": "The second half of the Sermon on the Plain moves from beatitudes (declarations about the disciples’ status) to commands (instructions for their conduct). The hinge is 6:35-36: be children of the Most High, be merciful as your Father is merciful. The commands are grounded in character — who God is defines what his children do. The sermon closes with the builders parable, which makes hearing and doing the criterion of the kingdom life."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 27\u201349 \u2014 Love Your Enemies; Judging Others; Two Builders",
+      "header": "Verses 27–49 — Love Your Enemies; Judging Others; Two Builders",
       "verse_start": 27,
       "verse_end": 49,
       "panels": {
@@ -222,92 +222,47 @@
             "word": "makarios",
             "transliteration": "ma-KAR-ee-os",
             "gloss": "blessed/happy/favoured",
-            "paragraph": "Blessed (makarios) are you who are poor. Unlike Matthew\u2019s \"poor in spirit\" (Matt 5:3), Luke\u2019s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour \u2014 the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat\u2019s theology (1:52-53) is here given its programmatic ethical form."
+            "paragraph": "Blessed (makarios) are you who are poor. Unlike Matthew’s \"poor in spirit\" (Matt 5:3), Luke’s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour — the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat’s theology (1:52-53) is here given its programmatic ethical form."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "1 Sam 21:1-6",
-              "note": "David eating the consecrated bread \u2014 the precedent Jesus cites against Sabbath legalism."
+              "note": "David eating the consecrated bread — the precedent Jesus cites against Sabbath legalism."
             },
             {
               "ref": "Isa 61:1-2",
-              "note": "The poor, the hungry, and the oppressed \u2014 the Isaiah programme Jesus claimed in Nazareth, now enacted in the beatitudes."
+              "note": "The poor, the hungry, and the oppressed — the Isaiah programme Jesus claimed in Nazareth, now enacted in the beatitudes."
             },
             {
               "ref": "Jer 17:5-8",
-              "note": "Cursed is the one who trusts in man\u2026 blessed is the one who trusts in the LORD \u2014 the OT structure of blessing-and-curse that the beatitudes and woes echo."
+              "note": "Cursed is the one who trusts in man… blessed is the one who trusts in the LORD — the OT structure of blessing-and-curse that the beatitudes and woes echo."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:5",
-              "note": "The Son of Man is Lord of the Sabbath \u2014 the most sweeping authority claim in the controversy section. The Sabbath was instituted by God (Gen 2:2-3). To claim lordship over it is to claim divine authority over the order of creation."
-            },
-            {
-              "ref": "6:20-26",
-              "note": "The four beatitudes are addressed to the literally poor, hungry, weeping, and persecuted disciples. The four woes address their opposites. Luke\u2019s version is not a spiritualized version of Matthew\u2019s but the same core teaching applied without qualification to the material conditions of the disciple community."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "6:12-13",
-              "note": "He spent the night in prayer, then chose the Twelve \u2014 Calvin: the sequence is not incidental. Every major act of the Son of God is preceded by communion with the Father. The appointment of the apostles is not an administrative decision but a covenant act emerging from the Father\u2019s will, disclosed through prayer."
-            },
-            {
-              "ref": "6:24",
-              "note": "Woe to you who are rich, for you have already received your comfort \u2014 Calvin: the woes are not directed against wealth as such but against those who have made wealth their comfort and found in it a substitute for God. To have received one\u2019s comfort in this world is to have spent the currency of hope."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "6:13",
-              "note": "Whom he also designated apostles \u2014 Luke is the only Synoptic evangelist to use apostolos (apostle) for the Twelve at their appointment. The term means sent one \u2014 their identity is defined by their commissioning and sending, not by their social status or prior qualifications."
-            },
-            {
-              "ref": "6:17",
-              "note": "A level place \u2014 Matthew has a mountain (5:1); Luke has a level place (topou pedinou). The difference is theologically significant for Luke: Jesus descends from the mountain of prayer (6:12) to stand on the level ground among the people. The teacher comes down to where the people are."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "6:12",
-              "note": "He spent the night praying to God \u2014 the longest prayer reference in Luke before Gethsemane. The appointment of the Twelve is preceded by an entire night of prayer. Luke consistently places the major decisions and disclosures of the ministry in the context of prayer."
-            },
-            {
-              "ref": "6:19",
-              "note": "Power was coming from him and healing them all \u2014 the Greek dynamis ex\u0113rcheto: power was going out from him. The healing is not a performance but an emanation \u2014 the overflow of divine power present in his person."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "6:20",
-              "note": "Blessed are you who are poor, for yours is the kingdom of God \u2014 Basil of Caesarea: the kingdom belongs to the poor not because poverty is virtuous in itself but because the poor have been stripped of every false security and are positioned to receive what God alone gives. The rich have already received their comfort and have no room for more."
-            },
-            {
-              "ref": "6:27",
-              "note": "Love your enemies \u2014 Origen: this command is the most radical in the gospel and the most universally violated. It cannot be fulfilled by natural human strength. Its fulfilment requires the same love that led Jesus to the cross for his enemies."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke\u2019s Sermon on the Plain (6:20-49) parallels Matthew\u2019s Sermon on the Mount but is shorter, more direct, and set on level ground \u2014 among the people rather than above them. The beatitudes and woes are addressed to \"you\" (the disciples) in second person, making them declarations about the disciples\u2019 present situation and future reversal, not general wisdom principles."
+          "context": "Luke’s Sermon on the Plain (6:20-49) parallels Matthew’s Sermon on the Mount but is shorter, more direct, and set on level ground — among the people rather than above them. The beatitudes and woes are addressed to \"you\" (the disciples) in second person, making them declarations about the disciples’ present situation and future reversal, not general wisdom principles."
         }
       }
     }
@@ -317,15 +272,15 @@
       {
         "name": "The Twelve Apostles",
         "role": "Named and appointed after a night of prayer (6:12-16)",
-        "text": "Luke\u2019s list closes with Judas Iscariot, who became a traitor \u2014 the shadow falls on the appointment from the moment of naming. The Twelve are defined by calling and by one member\u2019s betrayal."
+        "text": "Luke’s list closes with Judas Iscariot, who became a traitor — the shadow falls on the appointment from the moment of naming. The Twelve are defined by calling and by one member’s betrayal."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Blessed are you who are poor, for yours is the kingdom of God.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Blessed are you who are poor, for yours is the kingdom of God.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"Blessed be ye poor: for yours is the kingdom of God.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"Blessed are you who are poor, for yours is the kingdom of God.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"God blesses you who are poor, for the Kingdom of God is yours.\"</td></tr>",
     "src": [
       {
-        "title": "Qumran \u2014 4Q525 (Beatitudes)",
-        "quote": "A Qumran beatitude text praising the pure of heart, the seekers of wisdom, and the humble \u2014 a pre-Christian Jewish beatitude tradition.",
-        "note": "Confirms that the beatitude form was a recognized wisdom genre in Second Temple Judaism, not an innovation of Jesus\u2019s. What is distinctive is the content and the social address."
+        "title": "Qumran — 4Q525 (Beatitudes)",
+        "quote": "A Qumran beatitude text praising the pure of heart, the seekers of wisdom, and the humble — a pre-Christian Jewish beatitude tradition.",
+        "note": "Confirms that the beatitude form was a recognized wisdom genre in Second Temple Judaism, not an innovation of Jesus’s. What is distinctive is the content and the social address."
       },
       {
         "title": "Josephus, Life 74",
@@ -336,11 +291,11 @@
     "rec": [
       {
         "who": "Martin Luther King Jr., Strength to Love (1963)",
-        "text": "King drew on Luke 6:27-35 as the theological foundation of nonviolent resistance. The love of enemies is not passivity but the highest form of moral courage \u2014 the refusal to be defined by the enemy\u2019s hatred."
+        "text": "King drew on Luke 6:27-35 as the theological foundation of nonviolent resistance. The love of enemies is not passivity but the highest form of moral courage — the refusal to be defined by the enemy’s hatred."
       },
       {
         "who": "Dietrich Bonhoeffer, The Cost of Discipleship (1937)",
-        "text": "Bonhoeffer\u2019s treatment of the Sermon on the Plain (parallel to Matthew\u2019s Sermon on the Mount) argued that the commands are not impossible ideals but concrete demands of discipleship: expensive grace, not cheap."
+        "text": "Bonhoeffer’s treatment of the Sermon on the Plain (parallel to Matthew’s Sermon on the Mount) argued that the commands are not impossible ideals but concrete demands of discipleship: expensive grace, not cheap."
       }
     ],
     "lit": {
@@ -363,32 +318,32 @@
         "word": "makarios",
         "tlit": "ma-KAR-ee-os",
         "gloss": "blessed/happy/favoured",
-        "note": "Blessed (makarios) are you who are poor. Unlike Matthew\u2019s \"poor in spirit\" (Matt 5:3), Luke\u2019s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour \u2014 the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat\u2019s theology (1:52-53) is here given its programmatic ethical form."
+        "note": "Blessed (makarios) are you who are poor. Unlike Matthew’s \"poor in spirit\" (Matt 5:3), Luke’s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour — the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat’s theology (1:52-53) is here given its programmatic ethical form."
       },
       {
         "word": "agapate tous echthrous",
         "tlit": "a-GA-pa-te toos ek-THROUS",
         "gloss": "love your enemies",
-        "note": "Love (agapate) your enemies \u2014 the verb is agapa\u014d, the word for deliberate, willed, self-giving love \u2014 not philos (friendship love) or eros (romantic love). The command is not to feel warmly toward enemies but to act toward them with the same intentional goodwill that God shows the ungrateful and wicked (6:35). The theological grounding makes the command both comprehensible and executable: it is an extension of the divine character, not a superhuman emotional achievement."
+        "note": "Love (agapate) your enemies — the verb is agapaō, the word for deliberate, willed, self-giving love — not philos (friendship love) or eros (romantic love). The command is not to feel warmly toward enemies but to act toward them with the same intentional goodwill that God shows the ungrateful and wicked (6:35). The theological grounding makes the command both comprehensible and executable: it is an extension of the divine character, not a superhuman emotional achievement."
       },
       {
         "word": "makarios",
         "tlit": "ma-KAR-ee-os",
         "gloss": "blessed/happy/favoured",
-        "note": "Blessed (makarios) are you who are poor. Unlike Matthew\u2019s \"poor in spirit\" (Matt 5:3), Luke\u2019s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour \u2014 the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat\u2019s theology (1:52-53) is here given its programmatic ethical form."
+        "note": "Blessed (makarios) are you who are poor. Unlike Matthew’s \"poor in spirit\" (Matt 5:3), Luke’s beatitudes are unqualified: poor, hungry, weeping, hated. The Greek makarios is not a moral commendation but a declaration of divine favour — the blessed one is the one God regards with special care. Luke pairs each beatitude with a woe: the reversal is total and symmetric. The Magnificat’s theology (1:52-53) is here given its programmatic ethical form."
       }
     ],
     "tx": [
       {
         "ref": "6:1",
-        "title": "On a Sabbath (en sabbat\u014d deuteroproto) \u2014 \"second-first Sabbath\"",
-        "content": "Some MSS add deuteroproto (second-first) after \u201csabbath\u201d in 6:1 \u2014 a term of uncertain meaning. The NA28 omits it as a scribal gloss.",
+        "title": "On a Sabbath (en sabbatō deuteroproto) — \"second-first Sabbath\"",
+        "content": "Some MSS add deuteroproto (second-first) after “sabbath” in 6:1 — a term of uncertain meaning. The NA28 omits it as a scribal gloss.",
         "note": "The term, if original, may refer to a counting system for sabbaths between Passover and Pentecost (Leviticus 23:15-16). Its obscurity is evidence it was not invented by a scribe."
       }
     ],
     "debate": [
       {
-        "title": "Are Luke\u2019s beatitudes and Matthew\u2019s from the same sermon?",
+        "title": "Are Luke’s beatitudes and Matthew’s from the same sermon?",
         "positions": [
           {
             "name": "One sermon, two accounts",
@@ -430,7 +385,7 @@
           "score": 6
         }
       ],
-      "note": "Luke 6 is the ethical heart of the Gospel: the Sermon on the Plain defines kingdom conduct in terms of radical love, divine character, and the renunciation of judgment. It is both the hardest teaching and the most thoroughly grounded \u2014 in who God is."
+      "note": "Luke 6 is the ethical heart of the Gospel: the Sermon on the Plain defines kingdom conduct in terms of radical love, divine character, and the renunciation of judgment. It is both the hardest teaching and the most thoroughly grounded — in who God is."
     }
   },
   "vhl_groups": [
@@ -556,7 +511,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'Love your enemies' (v. 27). Radical enemy-love distinguishes kingdom ethics: bless those who curse, pray for those who mistreat. Even sinners love those who love them\u2014what's distinctive about that?",
+      "tip": "'Love your enemies' (v. 27). Radical enemy-love distinguishes kingdom ethics: bless those who curse, pray for those who mistreat. Even sinners love those who love them—what's distinctive about that?",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/luke/7.json
+++ b/content/luke/7.json
@@ -7,455 +7,365 @@
   "subtitle": "The Centurion's Servant; Widow of Nain; John's Question; The Anointing Woman",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201310 \u2014 The Centurion\u2019s Servant: Such Great Faith",
+      "header": "Verses 1–10 — The Centurion’s Servant: Such Great Faith",
       "verse_start": 1,
       "verse_end": 10,
       "panels": {
         "heb": [
           {
-            "word": "esplagchnisth\u0113",
-            "transliteration": "es-PLANK-nis-th\u0113",
+            "word": "esplagchnisthē",
+            "transliteration": "es-PLANK-nis-thē",
             "gloss": "he was moved with compassion/his heart went out",
-            "paragraph": "When the Lord saw her, his heart went out (esplagchnisth\u0113) to her. The verb comes from splanchna \u2014 the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
+            "paragraph": "When the Lord saw her, his heart went out (esplagchnisthē) to her. The verb comes from splanchna — the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
           }
         ],
         "places": [
           {
             "name": "Capernaum",
             "coords": "Northwest shore of Sea of Galilee; ministry base",
-            "text": "The centurion\u2019s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus\u2019s own base."
+            "text": "The centurion’s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus’s own base."
           },
           {
             "name": "Nain",
             "coords": "Village in lower Galilee, near Jezreel Valley; c.40km south of Capernaum",
-            "text": "The only occurrence of Nain in the NT. The resurrection of the widow\u2019s son occurs here \u2014 echoing Elijah\u2019s resurrection of the widow\u2019s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
+            "text": "The only occurrence of Nain in the NT. The resurrection of the widow’s son occurs here — echoing Elijah’s resurrection of the widow’s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 35:5-6",
-              "note": "Then will the eyes of the blind be opened and the ears of the deaf unstopped \u2014 the messianic catalogue Jesus recites to John\u2019s messengers."
+              "note": "Then will the eyes of the blind be opened and the ears of the deaf unstopped — the messianic catalogue Jesus recites to John’s messengers."
             },
             {
               "ref": "1 Kings 17:23",
-              "note": "And Elijah gave him to his mother \u2014 the exact phrase Luke uses after the Nain resurrection (7:15). The Elijah pattern is explicit."
+              "note": "And Elijah gave him to his mother — the exact phrase Luke uses after the Nain resurrection (7:15). The Elijah pattern is explicit."
             },
             {
               "ref": "Mal 3:1",
-              "note": "I will send my messenger ahead of you \u2014 the Malachi text Jesus quotes about John."
+              "note": "I will send my messenger ahead of you — the Malachi text Jesus quotes about John."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:9",
-              "note": "I have not found such great faith even in Israel \u2014 the Gentile\u2019s faith surpasses Israel\u2019s. The centurion understands authority: he knows that Jesus\u2019s authority over sickness is the same kind of authority he exercises over his soldiers \u2014 a word is sufficient. This is the theological core of faith as trust in the Word."
+              "note": "I have not found such great faith even in Israel — the Gentile’s faith surpasses Israel’s. The centurion understands authority: he knows that Jesus’s authority over sickness is the same kind of authority he exercises over his soldiers — a word is sufficient. This is the theological core of faith as trust in the Word."
             },
             {
               "ref": "7:22-23",
-              "note": "Go back and report to John what you have seen and heard \u2014 Jesus answers John\u2019s question by pointing to the evidence. The Isaiah 35/61 catalogue is the answer to \"are you the one?\" John is not told to believe on the basis of a declaration but to assess the evidence. The beatitude of 7:23 is for those who can see the evidence and not stumble at the form in which it comes."
+              "note": "Go back and report to John what you have seen and heard — Jesus answers John’s question by pointing to the evidence. The Isaiah 35/61 catalogue is the answer to \"are you the one?\" John is not told to believe on the basis of a declaration but to assess the evidence. The beatitude of 7:23 is for those who can see the evidence and not stumble at the form in which it comes."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:16",
-              "note": "God has come to help his people \u2014 the crowd\u2019s response is theologically correct without being fully understood. They identify Jesus\u2019s action as the divine visitation promised by the prophets. The Incarnation is God visiting (epeskepsato \u2014 the same word as 1:68) his people, and the crowd at Nain perceives it accurately."
+              "note": "God has come to help his people — the crowd’s response is theologically correct without being fully understood. They identify Jesus’s action as the divine visitation promised by the prophets. The Incarnation is God visiting (epeskepsato — the same word as 1:68) his people, and the crowd at Nain perceives it accurately."
             },
             {
               "ref": "7:23",
-              "note": "Blessed is anyone who does not stumble on account of me \u2014 Calvin: the stumbling block of the Messiah is that he comes in a form that contradicts expectation. John expected a Coming One with winnowing fork (3:17); he finds Jesus eating with sinners. The beatitude is for those who can receive the Messiah as he actually is rather than as they expect him to be."
+              "note": "Blessed is anyone who does not stumble on account of me — Calvin: the stumbling block of the Messiah is that he comes in a form that contradicts expectation. John expected a Coming One with winnowing fork (3:17); he finds Jesus eating with sinners. The beatitude is for those who can receive the Messiah as he actually is rather than as they expect him to be."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:3",
-              "note": "The centurion sent some elders of the Jews \u2014 the centurion uses Jewish intermediaries rather than approaching Jesus directly, showing both cultural sensitivity and humility. Luke\u2019s narrative of the mission to the Gentiles begins with a Gentile who already loves Israel."
+              "note": "The centurion sent some elders of the Jews — the centurion uses Jewish intermediaries rather than approaching Jesus directly, showing both cultural sensitivity and humility. Luke’s narrative of the mission to the Gentiles begins with a Gentile who already loves Israel."
             },
             {
               "ref": "7:22",
-              "note": "The dead are raised \u2014 Jesus\u2019s catalogue ends with this as the climactic sign. The Nain resurrection (7:11-17) has just demonstrated it. The answer to John is not abstract but evidential: these things are happening now."
+              "note": "The dead are raised — Jesus’s catalogue ends with this as the climactic sign. The Nain resurrection (7:11-17) has just demonstrated it. The answer to John is not abstract but evidential: these things are happening now."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "7:7",
-              "note": "Say the word (eipe log\u014d) \u2014 the military man understands verbal authority: the word of a superior is operative. He transfers this understanding to Jesus: your verbal authority is sufficient, whatever the distance. This is Robertson\u2019s definition of faith by analogy with military obedience."
+              "note": "Say the word (eipe logō) — the military man understands verbal authority: the word of a superior is operative. He transfers this understanding to Jesus: your verbal authority is sufficient, whatever the distance. This is Robertson’s definition of faith by analogy with military obedience."
             },
             {
               "ref": "7:28",
-              "note": "Among those born of women there is no one greater than John \u2014 the superlative includes every human being who has ever lived. Yet the one who is least in the kingdom is greater. The kingdom creates a new order of greatness that makes the greatest human achievement comparatively small."
+              "note": "Among those born of women there is no one greater than John — the superlative includes every human being who has ever lived. Yet the one who is least in the kingdom is greater. The kingdom creates a new order of greatness that makes the greatest human achievement comparatively small."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "7:13-15",
-              "note": "He gave him back to his mother \u2014 Ambrose: the resurrection at Nain is an act of mercy addressed not to the dead man but to his mother. The text says Jesus saw her, had compassion on her, spoke to her, and then raised her son \u2014 and gave him back to her. The miracle is framed as a gift of the son to the mother."
+              "note": "He gave him back to his mother — Ambrose: the resurrection at Nain is an act of mercy addressed not to the dead man but to his mother. The text says Jesus saw her, had compassion on her, spoke to her, and then raised her son — and gave him back to her. The miracle is framed as a gift of the son to the mother."
             },
             {
               "ref": "7:34",
-              "note": "A friend of tax collectors and sinners \u2014 Chrysostom: the accusation is a Christological title. What his accusers mean as an insult is precisely what he is: the friend of those whom the religious system has placed beyond friendship. The slander is the gospel."
+              "note": "A friend of tax collectors and sinners — Chrysostom: the accusation is a Christological title. What his accusers mean as an insult is precisely what he is: the friend of those whom the religious system has placed beyond friendship. The slander is the gospel."
             }
           ]
         },
         "hist": {
-          "context": "Luke 7 presents three encounters that address the question of Jesus\u2019s identity from different angles: the centurion (Gentile military faith), the widow of Nain (the resurrection of the dead), and John\u2019s messengers (the fulfilment of the Isaiah programme). Jesus\u2019s answer to John catalogues the signs of the messianic age \u2014 drawn from Isa 35 and 61 \u2014 and ends with the beatitude of non-stumbling (7:23)."
+          "context": "Luke 7 presents three encounters that address the question of Jesus’s identity from different angles: the centurion (Gentile military faith), the widow of Nain (the resurrection of the dead), and John’s messengers (the fulfilment of the Isaiah programme). Jesus’s answer to John catalogues the signs of the messianic age — drawn from Isa 35 and 61 — and ends with the beatitude of non-stumbling (7:23)."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 11\u201317 \u2014 The Widow of Nain: Young Man, Arise",
+      "header": "Verses 11–17 — The Widow of Nain: Young Man, Arise",
       "verse_start": 11,
       "verse_end": 17,
       "panels": {
         "heb": [
           {
-            "word": "h\u0113 pistis sou ses\u014dken se",
-            "transliteration": "h\u0113 pis-TIS soo se-SO-ken se",
+            "word": "hē pistis sou sesōken se",
+            "transliteration": "hē pis-TIS soo se-SO-ken se",
             "gloss": "your faith has saved you",
-            "paragraph": "Your faith has saved you; go in peace \u2014 the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Ses\u014dken is the perfect tense of s\u014dz\u014d \u2014 to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation \u2014 though the love is its evidence."
+            "paragraph": "Your faith has saved you; go in peace — the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Sesōken is the perfect tense of sōzō — to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation — though the love is its evidence."
           }
         ],
         "places": [
           {
             "name": "Capernaum",
             "coords": "Northwest shore of Sea of Galilee; ministry base",
-            "text": "The centurion\u2019s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus\u2019s own base."
+            "text": "The centurion’s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus’s own base."
           },
           {
             "name": "Nain",
             "coords": "Village in lower Galilee, near Jezreel Valley; c.40km south of Capernaum",
-            "text": "The only occurrence of Nain in the NT. The resurrection of the widow\u2019s son occurs here \u2014 echoing Elijah\u2019s resurrection of the widow\u2019s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
+            "text": "The only occurrence of Nain in the NT. The resurrection of the widow’s son occurs here — echoing Elijah’s resurrection of the widow’s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Prov 31:30",
-              "note": "Charm is deceptive, beauty is fleeting \u2014 the contrast between Simon\u2019s transactional hospitality and the woman\u2019s extravagant love."
+              "note": "Charm is deceptive, beauty is fleeting — the contrast between Simon’s transactional hospitality and the woman’s extravagant love."
             },
             {
               "ref": "Song 1:2",
-              "note": "Let him kiss me with the kisses of his mouth \u2014 the erotic language of the woman\u2019s devotion redirected into the language of covenant love."
+              "note": "Let him kiss me with the kisses of his mouth — the erotic language of the woman’s devotion redirected into the language of covenant love."
             },
             {
               "ref": "Ps 51:1-3",
-              "note": "Have mercy on me, O God; blot out my transgressions \u2014 the penitent prayer that the woman\u2019s weeping enacts."
+              "note": "Have mercy on me, O God; blot out my transgressions — the penitent prayer that the woman’s weeping enacts."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:47",
-              "note": "Her many sins have been forgiven \u2014 as her great love has shown \u2014 the sentence is causally ambiguous: does the love cause the forgiveness, or demonstrate it? The parable (7:41-43) makes it clear: the forgiven one loves more. The love is consequent upon the forgiveness, not prior to it."
+              "note": "Her many sins have been forgiven — as her great love has shown — the sentence is causally ambiguous: does the love cause the forgiveness, or demonstrate it? The parable (7:41-43) makes it clear: the forgiven one loves more. The love is consequent upon the forgiveness, not prior to it."
             },
             {
               "ref": "7:44-46",
-              "note": "Three contrasts: no water vs tears; no kiss vs continuous kissing; no oil vs perfume \u2014 Simon has provided the minimum required hospitality; the woman has gone beyond every cultural maximum. The contrast is between calculated obligation and overflowing gratitude."
+              "note": "Three contrasts: no water vs tears; no kiss vs continuous kissing; no oil vs perfume — Simon has provided the minimum required hospitality; the woman has gone beyond every cultural maximum. The contrast is between calculated obligation and overflowing gratitude."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "7:39",
-              "note": "If this man were a prophet, he would know who is touching him \u2014 Calvin: Simon\u2019s theology is inverted. He thinks prophetic knowledge would lead to the refusal of the woman\u2019s touch. But prophetic knowledge reveals the woman\u2019s need and the character of grace \u2014 which is precisely why Jesus permits the touch."
+              "note": "If this man were a prophet, he would know who is touching him — Calvin: Simon’s theology is inverted. He thinks prophetic knowledge would lead to the refusal of the woman’s touch. But prophetic knowledge reveals the woman’s need and the character of grace — which is precisely why Jesus permits the touch."
             },
             {
               "ref": "7:48",
-              "note": "Your sins are forgiven \u2014 Calvin: said to the woman directly, in the presence of the table guests, after the parable has done its work. The public declaration is not merely for her comfort but for the instruction of all present: this is what forgiveness looks like when it is received."
+              "note": "Your sins are forgiven — Calvin: said to the woman directly, in the presence of the table guests, after the parable has done its work. The public declaration is not merely for her comfort but for the instruction of all present: this is what forgiveness looks like when it is received."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "7:37",
-              "note": "A woman in that town who lived a sinful life (h\u0113marti\u014dlos en t\u0113 polei) \u2014 the Greek idiom indicates she was publicly known as a sinner, likely a prostitute. Luke does not name her, protecting her identity while making her social status clear."
+              "note": "A woman in that town who lived a sinful life (hēmartiōlos en tē polei) — the Greek idiom indicates she was publicly known as a sinner, likely a prostitute. Luke does not name her, protecting her identity while making her social status clear."
             },
             {
               "ref": "7:47",
-              "note": "As her great love has shown (hoti \u0113gap\u0113sen poly) \u2014 the hoti clause is causal or evidential: because she loved much (causal, meaning love caused the forgiveness) or which shows that she loved much (evidential). The parable requires the evidential reading."
+              "note": "As her great love has shown (hoti ēgapēsen poly) — the hoti clause is causal or evidential: because she loved much (causal, meaning love caused the forgiveness) or which shows that she loved much (evidential). The parable requires the evidential reading."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "7:47",
-              "note": "Whoever has been forgiven little loves little \u2014 the aphorism is not a general observation but a diagnostic. Simon has been forgiven little not because his sins are fewer but because he believes his sins are fewer. The one who recognizes the size of the debt loves proportionally to the recognition."
+              "note": "Whoever has been forgiven little loves little — the aphorism is not a general observation but a diagnostic. Simon has been forgiven little not because his sins are fewer but because he believes his sins are fewer. The one who recognizes the size of the debt loves proportionally to the recognition."
             },
             {
               "ref": "7:50",
-              "note": "Your faith has saved you; go in peace \u2014 hupago eis eir\u0113n\u0113n: depart into peace. The Hebrew shalom \u2014 wholeness, right relationship, completeness. The woman leaves not merely forgiven but restored to a state of complete shalom."
+              "note": "Your faith has saved you; go in peace — hupago eis eirēnēn: depart into peace. The Hebrew shalom — wholeness, right relationship, completeness. The woman leaves not merely forgiven but restored to a state of complete shalom."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "7:38",
-              "note": "She wet his feet with her tears and wiped them with her hair \u2014 Augustine: the hair with which she had adorned herself for seduction becomes the cloth of her repentance. The instrument of sin becomes the instrument of devotion. This is the pattern of conversion: the powers and capacities of the old life redirected toward the new."
+              "note": "She wet his feet with her tears and wiped them with her hair — Augustine: the hair with which she had adorned herself for seduction becomes the cloth of her repentance. The instrument of sin becomes the instrument of devotion. This is the pattern of conversion: the powers and capacities of the old life redirected toward the new."
             },
             {
               "ref": "7:41-43",
-              "note": "The parable of the two debtors \u2014 Origen: both debtors are forgiven \u2014 the one who owed five hundred and the one who owed fifty. The parable insists that no one leaves the encounter unforgiven; the difference is in the recognition of what has been received."
+              "note": "The parable of the two debtors — Origen: both debtors are forgiven — the one who owed five hundred and the one who owed fifty. The parable insists that no one leaves the encounter unforgiven; the difference is in the recognition of what has been received."
             }
           ]
         },
         "hist": {
-          "context": "Luke\u2019s anointing scene is unique in several respects from the parallel accounts in Matthew, Mark, and John: the woman is explicitly called a sinner (not Mary of Bethany), the setting is earlier in the ministry, and Jesus\u2019s teaching focus is on the connection between forgiveness and love. The parable of the two debtors (7:41-43) is the interpretive key: the woman\u2019s extravagant love is the evidence of her great forgiveness, not its cause."
+          "context": "Luke’s anointing scene is unique in several respects from the parallel accounts in Matthew, Mark, and John: the woman is explicitly called a sinner (not Mary of Bethany), the setting is earlier in the ministry, and Jesus’s teaching focus is on the connection between forgiveness and love. The parable of the two debtors (7:41-43) is the interpretive key: the woman’s extravagant love is the evidence of her great forgiveness, not its cause."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 18\u201335 \u2014 John\u2019s Question; Jesus\u2019 Testimony; This Generation",
+      "header": "Verses 18–35 — John’s Question; Jesus’ Testimony; This Generation",
       "verse_start": 18,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "esplagchnisth\u0113",
-            "transliteration": "es-PLANK-nis-th\u0113",
+            "word": "esplagchnisthē",
+            "transliteration": "es-PLANK-nis-thē",
             "gloss": "he was moved with compassion/his heart went out",
-            "paragraph": "When the Lord saw her, his heart went out (esplagchnisth\u0113) to her. The verb comes from splanchna \u2014 the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
+            "paragraph": "When the Lord saw her, his heart went out (esplagchnisthē) to her. The verb comes from splanchna — the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
           }
         ],
         "places": [
           {
             "name": "Capernaum",
             "coords": "Northwest shore of Sea of Galilee; ministry base",
-            "text": "The centurion\u2019s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus\u2019s own base."
+            "text": "The centurion’s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus’s own base."
           },
           {
             "name": "Nain",
             "coords": "Village in lower Galilee, near Jezreel Valley; c.40km south of Capernaum",
-            "text": "The only occurrence of Nain in the NT. The resurrection of the widow\u2019s son occurs here \u2014 echoing Elijah\u2019s resurrection of the widow\u2019s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
+            "text": "The only occurrence of Nain in the NT. The resurrection of the widow’s son occurs here — echoing Elijah’s resurrection of the widow’s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 35:5-6",
-              "note": "Then will the eyes of the blind be opened and the ears of the deaf unstopped \u2014 the messianic catalogue Jesus recites to John\u2019s messengers."
+              "note": "Then will the eyes of the blind be opened and the ears of the deaf unstopped — the messianic catalogue Jesus recites to John’s messengers."
             },
             {
               "ref": "1 Kings 17:23",
-              "note": "And Elijah gave him to his mother \u2014 the exact phrase Luke uses after the Nain resurrection (7:15). The Elijah pattern is explicit."
+              "note": "And Elijah gave him to his mother — the exact phrase Luke uses after the Nain resurrection (7:15). The Elijah pattern is explicit."
             },
             {
               "ref": "Mal 3:1",
-              "note": "I will send my messenger ahead of you \u2014 the Malachi text Jesus quotes about John."
+              "note": "I will send my messenger ahead of you — the Malachi text Jesus quotes about John."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "I have not found such great faith even in Israel \u2014 the Gentile\u2019s faith surpasses Israel\u2019s. The centurion understands authority: he knows that Jesus\u2019s authority over sickness is the same kind of authority he exercises over his soldiers \u2014 a word is sufficient. This is the theological core of faith as trust in the Word."
-            },
-            {
-              "ref": "7:22-23",
-              "note": "Go back and report to John what you have seen and heard \u2014 Jesus answers John\u2019s question by pointing to the evidence. The Isaiah 35/61 catalogue is the answer to \"are you the one?\" John is not told to believe on the basis of a declaration but to assess the evidence. The beatitude of 7:23 is for those who can see the evidence and not stumble at the form in which it comes."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:16",
-              "note": "God has come to help his people \u2014 the crowd\u2019s response is theologically correct without being fully understood. They identify Jesus\u2019s action as the divine visitation promised by the prophets. The Incarnation is God visiting (epeskepsato \u2014 the same word as 1:68) his people, and the crowd at Nain perceives it accurately."
-            },
-            {
-              "ref": "7:23",
-              "note": "Blessed is anyone who does not stumble on account of me \u2014 Calvin: the stumbling block of the Messiah is that he comes in a form that contradicts expectation. John expected a Coming One with winnowing fork (3:17); he finds Jesus eating with sinners. The beatitude is for those who can receive the Messiah as he actually is rather than as they expect him to be."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:3",
-              "note": "The centurion sent some elders of the Jews \u2014 the centurion uses Jewish intermediaries rather than approaching Jesus directly, showing both cultural sensitivity and humility. Luke\u2019s narrative of the mission to the Gentiles begins with a Gentile who already loves Israel."
-            },
-            {
-              "ref": "7:22",
-              "note": "The dead are raised \u2014 Jesus\u2019s catalogue ends with this as the climactic sign. The Nain resurrection (7:11-17) has just demonstrated it. The answer to John is not abstract but evidential: these things are happening now."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "7:7",
-              "note": "Say the word (eipe log\u014d) \u2014 the military man understands verbal authority: the word of a superior is operative. He transfers this understanding to Jesus: your verbal authority is sufficient, whatever the distance. This is Robertson\u2019s definition of faith by analogy with military obedience."
-            },
-            {
-              "ref": "7:28",
-              "note": "Among those born of women there is no one greater than John \u2014 the superlative includes every human being who has ever lived. Yet the one who is least in the kingdom is greater. The kingdom creates a new order of greatness that makes the greatest human achievement comparatively small."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "7:13-15",
-              "note": "He gave him back to his mother \u2014 Ambrose: the resurrection at Nain is an act of mercy addressed not to the dead man but to his mother. The text says Jesus saw her, had compassion on her, spoke to her, and then raised her son \u2014 and gave him back to her. The miracle is framed as a gift of the son to the mother."
-            },
-            {
-              "ref": "7:34",
-              "note": "A friend of tax collectors and sinners \u2014 Chrysostom: the accusation is a Christological title. What his accusers mean as an insult is precisely what he is: the friend of those whom the religious system has placed beyond friendship. The slander is the gospel."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke 7 presents three encounters that address the question of Jesus\u2019s identity from different angles: the centurion (Gentile military faith), the widow of Nain (the resurrection of the dead), and John\u2019s messengers (the fulfilment of the Isaiah programme). Jesus\u2019s answer to John catalogues the signs of the messianic age \u2014 drawn from Isa 35 and 61 \u2014 and ends with the beatitude of non-stumbling (7:23)."
+          "context": "Luke 7 presents three encounters that address the question of Jesus’s identity from different angles: the centurion (Gentile military faith), the widow of Nain (the resurrection of the dead), and John’s messengers (the fulfilment of the Isaiah programme). Jesus’s answer to John catalogues the signs of the messianic age — drawn from Isa 35 and 61 — and ends with the beatitude of non-stumbling (7:23)."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 36\u201350 \u2014 The Sinful Woman: Her Many Sins Are Forgiven",
+      "header": "Verses 36–50 — The Sinful Woman: Her Many Sins Are Forgiven",
       "verse_start": 36,
       "verse_end": 50,
       "panels": {
         "heb": [
           {
-            "word": "h\u0113 pistis sou ses\u014dken se",
-            "transliteration": "h\u0113 pis-TIS soo se-SO-ken se",
+            "word": "hē pistis sou sesōken se",
+            "transliteration": "hē pis-TIS soo se-SO-ken se",
             "gloss": "your faith has saved you",
-            "paragraph": "Your faith has saved you; go in peace \u2014 the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Ses\u014dken is the perfect tense of s\u014dz\u014d \u2014 to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation \u2014 though the love is its evidence."
+            "paragraph": "Your faith has saved you; go in peace — the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Sesōken is the perfect tense of sōzō — to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation — though the love is its evidence."
           }
         ],
         "places": [
           {
             "name": "Capernaum",
             "coords": "Northwest shore of Sea of Galilee; ministry base",
-            "text": "The centurion\u2019s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus\u2019s own base."
+            "text": "The centurion’s story is set here. Capernaum is the Gentile-encounter city: the centurion builds the synagogue, demonstrating that the Gentile mission begins at Jesus’s own base."
           },
           {
             "name": "Nain",
             "coords": "Village in lower Galilee, near Jezreel Valley; c.40km south of Capernaum",
-            "text": "The only occurrence of Nain in the NT. The resurrection of the widow\u2019s son occurs here \u2014 echoing Elijah\u2019s resurrection of the widow\u2019s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
+            "text": "The only occurrence of Nain in the NT. The resurrection of the widow’s son occurs here — echoing Elijah’s resurrection of the widow’s son at Zarephath (1 Kings 17). Luke has already cited this precedent in 4:26."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Prov 31:30",
-              "note": "Charm is deceptive, beauty is fleeting \u2014 the contrast between Simon\u2019s transactional hospitality and the woman\u2019s extravagant love."
+              "note": "Charm is deceptive, beauty is fleeting — the contrast between Simon’s transactional hospitality and the woman’s extravagant love."
             },
             {
               "ref": "Song 1:2",
-              "note": "Let him kiss me with the kisses of his mouth \u2014 the erotic language of the woman\u2019s devotion redirected into the language of covenant love."
+              "note": "Let him kiss me with the kisses of his mouth — the erotic language of the woman’s devotion redirected into the language of covenant love."
             },
             {
               "ref": "Ps 51:1-3",
-              "note": "Have mercy on me, O God; blot out my transgressions \u2014 the penitent prayer that the woman\u2019s weeping enacts."
+              "note": "Have mercy on me, O God; blot out my transgressions — the penitent prayer that the woman’s weeping enacts."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:47",
-              "note": "Her many sins have been forgiven \u2014 as her great love has shown \u2014 the sentence is causally ambiguous: does the love cause the forgiveness, or demonstrate it? The parable (7:41-43) makes it clear: the forgiven one loves more. The love is consequent upon the forgiveness, not prior to it."
-            },
-            {
-              "ref": "7:44-46",
-              "note": "Three contrasts: no water vs tears; no kiss vs continuous kissing; no oil vs perfume \u2014 Simon has provided the minimum required hospitality; the woman has gone beyond every cultural maximum. The contrast is between calculated obligation and overflowing gratitude."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:39",
-              "note": "If this man were a prophet, he would know who is touching him \u2014 Calvin: Simon\u2019s theology is inverted. He thinks prophetic knowledge would lead to the refusal of the woman\u2019s touch. But prophetic knowledge reveals the woman\u2019s need and the character of grace \u2014 which is precisely why Jesus permits the touch."
-            },
-            {
-              "ref": "7:48",
-              "note": "Your sins are forgiven \u2014 Calvin: said to the woman directly, in the presence of the table guests, after the parable has done its work. The public declaration is not merely for her comfort but for the instruction of all present: this is what forgiveness looks like when it is received."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:37",
-              "note": "A woman in that town who lived a sinful life (h\u0113marti\u014dlos en t\u0113 polei) \u2014 the Greek idiom indicates she was publicly known as a sinner, likely a prostitute. Luke does not name her, protecting her identity while making her social status clear."
-            },
-            {
-              "ref": "7:47",
-              "note": "As her great love has shown (hoti \u0113gap\u0113sen poly) \u2014 the hoti clause is causal or evidential: because she loved much (causal, meaning love caused the forgiveness) or which shows that she loved much (evidential). The parable requires the evidential reading."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "7:47",
-              "note": "Whoever has been forgiven little loves little \u2014 the aphorism is not a general observation but a diagnostic. Simon has been forgiven little not because his sins are fewer but because he believes his sins are fewer. The one who recognizes the size of the debt loves proportionally to the recognition."
-            },
-            {
-              "ref": "7:50",
-              "note": "Your faith has saved you; go in peace \u2014 hupago eis eir\u0113n\u0113n: depart into peace. The Hebrew shalom \u2014 wholeness, right relationship, completeness. The woman leaves not merely forgiven but restored to a state of complete shalom."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "7:38",
-              "note": "She wet his feet with her tears and wiped them with her hair \u2014 Augustine: the hair with which she had adorned herself for seduction becomes the cloth of her repentance. The instrument of sin becomes the instrument of devotion. This is the pattern of conversion: the powers and capacities of the old life redirected toward the new."
-            },
-            {
-              "ref": "7:41-43",
-              "note": "The parable of the two debtors \u2014 Origen: both debtors are forgiven \u2014 the one who owed five hundred and the one who owed fifty. The parable insists that no one leaves the encounter unforgiven; the difference is in the recognition of what has been received."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke\u2019s anointing scene is unique in several respects from the parallel accounts in Matthew, Mark, and John: the woman is explicitly called a sinner (not Mary of Bethany), the setting is earlier in the ministry, and Jesus\u2019s teaching focus is on the connection between forgiveness and love. The parable of the two debtors (7:41-43) is the interpretive key: the woman\u2019s extravagant love is the evidence of her great forgiveness, not its cause."
+          "context": "Luke’s anointing scene is unique in several respects from the parallel accounts in Matthew, Mark, and John: the woman is explicitly called a sinner (not Mary of Bethany), the setting is earlier in the ministry, and Jesus’s teaching focus is on the connection between forgiveness and love. The parable of the two debtors (7:41-43) is the interpretive key: the woman’s extravagant love is the evidence of her great forgiveness, not its cause."
         }
       }
     }
@@ -465,31 +375,31 @@
       {
         "name": "The Anointing Woman",
         "role": "A sinful woman in the city; unnamed in Luke",
-        "text": "The most extravagant act of devotion in the early chapters of Luke. Her love is the evidence of her forgiveness and the contrast that exposes Simon\u2019s poverty of gratitude."
+        "text": "The most extravagant act of devotion in the early chapters of Luke. Her love is the evidence of her forgiveness and the contrast that exposes Simon’s poverty of gratitude."
       },
       {
         "name": "The Centurion",
         "role": "Roman military officer; Gentile; builder of the Capernaum synagogue",
-        "text": "The first Gentile to receive a miracle in Luke, and the occasion for Jesus\u2019s most explicit commendation of faith: not found even in Israel. His understanding of authority is Luke\u2019s definition of faith."
+        "text": "The first Gentile to receive a miracle in Luke, and the occasion for Jesus’s most explicit commendation of faith: not found even in Israel. His understanding of authority is Luke’s definition of faith."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Go back and report to John what you have seen and heard: The blind receive sight, the lame walk, those who have leprosy are cleansed, the deaf hear, the dead are raised, and the good news is proclaimed to the poor.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Go and tell John what you have seen and heard: the blind receive their sight, the lame walk, lepers are cleansed, and the deaf hear, the dead are raised up, the poor have good news preached to them.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"Go your way, and tell John what things ye have seen and heard; how that the blind see, the lame walk, the lepers are cleansed, the deaf hear, the dead are raised, to the poor the gospel is preached.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"Go and report to John what you have seen and heard: those who were blind receive sight, those who limp walk, those with leprosy are cleansed, those who are deaf hear, dead people are raised, the poor have the gospel preached to them.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"Go back to John and tell him what you have seen and heard\u2014the blind see, the lame walk, the lepers are cured, the deaf hear, the dead are raised to life, and the Good News is being preached to the poor.\"</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Go back and report to John what you have seen and heard: The blind receive sight, the lame walk, those who have leprosy are cleansed, the deaf hear, the dead are raised, and the good news is proclaimed to the poor.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"Go and tell John what you have seen and heard: the blind receive their sight, the lame walk, lepers are cleansed, and the deaf hear, the dead are raised up, the poor have good news preached to them.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"Go your way, and tell John what things ye have seen and heard; how that the blind see, the lame walk, the lepers are cleansed, the deaf hear, the dead are raised, to the poor the gospel is preached.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"Go and report to John what you have seen and heard: those who were blind receive sight, those who limp walk, those with leprosy are cleansed, those who are deaf hear, dead people are raised, the poor have the gospel preached to them.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"Go back to John and tell him what you have seen and heard—the blind see, the lame walk, the lepers are cured, the deaf hear, the dead are raised to life, and the Good News is being preached to the poor.\"</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities 18.116-119",
-        "quote": "Josephus\u2019s account of John the Baptist confirms his importance as a public religious figure whose imprisonment by Herod Antipas was politically significant.",
-        "note": "Confirms the historical context of John\u2019s imprisonment from which he sends the question of 7:19."
+        "quote": "Josephus’s account of John the Baptist confirms his importance as a public religious figure whose imprisonment by Herod Antipas was politically significant.",
+        "note": "Confirms the historical context of John’s imprisonment from which he sends the question of 7:19."
       },
       {
         "title": "Isaiah 35:4-6; 61:1-2",
-        "quote": "The Old Testament catalogue of messianic signs \u2014 the texts that form Jesus\u2019s answer to John\u2019s messengers.",
-        "note": "Jesus\u2019s answer does not claim messianic status directly but points to the signs that Isaiah said would mark the messianic age. The logic: these things are happening; draw your own conclusion."
+        "quote": "The Old Testament catalogue of messianic signs — the texts that form Jesus’s answer to John’s messengers.",
+        "note": "Jesus’s answer does not claim messianic status directly but points to the signs that Isaiah said would mark the messianic age. The logic: these things are happening; draw your own conclusion."
       }
     ],
     "rec": [
       {
         "who": "Rembrandt, Christ at the House of Simon the Pharisee (c. 1648)",
-        "text": "Rembrandt depicts the moment of the woman\u2019s devotion and Simon\u2019s judgment in a single painting. The light falls on the woman and on Jesus; Simon is in shadow, his face turned away."
+        "text": "Rembrandt depicts the moment of the woman’s devotion and Simon’s judgment in a single painting. The light falls on the woman and on Jesus; Simon is in shadow, his face turned away."
       },
       {
         "who": "Pope Francis, Evangelii Gaudium (2013)",
@@ -513,35 +423,35 @@
     },
     "hebtext": [
       {
-        "word": "esplagchnisth\u0113",
-        "tlit": "es-PLANK-nis-th\u0113",
+        "word": "esplagchnisthē",
+        "tlit": "es-PLANK-nis-thē",
         "gloss": "he was moved with compassion/his heart went out",
-        "note": "When the Lord saw her, his heart went out (esplagchnisth\u0113) to her. The verb comes from splanchna \u2014 the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
+        "note": "When the Lord saw her, his heart went out (esplagchnisthē) to her. The verb comes from splanchna — the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
       },
       {
-        "word": "h\u0113 pistis sou ses\u014dken se",
-        "tlit": "h\u0113 pis-TIS soo se-SO-ken se",
+        "word": "hē pistis sou sesōken se",
+        "tlit": "hē pis-TIS soo se-SO-ken se",
         "gloss": "your faith has saved you",
-        "note": "Your faith has saved you; go in peace \u2014 the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Ses\u014dken is the perfect tense of s\u014dz\u014d \u2014 to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation \u2014 though the love is its evidence."
+        "note": "Your faith has saved you; go in peace — the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Sesōken is the perfect tense of sōzō — to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation — though the love is its evidence."
       },
       {
-        "word": "esplagchnisth\u0113",
-        "tlit": "es-PLANK-nis-th\u0113",
+        "word": "esplagchnisthē",
+        "tlit": "es-PLANK-nis-thē",
         "gloss": "he was moved with compassion/his heart went out",
-        "note": "When the Lord saw her, his heart went out (esplagchnisth\u0113) to her. The verb comes from splanchna \u2014 the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
+        "note": "When the Lord saw her, his heart went out (esplagchnisthē) to her. The verb comes from splanchna — the intestines, the viscera, the seat of deepest emotion in Greek thought. Luke uses it three times in the Gospel: here (7:13), for the Good Samaritan (10:33), and for the father in the Prodigal Son (15:20). Each time it is the divine-quality compassion that initiates an act of restoration. The verb is passive: the Lord's compassion is not a willed response but an involuntary stirring of the deepest self toward the suffering."
       },
       {
-        "word": "h\u0113 pistis sou ses\u014dken se",
-        "tlit": "h\u0113 pis-TIS soo se-SO-ken se",
+        "word": "hē pistis sou sesōken se",
+        "tlit": "hē pis-TIS soo se-SO-ken se",
         "gloss": "your faith has saved you",
-        "note": "Your faith has saved you; go in peace \u2014 the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Ses\u014dken is the perfect tense of s\u014dz\u014d \u2014 to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation \u2014 though the love is its evidence."
+        "note": "Your faith has saved you; go in peace — the same formula Jesus uses with Bartimaeus (18:42) and the healed woman (8:48). Sesōken is the perfect tense of sōzō — to save, rescue, make whole: she has been saved and remains so. The verb covers both physical healing and spiritual rescue; here the context is clearly the latter. Faith, not the extravagance of her love, is the instrumental cause of her salvation — though the love is its evidence."
       }
     ],
     "tx": [
       {
         "ref": "7:21",
-        "title": "He cured many who had diseases \u2014 at that very moment",
-        "content": "Luke inserts this detail (absent from Matthew\u2019s parallel) to show that Jesus\u2019s answer to John is not merely verbal but demonstrable: the cures are happening in real time as the messengers watch. The evidence is the answer.",
+        "title": "He cured many who had diseases — at that very moment",
+        "content": "Luke inserts this detail (absent from Matthew’s parallel) to show that Jesus’s answer to John is not merely verbal but demonstrable: the cures are happening in real time as the messengers watch. The evidence is the answer.",
         "note": "This insertion is characteristically Lukan: the eyewitness emphasis, the immediacy, and the grounding of theology in observable event."
       }
     ],
@@ -589,7 +499,7 @@
           "score": 8
         }
       ],
-      "note": "Luke 7 defines faith through three contrasting portraits and asks: which type of faith do you bring? Extravagant love proportional to recognized forgiveness is Luke\u2019s answer to John\u2019s question and to the reader\u2019s."
+      "note": "Luke 7 defines faith through three contrasting portraits and asks: which type of faith do you bring? Extravagant love proportional to recognized forgiveness is Luke’s answer to John’s question and to the reader’s."
     }
   },
   "vhl_groups": [
@@ -710,7 +620,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "The centurion's faith astonishes Jesus: 'I have not found such great faith even in Israel' (v. 9). A Gentile soldier grasps authority\u2014he commands, soldiers obey; Jesus commands, disease obeys.",
+      "tip": "The centurion's faith astonishes Jesus: 'I have not found such great faith even in Israel' (v. 9). A Gentile soldier grasps authority—he commands, soldiers obey; Jesus commands, disease obeys.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/luke/8.json
+++ b/content/luke/8.json
@@ -7,407 +7,317 @@
   "subtitle": "Parable of the Sower; Storm Stilled; Gerasene Demoniac; Jairus and the Bleeding Woman",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201315 \u2014 Women Who Followed Jesus; The Parable of the Sower",
+      "header": "Verses 1–15 — Women Who Followed Jesus; The Parable of the Sower",
       "verse_start": 1,
       "verse_end": 15,
       "panels": {
         "heb": [
           {
-            "word": "en kardi\u0105 kal\u0119 kai agath\u0119",
+            "word": "en kardią kalę kai agathę",
             "transliteration": "en kar-DEE-ah ka-LAY kai a-ga-THAY",
             "gloss": "in a good and noble heart",
-            "paragraph": "Those with a noble and good heart (kardi\u0105 kal\u0119 kai agath\u0119) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kal\u0113 kai agath\u0113 is the classical virtue formula kalos kagathos \u2014 the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke\u2019s unique addition to the parable\u2019s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
+            "paragraph": "Those with a noble and good heart (kardią kalę kai agathę) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kalē kai agathē is the classical virtue formula kalos kagathos — the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke’s unique addition to the parable’s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 6:9-10",
-              "note": "Be ever hearing, but never understanding \u2014 the Isaiah citation behind 8:10: the parabolic form that reveals to the receptive and conceals from the hardened."
+              "note": "Be ever hearing, but never understanding — the Isaiah citation behind 8:10: the parabolic form that reveals to the receptive and conceals from the hardened."
             },
             {
               "ref": "Ezek 2:7",
-              "note": "Whether they listen or fail to listen \u2014 the prophetic word sown among resistant hearers."
+              "note": "Whether they listen or fail to listen — the prophetic word sown among resistant hearers."
             },
             {
               "ref": "Dan 2:22",
-              "note": "He reveals deep and hidden things; he knows what lies in darkness \u2014 the secrets of the kingdom that are given to the disciples."
+              "note": "He reveals deep and hidden things; he knows what lies in darkness — the secrets of the kingdom that are given to the disciples."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:2-3",
-              "note": "Mary Magdalene, Joanna, Susanna, and many others \u2014 Luke is the only evangelist who names the women supporters and specifies their financial contribution. These women will be present at the cross (23:49), at the tomb (23:55), and at the resurrection (24:1-10). They are the continuity of eyewitness testimony through the Passion."
+              "note": "Mary Magdalene, Joanna, Susanna, and many others — Luke is the only evangelist who names the women supporters and specifies their financial contribution. These women will be present at the cross (23:49), at the tomb (23:55), and at the resurrection (24:1-10). They are the continuity of eyewitness testimony through the Passion."
             },
             {
               "ref": "8:15",
-              "note": "By persevering produce a crop (hypomon\u0113) \u2014 endurance is the distinguishing characteristic of genuine faith in Luke\u2019s interpretation. The three types of failed hearing are all failure modes of perseverance: snatched away before it takes root, withered under testing, choked by competing desires. Only the persevering heart produces."
+              "note": "By persevering produce a crop (hypomonē) — endurance is the distinguishing characteristic of genuine faith in Luke’s interpretation. The three types of failed hearing are all failure modes of perseverance: snatched away before it takes root, withered under testing, choked by competing desires. Only the persevering heart produces."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:10",
-              "note": "The knowledge of the secrets of the kingdom of God has been given to you \u2014 Calvin: the distinction between insiders and outsiders is not arbitrary election but the response to prior hearing. The disciples have already been following; the crowds have been watching. The parables do not create the division; they reveal it."
+              "note": "The knowledge of the secrets of the kingdom of God has been given to you — Calvin: the distinction between insiders and outsiders is not arbitrary election but the response to prior hearing. The disciples have already been following; the crowds have been watching. The parables do not create the division; they reveal it."
             },
             {
               "ref": "8:15",
-              "note": "Persevering produce a crop \u2014 Calvin: perseverance is the evidence of genuine regeneration, not its cause. Those who are genuinely born again will persevere because the Spirit sustains them. Those who fall away demonstrate by their falling that their reception was never the good-soil kind."
+              "note": "Persevering produce a crop — Calvin: perseverance is the evidence of genuine regeneration, not its cause. Those who are genuinely born again will persevere because the Spirit sustains them. Those who fall away demonstrate by their falling that their reception was never the good-soil kind."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "8:3",
-              "note": "Joanna the wife of Chuza, the manager of Herod's household \u2014 the Greek epitropos (manager/steward) indicates a senior household official. Chuza managed Herod Antipas's estate. Joanna\u2019s presence in the group of women supporters means that the Herodian court itself contained followers of Jesus."
+              "note": "Joanna the wife of Chuza, the manager of Herod's household — the Greek epitropos (manager/steward) indicates a senior household official. Chuza managed Herod Antipas's estate. Joanna’s presence in the group of women supporters means that the Herodian court itself contained followers of Jesus."
             },
             {
               "ref": "8:10",
-              "note": "Though seeing, they may not see; though hearing, they may not understand \u2014 the quotation of Isa 6:9-10 raises the question of divine hardening. Luke\u2019s form (hina \u2014 so that) suggests purpose; Matthew's form (hoti \u2014 because) suggests consequence. The hardening may be both simultaneously."
+              "note": "Though seeing, they may not see; though hearing, they may not understand — the quotation of Isa 6:9-10 raises the question of divine hardening. Luke’s form (hina — so that) suggests purpose; Matthew's form (hoti — because) suggests consequence. The hardening may be both simultaneously."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "8:10",
-              "note": "The secrets of the kingdom (ta myst\u0113ria) \u2014 the plural is significant. There is not one mystery but many \u2014 the whole hidden counsel of God that is being disclosed in Jesus\u2019s ministry, accessible to those with ears to hear."
+              "note": "The secrets of the kingdom (ta mystēria) — the plural is significant. There is not one mystery but many — the whole hidden counsel of God that is being disclosed in Jesus’s ministry, accessible to those with ears to hear."
             },
             {
               "ref": "8:18",
-              "note": "Consider carefully how you listen \u2014 the quality of hearing determines the quality of reception. The warning about taking away what they think they have is addressed to those who hear carelessly \u2014 the spiritual equivalent of the rocky ground."
+              "note": "Consider carefully how you listen — the quality of hearing determines the quality of reception. The warning about taking away what they think they have is addressed to those who hear carelessly — the spiritual equivalent of the rocky ground."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "8:8",
-              "note": "Whoever has ears to hear, let them hear \u2014 Origin: the call to hear is itself a diagnostic. Those who do not hear do not have ears for this kind of hearing. The parable creates the division it describes: those who hear the call to hearing, hear; those who do not, demonstrate by their non-hearing that they are the path, the rock, or the thorn."
+              "note": "Whoever has ears to hear, let them hear — Origin: the call to hear is itself a diagnostic. Those who do not hear do not have ears for this kind of hearing. The parable creates the division it describes: those who hear the call to hearing, hear; those who do not, demonstrate by their non-hearing that they are the path, the rock, or the thorn."
             },
             {
               "ref": "8:21",
-              "note": "My mother and brothers are those who hear God's word and put it into practice \u2014 Ambrose: the new family of Jesus is defined not by blood but by obedience. Mary is not excluded from this family; she is its exemplar \u2014 the one who said \"may your word to me be fulfilled\" (1:38). She belongs to this new family by virtue of the same faith that defines it."
+              "note": "My mother and brothers are those who hear God's word and put it into practice — Ambrose: the new family of Jesus is defined not by blood but by obedience. Mary is not excluded from this family; she is its exemplar — the one who said \"may your word to me be fulfilled\" (1:38). She belongs to this new family by virtue of the same faith that defines it."
             }
           ]
         },
         "hist": {
-          "context": "Luke 8 opens with the unique detail of the women who supported Jesus\u2019s ministry out of their own means \u2014 one of whom is Joanna, wife of a Herodian court official. The Sower parable (8:4-15) is the Gospel\u2019s parable about parables \u2014 its interpretation is the key to all the others. Luke\u2019s unique contribution to the explanation: the good-soil hearers are those who persevere (hypomon\u0113) \u2014 endurance through testing is what distinguishes genuine reception from temporary enthusiasm."
+          "context": "Luke 8 opens with the unique detail of the women who supported Jesus’s ministry out of their own means — one of whom is Joanna, wife of a Herodian court official. The Sower parable (8:4-15) is the Gospel’s parable about parables — its interpretation is the key to all the others. Luke’s unique contribution to the explanation: the good-soil hearers are those who persevere (hypomonē) — endurance through testing is what distinguishes genuine reception from temporary enthusiasm."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 16\u201325 \u2014 A Lamp on a Stand; True Family; Stilling the Storm",
+      "header": "Verses 16–25 — A Lamp on a Stand; True Family; Stilling the Storm",
       "verse_start": 16,
       "verse_end": 25,
       "panels": {
         "heb": [
           {
-            "word": "hypaterm\u0113 christou",
+            "word": "hypatermē christou",
             "transliteration": "The garment edge/fringe",
             "gloss": "edge of his cloak",
-            "paragraph": "She touched the edge (kraspedon) of his cloak \u2014 the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus\u2019s covenant obedience \u2014 and power flows out. The healing is mediated through the sign of the covenant."
+            "paragraph": "She touched the edge (kraspedon) of his cloak — the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus’s covenant obedience — and power flows out. The healing is mediated through the sign of the covenant."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ps 107:29",
-              "note": "He stilled the storm to a whisper; the waves of the sea were hushed \u2014 the Psalm that the storm stilling fulfils."
+              "note": "He stilled the storm to a whisper; the waves of the sea were hushed — the Psalm that the storm stilling fulfils."
             },
             {
               "ref": "1 Kings 17:22",
-              "note": "The boy\u2019s life returned to him \u2014 the Elijah resurrection that the Jairus raising echoes."
+              "note": "The boy’s life returned to him — the Elijah resurrection that the Jairus raising echoes."
             },
             {
               "ref": "Lev 15:25-30",
-              "note": "The discharge law that made the bleeding woman ritually impure for twelve years \u2014 the legal context of her isolation."
+              "note": "The discharge law that made the bleeding woman ritually impure for twelve years — the legal context of her isolation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:25",
-              "note": "Where is your faith? \u2014 the storm reveals the disciples\u2019 faith condition. They have been with Jesus, heard his teaching, watched his miracles \u2014 and in the storm they panic. The question is not a rebuke but a diagnostic: where is it located? Is your faith abstract (in the idea of Jesus) or concrete (in the present Jesus asleep in the stern)?"
+              "note": "Where is your faith? — the storm reveals the disciples’ faith condition. They have been with Jesus, heard his teaching, watched his miracles — and in the storm they panic. The question is not a rebuke but a diagnostic: where is it located? Is your faith abstract (in the idea of Jesus) or concrete (in the present Jesus asleep in the stern)?"
             },
             {
               "ref": "8:48",
-              "note": "Daughter, your faith has saved you \u2014 the one healing that Jesus publicly declares and names in Luke 8. He stops the forward movement of the narrative (Jairus is waiting), identifies the woman, calls her daughter, and pronounces the full formula of salvation. The delay is not an obstacle to Jairus\u2019s need but the occasion for a public declaration of saving faith."
+              "note": "Daughter, your faith has saved you — the one healing that Jesus publicly declares and names in Luke 8. He stops the forward movement of the narrative (Jairus is waiting), identifies the woman, calls her daughter, and pronounces the full formula of salvation. The delay is not an obstacle to Jairus’s need but the occasion for a public declaration of saving faith."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "8:24",
-              "note": "He rebuked the wind and the raging waters \u2014 Calvin: the rebuke (epetim\u0113sen) is the same word used for rebuking demons (4:35; 8:29; 9:42). Luke frames the natural world as subject to the same authority as the spiritual world. The storm and the demon are both obedient to the same command."
+              "note": "He rebuked the wind and the raging waters — Calvin: the rebuke (epetimēsen) is the same word used for rebuking demons (4:35; 8:29; 9:42). Luke frames the natural world as subject to the same authority as the spiritual world. The storm and the demon are both obedient to the same command."
             },
             {
               "ref": "8:50",
-              "note": "Don't be afraid; just believe \u2014 Calvin: the command to believe is given after the worst news has arrived (the daughter is dead). Faith is not trust that the situation will improve naturally but trust in the one who can act beyond natural improvement. The command does not make the situation less dark; it redefines what darkness is in the presence of the one who commands it."
+              "note": "Don't be afraid; just believe — Calvin: the command to believe is given after the worst news has arrived (the daughter is dead). Faith is not trust that the situation will improve naturally but trust in the one who can act beyond natural improvement. The command does not make the situation less dark; it redefines what darkness is in the presence of the one who commands it."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "8:26",
-              "note": "The region of the Gerasenes \u2014 textual variant: Gadarenes (Matt 8:28) or Gergesenes. The Gerasene/Gadarene problem is the most discussed geographical issue in the Synoptics. See Luke 8:26n in the NET Bible for the full textual and geographical discussion."
+              "note": "The region of the Gerasenes — textual variant: Gadarenes (Matt 8:28) or Gergesenes. The Gerasene/Gadarene problem is the most discussed geographical issue in the Synoptics. See Luke 8:26n in the NET Bible for the full textual and geographical discussion."
             },
             {
               "ref": "8:43",
-              "note": "A woman who had been subject to bleeding for twelve years \u2014 Luke, as a physician (Col 4:14), omits Mark's detail that she had suffered under many doctors and spent all she had (Mark 5:26). Luke does not mention the failed medical treatment, perhaps from professional sensitivity."
+              "note": "A woman who had been subject to bleeding for twelve years — Luke, as a physician (Col 4:14), omits Mark's detail that she had suffered under many doctors and spent all she had (Mark 5:26). Luke does not mention the failed medical treatment, perhaps from professional sensitivity."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "8:30",
-              "note": "What is your name? \"Legion\" \u2014 a Roman legion was 3,000-6,000 soldiers. The name identifies both the scale of the possession and (by implication) the imperial military context of first-century Galilee. Whether the political resonance is intentional is debated; the scale of the bondage is clear."
+              "note": "What is your name? \"Legion\" — a Roman legion was 3,000-6,000 soldiers. The name identifies both the scale of the possession and (by implication) the imperial military context of first-century Galilee. Whether the political resonance is intentional is debated; the scale of the bondage is clear."
             },
             {
               "ref": "8:46",
-              "note": "I know that power has gone out from me \u2014 the power (dynamis) is not exhausted by the healing but exits as an act of divine energy. The woman does not take it; it flows to her. The healing is active, not passive \u2014 an outpouring, not a depletion."
+              "note": "I know that power has gone out from me — the power (dynamis) is not exhausted by the healing but exits as an act of divine energy. The woman does not take it; it flows to her. The healing is active, not passive — an outpouring, not a depletion."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "8:31",
-              "note": "They begged Jesus not to order them to go into the Abyss \u2014 Origen: the demons\u2019 fear of the Abyss (abyssos) reveals the eschatological structure of the spiritual world: there is a place prepared for the ultimate judgment of the fallen powers. The man was in the tombs \u2014 in the realm of death; the demons sought to avoid the Abyss. Jesus holds authority over both."
+              "note": "They begged Jesus not to order them to go into the Abyss — Origen: the demons’ fear of the Abyss (abyssos) reveals the eschatological structure of the spiritual world: there is a place prepared for the ultimate judgment of the fallen powers. The man was in the tombs — in the realm of death; the demons sought to avoid the Abyss. Jesus holds authority over both."
             },
             {
               "ref": "8:52",
-              "note": "She is not dead but asleep \u2014 Ambrose: the distinction is not denial of death but a redefinition of what death is in the presence of the resurrection and the life. For Jesus, who is the resurrection, death has a different quality \u2014 it is interruptible, temporary, reversible. Talitha koum (in Mark) and \"My child, get up!\" are the same voice that will speak at the last trumpet."
+              "note": "She is not dead but asleep — Ambrose: the distinction is not denial of death but a redefinition of what death is in the presence of the resurrection and the life. For Jesus, who is the resurrection, death has a different quality — it is interruptible, temporary, reversible. Talitha koum (in Mark) and \"My child, get up!\" are the same voice that will speak at the last trumpet."
             }
           ]
         },
         "hist": {
-          "context": "Luke 8:22-56 is a sequence of four miracles, each demonstrating Jesus\u2019s authority over a different domain: the natural world (storm), the spiritual world (Legion), the physical body (bleeding woman), and death itself (Jairus\u2019s daughter). The Jairus/bleeding woman sandwich (the first Lukan intercalation) teaches that the delay created by one need does not cancel God\u2019s action for another."
+          "context": "Luke 8:22-56 is a sequence of four miracles, each demonstrating Jesus’s authority over a different domain: the natural world (storm), the spiritual world (Legion), the physical body (bleeding woman), and death itself (Jairus’s daughter). The Jairus/bleeding woman sandwich (the first Lukan intercalation) teaches that the delay created by one need does not cancel God’s action for another."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 26\u201339 \u2014 The Gerasene Demoniac: Legion",
+      "header": "Verses 26–39 — The Gerasene Demoniac: Legion",
       "verse_start": 26,
       "verse_end": 39,
       "panels": {
         "heb": [
           {
-            "word": "en kardi\u0105 kal\u0119 kai agath\u0119",
+            "word": "en kardią kalę kai agathę",
             "transliteration": "en kar-DEE-ah ka-LAY kai a-ga-THAY",
             "gloss": "in a good and noble heart",
-            "paragraph": "Those with a noble and good heart (kardi\u0105 kal\u0119 kai agath\u0119) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kal\u0113 kai agath\u0113 is the classical virtue formula kalos kagathos \u2014 the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke\u2019s unique addition to the parable\u2019s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
+            "paragraph": "Those with a noble and good heart (kardią kalę kai agathę) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kalē kai agathē is the classical virtue formula kalos kagathos — the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke’s unique addition to the parable’s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 6:9-10",
-              "note": "Be ever hearing, but never understanding \u2014 the Isaiah citation behind 8:10: the parabolic form that reveals to the receptive and conceals from the hardened."
+              "note": "Be ever hearing, but never understanding — the Isaiah citation behind 8:10: the parabolic form that reveals to the receptive and conceals from the hardened."
             },
             {
               "ref": "Ezek 2:7",
-              "note": "Whether they listen or fail to listen \u2014 the prophetic word sown among resistant hearers."
+              "note": "Whether they listen or fail to listen — the prophetic word sown among resistant hearers."
             },
             {
               "ref": "Dan 2:22",
-              "note": "He reveals deep and hidden things; he knows what lies in darkness \u2014 the secrets of the kingdom that are given to the disciples."
+              "note": "He reveals deep and hidden things; he knows what lies in darkness — the secrets of the kingdom that are given to the disciples."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:2-3",
-              "note": "Mary Magdalene, Joanna, Susanna, and many others \u2014 Luke is the only evangelist who names the women supporters and specifies their financial contribution. These women will be present at the cross (23:49), at the tomb (23:55), and at the resurrection (24:1-10). They are the continuity of eyewitness testimony through the Passion."
-            },
-            {
-              "ref": "8:15",
-              "note": "By persevering produce a crop (hypomon\u0113) \u2014 endurance is the distinguishing characteristic of genuine faith in Luke\u2019s interpretation. The three types of failed hearing are all failure modes of perseverance: snatched away before it takes root, withered under testing, choked by competing desires. Only the persevering heart produces."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "The knowledge of the secrets of the kingdom of God has been given to you \u2014 Calvin: the distinction between insiders and outsiders is not arbitrary election but the response to prior hearing. The disciples have already been following; the crowds have been watching. The parables do not create the division; they reveal it."
-            },
-            {
-              "ref": "8:15",
-              "note": "Persevering produce a crop \u2014 Calvin: perseverance is the evidence of genuine regeneration, not its cause. Those who are genuinely born again will persevere because the Spirit sustains them. Those who fall away demonstrate by their falling that their reception was never the good-soil kind."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:3",
-              "note": "Joanna the wife of Chuza, the manager of Herod's household \u2014 the Greek epitropos (manager/steward) indicates a senior household official. Chuza managed Herod Antipas's estate. Joanna\u2019s presence in the group of women supporters means that the Herodian court itself contained followers of Jesus."
-            },
-            {
-              "ref": "8:10",
-              "note": "Though seeing, they may not see; though hearing, they may not understand \u2014 the quotation of Isa 6:9-10 raises the question of divine hardening. Luke\u2019s form (hina \u2014 so that) suggests purpose; Matthew's form (hoti \u2014 because) suggests consequence. The hardening may be both simultaneously."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "8:10",
-              "note": "The secrets of the kingdom (ta myst\u0113ria) \u2014 the plural is significant. There is not one mystery but many \u2014 the whole hidden counsel of God that is being disclosed in Jesus\u2019s ministry, accessible to those with ears to hear."
-            },
-            {
-              "ref": "8:18",
-              "note": "Consider carefully how you listen \u2014 the quality of hearing determines the quality of reception. The warning about taking away what they think they have is addressed to those who hear carelessly \u2014 the spiritual equivalent of the rocky ground."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:8",
-              "note": "Whoever has ears to hear, let them hear \u2014 Origin: the call to hear is itself a diagnostic. Those who do not hear do not have ears for this kind of hearing. The parable creates the division it describes: those who hear the call to hearing, hear; those who do not, demonstrate by their non-hearing that they are the path, the rock, or the thorn."
-            },
-            {
-              "ref": "8:21",
-              "note": "My mother and brothers are those who hear God's word and put it into practice \u2014 Ambrose: the new family of Jesus is defined not by blood but by obedience. Mary is not excluded from this family; she is its exemplar \u2014 the one who said \"may your word to me be fulfilled\" (1:38). She belongs to this new family by virtue of the same faith that defines it."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke 8 opens with the unique detail of the women who supported Jesus\u2019s ministry out of their own means \u2014 one of whom is Joanna, wife of a Herodian court official. The Sower parable (8:4-15) is the Gospel\u2019s parable about parables \u2014 its interpretation is the key to all the others. Luke\u2019s unique contribution to the explanation: the good-soil hearers are those who persevere (hypomon\u0113) \u2014 endurance through testing is what distinguishes genuine reception from temporary enthusiasm."
+          "context": "Luke 8 opens with the unique detail of the women who supported Jesus’s ministry out of their own means — one of whom is Joanna, wife of a Herodian court official. The Sower parable (8:4-15) is the Gospel’s parable about parables — its interpretation is the key to all the others. Luke’s unique contribution to the explanation: the good-soil hearers are those who persevere (hypomonē) — endurance through testing is what distinguishes genuine reception from temporary enthusiasm."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 40\u201356 \u2014 Jairus\u2019s Daughter; The Bleeding Woman",
+      "header": "Verses 40–56 — Jairus’s Daughter; The Bleeding Woman",
       "verse_start": 40,
       "verse_end": 56,
       "panels": {
         "heb": [
           {
-            "word": "hypaterm\u0113 christou",
+            "word": "hypatermē christou",
             "transliteration": "The garment edge/fringe",
             "gloss": "edge of his cloak",
-            "paragraph": "She touched the edge (kraspedon) of his cloak \u2014 the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus\u2019s covenant obedience \u2014 and power flows out. The healing is mediated through the sign of the covenant."
+            "paragraph": "She touched the edge (kraspedon) of his cloak — the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus’s covenant obedience — and power flows out. The healing is mediated through the sign of the covenant."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ps 107:29",
-              "note": "He stilled the storm to a whisper; the waves of the sea were hushed \u2014 the Psalm that the storm stilling fulfils."
+              "note": "He stilled the storm to a whisper; the waves of the sea were hushed — the Psalm that the storm stilling fulfils."
             },
             {
               "ref": "1 Kings 17:22",
-              "note": "The boy\u2019s life returned to him \u2014 the Elijah resurrection that the Jairus raising echoes."
+              "note": "The boy’s life returned to him — the Elijah resurrection that the Jairus raising echoes."
             },
             {
               "ref": "Lev 15:25-30",
-              "note": "The discharge law that made the bleeding woman ritually impure for twelve years \u2014 the legal context of her isolation."
+              "note": "The discharge law that made the bleeding woman ritually impure for twelve years — the legal context of her isolation."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:25",
-              "note": "Where is your faith? \u2014 the storm reveals the disciples\u2019 faith condition. They have been with Jesus, heard his teaching, watched his miracles \u2014 and in the storm they panic. The question is not a rebuke but a diagnostic: where is it located? Is your faith abstract (in the idea of Jesus) or concrete (in the present Jesus asleep in the stern)?"
-            },
-            {
-              "ref": "8:48",
-              "note": "Daughter, your faith has saved you \u2014 the one healing that Jesus publicly declares and names in Luke 8. He stops the forward movement of the narrative (Jairus is waiting), identifies the woman, calls her daughter, and pronounces the full formula of salvation. The delay is not an obstacle to Jairus\u2019s need but the occasion for a public declaration of saving faith."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:24",
-              "note": "He rebuked the wind and the raging waters \u2014 Calvin: the rebuke (epetim\u0113sen) is the same word used for rebuking demons (4:35; 8:29; 9:42). Luke frames the natural world as subject to the same authority as the spiritual world. The storm and the demon are both obedient to the same command."
-            },
-            {
-              "ref": "8:50",
-              "note": "Don't be afraid; just believe \u2014 Calvin: the command to believe is given after the worst news has arrived (the daughter is dead). Faith is not trust that the situation will improve naturally but trust in the one who can act beyond natural improvement. The command does not make the situation less dark; it redefines what darkness is in the presence of the one who commands it."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:26",
-              "note": "The region of the Gerasenes \u2014 textual variant: Gadarenes (Matt 8:28) or Gergesenes. The Gerasene/Gadarene problem is the most discussed geographical issue in the Synoptics. See Luke 8:26n in the NET Bible for the full textual and geographical discussion."
-            },
-            {
-              "ref": "8:43",
-              "note": "A woman who had been subject to bleeding for twelve years \u2014 Luke, as a physician (Col 4:14), omits Mark's detail that she had suffered under many doctors and spent all she had (Mark 5:26). Luke does not mention the failed medical treatment, perhaps from professional sensitivity."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "8:30",
-              "note": "What is your name? \"Legion\" \u2014 a Roman legion was 3,000-6,000 soldiers. The name identifies both the scale of the possession and (by implication) the imperial military context of first-century Galilee. Whether the political resonance is intentional is debated; the scale of the bondage is clear."
-            },
-            {
-              "ref": "8:46",
-              "note": "I know that power has gone out from me \u2014 the power (dynamis) is not exhausted by the healing but exits as an act of divine energy. The woman does not take it; it flows to her. The healing is active, not passive \u2014 an outpouring, not a depletion."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:31",
-              "note": "They begged Jesus not to order them to go into the Abyss \u2014 Origen: the demons\u2019 fear of the Abyss (abyssos) reveals the eschatological structure of the spiritual world: there is a place prepared for the ultimate judgment of the fallen powers. The man was in the tombs \u2014 in the realm of death; the demons sought to avoid the Abyss. Jesus holds authority over both."
-            },
-            {
-              "ref": "8:52",
-              "note": "She is not dead but asleep \u2014 Ambrose: the distinction is not denial of death but a redefinition of what death is in the presence of the resurrection and the life. For Jesus, who is the resurrection, death has a different quality \u2014 it is interruptible, temporary, reversible. Talitha koum (in Mark) and \"My child, get up!\" are the same voice that will speak at the last trumpet."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "Luke 8:22-56 is a sequence of four miracles, each demonstrating Jesus\u2019s authority over a different domain: the natural world (storm), the spiritual world (Legion), the physical body (bleeding woman), and death itself (Jairus\u2019s daughter). The Jairus/bleeding woman sandwich (the first Lukan intercalation) teaches that the delay created by one need does not cancel God\u2019s action for another."
+          "context": "Luke 8:22-56 is a sequence of four miracles, each demonstrating Jesus’s authority over a different domain: the natural world (storm), the spiritual world (Legion), the physical body (bleeding woman), and death itself (Jairus’s daughter). The Jairus/bleeding woman sandwich (the first Lukan intercalation) teaches that the delay created by one need does not cancel God’s action for another."
         }
       }
     }
@@ -416,36 +326,36 @@
     "ppl": [
       {
         "name": "Mary Magdalene",
-        "role": "Healed of seven demons; Luke\u2019s first named female disciple",
-        "text": "Present at the Crucifixion (23:49), the burial (23:55), and the resurrection (24:1-10). The most faithful disciple in Luke\u2019s passion narrative."
+        "role": "Healed of seven demons; Luke’s first named female disciple",
+        "text": "Present at the Crucifixion (23:49), the burial (23:55), and the resurrection (24:1-10). The most faithful disciple in Luke’s passion narrative."
       },
       {
         "name": "Joanna",
-        "role": "Wife of Herod\u2019s household manager; financial supporter",
-        "text": "The presence of a Herodian court official\u2019s wife among Jesus\u2019s supporters demonstrates the social range of the movement. She appears again at the resurrection (24:10)."
+        "role": "Wife of Herod’s household manager; financial supporter",
+        "text": "The presence of a Herodian court official’s wife among Jesus’s supporters demonstrates the social range of the movement. She appears again at the resurrection (24:10)."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"But the seed on good soil stands for those with a noble and good heart, who hear the word, retain it, and by persevering produce a crop.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"As for that in the good soil, they are those who, hearing the word, hold it fast in an honest and good heart, and bear fruit with patience.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"But that on the good ground are they, which in an honest and good heart, having heard the word, keep it, and bring forth fruit with patience.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"But the seed in the good soil, these are the ones who have heard the word in an honest and good heart, and hold it firmly, and produce fruit with perseverance.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"And the seeds that fell on the good soil represent honest, good-hearted people who hear God's word, cling to it, and patiently produce a huge harvest.\"</td></tr>",
     "src": [
       {
         "title": "Josephus, Jewish War 2.120",
-        "quote": "Josephus describes the Essene practice of owning property communally and sharing resources \u2014 the practice of support out of one's own means that Luke describes for the women in 8:3.",
+        "quote": "Josephus describes the Essene practice of owning property communally and sharing resources — the practice of support out of one's own means that Luke describes for the women in 8:3.",
         "note": "Confirms the social practice of communal support for itinerant teachers in first-century Judaism."
       },
       {
         "title": "Philo, On Dreams 1.75",
-        "quote": "Philo uses the Sower image metaphorically for the planting of wisdom in the soul \u2014 a pre-Christian use of the agricultural metaphor for teaching.",
+        "quote": "Philo uses the Sower image metaphorically for the planting of wisdom in the soul — a pre-Christian use of the agricultural metaphor for teaching.",
         "note": "Confirms that the agricultural image of sowing and harvest was a natural metaphor for teaching in the Hellenistic Jewish world."
       }
     ],
     "rec": [
       {
         "who": "Caravaggio, The Raising of Lazarus (1608-09)",
-        "text": "Though depicting John 11, Caravaggio\u2019s treatment of the raising of the dead illuminates Luke\u2019s resurrection scenes in the same tradition."
+        "text": "Though depicting John 11, Caravaggio’s treatment of the raising of the dead illuminates Luke’s resurrection scenes in the same tradition."
       },
       {
         "who": "John Chrysostom, Homilies on Matthew 44",
-        "text": "Chrysostom\u2019s extended meditation on the Sower parable became the classical treatment: each soil type is a portrait of a spiritual condition, and the catalogue is a mirror for self-examination."
+        "text": "Chrysostom’s extended meditation on the Sower parable became the classical treatment: each soil type is a portrait of a spiritual condition, and the catalogue is a mirror for self-examination."
       }
     ],
     "lit": {
@@ -465,28 +375,28 @@
     },
     "hebtext": [
       {
-        "word": "en kardi\u0105 kal\u0119 kai agath\u0119",
+        "word": "en kardią kalę kai agathę",
         "tlit": "en kar-DEE-ah ka-LAY kai a-ga-THAY",
         "gloss": "in a good and noble heart",
-        "note": "Those with a noble and good heart (kardi\u0105 kal\u0119 kai agath\u0119) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kal\u0113 kai agath\u0113 is the classical virtue formula kalos kagathos \u2014 the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke\u2019s unique addition to the parable\u2019s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
+        "note": "Those with a noble and good heart (kardią kalę kai agathę) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kalē kai agathē is the classical virtue formula kalos kagathos — the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke’s unique addition to the parable’s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
       },
       {
-        "word": "hypaterm\u0113 christou",
+        "word": "hypatermē christou",
         "tlit": "The garment edge/fringe",
         "gloss": "edge of his cloak",
-        "note": "She touched the edge (kraspedon) of his cloak \u2014 the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus\u2019s covenant obedience \u2014 and power flows out. The healing is mediated through the sign of the covenant."
+        "note": "She touched the edge (kraspedon) of his cloak — the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus’s covenant obedience — and power flows out. The healing is mediated through the sign of the covenant."
       },
       {
-        "word": "en kardi\u0105 kal\u0119 kai agath\u0119",
+        "word": "en kardią kalę kai agathę",
         "tlit": "en kar-DEE-ah ka-LAY kai a-ga-THAY",
         "gloss": "in a good and noble heart",
-        "note": "Those with a noble and good heart (kardi\u0105 kal\u0119 kai agath\u0119) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kal\u0113 kai agath\u0113 is the classical virtue formula kalos kagathos \u2014 the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke\u2019s unique addition to the parable\u2019s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
+        "note": "Those with a noble and good heart (kardią kalę kai agathę) who hear the word, retain it, and by persevering produce a crop. The Greek phrase kalē kai agathē is the classical virtue formula kalos kagathos — the integrated excellence of the good and the beautiful, used in classical Athens for the ideal citizen. Luke applies it to the receptive heart: the person who hears, holds, and perseveres. Luke’s unique addition to the parable’s explanation (absent from Mark and Matthew) frames faith in the language of Greek moral formation."
       },
       {
-        "word": "hypaterm\u0113 christou",
+        "word": "hypatermē christou",
         "tlit": "The garment edge/fringe",
         "gloss": "edge of his cloak",
-        "note": "She touched the edge (kraspedon) of his cloak \u2014 the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus\u2019s covenant obedience \u2014 and power flows out. The healing is mediated through the sign of the covenant."
+        "note": "She touched the edge (kraspedon) of his cloak — the Greek kraspedon is specifically the hem or fringe, almost certainly the tassel (tzitzit) of the Jewish prayer garment. Numbers 15:38-40 commands these fringes as reminders of the commandments. The woman reaches for the most visible symbol of Jesus’s covenant obedience — and power flows out. The healing is mediated through the sign of the covenant."
       }
     ],
     "tx": [
@@ -494,7 +404,7 @@
         "ref": "8:26",
         "title": "Gerasenes, Gadarenes, or Gergesenes",
         "content": "Three different readings exist across the manuscript traditions of all three Synoptics. The Gerasene reading (Sinaiticus, Vaticanus) is preferred in Luke by NA28.",
-        "note": "No reading is geographically perfect. The Gergesene reading (Origen\u2019s preference, based on topography) may identify a specific site on the eastern shore of the lake. The historical problem is acknowledged; the theological point is secure."
+        "note": "No reading is geographically perfect. The Gergesene reading (Origen’s preference, based on topography) may identify a specific site on the eastern shore of the lake. The historical problem is acknowledged; the theological point is secure."
       }
     ],
     "debate": [
@@ -503,7 +413,7 @@
         "positions": [
           {
             "name": "Full-time travel",
-            "proponents": "8:1-3 implies they traveled with the Twelve \u2014 \"from one town and village to another... The Twelve were with him, and also some women.\"",
+            "proponents": "8:1-3 implies they traveled with the Twelve — \"from one town and village to another... The Twelve were with him, and also some women.\"",
             "argument": "Itinerant"
           },
           {
@@ -541,7 +451,7 @@
           "score": 8
         }
       ],
-      "note": "Luke 8 demonstrates the scope of the kingdom\u2019s power: no domain of need is beyond its reach. The chapter consistently honours women as disciples, supporters, and recipients of healing, anticipating their central role in the passion and resurrection narratives."
+      "note": "Luke 8 demonstrates the scope of the kingdom’s power: no domain of need is beyond its reach. The chapter consistently honours women as disciples, supporters, and recipients of healing, anticipating their central role in the passion and resurrection narratives."
     }
   },
   "vhl_groups": [
@@ -662,12 +572,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Women accompany Jesus: Mary Magdalene, Joanna, Susanna. They 'were helping to support them out of their own means' (v. 3). Financial partnership\u2014female patronage funds the mission.",
+      "tip": "Women accompany Jesus: Mary Magdalene, Joanna, Susanna. They 'were helping to support them out of their own means' (v. 3). Financial partnership—female patronage funds the mission.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 3,
-      "tip": "'Who touched me?' (v. 45). In the crowd's press, one touch was different\u2014faith drew power. The hemorrhaging woman is exposed and then blessed: 'Your faith has healed you; go in peace.'",
+      "tip": "'Who touched me?' (v. 45). In the crowd's press, one touch was different—faith drew power. The hemorrhaging woman is exposed and then blessed: 'Your faith has healed you; go in peace.'",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/luke/9.json
+++ b/content/luke/9.json
@@ -7,13 +7,13 @@
   "subtitle": "Mission of the Twelve; Feeding Five Thousand; Peter's Confession; Transfiguration",
   "timeline_link": {
     "event_id": "transfiguration",
-    "text": "See on Timeline \u2014 Transfiguration"
+    "text": "See on Timeline — Transfiguration"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201117 \u2014 The Twelve Sent Out; Herod\u2019s Perplexity; Feeding Five Thousand",
+      "header": "Verses 1‑17 — The Twelve Sent Out; Herod’s Perplexity; Feeding Five Thousand",
       "verse_start": 1,
       "verse_end": 17,
       "panels": {
@@ -22,87 +22,87 @@
             "word": "ton stauron autou",
             "transliteration": "ton STOW-ron ow-TOO",
             "gloss": "his cross",
-            "paragraph": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' h\u0113meran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once \u2014 the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke\u2019s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
+            "paragraph": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' hēmeran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once — the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke’s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Num 11:22",
-              "note": "Should flocks and herds be slaughtered for them? Or should all the fish in the sea be caught? \u2014 Moses\u2019s question when the people demand meat in the wilderness. The feeding of five thousand replays the wilderness feeding."
+              "note": "Should flocks and herds be slaughtered for them? Or should all the fish in the sea be caught? — Moses’s question when the people demand meat in the wilderness. The feeding of five thousand replays the wilderness feeding."
             },
             {
               "ref": "2 Kings 4:42-44",
-              "note": "Feed the people \u2014 Elisha\u2019s multiplication of twenty loaves for a hundred people. Jesus\u2019s feeding far exceeds this Elisha miracle."
+              "note": "Feed the people — Elisha’s multiplication of twenty loaves for a hundred people. Jesus’s feeding far exceeds this Elisha miracle."
             },
             {
               "ref": "Isa 53:3",
-              "note": "He was despised and rejected \u2014 the passion prediction of 9:22 draws on the Servant Song."
+              "note": "He was despised and rejected — the passion prediction of 9:22 draws on the Servant Song."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:20",
-              "note": "God's Messiah \u2014 Peter's confession is the structural midpoint of Luke\u2019s Gospel. Everything before has been building to this declaration; everything after follows from it. The question Jesus asks is the question the whole Gospel has been posing since 1:1."
+              "note": "God's Messiah — Peter's confession is the structural midpoint of Luke’s Gospel. Everything before has been building to this declaration; everything after follows from it. The question Jesus asks is the question the whole Gospel has been posing since 1:1."
             },
             {
               "ref": "9:23",
-              "note": "Deny themselves and take up their cross daily \u2014 the cross-bearing command immediately follows the first passion prediction and Peter's confession. The sequence is crucial: once you know who Jesus is, you must reckon with what following him costs. Confessing the Messiah and carrying the cross are inseparable in Luke."
+              "note": "Deny themselves and take up their cross daily — the cross-bearing command immediately follows the first passion prediction and Peter's confession. The sequence is crucial: once you know who Jesus is, you must reckon with what following him costs. Confessing the Messiah and carrying the cross are inseparable in Luke."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:20",
-              "note": "God's Messiah \u2014 Calvin: Peter\u2019s confession is given by divine revelation (Matt 16:17), not by human insight. The disciples have been seeing the same evidence as the crowds; only the disciples confess correctly. The difference is the illumination of the Spirit, not the superiority of the disciples\u2019 natural perception."
+              "note": "God's Messiah — Calvin: Peter’s confession is given by divine revelation (Matt 16:17), not by human insight. The disciples have been seeing the same evidence as the crowds; only the disciples confess correctly. The difference is the illumination of the Spirit, not the superiority of the disciples’ natural perception."
             },
             {
               "ref": "9:23",
-              "note": "Take up their cross daily \u2014 Calvin: the cross is not merely the martyrdom risk but the daily practice of self-denial in all its forms. Luther extended this: the Christian life is a continuous dying to self and rising in Christ \u2014 not a single dramatic event but the pattern of every day."
+              "note": "Take up their cross daily — Calvin: the cross is not merely the martyrdom risk but the daily practice of self-denial in all its forms. Luther extended this: the Christian life is a continuous dying to self and rising in Christ — not a single dramatic event but the pattern of every day."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:7",
-              "note": "Herod was perplexed \u2014 the Greek dieporei (was completely at a loss). Herod's perplexity about Jesus\u2019s identity (John? Elijah? A prophet?) exactly mirrors the popular confusion catalogued in 9:19. The tetrarch who executed John cannot process the one whom John preceded."
+              "note": "Herod was perplexed — the Greek dieporei (was completely at a loss). Herod's perplexity about Jesus’s identity (John? Elijah? A prophet?) exactly mirrors the popular confusion catalogued in 9:19. The tetrarch who executed John cannot process the one whom John preceded."
             },
             {
               "ref": "9:27",
-              "note": "Some who are standing here will not taste death before they see the kingdom of God \u2014 the most debated prediction in Luke. Interpretations include: the Transfiguration (the most natural antecedent), Pentecost, the destruction of Jerusalem, or an ongoing realized eschatology in the church."
+              "note": "Some who are standing here will not taste death before they see the kingdom of God — the most debated prediction in Luke. Interpretations include: the Transfiguration (the most natural antecedent), Pentecost, the destruction of Jerusalem, or an ongoing realized eschatology in the church."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "9:18",
-              "note": "Once when Jesus was praying in private \u2014 Luke\u2019s unique Petrine context for the confession. The question about identity arises in the context of prayer. The Messianic disclosure comes from a moment of communion, not from a public gathering."
+              "note": "Once when Jesus was praying in private — Luke’s unique Petrine context for the confession. The question about identity arises in the context of prayer. The Messianic disclosure comes from a moment of communion, not from a public gathering."
             },
             {
               "ref": "9:22",
-              "note": "The Son of Man must (dei) suffer \u2014 the divine necessity is the first element: not that he will suffer (as if by accident) but that he must suffer (as by divine appointment). The cross is not a tragic interruption of the mission but its divinely ordained fulfilment."
+              "note": "The Son of Man must (dei) suffer — the divine necessity is the first element: not that he will suffer (as if by accident) but that he must suffer (as by divine appointment). The cross is not a tragic interruption of the mission but its divinely ordained fulfilment."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "9:13",
-              "note": "You give them something to eat \u2014 Origen: the command to the disciples is a command to the church in every age. The crowd is hungry; Jesus does not dismiss them but says to his disciples: you feed them. The church is the instrument of kingdom provision, with resources that appear inadequate until they are surrendered to Jesus and distributed."
+              "note": "You give them something to eat — Origen: the command to the disciples is a command to the church in every age. The crowd is hungry; Jesus does not dismiss them but says to his disciples: you feed them. The church is the instrument of kingdom provision, with resources that appear inadequate until they are surrendered to Jesus and distributed."
             },
             {
               "ref": "9:24",
-              "note": "Whoever wants to save their life will lose it \u2014 Augustine: the paradox of self-preservation is the Gospel\u2019s central economy. The one who grasps for life loses it; the one who releases life into the service of the kingdom receives it back. This is the pattern of the cross: death as the path to life."
+              "note": "Whoever wants to save their life will lose it — Augustine: the paradox of self-preservation is the Gospel’s central economy. The one who grasps for life loses it; the one who releases life into the service of the kingdom receives it back. This is the pattern of the cross: death as the path to life."
             }
           ]
         },
@@ -110,17 +110,17 @@
           {
             "name": "The Transfiguration Mountain",
             "coords": "Traditionally identified as Mt. Tabor or Mt. Hermon",
-            "text": "The \u201chigh mountain\u201d (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
+            "text": "The “high mountain” (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
           }
         ],
         "hist": {
-          "context": "Luke 9 is the turning-point chapter. It opens with the mission of the Twelve (the first extension of Jesus\u2019s own ministry to his disciples) and ends with the determination to go to Jerusalem (9:51). Between them: the feeding of five thousand, Herod\u2019s question, Peter\u2019s confession, the first passion prediction, the cost of discipleship, the Transfiguration, the failed exorcism, the second passion prediction, and the cost of following. Luke compresses more theological content into chapter 9 than any other chapter in the Gospel."
+          "context": "Luke 9 is the turning-point chapter. It opens with the mission of the Twelve (the first extension of Jesus’s own ministry to his disciples) and ends with the determination to go to Jerusalem (9:51). Between them: the feeding of five thousand, Herod’s question, Peter’s confession, the first passion prediction, the cost of discipleship, the Transfiguration, the failed exorcism, the second passion prediction, and the cost of following. Luke compresses more theological content into chapter 9 than any other chapter in the Gospel."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 18\u201327 \u2014 Peter\u2019s Confession; First Passion Prediction; Take Up Your Cross",
+      "header": "Verses 18–27 — Peter’s Confession; First Passion Prediction; Take Up Your Cross",
       "verse_start": 18,
       "verse_end": 27,
       "panels": {
@@ -129,87 +129,87 @@
             "word": "exodon",
             "transliteration": "EK-so-don",
             "gloss": "departure/exodus",
-            "paragraph": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos \u2014 the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus\u2019s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah \u2014 the architect of the Exodus and the prophet of the return from exile \u2014 are the appropriate witnesses to the event that both their lives anticipated."
+            "paragraph": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos — the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus’s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah — the architect of the Exodus and the prophet of the return from exile — are the appropriate witnesses to the event that both their lives anticipated."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 24:15-16",
-              "note": "The cloud covered the mountain and the glory of the LORD settled on it \u2014 the Sinai theophany that the Transfiguration cloud echoes."
+              "note": "The cloud covered the mountain and the glory of the LORD settled on it — the Sinai theophany that the Transfiguration cloud echoes."
             },
             {
               "ref": "Deut 18:15",
-              "note": "Listen to him \u2014 the voice from the cloud quotes the Deuteronomy command about the prophet like Moses: hear the fulfiller."
+              "note": "Listen to him — the voice from the cloud quotes the Deuteronomy command about the prophet like Moses: hear the fulfiller."
             },
             {
               "ref": "Mal 4:5",
-              "note": "See, I will send the prophet Elijah to you before that great and dreadful day of the LORD comes \u2014 Elijah\u2019s presence at the Transfiguration confirms that the Elijah-promise has been fulfilled."
+              "note": "See, I will send the prophet Elijah to you before that great and dreadful day of the LORD comes — Elijah’s presence at the Transfiguration confirms that the Elijah-promise has been fulfilled."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:31",
-              "note": "They spoke about his departure, which he was about to bring to completion at Jerusalem \u2014 the subject of the divine conversation is the cross. The law (Moses) and the prophets (Elijah) are speaking with Jesus about the event that both have been anticipating. The Transfiguration is the OT endorsing the NT before it happens."
+              "note": "They spoke about his departure, which he was about to bring to completion at Jerusalem — the subject of the divine conversation is the cross. The law (Moses) and the prophets (Elijah) are speaking with Jesus about the event that both have been anticipating. The Transfiguration is the OT endorsing the NT before it happens."
             },
             {
               "ref": "9:51",
-              "note": "He resolutely set his face to go to Jerusalem \u2014 the Greek is st\u0113riz\u014d \u2014 he fixed, established, set. The Jerusalem journey begins here and does not arrive until 19:28. Luke\u2019s longest section (9:51-19:27) is the travel narrative, the Gospel\u2019s central block, structured around the journey to the city where the Son of Man must be delivered."
+              "note": "He resolutely set his face to go to Jerusalem — the Greek is stērizō — he fixed, established, set. The Jerusalem journey begins here and does not arrive until 19:28. Luke’s longest section (9:51-19:27) is the travel narrative, the Gospel’s central block, structured around the journey to the city where the Son of Man must be delivered."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "9:31",
-              "note": "His departure, which he was about to bring to completion at Jerusalem \u2014 Calvin: the conversation on the mountain is the most theological conversation in the Gospels, and Luke gives us its subject: the cross. The entire OT \u2014 represented by Moses and Elijah \u2014 has been pointing here. The fulfilment is the departure that is also the completion."
+              "note": "His departure, which he was about to bring to completion at Jerusalem — Calvin: the conversation on the mountain is the most theological conversation in the Gospels, and Luke gives us its subject: the cross. The entire OT — represented by Moses and Elijah — has been pointing here. The fulfilment is the departure that is also the completion."
             },
             {
               "ref": "9:60",
-              "note": "Let the dead bury their own dead \u2014 Calvin: the apparent harshness of Jesus\u2019s response is a refusal of any priority over the kingdom\u2019s urgency. The burying of the father is a legitimate duty; the kingdom\u2019s call is more urgent. This is not an attack on family obligations but a statement about the relative weight of the kingdom demand."
+              "note": "Let the dead bury their own dead — Calvin: the apparent harshness of Jesus’s response is a refusal of any priority over the kingdom’s urgency. The burying of the father is a legitimate duty; the kingdom’s call is more urgent. This is not an attack on family obligations but a statement about the relative weight of the kingdom demand."
             }
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "9:51",
-              "note": "As the time approached for him to be taken up to heaven (analpsis) \u2014 the Greek analpsis (taking up) refers to the Ascension, not the Crucifixion. Luke frames the journey to Jerusalem in terms of its ultimate destination: not merely the cross but the exaltation through the cross. The Ascension of Luke 24 is already in view from 9:51."
+              "note": "As the time approached for him to be taken up to heaven (analpsis) — the Greek analpsis (taking up) refers to the Ascension, not the Crucifixion. Luke frames the journey to Jerusalem in terms of its ultimate destination: not merely the cross but the exaltation through the cross. The Ascension of Luke 24 is already in view from 9:51."
             },
             {
               "ref": "9:59-60",
-              "note": "Let the dead bury their own dead \u2014 one of the most debated sayings in the Gospels. The most common interpretation: let the spiritually dead (those outside the kingdom) handle the social obligations of the physically dead. The disciple\u2019s primary obligation is the kingdom, even over pressing family duty."
+              "note": "Let the dead bury their own dead — one of the most debated sayings in the Gospels. The most common interpretation: let the spiritually dead (those outside the kingdom) handle the social obligations of the physically dead. The disciple’s primary obligation is the kingdom, even over pressing family duty."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "9:35",
-              "note": "This is my Son, whom I have chosen \u2014 Luke alone has \"whom I have chosen\" (ho eklelegmenos) rather than Matthew\u2019s and Mark\u2019s \"whom I love\" (ho agap\u0113tos). The verb eklelegmenos (chosen/elect) is the language of divine election: Jesus is the Chosen One of Israel, the Servant of Isa 42:1 (\"my chosen one in whom I delight\")."
+              "note": "This is my Son, whom I have chosen — Luke alone has \"whom I have chosen\" (ho eklelegmenos) rather than Matthew’s and Mark’s \"whom I love\" (ho agapētos). The verb eklelegmenos (chosen/elect) is the language of divine election: Jesus is the Chosen One of Israel, the Servant of Isa 42:1 (\"my chosen one in whom I delight\")."
             },
             {
               "ref": "9:62",
-              "note": "No one who puts a hand to the plow and looks back \u2014 the agricultural image: a plowman who looks back plows crooked furrows. The kingdom requires the same total forward orientation that good plowing does. The comparison of following Jesus to farming is a Lukan compression of the cost of discipleship."
+              "note": "No one who puts a hand to the plow and looks back — the agricultural image: a plowman who looks back plows crooked furrows. The kingdom requires the same total forward orientation that good plowing does. The comparison of following Jesus to farming is a Lukan compression of the cost of discipleship."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "9:28-29",
-              "note": "He went up onto a mountain to pray. As he was praying, his face changed \u2014 Origen: the Transfiguration is a consequence of prayer. Not every prayer produces this effect; but prayer is the context in which the divine glory becomes visible. The mountain of prayer is the place where earth and heaven overlap."
+              "note": "He went up onto a mountain to pray. As he was praying, his face changed — Origen: the Transfiguration is a consequence of prayer. Not every prayer produces this effect; but prayer is the context in which the divine glory becomes visible. The mountain of prayer is the place where earth and heaven overlap."
             },
             {
               "ref": "9:51",
-              "note": "He set his face to go to Jerusalem \u2014 Chrysostom: the phrase echoes Isa 50:7: \"I have set my face like flint\" \u2014 the Servant's determination to face suffering without turning aside. Jesus begins the Passion journey with the Servant\u2019s posture: voluntary, determined, facing the cost."
+              "note": "He set his face to go to Jerusalem — Chrysostom: the phrase echoes Isa 50:7: \"I have set my face like flint\" — the Servant's determination to face suffering without turning aside. Jesus begins the Passion journey with the Servant’s posture: voluntary, determined, facing the cost."
             }
           ]
         },
@@ -217,17 +217,17 @@
           {
             "name": "The Transfiguration Mountain",
             "coords": "Traditionally identified as Mt. Tabor or Mt. Hermon",
-            "text": "The \u201chigh mountain\u201d (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
+            "text": "The “high mountain” (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
           }
         ],
         "hist": {
-          "context": "The Transfiguration is the visual counterpart to the baptism: the same Father speaks, the same Son is confirmed, the same divine commissioning is enacted. But now in the context of the passion: the topic of conversation is his departure/exodus in Jerusalem. Luke\u2019s Transfiguration leads directly into the journey to Jerusalem (9:51 \u2014 he resolutely set his face), making the glory of the mountain the preparation for the suffering of the road."
+          "context": "The Transfiguration is the visual counterpart to the baptism: the same Father speaks, the same Son is confirmed, the same divine commissioning is enacted. But now in the context of the passion: the topic of conversation is his departure/exodus in Jerusalem. Luke’s Transfiguration leads directly into the journey to Jerusalem (9:51 — he resolutely set his face), making the glory of the mountain the preparation for the suffering of the road."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 28\u201145 \u2014 The Transfiguration; Elijah; The Epileptic Boy; Second Passion Prediction",
+      "header": "Verses 28‑45 — The Transfiguration; Elijah; The Epileptic Boy; Second Passion Prediction",
       "verse_start": 28,
       "verse_end": 45,
       "panels": {
@@ -236,105 +236,60 @@
             "word": "ton stauron autou",
             "transliteration": "ton STOW-ron ow-TOO",
             "gloss": "his cross",
-            "paragraph": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' h\u0113meran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once \u2014 the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke\u2019s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
+            "paragraph": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' hēmeran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once — the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke’s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Num 11:22",
-              "note": "Should flocks and herds be slaughtered for them? Or should all the fish in the sea be caught? \u2014 Moses\u2019s question when the people demand meat in the wilderness. The feeding of five thousand replays the wilderness feeding."
+              "note": "Should flocks and herds be slaughtered for them? Or should all the fish in the sea be caught? — Moses’s question when the people demand meat in the wilderness. The feeding of five thousand replays the wilderness feeding."
             },
             {
               "ref": "2 Kings 4:42-44",
-              "note": "Feed the people \u2014 Elisha\u2019s multiplication of twenty loaves for a hundred people. Jesus\u2019s feeding far exceeds this Elisha miracle."
+              "note": "Feed the people — Elisha’s multiplication of twenty loaves for a hundred people. Jesus’s feeding far exceeds this Elisha miracle."
             },
             {
               "ref": "Isa 53:3",
-              "note": "He was despised and rejected \u2014 the passion prediction of 9:22 draws on the Servant Song."
+              "note": "He was despised and rejected — the passion prediction of 9:22 draws on the Servant Song."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:20",
-              "note": "God's Messiah \u2014 Peter's confession is the structural midpoint of Luke\u2019s Gospel. Everything before has been building to this declaration; everything after follows from it. The question Jesus asks is the question the whole Gospel has been posing since 1:1."
-            },
-            {
-              "ref": "9:23",
-              "note": "Deny themselves and take up their cross daily \u2014 the cross-bearing command immediately follows the first passion prediction and Peter's confession. The sequence is crucial: once you know who Jesus is, you must reckon with what following him costs. Confessing the Messiah and carrying the cross are inseparable in Luke."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:20",
-              "note": "God's Messiah \u2014 Calvin: Peter\u2019s confession is given by divine revelation (Matt 16:17), not by human insight. The disciples have been seeing the same evidence as the crowds; only the disciples confess correctly. The difference is the illumination of the Spirit, not the superiority of the disciples\u2019 natural perception."
-            },
-            {
-              "ref": "9:23",
-              "note": "Take up their cross daily \u2014 Calvin: the cross is not merely the martyrdom risk but the daily practice of self-denial in all its forms. Luther extended this: the Christian life is a continuous dying to self and rising in Christ \u2014 not a single dramatic event but the pattern of every day."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:7",
-              "note": "Herod was perplexed \u2014 the Greek dieporei (was completely at a loss). Herod's perplexity about Jesus\u2019s identity (John? Elijah? A prophet?) exactly mirrors the popular confusion catalogued in 9:19. The tetrarch who executed John cannot process the one whom John preceded."
-            },
-            {
-              "ref": "9:27",
-              "note": "Some who are standing here will not taste death before they see the kingdom of God \u2014 the most debated prediction in Luke. Interpretations include: the Transfiguration (the most natural antecedent), Pentecost, the destruction of Jerusalem, or an ongoing realized eschatology in the church."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "9:18",
-              "note": "Once when Jesus was praying in private \u2014 Luke\u2019s unique Petrine context for the confession. The question about identity arises in the context of prayer. The Messianic disclosure comes from a moment of communion, not from a public gathering."
-            },
-            {
-              "ref": "9:22",
-              "note": "The Son of Man must (dei) suffer \u2014 the divine necessity is the first element: not that he will suffer (as if by accident) but that he must suffer (as by divine appointment). The cross is not a tragic interruption of the mission but its divinely ordained fulfilment."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:13",
-              "note": "You give them something to eat \u2014 Origen: the command to the disciples is a command to the church in every age. The crowd is hungry; Jesus does not dismiss them but says to his disciples: you feed them. The church is the instrument of kingdom provision, with resources that appear inadequate until they are surrendered to Jesus and distributed."
-            },
-            {
-              "ref": "9:24",
-              "note": "Whoever wants to save their life will lose it \u2014 Augustine: the paradox of self-preservation is the Gospel\u2019s central economy. The one who grasps for life loses it; the one who releases life into the service of the kingdom receives it back. This is the pattern of the cross: death as the path to life."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
             "name": "The Transfiguration Mountain",
             "coords": "Traditionally identified as Mt. Tabor or Mt. Hermon",
-            "text": "The \u201chigh mountain\u201d (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
+            "text": "The “high mountain” (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
           }
         ],
         "hist": {
-          "context": "Luke 9 is the turning-point chapter. It opens with the mission of the Twelve (the first extension of Jesus\u2019s own ministry to his disciples) and ends with the determination to go to Jerusalem (9:51). Between them: the feeding of five thousand, Herod\u2019s question, Peter\u2019s confession, the first passion prediction, the cost of discipleship, the Transfiguration, the failed exorcism, the second passion prediction, and the cost of following. Luke compresses more theological content into chapter 9 than any other chapter in the Gospel."
+          "context": "Luke 9 is the turning-point chapter. It opens with the mission of the Twelve (the first extension of Jesus’s own ministry to his disciples) and ends with the determination to go to Jerusalem (9:51). Between them: the feeding of five thousand, Herod’s question, Peter’s confession, the first passion prediction, the cost of discipleship, the Transfiguration, the failed exorcism, the second passion prediction, and the cost of following. Luke compresses more theological content into chapter 9 than any other chapter in the Gospel."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 46\u201162 \u2014 Who Is Greatest?; Against Us or For Us; Cost of Discipleship",
+      "header": "Verses 46‑62 — Who Is Greatest?; Against Us or For Us; Cost of Discipleship",
       "verse_start": 46,
       "verse_end": 62,
       "panels": {
@@ -343,99 +298,54 @@
             "word": "exodon",
             "transliteration": "EK-so-don",
             "gloss": "departure/exodus",
-            "paragraph": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos \u2014 the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus\u2019s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah \u2014 the architect of the Exodus and the prophet of the return from exile \u2014 are the appropriate witnesses to the event that both their lives anticipated."
+            "paragraph": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos — the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus’s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah — the architect of the Exodus and the prophet of the return from exile — are the appropriate witnesses to the event that both their lives anticipated."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Exod 24:15-16",
-              "note": "The cloud covered the mountain and the glory of the LORD settled on it \u2014 the Sinai theophany that the Transfiguration cloud echoes."
+              "note": "The cloud covered the mountain and the glory of the LORD settled on it — the Sinai theophany that the Transfiguration cloud echoes."
             },
             {
               "ref": "Deut 18:15",
-              "note": "Listen to him \u2014 the voice from the cloud quotes the Deuteronomy command about the prophet like Moses: hear the fulfiller."
+              "note": "Listen to him — the voice from the cloud quotes the Deuteronomy command about the prophet like Moses: hear the fulfiller."
             },
             {
               "ref": "Mal 4:5",
-              "note": "See, I will send the prophet Elijah to you before that great and dreadful day of the LORD comes \u2014 Elijah\u2019s presence at the Transfiguration confirms that the Elijah-promise has been fulfilled."
+              "note": "See, I will send the prophet Elijah to you before that great and dreadful day of the LORD comes — Elijah’s presence at the Transfiguration confirms that the Elijah-promise has been fulfilled."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:31",
-              "note": "They spoke about his departure, which he was about to bring to completion at Jerusalem \u2014 the subject of the divine conversation is the cross. The law (Moses) and the prophets (Elijah) are speaking with Jesus about the event that both have been anticipating. The Transfiguration is the OT endorsing the NT before it happens."
-            },
-            {
-              "ref": "9:51",
-              "note": "He resolutely set his face to go to Jerusalem \u2014 the Greek is st\u0113riz\u014d \u2014 he fixed, established, set. The Jerusalem journey begins here and does not arrive until 19:28. Luke\u2019s longest section (9:51-19:27) is the travel narrative, the Gospel\u2019s central block, structured around the journey to the city where the Son of Man must be delivered."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:31",
-              "note": "His departure, which he was about to bring to completion at Jerusalem \u2014 Calvin: the conversation on the mountain is the most theological conversation in the Gospels, and Luke gives us its subject: the cross. The entire OT \u2014 represented by Moses and Elijah \u2014 has been pointing here. The fulfilment is the departure that is also the completion."
-            },
-            {
-              "ref": "9:60",
-              "note": "Let the dead bury their own dead \u2014 Calvin: the apparent harshness of Jesus\u2019s response is a refusal of any priority over the kingdom\u2019s urgency. The burying of the father is a legitimate duty; the kingdom\u2019s call is more urgent. This is not an attack on family obligations but a statement about the relative weight of the kingdom demand."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:51",
-              "note": "As the time approached for him to be taken up to heaven (analpsis) \u2014 the Greek analpsis (taking up) refers to the Ascension, not the Crucifixion. Luke frames the journey to Jerusalem in terms of its ultimate destination: not merely the cross but the exaltation through the cross. The Ascension of Luke 24 is already in view from 9:51."
-            },
-            {
-              "ref": "9:59-60",
-              "note": "Let the dead bury their own dead \u2014 one of the most debated sayings in the Gospels. The most common interpretation: let the spiritually dead (those outside the kingdom) handle the social obligations of the physically dead. The disciple\u2019s primary obligation is the kingdom, even over pressing family duty."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "9:35",
-              "note": "This is my Son, whom I have chosen \u2014 Luke alone has \"whom I have chosen\" (ho eklelegmenos) rather than Matthew\u2019s and Mark\u2019s \"whom I love\" (ho agap\u0113tos). The verb eklelegmenos (chosen/elect) is the language of divine election: Jesus is the Chosen One of Israel, the Servant of Isa 42:1 (\"my chosen one in whom I delight\")."
-            },
-            {
-              "ref": "9:62",
-              "note": "No one who puts a hand to the plow and looks back \u2014 the agricultural image: a plowman who looks back plows crooked furrows. The kingdom requires the same total forward orientation that good plowing does. The comparison of following Jesus to farming is a Lukan compression of the cost of discipleship."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:28-29",
-              "note": "He went up onto a mountain to pray. As he was praying, his face changed \u2014 Origen: the Transfiguration is a consequence of prayer. Not every prayer produces this effect; but prayer is the context in which the divine glory becomes visible. The mountain of prayer is the place where earth and heaven overlap."
-            },
-            {
-              "ref": "9:51",
-              "note": "He set his face to go to Jerusalem \u2014 Chrysostom: the phrase echoes Isa 50:7: \"I have set my face like flint\" \u2014 the Servant's determination to face suffering without turning aside. Jesus begins the Passion journey with the Servant\u2019s posture: voluntary, determined, facing the cost."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "places": [
           {
             "name": "The Transfiguration Mountain",
             "coords": "Traditionally identified as Mt. Tabor or Mt. Hermon",
-            "text": "The \u201chigh mountain\u201d (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
+            "text": "The “high mountain” (in Mark) is not named in Luke. Tabor (Lower Galilee) and Hermon (near Caesarea Philippi) are the main candidates. The mountain functions as the site of divine disclosure throughout the OT (Sinai, Horeb, Carmel)."
           }
         ],
         "hist": {
-          "context": "The Transfiguration is the visual counterpart to the baptism: the same Father speaks, the same Son is confirmed, the same divine commissioning is enacted. But now in the context of the passion: the topic of conversation is his departure/exodus in Jerusalem. Luke\u2019s Transfiguration leads directly into the journey to Jerusalem (9:51 \u2014 he resolutely set his face), making the glory of the mountain the preparation for the suffering of the road."
+          "context": "The Transfiguration is the visual counterpart to the baptism: the same Father speaks, the same Son is confirmed, the same divine commissioning is enacted. But now in the context of the passion: the topic of conversation is his departure/exodus in Jerusalem. Luke’s Transfiguration leads directly into the journey to Jerusalem (9:51 — he resolutely set his face), making the glory of the mountain the preparation for the suffering of the road."
         }
       }
     }
@@ -445,30 +355,30 @@
       {
         "name": "Moses and Elijah",
         "role": "The Law and the Prophets; present at the Transfiguration",
-        "text": "Their conversation with Jesus is about his exodus/departure \u2014 confirming that the OT is fulfilled in the cross, not superseded by it."
+        "text": "Their conversation with Jesus is about his exodus/departure — confirming that the OT is fulfilled in the cross, not superseded by it."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Whoever wants to be my disciple must deny themselves and take up their cross daily and follow me.\"</td></tr><tr><td class=\"t-label\">ESV</td><td>\"If anyone would come after me, let him deny himself and take up his cross daily and follow me.\"</td></tr><tr><td class=\"t-label\">KJV</td><td>\"If any man will come after me, let him deny himself, and take up his cross daily, and follow me.\"</td></tr><tr><td class=\"t-label\">NASB</td><td>\"If anyone wants to come after Me, he must deny himself, take up his cross daily, and follow Me.\"</td></tr><tr><td class=\"t-label\">NLT</td><td>\"If any of you wants to be my follower, you must give up your own way, take up your cross daily, and follow me.\"</td></tr>",
     "src": [
       {
         "title": "Josephus, Antiquities 18.63-64 (Testimonium Flavianum)",
-        "quote": "Josephus\u2019s reference to Jesus as a wise man and teacher \u2014 the most significant non-Christian ancient source for Jesus\u2019s existence and reputation.",
-        "note": "Confirms the general historical framework of a Galilean teacher with a substantial following, consistent with Luke\u2019s narrative of Jesus\u2019s public profile in chapter 9."
+        "quote": "Josephus’s reference to Jesus as a wise man and teacher — the most significant non-Christian ancient source for Jesus’s existence and reputation.",
+        "note": "Confirms the general historical framework of a Galilean teacher with a substantial following, consistent with Luke’s narrative of Jesus’s public profile in chapter 9."
       },
       {
         "title": "4Q246 (Son of God Text, Qumran)",
-        "quote": "A Qumran fragment about a figure called \"Son of God\" and \"Son of the Most High\" who will reign over an eternal kingdom \u2014 language remarkably close to Gabriel\u2019s announcement (1:32-35).",
+        "quote": "A Qumran fragment about a figure called \"Son of God\" and \"Son of the Most High\" who will reign over an eternal kingdom — language remarkably close to Gabriel’s announcement (1:32-35).",
         "note": "Demonstrates that \"Son of God\" / \"Son of the Most High\" was a known messianic or royal title in pre-Christian Judaism."
       }
     ],
     "rec": [
       {
         "who": "Raphael, The Transfiguration (1520)",
-        "text": "Raphael\u2019s last painting juxtaposes the Transfiguration above with the failed exorcism below \u2014 structurally identical to Luke\u2019s narrative sequence (9:28-36 / 9:37-43). The painting is a visual commentary on Luke 9."
+        "text": "Raphael’s last painting juxtaposes the Transfiguration above with the failed exorcism below — structurally identical to Luke’s narrative sequence (9:28-36 / 9:37-43). The painting is a visual commentary on Luke 9."
       },
       {
         "who": "Karl Barth, Church Dogmatics IV/2",
-        "text": "Barth treated the Transfiguration as the moment when Jesus\u2019s eternal glory was disclosed within his humiliation. The cross and the glory are not sequential but simultaneous: the humiliated one is the glorified one, and the glory is visible from the mountain of prayer."
+        "text": "Barth treated the Transfiguration as the moment when Jesus’s eternal glory was disclosed within his humiliation. The cross and the glory are not sequential but simultaneous: the humiliated one is the glorified one, and the glory is visible from the mountain of prayer."
       }
     ],
     "lit": {
@@ -491,33 +401,33 @@
         "word": "ton stauron autou",
         "tlit": "ton STOW-ron ow-TOO",
         "gloss": "his cross",
-        "note": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' h\u0113meran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once \u2014 the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke\u2019s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
+        "note": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' hēmeran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once — the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke’s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
       },
       {
         "word": "exodon",
         "tlit": "EK-so-don",
         "gloss": "departure/exodus",
-        "note": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos \u2014 the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus\u2019s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah \u2014 the architect of the Exodus and the prophet of the return from exile \u2014 are the appropriate witnesses to the event that both their lives anticipated."
+        "note": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos — the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus’s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah — the architect of the Exodus and the prophet of the return from exile — are the appropriate witnesses to the event that both their lives anticipated."
       },
       {
         "word": "ton stauron autou",
         "tlit": "ton STOW-ron ow-TOO",
         "gloss": "his cross",
-        "note": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' h\u0113meran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once \u2014 the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke\u2019s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
+        "note": "Take up their cross daily (ton stauron autou) and follow me. Luke uniquely adds the word daily (kath' hēmeran) to the cross-bearing command. In Matthew and Mark, the cross is taken up once — the singular act of following even to death. In Luke it becomes a daily discipline: the self-denying life is not a crisis decision but a continuous practice. Luke’s addition frames discipleship as an ongoing posture rather than a singular dramatic act."
       },
       {
         "word": "exodon",
         "tlit": "EK-so-don",
         "gloss": "departure/exodus",
-        "note": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos \u2014 the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus\u2019s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah \u2014 the architect of the Exodus and the prophet of the return from exile \u2014 are the appropriate witnesses to the event that both their lives anticipated."
+        "note": "Moses and Elijah appeared in glorious splendor, talking with Jesus about his departure (exodon), which he was about to bring to completion at Jerusalem. The Greek word is exodos — the same word as the book of Exodus. Luke uses it to frame the cross as the new Exodus: Jesus’s death in Jerusalem is the ultimate liberation, the final Passover. Moses and Elijah — the architect of the Exodus and the prophet of the return from exile — are the appropriate witnesses to the event that both their lives anticipated."
       }
     ],
     "tx": [
       {
         "ref": "9:54",
         "title": "Some MSS add \"as Elijah did\" after \"call fire down from heaven\"",
-        "content": "Some later MSS add \"as Elijah did\" (h\u014ds kai Elias epoi\u0113sen) to the disciples\u2019 request (9:54), making the Elijah reference explicit. NA28 omits it as a scribal gloss.",
-        "note": "The addition is almost certainly secondary \u2014 it harmonises with 1 Kings 18:38 and may have been added to explain the Elijah reference. The shorter reading is original."
+        "content": "Some later MSS add \"as Elijah did\" (hōs kai Elias epoiēsen) to the disciples’ request (9:54), making the Elijah reference explicit. NA28 omits it as a scribal gloss.",
+        "note": "The addition is almost certainly secondary — it harmonises with 1 Kings 18:38 and may have been added to explain the Elijah reference. The shorter reading is original."
       }
     ],
     "debate": [
@@ -526,12 +436,12 @@
         "positions": [
           {
             "name": "The Transfiguration",
-            "proponents": "The most natural referent: the Transfiguration follows immediately (9:28) and is a proleptic vision of the kingdom\u2019s glory.",
+            "proponents": "The most natural referent: the Transfiguration follows immediately (9:28) and is a proleptic vision of the kingdom’s glory.",
             "argument": "Transfiguration"
           },
           {
             "name": "Pentecost and the church",
-            "proponents": "The kingdom\u2019s visible arrival in the community of the Spirit, experienced by those who survived to Pentecost.",
+            "proponents": "The kingdom’s visible arrival in the community of the Spirit, experienced by those who survived to Pentecost.",
             "argument": "Pentecost"
           }
         ]
@@ -564,7 +474,7 @@
           "score": 10
         }
       ],
-      "note": "Luke 9 turns the Gospel toward its destination. Every major element \u2014 feeding, confession, transfiguration, passion prediction, cost of following \u2014 is oriented toward Jerusalem and the cross. The journey begins at 9:51 and the Gospel will not arrive until 19:28."
+      "note": "Luke 9 turns the Gospel toward its destination. Every major element — feeding, confession, transfiguration, passion prediction, cost of following — is oriented toward Jerusalem and the cross. The journey begins at 9:51 and the Gospel will not arrive until 19:28."
     }
   },
   "vhl_groups": [

--- a/content/mark/11.json
+++ b/content/mark/11.json
@@ -286,16 +286,7 @@
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12-25",
-              "note": "Rhoads: The fig tree / Temple / fig tree intercalation is the most explicitly structural of Mark's sandwiches. The two halves of the fig tree story (11:12-14, 20-25) bracket the Temple cleansing (11:15-19). Rhoads's interpretive principle: the two parts of the sandwich are meant to be read through each other. The fig tree's judgment (withering from the roots) is the Temple's judgment. The Temple cleansing is the fig tree's leaves being stripped. The withering visible the next morning is the Temple's visible coming fall."
-            },
-            {
-              "ref": "11:27-33",
-              "note": "Rhoads: The authority challenge is the first of five controversy exchanges in chs.11-12. The narrator characterizes the chief priests, scribes, and elders as a bloc rather than as individuals — they speak with a collective voice, deliberate collectively, and are collectively silenced. This group characterization distances them from the \"one of the teachers of the law\" in 12:28-34 who is treated as an individual and commended. The narrative distinguishes between the institutional establishment and the person within it who seeks honestly."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
@@ -312,16 +303,7 @@
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:17",
-              "note": "A house of prayer for all nations / a den of robbers — the contrast is total. Isa 56:7 defined the Temple’s universal purpose; Jer 7:11 named its corruption. Jesus uses both texts simultaneously to indict the same institution."
-            },
-            {
-              "ref": "11:18",
-              "note": "The chief priests and teachers of the law began looking for a way to kill him — the death conspiracy now becomes explicit within the Temple itself. The cleansing has sealed his fate."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
@@ -447,81 +429,27 @@
         },
         "mar": {
           "source": "Joel Marcus,Mark 1–8; Mark 8–16(Word Biblical Commentary) — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:1-6",
-              "note": "Joel Marcus (Word Biblical Commentary) notes that the preparation for the entry is structured as a royal requisition — the disciples' password-like exchange (\"The Lord needs it\") echoes the right of a king to commandeer property for state use (cf. 1 Sam 8:11-18). This is not simply logistical but theological: Jesus approaches Jerusalem as a king approaches his capital, and his arrival cannot be refused. The detail that the colt has never been ridden (v2) marks it as ritually fit for sacred use, parallel to the unbroken heifer of Numbers 19."
-            },
-            {
-              "ref": "11:7-11",
-              "note": "Marcus notes the deliberate restraint of Mark's entry narrative compared to later Christian readings: the crowd acclaims Jesus using Psalm 118 language, but the psalm is a pilgrimage song, not necessarily a messianic proclamation. The cry \"Blessed is the coming kingdom of our father David!\" (v10) is Mark's unique phrasing — the kingdom, not just the king, is announced. Marcus argues that the entry is best read as a prophetic sign-act, not a triumphal march: its significance is enacted, not explained, and the explanation comes only in retrospect through the passion."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "11:12-25",
-              "note": "Rhoads: The fig tree / Temple / fig tree intercalation is the most explicitly structural of Mark's sandwiches. The two halves of the fig tree story (11:12-14, 20-25) bracket the Temple cleansing (11:15-19). Rhoads's interpretive principle: the two parts of the sandwich are meant to be read through each other. The fig tree's judgment (withering from the roots) is the Temple's judgment. The Temple cleansing is the fig tree's leaves being stripped. The withering visible the next morning is the Temple's visible coming fall."
-            },
-            {
-              "ref": "11:27-33",
-              "note": "Rhoads: The authority challenge is the first of five controversy exchanges in chs.11-12. The narrator characterizes the chief priests, scribes, and elders as a bloc rather than as individuals — they speak with a collective voice, deliberate collectively, and are collectively silenced. This group characterization distances them from the \"one of the teachers of the law\" in 12:28-34 who is treated as an individual and commended. The narrative distinguishes between the institutional establishment and the person within it who seeks honestly."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:1-6",
-              "note": "The instruction about the colt (vv.1-6) is, for Chrysostom, a display of divine foreknowledge: the animal has never been ridden and awaits precisely this use. Origen notes that the disciples' readiness to answer \"The Lord needs it\" is itself a model of apostolic obedience — no extended explanation, just the word of the Lord and the expectation of compliance. The literal fulfilment of Zechariah 9:9 is, for Bede, the first public signal that Jesus is acting with full messianic intentionality."
-            },
-            {
-              "ref": "11:7-11",
-              "note": "The spreading of cloaks on the road is, for Theophylact, a royal carpet ceremony (cf. 2 Kings 9:13 for Jehu). The Hosanna cry from Psalm 118:25-26 is, for Chrysostom, both a petition and an acclamation — the crowd is crying for salvation to the very one who is bringing it. The anti-climactic close — Jesus looked around at everything and left for Bethany because it was late — is, for Bede, Mark's characteristic restraint: no triumphal occupation, no immediate revolution, just the measured advance of the servant-king."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:17",
-              "note": "A house of prayer for all nations / a den of robbers — the contrast is total. Isa 56:7 defined the Temple’s universal purpose; Jer 7:11 named its corruption. Jesus uses both texts simultaneously to indict the same institution."
-            },
-            {
-              "ref": "11:18",
-              "note": "The chief priests and teachers of the law began looking for a way to kill him — the death conspiracy now becomes explicit within the Temple itself. The cleansing has sealed his fate."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:9-10",
-              "note": "Calvin: The crowd’s acclamation of the Davidic kingdom is genuine faith expressing itself in the only categories available. They correctly identify Jesus as the Davidic Messiah; their error is in the kingdom’s content, not its king."
-            },
-            {
-              "ref": "11:7",
-              "note": "He sat on it — the deliberate fulfilment of Zech 9:9. Calvin notes that Jesus does not announce his messiahship with a speech but with an enacted sign. The sign is legible to those who know the Scripture."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:10",
-              "note": "The coming kingdom of our father David — the only place in Mark where the Davidic kingdom is explicitly named in the context of Jesus’s ministry. The crowd’s language is eschatologically charged: they are hailing the restoration of the Davidic era."
-            },
-            {
-              "ref": "11:11",
-              "note": "Went out to Bethany — Bethany (modern el-Azariyeh, on the eastern slope of Olives) becomes Jesus’s base for Passion Week. He enters the city each day and returns each evening, keeping his lodging outside Jerusalem’s walls."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Mark uses his signature sandwich structure: fig tree cursed (Monday morning) / Temple cleansed (Monday) / fig tree withered (Tuesday morning). The fig tree is the parable of the Temple: full of leaves (religious activity) but bearing no fruit (true worship). The authority question is the Temple establishment’s challenge to the one who has just overturned their tables."

--- a/content/mark/12.json
+++ b/content/mark/12.json
@@ -421,81 +421,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:1-9",
-              "note": "Marcus: The wicked tenants parable draws explicitly on Isa 5:1-7 (the vineyard song), which would have been immediately recognized by a Jewish audience. Marcus argues that the escalating violence of the tenants (beating → wounding → killing) and the repeated sending of servants maps onto the prophetic tradition: Israel's history is the history of rejecting the prophets. The son's death \"outside the vineyard\" (12:8) echoes Heb 13:12 (Jesus suffered \"outside the gate\") and may reflect awareness that crucifixion took place outside Jerusalem's walls."
-            },
-            {
-              "ref": "12:26-27",
-              "note": "Marcus: Jesus's argument for resurrection from Exod 3:6 uses a present-tense verb (\"I am the God of Abraham\") to establish ongoing relational existence. Marcus notes this exegetical move has parallels in 4 Maccabees 7:19 and the rabbinic tradition (b. Sanhedrin 90b), where the Abrahamic promise establishes that the patriarchs must be alive to receive it. Jesus's argument is not novel but represents the strongest available form of Torah-based resurrection argument — which is why the Sadducees are silenced."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "12:1-12",
-              "note": "Rhoads: The wicked tenants parable is the one parable in Mark where the audience recognizes itself in the story immediately: \"They knew he had spoken the parable against them\" (12:12). This is the inverse of the Sower parable (4:12: those outside do not understand). Here the insiders — the establishment — understand perfectly and are condemned by their understanding. Rhoads argues this is the climax of the controversy sequence: the parable exposes not confusion but deliberate rejection. The transparent allegory is the point."
-            },
-            {
-              "ref": "12:13-27",
-              "note": "Rhoads: The tax and resurrection questions follow a pattern: hostile questioners, a complimentary setup, the trap question, Jesus's request for evidence, the counter-revelation. The narrator characterizes both groups (Pharisees+Herodians, Sadducees) through their framing of questions designed to discredit rather than discover. Jesus's counter-questions consistently expose the bad faith of the inquiry. Rhoads argues that the controversy sequence as a whole characterizes Jesus as rhetorical master of his opponents — each engagement strengthens his authority rather than weakening it."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "12:1-12",
-              "note": "The Parable of the Tenants is, for Origen, the most explicit allegorical statement of salvation history in the Synoptics: the vineyard is Israel (from Isaiah 5), the tenants are the religious leaders, the servants are the prophets, the son is the Messiah. Chrysostom notes that the leaders' recognition that the parable was \"against them\" (v12) and their desire to arrest Jesus on the spot is the parable's action confirming its own prediction — they become the tenants who reject the son at the very moment the son describes their rejection. The capstone quotation from Psalm 118 is, for Bede, the pivot between rejection and vindication."
-            },
-            {
-              "ref": "12:13-27",
-              "note": "The tribute question (vv.13-17) is, for Chrysostom, a dilemma that Jesus dissolves by questioning its premise: Caesar's image on the coin places the coin within Caesar's domain; but the human being is made in God's image (Genesis 1:27), and thus belongs to God. The Sadducees' resurrection question (vv.18-27) is answered by Jesus on two fronts: they err about the power of God (resurrection is not a simple extension of present life) and about Scripture (the burning bush passage implies the continued existence of the patriarchs). Bede notes that Jesus uses the most Torah-centric argument imaginable for a Sadducee audience."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:10-11",
-              "note": "The cornerstone — Ps 118:22 applied to the resurrection. The Jewish leaders are the builders who reject; the resurrection is the divine act that makes the rejected stone the cornerstone. The parable predicts both the crucifixion and the vindication."
-            },
-            {
-              "ref": "12:17",
-              "note": "Give to Caesar what is Caesar’s and to God what is God’s — a political principle (Caesar’s image on his coins; God’s image on human beings) that refuses both revolutionary nationalism and complete Roman collaboration."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:10-11",
-              "note": "The cornerstone — Calvin: the application of Ps 118 is the first explicit resurrection prophecy in the Passion narrative. Jesus predicts both his rejection and his vindication in a single quotation. The leaders understand the threat and intensify their plans."
-            },
-            {
-              "ref": "12:17",
-              "note": "Calvin: Give to Caesar…and to God — the distinction is the foundation of two-kingdoms theology. Caesar’s domain is temporal administration; God’s domain is the conscience and the soul. The coin bears Caesar’s image; the human being bears God’s image."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:13",
-              "note": "Pharisees and Herodians — the same coalition as 3:6. Political adversaries united against Jesus. The flattering introduction (“you teach the way of God in accordance with the truth”) is a rhetorical setup for the trap."
-            },
-            {
-              "ref": "12:25",
-              "note": "They will be like the angels — the resurrection state transcends present marital arrangements. Jesus does not deny bodily resurrection; he denies that the resurrection body is simply the present body extended."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The parable of the wicked tenants is the most transparent of Jesus’s parables — the chief priests immediately understand it is about them (v.12). The vineyard is Israel (Isa 5), the tenants are the leaders, the servants are the prophets, and the son is Jesus. The tax question and the resurrection question follow as further attempts to trap Jesus. Each reply silences the questioners."

--- a/content/mark/13.json
+++ b/content/mark/13.json
@@ -422,81 +422,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:2",
-              "note": "Marcus: \"Not one stone will be left on another\" — Josephus confirms that Titus ordered the Temple stones thrown down to recover the gold that had melted between them in the fire of AD 70 (Jewish War 7.1-3). The prediction is thus precisely fulfilled. Marcus argues that the discourse is not a post-eventum prophecy inserted after AD 70 but an authentic prediction: the general expectation of Temple destruction (cf. Micah 3:12, which already predicted it once) was available to any prophet in the Second Temple period."
-            },
-            {
-              "ref": "13:14",
-              "note": "Marcus: \"The abomination that causes desolation\" (bdelygma tēs erēmōseōs) is cited from Dan 9:27 and 11:31. In Daniel the phrase refers to Antiochus IV Epiphanes' desecration in 167 BC. Jesus applies the same Danielic language to a future desecration. Marcus argues that the masculine participle \"standing\" (hestēkota) points to a person rather than an object — possibly the Roman standards (which carried divine images) entering the Temple courts in AD 70, or the emperor Caligula's attempted statue installation in AD 40."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "13:1-23",
-              "note": "Rhoads: The Olivet Discourse begins with an architectural observation by an unnamed disciple (\"What massive stones!\") and ends with a command to all (\"So be on your guard\"). The narrative moves from wonder at the visible to urgency about the invisible. Rhoads notes that the disciples' four private questions (Peter, James, John, Andrew — the first four called) frame the discourse as insider teaching: the Olivet Discourse is the final installment of the private explanation pattern that began with the parable explanation in 4:10-20."
-            },
-            {
-              "ref": "13:9-13",
-              "note": "Rhoads: \"You will be handed over to local councils... you will stand before governors and kings as witnesses to them\" — the narrator's Jesus here speaks prophetically into the future of the narrative's implied audience. The verb \"handed over\" (paradidōmi) links the disciples' fate to Jesus's own fate (9:31; 14:10, 11, 18, 21, 41, 42, 44). The disciples' mission and suffering will be a continuation and extension of Jesus's own delivery into hostile hands. The audience is told this before experiencing it."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "13:1-13",
-              "note": "The Olivet Discourse begins with the disciples' admiration of the Temple stones — and Jesus's prediction of their total destruction. Chrysostom notes that the question \"When will these things happen?\" leads to a discourse that does not primarily answer it, but redirects attention to how to live in the uncertainty between present and consummation. The birth pains metaphor (v8) is, for Origen, an image of creative suffering: the end is not destruction but a new birth. The promise \"the one who stands firm to the end will be saved\" (v13) is, for Bede, the thesis of the entire discourse."
-            },
-            {
-              "ref": "13:14-23",
-              "note": "The \"abomination of desolation\" (v14) is interpreted in the Catena tradition through Daniel 9:27, 11:31, 12:11. Chrysostom reads the immediate reference as the Roman destruction of Jerusalem (AD 70) and the ultimate reference as the end-time desecration. The instruction to flee to the mountains without returning for possessions is, for Origen, both a practical warning to the Jerusalem church (historically heeded in the flight to Pella) and a spiritual instruction: when the final crisis comes, no earthly attachment must delay escape. The warning against false messiahs (vv.21-22) is, for Bede, the permanent pastoral application."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:2",
-              "note": "Not one stone will be left on another — fulfilled in AD 70 when Titus systematically dismantled the Temple platform to recover the gold that had melted between the stones during the fire."
-            },
-            {
-              "ref": "13:10",
-              "note": "The gospel must first be preached to all nations — the universal mission is embedded in the eschatological timetable. The Gentile mission is not an afterthought; it is a necessary condition for the end."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "13:7",
-              "note": "Such things must happen — Calvin: dei (must) is the language of divine sovereignty. The wars, famines, and earthquakes are not accidents but are within the providential order. This does not make them good but makes them purposeful."
-            },
-            {
-              "ref": "13:13",
-              "note": "The one who stands firm to the end will be saved — Calvin: endurance is not the cause of salvation but its evidence. Those who are truly elect will be given the grace to endure. The promise of salvation does not diminish the necessity of perseverance."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "13:14",
-              "note": "Standing where it does not belong — the masculine participle (hestēkota) for the abomination suggests a person rather than an object, possibly pointing to the Roman emperor Caligula’s attempt to set up his statue in the Temple (AD 40) or to the events of AD 70."
-            },
-            {
-              "ref": "13:22",
-              "note": "Signs and wonders to deceive, if possible, even the elect — the qualification “if possible” (ei dynaton) implies it is not possible. The elect will not ultimately be deceived, but the attempt will be extraordinarily compelling."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Olivet Discourse is Jesus’s extended eschatological teaching, prompted by the disciples’ amazement at the Temple’s grandeur. Jesus’s prediction that not one stone will be left (v.2) was fulfilled in AD 70 when Titus destroyed Jerusalem. The discourse weaves together near-term events (the Jerusalem siege) and far-term events (the Son of Man’s coming) in a way that has produced sustained interpretive disagreement."

--- a/content/mark/14.json
+++ b/content/mark/14.json
@@ -401,81 +401,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:3",
-              "note": "Marcus: The anointing at Simon the Leper's house (in Bethany) is connected by Marcus to the OT anointing of kings: David was anointed in private before his public acclamation (1 Sam 16:13); Jesus is anointed in private before his public coronation (the crucifixion, with its ironic title \"King of the Jews\"). The nard used (nardos pistikē — pure nard) was one of the most expensive substances in the ancient world, imported from the Himalayan region via the spice trade. Her act is an economic sacrifice and a prophetic sign."
-            },
-            {
-              "ref": "14:22-24",
-              "note": "Marcus: \"This is my blood of the covenant, poured out for many\" — Marcus argues that the phrase combines Exod 24:8 (the covenant ratification blood: \"This is the blood of the covenant\") with Isa 53:12 (\"he poured out his life unto death... he bore the sin of many\"). The cup interprets the cross before it happens: the death is not a martyrdom or a tragedy but a covenant-ratifying, sin-bearing act. The Last Supper is the theological key to the Passion narrative."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:1-21",
-              "note": "Rhoads: Mark 14 opens with a two-verse statement of the establishment's plot (14:1-2) and then cuts immediately to the anointing woman — a narrative juxtaposition without transition. The effect: the opposition's cold calculation is placed beside an act of extravagant love. Rhoads argues that the woman's act characterizes the right response to Jesus's impending death while the establishment's planning characterizes the wrong use of power. The two opening scenes encode the chapter's theological poles."
-            },
-            {
-              "ref": "14:17-25",
-              "note": "Rhoads: The betrayer prediction (\"one of you will betray me — one who is eating with me\") creates narrative suspense through distributed knowledge. Jesus knows; the reader knows (Judas was named in 3:19 with \"who betrayed him\"); the disciples do not know which one. Their individual question — \"Surely not I?\" — characterizes them collectively as anxious but loyal. The irony is that their anxiety is real and their loyalty is fragile. The reader knows the outcome; the characters do not."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "14:1-21",
-              "note": "The anointing at Bethany (vv.1-9) is, for Chrysostom, the act of worship that frames the entire Passion narrative. Judas's objection about the wasted ointment is, for Origen, the permanent voice of utilitarian calculation against extravagant devotion. Jesus's response \"She has done a beautiful thing to me\" is the Gospel's endorsement of worship that exceeds what appears necessary. Bede notes the promise — \"wherever the gospel is preached throughout the world, what she has done will also be told\" — which the Catena tradition reads as already fulfilled in their own citation of the story. The betrayal agreement (vv.10-11) is, for Ambrose, the anti-type: where she gave everything, he sold for thirty pieces."
-            },
-            {
-              "ref": "14:12-31",
-              "note": "The Last Supper is, for Chrysostom, the final Passover and its own fulfilment simultaneously: the lamb is present as the one who will be sacrificed. The eucharistic words \"This is my body... This is my blood\" are, for Origen, not merely memorial but participatory — the cup is \"my blood of the covenant, which is poured out for many.\" Bede connects the \"many\" (v24) to Isaiah 53:12, understanding it as the universal scope of the atoning work. The prediction of Peter's denial (vv.27-31) closes the supper with a realistic portrait of the disciples who will abandon Jesus — the Passover has not yet accomplished what it promises."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:8",
-              "note": "She poured perfume on my body beforehand to prepare for my burial — the woman’s act is unconsciously prophetic. Jesus interprets an act of love as funeral preparation. The anointing of the dead happens after death; her anointing happens before."
-            },
-            {
-              "ref": "14:22-24",
-              "note": "Take it; this is my body… This is my blood of the covenant — the two elements of the Eucharist are the covenant meal Jesus institutes on the night of his betrayal. Mark’s account is the most compact of the four institution narratives."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:6-9",
-              "note": "Calvin: She has done a beautiful thing — Calvin uses the anointing to argue against both excessive austerity (which would condemn all costly worship) and excessive display (which would make spending a virtue). The act is beautiful because of its motive: extravagant love for Christ in the shadow of his death."
-            },
-            {
-              "ref": "14:24",
-              "note": "The blood of the covenant — Calvin: the cup is the new covenant in blood (following Paul’s version), ratifying the covenant by the death of the covenant’s mediator. As Moses sprinkled blood to ratify the first covenant, so Christ’s blood ratifies the new."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:12",
-              "note": "When it was customary to sacrifice the Passover lamb — Nisan 14, the Day of Preparation. The Last Supper is set within the Passover framework: the lamb’s sacrifice and the covenant meal are the matrix within which Jesus reinterprets the elements."
-            },
-            {
-              "ref": "14:25",
-              "note": "I will not drink again… until I drink it new in the kingdom of God — the eschatological dimension of the Eucharist: it points backward (to the exodus) and forward (to the Messianic banquet). The present meal is a foretaste of the kingdom feast."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Mark 14:1-31 is the preparation for the Passion in three movements: the anointing at Bethany (prophetic preparation for burial), the Last Supper (covenant inauguration), and the Mount of Olives predictions (betrayal, denial, scattering). The anointing woman who wastes expensive perfume for Jesus is placed in sharp contrast to Judas who immediately goes to sell him for money."
@@ -558,81 +504,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:36",
-              "note": "Marcus: \"Abba, Father\" — the Aramaic abba preserved in Greek transliteration is one of the most discussed words in NT scholarship. Marcus reviews the evidence: it was not the normal Jewish address to God in prayer (though not unprecedented), and its preservation in early Gentile Christianity (Rom 8:15; Gal 4:6) suggests it was regarded as theologically significant. The combination of familiarity (abba — papa) and theological weight (the Son addressing the Father at the moment of ultimate obedience) makes it the most intimate address to God in the entire NT."
-            },
-            {
-              "ref": "14:62",
-              "note": "Marcus: \"I am\" (egō eimi) — the two-word answer is simultaneously the answer to the high priest's question and the divine self-identification of Exod 3:14 LXX (\"I am the one who is\"). Marcus argues that Jesus' statement is the Messianic Secret's final and permanent dissolution: the public declaration of divine sonship before the Sanhedrin, at the cost of his life, is the inverse of every previous silencing. The silence and the declaration together form the Gospel's Christological arc."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "14:32-52",
-              "note": "Rhoads: The Gethsemane scene is the Gospel's most psychologically intensive passage. The narrator gives us Jesus's interior state directly: \"greatly distressed and troubled\" (14:33); \"overwhelmed with sorrow to the point of death\" (14:34). The three-fold return to the sleeping disciples mirrors the three-fold passion predictions and the three-fold denial that follows (14:66-72). Rhoads argues that the three-fold structure is Mark's signature: events of supreme importance are told in threes, with the third occurrence bringing either climax or catastrophe."
-            },
-            {
-              "ref": "14:53-72",
-              "note": "Rhoads: The trial and denial scenes are the most fully developed intercalation in the Gospel: Jesus confessing (above, in the hall) / Peter denying (below, at the fire). The spatial juxtaposition — \"above\" and \"below\" — is not coincidental. The narrator cuts between the two scenes without comment, leaving the reader to observe the contrast. Peter denies the man whose name he cannot bring himself to say (\"this man\"); Jesus declares his identity before his executioners. The same event (identity under pressure) produces opposite responses."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "14:32-52",
-              "note": "The Gethsemane prayer is, for Chrysostom, the moment in Mark most clearly displaying the full weight of the humanity of the Son — the shrinking from the cup, the request that it pass, the submission \"not what I will, but what you will.\" Origen says the three disciples sleeping represent the threefold sleep of the soul under spiritual pressure: they sleep while he prays, as the church often sleeps in its watch. The betrayal kiss is, for Ambrose, the most corrupt use of an intimate sign in history — the gesture of affection is the gesture of treachery. The flight of the disciples (v50) and the naked young man (vv.51-52) are, for Bede, both historical detail and the figure of the church abandoning its Lord."
-            },
-            {
-              "ref": "14:53-72",
-              "note": "The trial before the Sanhedrin and Peter's denial are, for Chrysostom, deliberate parallels: inside, Jesus confesses before the high priest what he is; outside, Peter denies three times who he knows. The false testimony fails to agree (v59) — which Bede says is a providential sign that even the enemies of the truth cannot falsify it when called to be witnesses. The high priest's tearing of his robes at the claim to be \"the Son of the Blessed One\" is, for Origen, the moment when the entire Jewish legal structure renders its verdict — and in doing so fulfils the prophecy it was trying to prevent."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:36",
-              "note": "Abba, Father, everything is possible for you. Take this cup from me. Yet not what I will, but what you will — the prayer of Gethsemane is the supreme act of covenant obedience. Jesus does not suppress the desire for the cup to be removed; he submits it entirely to the Father’s will. The full humanity of the prayer is as important as the full obedience."
-            },
-            {
-              "ref": "14:62",
-              "note": "I am — egō eimi. The response to the high priest’s question about the Messiah is the divine name, combined with the Danielic Son of Man coming in glory. Jesus answers the question that Mark’s Gospel has been building toward since 1:1 with a full, unqualified “I am.”"
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:36",
-              "note": "Take this cup from me — Calvin: the prayer is not weakness but the legitimate expression of the will to live. Jesus’s humanity is genuine: he desires to avoid the cup. His submission (“not what I will”) is not the suppression of desire but its offering. The prayer is Gethsemane’s theological centre."
-            },
-            {
-              "ref": "14:62",
-              "note": "Calvin: Jesus’s declaration before the Sanhedrin is the moment when the Messianic Secret is permanently broken. He will not maintain the silence here. The question demands the answer; the answer costs him his life. Calvin reads this as the confessor’s moment: truth spoken in the face of death."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:36",
-              "note": "Abba — the Aramaic preserved verbatim (the sixth time Mark preserves actual Aramaic). Paul’s use in Rom 8:15 and Gal 4:6 indicates that the Aramaic Abba became a marker of Christian prayer, linking adopted children to the Son’s own Gethsemane cry."
-            },
-            {
-              "ref": "14:62",
-              "note": "Egō eimi — the Greek equivalent of the Hebrew divine name (Exod 3:14 LXX). The two-word answer is simultaneously the mundane “I am he” (answering “are you the Messiah?”) and the divine self-identification. The high priest correctly hears both dimensions: this is why he tears his robe."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Gethsemane scene is the most intimate in Mark: three inner disciples, one prayer, three failures to watch. The cup Jesus asks to be removed is the cup of divine wrath (Isa 51:17; Jer 25:15) — the cup he will drink at Golgotha so that others do not have to. His trial before the high priest is the first public declaration of his messianic identity: “I am” with the Danielic-parousia claim. Peter’s denial at the fire mirrors the trial: while Jesus confesses, Peter denies."

--- a/content/mark/15.json
+++ b/content/mark/15.json
@@ -401,81 +401,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:2",
-              "note": "Marcus: \"Are you the king of the Jews?\" — the charge is political: claiming royal status is sedition against Caesar. Marcus notes the bitter irony: Jesus will be executed under a charge that is simultaneously false (he never led an armed revolt) and true (he is the Davidic king). The INRI placard makes the irony permanent and public. Marcus argues that Pilate's triple affirmation of Jesus' innocence (15:10, 14, \"Why? What crime has he committed?\") functions as a Roman legal testimony to the injustice of the execution."
-            },
-            {
-              "ref": "15:15",
-              "note": "Marcus: The Barabbas exchange is the Passion narrative's clearest enacted substitution: the guilty goes free; the innocent is condemned. Marcus notes that the name Barabbas (bar Abba — son of the father) may carry deliberate irony: the \"son of the father\" who is released is replaced by the Son of the Father who is executed. Whether or not the irony was intended in the historical event, Mark's narrative deploys it — the name is given without explanation, as if its resonance would be immediately apparent."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "15:1-20",
-              "note": "Rhoads: Pilate is characterized through a sequence of questions and reactions rather than through direct evaluation. He asks the right questions (\"What crime has he committed?\"); he perceives the real motive (\"he knew it was out of self-interest\"); he wants to release Jesus (15:9-11); and he capitulates to the crowd. Rhoads argues that Pilate is Mark's most fully developed portrait of moral failure: not ignorance, not malice, but the preference for social safety over just action. He is the narrative's mirror of Herod Antipas (6:26)."
-            },
-            {
-              "ref": "15:16-20",
-              "note": "Rhoads: The soldiers' mock coronation is the Gospel's most sustained sustained enactment of irony. Purple robe, crown of thorns, homage (\"Hail, King of the Jews!\"), striking, spitting, kneeling — each gesture of mockery performs the truth it intends to deny. Rhoads argues that Mark's narrator presents this scene without evaluative comment, trusting the reader to supply the irony. The soldiers unknowingly crown, robes, and enthrone the actual king. The mockery is the coronation."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "15:1-20",
-              "note": "The Roman trial before Pilate is, for Chrysostom, a study in the cowardice of power. Pilate knows Jesus is innocent (v14: \"What crime has he committed?\") and fears the crowd. The choice of Barabbas over Jesus is, for Origen, a figure charged with substitutionary theology: the genuinely guilty man is released; the genuinely innocent man is condemned. Bede notes the irony of the soldiers' mock homage — the purple robe, the crown of thorns, \"Hail, King of the Jews\" — as the truth spoken in derision: he is the king, the crown is his, the homage is due. The mockery is the inadvertent liturgy of those who do not know what they are doing."
-            },
-            {
-              "ref": "15:21-47",
-              "note": "The crucifixion narrative in Mark is, for Chrysostom, the most compressed of the four Gospels — there is no word from the cross except the cry of dereliction. Origen devotes extensive reflection to \"My God, my God, why have you forsaken me?\" (Psalm 22:1): the question is not theological despair but the opening of a psalm that ends in vindication (Psalm 22:24-31). The tearing of the Temple curtain (v38) is, for Ambrose, the simultaneous end of the old covenant economy and the opening of access to the holy of holies for all people. The centurion's confession \"Surely this man was the Son of God!\" is, for Theophylact, the Gentile world's first act of faith — the cross itself is the first proclamation."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:2",
-              "note": "You have said so — the response is neither affirmation nor denial but a deliberate deflection: the title “king of the Jews” is Pilate’s Roman frame; Jesus will not use it of himself but neither will he deny its truth."
-            },
-            {
-              "ref": "15:15",
-              "note": "Wanting to satisfy the crowd — the political calculation that condemns Jesus. Pilate knows Jesus is innocent (v.10, 14) and condemns him for crowd management. The same motivation that killed John the Baptist (6:26) kills Jesus."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:6-14",
-              "note": "Calvin: The Barabbas exchange is the clearest image in the Gospels of substitutionary release. Barabbas’s freedom is the direct result of Jesus’s condemnation. Calvin uses this to explain justification: the guilty go free because the innocent bears the punishment."
-            },
-            {
-              "ref": "15:5",
-              "note": "Jesus made no reply, and Pilate was amazed — Calvin: the silence fulfils Isa 53:7. Jesus’s silence is not passivity but the active submission of the Servant who has chosen to bear what is being laid on him."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:2",
-              "note": "King of the Jews — the charge is political: claiming to be king is sedition against Rome. The accusation is simultaneously false (Jesus never led an armed rebellion) and true (he is the Davidic king). Pilate’s placard (v.26) will make the charge permanent: King of the Jews."
-            },
-            {
-              "ref": "15:15",
-              "note": "Flogged (ephragelōsen) — verberatio was so severe that victims sometimes died from it. The pre-crucifixion flogging guaranteed rapid death on the cross. The medical evidence for the physical devastation of Roman flogging supports the narrative’s plausibility."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "Pilate’s trial of Jesus is a study in political cowardice that mirrors Herod’s in chapter 6: both men know the prisoner is innocent, both protect him briefly, both capitulate to external pressure. Barabbas is the paradigm of substitutionary atonement: the guilty party goes free while the innocent one is condemned. The soldiers’ mock coronation (purple robe, crown of thorns, “Hail, king!”) is an unwitting enactment of the truth."

--- a/content/mark/2.json
+++ b/content/mark/2.json
@@ -290,81 +290,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:4",
-              "note": "Marcus: The roof-opening detail is significant historically. Galilean village houses typically had flat roofs of wooden beams, reeds, and packed mud — easily removable for lowering a pallet. This is not a tile roof (as Luke's version has it). Mark's version may reflect the Palestinian setting more accurately. The four friends' action creates a social disturbance that Jesus converts into a theological teaching moment."
-            },
-            {
-              "ref": "2:10",
-              "note": "Marcus: \"The Son of Man has authority on earth to forgive sins\" — this is the first Son of Man saying in Mark. The title (bar enasha in Aramaic) was an ordinary idiom for \"a person\" or \"I,\" but it also carried the exalted Danielic resonance of 7:13-14. Marcus argues that Mark's Jesus exploits the ambiguity deliberately: the title asserts both the humanity of the one who forgives and his divine-Danielic authority."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "2:1-12",
-              "note": "Rhoads: The healing of the paralytic introduces a narrative technique that will recur throughout Mark 2-3: the embedded controversy. The crowd waits outside; friends create the opening from above; Jesus addresses the paralytic; the scribes object silently; Jesus reads their thoughts. The story moves through five distinct perspectives and shifts of attention in twelve verses — a narrative density characteristic of Mark's storytelling economy."
-            },
-            {
-              "ref": "2:10-12",
-              "note": "Rhoads: \"But I want you to know...\" — Jesus directly addresses the narrator's audience as much as the scribes. This breaking of the story-world frame (addressing the narrative challenge as though answering objectors outside the scene) is rare in Mark but significant. The healing becomes theatrical proof, performed for the watching crowd and the skeptical scribes simultaneously."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "2:1-7",
-              "note": "Chrysostom observes that the four men who lowered the paralytic through the roof display a faith notable for its ingenuity — they did not give up when the crowd blocked the door, but found another way. This, says Aquinas following Ambrose, is the figure of intercessory prayer: the faith of others can carry the helpless to Christ. The scribes' objection \"Who can forgive sins but God alone?\" is, for Cyril of Alexandria, the most accurate theological statement in the chapter — which is precisely why Jesus accepts the premise and fulfils it."
-            },
-            {
-              "ref": "2:8-12",
-              "note": "The question \"Which is easier?\" is, for Theophylact, a rhetorical trap Jesus sets for the scribes: healing is visible and testable; forgiveness is not. By performing the visible sign, Jesus provides evidence for the invisible authority. Chrysostom notes that the crowd glorified God, not Jesus — and Mark records this without correction, which is itself instructive. The miracle does not compel worship but directs it; the proper response to divine power is theological reorientation, not merely amazement."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:5",
-              "note": "When Jesus saw their faith — the faith of the four friends who carried the paralytic. Corporate faith as the context for individual healing. Jesus responds to the community’s determination."
-            },
-            {
-              "ref": "2:10",
-              "note": "Son of Man has authority on earth to forgive sins — the first appearance of this title. Jesus uses it as a self-designation that is simultaneously humble (human figure) and exalted (Danielic universal ruler)."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "2:5-7",
-              "note": "Calvin: The scribes are technically correct that only God forgives sins. Their error is not in the theology but in the conclusion — they should have asked who this man is, not accused him of blasphemy. Jesus’s response does not deny their theological principle; it confirms it while claiming to embody it."
-            },
-            {
-              "ref": "2:10",
-              "note": "The healing is a “perceptible sign” that authenticates the imperceptible grace. God accommodates human weakness by providing visible evidence of invisible realities."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "2:10",
-              "note": "Son of Man — ho huios tou anthrōpou. This phrase occurs 14 times in Mark. It is Jesus’s preferred self-designation — simultaneously evoking Dan 7:13 (heavenly authority) and the human solidarity of Ps 8:4 (son of man as mortal). The ambiguity is deliberate."
-            },
-            {
-              "ref": "2:12",
-              "note": "In full view of them all — emprosthen pantōn. The public nature of the healing is emphasized. This is not private certification but community witness."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The healing of the paralytic through the roof is the first direct controversy with the scribes and the first explicit claim of divine authority over sin. Jesus’s question “Which is easier” is a logical trap: the visible miracle proves the invisible pardon. The Son of Man title (v.10) appears for the first time — the Danielic figure who has authority on earth."

--- a/content/mark/3.json
+++ b/content/mark/3.json
@@ -300,81 +300,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "Marcus: Jesus's anger (orgē) combined with grief (syllypoumenos) at hardness of heart (pōrōsis) is a theologically rich combination. In the LXX, pōrōsis describes the hardening that comes as divine judgment on persistent rejection (Isa 6:10; Exod 7:3). The fact that Jesus experiences grief alongside anger suggests that the hardening is not merely judicial but is mourned as a tragedy. This is consistent with the prophetic tradition in which divine judgment is always accompanied by divine sorrow."
-            },
-            {
-              "ref": "3:6",
-              "note": "Marcus: The Pharisee-Herodian coalition is historically striking. The Pharisees were a religious reform movement; the Herodians were supporters of Roman client-king Herod Antipas — political adversaries under normal conditions. Marcus notes that a similar coalition appears in the Damascus Document (CD 1:14-21) as an example of parties united by hostility to the righteous teacher. The unusual alliance signals the unprecedented threat Jesus represented to both groups."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "3:1-6",
-              "note": "Rhoads: The synagogue healing scene economizes information to heighten conflict. The man's condition is stated in one phrase; the Pharisees' intent is stated before the action; Jesus's anger and question are compressed into two sentences. The narrator reveals Jesus's inner state (anger, grief) but never reveals the Pharisees' interior response to the healing. The withholding of their reaction after the miracle focuses the reader entirely on the decision to kill — character revealed through action, not psychology."
-            },
-            {
-              "ref": "3:7-12",
-              "note": "Rhoads: The summary scene (3:7-12) is a narrator's aerial view — compressed summary of what has been happening across the whole region. Such summaries bracket and interpret the surrounding episodes. The geographic inventory (Galilee, Judea, Jerusalem, Idumea, Transjordan, Tyre, Sidon) signals the widening scope of the narrative. The demons' repeated falling and confessing create a counterpoint to the human characters' silence and confusion."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "3:1-6",
-              "note": "Chrysostom notes that Jesus looked at the Pharisees \"with anger and deep distress at their stubborn hearts\" — the only place in the Synoptics where Jesus's anger is explicitly named. Aquinas, following Gregory the Great, says that anger at sin is not a vice but a virtue: the absence of righteous anger in the face of injustice is indifference, not holiness. The healing on the Sabbath, says Bede, is deliberate provocation — Jesus does not wait for a less contentious moment. The Pharisees' immediate plot with the Herodians signals, for Origen, the unholy alliance that only Jesus could produce: political and religious enemies united by a common threat."
-            },
-            {
-              "ref": "3:7-12",
-              "note": "Theophylact says the great crowd from every region of Israel pressing on Jesus — to the point of needing a boat (v9) — represents the universal reach of the Gospel before the Gentile mission is formally commissioned. The unclean spirits' repeated identification of Jesus as \"the Son of God\" is, for Chrysostom, a pattern throughout Mark: the spiritual world recognizes what the religious establishment denies. The silencing command is, for Origen, protective of the faith: belief built on demonic testimony would be corrupt from its foundation."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "He looked around at them in anger — Jesus’s anger is righteous and specific: it is directed at hard hearts that would rather preserve religious tradition than see a man healed. The grief (syllypoumenos) softens and deepens the anger: he is not indignant but heartbroken."
-            },
-            {
-              "ref": "3:6",
-              "note": "The Pharisees and Herodians plot together — political opposites united by threat. The death conspiracy begins in chapter 3, not chapter 11. Mark’s passion shadow falls early."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "Calvin: The hardness of heart (pōrōsis) is a judicial condition — God’s response to persistent rejection. The Pharisees have not merely misunderstood; they have hardened themselves against the evident truth. Jesus’s grief is the grief of a God who wills that none perish."
-            },
-            {
-              "ref": "3:6",
-              "note": "The coalition with the Herodians is a moral inversion: religious leaders ally with the compromised collaborators they otherwise despised in order to eliminate the prophet who is exposing them both."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "3:5",
-              "note": "Syllypoumenos — deeply grieved/distressed. This is the most emotionally charged verse in Mark’s first three chapters. The divine anger and grief at human hardness are held together without resolution — a window into the character of God."
-            },
-            {
-              "ref": "3:12",
-              "note": "He gave strict orders not to tell anyone — the Messianic Secret in its strongest form to this point. The prohibition is given to the demons, not the healed. The demonic knowledge of Jesus’s identity is suppressed because it cannot be the channel of covenant disclosure."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Sabbath healing crystallizes the conflict: the Pharisees have already decided to kill Jesus (v.6) before his Galilean ministry is even half over. The coalition with the Herodians — normally political rivals — shows how threatening Jesus has become. The crowd geography of vv.7-8 is remarkable: all four points of the compass — Galilee, Judea, Idumea, Transjordan, and the Phoenician coast — converge on Jesus."

--- a/content/mark/5.json
+++ b/content/mark/5.json
@@ -305,81 +305,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:9",
-              "note": "Marcus: \"Legion, for we are many\" — the Roman military legion (3,000-6,000 troops) was the symbol of Roman imperial violence in the occupied provinces. Marcus's influential reading sees the exorcism as a covert anti-imperial story: the \"Legion\" driven into pigs (unclean animals, associated with Rome) and drowned in the sea reverses the Exodus — this time Roman military power is swallowed by the sea. The story's original audience in Roman Galilee would have heard the political resonance."
-            },
-            {
-              "ref": "5:19",
-              "note": "Marcus: \"Go home to your own people and tell them how much the Lord has done for you\" — the first explicit evangelistic commission in Mark, given to a Gentile, in Gentile territory. The Decapolis mission anticipates the Great Commission. That the command breaks the Messianic Secret (operative in Jewish territory) and is given in Gentile space suggests that the Secret's function is not about Christology per se but about the management of Jewish messianic expectations."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "5:1-20",
-              "note": "Rhoads: The Gerasene demoniac is the most fully characterized minor figure in Mark. He has a habitat (tombs), a condition (superhuman strength, self-harm, cries), a name (Legion), a location-preference (v.10: begging not to be sent out of the area), a request (the pigs), and a post-healing description (clothed, in his right mind). The detailed characterization invites reader sympathy before the miracle and makes the village's rejection of Jesus after the healing — preferring the loss of their pigs — all the more striking."
-            },
-            {
-              "ref": "5:15",
-              "note": "Rhoads: \"Sitting, clothed, and in his right mind\" — the three details reverse the three elements of the possessed state (roaming naked among tombs, breaking chains, crying out). Rhoads's narrative criticism highlights how Mark uses this reversal-pattern to signal restoration: the character's new state is described by the exact negation of their former state. The village's fear in the face of this restoration is one of Mark's sharpest ironies."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "5:1-13",
-              "note": "Origen devotes extended attention to the Gerasene demoniac in the Catena tradition. The possessed man living among the tombs is, for him, the image of a soul in complete disorder: its natural home (the body) turned to a place of death. The demons' request to enter the pigs is permitted, says Chrysostom, both to demonstrate the number and malice of the spirits and to give the man unambiguous evidence of his deliverance. Bede adds that the pigs rushing into the lake is a figure of the self-destructive nature of demonic influence when unleashed from a human host."
-            },
-            {
-              "ref": "5:14-20",
-              "note": "The townspeople's fear at seeing the demoniac \"sitting there, dressed and in his mind\" is, for Chrysostom, a profound comment on human perversity: they are more comfortable with a known disorder than an unexpected healing. The request that Jesus leave their region is, for Origen, a type of those who love their property more than the presence of God. The man's request to accompany Jesus is refused — he is instead sent back as a missionary to his own people. Chrysostom notes that he is the first Gentile missionary in Mark, commissioned not from Jerusalem but from Decapolis."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:9",
-              "note": "Legion — for we are many. The plural within the singular (“my name is Legion / for we are many”) reflects demonic fragmentation: the possessed man has no single self left. The restoration in v.15 — sitting, clothed, in his right mind — is the reversal of every element of the possession."
-            },
-            {
-              "ref": "5:19",
-              "note": "Go home to your own people — the first explicit mission. Jesus breaks the Messianic Secret here because this is Gentile territory where there is no messianic expectation to be managed. The restored man becomes Mark’s first evangelist."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "5:9",
-              "note": "Calvin: The naming of the demons as Legion is not merely descriptive but a confession of defeat. When demons name themselves to Jesus they are acknowledging his authority to command them. The name is given in response to Jesus’s question — he has power to compel even the identification of his enemies."
-            },
-            {
-              "ref": "5:19-20",
-              "note": "The mission to the Decapolis is the first deliberate Gentile outreach. Calvin notes that Jesus employs a man who is not one of the Twelve — the Spirit’s mission is not confined to official channels."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "5:13",
-              "note": "The herd rushed down the bank into the lake — the verb hormēsen (rushed/charged) is violent and directional. The demons’ destination is the sea, which in apocalyptic tradition is the domain of chaos and the Abyss. Their request to enter the pigs rather than be sent to the Abyss (v.10) is ultimately futile — they end in the sea anyway."
-            },
-            {
-              "ref": "5:20",
-              "note": "He began to tell in the Decapolis — the ten Greek cities of the Transjordan region. The Gentile mission, barely visible in Mark, is planted here. By the time of Acts 9 there are disciples throughout the region."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Gerasene exorcism is the longest and most dramatic in Mark. Three elements make it distinctive: the man’s extreme condition (tombs, chains, self-harm), the demons’ naming as Legion, and the first explicit mission to Gentiles — Jesus tells the restored man to go home and testify in the Decapolis, breaking the Messianic Secret pattern that governs Jewish territory."

--- a/content/mark/7.json
+++ b/content/mark/7.json
@@ -269,81 +269,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:3-4",
-              "note": "Marcus: The parenthetical explanation of Jewish purity customs for non-Jewish readers is among the strongest internal evidence for Mark's Gentile-Roman audience. Marcus notes that Mark is the only Gospel that explains these customs, suggesting a community not observant of or familiar with Second Temple Jewish practice. The Mishnah (tractate Yadayim) provides extensive discussion of hand-washing before meals, confirming this was a genuine Pharisaic practice, not a Markan caricature."
-            },
-            {
-              "ref": "7:11",
-              "note": "Marcus: The Corban practice is attested in Josephus (Against Apion 1.167) and in a Qumran fragment (4Q270). Marcus argues that the rabbinic sources (Mishnah Nedarim) show the sages were themselves uncomfortable with vows that disadvantaged parents — suggesting Jesus's critique was an internal Jewish debate, not an attack on Torah observance per se. The force of the criticism is not that the tradition is Jewish but that it has been used to nullify the higher principle it claimed to honour."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "7:1-23",
-              "note": "Rhoads: The clean/unclean controversy has a three-part structure: dispute (7:1-13), public teaching (7:14-16), private explanation (7:17-23). This structure mirrors the parable sections of ch.4: public pronouncement that confuses, followed by private clarification for insiders. The narrator's interjection in 7:19 (\"In saying this, Jesus declared all foods clean\") is the narrator speaking directly to the reader, interpreting Jesus's teaching for a community apparently living under the implications of that teaching."
-            },
-            {
-              "ref": "7:24",
-              "note": "Rhoads: \"Jesus left that place and went to the vicinity of Tyre. He entered a house and did not want anyone to know it; yet he could not keep his presence secret.\" The tension between Jesus's desire for hiddenness and his unavoidable notoriety is a recurring narrative pattern in Mark. Rhoads identifies this as a characterization technique: the Messianic Secret operates as an element of plot tension, not just theology. Every time Jesus withdraws, he is found; every time he silences testimony, it spreads. The character cannot be contained."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "7:1-13",
-              "note": "Chrysostom notes that the Pharisees' challenge about unwashed hands is not about hygiene but about the authority of oral tradition. Jesus's response cuts to the root: the tradition has been used to nullify the command. The Corban example is, for Aquinas, an instance of legal ingenuity deployed against moral obligation — a person could declare property dedicated to God and thereby escape the duty to support parents. Bede observes that Jesus quotes Isaiah 29:13 precisely: \"their hearts are far from me\" — the critique is not of ritual practice as such but of ritual practice divorced from inward reality."
-            },
-            {
-              "ref": "7:14-23",
-              "note": "The teaching on defilement — \"Nothing outside a person can defile them\" — is, for Origen, the most radical dietary pronouncement in the Synoptics: Mark notes parenthetically that Jesus \"declared all foods clean\" (v19). Chrysostom says this is not the abolition of the law but its fulfilment: the law's food codes were pedagogical, pointing toward the interior purity that alone makes a person acceptable to God. The catalogue of vices in vv.21-22 is, for Theophylact, a comprehensive anatomy of the sinful heart — beginning with evil thoughts and ending with foolishness, showing that moral failure begins in the mind."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:8",
-              "note": "You have let go of the commands of God and are holding on to human traditions — the reversal is the charge: what was meant to protect the Torah has replaced the Torah. Tradition has swallowed the text it claimed to honour."
-            },
-            {
-              "ref": "7:19",
-              "note": "Jesus declared all foods clean — Mark’s editorial comment, not part of Jesus’s direct speech. This parenthetical interpretation by the narrator is the most significant food-law statement in the Synoptics and becomes the theological basis for Peter’s Cornelius vision (Acts 10)."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:9",
-              "note": "You have a fine way of setting aside the commands of God — Calvin reads this as the defining critique of all religion that substitutes human invention for divine command. The Reformation’s critique of tradition-over-Scripture is exegetically grounded here."
-            },
-            {
-              "ref": "7:19",
-              "note": "All foods clean — Calvin notes that this anticipates the abolition of the ceremonial law in Christ. The dietary laws were shadows of the covenant reality. Their fulfilment in Christ releases their binding force."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:11",
-              "note": "Corban (korbanas) — a loanword from Hebrew qorban (offering). The practice of corban vows is attested in Mishnah Nedarim 9:1, which shows that rabbis were themselves uncomfortable with vows that disadvantaged parents. Jesus’s criticism reflects a genuine abuse within the tradition."
-            },
-            {
-              "ref": "7:19",
-              "note": "“In saying this” — the phrase is a participial clause describing Jesus’s action: as he said this, he was pronouncing all foods clean. Mark’s editorial recognition of the implication is confirmed in Acts 10:9-16 (Peter’s vision) and Acts 15:28-29 (Jerusalem council decision)."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The clean/unclean controversy is the theological centre of Mark’s Galilean section. Jesus makes two claims: (1) external ritual cannot defile the heart — the oral tradition overrides the written Torah; (2) only internal evil defiles — overturning the Levitical purity system entirely. Mark’s editorial note (v.19: “In saying this, Jesus declared all foods clean”) is one of the most significant theological parentheses in the NT."

--- a/content/mark/8.json
+++ b/content/mark/8.json
@@ -269,81 +269,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:12",
-              "note": "Marcus: The \"deep sigh\" (anastenaxas) in response to the demand for a sign is the strongest emotional reaction in Mark before Gethsemane. Marcus connects it to the LXX of Ezek 21:11-12, where God commands the prophet to sigh deeply because of coming judgment. Jesus's sigh is the prophet's grief at a generation that has witnessed extraordinary things and remained impervious. The rhetorical question \"Why does this generation ask for a sign?\" echoes Ps 95:8-11 (\"Do not harden your hearts as at Meribah\") — judgment language for a recalcitrant generation."
-            },
-            {
-              "ref": "8:19-20",
-              "note": "Marcus: The two feeding miracles produce different numbers of leftovers: twelve baskets (kophinos — a distinctively Jewish basket type used in Roman sources as a Jewish identifier, Juvenal Sat. 3.14) and seven baskets (spyridos — a large Gentile basket). Marcus argues the numbers are intentional: twelve = the twelve tribes of Israel; seven = the seven nations of Canaan or the number of completeness. The two feedings together enact the inclusion of both covenant communities in the messianic provision."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "8:14-21",
-              "note": "Rhoads: The leaven-warning scene is the narrative's most explicit diagnosis of the disciples' condition. Jesus's seven questions (8:17-21) are a rhetorical crescendo: \"Why are you talking about bread? Do you still not see? Do you still not understand? Are your hearts hardened? Do you have eyes but fail to see? Do you have ears but fail to hear? Don't you remember?\" Each question isolates a different dimension of their failure. Rhoads identifies this as the low point of the disciples' characterization before Peter's confession — the nadir preceding the turning point."
-            },
-            {
-              "ref": "8:17",
-              "note": "Rhoads: \"Are your hearts hardened?\" — here the narrative's key characterization term (pōroō) is applied directly to the disciples, not to the Pharisees or outsiders. The insider/outsider distinction established in 4:11 has been progressively eroded. Rhoads's analysis: the disciples were characterized positively at their calling (immediate obedience), given privileged access to the parables (4:11), and sent out with authority (6:7-13). Now they are diagnosed with the same hardness as the antagonists. The narrative is preparing for the confessional breakthrough of 8:29 — but also for the collapse of 14:50."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:1-21",
-              "note": "The second feeding miracle (four thousand, vv.1-10) is treated separately in the Catena from the first. Chrysostom notes the disciples' apparent forgetfulness — \"where in this remote place can anyone get enough bread to feed them?\" — after having witnessed the feeding of five thousand. Origen says this is not stupidity but a figure of the spiritual forgetfulness that can overtake even those who have witnessed great things. The request for a sign from heaven (vv.11-12) is, for Bede, the permanent condition of unbelief: no sign will satisfy the person who has decided in advance to reject. The leaven of the Pharisees and Herod (v15) is, for Chrysostom, not a single teaching but a general disposition — the corrosive influence of unbelief spreading through a community."
-            },
-            {
-              "ref": "8:14-21",
-              "note": "The disciples' literal misunderstanding about bread is, for Chrysostom, Mark's most explicit statement about the disciples' spiritual density in this section of the Gospel. Jesus's series of rhetorical questions — \"Do you still not see or understand? Are your hearts hardened?\" — repeats the language used of Pharaoh and of the wilderness generation. Origen notes the disturbing echo: the same hardness Jesus diagnoses in the Pharisees appears now in his own disciples. The question \"Do you still not understand?\" ends the passage without an answer, which Theophylact says is deliberate — the reader is left to supply the answer for themselves."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:17",
-              "note": "Are your hearts hardened? — the most devastating question Jesus asks his disciples in Mark. The Greek pōroō is used for Pharaoh, the Pharisees (3:5), and now the Twelve. The disciples are not simply slow learners; they are in danger of the same judicial hardening as Jesus’s opponents."
-            },
-            {
-              "ref": "8:21",
-              "note": "Do you still not understand? — the question is left unanswered. Mark does not give the disciples a satisfying moment of comprehension. Their failure to understand is suspended in tension until the confession of 8:29."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:11-12",
-              "note": "Calvin: The Pharisees’ demand for a sign from heaven exposes the nature of their unbelief. They have not lacked signs — they have lacked the willingness to receive them. A sign for the sign-demander is not possible because the demand is evidence of the spiritual condition that no sign can cure."
-            },
-            {
-              "ref": "8:17-21",
-              "note": "Calvin: The disciples’ hardness is a warning to all who receive extraordinary privilege without the inner illumination of the Spirit. To have witnessed the feedings and not understood is more culpable than never having witnessed them."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:19-20",
-              "note": "Twelve…seven — the two numbers invite symbolic interpretation. Twelve recalls the tribes of Israel; seven recalls either the seven nations of Canaan (Deut 7:1) or the number of fullness. The two feedings together suggest that Jesus’s provision encompasses both covenant communities."
-            },
-            {
-              "ref": "8:21",
-              "note": "Do you still not understand? — the open question creates narrative suspense. The answer begins in v.27-29 (Peter’s confession) but is not fully given until 15:39. Mark structures the Gospel around this progressive, incomplete comprehension."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The feeding of four thousand is parallel to the five thousand but in Gentile territory (Decapolis). The two feedings together form a diptych: one Jewish (twelve basketfuls = twelve tribes), one Gentile (seven basketfuls = seven nations of Canaan or the number of completion). Jesus’s challenge to the disciples in vv.17-21 is the most severe rebuke in Mark: they have witnessed both feedings and still do not understand."

--- a/content/mark/9.json
+++ b/content/mark/9.json
@@ -290,81 +290,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:2-4",
-              "note": "Marcus: The Transfiguration mountain is described as \"a high mountain\" (oros hypsēlon) — the same phrase used in the LXX for Sinai-type theophanic mountains (Isa 2:2; Ezek 40:2). The \"six days\" connects to the Sinai narrative: Moses waited six days before the glory cloud descended and God called him on the seventh day (Exod 24:16). The parallel positions the Transfiguration as the new Sinai, with Jesus as the new Moses receiving divine attestation on the mountain."
-            },
-            {
-              "ref": "9:7",
-              "note": "Marcus: \"Listen to him\" (akouete autou) is the verbatim command of Deut 18:15 (LXX) concerning the prophet like Moses. The Transfiguration voice adds this command to the baptismal formula (\"You are my Son, whom I love\"), combining royal-messianic (Ps 2:7) and prophetic-Mosaic (Deut 18:15) categories in a single declaration. This dual attestation — Son and Prophet — defines Jesus's role as both king and the culminating prophetic revelation."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:2-8",
-              "note": "Rhoads: The Transfiguration is the only scene in Mark where Jesus's appearance is described. The narrator withholds physical description throughout the Gospel — we never learn what Jesus looked like — making the dazzling white of 9:3 all the more striking. The scene functions as a narrator's aside to the reader: a direct disclosure of what the disciples see but do not fully comprehend. Moses and Elijah appear and vanish; \"suddenly, when they looked around, they no longer saw anyone with them except Jesus.\" The visual statement is the theological statement."
-            },
-            {
-              "ref": "9:9-10",
-              "note": "Rhoads: The secrecy command carries a temporal qualifier unique in Mark: \"until the Son of Man had risen from the dead.\" This is the first time the secrecy has a built-in expiration. The disciples' question — \"what does 'rising from the dead' mean?\" — shows that even the inner circle cannot process the prediction. The narrator positions the reader to understand what the disciples cannot: the secrecy that has dominated the first half of the Gospel has an end-point, and it is the resurrection."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:1-8",
-              "note": "The Transfiguration is, for Origen, the moment when the veil between the present age and the age to come is briefly lifted for three witnesses. The appearance of Moses and Elijah is, for Chrysostom, a deliberate theological statement: the Law and the Prophets attend the fulfilment of their own testimony. Peter's offer to build three shelters is, for Bede, a misreading of the moment — he wishes to prolong the revelation; the revelation is given precisely for the descent, not the mountain top. The cloud and the divine voice repeat the baptism formula, which Cyril of Alexandria says frames the entire public ministry between two heavenly declarations."
-            },
-            {
-              "ref": "9:9-13",
-              "note": "The command to silence \"until the Son of Man had risen from the dead\" is, for Chrysostom, the first explicit mention of the resurrection in direct connection with the passion. The disciples' discussion about what \"rising from the dead means\" is, for Origen, historical evidence that Jewish resurrection expectation was corporate and eschatological — they did not expect an individual resurrection in the middle of history. The identification of John the Baptist as Elijah who \"has come\" interprets Malachi 4:5 christologically: the promised return of Elijah was not Elijah literally but the Elijah-spirit active in John."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:4",
-              "note": "Moses and Elijah — the Law and the Prophets appear with Jesus and then vanish. Jesus does not supplement them; he fulfils and supersedes them. The Father’s command is not “obey the law” but “listen to my Son.”"
-            },
-            {
-              "ref": "9:7",
-              "note": "This is my Son, whom I love. Listen to him! — the addition of “Listen to him” over the baptismal voice. The Deut 18 echo is deliberate: Jesus is the prophet like Moses whom Israel must obey."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:3",
-              "note": "Dazzling white — the brightness of the transfigured Christ is a foretaste of the resurrection body. What the disciples see on the mountain is what they will see at the resurrection: the glory always present beneath the incarnate form, momentarily visible."
-            },
-            {
-              "ref": "9:9-10",
-              "note": "Not to tell anyone until the Son of Man rises — the Transfiguration would be incomprehensible before the resurrection. The timing of disclosure is pedagogically precise."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:5",
-              "note": "Three shelters (skēnas) — tabernacles/tents. Peter’s proposal may echo the Feast of Tabernacles theology: God dwelling with humanity. The irony is that the true Tabernacle (John 1:14) is already present in Jesus."
-            },
-            {
-              "ref": "9:13",
-              "note": "Elijah has come — the identification of John the Baptist as the Elijah-figure is implicit. Mark’s readers know John was beheaded; the application is clear: John came and was treated as they wished, just as the Son of Man will be."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The Transfiguration follows Peter’s confession by six days. The Father’s voice repeats the baptismal declaration with one addition: “Listen to him!” — the echo of Deut 18:15’s command about the prophet like Moses. Moses (law) and Elijah (prophets) appear and then vanish; Jesus alone remains. The mountain is Israel’s covenant mountain in concentrated form."
@@ -410,81 +356,27 @@
         },
         "mar": {
           "source": "Joel Marcus, Mark 1–8 / 8–16, Anchor Bible (2000/2009) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:24",
-              "note": "Marcus: \"I do believe; help me overcome my unbelief\" — the combination of pistis and apistia (faith and faithlessness) in a single sentence has no close parallel in ancient prayer literature. Marcus argues that this prayer is theologically more sophisticated than most confessional formulas: it acknowledges the reality of partial faith without treating partial faith as disqualifying. The prayer is accepted and the boy is healed, establishing a crucial Markan principle — faith the size of incomplete trust is sufficient when honestly presented."
-            },
-            {
-              "ref": "9:31",
-              "note": "Marcus: The second passion prediction uses the divine passive \"is going to be delivered\" (paradidotai — present passive). Marcus argues the present tense is deliberate: the betrayal is already in motion, not merely a future event. The passive voice throughout the passion predictions signals divine agency: the Son of Man is not merely being handed over by human betrayal but is being delivered by God as a theological act. This reading unites the human betrayal of Judas with the divine purpose — both are at work simultaneously."
-            }
-          ]
+          "notes": []
         },
         "rho": {
           "source": "David Rhoads & Donald Michie, Mark as Story (3rd ed., 2012) — Scholarly Paraphrase",
-          "notes": [
-            {
-              "ref": "9:14-29",
-              "note": "Rhoads: The failed exorcism creates the Gospel's sharpest contrast between the mountain and the plain. The mountain: three disciples, divine voice, dazzling glory. The plain: the remaining nine, a failed exorcism, a weeping father. Rhoads's structural observation: every time Jesus ascends toward divine disclosure (transfiguration, prayer, the cross), the disciples below are characterized by failure (sleeping in Gethsemane, denial in the courtyard, flight at the arrest). The geography of the narrative encodes a theology of discipleship."
-            },
-            {
-              "ref": "9:33-37",
-              "note": "Rhoads: The road to Capernaum controversy about greatness is followed by the child-in-arms scene (9:36-37). The disciples are characterized by their silence — they \"kept quiet\" because they were arguing about status. Jesus's response is not a rebuke of the argument but a physical enactment of the answer: he takes a child in his arms. Rhoads argues that Mark's Jesus characteristically answers conceptual questions with embodied action rather than extended discourse. The gesture is the teaching."
-            }
-          ]
+          "notes": []
         },
         "cat": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:14-29",
-              "note": "The exorcism of the deaf and mute spirit is, for Chrysostom, a study in the relationship between faith and power. The father's anguished \"I do believe; help me overcome my unbelief!\" (v24) is, for Origen, the most honest prayer in the Gospels — the model of all petitionary prayer that comes in mixed states of trust and doubt. Bede notes that the disciples' failure to cast out the spirit is explained privately: \"This kind can come out only by prayer.\" The disciples had been commissioned (6:7-13) and had succeeded; here they fail because they were relying on past authorization rather than present dependence."
-            },
-            {
-              "ref": "9:30-50",
-              "note": "The second passion prediction (vv.30-32) is, for Chrysostom, deliberately paired with the disciples' dispute about greatness (vv.33-37): they have just been told Jesus will be handed over and killed, and they argue about status. Ambrose says the child placed in their midst is not just an illustration of humility but a re-ordering of value: greatness in the kingdom is measured by willingness to receive the last and least. The fire and salt sayings (vv.42-50) are, for Origen, a sustained metaphor about the seriousness of spiritual formation — better to enter life maimed than to arrive whole at destruction."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:24",
-              "note": "I do believe; help me overcome my unbelief — the most theologically honest prayer in Mark. Genuine faith coexists with genuine doubt, and the honest acknowledgment of both is itself an act of faith."
-            },
-            {
-              "ref": "9:35",
-              "note": "Anyone who wants to be first must be the very last, and the servant of all — the kingdom’s inversion of every human power structure."
-            }
-          ]
+          "notes": []
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:23",
-              "note": "Everything is possible for one who believes — faith does not empower God; it receives God’s power. The father’s partial faith is enough because faith’s value lies in its object, not its quality."
-            },
-            {
-              "ref": "9:43-48",
-              "note": "The radical surgery sayings are hyperbolic intensifications: no temporal good is worth eternal loss."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:31",
-              "note": "Delivered into the hands of men — paradidotai: divine passive. God delivers the Son of Man. The betrayal is not a tragedy that overrules divine intention but the divine plan through human agency."
-            },
-            {
-              "ref": "9:43-48",
-              "note": "Gehenna (geenna) — the Valley of Hinnom south of Jerusalem, associated with child sacrifice (2 Kings 23:10) and later Jerusalem’s refuse dump. Jesus employs it as the image of eternal judgment, quoting Isa 66:24 in v.48."
-            }
-          ]
+          "notes": []
         },
         "hist": {
           "context": "The failed exorcism at the foot of the mountain contrasts with the Transfiguration glory above. The disciples’ failure provokes Jesus’s rebuke of an unbelieving generation. The second passion prediction follows (9:31), and the disciples’ immediate argument about greatness reveals complete misunderstanding. Jesus’s response — a child in the arms — redefines greatness as servitude."

--- a/content/matthew/10.json
+++ b/content/matthew/10.json
@@ -299,68 +299,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:5-7",
-              "note": "Calvin on 'go to the lost sheep of the house of Israel': The mission is temporary and limited in its first form -- the Gentile mission awaits the resurrection. This is not ethnic exclusivism but eschatological order: the covenant must first be offered to covenant Israel before going to the nations. The pattern in Acts confirms this: 'to the Jew first, and also to the Greek.'"
-            },
-            {
-              "ref": "10:28",
-              "note": "Calvin on fear: Do not fear those who kill the body but cannot kill the soul -- the fear of God relativises all human threats. The person who fears the Father has nothing else to fear, because no human threat can reach what the Father holds. The person who does not fear the Father fears everyone and everything, because earthly threats are all they have to lose."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "10:1-4",
-              "note": "The NET note on the Twelve discusses their representative function: twelve apostles for twelve tribes of Israel. The note traces the apostolic function through the NT: those sent with the authority of the sender, representing the sender, accountable to the sender. Apostolic authority is derived, not inherent."
-            },
-            {
-              "ref": "10:32-33",
-              "note": "The NET note on confession (homologeo) and denial (arneomai) discusses the public context: confession before people means public acknowledgment of allegiance to Jesus. The note traces the connection to Rom 10:9-10 where the same verb is used for the confession that constitutes saving faith."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "10:1-4",
-              "note": "Robertson notes the Twelve are given authority (exousia) over unclean spirits and all disease -- the same authority Jesus exercised in chs.8-9 is now delegated. The list of apostles is the only authoritative list in Matthew; Robertson notes the pairing (sent two by two per Mark 6:7) and Judas Iscariot's placement last with the identification 'who betrayed him' -- the list already bears the shadow of its ending."
-            },
-            {
-              "ref": "10:32-33",
-              "note": "Robertson identifies the public confession/denial contrast as the mission discourse's theological climax. Homologeo (confess, v.32) and arneomai (deny, v.33) are present subjunctives -- habitual pattern, not single act. The reciprocal structure is exact: whoever confesses me before people, I will confess before my Father; whoever denies me, I will deny. The eternal stakes of the mission are established."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "10:1-4",
-              "note": "Chrysostom: He chose twelve in order to show that the success of the gospel would depend not on human numbers or power but on the authority given them. He sent out not philosophers or rhetoricians but fishermen, tax collectors, and simple men -- that the power of the message might be seen to be from God and not from human eloquence."
-            },
-            {
-              "ref": "10:32-33",
-              "note": "Augustine: Whoever confesses me before men I will confess before my Father -- this is the double promise and warning that governs all Christian witness. The confession that risks earthly loss receives heavenly acknowledgment. The denial that seeks earthly safety receives heavenly denial. Nothing in the earthly calculus changes the eternal arithmetic."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "10:1-15",
-              "note": "MacArthur: The commissioning of the Twelve is the first formal extension of the kingdom mission beyond Jesus himself. The authority to drive out spirits and heal is delegated authority — the disciples perform the same acts Jesus has been performing, in his name. The mission is an extension, not an independent operation."
-            },
-            {
-              "ref": "10:5-6",
-              "note": "MacArthur: Do not go among the Gentiles or enter any Samaritan town... go rather to the lost sheep of Israel. The restriction to Israel in this first commission is not permanent (28:19 universalizes it) but sequential: Israel must be offered the kingdom first. The pattern — to the Jew first, and also to the Gentile — is Paul's summary of the gospel's historical sequence (Rom 1:16)."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/matthew/11.json
+++ b/content/matthew/11.json
@@ -284,55 +284,19 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:11",
-              "note": "Calvin on John being the greatest among those born of women yet the least in the kingdom: This is not a diminishment of John but a statement about the progressive nature of revelation. John stands at the threshold; those who enter the kingdom receive what John could only see from the outside. The greater revelation produces the greater privilege -- even the least in the kingdom stands inside what John saw only from the border."
-            },
-            {
-              "ref": "11:28-30",
-              "note": "Calvin on 'learn from me, for I am gentle and humble in heart': This is the description of the Saviour who receives weary sinners. The divine Lawgiver who could demand and condemn presents himself as gentle and humble -- the qualities that make the yoke bearable. The person who comes to Christ for rest finds not a demanding judge but a servant master who bears the yoke alongside them."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "11:2-6",
-              "note": "The NET note on the messianic evidence Jesus cites traces each element to its prophetic source: blind see (Isa 29:18; 35:5), lame walk (35:6), lepers cleansed (implicitly through the purity-restoration theme), deaf hear (35:5), dead raised (26:19), poor have good news (61:1). The cumulative citation establishes that Jesus' ministry fulfils the eschatological programme Isaiah described."
-            },
-            {
-              "ref": "11:25-27",
-              "note": "The NET note on 'no one knows the Son except the Father, and no one knows the Father except the Son' discusses the mutual knowledge formula. The note identifies this as the highest Christological claim in Matthew: the Son has the same exclusive, direct knowledge of the Father that the Father has of the Son -- the mutual knowledge of divine persons."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "11:2-6",
-              "note": "Robertson notes John's question from prison is not doubt but a request for clarification -- or possibly a pastoral prompt to his own disciples to hear Jesus directly. The response lists six types of healing (blind see, lame walk, lepers cleansed, deaf hear, dead raised, poor have good news proclaimed) that correspond to Isaiah's messianic programme (Isa 35:5-6; 61:1). Jesus answers the question with evidence rather than assertion."
-            },
-            {
-              "ref": "11:28-30",
-              "note": "Robertson identifies the yoke metaphor as drawn from Jewish wisdom tradition (Sirach 51:23-27) where wisdom invites students to take up her yoke. Jesus presents himself as the embodiment of wisdom -- taking his yoke is learning from him directly. The paradox (my yoke is easy, my burden is light) is answered by the qualifier: I am gentle and humble in heart. The burden is heavy if the master is harsh; it is light if the master bears it alongside you."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "11:2-6",
-              "note": "Chrysostom: John did not doubt -- a man who had seen the Spirit descend like a dove and heard the voice from heaven could not have doubted. He sent his disciples to Christ for their own benefit, not his. He was preparing them to leave him and follow Christ. The answer Jesus gave was not to rebuke John but to instruct his disciples by the evidence."
-            },
-            {
-              "ref": "11:28-30",
-              "note": "Augustine: Come to me, all you who are weary and burdened, and I will give you rest -- this is the gospel in miniature. The weary are those exhausted by the law's demands without the law's grace. The burdened are those carrying guilt, shame, and the weight of unforgiven sin. Christ offers what the law requires but cannot supply: rest for the soul."
-            }
-          ]
+          "notes": []
         },
         "poi": [
           {
@@ -353,16 +317,7 @@
         ],
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "11:1-19",
-              "note": "MacArthur: John the Baptist's question from prison — are you the one who is to come, or should we expect someone else? — is not a failure of faith but an honest question from a man in a context that did not match his expectation. Jesus's answer cites Isaiah's signs of the messianic age, not the military triumph John had preached."
-            },
-            {
-              "ref": "11:11",
-              "note": "MacArthur: Among those born of women there has not risen anyone greater than John the Baptist; yet whoever is least in the kingdom of heaven is greater than he. The paradox is not a demotion of John but a definition of the kingdom: membership in the new covenant age exceeds in privilege the highest position in the old covenant era. John is at the threshold but not yet through the door."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/matthew/12.json
+++ b/content/matthew/12.json
@@ -262,68 +262,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:6-8",
-              "note": "Calvin on 'one greater than the temple is here': The accumulated argument -- David, the priests, the temple -- culminates in this claim. The one who exceeds the temple in significance has authority over the Sabbath regulations that governed the temple service. This is Jesus' implicit claim to divine authority expressed through the logic of precedent."
-            },
-            {
-              "ref": "12:31-32",
-              "note": "Calvin on the unforgivable sin: This sin is not committed accidentally or in ignorance -- it requires the full light of evidence and the deliberate choice to call it demonic. The Pharisees have seen the Spirit's work, acknowledged it implicitly by their own exorcism tradition (v.27), and chosen to attribute it to Satan. This is the wilful suppression of known truth that constitutes the final sin."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "12:1-8",
-              "note": "The NET note on the Sabbath controversy discusses the legal categories: the disciples were not working but gleaning (Deut 23:25 permits gleaning). The note identifies the Pharisees' error: they applied the prohibition of work to a permitted activity. Jesus' three counter-examples establish the principle that mercy takes precedence over ritual regulation when they conflict."
-            },
-            {
-              "ref": "12:31-32",
-              "note": "The NET note on the blasphemy against the Holy Spirit discusses the difference between speaking against the Son of Man (forgivable) and speaking against the Spirit (unforgivable). The note identifies the distinction: the Son of Man's identity could be misunderstood; the Spirit's works (healings, exorcisms) are unmistakable evidence of divine power. To call them demonic after full exposure is the total inversion that is irreversible."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "12:1-8",
-              "note": "Robertson notes that the Pharisees' accusation against the disciples addresses not Jesus directly but the disciples' behaviour. Jesus responds with three counter-examples: David's eating the showbread (1 Sam 21), the priests' Sabbath work in the temple, and the statement 'one greater than the temple is here.' The escalation is deliberate: if David could do it, and the priests can do it, then the Lord of the Sabbath can certainly permit it."
-            },
-            {
-              "ref": "12:22-32",
-              "note": "Robertson identifies the Beelzebul controversy as the narrative climax of ch.12's conflict. The blasphemy against the Holy Spirit (v.32) -- attributing the Spirit's work to Satan -- is the unforgivable sin because it represents the total inversion of moral perception: calling the holy evil. Robertson notes it is unforgivable not because it is beyond God's power to forgive but because the one who commits it has so hardened their heart that they will never repent."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "12:1-8",
-              "note": "Chrysostom: I desire mercy and not sacrifice -- Christ quotes Hosea 6:6 for the second time to rebuke the Pharisees' letter-of-the-law severity. The Sabbath was made for the people; the people were not made for the Sabbath. The one who is Lord of the Sabbath has authority to interpret its purpose and distinguish legitimate from illegitimate uses."
-            },
-            {
-              "ref": "12:22-32",
-              "note": "Augustine on the unforgivable sin: The sin against the Holy Spirit is the persistent, final refusal to repent -- the hardness that will not receive the forgiveness the Spirit offers. It is not a single act but a settled disposition of total resistance to grace. Augustine notes that anyone who fears they may have committed it almost certainly has not -- the very fear is itself evidence of the Spirit's continued working."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "12:1-21",
-              "note": "MacArthur: The Sabbath controversies of ch.12 turn on the question of authority: who has the right to interpret the Sabbath? Jesus's claim — the Son of Man is Lord of the Sabbath (v.8) — is a claim to divine authority over the institution God himself established. The Pharisees respond by plotting to kill him (v.14)."
-            },
-            {
-              "ref": "12:18-21",
-              "note": "MacArthur: Matthew's extended Isaiah 42 citation (vv.18-21) interprets Jesus's withdrawal and his instruction not to tell others who he is. The Servant does not cry out or shout in the streets — the messianic strategy is not mass mobilization but quiet faithfulness. The Gentiles will put their hope in him, but the path runs through suffering, not triumph."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/matthew/14.json
+++ b/content/matthew/14.json
@@ -7,59 +7,59 @@
   "subtitle": "John Beheaded; Feeding the Five Thousand; Walking on Water",
   "timeline_link": {
     "event_id": "feeding-five-thousand",
-    "text": "See on Timeline \u2014 Feeding of the Five Thousand"
+    "text": "See on Timeline — Feeding of the Five Thousand"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201312 \u2014 John the Baptist Beheaded",
+      "header": "Verses 1–12 — John the Baptist Beheaded",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
         "heb": [
           {
-            "word": "\u03c6\u03cc\u03b2\u03bf\u03c2",
+            "word": "φόβος",
             "transliteration": "phobos",
             "gloss": "fear / terror",
-            "paragraph": "Herod feared John (Mark says), feared the crowd, and feared the implications of Jesus' miracles. His execution of John is driven not by conviction but by cowardice \u2014 he made an oath at a feast and feared losing face more than taking a life. Fear of man replaces fear of God."
+            "paragraph": "Herod feared John (Mark says), feared the crowd, and feared the implications of Jesus' miracles. His execution of John is driven not by conviction but by cowardice — he made an oath at a feast and feared losing face more than taking a life. Fear of man replaces fear of God."
           },
           {
-            "word": "\u1f40\u03c1\u03c7\u03ad\u03bf\u03bc\u03b1\u03b9",
+            "word": "ὀρχέομαι",
             "transliteration": "orcheomai",
             "gloss": "dance",
-            "paragraph": "Herodias' daughter danced before Herod and his guests. The verb is simple but the context is loaded \u2014 the dance leads to the Baptist's beheading. Matthew draws a grim line from entertainment to murder. The most consequential moral failures often begin with triviality."
+            "paragraph": "Herodias' daughter danced before Herod and his guests. The verb is simple but the context is loaded — the dance leads to the Baptist's beheading. Matthew draws a grim line from entertainment to murder. The most consequential moral failures often begin with triviality."
           }
         ],
         "poi": [
           {
             "name": "Herod's palace / court",
             "coords": "Tiberias or Machaerus; Herod Antipas's territory",
-            "text": "The beheading of John occurs at Herod Antipas's birthday banquet \u2014 either at his Galilean capital Tiberias or at the fortress Machaerus east of the Dead Sea (Josephus locates John's imprisonment at Machaerus). The geography of power executes the one who challenged it."
+            "text": "The beheading of John occurs at Herod Antipas's birthday banquet — either at his Galilean capital Tiberias or at the fortress Machaerus east of the Dead Sea (Josephus locates John's imprisonment at Machaerus). The geography of power executes the one who challenged it."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Mark 6:14\u201329",
+              "ref": "Mark 6:14–29",
               "note": "Mark's fuller account includes the name Salome for the daughter of Herodias (from Josephus). Matthew's abbreviated version focuses the irony: a king bound by his own rash oath."
             },
             {
-              "ref": "Matt 11:2\u201314",
-              "note": "John's death fulfils what Jesus implied \u2014 the forerunner suffers the Elijah's fate (17:12) before the Son of Man suffers his."
+              "ref": "Matt 11:2–14",
+              "note": "John's death fulfils what Jesus implied — the forerunner suffers the Elijah's fate (17:12) before the Son of Man suffers his."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "14:3\u20134",
-              "note": "John had been saying to him: \"It is not lawful for you to have her.\" John's imprisonment is the direct consequence of speaking truth to power. The pattern is the same as the prophets before him (Matt 5:12) and the disciples after him (10:17\u201322). Faithfulness to God's word generates opposition from those with something to lose."
+              "ref": "14:3–4",
+              "note": "John had been saying to him: \"It is not lawful for you to have her.\" John's imprisonment is the direct consequence of speaking truth to power. The pattern is the same as the prophets before him (Matt 5:12) and the disciples after him (10:17–22). Faithfulness to God's word generates opposition from those with something to lose."
             },
             {
               "ref": "14:9",
-              "note": "The king was distressed. Herod didn't want to kill John \u2014 he was afraid of him (Mark 6:20: \"he protected John, knowing him to be a righteous and holy man\"). But political calculation overcame his conscience. He is the portrait of the person who knows the right thing and does the wrong one for social reasons."
+              "note": "The king was distressed. Herod didn't want to kill John — he was afraid of him (Mark 6:20: \"he protected John, knowing him to be a righteous and holy man\"). But political calculation overcame his conscience. He is the portrait of the person who knows the right thing and does the wrong one for social reasons."
             },
             {
               "ref": "14:12",
@@ -68,7 +68,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:1-5",
@@ -81,7 +81,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "14:3-5",
@@ -94,7 +94,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "14:3-12",
@@ -107,7 +107,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "14:1-12",
@@ -120,52 +120,52 @@
           ]
         },
         "hist": {
-          "context": "The death of John is recounted as a flashback triggered by Herod's superstitious fear (v.2). Its placement here is structural: the forerunner who prepared the way has been killed; the one whose way he prepared is about to demonstrate who he is in the feeding of the five thousand. The pattern of prophet-rejection and murder is the context in which Matthew 14\u201328 operates. John's disciples report to Jesus \u2014 and Jesus withdraws, but then the crowds find him anyway."
+          "context": "The death of John is recounted as a flashback triggered by Herod's superstitious fear (v.2). Its placement here is structural: the forerunner who prepared the way has been killed; the one whose way he prepared is about to demonstrate who he is in the feeding of the five thousand. The pattern of prophet-rejection and murder is the context in which Matthew 14–28 operates. John's disciples report to Jesus — and Jesus withdraws, but then the crowds find him anyway."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201321 \u2014 Feeding the Five Thousand",
+      "header": "Verses 13–21 — Feeding the Five Thousand",
       "verse_start": 13,
       "verse_end": 21,
       "panels": {
         "heb": [
           {
-            "word": "\u03b5\u1f50\u03bb\u03bf\u03b3\u03ad\u03c9",
-            "transliteration": "euloge\u014d",
+            "word": "εὐλογέω",
+            "transliteration": "eulogeō",
             "gloss": "bless / give thanks",
-            "paragraph": "Jesus 'blessed' the five loaves \u2014 the same verb used at the Last Supper (26:26). The feeding miracle prefigures the Eucharist: taking, blessing, breaking, giving. The pattern is eucharistic before the Eucharist exists. Every shared meal points toward the final one."
+            "paragraph": "Jesus 'blessed' the five loaves — the same verb used at the Last Supper (26:26). The feeding miracle prefigures the Eucharist: taking, blessing, breaking, giving. The pattern is eucharistic before the Eucharist exists. Every shared meal points toward the final one."
           },
           {
-            "word": "\u03ba\u03bb\u03ac\u03c3\u03bc\u03b1",
+            "word": "κλάσμα",
             "transliteration": "klasma",
             "gloss": "fragment / broken piece",
-            "paragraph": "Twelve baskets of fragments (klasmata) remained \u2014 one per apostle. The surplus is not accidental but deliberate: God provides not merely enough but more than enough. The number twelve echoes the twelve tribes; the abundance is for all Israel."
+            "paragraph": "Twelve baskets of fragments (klasmata) remained — one per apostle. The surplus is not accidental but deliberate: God provides not merely enough but more than enough. The number twelve echoes the twelve tribes; the abundance is for all Israel."
           }
         ],
         "poi": [
           {
             "name": "Desolate place near Bethsaida",
             "coords": "Northeast shore of Sea of Galilee",
-            "text": "Jesus withdraws to a desolate place after hearing of John's death \u2014 but the crowd follows on foot from the towns. The withdrawal becomes the feeding: the desolate geography is transformed into the site of abundant provision, echoing the wilderness manna."
+            "text": "Jesus withdraws to a desolate place after hearing of John's death — but the crowd follows on foot from the towns. The withdrawal becomes the feeding: the desolate geography is transformed into the site of abundant provision, echoing the wilderness manna."
           },
           {
-            "name": "Sea of Galilee \u2014 on water",
+            "name": "Sea of Galilee — on water",
             "coords": "The lake itself",
-            "text": "Jesus walks on the Sea of Galilee and Peter briefly does too. The sea geography is theologically loaded: the sea is the chaos symbol of the ancient world. Jesus walking on the sea is the Creator ordering chaos \u2014 the same act as the Exodus sea crossing and the creation separation of waters."
+            "text": "Jesus walks on the Sea of Galilee and Peter briefly does too. The sea geography is theologically loaded: the sea is the chaos symbol of the ancient world. Jesus walking on the sea is the Creator ordering chaos — the same act as the Exodus sea crossing and the creation separation of waters."
           },
           {
             "name": "Gennesaret",
             "coords": "Northwest shore of Sea of Galilee",
-            "text": "The landing at Gennesaret triggers another wave of healings. Gennesaret is a fertile plain on the northwest shore \u2014 a prosperous agricultural area. Even landing in Gennesaret produces healing: Jesus's geographical presence generates covenant restoration."
+            "text": "The landing at Gennesaret triggers another wave of healings. Gennesaret is a fertile plain on the northwest shore — a prosperous agricultural area. Even landing in Gennesaret produces healing: Jesus's geographical presence generates covenant restoration."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "2 Kgs 4:42\u201344",
-              "note": "Elisha feeding a hundred with twenty loaves, with food left over. Jesus feeds five thousand with five loaves \u2014 the eschatological multiplication exceeds the prophetic precedent."
+              "ref": "2 Kgs 4:42–44",
+              "note": "Elisha feeding a hundred with twenty loaves, with food left over. Jesus feeds five thousand with five loaves — the eschatological multiplication exceeds the prophetic precedent."
             },
             {
               "ref": "Job 9:8; Ps 77:19",
@@ -173,20 +173,20 @@
             },
             {
               "ref": "Matt 26:26",
-              "note": "Took bread, gave thanks, broke it, gave it to the disciples. The fourfold action of the feeding is the fourfold action of the Last Supper \u2014 the wilderness feeding anticipates the covenant meal."
+              "note": "Took bread, gave thanks, broke it, gave it to the disciples. The fourfold action of the feeding is the fourfold action of the Last Supper — the wilderness feeding anticipates the covenant meal."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:19",
-              "note": "He gave thanks and broke the loaves and gave them to the disciples. The eucharistic structure (took/blessed/broke/gave) is the same in 14:19, 15:36, and 26:26\u201327. Matthew is drawing a deliberate line from the wilderness feeding through the second feeding to the Last Supper. Every time Jesus feeds a crowd, it anticipates the meal that will interpret his death."
+              "note": "He gave thanks and broke the loaves and gave them to the disciples. The eucharistic structure (took/blessed/broke/gave) is the same in 14:19, 15:36, and 26:26–27. Matthew is drawing a deliberate line from the wilderness feeding through the second feeding to the Last Supper. Every time Jesus feeds a crowd, it anticipates the meal that will interpret his death."
             },
             {
               "ref": "14:27",
-              "note": "It is I \u2014 eg\u014d eimi. The divine name from Exod 3:14 and the \"I am\" language of Isa 43:10\u201313 (\"I am he\"). The disciples who saw Jesus calm a storm (8:27: \"what kind of man is this?\") now have their answer confirmed: the Son of God who walks on water is the one whom the OT reserves this language for \u2014 the LORD himself."
+              "note": "It is I — egō eimi. The divine name from Exod 3:14 and the \"I am\" language of Isa 43:10–13 (\"I am he\"). The disciples who saw Jesus calm a storm (8:27: \"what kind of man is this?\") now have their answer confirmed: the Son of God who walks on water is the one whom the OT reserves this language for — the LORD himself."
             },
             {
               "ref": "14:33",
@@ -195,7 +195,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "14:13-21",
@@ -208,7 +208,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "14:13-21",
@@ -216,12 +216,12 @@
             },
             {
               "ref": "14:28-31",
-              "note": "The NET note on Peter walking on water discusses distaz\u014d (to doubt, v.31) -- appearing only twice in Matthew (here and 28:17). The note distinguishes distaz\u014d from apistia (unbelief): doubt is wavering faith, not absent faith. Peter's faith is present but insufficient to sustain under pressure without fixing attention on Christ."
+              "note": "The NET note on Peter walking on water discusses distazō (to doubt, v.31) -- appearing only twice in Matthew (here and 28:17). The note distinguishes distazō from apistia (unbelief): doubt is wavering faith, not absent faith. Peter's faith is present but insufficient to sustain under pressure without fixing attention on Christ."
             }
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "14:13-21",
@@ -234,7 +234,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "14:19-21",
@@ -247,120 +247,71 @@
           ]
         },
         "hist": {
-          "context": "The feeding of the five thousand (vv.13\u201321) is the only miracle recorded in all four gospels. Its eucharistic resonance is unmistakable: took, blessed, broke, gave \u2014 the same four verbs as the Last Supper (26:26). Jesus begins the gesture that will be completed in the upper room. The walking on water (vv.22\u201333) follows immediately \u2014 both miracles occurring after John's death, as if the forerunner's death triggers a new level of self-disclosure. The disciples' \"Truly you are the Son of God\" (v.33) is the first corporate confession of his divine identity in Matthew."
+          "context": "The feeding of the five thousand (vv.13–21) is the only miracle recorded in all four gospels. Its eucharistic resonance is unmistakable: took, blessed, broke, gave — the same four verbs as the Last Supper (26:26). Jesus begins the gesture that will be completed in the upper room. The walking on water (vv.22–33) follows immediately — both miracles occurring after John's death, as if the forerunner's death triggers a new level of self-disclosure. The disciples' \"Truly you are the Son of God\" (v.33) is the first corporate confession of his divine identity in Matthew."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 22\u201336 \u2014 Walking on Water; Peter Sinks; Healings at Gennesaret",
+      "header": "Verses 22–36 — Walking on Water; Peter Sinks; Healings at Gennesaret",
       "verse_start": 22,
       "verse_end": 36,
       "panels": {
         "heb": [
           {
-            "word": "\u03b8\u03b1\u03c1\u03c3\u03ad\u03c9",
-            "transliteration": "tharse\u014d",
+            "word": "θαρσέω",
+            "transliteration": "tharseō",
             "gloss": "take courage / be of good cheer",
-            "paragraph": "'Take courage! It is I. Don't be afraid.' Tharse\u014d is a command to be brave in the face of the terrifying. Jesus' self-identification ('It is I' \u2014 eg\u014d eimi) may echo the divine name from Exodus 3:14. The one walking on water identifies himself with the God who controls the sea."
+            "paragraph": "'Take courage! It is I. Don't be afraid.' Tharseō is a command to be brave in the face of the terrifying. Jesus' self-identification ('It is I' — egō eimi) may echo the divine name from Exodus 3:14. The one walking on water identifies himself with the God who controls the sea."
           },
           {
-            "word": "\u03b4\u03b9\u03c3\u03c4\u03ac\u03b6\u03c9",
-            "transliteration": "distaz\u014d",
+            "word": "διστάζω",
+            "transliteration": "distazō",
             "gloss": "to doubt / waver / hesitate",
-            "paragraph": "Peter walks on water, then 'doubts' (distaz\u014d \u2014 to stand in two ways, to be in two minds). The word captures the moment of divided attention: eyes on Jesus, then eyes on waves. Faith and doubt coexist in the same person, in the same moment. Jesus rescues both."
+            "paragraph": "Peter walks on water, then 'doubts' (distazō — to stand in two ways, to be in two minds). The word captures the moment of divided attention: eyes on Jesus, then eyes on waves. Faith and doubt coexist in the same person, in the same moment. Jesus rescues both."
           }
         ],
         "poi": [
           {
             "name": "Herod's palace / court",
             "coords": "Tiberias or Machaerus; Herod Antipas's territory",
-            "text": "The beheading of John occurs at Herod Antipas's birthday banquet \u2014 either at his Galilean capital Tiberias or at the fortress Machaerus east of the Dead Sea (Josephus locates John's imprisonment at Machaerus). The geography of power executes the one who challenged it."
+            "text": "The beheading of John occurs at Herod Antipas's birthday banquet — either at his Galilean capital Tiberias or at the fortress Machaerus east of the Dead Sea (Josephus locates John's imprisonment at Machaerus). The geography of power executes the one who challenged it."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Mark 6:14\u201329",
+              "ref": "Mark 6:14–29",
               "note": "Mark's fuller account includes the name Salome for the daughter of Herodias (from Josephus). Matthew's abbreviated version focuses the irony: a king bound by his own rash oath."
             },
             {
-              "ref": "Matt 11:2\u201314",
-              "note": "John's death fulfils what Jesus implied \u2014 the forerunner suffers the Elijah's fate (17:12) before the Son of Man suffers his."
+              "ref": "Matt 11:2–14",
+              "note": "John's death fulfils what Jesus implied — the forerunner suffers the Elijah's fate (17:12) before the Son of Man suffers his."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:3\u20134",
-              "note": "John had been saying to him: \"It is not lawful for you to have her.\" John's imprisonment is the direct consequence of speaking truth to power. The pattern is the same as the prophets before him (Matt 5:12) and the disciples after him (10:17\u201322). Faithfulness to God's word generates opposition from those with something to lose."
-            },
-            {
-              "ref": "14:9",
-              "note": "The king was distressed. Herod didn't want to kill John \u2014 he was afraid of him (Mark 6:20: \"he protected John, knowing him to be a righteous and holy man\"). But political calculation overcame his conscience. He is the portrait of the person who knows the right thing and does the wrong one for social reasons."
-            },
-            {
-              "ref": "14:12",
-              "note": "They went and told Jesus. The disciples' report to Jesus is both an act of discipleship (bringing the loss to the teacher) and the narrative hinge: it triggers Jesus's withdrawal, which is interrupted by the crowds, which produces the feeding of the five thousand. John's death is the shadow over the whole chapter."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "14:1-5",
-              "note": "Calvin: Herod feared John yet imprisoned him -- conviction without conversion. He knew John was righteous but was not willing to pay the price of repentance. Conviction that stops short of action is worse than ignorance: it leaves the person responsible for the light they refused."
-            },
-            {
-              "ref": "14:9-11",
-              "note": "Calvin on Herod's oath: he swore rashly and kept his oath rashly. A rash oath made to commit wickedness should not be kept -- the sin of oath-breaking would have been far less than the sin of murder. But Herod, more afraid of losing face before his guests than of murdering the innocent, adds one sin to another."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "14:3-5",
-              "note": "The NET note on Herodias as Herod Philip's wife discusses the complex Herodian family relationships documented by Josephus. Antipas met Herodias while visiting his half-brother in Rome, divorced his own wife (daughter of the Nabataean king Aretas IV), and married Herodias -- which John condemned as unlawful under Lev 18:16."
-            },
-            {
-              "ref": "14:12-13",
-              "note": "The NET note on Jesus withdrawing to a solitary place when he heard of John's death discusses the theological significance. It is not panic but prayerful retreat -- the same pattern seen at Gethsemane. Jesus processes the forerunner's death in solitude before continuing his ministry."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "14:3-12",
-              "note": "Robertson notes Herod Antipas the tetrarch is distinguished from Herod the Great throughout Matthew. The imprisonment of John for rebuking the marriage is the political backstory explaining why Jesus withdraws when he hears the news (v.13). Robertson traces the political geography: Herod Antipas ruled Galilee and Perea, where John was baptising when arrested."
-            },
-            {
-              "ref": "14:10-12",
-              "note": "Robertson on apekephalisen (he beheaded him) -- aorist, a single decisive act. The disciples' burial of John's body and their reporting to Jesus connects the Baptist's death directly to Jesus's ministry: the forerunner's fate foreshadows the messianic fate."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "14:1-12",
-              "note": "The patristic commentators consistently read John's beheading as a martyrdom typology. Chrysostom notes John is the last OT prophet who died for speaking truth to power. His willingness to rebuke the king at personal cost is the prophetic model Jesus himself will follow."
-            },
-            {
-              "ref": "14:9-12",
-              "note": "The Catena notes Origen's reading of Herodias's daughter as a figure of pleasure that destroys wisdom. The dance at a birthday banquet -- a context of celebration and indulgence -- produces the death of the greatest prophet. Unchecked pleasure produces moral catastrophe."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The death of John is recounted as a flashback triggered by Herod's superstitious fear (v.2). Its placement here is structural: the forerunner who prepared the way has been killed; the one whose way he prepared is about to demonstrate who he is in the feeding of the five thousand. The pattern of prophet-rejection and murder is the context in which Matthew 14\u201328 operates. John's disciples report to Jesus \u2014 and Jesus withdraws, but then the crowds find him anyway."
+          "context": "The death of John is recounted as a flashback triggered by Herod's superstitious fear (v.2). Its placement here is structural: the forerunner who prepared the way has been killed; the one whose way he prepared is about to demonstrate who he is in the feeding of the five thousand. The pattern of prophet-rejection and murder is the context in which Matthew 14–28 operates. John's disciples report to Jesus — and Jesus withdraws, but then the crowds find him anyway."
         }
       }
     }
@@ -375,41 +326,41 @@
       {
         "name": "Peter",
         "role": "Walks on water; sinks",
-        "text": "Gets out of the boat \u2014 more faith than the eleven. His sinking is rescued, not condemned."
+        "text": "Gets out of the boat — more faith than the eleven. His sinking is rescued, not condemned."
       },
       {
         "name": "The five thousand",
         "role": "Fed in the wilderness",
-        "text": "The first eucharistic feeding \u2014 the wilderness community in anticipation of the covenant meal."
+        "text": "The first eucharistic feeding — the wilderness community in anticipation of the covenant meal."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Take courage! It is I. Don't be afraid.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Eg\u014d eimi \u2014 \"I am.\" Simultaneously identification and divine self-disclosure. The LORD who walks on the waves (Job 9:8; Ps 77:19) is present. The disciples' \"Son of God\" confession (v.33) is the appropriate response.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Take courage! It is I. Don't be afraid.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Egō eimi — \"I am.\" Simultaneously identification and divine self-disclosure. The LORD who walks on the waves (Job 9:8; Ps 77:19) is present. The disciples' \"Son of God\" confession (v.33) is the appropriate response.</td></tr>",
     "src": [
       {
         "title": "Josephus on John's death",
-        "quote": "Josephus (Ant. 18.5.2) records John's imprisonment and execution by Herod Antipas for political reasons \u2014 fear of John's influence. Matthew's account centres on the dance and oath; Josephus focuses on political threat. Both agree on the essential facts.",
+        "quote": "Josephus (Ant. 18.5.2) records John's imprisonment and execution by Herod Antipas for political reasons — fear of John's influence. Matthew's account centres on the dance and oath; Josephus focuses on political threat. Both agree on the essential facts.",
         "note": "The two accounts are complementary, not contradictory."
       },
       {
         "title": "The feeding and Eucharist",
-        "quote": "The four verbs \u2014 took, blessed/gave thanks, broke, gave \u2014 appear verbatim in 14:19, 15:36, and 26:26. Matthew's repetition is deliberate: the wilderness feedings are pre-enactments of the Last Supper.",
+        "quote": "The four verbs — took, blessed/gave thanks, broke, gave — appear verbatim in 14:19, 15:36, and 26:26. Matthew's repetition is deliberate: the wilderness feedings are pre-enactments of the Last Supper.",
         "note": "The parallel structure is the strongest argument for eucharistic intent."
       }
     ],
     "rec": [
       {
         "who": "The feeding in early Christianity",
-        "text": "The feeding miracle was one of the earliest depicted in Christian catacomb art \u2014 loaves and fish as symbols of the Eucharist and resurrection. The connection between feeding and resurrection was made from the beginning."
+        "text": "The feeding miracle was one of the earliest depicted in Christian catacomb art — loaves and fish as symbols of the Eucharist and resurrection. The connection between feeding and resurrection was made from the beginning."
       },
       {
         "who": "Peter's sinking",
-        "text": "Peter's walk-and-sink has been the pattern text for understanding discipleship as real but insufficient faith \u2014 Augustine, Luther, and contemporary preachers all use it to describe the disciple who acts on faith and needs rescue when fear takes over."
+        "text": "Peter's walk-and-sink has been the pattern text for understanding discipleship as real but insufficient faith — Augustine, Luther, and contemporary preachers all use it to describe the disciple who acts on faith and needs rescue when fear takes over."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "The Feeding: Compassion Before Theology \u2014 14:13-21",
+          "label": "The Feeding: Compassion Before Theology — 14:13-21",
           "text": "Jesus saw the crowd, had compassion, healed their sick, then fed them. The sequence -- compassion, healing, provision -- is Matthew's portrait of kingdom priorities.",
           "is_key": false
         },
@@ -577,7 +528,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Herod's guilt-haunted fear: 'John has risen from the dead!' (v. 2). A guilty conscience sees resurrection everywhere. The flashback to John's execution foreshadows Jesus' fate\u2014prophets die at rulers' hands.",
+      "tip": "Herod's guilt-haunted fear: 'John has risen from the dead!' (v. 2). A guilty conscience sees resurrection everywhere. The flashback to John's execution foreshadows Jesus' fate—prophets die at rulers' hands.",
       "genre_tag": "canonical_thread"
     },
     {

--- a/content/matthew/15.json
+++ b/content/matthew/15.json
@@ -10,55 +10,55 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201320 \u2014 What Defiles: Tradition vs Command of God",
+      "header": "Verses 1–20 — What Defiles: Tradition vs Command of God",
       "verse_start": 1,
       "verse_end": 20,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b1\u03c1\u03ac\u03b4\u03bf\u03c3\u03b9\u03c2",
+            "word": "παράδοσις",
             "transliteration": "paradosis",
             "gloss": "tradition / what is handed down",
-            "paragraph": "Jesus confronts the Pharisees over 'the tradition of the elders' (paradosis t\u014dn presbyter\u014dn). He distinguishes sharply between God's command (entol\u0113) and human tradition (paradosis). When tradition nullifies command, the tradition must yield. The principle protects Scripture's authority from institutional accumulation."
+            "paragraph": "Jesus confronts the Pharisees over 'the tradition of the elders' (paradosis tōn presbyterōn). He distinguishes sharply between God's command (entolē) and human tradition (paradosis). When tradition nullifies command, the tradition must yield. The principle protects Scripture's authority from institutional accumulation."
           },
           {
-            "word": "\u03ba\u03bf\u03b9\u03bd\u03cc\u03c9",
-            "transliteration": "koino\u014d",
+            "word": "κοινόω",
+            "transliteration": "koinoō",
             "gloss": "defile / make common / make unclean",
-            "paragraph": "'What goes into someone's mouth does not defile them, but what comes out.' Koino\u014d means to make ritually common or impure. Jesus relocates the source of impurity from external contamination (food) to internal corruption (evil thoughts). This is a revolution in purity theology."
+            "paragraph": "'What goes into someone's mouth does not defile them, but what comes out.' Koinoō means to make ritually common or impure. Jesus relocates the source of impurity from external contamination (food) to internal corruption (evil thoughts). This is a revolution in purity theology."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 29:13",
-              "note": "These people honour me with their lips, but their hearts are far from me \u2014 quoted in v.8. Isaiah's critique of empty worship becomes Jesus's diagnosis of tradition-based religion."
+              "note": "These people honour me with their lips, but their hearts are far from me — quoted in v.8. Isaiah's critique of empty worship becomes Jesus's diagnosis of tradition-based religion."
             },
             {
               "ref": "Exod 20:12; 21:17",
-              "note": "Honour your father and mother / anyone who curses parents must die \u2014 the fifth commandment that the Corban tradition nullified. Jesus defends Torah against its supposed guardians."
+              "note": "Honour your father and mother / anyone who curses parents must die — the fifth commandment that the Corban tradition nullified. Jesus defends Torah against its supposed guardians."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:6",
-              "note": "Thus you nullify the word of God for the sake of your tradition. The charge is precise and devastating: the tradition of the elders \u2014 meant to build a hedge around Torah \u2014 has become the instrument of its circumvention. Human religious tradition, however well-intentioned, can be deployed against the divine command it was meant to protect."
+              "note": "Thus you nullify the word of God for the sake of your tradition. The charge is precise and devastating: the tradition of the elders — meant to build a hedge around Torah — has become the instrument of its circumvention. Human religious tradition, however well-intentioned, can be deployed against the divine command it was meant to protect."
             },
             {
               "ref": "15:11",
-              "note": "What comes out of the mouth \u2014 that is what defiles. The most direct assault on the Levitical purity system in the Synoptics. Mark 7:19 adds the explanatory note \"thus he declared all foods clean.\" Matthew's version is implicit but equally clear: external ritual cannot substitute for internal moral transformation."
+              "note": "What comes out of the mouth — that is what defiles. The most direct assault on the Levitical purity system in the Synoptics. Mark 7:19 adds the explanatory note \"thus he declared all foods clean.\" Matthew's version is implicit but equally clear: external ritual cannot substitute for internal moral transformation."
             },
             {
               "ref": "15:19",
-              "note": "Out of the heart come evil thoughts \u2014 murder, adultery, sexual immorality, theft, false testimony, slander. The heart-list is a partial catalogue of Torah violations. The point: the commandments address outward acts because inner corruption produces outward destruction. Ritual cleanliness cannot address the source of the problem."
+              "note": "Out of the heart come evil thoughts — murder, adultery, sexual immorality, theft, false testimony, slander. The heart-list is a partial catalogue of Torah violations. The point: the commandments address outward acts because inner corruption produces outward destruction. Ritual cleanliness cannot address the source of the problem."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:3-6",
@@ -71,7 +71,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "15:1-9",
@@ -84,7 +84,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:1-9",
@@ -97,7 +97,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "15:3-9",
@@ -113,70 +113,70 @@
           {
             "name": "Region of Tyre and Sidon",
             "coords": "Phoenician coast; modern Lebanon",
-            "text": "Jesus withdraws to the region of Tyre and Sidon \u2014 the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
+            "text": "Jesus withdraws to the region of Tyre and Sidon — the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
           },
           {
             "name": "Sea of Galilee shore",
             "coords": "Back to Jewish territory",
-            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd \u2014 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
+            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd — 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
           }
         ],
         "hist": {
-          "context": "The tradition controversy (vv.1\u201320) is one of the most significant theological exchanges in Matthew. The Pharisees challenge Jesus over hand-washing; Jesus counter-challenges them over Corban \u2014 exposing a tradition that circumvents Torah. The principle that emerges (v.11) is one of the most radical statements in the Sermon-tradition: defilement is moral, not ritual; it comes from the heart, not the hands. This has enormous implications for the Gentile mission that follows immediately in vv.21\u201328."
+          "context": "The tradition controversy (vv.1–20) is one of the most significant theological exchanges in Matthew. The Pharisees challenge Jesus over hand-washing; Jesus counter-challenges them over Corban — exposing a tradition that circumvents Torah. The principle that emerges (v.11) is one of the most radical statements in the Sermon-tradition: defilement is moral, not ritual; it comes from the heart, not the hands. This has enormous implications for the Gentile mission that follows immediately in vv.21–28."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 21\u201328 \u2014 The Canaanite Woman\u2019s Faith",
+      "header": "Verses 21–28 — The Canaanite Woman’s Faith",
       "verse_start": 21,
       "verse_end": 28,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03c5\u03bd\u03ac\u03c1\u03b9\u03bf\u03bd",
+            "word": "κυνάριον",
             "transliteration": "kynarion",
             "gloss": "little dog / puppy",
-            "paragraph": "The Canaanite woman accepts Jesus' metaphor of 'dogs' (kynarion \u2014 the diminutive, 'puppies,' not wild dogs) and turns it back: even puppies eat crumbs from the master's table. Her wit and persistence do not offend Jesus but delight him. She argues her way into blessing."
+            "paragraph": "The Canaanite woman accepts Jesus' metaphor of 'dogs' (kynarion — the diminutive, 'puppies,' not wild dogs) and turns it back: even puppies eat crumbs from the master's table. Her wit and persistence do not offend Jesus but delight him. She argues her way into blessing."
           },
           {
-            "word": "\u03bc\u03b5\u03b3\u03ac\u03bb\u03b7 \u1f21 \u03c0\u03af\u03c3\u03c4\u03b9\u03c2 \u03c3\u03bf\u03c5",
-            "transliteration": "megal\u0113 h\u0113 pistis sou",
+            "word": "μεγάλη ἡ πίστις σου",
+            "transliteration": "megalē hē pistis sou",
             "gloss": "great is your faith",
-            "paragraph": "Only two people receive this commendation: the Roman centurion (8:10) and the Canaanite woman (15:28) \u2014 both Gentiles. The greatest faith in Matthew's Gospel comes from those outside the covenant community. The irony is deliberate and pointed."
+            "paragraph": "Only two people receive this commendation: the Roman centurion (8:10) and the Canaanite woman (15:28) — both Gentiles. The greatest faith in Matthew's Gospel comes from those outside the covenant community. The irony is deliberate and pointed."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Matt 8:10\u201311",
-              "note": "I have not found such great faith in Israel \u2014 the centurion. The Canaanite woman is the second Gentile to be credited with great faith. Both precede and anticipate 28:19's commission to all nations."
+              "ref": "Matt 8:10–11",
+              "note": "I have not found such great faith in Israel — the centurion. The Canaanite woman is the second Gentile to be credited with great faith. Both precede and anticipate 28:19's commission to all nations."
             },
             {
               "ref": "Ruth 2:12",
-              "note": "The Gentile woman who throws herself on the LORD's mercy and receives more than she asked for. Ruth \u2192 the Canaanite woman \u2192 the Gentile church."
+              "note": "The Gentile woman who throws herself on the LORD's mercy and receives more than she asked for. Ruth → the Canaanite woman → the Gentile church."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:22",
-              "note": "Lord, Son of David, have mercy on me. A Canaanite woman uses the Jewish messianic title \u2014 demonstrating that she understands more about who Jesus is than many Israelites. Her persistence (she keeps crying after them, v.23) is itself the faith that will be commended. She does not accept dismissal as God's final word."
+              "note": "Lord, Son of David, have mercy on me. A Canaanite woman uses the Jewish messianic title — demonstrating that she understands more about who Jesus is than many Israelites. Her persistence (she keeps crying after them, v.23) is itself the faith that will be commended. She does not accept dismissal as God's final word."
             },
             {
               "ref": "15:27",
-              "note": "Even the dogs eat the crumbs that fall from their master's table. The woman's response is theologically brilliant: she accepts the priority of Israel (\"children\") without conceding Gentile exclusion. She argues from within the metaphor: there are crumbs even at a children's table. This is not clever deflection but genuine faith \u2014 she is trusting in the overflow of God's mercy, not its exhaustion."
+              "note": "Even the dogs eat the crumbs that fall from their master's table. The woman's response is theologically brilliant: she accepts the priority of Israel (\"children\") without conceding Gentile exclusion. She argues from within the metaphor: there are crumbs even at a children's table. This is not clever deflection but genuine faith — she is trusting in the overflow of God's mercy, not its exhaustion."
             },
             {
               "ref": "15:28",
-              "note": "Great is your faith! The commendation contrasts with every previous faith-assessment in Matthew \u2014 little faith (disciples), no faith mentioned (scribes and Pharisees). The greatest faith commendation in the gospel goes to the most unexpected recipient. This is the gospel's thesis in miniature: the kingdom's treasure goes to those who recognise they are crumbs-worthy, not those who claim table-rights."
+              "note": "Great is your faith! The commendation contrasts with every previous faith-assessment in Matthew — little faith (disciples), no faith mentioned (scribes and Pharisees). The greatest faith commendation in the gospel goes to the most unexpected recipient. This is the gospel's thesis in miniature: the kingdom's treasure goes to those who recognise they are crumbs-worthy, not those who claim table-rights."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "15:29-31",
@@ -189,7 +189,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "15:26-28",
@@ -202,7 +202,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "15:29-31",
@@ -215,7 +215,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "15:32-38",
@@ -231,128 +231,79 @@
           {
             "name": "Region of Tyre and Sidon",
             "coords": "Phoenician coast; modern Lebanon",
-            "text": "Jesus withdraws to the region of Tyre and Sidon \u2014 the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
+            "text": "Jesus withdraws to the region of Tyre and Sidon — the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
           },
           {
             "name": "Sea of Galilee shore",
             "coords": "Back to Jewish territory",
-            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd \u2014 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
+            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd — 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
           }
         ],
         "hist": {
-          "context": "The Canaanite woman episode (vv.21\u201328) is the structural complement to the tradition controversy (vv.1\u201320). The debate established that defilement is moral, not ethnic; the healing demonstrates it. Jesus's silence, his apparent restriction to Israel (v.24), and his \"dogs\" response have been much discussed \u2014 the exchange reads as a test of the woman's theological persistence rather than a genuine refusal. Her crumb-argument shows she understands the covenant structure better than the Pharisees who opened the chapter."
+          "context": "The Canaanite woman episode (vv.21–28) is the structural complement to the tradition controversy (vv.1–20). The debate established that defilement is moral, not ethnic; the healing demonstrates it. Jesus's silence, his apparent restriction to Israel (v.24), and his \"dogs\" response have been much discussed — the exchange reads as a test of the woman's theological persistence rather than a genuine refusal. Her crumb-argument shows she understands the covenant structure better than the Pharisees who opened the chapter."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 29\u201339 \u2014 Great Crowds Healed; Feeding the Four Thousand",
+      "header": "Verses 29–39 — Great Crowds Healed; Feeding the Four Thousand",
       "verse_start": 29,
       "verse_end": 39,
       "panels": {
         "heb": [
           {
-            "word": "\u03b8\u03b5\u03c1\u03b1\u03c0\u03b5\u03cd\u03c9",
-            "transliteration": "therapeu\u014d",
+            "word": "θεραπεύω",
+            "transliteration": "therapeuō",
             "gloss": "heal / serve / care for",
-            "paragraph": "The original meaning of therapeu\u014d is 'to serve' or 'attend to' \u2014 healing is an extension of attentive care. The mass healings on the mountainside (v.30) recall Isaiah 35:5-6: the blind see, the lame walk, the mute speak. Jesus' healing ministry is Isaiah's prophecy in action."
+            "paragraph": "The original meaning of therapeuō is 'to serve' or 'attend to' — healing is an extension of attentive care. The mass healings on the mountainside (v.30) recall Isaiah 35:5-6: the blind see, the lame walk, the mute speak. Jesus' healing ministry is Isaiah's prophecy in action."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 29:13",
-              "note": "These people honour me with their lips, but their hearts are far from me \u2014 quoted in v.8. Isaiah's critique of empty worship becomes Jesus's diagnosis of tradition-based religion."
+              "note": "These people honour me with their lips, but their hearts are far from me — quoted in v.8. Isaiah's critique of empty worship becomes Jesus's diagnosis of tradition-based religion."
             },
             {
               "ref": "Exod 20:12; 21:17",
-              "note": "Honour your father and mother / anyone who curses parents must die \u2014 the fifth commandment that the Corban tradition nullified. Jesus defends Torah against its supposed guardians."
+              "note": "Honour your father and mother / anyone who curses parents must die — the fifth commandment that the Corban tradition nullified. Jesus defends Torah against its supposed guardians."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:6",
-              "note": "Thus you nullify the word of God for the sake of your tradition. The charge is precise and devastating: the tradition of the elders \u2014 meant to build a hedge around Torah \u2014 has become the instrument of its circumvention. Human religious tradition, however well-intentioned, can be deployed against the divine command it was meant to protect."
-            },
-            {
-              "ref": "15:11",
-              "note": "What comes out of the mouth \u2014 that is what defiles. The most direct assault on the Levitical purity system in the Synoptics. Mark 7:19 adds the explanatory note \"thus he declared all foods clean.\" Matthew's version is implicit but equally clear: external ritual cannot substitute for internal moral transformation."
-            },
-            {
-              "ref": "15:19",
-              "note": "Out of the heart come evil thoughts \u2014 murder, adultery, sexual immorality, theft, false testimony, slander. The heart-list is a partial catalogue of Torah violations. The point: the commandments address outward acts because inner corruption produces outward destruction. Ritual cleanliness cannot address the source of the problem."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "15:3-6",
-              "note": "Calvin on corban: the scribes invented a method by which children could legally abandon their parents under the pretence of religion. Under the mask of piety, natural duty was violated. This is the pattern of all human traditions that conflict with God's law: they release people from genuine obligations under the guise of religious ones."
-            },
-            {
-              "ref": "15:21-28",
-              "note": "Calvin on the Canaanite woman: three times repulsed and three times she persists. This teaches us that when God seems to repulse us, we must not immediately despair. The apparent repulsion is a test of faith, not a final rejection. The faith that will not be denied is the faith that receives what it seeks."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "15:1-9",
-              "note": "The NET note on the handwashing tradition discusses the distinction between biblical commandments and oral tradition. The Pharisaic handwashing practice was originally applicable only to priests -- the Pharisees had extended it to all Jews as a mark of covenantal identity."
-            },
-            {
-              "ref": "15:22-28",
-              "note": "The NET note on 'I was sent only to the lost sheep of Israel' discusses the apparent limitation of Jesus's mission in its historical context. The universal mission (28:19) is implicit throughout but strategically deployed: the Canaanite woman's healing signals the coming inclusion rather than contradicting the primary mission."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "15:1-9",
-              "note": "Robertson traces the handwashing controversy as a matter of oral tradition, not Mosaic law. The paradosis ton presbyteron (tradition of the elders) is the oral Torah the rabbis claimed had equal authority with written Torah. Jesus's counter-charge -- you nullify the word of God for the sake of your tradition -- cuts to the heart of the authority dispute."
-            },
-            {
-              "ref": "15:10-20",
-              "note": "Robertson notes the parabolic saying (v.11: not what enters the mouth defiles) is explicitly called a parable by Peter (v.15). On v.17: 'What a revolution this thought would carry!' Jesus is declaring all foods clean (cf. Mark 7:19), though Matthew omits Mark's editorial comment. The full implication unfolds gradually in early church history."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "15:3-9",
-              "note": "The Catena records Chrysostom's treatment of the corban problem: a son could declare his property 'corban' (dedicated to God) and thereby exempt himself from supporting his parents while retaining use of the property. Chrysostom notes the tradition found a religious loophole to void a divine commandment -- piety deployed to avoid responsibility."
-            },
-            {
-              "ref": "15:21-28",
-              "note": "The Catena traces the Fathers' rich engagement with the Canaanite woman. Chrysostom sees her as a model of persistent faith: three times she is discouraged (silence, dismissal, the dogs saying) and three times she presses forward, each time more boldly. Persistence is not presumption but the faith that will not accept a final no from a merciful God."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "poi": [
           {
             "name": "Region of Tyre and Sidon",
             "coords": "Phoenician coast; modern Lebanon",
-            "text": "Jesus withdraws to the region of Tyre and Sidon \u2014 the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
+            "text": "Jesus withdraws to the region of Tyre and Sidon — the first explicit movement into Gentile territory in Matthew. The Canaanite woman (a Gentile by Matthew's designation) finds him there. The faith that Israel's cities failed to show is found in Phoenician-territory Gentile geography."
           },
           {
             "name": "Sea of Galilee shore",
             "coords": "Back to Jewish territory",
-            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd \u2014 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
+            "text": "After the Gentile withdrawal, Jesus returns to the Sea of Galilee and feeds another crowd — 4,000 this time. The two feeding miracles (5,000 in Jewish geography; 4,000 here) bracket the Gentile incursion, suggesting the feedings represent both covenantal communities."
           }
         ],
         "hist": {
-          "context": "The tradition controversy (vv.1\u201320) is one of the most significant theological exchanges in Matthew. The Pharisees challenge Jesus over hand-washing; Jesus counter-challenges them over Corban \u2014 exposing a tradition that circumvents Torah. The principle that emerges (v.11) is one of the most radical statements in the Sermon-tradition: defilement is moral, not ritual; it comes from the heart, not the hands. This has enormous implications for the Gentile mission that follows immediately in vv.21\u201328."
+          "context": "The tradition controversy (vv.1–20) is one of the most significant theological exchanges in Matthew. The Pharisees challenge Jesus over hand-washing; Jesus counter-challenges them over Corban — exposing a tradition that circumvents Torah. The principle that emerges (v.11) is one of the most radical statements in the Sermon-tradition: defilement is moral, not ritual; it comes from the heart, not the hands. This has enormous implications for the Gentile mission that follows immediately in vv.21–28."
         }
       }
     }
@@ -362,7 +313,7 @@
       {
         "name": "The Pharisees and scribes",
         "role": "From Jerusalem; challenge hand-washing",
-        "text": "Nullify Torah with their tradition \u2014 the irony exposed."
+        "text": "Nullify Torah with their tradition — the irony exposed."
       },
       {
         "name": "The Canaanite woman",
@@ -370,27 +321,27 @@
         "text": "Excluded by every category; included by her crumb-theology. Faith that argues from God's overflow rather than its exhaustion."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Yes it is, Lord. Even the dogs eat the crumbs that fall from their master's table.\"</td></tr><tr><td class=\"t-label\">Note</td><td>The most theologically precise faith-statement in Matthew. She does not deny the priority of Israel; she argues from within the metaphor: even secondary recipients receive something from the master's table. This is the gospel's logic \u2014 salvation overflows from Israel to the nations.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"Yes it is, Lord. Even the dogs eat the crumbs that fall from their master's table.\"</td></tr><tr><td class=\"t-label\">Note</td><td>The most theologically precise faith-statement in Matthew. She does not deny the priority of Israel; she argues from within the metaphor: even secondary recipients receive something from the master's table. This is the gospel's logic — salvation overflows from Israel to the nations.</td></tr>",
     "src": [
       {
         "title": "Oral Torah and hand-washing",
-        "quote": "The Pharisaic tradition of hand-washing before meals was part of extending priestly purity rules to everyday life \u2014 an admirable impulse. Jesus's objection is not to the practice but to its elevation above explicit Torah commands.",
+        "quote": "The Pharisaic tradition of hand-washing before meals was part of extending priestly purity rules to everyday life — an admirable impulse. Jesus's objection is not to the practice but to its elevation above explicit Torah commands.",
         "note": "The conflict is between tradition and Torah, not between piety and impiety."
       },
       {
         "title": "Tyre and Sidon",
-        "quote": "Gentile cities on the Phoenician coast, northwest of Galilee. The Canaanite woman's location outside Israel's territory makes her use of \"Son of David\" all the more remarkable \u2014 she is claiming a covenant title from outside the covenant community.",
+        "quote": "Gentile cities on the Phoenician coast, northwest of Galilee. The Canaanite woman's location outside Israel's territory makes her use of \"Son of David\" all the more remarkable — she is claiming a covenant title from outside the covenant community.",
         "note": "The geography signals Gentile inclusion before the commission makes it explicit."
       }
     ],
     "rec": [
       {
         "who": "The Canaanite woman in feminist theology",
-        "text": "The episode has been central to discussions of how Jesus treats women and Gentiles \u2014 simultaneously the most difficult and most affirming passage for both. The woman's theological argument is presented without condescension; her faith is the chapter's highest point."
+        "text": "The episode has been central to discussions of how Jesus treats women and Gentiles — simultaneously the most difficult and most affirming passage for both. The woman's theological argument is presented without condescension; her faith is the chapter's highest point."
       },
       {
         "who": "The defilement teaching and Mark 7",
-        "text": "Matthew 15:1\u201320 is the parallel of Mark 7:1\u201323. Mark adds the explicit conclusion \"thus he declared all foods clean\" (Mark 7:19b). Matthew's version is implicit, consistent with his Jewish audience for whom the implication would be understood."
+        "text": "Matthew 15:1–20 is the parallel of Mark 7:1–23. Mark adds the explicit conclusion \"thus he declared all foods clean\" (Mark 7:19b). Matthew's version is implicit, consistent with his Jewish audience for whom the implication would be understood."
       }
     ],
     "lit": {
@@ -406,7 +357,7 @@
           "is_key": false
         },
         {
-          "label": "The Canaanite Woman: Faith That Will Not Be Denied \u2014 15:21-28",
+          "label": "The Canaanite Woman: Faith That Will Not Be Denied — 15:21-28",
           "text": "Three apparent repulsions produce three increasingly bold responses. The crumbs argument turns the limitation into a theological claim. Persistent faith is the faith that receives.",
           "is_key": false
         }
@@ -574,7 +525,7 @@
     },
     {
       "after_section": 2,
-      "tip": "The Canaanite woman accepts the 'dog' label and turns it: 'Even the dogs eat the crumbs' (v. 27). Her faith doesn't demand inclusion\u2014it humbly accepts overflow. Jesus calls it 'great faith.'",
+      "tip": "The Canaanite woman accepts the 'dog' label and turns it: 'Even the dogs eat the crumbs' (v. 27). Her faith doesn't demand inclusion—it humbly accepts overflow. Jesus calls it 'great faith.'",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/matthew/16.json
+++ b/content/matthew/16.json
@@ -7,22 +7,22 @@
   "subtitle": "Sign of Jonah; Yeast of Pharisees; Peter's Confession; Keys of the Kingdom; Passion Predicted",
   "timeline_link": {
     "event_id": "peter-confession",
-    "text": "See on Timeline \u2014 Peter Confession"
+    "text": "See on Timeline — Peter Confession"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201312 \u2014 Sign of Jonah; Yeast of the Pharisees",
+      "header": "Verses 1–12 — Sign of Jonah; Yeast of the Pharisees",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b5\u03b9\u03c1\u03ac\u03b6\u03c9",
-            "transliteration": "peiraz\u014d",
+            "word": "πειράζω",
+            "transliteration": "peirazō",
             "gloss": "test / tempt",
-            "paragraph": "The Pharisees and Sadducees test Jesus by demanding a sign from heaven. The same verb used in the wilderness temptation (4:1). What Satan did in the desert, the religious leaders do in public. The demand for proof on their terms is itself the test \u2014 and Jesus refuses it."
+            "paragraph": "The Pharisees and Sadducees test Jesus by demanding a sign from heaven. The same verb used in the wilderness temptation (4:1). What Satan did in the desert, the religious leaders do in public. The demand for proof on their terms is itself the test — and Jesus refuses it."
           }
         ],
         "poi": [
@@ -35,30 +35,30 @@
         "cross": {
           "refs": [
             {
-              "ref": "Matt 12:38\u201339",
-              "note": "The sign of Jonah \u2014 first occurrence. The second repetition here signals the finality of the refusal: no other sign will be given."
+              "ref": "Matt 12:38–39",
+              "note": "The sign of Jonah — first occurrence. The second repetition here signals the finality of the refusal: no other sign will be given."
             },
             {
               "ref": "Matt 13:33",
-              "note": "Yeast that works through the whole batch \u2014 used positively of the kingdom. Here used negatively of corrupting teaching. The same mechanism, two applications: kingdom growth and doctrinal corruption both work invisibly and pervasively."
+              "note": "Yeast that works through the whole batch — used positively of the kingdom. Here used negatively of corrupting teaching. The same mechanism, two applications: kingdom growth and doctrinal corruption both work invisibly and pervasively."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:6",
-              "note": "Be on your guard against the yeast of the Pharisees and Sadducees. The disciples misunderstand and think about literal bread \u2014 the same misunderstanding Peter will show in v.22 (taking Jesus's passion prediction literally and wrongly). Matthew uses these literalism moments to show how much the disciples still have to learn before the resurrection re-educates them."
+              "note": "Be on your guard against the yeast of the Pharisees and Sadducees. The disciples misunderstand and think about literal bread — the same misunderstanding Peter will show in v.22 (taking Jesus's passion prediction literally and wrongly). Matthew uses these literalism moments to show how much the disciples still have to learn before the resurrection re-educates them."
             },
             {
-              "ref": "16:9\u201310",
-              "note": "Do you not remember? The two feedings are not merely compassion stories \u2014 they are object lessons in the sufficiency of Jesus's provision. The disciples have witnessed the feeding of 9,000 people from 12 loaves and are worried about not having brought bread. The failure to connect the miracles to present trust is the diagnosis of \"little faith.\""
+              "ref": "16:9–10",
+              "note": "Do you not remember? The two feedings are not merely compassion stories — they are object lessons in the sufficiency of Jesus's provision. The disciples have witnessed the feeding of 9,000 people from 12 loaves and are worried about not having brought bread. The failure to connect the miracles to present trust is the diagnosis of \"little faith.\""
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:1-4",
@@ -71,7 +71,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:4",
@@ -84,7 +84,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "16:1-4",
@@ -97,7 +97,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "16:1-4",
@@ -124,7 +124,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Peter's confession at Caesarea Philippi \u2014 this passage",
+            "name": "Peter's confession at Caesarea Philippi — this passage",
             "text": "\"From that time on Jesus began to explain to his disciples that he must go to Jerusalem and suffer.\" This is Matthew's first \"from that time on\" pivot. The Galilean teaching ministry ends here; the passion journey begins.",
             "current": true
           },
@@ -148,68 +148,68 @@
           }
         ],
         "hist": {
-          "context": "The sign demand (vv.1\u20134) from the combined Pharisees and Sadducees \u2014 an unusual alliance \u2014 repeats the 12:38 request and receives the same answer: the sign of Jonah. The yeast warning (vv.5\u201312) applies the metaphor from 13:33 negatively: as a small amount of yeast works through the whole dough, the teaching of the religious establishment corrupts everything it touches. The disciples' literalism (thinking about bread) reveals how little they have absorbed from the two wilderness feedings."
+          "context": "The sign demand (vv.1–4) from the combined Pharisees and Sadducees — an unusual alliance — repeats the 12:38 request and receives the same answer: the sign of Jonah. The yeast warning (vv.5–12) applies the metaphor from 13:33 negatively: as a small amount of yeast works through the whole dough, the teaching of the religious establishment corrupts everything it touches. The disciples' literalism (thinking about bread) reveals how little they have absorbed from the two wilderness feedings."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201320 \u2014 Peter\u2019s Confession: You Are the Christ",
+      "header": "Verses 13–20 — Peter’s Confession: You Are the Christ",
       "verse_start": 13,
       "verse_end": 20,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03ad\u03c4\u03c1\u03bf\u03c2... \u03c0\u03ad\u03c4\u03c1\u03b1",
+            "word": "πέτρος... πέτρα",
             "transliteration": "petros... petra",
             "gloss": "Peter (stone)... rock (bedrock)",
             "paragraph": "'You are Petros (stone), and on this petra (bedrock) I will build my church.' The wordplay is central: Petros is a movable stone; petra is immovable bedrock. Whether 'this rock' refers to Peter, his confession, or Christ himself has generated centuries of interpretation. The ambiguity may be intentional."
           },
           {
-            "word": "\u1f10\u03ba\u03ba\u03bb\u03b7\u03c3\u03af\u03b1",
-            "transliteration": "ekkl\u0113sia",
+            "word": "ἐκκλησία",
+            "transliteration": "ekklēsia",
             "gloss": "church / assembly / gathering",
-            "paragraph": "Matthew's Gospel is the only one to use ekkl\u0113sia (here and 18:17). The word means 'called-out assembly' \u2014 the same term the LXX uses for Israel's covenant congregation. Jesus is not founding a new religion but reconstituting the people of God around himself."
+            "paragraph": "Matthew's Gospel is the only one to use ekklēsia (here and 18:17). The word means 'called-out assembly' — the same term the LXX uses for Israel's covenant congregation. Jesus is not founding a new religion but reconstituting the people of God around himself."
           }
         ],
         "poi": [
           {
             "name": "Caesarea Philippi",
             "coords": "Northern Israel; foot of Mount Hermon",
-            "text": "Peter's confession occurs at Caesarea Philippi \u2014 the most remote location in Matthew's Galilean ministry, 40km north of the Sea of Galilee at the foot of Mount Hermon. The city was built by Philip, son of Herod, beside the spring cave dedicated to Pan (a pagan site). Peter identifies Jesus as Messiah in a city named after Caesar, near a pagan shrine \u2014 the geography of bold confession."
+            "text": "Peter's confession occurs at Caesarea Philippi — the most remote location in Matthew's Galilean ministry, 40km north of the Sea of Galilee at the foot of Mount Hermon. The city was built by Philip, son of Herod, beside the spring cave dedicated to Pan (a pagan site). Peter identifies Jesus as Messiah in a city named after Caesar, near a pagan shrine — the geography of bold confession."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 22:22",
-              "note": "The key of the house of David \u2014 the authority to open and shut given to Eliakim. Jesus gives the keys of the kingdom to Peter/the church, drawing on the same image of steward-authority."
+              "note": "The key of the house of David — the authority to open and shut given to Eliakim. Jesus gives the keys of the kingdom to Peter/the church, drawing on the same image of steward-authority."
             },
             {
-              "ref": "Dan 2:34\u201335; 7:13\u201314",
+              "ref": "Dan 2:34–35; 7:13–14",
               "note": "The rock that crushed the kingdoms (Dan 2) and the Son of Man receiving the kingdom (Dan 7). The church built on the rock-confession, given the kingdom's keys, is the fulfilment of both Danielic visions."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:16",
-              "note": "You are the Messiah, the Son of the living God. The fullest confession in Matthew to this point. Peter adds \"the living God\" \u2014 the God who is active, present, and sovereign, contrasting with the dead idols. The confession is revelatory in origin (v.17: revealed by my Father) \u2014 a divine act producing a human declaration."
+              "note": "You are the Messiah, the Son of the living God. The fullest confession in Matthew to this point. Peter adds \"the living God\" — the God who is active, present, and sovereign, contrasting with the dead idols. The confession is revelatory in origin (v.17: revealed by my Father) — a divine act producing a human declaration."
             },
             {
               "ref": "16:21",
-              "note": "From that time on Jesus began to explain that he must go to Jerusalem and suffer. The gospel's second great pivot (the first is 4:17). The dei \u2014 \"must\" \u2014 is the constraint of divine necessity. Not fate but purpose: the cross is not a defeat to be avoided but the goal toward which everything has been moving. Peter's immediate resistance (v.22) shows how foreign this is to messianic expectation."
+              "note": "From that time on Jesus began to explain that he must go to Jerusalem and suffer. The gospel's second great pivot (the first is 4:17). The dei — \"must\" — is the constraint of divine necessity. Not fate but purpose: the cross is not a defeat to be avoided but the goal toward which everything has been moving. Peter's immediate resistance (v.22) shows how foreign this is to messianic expectation."
             },
             {
               "ref": "16:23",
-              "note": "Get behind me, Satan! The sharpest rebuke in Matthew, directed at Peter who had just received the highest commendation. The distance between \"blessed are you, Simon\" (v.17) and \"get behind me, Satan\" (v.23) is five verses. The man who received divine revelation immediately becomes the instrument of satanic temptation \u2014 offering Jesus the cross-less route the desert temptation offered (4:8\u201310). The pattern repeats."
+              "note": "Get behind me, Satan! The sharpest rebuke in Matthew, directed at Peter who had just received the highest commendation. The distance between \"blessed are you, Simon\" (v.17) and \"get behind me, Satan\" (v.23) is five verses. The man who received divine revelation immediately becomes the instrument of satanic temptation — offering Jesus the cross-less route the desert temptation offered (4:8–10). The pattern repeats."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "16:13-20",
@@ -222,7 +222,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "16:18-19",
@@ -235,7 +235,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "16:13-20",
@@ -248,7 +248,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "16:13-20",
@@ -275,7 +275,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Peter's confession at Caesarea Philippi \u2014 this passage",
+            "name": "Peter's confession at Caesarea Philippi — this passage",
             "text": "\"From that time on Jesus began to explain to his disciples that he must go to Jerusalem and suffer.\" This is Matthew's first \"from that time on\" pivot. The Galilean teaching ministry ends here; the passion journey begins.",
             "current": true
           },
@@ -299,28 +299,28 @@
           }
         ],
         "hist": {
-          "context": "Matthew 16:13\u201328 is the structural pivot of the gospel \u2014 the second of Matthew's two great turning points (4:17 \u2014 \"from that time on Jesus began to preach\"; 16:21 \u2014 \"from that time on Jesus began to explain that he must go to Jerusalem\"). Peter's confession produces the first explicit disclosure of the Passion (v.21) and the immediate Satanic resistance (vv.22\u201323) which demonstrates how precisely the path to the cross must be walked. The section closes with the cross-carrying call repeated from 10:38."
+          "context": "Matthew 16:13–28 is the structural pivot of the gospel — the second of Matthew's two great turning points (4:17 — \"from that time on Jesus began to preach\"; 16:21 — \"from that time on Jesus began to explain that he must go to Jerusalem\"). Peter's confession produces the first explicit disclosure of the Passion (v.21) and the immediate Satanic resistance (vv.22–23) which demonstrates how precisely the path to the cross must be walked. The section closes with the cross-carrying call repeated from 10:38."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 21\u201328 \u2014 First Passion Prediction; Take Up Your Cross",
+      "header": "Verses 21–28 — First Passion Prediction; Take Up Your Cross",
       "verse_start": 21,
       "verse_end": 28,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c4\u03b1\u03c5\u03c1\u03cc\u03c2",
+            "word": "σταυρός",
             "transliteration": "stauros",
             "gloss": "cross",
-            "paragraph": "'Take up your cross and follow me' \u2014 before the crucifixion, this metaphor was already terrifying. Crucifixion was Rome's most public, humiliating, agonising execution. To take up a cross is to accept social death, not merely inconvenience. Discipleship is not self-improvement; it is self-execution."
+            "paragraph": "'Take up your cross and follow me' — before the crucifixion, this metaphor was already terrifying. Crucifixion was Rome's most public, humiliating, agonising execution. To take up a cross is to accept social death, not merely inconvenience. Discipleship is not self-improvement; it is self-execution."
           },
           {
-            "word": "\u03c8\u03c5\u03c7\u03ae",
-            "transliteration": "psych\u0113",
+            "word": "ψυχή",
+            "transliteration": "psychē",
             "gloss": "soul / life / self",
-            "paragraph": "'Whoever loses their psych\u0113 for my sake will find it.' Psych\u0113 means the whole self \u2014 the life one lives, the identity one constructs. Jesus says the self preserved at any cost is the self lost; the self surrendered for his sake is the self found. The economics of the kingdom invert."
+            "paragraph": "'Whoever loses their psychē for my sake will find it.' Psychē means the whole self — the life one lives, the identity one constructs. Jesus says the self preserved at any cost is the self lost; the self surrendered for his sake is the self found. The economics of the kingdom invert."
           }
         ],
         "poi": [
@@ -333,79 +333,34 @@
         "cross": {
           "refs": [
             {
-              "ref": "Matt 12:38\u201339",
-              "note": "The sign of Jonah \u2014 first occurrence. The second repetition here signals the finality of the refusal: no other sign will be given."
+              "ref": "Matt 12:38–39",
+              "note": "The sign of Jonah — first occurrence. The second repetition here signals the finality of the refusal: no other sign will be given."
             },
             {
               "ref": "Matt 13:33",
-              "note": "Yeast that works through the whole batch \u2014 used positively of the kingdom. Here used negatively of corrupting teaching. The same mechanism, two applications: kingdom growth and doctrinal corruption both work invisibly and pervasively."
+              "note": "Yeast that works through the whole batch — used positively of the kingdom. Here used negatively of corrupting teaching. The same mechanism, two applications: kingdom growth and doctrinal corruption both work invisibly and pervasively."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:6",
-              "note": "Be on your guard against the yeast of the Pharisees and Sadducees. The disciples misunderstand and think about literal bread \u2014 the same misunderstanding Peter will show in v.22 (taking Jesus's passion prediction literally and wrongly). Matthew uses these literalism moments to show how much the disciples still have to learn before the resurrection re-educates them."
-            },
-            {
-              "ref": "16:9\u201310",
-              "note": "Do you not remember? The two feedings are not merely compassion stories \u2014 they are object lessons in the sufficiency of Jesus's provision. The disciples have witnessed the feeding of 9,000 people from 12 loaves and are worried about not having brought bread. The failure to connect the miracles to present trust is the diagnosis of \"little faith.\""
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "16:1-4",
-              "note": "Calvin on the sign demand: they ask for a sign not because they are genuinely seeking but to use his refusal as evidence of inadequacy. Christ refuses to be manipulated by those who have already decided against him. The sign of Jonah will be given, but those who harden their hearts against it will not benefit from it."
-            },
-            {
-              "ref": "16:11-12",
-              "note": "Calvin on the yeast teaching: Christ does not mean their teaching is wholly corrupt but that it is mixed with errors that spread like yeast through the whole lump. A small error in the foundation corrupts the entire building. The Pharisees had made the human addition so large it had consumed the original divine commandment."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "16:4",
-              "note": "The NET note on 'an evil and adulterous generation' traces the OT background: Israel's unfaithfulness to YHWH is consistently described as spiritual adultery (Jer 3:8; Ezek 16:15-58; Hos 1-3). The sign demand is itself evidence of the adulterous generation: those genuinely seeking God do not demand signs on their own terms."
-            },
-            {
-              "ref": "16:11-12",
-              "note": "The NET note on 'the yeast of the Pharisees and Sadducees' explains the disciples' failure to understand as a recurring Matthean theme: they understand more than outsiders but less than the full revelation requires. Comprehension is gradual and requires the Spirit's illumination."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "16:1-4",
-              "note": "Robertson on 'the sign of Jonah': the Pharisees and Sadducees (unusual alliance) demand a semeion from heaven. Jesus's refusal and counter-reference to Jonah points to his death and resurrection as the only sign that will be given. The genitive semeion Iona (sign of Jonah) is the same phrase as 12:39-40 -- the repetition emphasises the single authenticating event that is coming."
-            },
-            {
-              "ref": "16:5-12",
-              "note": "Robertson on 'the yeast of the Pharisees and Sadducees': the disciples think Jesus is rebuking them for forgetting bread. Robertson traces the progression from literal (bread) to metaphorical (teaching/influence). The yeast metaphor for corrupting influence appears in 1 Cor 5:6-7 -- Robertson notes Paul may be drawing on this dominical saying."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "16:1-4",
-              "note": "The Catena records Chrysostom's treatment of the sign demand: the Pharisees and Sadducees who oppose each other on every theological question are united in opposition to Jesus. Their coalition is the sign that Jesus represents a threat transcending sectarian divisions. The only sign offered is death and resurrection -- which they will refuse to see even when given it."
-            },
-            {
-              "ref": "16:6-12",
-              "note": "The Catena traces the patristic consensus that the yeast of the Pharisees is specifically their hypocritical teaching -- outwardly pious, inwardly corrupt. Chrysostom notes that yeast works invisibly and pervasively: the most dangerous false teaching appears orthodox on the surface. The disciples' misunderstanding of the bread reference is a failure of spiritual perception."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "tl": [
           {
@@ -422,7 +377,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Peter's confession at Caesarea Philippi \u2014 this passage",
+            "name": "Peter's confession at Caesarea Philippi — this passage",
             "text": "\"From that time on Jesus began to explain to his disciples that he must go to Jerusalem and suffer.\" This is Matthew's first \"from that time on\" pivot. The Galilean teaching ministry ends here; the passion journey begins.",
             "current": true
           },
@@ -446,7 +401,7 @@
           }
         ],
         "hist": {
-          "context": "The sign demand (vv.1\u20134) from the combined Pharisees and Sadducees \u2014 an unusual alliance \u2014 repeats the 12:38 request and receives the same answer: the sign of Jonah. The yeast warning (vv.5\u201312) applies the metaphor from 13:33 negatively: as a small amount of yeast works through the whole dough, the teaching of the religious establishment corrupts everything it touches. The disciples' literalism (thinking about bread) reveals how little they have absorbed from the two wilderness feedings."
+          "context": "The sign demand (vv.1–4) from the combined Pharisees and Sadducees — an unusual alliance — repeats the 12:38 request and receives the same answer: the sign of Jonah. The yeast warning (vv.5–12) applies the metaphor from 13:33 negatively: as a small amount of yeast works through the whole dough, the teaching of the religious establishment corrupts everything it touches. The disciples' literalism (thinking about bread) reveals how little they have absorbed from the two wilderness feedings."
         }
       }
     }
@@ -455,7 +410,7 @@
     "ppl": [
       {
         "name": "Peter",
-        "role": "Confessor and stumbling block \u2014 five verses apart",
+        "role": "Confessor and stumbling block — five verses apart",
         "text": "Receives divine revelation (v.17) and immediately becomes the vehicle of Satanic temptation (v.23). The portrait of the disciple in full."
       },
       {
@@ -464,7 +419,7 @@
         "text": "The unusual alliance signals the final consolidation of opposition."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"You are the Messiah, the Son of the living God.\"</td></tr><tr><td class=\"t-label\">Note</td><td>The fullest human confession in Matthew \u2014 Messiah (royal) and Son of the living God (divine). Revealed by the Father, not reasoned by Peter. The confession produces the first explicit passion prediction five verses later.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"You are the Messiah, the Son of the living God.\"</td></tr><tr><td class=\"t-label\">Note</td><td>The fullest human confession in Matthew — Messiah (royal) and Son of the living God (divine). Revealed by the Father, not reasoned by Peter. The confession produces the first explicit passion prediction five verses later.</td></tr>",
     "src": [
       {
         "title": "Caesarea Philippi",
@@ -484,7 +439,7 @@
       },
       {
         "who": "16:21 as structural pivot",
-        "text": "Virtually all Matthew scholars identify 16:21 (\"from that time on\") as the gospel's second structural hinge \u2014 the transition from the Galilean ministry to the passion journey. The formula exactly mirrors 4:17."
+        "text": "Virtually all Matthew scholars identify 16:21 (\"from that time on\") as the gospel's second structural hinge — the transition from the Galilean ministry to the passion journey. The formula exactly mirrors 4:17."
       }
     ],
     "lit": {
@@ -500,7 +455,7 @@
           "is_key": false
         },
         {
-          "label": "Get Behind Me: The Passion Cannot Be Avoided \u2014 16:21-23",
+          "label": "Get Behind Me: The Passion Cannot Be Avoided — 16:21-23",
           "text": "Peter who confessed the Messiah now opposes the Messiah's path. The cross is not a failure of the messianic plan but its very centre.",
           "is_key": false
         }
@@ -668,7 +623,7 @@
   "coaching": [
     {
       "after_section": 2,
-      "tip": "'You are the Christ, the Son of the living God' (v. 16). Peter's confession is revelation, not deduction: 'Flesh and blood did not reveal this.' Upon this rock\u2014Peter's confession\u2014Jesus builds his church.",
+      "tip": "'You are the Christ, the Son of the living God' (v. 16). Peter's confession is revelation, not deduction: 'Flesh and blood did not reveal this.' Upon this rock—Peter's confession—Jesus builds his church.",
       "genre_tag": "theological_insight"
     },
     {

--- a/content/matthew/17.json
+++ b/content/matthew/17.json
@@ -7,28 +7,28 @@
   "subtitle": "The Transfiguration; Elijah Has Come; Failed Exorcism; Second Passion Prediction; Temple Tax",
   "timeline_link": {
     "event_id": "transfiguration",
-    "text": "See on Timeline \u2014 Transfiguration"
+    "text": "See on Timeline — Transfiguration"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201313 \u2014 The Transfiguration; Elijah Has Already Come",
+      "header": "Verses 1–13 — The Transfiguration; Elijah Has Already Come",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
         "heb": [
           {
-            "word": "\u03bc\u03b5\u03c4\u03b1\u03bc\u03bf\u03c1\u03c6\u03cc\u03c9",
-            "transliteration": "metamorpho\u014d",
+            "word": "μεταμορφόω",
+            "transliteration": "metamorphoō",
             "gloss": "transfigure / transform",
-            "paragraph": "Jesus was 'transfigured' \u2014 metamorpho\u014d means a change of form revealing inner reality. The transfiguration does not add glory to Jesus; it temporarily reveals the glory always present but normally hidden. For one moment, the disciples see what is always true."
+            "paragraph": "Jesus was 'transfigured' — metamorphoō means a change of form revealing inner reality. The transfiguration does not add glory to Jesus; it temporarily reveals the glory always present but normally hidden. For one moment, the disciples see what is always true."
           },
           {
-            "word": "\u03c3\u03ba\u03b7\u03bd\u03ae",
-            "transliteration": "sk\u0113n\u0113",
+            "word": "σκηνή",
+            "transliteration": "skēnē",
             "gloss": "tent / tabernacle / booth",
-            "paragraph": "Peter offers to build three 'tents' (sk\u0113nai), echoing the Feast of Tabernacles and perhaps the wilderness tabernacle. He wants to institutionalise the moment. The Father interrupts: 'Listen to him.' The point is not staying on the mountain but hearing the Son and following him down."
+            "paragraph": "Peter offers to build three 'tents' (skēnai), echoing the Feast of Tabernacles and perhaps the wilderness tabernacle. He wants to institutionalise the moment. The Father interrupts: 'Listen to him.' The point is not staying on the mountain but hearing the Son and following him down."
           }
         ],
         "tl": [
@@ -40,7 +40,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Six days later \u2014 Transfiguration \u2014 this passage",
+            "name": "Six days later — Transfiguration — this passage",
             "text": "\"After six days Jesus took Peter, James and John with him.\" Six days after the confession at Caesarea Philippi. The same three disciples who will witness the agony of Gethsemane are first shown the glory of the Transfiguration. The sequence is deliberate: glory before suffering.",
             "current": true
           },
@@ -79,21 +79,21 @@
         "cross": {
           "refs": [
             {
-              "ref": "Exod 24:15\u201316; 34:29\u201330",
-              "note": "The cloud of divine presence on Sinai; Moses's face shining. The transfiguration echoes both: the glory-cloud of God's presence; the shining face of the one who stands in God's presence. Jesus is the new Moses \u2014 and more."
+              "ref": "Exod 24:15–16; 34:29–30",
+              "note": "The cloud of divine presence on Sinai; Moses's face shining. The transfiguration echoes both: the glory-cloud of God's presence; the shining face of the one who stands in God's presence. Jesus is the new Moses — and more."
             },
             {
-              "ref": "Mal 4:5\u20136",
-              "note": "I will send you the prophet Elijah before the great and dreadful day of the LORD. Jesus identifies John as this Elijah \u2014 and immediately applies the pattern to himself: they did to him what they wished, and so with the Son of Man."
+              "ref": "Mal 4:5–6",
+              "note": "I will send you the prophet Elijah before the great and dreadful day of the LORD. Jesus identifies John as this Elijah — and immediately applies the pattern to himself: they did to him what they wished, and so with the Son of Man."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:2",
-              "note": "His face shone like the sun. The superlative brightness in the NT: brighter than Sinai, brighter than any comparison the disciples had seen. This is the glory of the pre-existent Son becoming visible \u2014 the Shekinah-glory that the temple was meant to house, now resident in a person. The disciples fall on their faces (v.6) in the appropriate theophanic response."
+              "note": "His face shone like the sun. The superlative brightness in the NT: brighter than Sinai, brighter than any comparison the disciples had seen. This is the glory of the pre-existent Son becoming visible — the Shekinah-glory that the temple was meant to house, now resident in a person. The disciples fall on their faces (v.6) in the appropriate theophanic response."
             },
             {
               "ref": "17:5",
@@ -101,12 +101,12 @@
             },
             {
               "ref": "17:12",
-              "note": "Elijah has already come, and they did not recognise him. The pattern of rejection is now traceable: John (Elijah) \u2192 killed; the Son of Man \u2192 to suffer in the same way. The transfiguration's glory and the passion's suffering are not contradictions but the two dimensions of the same identity."
+              "note": "Elijah has already come, and they did not recognise him. The pattern of rejection is now traceable: John (Elijah) → killed; the Son of Man → to suffer in the same way. The transfiguration's glory and the passion's suffering are not contradictions but the two dimensions of the same identity."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:1-5",
@@ -119,7 +119,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:2-5",
@@ -132,7 +132,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "17:1-8",
@@ -145,7 +145,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:1-8",
@@ -158,22 +158,22 @@
           ]
         },
         "hist": {
-          "context": "The transfiguration (vv.1\u20139) is the visual confirmation of Peter's confession (16:16) and the counterweight to the passion announcement (16:21): the one who must suffer is the one whose face shines like the sun. Moses and Elijah represent Torah and the Prophets \u2014 the whole of the OT \u2014 in conversation with Jesus, whose presence supersedes them (v.8: \"they saw no one except Jesus\"). The cloud and voice repeat the baptism's theophany with the crucial addition: \"Listen to him.\" The question about Elijah (vv.10\u201313) then confirms that the Elijah of Malachi 4 was John the Baptist \u2014 and that John's fate was the pattern for the Son of Man's."
+          "context": "The transfiguration (vv.1–9) is the visual confirmation of Peter's confession (16:16) and the counterweight to the passion announcement (16:21): the one who must suffer is the one whose face shines like the sun. Moses and Elijah represent Torah and the Prophets — the whole of the OT — in conversation with Jesus, whose presence supersedes them (v.8: \"they saw no one except Jesus\"). The cloud and voice repeat the baptism's theophany with the crucial addition: \"Listen to him.\" The question about Elijah (vv.10–13) then confirms that the Elijah of Malachi 4 was John the Baptist — and that John's fate was the pattern for the Son of Man's."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201323 \u2014 The Epileptic Boy; Second Passion Prediction",
+      "header": "Verses 14–23 — The Epileptic Boy; Second Passion Prediction",
       "verse_start": 14,
       "verse_end": 23,
       "panels": {
         "heb": [
           {
-            "word": "\u1f40\u03bb\u03b9\u03b3\u03bf\u03c0\u03b9\u03c3\u03c4\u03af\u03b1",
+            "word": "ὀλιγοπιστία",
             "transliteration": "oligopistia",
             "gloss": "littleness of faith",
-            "paragraph": "The disciples could not cast out the demon because of their 'little faith' (oligopistia). Faith the size of a mustard seed can move mountains \u2014 the issue is not quantity but quality. Even tiny faith in a great God accomplishes what great effort without faith cannot."
+            "paragraph": "The disciples could not cast out the demon because of their 'little faith' (oligopistia). Faith the size of a mustard seed can move mountains — the issue is not quantity but quality. Even tiny faith in a great God accomplishes what great effort without faith cannot."
           }
         ],
         "tl": [
@@ -185,7 +185,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Six days later \u2014 Transfiguration \u2014 this passage",
+            "name": "Six days later — Transfiguration — this passage",
             "text": "\"After six days Jesus took Peter, James and John with him.\" Six days after the confession at Caesarea Philippi. The same three disciples who will witness the agony of Gethsemane are first shown the glory of the Transfiguration. The sequence is deliberate: glory before suffering.",
             "current": true
           },
@@ -224,25 +224,25 @@
         "cross": {
           "refs": [
             {
-              "ref": "Exod 30:13\u201316",
-              "note": "The two-drachma temple tax \u2014 half a shekel per adult male Israelite, collected annually for the upkeep of the sanctuary. Jesus's exemption claim is based on the Son's relationship to the Father: he would not be taxed for his own Father's house."
+              "ref": "Exod 30:13–16",
+              "note": "The two-drachma temple tax — half a shekel per adult male Israelite, collected annually for the upkeep of the sanctuary. Jesus's exemption claim is based on the Son's relationship to the Father: he would not be taxed for his own Father's house."
             },
             {
               "ref": "Matt 13:31",
-              "note": "Mustard seed faith \u2014 the parable used positively (kingdom growth) and now diagnostically (faith sufficient for the impossible). The same image carries both the promise and the rebuke."
+              "note": "Mustard seed faith — the parable used positively (kingdom growth) and now diagnostically (faith sufficient for the impossible). The same image carries both the promise and the rebuke."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:17",
-              "note": "You unbelieving and perverse generation. The rebuke is addressed to the crowd and the disciples \u2014 but then privately the disciples ask Jesus to diagnose them specifically (v.19). Jesus does: little faith. The sharpness of v.17 is the sharpness of the teacher who knows what is possible and sees what is being missed."
+              "note": "You unbelieving and perverse generation. The rebuke is addressed to the crowd and the disciples — but then privately the disciples ask Jesus to diagnose them specifically (v.19). Jesus does: little faith. The sharpness of v.17 is the sharpness of the teacher who knows what is possible and sees what is being missed."
             },
             {
               "ref": "17:20",
-              "note": "Mustard seed faith. The smallest possible measure of genuine faith is sufficient for the impossible. The disciples' failure was not that their faith was small but that it was insufficient \u2014 perhaps performative, perhaps dependent on method rather than trust. Even a tiny amount of genuine, living faith is enough. The mountain-moving promise is not hyperbole but the description of what genuine trust in the living God produces."
+              "note": "Mustard seed faith. The smallest possible measure of genuine faith is sufficient for the impossible. The disciples' failure was not that their faith was small but that it was insufficient — perhaps performative, perhaps dependent on method rather than trust. Even a tiny amount of genuine, living faith is enough. The mountain-moving promise is not hyperbole but the description of what genuine trust in the living God produces."
             },
             {
               "ref": "17:27",
@@ -251,7 +251,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "17:17-21",
@@ -264,7 +264,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "17:20",
@@ -277,7 +277,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "17:14-21",
@@ -290,7 +290,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "17:14-21",
@@ -303,22 +303,22 @@
           ]
         },
         "hist": {
-          "context": "The descent from the transfiguration into the failed exorcism (vv.14\u201320) is a deliberate contrast. The disciples who were not on the mountain have failed; faith the size of a mustard seed would have been enough, but their faith was insufficient. The second passion prediction (vv.22\u201323) follows \u2014 the disciples grieve, but do not yet understand. The temple tax episode (vv.24\u201327) closes the chapter on a surprising note: Jesus the Son, exempt from the Father's house-tax, pays it anyway to avoid causing offense. Sovereignty and servanthood coexist."
+          "context": "The descent from the transfiguration into the failed exorcism (vv.14–20) is a deliberate contrast. The disciples who were not on the mountain have failed; faith the size of a mustard seed would have been enough, but their faith was insufficient. The second passion prediction (vv.22–23) follows — the disciples grieve, but do not yet understand. The temple tax episode (vv.24–27) closes the chapter on a surprising note: Jesus the Son, exempt from the Father's house-tax, pays it anyway to avoid causing offense. Sovereignty and servanthood coexist."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 24\u201327 \u2014 The Temple Tax: A Fish with a Coin",
+      "header": "Verses 24–27 — The Temple Tax: A Fish with a Coin",
       "verse_start": 24,
       "verse_end": 27,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03af\u03b4\u03c1\u03b1\u03c7\u03bc\u03bf\u03bd",
+            "word": "δίδραχμον",
             "transliteration": "didrachmon",
             "gloss": "two-drachma coin / temple tax",
-            "paragraph": "The temple tax of two drachmas (half-shekel) funded temple operations. Jesus pays it to avoid 'offence' (skandaliz\u014d) but first establishes that as the King's son, he is exempt. He voluntarily submits to an obligation he could legitimately refuse \u2014 a pattern repeated at the cross."
+            "paragraph": "The temple tax of two drachmas (half-shekel) funded temple operations. Jesus pays it to avoid 'offence' (skandalizō) but first establishes that as the King's son, he is exempt. He voluntarily submits to an obligation he could legitimately refuse — a pattern repeated at the cross."
           }
         ],
         "tl": [
@@ -330,7 +330,7 @@
           },
           {
             "date": "c. AD 28",
-            "name": "Six days later \u2014 Transfiguration \u2014 this passage",
+            "name": "Six days later — Transfiguration — this passage",
             "text": "\"After six days Jesus took Peter, James and John with him.\" Six days after the confession at Caesarea Philippi. The same three disciples who will witness the agony of Gethsemane are first shown the glory of the Transfiguration. The sequence is deliberate: glory before suffering.",
             "current": true
           },
@@ -369,86 +369,37 @@
         "cross": {
           "refs": [
             {
-              "ref": "Exod 24:15\u201316; 34:29\u201330",
-              "note": "The cloud of divine presence on Sinai; Moses's face shining. The transfiguration echoes both: the glory-cloud of God's presence; the shining face of the one who stands in God's presence. Jesus is the new Moses \u2014 and more."
+              "ref": "Exod 24:15–16; 34:29–30",
+              "note": "The cloud of divine presence on Sinai; Moses's face shining. The transfiguration echoes both: the glory-cloud of God's presence; the shining face of the one who stands in God's presence. Jesus is the new Moses — and more."
             },
             {
-              "ref": "Mal 4:5\u20136",
-              "note": "I will send you the prophet Elijah before the great and dreadful day of the LORD. Jesus identifies John as this Elijah \u2014 and immediately applies the pattern to himself: they did to him what they wished, and so with the Son of Man."
+              "ref": "Mal 4:5–6",
+              "note": "I will send you the prophet Elijah before the great and dreadful day of the LORD. Jesus identifies John as this Elijah — and immediately applies the pattern to himself: they did to him what they wished, and so with the Son of Man."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:2",
-              "note": "His face shone like the sun. The superlative brightness in the NT: brighter than Sinai, brighter than any comparison the disciples had seen. This is the glory of the pre-existent Son becoming visible \u2014 the Shekinah-glory that the temple was meant to house, now resident in a person. The disciples fall on their faces (v.6) in the appropriate theophanic response."
-            },
-            {
-              "ref": "17:5",
-              "note": "Listen to him. The three-word command added to the baptismal declaration. In the immediate context of ch.16's passion announcement and Peter's resistance, \"listen to him\" means: hear what he said about the cross and believe it, even though it violates your expectations. The voice from the cloud is answering Peter's \"this shall never happen to you\" with divine authority."
-            },
-            {
-              "ref": "17:12",
-              "note": "Elijah has already come, and they did not recognise him. The pattern of rejection is now traceable: John (Elijah) \u2192 killed; the Son of Man \u2192 to suffer in the same way. The transfiguration's glory and the passion's suffering are not contradictions but the two dimensions of the same identity."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "17:1-5",
-              "note": "Calvin on the Transfiguration: 'Christ was transfigured not to display his glory permanently during the earthly ministry but to give his disciples a momentary glimpse so that they might endure the scandal of the cross. The glory was real but brief -- a down-payment, not the final possession. Faith must hold the glimpsed glory through the long darkness that follows.'"
-            },
-            {
-              "ref": "17:9-13",
-              "note": "Calvin on John as Elijah: 'John was not literally Elijah, but he came in the spirit and power of Elijah (Luke 1:17). This fulfils the prophecy without requiring a literal reincarnation. The fulfilment is real and substantial; the literalism that demands the exact person misunderstands the nature of prophetic typology.'"
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "17:2-5",
-              "note": "The NET note on the cloud (nephele) in v.5 traces the Shekinah cloud of divine presence through the OT: the cloud at Sinai (Exod 24:15-18), the cloud in the wilderness tabernacle (Exod 40:34-38), the cloud filling Solomon's temple (1 Kgs 8:10-11). The cloud at the Transfiguration places Jesus within the canonical sequence of divine-presence manifestations."
-            },
-            {
-              "ref": "17:10-13",
-              "note": "The NET note on the Elijah-who-must-come-first (Mal 4:5) discusses the two-Elijah pattern in Jewish expectation: a literal return of Elijah versus an Elijah-like figure. Jesus resolves the ambiguity by identifying John the Baptist as the Elijah who has already come -- and been rejected. The note traces the implications for understanding the Messiah's rejection that follows."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "17:1-8",
-              "note": "Robertson on metamorphothe (he was transfigured, v.2): the same word as Rom 12:2 and 2 Cor 3:18 for spiritual transformation. The physical shining of Jesus's face and clothes is an uncloaking of the divine glory that the Incarnation veiled. Robertson notes that Moses and Elijah represent the Law and the Prophets bearing witness to Jesus -- the very authorities the Pharisees claim to follow."
-            },
-            {
-              "ref": "17:9-13",
-              "note": "Robertson traces the Elijah identification (v.13: 'then the disciples understood that he was speaking to them about John the Baptist'). The disciples finally grasp what Jesus has been implying: Malachi's Elijah who must come first (Mal 4:5) is John the Baptist, whose ministry of preparation has been completed -- and rejected -- before Jesus's own ministry."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "17:1-8",
-              "note": "The Catena records the patristic reading of the Transfiguration as the preview of the resurrection glory. Chrysostom: 'Before the cross, Christ shows the resurrection, so that the disciples may know that the suffering is not defeat but the path to the glory.' The three witnesses (Peter, James, John) are the same three who will witness the agony in Gethsemane -- glory and suffering have the same witnesses."
-            },
-            {
-              "ref": "17:9-13",
-              "note": "The Catena notes Origen's reading of the 'until the Son of Man is raised from the dead' instruction (v.9): the Transfiguration vision is sealed until the resurrection interprets it. The resurrection is the hermeneutical key to the Transfiguration. The disciples' confusion (v.10: but why do the teachers of the law say Elijah must come first?) shows they still cannot connect the suffering to the glory."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The transfiguration (vv.1\u20139) is the visual confirmation of Peter's confession (16:16) and the counterweight to the passion announcement (16:21): the one who must suffer is the one whose face shines like the sun. Moses and Elijah represent Torah and the Prophets \u2014 the whole of the OT \u2014 in conversation with Jesus, whose presence supersedes them (v.8: \"they saw no one except Jesus\"). The cloud and voice repeat the baptism's theophany with the crucial addition: \"Listen to him.\" The question about Elijah (vv.10\u201313) then confirms that the Elijah of Malachi 4 was John the Baptist \u2014 and that John's fate was the pattern for the Son of Man's."
+          "context": "The transfiguration (vv.1–9) is the visual confirmation of Peter's confession (16:16) and the counterweight to the passion announcement (16:21): the one who must suffer is the one whose face shines like the sun. Moses and Elijah represent Torah and the Prophets — the whole of the OT — in conversation with Jesus, whose presence supersedes them (v.8: \"they saw no one except Jesus\"). The cloud and voice repeat the baptism's theophany with the crucial addition: \"Listen to him.\" The question about Elijah (vv.10–13) then confirms that the Elijah of Malachi 4 was John the Baptist — and that John's fate was the pattern for the Son of Man's."
         }
       }
     }
@@ -458,7 +409,7 @@
       {
         "name": "Moses and Elijah",
         "role": "Torah and Prophets",
-        "text": "Appear with Jesus \u2014 the whole OT testifies to him. Then only Jesus remains."
+        "text": "Appear with Jesus — the whole OT testifies to him. Then only Jesus remains."
       },
       {
         "name": "Peter",
@@ -470,7 +421,7 @@
     "src": [
       {
         "title": "Mount Hermon",
-        "quote": "The most probable transfiguration site \u2014 a 2,800m peak north of Caesarea Philippi. The six days connect to Exod 24:16 (the cloud covered Sinai for six days before God spoke on the seventh).",
+        "quote": "The most probable transfiguration site — a 2,800m peak north of Caesarea Philippi. The six days connect to Exod 24:16 (the cloud covered Sinai for six days before God spoke on the seventh).",
         "note": "The Sinai typology is reinforced by the timing."
       },
       {
@@ -482,11 +433,11 @@
     "rec": [
       {
         "who": "The Transfiguration in Eastern Orthodoxy",
-        "text": "The Transfiguration (August 6) is one of the twelve Great Feasts of the Eastern Orthodox calendar \u2014 the visible disclosure of Christ's divine nature, the goal of theosis (participation in God's nature)."
+        "text": "The Transfiguration (August 6) is one of the twelve Great Feasts of the Eastern Orthodox calendar — the visible disclosure of Christ's divine nature, the goal of theosis (participation in God's nature)."
       },
       {
         "who": "Mustard seed faith in preaching",
-        "text": "17:20 has been the text for countless sermons on the sufficiency of small, genuine faith. The danger of over-literalism is real \u2014 the point is not quantity but quality and genuineness of trust."
+        "text": "17:20 has been the text for countless sermons on the sufficiency of small, genuine faith. The danger of over-literalism is real — the point is not quantity but quality and genuineness of trust."
       }
     ],
     "lit": {
@@ -502,7 +453,7 @@
           "is_key": false
         },
         {
-          "label": "Failed Exorcism: Faith vs Confidence \u2014 17:14-21",
+          "label": "Failed Exorcism: Faith vs Confidence — 17:14-21",
           "text": "The disciples fail not because they lack authority but because they lack the undivided, dependent faith that exercises authority properly. The mustard seed is about quality, not quantity.",
           "is_key": false
         }
@@ -525,7 +476,7 @@
           "summary": "The verse 'But this kind does not go out except by prayer and fasting' is absent from the earliest and best manuscripts of Matthew. It appears to have been imported from Mark 9:29, where it has better attestation.",
           "evidence": [
             {
-              "manuscript": "Codex Sinaiticus (\u2135, 4th c.)",
+              "manuscript": "Codex Sinaiticus (ℵ, 4th c.)",
               "reading": "Omits verse 21 entirely"
             },
             {
@@ -533,7 +484,7 @@
               "reading": "Omits verse 21"
             },
             {
-              "manuscript": "Theta (\u0398, 9th c.)",
+              "manuscript": "Theta (Θ, 9th c.)",
               "reading": "Omits verse 21"
             },
             {
@@ -554,7 +505,7 @@
             }
           ],
           "consensus": "The verse is almost certainly not original to Matthew. Scribes harmonized Matthew with Mark 9:29, adding the explanation for why the disciples failed to cast out the demon. Modern translations either omit it or relegate it to a footnote.",
-          "significance": "This variant illustrates scribal tendency toward harmonization \u2014 making parallel Gospel accounts match. The KJV's verse 21 led generations to believe Matthew included teaching on fasting that was actually imported from Mark."
+          "significance": "This variant illustrates scribal tendency toward harmonization — making parallel Gospel accounts match. The KJV's verse 21 led generations to believe Matthew included teaching on fasting that was actually imported from Mark."
         }
       ]
     },
@@ -706,12 +657,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Moses and Elijah appear\u2014Law and Prophets converging on Jesus. Peter wants three tents; the Father interrupts: 'Listen to him!' (v. 5). Jesus alone remains. The Old Testament points; Jesus fulfills.",
+      "tip": "Moses and Elijah appear—Law and Prophets converging on Jesus. Peter wants three tents; the Father interrupts: 'Listen to him!' (v. 5). Jesus alone remains. The Old Testament points; Jesus fulfills.",
       "genre_tag": "canonical_thread"
     },
     {
       "after_section": 2,
-      "tip": "'If you have faith as small as a mustard seed' (v. 20). The disciples couldn't cast out the demon; Jesus says faith\u2014even tiny faith\u2014moves mountains. The issue isn't quantity but genuine dependence.",
+      "tip": "'If you have faith as small as a mustard seed' (v. 20). The disciples couldn't cast out the demon; Jesus says faith—even tiny faith—moves mountains. The issue isn't quantity but genuine dependence.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/matthew/18.json
+++ b/content/matthew/18.json
@@ -7,48 +7,48 @@
   "subtitle": "Greatness in the Kingdom; The Child; The Lost Sheep; Discipline; Forgiveness; The Unforgiving Servant",
   "timeline_link": {
     "event_id": "sermon-mount",
-    "text": "See on Timeline \u2014 Sermon on the Mount"
+    "text": "See on Timeline — Sermon on the Mount"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20139 \u2014 The Greatest in the Kingdom; Causes of Stumbling",
+      "header": "Verses 1–9 — The Greatest in the Kingdom; Causes of Stumbling",
       "verse_start": 1,
       "verse_end": 9,
       "panels": {
         "heb": [
           {
-            "word": "\u03c4\u03b1\u03c0\u03b5\u03b9\u03bd\u03cc\u03c9",
-            "transliteration": "tapeino\u014d",
+            "word": "ταπεινόω",
+            "transliteration": "tapeinoō",
             "gloss": "humble / make low",
-            "paragraph": "'Whoever humbles himself like this child is the greatest in the kingdom.' Tapeino\u014d means to make oneself low \u2014 not self-abasement but the abandonment of status competition. Children in the ancient world had no social rank. Greatness in the kingdom is measured by willingness to be unranked."
+            "paragraph": "'Whoever humbles himself like this child is the greatest in the kingdom.' Tapeinoō means to make oneself low — not self-abasement but the abandonment of status competition. Children in the ancient world had no social rank. Greatness in the kingdom is measured by willingness to be unranked."
           },
           {
-            "word": "\u03c3\u03ba\u03b1\u03bd\u03b4\u03b1\u03bb\u03af\u03b6\u03c9",
-            "transliteration": "skandaliz\u014d",
+            "word": "σκανδαλίζω",
+            "transliteration": "skandalizō",
             "gloss": "cause to stumble / lead astray",
-            "paragraph": "'Woe to the one through whom stumbling blocks come.' The warning is severe \u2014 better a millstone and the sea. Skandaliz\u014d means triggering another's fall from faith. The responsibility for spiritual influence is treated as a matter of life and death."
+            "paragraph": "'Woe to the one through whom stumbling blocks come.' The warning is severe — better a millstone and the sea. Skandalizō means triggering another's fall from faith. The responsibility for spiritual influence is treated as a matter of life and death."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ezek 34:16",
-              "note": "I will search for the lost, bring back the strays \u2014 the divine shepherd's programme. Jesus's lost-sheep parable draws on Ezekiel's portrait of God's priority for the wandering one."
+              "note": "I will search for the lost, bring back the strays — the divine shepherd's programme. Jesus's lost-sheep parable draws on Ezekiel's portrait of God's priority for the wandering one."
             },
             {
-              "ref": "Matt 5:29\u201330",
-              "note": "Cut off hand and eye \u2014 the same hyperbolic language from the Sermon on the Mount. The Sermon's internal command (deal radically with your own temptation) is now applied to causing others to stumble."
+              "ref": "Matt 5:29–30",
+              "note": "Cut off hand and eye — the same hyperbolic language from the Sermon on the Mount. The Sermon's internal command (deal radically with your own temptation) is now applied to causing others to stumble."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:3",
-              "note": "Unless you change and become like little children, you will never enter the kingdom. The greatness question is answered by a child \u2014 the most status-less person in ancient society. Entering the kingdom requires not achievement but a fundamental reorientation: away from status-seeking toward receptivity. The disciples' question (\"who is greatest?\") is itself the diagnostic of the problem."
+              "note": "Unless you change and become like little children, you will never enter the kingdom. The greatness question is answered by a child — the most status-less person in ancient society. Entering the kingdom requires not achievement but a fundamental reorientation: away from status-seeking toward receptivity. The disciples' question (\"who is greatest?\") is itself the diagnostic of the problem."
             },
             {
               "ref": "18:6",
@@ -56,12 +56,12 @@
             },
             {
               "ref": "18:14",
-              "note": "Your Father in heaven is not willing that any of these little ones should perish. The Father's will applied to the lost sheep \u2014 the theological basis for the community's pursuit of the wandering member. If the Father is unwilling that any should perish, then leaving the ninety-nine to seek the one is not obsessive but consistent with the Father's character."
+              "note": "Your Father in heaven is not willing that any of these little ones should perish. The Father's will applied to the lost sheep — the theological basis for the community's pursuit of the wandering member. If the Father is unwilling that any should perish, then leaving the ninety-nine to seek the one is not obsessive but consistent with the Father's character."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:1-5",
@@ -74,7 +74,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:3-4",
@@ -87,7 +87,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "18:1-14",
@@ -100,7 +100,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:1-9",
@@ -113,35 +113,35 @@
           ]
         },
         "hist": {
-          "context": "The fourth great discourse (chs.18) addresses community life \u2014 triggered by the disciples' status-competition (v.1). The child placed in the middle (v.2) inverts the question: greatness is not achieved but received; the kingdom goes to the childlike, not the powerful. The three units \u2014 child/stumbling blocks (vv.1\u20139), the lost sheep (vv.10\u201314), and church discipline/forgiveness (vv.15\u201335) \u2014 are united by the concern for \"little ones\": protecting them, recovering them, and forgiving them."
+          "context": "The fourth great discourse (chs.18) addresses community life — triggered by the disciples' status-competition (v.1). The child placed in the middle (v.2) inverts the question: greatness is not achieved but received; the kingdom goes to the childlike, not the powerful. The three units — child/stumbling blocks (vv.1–9), the lost sheep (vv.10–14), and church discipline/forgiveness (vv.15–35) — are united by the concern for \"little ones\": protecting them, recovering them, and forgiving them."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 10\u201320 \u2014 The Lost Sheep; Binding and Loosing; Two or Three Gathered",
+      "header": "Verses 10–20 — The Lost Sheep; Binding and Loosing; Two or Three Gathered",
       "verse_start": 10,
       "verse_end": 20,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03ad\u03c9... \u03bb\u03cd\u03c9",
-            "transliteration": "de\u014d... ly\u014d",
+            "word": "δέω... λύω",
+            "transliteration": "deō... lyō",
             "gloss": "bind... loose",
-            "paragraph": "'Whatever you bind on earth will be bound in heaven.' Binding and loosing are rabbinic terms for forbidding and permitting \u2014 making halakhic decisions. Jesus grants the community (not just Peter, as in 16:19) authority to make disciplinary and interpretive decisions with heavenly backing."
+            "paragraph": "'Whatever you bind on earth will be bound in heaven.' Binding and loosing are rabbinic terms for forbidding and permitting — making halakhic decisions. Jesus grants the community (not just Peter, as in 16:19) authority to make disciplinary and interpretive decisions with heavenly backing."
           },
           {
-            "word": "\u03c3\u03c5\u03bc\u03c6\u03c9\u03bd\u03ad\u03c9",
-            "transliteration": "symph\u014dne\u014d",
+            "word": "συμφωνέω",
+            "transliteration": "symphōneō",
             "gloss": "agree / harmonize",
-            "paragraph": "'If two of you agree (symph\u014dne\u014d) on earth about anything' \u2014 the word means to sound together, like instruments in harmony. Agreement in prayer is not mere verbal consensus but genuine spiritual alignment. The promise is for united prayer, not individual wish lists."
+            "paragraph": "'If two of you agree (symphōneō) on earth about anything' — the word means to sound together, like instruments in harmony. Agreement in prayer is not mere verbal consensus but genuine spiritual alignment. The promise is for united prayer, not individual wish lists."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Deut 19:15",
-              "note": "Every matter shall be established by two or three witnesses \u2014 quoted in v.16. Jesus applies the OT legal standard to church discipline: the community's judgment is built on proper testimony."
+              "note": "Every matter shall be established by two or three witnesses — quoted in v.16. Jesus applies the OT legal standard to church discipline: the community's judgment is built on proper testimony."
             },
             {
               "ref": "Gen 4:24",
@@ -150,15 +150,15 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:20",
-              "note": "Where two or three gather in my name, there am I with them. The smallest quorum for the presence of Christ \u2014 not the temple's thousands, not a synagogue's required ten, but two or three. The new community's gathering criterion is Christ's name, not numbers. The promise is the Immanuel-promise of 1:23 applied to the gathered community."
+              "note": "Where two or three gather in my name, there am I with them. The smallest quorum for the presence of Christ — not the temple's thousands, not a synagogue's required ten, but two or three. The new community's gathering criterion is Christ's name, not numbers. The promise is the Immanuel-promise of 1:23 applied to the gathered community."
             },
             {
               "ref": "18:27",
-              "note": "The master took pity on him, cancelled the debt and let him go. The act of forgiveness in the parable is entirely gracious \u2014 the servant asked for time to pay (an impossible request given the debt's size); the king gave complete cancellation. The gap between what was requested and what was given is the parable's heart: kingdom-forgiveness is not the reduction of debt but its elimination."
+              "note": "The master took pity on him, cancelled the debt and let him go. The act of forgiveness in the parable is entirely gracious — the servant asked for time to pay (an impossible request given the debt's size); the king gave complete cancellation. The gap between what was requested and what was given is the parable's heart: kingdom-forgiveness is not the reduction of debt but its elimination."
             },
             {
               "ref": "18:35",
@@ -167,7 +167,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "18:15-20",
@@ -180,7 +180,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "18:15-20",
@@ -193,7 +193,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "18:15-20",
@@ -201,12 +201,12 @@
             },
             {
               "ref": "18:21-35",
-              "note": "Robertson on the parable of the unforgiving servant: the 10,000 talents (muri\u014dn talant\u014dn, v.24) is a deliberately absurd sum -- Robertson notes 10,000 talents would be 60 million denarii, equivalent to 200,000 years of a day-labourer's wages. The contrast with the 100 denarii (three months' wages) is the parable's rhetorical engine: the forgiven debtor who refuses to forgive a trivial debt is the definition of ingratitude."
+              "note": "Robertson on the parable of the unforgiving servant: the 10,000 talents (muriōn talantōn, v.24) is a deliberately absurd sum -- Robertson notes 10,000 talents would be 60 million denarii, equivalent to 200,000 years of a day-labourer's wages. The contrast with the 100 denarii (three months' wages) is the parable's rhetorical engine: the forgiven debtor who refuses to forgive a trivial debt is the definition of ingratitude."
             }
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "18:15-20",
@@ -219,113 +219,64 @@
           ]
         },
         "hist": {
-          "context": "The church discipline section (vv.15\u201320) and the unforgiving servant parable (vv.21\u201335) form the second half of the community discourse. The discipline process moves from private to semi-private to ecclesial \u2014 always with the goal of \"winning\" the brother, not punishing them. The binding/loosing authority (v.18 = 16:19) is given to the community, not just to Peter. The unforgiving servant parable is the sharpest statement of the connection between received forgiveness and extended forgiveness in Matthew: those who have been forgiven an infinite debt and refuse to forgive a finite one face the restoration of the original judgment."
+          "context": "The church discipline section (vv.15–20) and the unforgiving servant parable (vv.21–35) form the second half of the community discourse. The discipline process moves from private to semi-private to ecclesial — always with the goal of \"winning\" the brother, not punishing them. The binding/loosing authority (v.18 = 16:19) is given to the community, not just to Peter. The unforgiving servant parable is the sharpest statement of the connection between received forgiveness and extended forgiveness in Matthew: those who have been forgiven an infinite debt and refuse to forgive a finite one face the restoration of the original judgment."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 21\u201335 \u2014 Forgiving Seventy-Seven Times; The Unforgiving Servant",
+      "header": "Verses 21–35 — Forgiving Seventy-Seven Times; The Unforgiving Servant",
       "verse_start": 21,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03c6\u03af\u03b7\u03bc\u03b9",
-            "transliteration": "aphi\u0113mi",
+            "word": "ἀφίημι",
+            "transliteration": "aphiēmi",
             "gloss": "forgive / release",
-            "paragraph": "Peter asks about forgiving seven times; Jesus says seventy-seven (or seventy times seven). The number is not a limit but its abolition \u2014 forgiveness is not an accounting exercise. The parable that follows shows the absurdity of receiving infinite forgiveness and then refusing to forgive a trivial debt."
+            "paragraph": "Peter asks about forgiving seven times; Jesus says seventy-seven (or seventy times seven). The number is not a limit but its abolition — forgiveness is not an accounting exercise. The parable that follows shows the absurdity of receiving infinite forgiveness and then refusing to forgive a trivial debt."
           },
           {
-            "word": "\u03bc\u03c5\u03c1\u03af\u03bf\u03b9 \u03c4\u03ac\u03bb\u03b1\u03bd\u03c4\u03b1",
+            "word": "μυρίοι τάλαντα",
             "transliteration": "myrioi talanta",
             "gloss": "ten thousand talents",
-            "paragraph": "Ten thousand talents was an incomprehensible sum \u2014 roughly the annual tax revenue of an entire province. Jesus uses the largest number (myrioi = 10,000) and the largest monetary unit (talent) to describe the debt God forgives. Against this, the hundred denarii owed by the fellow servant is mathematically absurd."
+            "paragraph": "Ten thousand talents was an incomprehensible sum — roughly the annual tax revenue of an entire province. Jesus uses the largest number (myrioi = 10,000) and the largest monetary unit (talent) to describe the debt God forgives. Against this, the hundred denarii owed by the fellow servant is mathematically absurd."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Ezek 34:16",
-              "note": "I will search for the lost, bring back the strays \u2014 the divine shepherd's programme. Jesus's lost-sheep parable draws on Ezekiel's portrait of God's priority for the wandering one."
+              "note": "I will search for the lost, bring back the strays — the divine shepherd's programme. Jesus's lost-sheep parable draws on Ezekiel's portrait of God's priority for the wandering one."
             },
             {
-              "ref": "Matt 5:29\u201330",
-              "note": "Cut off hand and eye \u2014 the same hyperbolic language from the Sermon on the Mount. The Sermon's internal command (deal radically with your own temptation) is now applied to causing others to stumble."
+              "ref": "Matt 5:29–30",
+              "note": "Cut off hand and eye — the same hyperbolic language from the Sermon on the Mount. The Sermon's internal command (deal radically with your own temptation) is now applied to causing others to stumble."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:3",
-              "note": "Unless you change and become like little children, you will never enter the kingdom. The greatness question is answered by a child \u2014 the most status-less person in ancient society. Entering the kingdom requires not achievement but a fundamental reorientation: away from status-seeking toward receptivity. The disciples' question (\"who is greatest?\") is itself the diagnostic of the problem."
-            },
-            {
-              "ref": "18:6",
-              "note": "It would be better for a millstone to be hung around their neck and be thrown into the sea. The most severe protective statement in Matthew. The judgment reserved for those who cause Jesus's \"little ones\" to stumble is more severe than that reserved for most sins. The vulnerability of the little ones is the measure of the responsibility of those in positions of influence."
-            },
-            {
-              "ref": "18:14",
-              "note": "Your Father in heaven is not willing that any of these little ones should perish. The Father's will applied to the lost sheep \u2014 the theological basis for the community's pursuit of the wandering member. If the Father is unwilling that any should perish, then leaving the ninety-nine to seek the one is not obsessive but consistent with the Father's character."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "18:1-5",
-              "note": "Calvin on the child: 'Christ does not require us to imitate children in all things, but only in the simplicity and humility which is natural to that age. Children do not yet grasp at honour or distinction; they do not compete for precedence. This freedom from status-competition is the spiritual posture that must characterise kingdom members.'"
-            },
-            {
-              "ref": "18:10-14",
-              "note": "Calvin on the lost sheep: 'God's care extends to every single member of his flock -- not to the flock in the aggregate but to each individual. The shepherd who has ninety-nine does not consider the loss of one acceptable. This teaches us that God's care is not statistical but personal: every member is the object of individual divine attention.'"
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "18:3-4",
-              "note": "The NET note on straphete (unless you turn/are converted, v.3) discusses the sense: not spiritual conversion (which the disciples already have) but a reorientation of attitude toward greatness. The note traces the child-as-image-of-humility through the social context: children in the ancient world had no status or rights -- they were, in social terms, nobodies."
-            },
-            {
-              "ref": "18:10",
-              "note": "The NET note on the angels of the little ones 'always seeing the face of my Father' discusses the guardian-angel interpretation and its OT background (Dan 10:13-21 and the angels of nations). The note identifies the pastoral point: God's attention to the humble is mediated by angelic access to the divine throne -- the little ones are not forgotten."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "18:1-14",
-              "note": "Robertson on straphete (unless you turn and become like children, v.3): the same root as the epistrepho of conversion. Robertson traces the connection: becoming like a child is not a regression but a reorientation -- the total dependence and receptivity of the child is the spiritual posture the kingdom requires. The child is not an image of innocence but of trusting dependence on the parent."
-            },
-            {
-              "ref": "18:10-14",
-              "note": "Robertson on the lost sheep parable: Matthew's version addresses it to the disciples as a rebuke of the attitude that would despise a little one (v.10). The one who loses the sheep is not a sinner finding his way back (Luke 15 context) but a shepherd who must seek the wandering member of the flock. Robertson notes the application to church responsibility: the community's obligation to pursue the straying."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "18:1-9",
-              "note": "The Catena records Chrysostom's treatment of the child placed in the midst: Jesus answers the disciples' 'who is the greatest?' by placing a child where they expected a person of status. The child is the visual argument: the kingdom inverts greatness. Chrysostom notes that 'whoever humbles himself like this child' does not mean to become childish but to acquire the child's complete lack of status-anxiety."
-            },
-            {
-              "ref": "18:10-14",
-              "note": "The Catena traces the patristic reading of the angels of the little ones who 'always see the face of my Father in heaven' (v.10) as guardian angels. Chrysostom and Jerome both read this as the assignment of angelic guardians to the humble. The pastoral application: to despise a little one is to despise someone with direct angelic access to the Father."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The fourth great discourse (chs.18) addresses community life \u2014 triggered by the disciples' status-competition (v.1). The child placed in the middle (v.2) inverts the question: greatness is not achieved but received; the kingdom goes to the childlike, not the powerful. The three units \u2014 child/stumbling blocks (vv.1\u20139), the lost sheep (vv.10\u201314), and church discipline/forgiveness (vv.15\u201335) \u2014 are united by the concern for \"little ones\": protecting them, recovering them, and forgiving them."
+          "context": "The fourth great discourse (chs.18) addresses community life — triggered by the disciples' status-competition (v.1). The child placed in the middle (v.2) inverts the question: greatness is not achieved but received; the kingdom goes to the childlike, not the powerful. The three units — child/stumbling blocks (vv.1–9), the lost sheep (vv.10–14), and church discipline/forgiveness (vv.15–35) — are united by the concern for \"little ones\": protecting them, recovering them, and forgiving them."
         }
       }
     }
@@ -335,7 +286,7 @@
       {
         "name": "The child",
         "role": "Placed in the centre",
-        "text": "The answer to the greatness question \u2014 and the measure of the community's obligation to the vulnerable."
+        "text": "The answer to the greatness question — and the measure of the community's obligation to the vulnerable."
       },
       {
         "name": "Peter",
@@ -347,7 +298,7 @@
     "src": [
       {
         "title": "Ten thousand talents",
-        "quote": "10,000 \u00d7 6,000 denarii = 60,000,000 denarii. Herod the Great's annual income was approximately 900 talents \u2014 so 10,000 talents was an impossible royal debt. The hyperbole is the parable's point: the debt is beyond calculation, the forgiveness is beyond comprehension.",
+        "quote": "10,000 × 6,000 denarii = 60,000,000 denarii. Herod the Great's annual income was approximately 900 talents — so 10,000 talents was an impossible royal debt. The hyperbole is the parable's point: the debt is beyond calculation, the forgiveness is beyond comprehension.",
         "note": "The economic realism makes the absurdity deliberate."
       },
       {
@@ -358,12 +309,12 @@
     ],
     "rec": [
       {
-        "who": "18:15\u201317 and church practice",
-        "text": "The discipline process has been foundational for church order across traditions \u2014 used by Anabaptists, Quakers, and Reformed churches as the basis for church discipline. The goal is always restoration, not punishment."
+        "who": "18:15–17 and church practice",
+        "text": "The discipline process has been foundational for church order across traditions — used by Anabaptists, Quakers, and Reformed churches as the basis for church discipline. The goal is always restoration, not punishment."
       },
       {
         "who": "18:20 and gathered worship",
-        "text": "The promise of Christ's presence where two or three gather has grounded Christian worship from house churches to cathedrals \u2014 the minimum quorum for the real presence of Christ is fellowship in his name."
+        "text": "The promise of Christ's presence where two or three gather has grounded Christian worship from house churches to cathedrals — the minimum quorum for the real presence of Christ is fellowship in his name."
       }
     ],
     "lit": {
@@ -379,7 +330,7 @@
           "is_key": false
         },
         {
-          "label": "The Unforgiving Servant: Forgiveness Must Be Received and Extended \u2014 18:21-35",
+          "label": "The Unforgiving Servant: Forgiveness Must Be Received and Extended — 18:21-35",
           "text": "The 10,000-talent debt is incalculably beyond repayment. The servant who cannot extend 100 denarii of forgiveness has not received his forgiveness -- his unforgiveness is the evidence of an unmoved heart.",
           "is_key": false
         }
@@ -402,7 +353,7 @@
           "summary": "The verse 'For the Son of Man came to save the lost' is absent from the earliest manuscripts of Matthew but appears in Luke 19:10 with excellent attestation. Scribes likely imported it to Matthew to create a smoother transition to the parable of the lost sheep.",
           "evidence": [
             {
-              "manuscript": "Codex Sinaiticus (\u2135, 4th c.)",
+              "manuscript": "Codex Sinaiticus (ℵ, 4th c.)",
               "reading": "Omits verse 11"
             },
             {
@@ -431,7 +382,7 @@
             }
           ],
           "consensus": "The verse was imported from Luke 19:10 (Zacchaeus story) to introduce Matthew's lost sheep parable. It is not original to Matthew. Modern translations omit it or footnote it.",
-          "significance": "The saying itself is authentic Jesus tradition \u2014 it's firmly in Luke. But Matthew apparently did not include it here. This shows how beloved sayings migrated across Gospels in the scribal process."
+          "significance": "The saying itself is authentic Jesus tradition — it's firmly in Luke. But Matthew apparently did not include it here. This shows how beloved sayings migrated across Gospels in the scribal process."
         }
       ]
     },
@@ -583,12 +534,12 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Unless you change and become like little children' (v. 3). Greatness in the kingdom requires smallness\u2014dependence, not achievement. The disciples asked 'who is greatest'; Jesus reframes success entirely.",
+      "tip": "'Unless you change and become like little children' (v. 3). Greatness in the kingdom requires smallness—dependence, not achievement. The disciples asked 'who is greatest'; Jesus reframes success entirely.",
       "genre_tag": "close_reading"
     },
     {
       "after_section": 3,
-      "tip": "Seventy-seven times (v. 22)\u2014or seventy times seven. Either way, unlimited forgiveness. The parable that follows makes the point brutal: forgiven much, forgive others. Unforgiveness imprisons the unforgiving.",
+      "tip": "Seventy-seven times (v. 22)—or seventy times seven. Either way, unlimited forgiveness. The parable that follows makes the point brutal: forgiven much, forgive others. Unforgiveness imprisons the unforgiving.",
       "genre_tag": "theological_insight"
     }
   ]

--- a/content/matthew/19.json
+++ b/content/matthew/19.json
@@ -10,58 +10,58 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201312 \u2014 Teaching on Divorce",
+      "header": "Verses 1–12 — Teaching on Divorce",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03ba\u03bb\u03b7\u03c1\u03bf\u03ba\u03b1\u03c1\u03b4\u03af\u03b1",
-            "transliteration": "skl\u0113rokardia",
+            "word": "σκληροκαρδία",
+            "transliteration": "sklērokardia",
             "gloss": "hardness of heart",
-            "paragraph": "Moses permitted divorce 'because of your hardness of heart' (skl\u0113rokardia). The compound word combines 'hard' (skl\u0113ros) and 'heart' (kardia) \u2014 a heart that cannot be softened, that resists change. Divorce legislation is not God's ideal but his concession to human moral limitation."
+            "paragraph": "Moses permitted divorce 'because of your hardness of heart' (sklērokardia). The compound word combines 'hard' (sklēros) and 'heart' (kardia) — a heart that cannot be softened, that resists change. Divorce legislation is not God's ideal but his concession to human moral limitation."
           },
           {
-            "word": "\u03b5\u1f50\u03bd\u03bf\u1fe6\u03c7\u03bf\u03c2",
+            "word": "εὐνοῦχος",
             "transliteration": "eunouchos",
             "gloss": "eunuch / celibate",
-            "paragraph": "Jesus identifies three types of eunuchs \u2014 born so, made so by others, and those who choose celibacy 'for the sake of the kingdom.' The third category is voluntary renunciation of marriage for mission. 'The one who can accept this should accept it' \u2014 it is a calling, not a command."
+            "paragraph": "Jesus identifies three types of eunuchs — born so, made so by others, and those who choose celibacy 'for the sake of the kingdom.' The third category is voluntary renunciation of marriage for mission. 'The one who can accept this should accept it' — it is a calling, not a command."
           }
         ],
         "poi": [
           {
             "name": "Region of Judea beyond the Jordan",
             "coords": "Transjordan / Perea",
-            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey \u2014 the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
+            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey — the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 1:27; 2:24",
-              "note": "Male and female; one flesh \u2014 Jesus goes behind Deuteronomy's divorce provision to Genesis's creation order. The creational intent is the standard; Mosaic accommodation is the exception."
+              "note": "Male and female; one flesh — Jesus goes behind Deuteronomy's divorce provision to Genesis's creation order. The creational intent is the standard; Mosaic accommodation is the exception."
             },
             {
               "ref": "Deut 24:1",
-              "note": "The certificate of divorce \u2014 Moses's provision. Jesus places it in the context of hard-heartedness: not God's design but human failure accommodated."
+              "note": "The certificate of divorce — Moses's provision. Jesus places it in the context of hard-heartedness: not God's design but human failure accommodated."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "19:4\u20136",
-              "note": "Haven't you read that at the beginning the Creator made them male and female? Jesus grounds marriage ethics in creation theology, not Mosaic legislation. The marriage standard is \"from the beginning\" \u2014 before the fall, before the hardness of heart, before the need for divorce provisions. The restoration of all things that Jesus brings includes the restoration of creational marriage."
+              "ref": "19:4–6",
+              "note": "Haven't you read that at the beginning the Creator made them male and female? Jesus grounds marriage ethics in creation theology, not Mosaic legislation. The marriage standard is \"from the beginning\" — before the fall, before the hardness of heart, before the need for divorce provisions. The restoration of all things that Jesus brings includes the restoration of creational marriage."
             },
             {
               "ref": "19:14",
-              "note": "Let the little children come to me, and do not hinder them, for the kingdom of heaven belongs to such as these. The disciples' rebuke is the opposite of the ch.18 command to welcome the little ones. They are doing exactly what Jesus warned against \u2014 treating the insignificant as a distraction. His \"do not hinder them\" corrects the rebuke and defines the kingdom's membership: those who belong to the kingdom are those who receive it as children receive a gift."
+              "note": "Let the little children come to me, and do not hinder them, for the kingdom of heaven belongs to such as these. The disciples' rebuke is the opposite of the ch.18 command to welcome the little ones. They are doing exactly what Jesus warned against — treating the insignificant as a distraction. His \"do not hinder them\" corrects the rebuke and defines the kingdom's membership: those who belong to the kingdom are those who receive it as children receive a gift."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:4-6",
@@ -74,7 +74,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:9",
@@ -87,7 +87,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "19:1-12",
@@ -100,7 +100,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:3-9",
@@ -113,29 +113,29 @@
           ]
         },
         "hist": {
-          "context": "The divorce question (vv.3\u201312) and the children episode (vv.13\u201315) are thematically linked through the theme of vulnerability and covenant. The divorce debate restores the creational standard from Gen 2 \u2014 marriage as the one-flesh union that only death (not convenience) ends. The disciples' reaction (better not to marry, v.10) leads to the teaching on celibacy as a kingdom gift. The children episode immediately follows \u2014 those the disciples try to exclude are exactly the ones the kingdom belongs to (v.14). The pattern from ch.18 continues: the kingdom inverts normal power dynamics."
+          "context": "The divorce question (vv.3–12) and the children episode (vv.13–15) are thematically linked through the theme of vulnerability and covenant. The divorce debate restores the creational standard from Gen 2 — marriage as the one-flesh union that only death (not convenience) ends. The disciples' reaction (better not to marry, v.10) leads to the teaching on celibacy as a kingdom gift. The children episode immediately follows — those the disciples try to exclude are exactly the ones the kingdom belongs to (v.14). The pattern from ch.18 continues: the kingdom inverts normal power dynamics."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201322 \u2014 Children Brought to Jesus; The Rich Young Man",
+      "header": "Verses 13–22 — Children Brought to Jesus; The Rich Young Man",
       "verse_start": 13,
       "verse_end": 22,
       "panels": {
         "heb": [
           {
-            "word": "\u03c4\u03ad\u03bb\u03b5\u03b9\u03bf\u03c2",
+            "word": "τέλειος",
             "transliteration": "teleios",
             "gloss": "perfect / complete / whole",
-            "paragraph": "'If you want to be perfect (teleios), go, sell your possessions.' The same word from 5:48 reappears. For the rich young man, wholeness requires one specific act \u2014 releasing his grip on wealth. Teleios is not generic but personalised: what completeness requires differs for each person."
+            "paragraph": "'If you want to be perfect (teleios), go, sell your possessions.' The same word from 5:48 reappears. For the rich young man, wholeness requires one specific act — releasing his grip on wealth. Teleios is not generic but personalised: what completeness requires differs for each person."
           }
         ],
         "poi": [
           {
             "name": "Region of Judea beyond the Jordan",
             "coords": "Transjordan / Perea",
-            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey \u2014 the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
+            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey — the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
           }
         ],
         "cross": {
@@ -146,29 +146,29 @@
             },
             {
               "ref": "Isa 65:17",
-              "note": "I will create new heavens and a new earth \u2014 the palingenesia of v.28 echoes Isaiah's new creation. The disciples' thrones in the renewed creation are the restoration of the twelve-tribe structure of Israel."
+              "note": "I will create new heavens and a new earth — the palingenesia of v.28 echoes Isaiah's new creation. The disciples' thrones in the renewed creation are the restoration of the twelve-tribe structure of Israel."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:21",
-              "note": "If you want to be perfect, go, sell your possessions. The command is specific to this man \u2014 it targets the precise thing that has become his master. Jesus does not give this command to everyone, but he gives it to everyone for whom \"one thing\" stands between them and complete loyalty. The question is not whether you have wealth but whether wealth has you."
+              "note": "If you want to be perfect, go, sell your possessions. The command is specific to this man — it targets the precise thing that has become his master. Jesus does not give this command to everyone, but he gives it to everyone for whom \"one thing\" stands between them and complete loyalty. The question is not whether you have wealth but whether wealth has you."
             },
             {
               "ref": "19:24",
-              "note": "A camel through the eye of a needle. The most extreme impossibility image in ancient rhetoric. Various interpretations have softened it (a narrow gate called \"the needle's eye\"; a rope, not a camel). But the disciples' astonished response (\"who then can be saved?\") confirms that the original hearers understood it as absolute impossibility \u2014 which is exactly what v.26 then addresses: \"with God all things are possible.\""
+              "note": "A camel through the eye of a needle. The most extreme impossibility image in ancient rhetoric. Various interpretations have softened it (a narrow gate called \"the needle's eye\"; a rope, not a camel). But the disciples' astonished response (\"who then can be saved?\") confirms that the original hearers understood it as absolute impossibility — which is exactly what v.26 then addresses: \"with God all things are possible.\""
             },
             {
               "ref": "19:26",
-              "note": "With man this is impossible, but with God all things are possible. The answer to the disciples' soteriological panic. Salvation is impossible for humans to achieve \u2014 the camel-and-needle is precisely true if salvation is an achievement. But salvation is God's act, not human attainment. The disciples' \"we have left everything\" (v.27) shows they still haven't quite understood this \u2014 Peter is still calculating the reward."
+              "note": "With man this is impossible, but with God all things are possible. The answer to the disciples' soteriological panic. Salvation is impossible for humans to achieve — the camel-and-needle is precisely true if salvation is an achievement. But salvation is God's act, not human attainment. The disciples' \"we have left everything\" (v.27) shows they still haven't quite understood this — Peter is still calculating the reward."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "19:23-26",
@@ -181,7 +181,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "19:23-24",
@@ -194,7 +194,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "19:16-22",
@@ -207,7 +207,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "19:16-22",
@@ -220,110 +220,65 @@
           ]
         },
         "hist": {
-          "context": "The rich young man episode (vv.16\u201322) is the most poignant refusal in Matthew \u2014 a man who has genuinely kept the commandments, asks the right question, and walks away sad because he has great wealth. The episode produces the camel-needle saying (v.24) and the disciples' astonishment (\"who then can be saved?\"). Jesus's answer is the theological hinge: \"With man this is impossible, but with God all things are possible\" (v.26). The first/last saying closes the chapter and introduces the parable of the workers that opens ch.20."
+          "context": "The rich young man episode (vv.16–22) is the most poignant refusal in Matthew — a man who has genuinely kept the commandments, asks the right question, and walks away sad because he has great wealth. The episode produces the camel-needle saying (v.24) and the disciples' astonishment (\"who then can be saved?\"). Jesus's answer is the theological hinge: \"With man this is impossible, but with God all things are possible\" (v.26). The first/last saying closes the chapter and introduces the parable of the workers that opens ch.20."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201330 \u2014 Camel Through a Needle\u2019s Eye; The Twelve on Thrones",
+      "header": "Verses 23–30 — Camel Through a Needle’s Eye; The Twelve on Thrones",
       "verse_start": 23,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b1\u03bb\u03b9\u03b3\u03b3\u03b5\u03bd\u03b5\u03c3\u03af\u03b1",
+            "word": "παλιγγενεσία",
             "transliteration": "palingenesia",
             "gloss": "renewal / regeneration / new world",
-            "paragraph": "'In the renewal of all things (palingenesia), when the Son of Man sits on his glorious throne' \u2014 this rare word (used only here and Titus 3:5 in the NT) means literally 'genesis again.' Jesus promises not repair but re-creation: a new genesis, a new beginning for the cosmos itself."
+            "paragraph": "'In the renewal of all things (palingenesia), when the Son of Man sits on his glorious throne' — this rare word (used only here and Titus 3:5 in the NT) means literally 'genesis again.' Jesus promises not repair but re-creation: a new genesis, a new beginning for the cosmos itself."
           }
         ],
         "poi": [
           {
             "name": "Region of Judea beyond the Jordan",
             "coords": "Transjordan / Perea",
-            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey \u2014 the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
+            "text": "\"Jesus left Galilee and went into the region of Judea beyond the Jordan.\" This is the beginning of the Jerusalem journey — the sustained movement south that will culminate in the Triumphal Entry (ch.21). Matthew marks the geographical turning point here: the Galilean ministry is ending."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Gen 1:27; 2:24",
-              "note": "Male and female; one flesh \u2014 Jesus goes behind Deuteronomy's divorce provision to Genesis's creation order. The creational intent is the standard; Mosaic accommodation is the exception."
+              "note": "Male and female; one flesh — Jesus goes behind Deuteronomy's divorce provision to Genesis's creation order. The creational intent is the standard; Mosaic accommodation is the exception."
             },
             {
               "ref": "Deut 24:1",
-              "note": "The certificate of divorce \u2014 Moses's provision. Jesus places it in the context of hard-heartedness: not God's design but human failure accommodated."
+              "note": "The certificate of divorce — Moses's provision. Jesus places it in the context of hard-heartedness: not God's design but human failure accommodated."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:4\u20136",
-              "note": "Haven't you read that at the beginning the Creator made them male and female? Jesus grounds marriage ethics in creation theology, not Mosaic legislation. The marriage standard is \"from the beginning\" \u2014 before the fall, before the hardness of heart, before the need for divorce provisions. The restoration of all things that Jesus brings includes the restoration of creational marriage."
-            },
-            {
-              "ref": "19:14",
-              "note": "Let the little children come to me, and do not hinder them, for the kingdom of heaven belongs to such as these. The disciples' rebuke is the opposite of the ch.18 command to welcome the little ones. They are doing exactly what Jesus warned against \u2014 treating the insignificant as a distraction. His \"do not hinder them\" corrects the rebuke and defines the kingdom's membership: those who belong to the kingdom are those who receive it as children receive a gift."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "19:4-6",
-              "note": "Calvin on creational marriage: 'Christ goes back to the original institution to show that God's intention from the beginning was the permanent union of one man and one woman. Divorce is a concession to human hardness of heart (v.8), not a positive provision. The original order is the norm; the Mosaic allowance is the accommodation to sin that sin made necessary.'"
-            },
-            {
-              "ref": "19:16-22",
-              "note": "Calvin on the rich young man: 'His question -- what good thing must I do to inherit eternal life? -- reveals the fundamental error: he conceives of eternal life as the reward of accumulated merit. Jesus's answer redirects him to the commandments; when he claims to have kept them, Jesus exposes the one thing lacking. The rich man's face falls: he had not bargained for total surrender.'"
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "19:9",
-              "note": "The NET note on the exception clause (porneia) surveys the major interpretive positions: (1) any sexual immorality permits divorce and remarriage (evangelical consensus); (2) premarital unchastity discovered after marriage (betrothal interpretation); (3) incestuous marriages invalid from the start (Acts 15:20 application). The note also discusses the 'no remarriage' reading held by many early church fathers."
-            },
-            {
-              "ref": "19:16-22",
-              "note": "The NET note on 'what good thing must I do?' discusses the man's moral framework: he assumes eternal life is earned by moral achievement. The note traces Jesus's engagement -- confirming the commandments, then exposing the one remaining deficiency -- as the Socratic method applied to self-assessment. The man's claim to have kept all the commandments is challenged not by disputing it but by pushing one step further."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "19:1-12",
-              "note": "Robertson on the Pharisees' divorce test (v.3): 'for any cause' (kata pasan aitian) -- the debate between the Shammai school (adultery only) and Hillel school (any displeasure) is the background. Jesus refuses both options and grounds marriage in the creational order (Gen 1:27; 2:24), before Moses, before any rabbinic school. The Pharisees are debating the terms of divorce; Jesus is questioning whether divorce is the right category."
-            },
-            {
-              "ref": "19:10-12",
-              "note": "Robertson on the disciples' startled response ('it is better not to marry') and Jesus's eunuch-for-the-kingdom teaching (v.12): Robertson notes three categories of eunuchs are distinguished -- born eunuchs, made eunuchs by others, and those who choose celibacy for the kingdom. The third category is a genuine calling, not a requirement. 'Let the one who can accept this accept it' (v.12b) makes the calling self-selecting."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "19:3-9",
-              "note": "The Catena records the patristic debate on the exception clause (porneia, v.9). Most Eastern Fathers (Origen, Chrysostom) read porneia narrowly as sexual immorality and permit remarriage after such divorce. The Western tradition generally permits separation but not remarriage. The Catena notes the exception clause is unique to Matthew (both occurrences: 5:32 and 19:9) and absent from Mark and Luke, producing the long history of exegetical debate."
-            },
-            {
-              "ref": "19:13-15",
-              "note": "The Catena records Chrysostom's reading of the children being brought to Jesus: the disciples who rebuke those bringing children have forgotten the lesson of ch.18. Jesus's anger at the disciples (Mark 10:14 records this; Matthew omits it) and his welcome of the children is the enacted repetition of the kingdom-belongs-to-such-as-these teaching."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The divorce question (vv.3\u201312) and the children episode (vv.13\u201315) are thematically linked through the theme of vulnerability and covenant. The divorce debate restores the creational standard from Gen 2 \u2014 marriage as the one-flesh union that only death (not convenience) ends. The disciples' reaction (better not to marry, v.10) leads to the teaching on celibacy as a kingdom gift. The children episode immediately follows \u2014 those the disciples try to exclude are exactly the ones the kingdom belongs to (v.14). The pattern from ch.18 continues: the kingdom inverts normal power dynamics."
+          "context": "The divorce question (vv.3–12) and the children episode (vv.13–15) are thematically linked through the theme of vulnerability and covenant. The divorce debate restores the creational standard from Gen 2 — marriage as the one-flesh union that only death (not convenience) ends. The disciples' reaction (better not to marry, v.10) leads to the teaching on celibacy as a kingdom gift. The children episode immediately follows — those the disciples try to exclude are exactly the ones the kingdom belongs to (v.14). The pattern from ch.18 continues: the kingdom inverts normal power dynamics."
         }
       }
     }
@@ -338,30 +293,30 @@
       {
         "name": "Peter",
         "role": "We have left everything",
-        "text": "Asks the right question for the wrong reason \u2014 calculating return on investment. Jesus answers graciously."
+        "text": "Asks the right question for the wrong reason — calculating return on investment. Jesus answers graciously."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"With man this is impossible, but with God all things are possible.\"</td></tr><tr><td class=\"t-label\">Note</td><td>The answer to the soteriological impossibility the camel-needle image creates. Salvation is not human achievement (impossible for the rich; the disciples' \"who then can be saved?\" is correct) but divine gift.</td></tr>",
     "src": [
       {
         "title": "Divorce schools",
-        "quote": "The Pharisaic debate was between Shammai (divorce only for sexual immorality) and Hillel (divorce for any reason, including bad cooking). Jesus addresses the test by going behind both schools to Genesis \u2014 the creation standard supersedes both.",
+        "quote": "The Pharisaic debate was between Shammai (divorce only for sexual immorality) and Hillel (divorce for any reason, including bad cooking). Jesus addresses the test by going behind both schools to Genesis — the creation standard supersedes both.",
         "note": "Jesus's answer bypasses the schools entirely."
       },
       {
         "title": "Celibacy in Judaism",
-        "quote": "Voluntary celibacy was extremely rare and generally disapproved in Judaism \u2014 children were a covenantal obligation (Gen 1:28). Jesus's commendation of kingdom-celibacy (v.12) is without precedent in Jewish tradition.",
+        "quote": "Voluntary celibacy was extremely rare and generally disapproved in Judaism — children were a covenantal obligation (Gen 1:28). Jesus's commendation of kingdom-celibacy (v.12) is without precedent in Jewish tradition.",
         "note": "The teaching would have been striking to a Jewish audience."
       }
     ],
     "rec": [
       {
         "who": "19:14 and infant baptism",
-        "text": "Let the children come to me \u2014 the primary NT text cited in debates about infant baptism. The context is blessing, not baptism; but the theology of kingdom-belonging for the young is foundational for paedo-baptist traditions."
+        "text": "Let the children come to me — the primary NT text cited in debates about infant baptism. The context is blessing, not baptism; but the theology of kingdom-belonging for the young is foundational for paedo-baptist traditions."
       },
       {
         "who": "19:24 in Christian ethics",
-        "text": "The camel-needle image has been the primary text for Christian engagement with wealth across history \u2014 from the desert fathers who took it literally through Francis of Assisi to liberation theology. The question of whether it applies universally or situationally remains contested."
+        "text": "The camel-needle image has been the primary text for Christian engagement with wealth across history — from the desert fathers who took it literally through Francis of Assisi to liberation theology. The question of whether it applies universally or situationally remains contested."
       }
     ],
     "lit": {
@@ -377,7 +332,7 @@
           "is_key": false
         },
         {
-          "label": "The Rich Young Man: Moral Attainment Without Surrender \u2014 19:16-22",
+          "label": "The Rich Young Man: Moral Attainment Without Surrender — 19:16-22",
           "text": "He has kept the commandments; he lacks the one thing. The face that falls reveals what was truly treasured. Wealth has filled the space where need should be.",
           "is_key": false
         }
@@ -545,7 +500,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'Moses permitted you to divorce... because your hearts were hard' (v. 8). Jesus distinguishes permission from intention. Creation's design\u2014'one flesh'\u2014precedes Mosaic concession. Hardness, not holiness, required the loophole.",
+      "tip": "'Moses permitted you to divorce... because your hearts were hard' (v. 8). Jesus distinguishes permission from intention. Creation's design—'one flesh'—precedes Mosaic concession. Hardness, not holiness, required the loophole.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/matthew/20.json
+++ b/content/matthew/20.json
@@ -10,22 +10,22 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201316 \u2014 Labourers in the Vineyard: The Last Will Be First",
+      "header": "Verses 1–16 — Labourers in the Vineyard: The Last Will Be First",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03b3\u03b1\u03b8\u03cc\u03c2",
+            "word": "ἀγαθός",
             "transliteration": "agathos",
             "gloss": "good / generous",
-            "paragraph": "'Are you envious because I am generous?' \u2014 literally 'Is your eye evil because I am good (agathos)?' The landowner's generosity offends the workers' sense of proportional justice. The parable insists that God's goodness is not bound by human merit calculations."
+            "paragraph": "'Are you envious because I am generous?' — literally 'Is your eye evil because I am good (agathos)?' The landowner's generosity offends the workers' sense of proportional justice. The parable insists that God's goodness is not bound by human merit calculations."
           },
           {
-            "word": "\u1f14\u03c3\u03c7\u03b1\u03c4\u03bf\u03c2... \u03c0\u03c1\u1ff6\u03c4\u03bf\u03c2",
-            "transliteration": "eschatos... pr\u014dtos",
+            "word": "ἔσχατος... πρῶτος",
+            "transliteration": "eschatos... prōtos",
             "gloss": "last... first",
-            "paragraph": "'The last will be first, and the first will be last.' This reversal is the parable's thesis statement. Kingdom economics invert marketplace economics. Those who worked one hour receive the same as those who worked twelve \u2014 not because work is meaningless but because grace is sovereign."
+            "paragraph": "'The last will be first, and the first will be last.' This reversal is the parable's thesis statement. Kingdom economics invert marketplace economics. Those who worked one hour receive the same as those who worked twelve — not because work is meaningless but because grace is sovereign."
           }
         ],
         "tl": [
@@ -43,7 +43,7 @@
           },
           {
             "date": "c. AD 29",
-            "name": "Third passion prediction \u2014 this passage",
+            "name": "Third passion prediction — this passage",
             "text": "\"We are going up to Jerusalem, and the Son of Man will be delivered to the chief priests.\" Three passion predictions mark the journey's stages. This is the most detailed: betrayal, condemnation, handed to Gentiles, mocked, flogged, crucified, raised on the third day.",
             "current": true
           },
@@ -69,30 +69,30 @@
         "cross": {
           "refs": [
             {
-              "ref": "Isa 5:1\u20137",
-              "note": "The vineyard of the LORD of hosts is the house of Israel \u2014 the vineyard image from Isaiah. The parable draws on this established OT metaphor."
+              "ref": "Isa 5:1–7",
+              "note": "The vineyard of the LORD of hosts is the house of Israel — the vineyard image from Isaiah. The parable draws on this established OT metaphor."
             },
             {
               "ref": "Matt 19:30",
-              "note": "Many who are first will be last \u2014 the same first/last reversal that closes ch.19 opens ch.20. The parable is the illustration of the principle."
+              "note": "Many who are first will be last — the same first/last reversal that closes ch.19 opens ch.20. The parable is the illustration of the principle."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:15",
-              "note": "Don't I have the right to do what I want with my own money? Or are you envious because I am generous? The most pointed question about grace in the parables. The parable's scandal is that equal pay for unequal work feels unjust \u2014 which is exactly how grace feels to those who think they have earned it. The landowner is not unjust (he paid what was agreed) but he is generous beyond merit. Envy resents what grace gives to others."
+              "note": "Don't I have the right to do what I want with my own money? Or are you envious because I am generous? The most pointed question about grace in the parables. The parable's scandal is that equal pay for unequal work feels unjust — which is exactly how grace feels to those who think they have earned it. The landowner is not unjust (he paid what was agreed) but he is generous beyond merit. Envy resents what grace gives to others."
             },
             {
-              "ref": "20:18\u201319",
-              "note": "The Son of Man will be delivered to the Gentiles to be mocked and flogged and crucified. The third and most specific passion prediction \u2014 now including the Gentile involvement, the specific tortures, and crucifixion by name. The disciples have heard this twice before and still do not understand (v.22 will confirm it). The prediction is a gift of preparation that they are not yet able to receive."
+              "ref": "20:18–19",
+              "note": "The Son of Man will be delivered to the Gentiles to be mocked and flogged and crucified. The third and most specific passion prediction — now including the Gentile involvement, the specific tortures, and crucifixion by name. The disciples have heard this twice before and still do not understand (v.22 will confirm it). The prediction is a gift of preparation that they are not yet able to receive."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:1-16",
@@ -105,7 +105,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:1-16",
@@ -118,7 +118,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "20:1-16",
@@ -131,7 +131,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:1-16",
@@ -147,32 +147,32 @@
           {
             "name": "Jericho",
             "coords": "Jordan Valley; lowest city on earth",
-            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region \u2014 \"going up to Jerusalem\" is literal."
+            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region — \"going up to Jerusalem\" is literal."
           }
         ],
         "hist": {
-          "context": "The workers-in-the-vineyard parable (vv.1\u201316) directly answers 19:27\u201330's first/last reversal and Peter's reward-calculation. The parable teaches not that later-arriving workers are better but that the owner's generosity is sovereign \u2014 he has the right to give the last the same as the first. The third passion prediction (vv.17\u201319) is Matthew's most detailed \u2014 explicitly including the Gentiles, the mocking, the flogging, the crucifixion, and the resurrection. This is the clearest announcement of the cross before Jerusalem."
+          "context": "The workers-in-the-vineyard parable (vv.1–16) directly answers 19:27–30's first/last reversal and Peter's reward-calculation. The parable teaches not that later-arriving workers are better but that the owner's generosity is sovereign — he has the right to give the last the same as the first. The third passion prediction (vv.17–19) is Matthew's most detailed — explicitly including the Gentiles, the mocking, the flogging, the crucifixion, and the resurrection. This is the clearest announcement of the cross before Jerusalem."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201328 \u2014 Third Passion Prediction; James and John\u2019s Request",
+      "header": "Verses 17–28 — Third Passion Prediction; James and John’s Request",
       "verse_start": 17,
       "verse_end": 28,
       "panels": {
         "heb": [
           {
-            "word": "\u03bb\u03cd\u03c4\u03c1\u03bf\u03bd",
+            "word": "λύτρον",
             "transliteration": "lytron",
             "gloss": "ransom / redemption price",
             "paragraph": "'The Son of Man came not to be served but to serve, and to give his life as a ransom (lytron) for many.' Lytron is the price paid to release a slave or prisoner. Jesus' death is not merely exemplary (a model of sacrifice) but substitutionary (the actual price of freedom)."
           },
           {
-            "word": "\u03b4\u03b9\u03b1\u03ba\u03bf\u03bd\u03ad\u03c9",
-            "transliteration": "diakone\u014d",
+            "word": "διακονέω",
+            "transliteration": "diakoneō",
             "gloss": "serve / minister to",
-            "paragraph": "Jesus redefines greatness as service (diakonia). The request for thrones is met with the promise of suffering. The Son of Man came to serve \u2014 the verb used for table service, for waiting on others. The highest person serves most. Leadership is redefined from the top down."
+            "paragraph": "Jesus redefines greatness as service (diakonia). The request for thrones is met with the promise of suffering. The Son of Man came to serve — the verb used for table service, for waiting on others. The highest person serves most. Leadership is redefined from the top down."
           }
         ],
         "tl": [
@@ -190,7 +190,7 @@
           },
           {
             "date": "c. AD 29",
-            "name": "Third passion prediction \u2014 this passage",
+            "name": "Third passion prediction — this passage",
             "text": "\"We are going up to Jerusalem, and the Son of Man will be delivered to the chief priests.\" Three passion predictions mark the journey's stages. This is the most detailed: betrayal, condemnation, handed to Gentiles, mocked, flogged, crucified, raised on the third day.",
             "current": true
           },
@@ -216,34 +216,34 @@
         "cross": {
           "refs": [
             {
-              "ref": "Isa 53:11\u201312",
-              "note": "He bore the sin of many \u2014 the Servant who gives his life as a ransom. Matthew 20:28 is the Synoptics' most direct citation of Isa 53 for the atonement."
+              "ref": "Isa 53:11–12",
+              "note": "He bore the sin of many — the Servant who gives his life as a ransom. Matthew 20:28 is the Synoptics' most direct citation of Isa 53 for the atonement."
             },
             {
-              "ref": "Mark 10:38\u201340",
-              "note": "Mark's parallel \u2014 the mother is not mentioned; the sons themselves make the request. Matthew's addition of the mother softens the disciples' directness slightly but preserves the same theological exchange."
+              "ref": "Mark 10:38–40",
+              "note": "Mark's parallel — the mother is not mentioned; the sons themselves make the request. Matthew's addition of the mother softens the disciples' directness slightly but preserves the same theological exchange."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:22",
-              "note": "You don't know what you are asking. The gentlest possible rebuke \u2014 addressed to those who want to be great without knowing what greatness costs. The cup they are so confidently claiming is the cup of judgment that Jesus will ask to be taken from him in Gethsemane. Their \"we can\" is sincere and wrong."
+              "note": "You don't know what you are asking. The gentlest possible rebuke — addressed to those who want to be great without knowing what greatness costs. The cup they are so confidently claiming is the cup of judgment that Jesus will ask to be taken from him in Gethsemane. Their \"we can\" is sincere and wrong."
             },
             {
               "ref": "20:28",
-              "note": "The Son of Man did not come to be served, but to serve, and to give his life as a ransom for many. The most theologically concentrated verse in Matthew 20. It answers the status-competition that has run through chs.18\u201320 with the ultimate example: the Son of Man himself, who had every right to be served, came to serve and to die in the place of others. The ransom-for-many is both the means of salvation and the model of discipleship."
+              "note": "The Son of Man did not come to be served, but to serve, and to give his life as a ransom for many. The most theologically concentrated verse in Matthew 20. It answers the status-competition that has run through chs.18–20 with the ultimate example: the Son of Man himself, who had every right to be served, came to serve and to die in the place of others. The ransom-for-many is both the means of salvation and the model of discipleship."
             },
             {
               "ref": "20:34",
-              "note": "Jesus had compassion on them and touched their eyes. The chapter that opened with a vineyard parable about equal grace closes with two blind men healed by compassion. They receive sight and follow him. The trajectory of the chapter \u2014 from entitlement (workers' grumbling) through ambition (James and John) to persistent, receiving faith (the blind men) \u2014 is the trajectory the disciples must travel."
+              "note": "Jesus had compassion on them and touched their eyes. The chapter that opened with a vineyard parable about equal grace closes with two blind men healed by compassion. They receive sight and follow him. The trajectory of the chapter — from entitlement (workers' grumbling) through ambition (James and John) to persistent, receiving faith (the blind men) — is the trajectory the disciples must travel."
             }
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "20:24-28",
@@ -256,7 +256,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "20:28",
@@ -269,7 +269,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "20:20-28",
@@ -282,7 +282,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "20:20-28",
@@ -298,26 +298,26 @@
           {
             "name": "Jericho",
             "coords": "Jordan Valley; lowest city on earth",
-            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region \u2014 \"going up to Jerusalem\" is literal."
+            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region — \"going up to Jerusalem\" is literal."
           }
         ],
         "hist": {
-          "context": "The request of James and John (vv.20\u201328) is the most poignant misunderstanding in Matthew \u2014 the third passion prediction has just been given (vv.17\u201319) and the response is an immediate jockeying for seats of honour. The request produces Jesus's most concentrated statement of kingdom leadership: greatness means servanthood; first means slave; and the Son of Man himself is the model and the reason (v.28 \u2014 \"just as the Son of Man\"). The two blind men at Jericho (vv.29\u201334) close the chapter with a healing that dramatises the whole section: those who cannot see but cry out persistently are given sight and \"follow him\" \u2014 the definition of discipleship."
+          "context": "The request of James and John (vv.20–28) is the most poignant misunderstanding in Matthew — the third passion prediction has just been given (vv.17–19) and the response is an immediate jockeying for seats of honour. The request produces Jesus's most concentrated statement of kingdom leadership: greatness means servanthood; first means slave; and the Son of Man himself is the model and the reason (v.28 — \"just as the Son of Man\"). The two blind men at Jericho (vv.29–34) close the chapter with a healing that dramatises the whole section: those who cannot see but cry out persistently are given sight and \"follow him\" — the definition of discipleship."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 29\u201334 \u2014 Two Blind Men at Jericho",
+      "header": "Verses 29–34 — Two Blind Men at Jericho",
       "verse_start": 29,
       "verse_end": 34,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bb\u03ad\u03b7\u03c3\u03bf\u03bd",
-            "transliteration": "ele\u0113son",
+            "word": "ἐλέησον",
+            "transliteration": "eleēson",
             "gloss": "have mercy",
-            "paragraph": "The blind men cry 'Lord, have mercy on us, Son of David!' \u2014 ele\u0113son is the imperative of elee\u014d. This cry becomes the church's oldest prayer (Kyrie eleison). The blind see what the sighted miss: Jesus is the merciful Davidic king."
+            "paragraph": "The blind men cry 'Lord, have mercy on us, Son of David!' — eleēson is the imperative of eleeō. This cry becomes the church's oldest prayer (Kyrie eleison). The blind see what the sighted miss: Jesus is the merciful Davidic king."
           }
         ],
         "tl": [
@@ -335,7 +335,7 @@
           },
           {
             "date": "c. AD 29",
-            "name": "Third passion prediction \u2014 this passage",
+            "name": "Third passion prediction — this passage",
             "text": "\"We are going up to Jerusalem, and the Son of Man will be delivered to the chief priests.\" Three passion predictions mark the journey's stages. This is the most detailed: betrayal, condemnation, handed to Gentiles, mocked, flogged, crucified, raised on the third day.",
             "current": true
           },
@@ -361,89 +361,44 @@
         "cross": {
           "refs": [
             {
-              "ref": "Isa 5:1\u20137",
-              "note": "The vineyard of the LORD of hosts is the house of Israel \u2014 the vineyard image from Isaiah. The parable draws on this established OT metaphor."
+              "ref": "Isa 5:1–7",
+              "note": "The vineyard of the LORD of hosts is the house of Israel — the vineyard image from Isaiah. The parable draws on this established OT metaphor."
             },
             {
               "ref": "Matt 19:30",
-              "note": "Many who are first will be last \u2014 the same first/last reversal that closes ch.19 opens ch.20. The parable is the illustration of the principle."
+              "note": "Many who are first will be last — the same first/last reversal that closes ch.19 opens ch.20. The parable is the illustration of the principle."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:15",
-              "note": "Don't I have the right to do what I want with my own money? Or are you envious because I am generous? The most pointed question about grace in the parables. The parable's scandal is that equal pay for unequal work feels unjust \u2014 which is exactly how grace feels to those who think they have earned it. The landowner is not unjust (he paid what was agreed) but he is generous beyond merit. Envy resents what grace gives to others."
-            },
-            {
-              "ref": "20:18\u201319",
-              "note": "The Son of Man will be delivered to the Gentiles to be mocked and flogged and crucified. The third and most specific passion prediction \u2014 now including the Gentile involvement, the specific tortures, and crucifixion by name. The disciples have heard this twice before and still do not understand (v.22 will confirm it). The prediction is a gift of preparation that they are not yet able to receive."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "20:1-16",
-              "note": "Calvin on the parable: 'The landowner is not unjust to those who worked the whole day -- they received what was agreed. He is generous to those who worked less. The complaint arises from comparing oneself with others rather than being grateful for what one has received. The kingdom's economy destroys the comparative resentment that calculates one's share by measuring another's.'"
-            },
-            {
-              "ref": "20:20-28",
-              "note": "Calvin on the ransom saying (v.28: 'to give his life as a ransom for many'): 'The word ransom (lytron) is the key to the atonement theology of the gospel. Christ gave his life antilytron -- a price paid in exchange for others. The preposition anti (in exchange for, in the place of) is the substitutionary formula: he died in the place of the many. This is not metaphor but transaction.'"
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "20:1-16",
-              "note": "The NET note on 'the last will be first and the first will be last' (v.16) discusses the relationship to the same statement in 19:30: the parable is the explanation of the principle. The note traces the reversal theme through the Magnificat (Luke 1:52-53) and identifies it as the kingdom's structural inversion: the world's first (those who calculate their entitlement) become last in the kingdom's economy."
-            },
-            {
-              "ref": "20:17-19",
-              "note": "The NET note on the third passion prediction traces its growing specificity: the first (16:21) mentions suffering, death, and resurrection; the second (17:22-23) adds the betrayal; the third adds handing over to Gentiles, mocking, flogging, and crucifying. The increasing specificity as Jerusalem approaches is Matthew's narrative signal that the passion is now the story."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "20:1-16",
-              "note": "Robertson on the parable of the workers in the vineyard: the denarius (a day's wage) given to all workers regardless of hours reveals that the kingdom's justice is the landowner's generosity, not the workers' calculation of equity. Robertson notes that the workers hired first agreed to the denarius (v.2: suphonesei) -- they entered a contract. The later workers simply trusted the landowner's what-is-right promise (v.4). The grumbling (v.11) comes from those who substituted their calculation for the landowner's generosity."
-            },
-            {
-              "ref": "20:17-19",
-              "note": "Robertson on the third passion prediction (vv.17-19): the most specific of the three -- handing over to the Gentiles, mocking, flogging, crucifying, and rising on the third day. Robertson notes that as Jerusalem approaches, the predictions become more specific. The disciples still do not understand (cf. the immediately following request of James and John's mother), revealing the gap between Jesus's clarity about what is coming and the disciples' continued confusion."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "20:1-16",
-              "note": "The Catena traces multiple patristic readings of the vineyard parable. Chrysostom reads the hours as the hours of the day at which different people come to faith: from childhood (first hour) to deathbed (eleventh hour). All receive the same eternal life because eternal life is not proportional to the length of the work but to the generosity of the one who gives it."
-            },
-            {
-              "ref": "20:20-23",
-              "note": "The Catena records the patristic reading of the mother of Zebedee's sons as representing the misunderstanding of the disciples: even those closest to Jesus share the confusion about the kingdom's nature. Chrysostom notes that the request -- the best seats in the kingdom -- reveals that they still conceive the kingdom as a political hierarchy where proximity to the king confers status."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "poi": [
           {
             "name": "Jericho",
             "coords": "Jordan Valley; lowest city on earth",
-            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region \u2014 \"going up to Jerusalem\" is literal."
+            "text": "\"As Jesus and his disciples were leaving Jericho...\" The blind men at Jericho are the last healing before Jerusalem. Jericho is 25km from Jerusalem, 250m below sea level. The journey from Jericho to Jerusalem is the steepest sustained ascent in the region — \"going up to Jerusalem\" is literal."
           }
         ],
         "hist": {
-          "context": "The workers-in-the-vineyard parable (vv.1\u201316) directly answers 19:27\u201330's first/last reversal and Peter's reward-calculation. The parable teaches not that later-arriving workers are better but that the owner's generosity is sovereign \u2014 he has the right to give the last the same as the first. The third passion prediction (vv.17\u201319) is Matthew's most detailed \u2014 explicitly including the Gentiles, the mocking, the flogging, the crucifixion, and the resurrection. This is the clearest announcement of the cross before Jerusalem."
+          "context": "The workers-in-the-vineyard parable (vv.1–16) directly answers 19:27–30's first/last reversal and Peter's reward-calculation. The parable teaches not that later-arriving workers are better but that the owner's generosity is sovereign — he has the right to give the last the same as the first. The third passion prediction (vv.17–19) is Matthew's most detailed — explicitly including the Gentiles, the mocking, the flogging, the crucifixion, and the resurrection. This is the clearest announcement of the cross before Jerusalem."
         }
       }
     }
@@ -458,15 +413,15 @@
       {
         "name": "James and John",
         "role": "Request seats of honour after the passion prediction",
-        "text": "The most poignant timing in Matthew \u2014 immediately after the cross is named, they compete for positions."
+        "text": "The most poignant timing in Matthew — immediately after the cross is named, they compete for positions."
       },
       {
         "name": "The two blind men",
         "role": "Cry out; receive sight; follow",
-        "text": "The chapter's final portrait of discipleship \u2014 persistent faith that receives and follows."
+        "text": "The chapter's final portrait of discipleship — persistent faith that receives and follows."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"The Son of Man did not come to be served, but to serve, and to give his life as a ransom for many.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Lytron anti poll\u014dn \u2014 ransom in place of the many. Matthew's most explicit atonement statement. The Son of Man's service is simultaneously the model of discipleship and the ground of salvation.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"The Son of Man did not come to be served, but to serve, and to give his life as a ransom for many.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Lytron anti pollōn — ransom in place of the many. Matthew's most explicit atonement statement. The Son of Man's service is simultaneously the model of discipleship and the ground of salvation.</td></tr>",
     "src": [
       {
         "title": "The denarius",
@@ -486,13 +441,13 @@
       },
       {
         "who": "The vineyard parable and grace",
-        "text": "The parable has been cited in disputes about merit and grace across church history \u2014 whether salvation is entirely God's free gift (Augustine, Luther) or partly responsive to human effort (Pelagius, Arminius). The landowner's final question (\"are you envious because I am generous?\") is the definitive answer."
+        "text": "The parable has been cited in disputes about merit and grace across church history — whether salvation is entirely God's free gift (Augustine, Luther) or partly responsive to human effort (Pelagius, Arminius). The landowner's final question (\"are you envious because I am generous?\") is the definitive answer."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Workers in the Vineyard: Grace Destroys Comparison \u2014 20:1-16",
+          "label": "Workers in the Vineyard: Grace Destroys Comparison — 20:1-16",
           "text": "All workers receive the same denarius because the landowner's generosity, not the workers' calculation, is the kingdom's justice. The grumbling worker compared when gratitude was required.",
           "is_key": false
         },
@@ -665,7 +620,7 @@
     },
     {
       "after_section": 3,
-      "tip": "'The Son of Man did not come to be served, but to serve' (v. 28). James and John want thrones; Jesus offers cups and baptisms\u2014suffering. Greatness is servanthood. The cross defines leadership.",
+      "tip": "'The Son of Man did not come to be served, but to serve' (v. 28). James and John want thrones; Jesus offers cups and baptisms—suffering. Greatness is servanthood. The cross defines leadership.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/matthew/21.json
+++ b/content/matthew/21.json
@@ -7,31 +7,31 @@
   "subtitle": "Triumphal Entry; Temple Cleansed; Fig Tree; Authority Question; Two Sons; Tenants",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": {
     "story_id": "final-week",
-    "text": "See on Map \u2014 Passion Week"
+    "text": "See on Map — Passion Week"
   },
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201311 \u2014 The Triumphal Entry into Jerusalem",
+      "header": "Verses 1–11 — The Triumphal Entry into Jerusalem",
       "verse_start": 1,
       "verse_end": 11,
       "panels": {
         "heb": [
           {
-            "word": "\u1f61\u03c3\u03b1\u03bd\u03bd\u03ac",
-            "transliteration": "h\u014dsanna",
+            "word": "ὡσαννά",
+            "transliteration": "hōsanna",
             "gloss": "hosanna / save now",
-            "paragraph": "A transliteration of Hebrew h\u00f4\u0161\u00ee'\u0101h-nn\u0101' (Psalm 118:25) \u2014 'Save, we pray!' By Jesus' time it had become an acclamation of praise, but the original meaning is a desperate plea for deliverance. The crowd shouts salvation language without understanding what kind of salvation approaches."
+            "paragraph": "A transliteration of Hebrew hôšî'āh-nnā' (Psalm 118:25) — 'Save, we pray!' By Jesus' time it had become an acclamation of praise, but the original meaning is a desperate plea for deliverance. The crowd shouts salvation language without understanding what kind of salvation approaches."
           },
           {
-            "word": "\u03c0\u03c1\u03b1\u03b0\u03c2",
+            "word": "πραΰς",
             "transliteration": "praus",
             "gloss": "gentle / meek",
-            "paragraph": "Matthew quotes Zechariah 9:9: the king comes 'gentle (praus), riding on a donkey.' The same word used in the Beatitudes (5:5). The king's entrance is deliberately anti-triumphal \u2014 no war horse, no chariot, no military escort. The entry parodies imperial power while fulfilling prophetic promise."
+            "paragraph": "Matthew quotes Zechariah 9:9: the king comes 'gentle (praus), riding on a donkey.' The same word used in the Beatitudes (5:5). The king's entrance is deliberately anti-triumphal — no war horse, no chariot, no military escort. The entry parodies imperial power while fulfilling prophetic promise."
           }
         ],
         "tl": [
@@ -49,7 +49,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Triumphal Entry \u2014 Palm Sunday \u2014 this passage",
+            "name": "Triumphal Entry — Palm Sunday — this passage",
             "text": "\"Hosanna to the Son of David! Blessed is he who comes in the name of the Lord!\" The Triumphal Entry is Passover week, Sunday. The crowd hails Jesus with messianic language from Psalm 118. The whole city is stirred. Jesus enters Jerusalem as King.",
             "current": true
           },
@@ -76,28 +76,28 @@
           {
             "name": "Bethphage and the Mount of Olives",
             "coords": "East of Jerusalem",
-            "text": "The entry begins at Bethphage on the Mount of Olives \u2014 the eastern approach to Jerusalem. The Mount of Olives overlooks Jerusalem from the east; it is the traditional route for the Messiah's coming (Zech 14:4). The colt is fetched from here: the entry is planned geographically."
+            "text": "The entry begins at Bethphage on the Mount of Olives — the eastern approach to Jerusalem. The Mount of Olives overlooks Jerusalem from the east; it is the traditional route for the Messiah's coming (Zech 14:4). The colt is fetched from here: the entry is planned geographically."
           },
           {
             "name": "Jerusalem",
             "coords": "Capital of Judea; Temple mount",
-            "text": "\"The whole city was stirred.\" Jesus enters Jerusalem \u2014 for the first extended time in Matthew's Gospel. The Temple is his immediate destination. The cleansing of the Temple and the children's praise all occur in the Temple courts: Jerusalem is the stage for the final conflict."
+            "text": "\"The whole city was stirred.\" Jesus enters Jerusalem — for the first extended time in Matthew's Gospel. The Temple is his immediate destination. The cleansing of the Temple and the children's praise all occur in the Temple courts: Jerusalem is the stage for the final conflict."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "Your king comes gentle on a donkey \u2014 the precise fulfilment."
+              "note": "Your king comes gentle on a donkey — the precise fulfilment."
             },
             {
               "ref": "Isa 56:7; Jer 7:11",
-              "note": "House of prayer for all nations / den of robbers \u2014 two OT prophecies quoted simultaneously at the cleansing."
+              "note": "House of prayer for all nations / den of robbers — two OT prophecies quoted simultaneously at the cleansing."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:1-11",
@@ -110,7 +110,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:8-11",
@@ -123,7 +123,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:4-5",
@@ -136,7 +136,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:1-11",
@@ -149,7 +149,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "21:1-11",
@@ -162,40 +162,40 @@
           ]
         },
         "hist": {
-          "context": "The entry is staged to fulfil Zech 9:9 precisely. The crowd responds with Ps 118 \u2014 the same psalm that supplies the cornerstone image at the chapter's close (v.42). The temple cleansing is an enacted parable: the Court of Gentiles \u2014 where non-Jews could pray \u2014 has become a market. The blind and lame healed in the temple enact what Isaiah said the temple was for."
+          "context": "The entry is staged to fulfil Zech 9:9 precisely. The crowd responds with Ps 118 — the same psalm that supplies the cornerstone image at the chapter's close (v.42). The temple cleansing is an enacted parable: the Court of Gentiles — where non-Jews could pray — has become a market. The blind and lame healed in the temple enact what Isaiah said the temple was for."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 12\u201322 \u2014 Cleansing the Temple; The Withered Fig Tree",
+      "header": "Verses 12–22 — Cleansing the Temple; The Withered Fig Tree",
       "verse_start": 12,
       "verse_end": 22,
       "panels": {
         "heb": [
           {
-            "word": "\u1f31\u03b5\u03c1\u03cc\u03bd",
+            "word": "ἱερόν",
             "transliteration": "hieron",
             "gloss": "temple / temple complex",
-            "paragraph": "Jesus cleanses the hieron (the whole temple precinct, not the naos/inner sanctuary). The commerce he overturns was in the Court of the Gentiles \u2014 the only space where non-Jews could pray. The merchants had turned the Gentiles' prayer space into a marketplace. Jesus restores access."
+            "paragraph": "Jesus cleanses the hieron (the whole temple precinct, not the naos/inner sanctuary). The commerce he overturns was in the Court of the Gentiles — the only space where non-Jews could pray. The merchants had turned the Gentiles' prayer space into a marketplace. Jesus restores access."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Triumphal Entry \u2014 Sunday",
+            "name": "Triumphal Entry — Sunday",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Temple cleansing \u2014 Monday morning \u2014 this passage",
+            "name": "Temple cleansing — Monday morning — this passage",
             "text": "Jesus returns from Bethany on Monday morning, curses the fig tree on the way, and cleanses the Temple. \"In the morning\" marks Monday of Passion Week. The fig tree and Temple cleansing are interleaved in Mark; Matthew presents the fig tree wilting all at once.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Fig tree withered \u2014 Tuesday morning",
+            "name": "Fig tree withered — Tuesday morning",
             "text": "",
             "current": false
           },
@@ -222,23 +222,23 @@
           {
             "name": "Bethany",
             "coords": "Village on the eastern slope of the Mount of Olives",
-            "text": "Jesus returns to Bethany each evening during Passion Week \u2014 it is his base outside Jerusalem. The fig tree is cursed \"in the morning\" on the road from Bethany to Jerusalem. Bethany is the home of Mary, Martha, and Lazarus \u2014 the covenant's domestic refuge during the most dangerous week."
+            "text": "Jesus returns to Bethany each evening during Passion Week — it is his base outside Jerusalem. The fig tree is cursed \"in the morning\" on the road from Bethany to Jerusalem. Bethany is the home of Mary, Martha, and Lazarus — the covenant's domestic refuge during the most dangerous week."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 5:1-7",
-              "note": "The vineyard of the LORD is the house of Israel \u2014 the OT background for the parable."
+              "note": "The vineyard of the LORD is the house of Israel — the OT background for the parable."
             },
             {
               "ref": "Ps 118:22",
-              "note": "The rejected stone becomes the cornerstone \u2014 same psalm as the Hosanna. Rejection and vindication from the same source."
+              "note": "The rejected stone becomes the cornerstone — same psalm as the Hosanna. Rejection and vindication from the same source."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:18-22",
@@ -251,7 +251,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "21:28-32",
@@ -264,7 +264,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "21:28-32",
@@ -277,7 +277,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "21:18-22",
@@ -290,7 +290,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "21:18-22",
@@ -303,22 +303,22 @@
           ]
         },
         "hist": {
-          "context": "The withered fig tree dramatises fruitless religion \u2014 leaves without fruit. The authority question traps the questioners. The two parables are transparent: the chief priests know Jesus is talking about them (v.45) and respond with arrest-plotting, confirming the wicked tenants parable precisely."
+          "context": "The withered fig tree dramatises fruitless religion — leaves without fruit. The authority question traps the questioners. The two parables are transparent: the chief priests know Jesus is talking about them (v.45) and respond with arrest-plotting, confirming the wicked tenants parable precisely."
         }
       }
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201332 \u2014 By What Authority? The Two Sons",
+      "header": "Verses 23–32 — By What Authority? The Two Sons",
       "verse_start": 23,
       "verse_end": 32,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03be\u03bf\u03c5\u03c3\u03af\u03b1",
+            "word": "ἐξουσία",
             "transliteration": "exousia",
             "gloss": "authority",
-            "paragraph": "'By what authority are you doing these things?' The chief priests' question is legitimate \u2014 Jesus has no rabbinic ordination, no priestly lineage, no Sanhedrin commission. His authority is not institutional but personal. He answers with a counter-question about John's authority, exposing their inability to recognise any authority outside their system."
+            "paragraph": "'By what authority are you doing these things?' The chief priests' question is legitimate — Jesus has no rabbinic ordination, no priestly lineage, no Sanhedrin commission. His authority is not institutional but personal. He answers with a counter-question about John's authority, exposing their inability to recognise any authority outside their system."
           }
         ],
         "tl": [
@@ -336,7 +336,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Triumphal Entry \u2014 Palm Sunday \u2014 this passage",
+            "name": "Triumphal Entry — Palm Sunday — this passage",
             "text": "\"Hosanna to the Son of David! Blessed is he who comes in the name of the Lord!\" The Triumphal Entry is Passover week, Sunday. The crowd hails Jesus with messianic language from Psalm 118. The whole city is stirred. Jesus enters Jerusalem as King.",
             "current": true
           },
@@ -363,126 +363,81 @@
           {
             "name": "Bethphage and the Mount of Olives",
             "coords": "East of Jerusalem",
-            "text": "The entry begins at Bethphage on the Mount of Olives \u2014 the eastern approach to Jerusalem. The Mount of Olives overlooks Jerusalem from the east; it is the traditional route for the Messiah's coming (Zech 14:4). The colt is fetched from here: the entry is planned geographically."
+            "text": "The entry begins at Bethphage on the Mount of Olives — the eastern approach to Jerusalem. The Mount of Olives overlooks Jerusalem from the east; it is the traditional route for the Messiah's coming (Zech 14:4). The colt is fetched from here: the entry is planned geographically."
           },
           {
             "name": "Jerusalem",
             "coords": "Capital of Judea; Temple mount",
-            "text": "\"The whole city was stirred.\" Jesus enters Jerusalem \u2014 for the first extended time in Matthew's Gospel. The Temple is his immediate destination. The cleansing of the Temple and the children's praise all occur in the Temple courts: Jerusalem is the stage for the final conflict."
+            "text": "\"The whole city was stirred.\" Jesus enters Jerusalem — for the first extended time in Matthew's Gospel. The Temple is his immediate destination. The cleansing of the Temple and the children's praise all occur in the Temple courts: Jerusalem is the stage for the final conflict."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Zech 9:9",
-              "note": "Your king comes gentle on a donkey \u2014 the precise fulfilment."
+              "note": "Your king comes gentle on a donkey — the precise fulfilment."
             },
             {
               "ref": "Isa 56:7; Jer 7:11",
-              "note": "House of prayer for all nations / den of robbers \u2014 two OT prophecies quoted simultaneously at the cleansing."
+              "note": "House of prayer for all nations / den of robbers — two OT prophecies quoted simultaneously at the cleansing."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:1-11",
-              "note": "MacArthur: The Triumphal Entry fulfilled Zechariah 9:9 precisely. The crowd spread cloaks and palm branches, shouting Hosanna -- 'Save now!' from Psalm 118:25. They acclaimed Jesus as the Son of David, the messianic king. Yet the city asked 'Who is this?' -- the crowd knew the event's form but not its full significance."
-            },
-            {
-              "ref": "21:12-17",
-              "note": "MacArthur: The Temple cleansing was an act of messianic authority. Jesus overturned the money-changers' tables and drove out those buying and selling, citing Isaiah 56:7 and Jeremiah 7:11. The religious leaders were indignant; the children cried Hosanna. Jesus accepted the children's praise as fulfilment of Psalm 8:2."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:8-11",
-              "note": "Calvin on the Triumphal Entry: the crowd's welcome was genuine but inadequate -- they hail him as a prophet from Galilee when he is the Son of God. Partial recognition that falls short of the full truth recurs throughout the passion."
-            },
-            {
-              "ref": "21:12-13",
-              "note": "Calvin on the Temple cleansing: the Temple had been converted from its proper use into a marketplace. Christ declares that outward ceremony without the heart is not acceptable worship. He drives out not only the corrupt worship but the worldly mind that produces it."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:4-5",
-              "note": "The NET note on the Zech 9:9 fulfilment discusses the Matthew-unique detail of two animals. Matthew may be presenting a literal fulfilment of the Hebrew parallelism, where the colt and the donkey describe the same animal from two angles or are read as two distinct animals."
-            },
-            {
-              "ref": "21:12-13",
-              "note": "The NET note on 'den of robbers' (spelaion leston) traces the Jer 7:11 allusion: Jeremiah condemned those who performed Temple rituals while oppressing the poor and then used the Temple as a refuge. The same pattern of religious practice as cover for injustice is what Jesus indicts."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "21:1-11",
-              "note": "Robertson on the Triumphal Entry: the two animals are unique to Matthew, fulfilling Zech 9:9 literally. Robertson notes the crowd's Hosanna (from Hebrew hoshi'ah-na -- save now!) is drawn from Ps 118:25-26. The question of the whole city (who is this?, v.10) and the answer (the prophet Jesus from Nazareth, v.11) reveals the gap between popular perception and the truth Matthew has been unfolding."
-            },
-            {
-              "ref": "21:12-17",
-              "note": "Robertson on the Temple cleansing: the two OT citations -- 'my house shall be called a house of prayer' (Isa 56:7) and 'you have made it a den of robbers' (Jer 7:11) -- are combined into a single indictment. The children's Hosanna (v.15) fulfils Ps 8:2, and Jesus's citation of Ps 8:2 makes a claim about his own identity: the praise ordained by God in creation is now being offered to him."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "21:1-11",
-              "note": "The Catena records the patristic reading of the meekness of the entry (on a donkey, not a warhorse) as itself the prophetic sign. Chrysostom: the King comes not as a military conqueror but as a servant-king. The crowd's festive welcome contrasts with Jerusalem's troubled question, anticipating the passion's coming rejection."
-            },
-            {
-              "ref": "21:12-17",
-              "note": "Chrysostom on the Temple cleansing: what was the Temple for? Prayer. What had it become? A marketplace. Christ's action is restoration -- he expels what corrupted the Temple's purpose and immediately fills it with what that purpose was: healing (v.14) and prayer."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The entry is staged to fulfil Zech 9:9 precisely. The crowd responds with Ps 118 \u2014 the same psalm that supplies the cornerstone image at the chapter's close (v.42). The temple cleansing is an enacted parable: the Court of Gentiles \u2014 where non-Jews could pray \u2014 has become a market. The blind and lame healed in the temple enact what Isaiah said the temple was for."
+          "context": "The entry is staged to fulfil Zech 9:9 precisely. The crowd responds with Ps 118 — the same psalm that supplies the cornerstone image at the chapter's close (v.42). The temple cleansing is an enacted parable: the Court of Gentiles — where non-Jews could pray — has become a market. The blind and lame healed in the temple enact what Isaiah said the temple was for."
         }
       }
     },
     {
       "section_num": 4,
-      "header": "Verses 33\u201346 \u2014 The Parable of the Wicked Tenants",
+      "header": "Verses 33–46 — The Parable of the Wicked Tenants",
       "verse_start": 33,
       "verse_end": 46,
       "panels": {
         "heb": [
           {
-            "word": "\u03bb\u03af\u03b8\u03bf\u03c2",
+            "word": "λίθος",
             "transliteration": "lithos",
             "gloss": "stone / cornerstone",
-            "paragraph": "Jesus quotes Psalm 118:22-23: 'the stone the builders rejected has become the cornerstone.' The builders are Israel's leaders; the rejected stone is Jesus. The cornerstone (kephal\u0113 g\u014dnias \u2014 literally 'head of the corner') is the stone that determines the alignment of the entire building. Reject it and the whole structure is misaligned."
+            "paragraph": "Jesus quotes Psalm 118:22-23: 'the stone the builders rejected has become the cornerstone.' The builders are Israel's leaders; the rejected stone is Jesus. The cornerstone (kephalē gōnias — literally 'head of the corner') is the stone that determines the alignment of the entire building. Reject it and the whole structure is misaligned."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Triumphal Entry \u2014 Sunday",
+            "name": "Triumphal Entry — Sunday",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Temple cleansing \u2014 Monday morning \u2014 this passage",
+            "name": "Temple cleansing — Monday morning — this passage",
             "text": "Jesus returns from Bethany on Monday morning, curses the fig tree on the way, and cleanses the Temple. \"In the morning\" marks Monday of Passion Week. The fig tree and Temple cleansing are interleaved in Mark; Matthew presents the fig tree wilting all at once.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Fig tree withered \u2014 Tuesday morning",
+            "name": "Fig tree withered — Tuesday morning",
             "text": "",
             "current": false
           },
@@ -509,88 +464,43 @@
           {
             "name": "Bethany",
             "coords": "Village on the eastern slope of the Mount of Olives",
-            "text": "Jesus returns to Bethany each evening during Passion Week \u2014 it is his base outside Jerusalem. The fig tree is cursed \"in the morning\" on the road from Bethany to Jerusalem. Bethany is the home of Mary, Martha, and Lazarus \u2014 the covenant's domestic refuge during the most dangerous week."
+            "text": "Jesus returns to Bethany each evening during Passion Week — it is his base outside Jerusalem. The fig tree is cursed \"in the morning\" on the road from Bethany to Jerusalem. Bethany is the home of Mary, Martha, and Lazarus — the covenant's domestic refuge during the most dangerous week."
           }
         ],
         "cross": {
           "refs": [
             {
               "ref": "Isa 5:1-7",
-              "note": "The vineyard of the LORD is the house of Israel \u2014 the OT background for the parable."
+              "note": "The vineyard of the LORD is the house of Israel — the OT background for the parable."
             },
             {
               "ref": "Ps 118:22",
-              "note": "The rejected stone becomes the cornerstone \u2014 same psalm as the Hosanna. Rejection and vindication from the same source."
+              "note": "The rejected stone becomes the cornerstone — same psalm as the Hosanna. Rejection and vindication from the same source."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:18-22",
-              "note": "MacArthur: The cursed fig tree illustrates the principle that fruitless profession invites judgment. The tree had leaves (the appearance of life) but no fruit (the reality). Israel's religious establishment had the form of covenant life without its substance."
-            },
-            {
-              "ref": "21:33-46",
-              "note": "MacArthur: The parable of the tenants is a transparent allegory of Israel's rejection of the prophets and the Son. The religious leaders understood it was about them (v.45) and sought to arrest Jesus -- confirming the parable's diagnosis. The cornerstone rejected by the builders (Ps 118:22) is the risen Christ, the church's foundation."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "21:28-32",
-              "note": "Calvin on the parable of the two sons: the tax collectors and prostitutes -- who at first refused the kingdom but repented at John's preaching -- are entering the kingdom ahead of the religious leaders who promised obedience but never produced it. Repentance following initial refusal is better than profession preceding persistent disobedience."
-            },
-            {
-              "ref": "21:42-44",
-              "note": "Calvin on the cornerstone: those who stumble on Christ in this life will be broken; those on whom he falls will be crushed. The rejection of Christ does not displace him from his position; it determines the fate of those who reject him. The cornerstone either supports or destroys -- it cannot be ignored."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "21:28-32",
-              "note": "The NET note on the parable of the two sons discusses the textual problem in vv.29-31: different manuscript traditions give different answers about which son said yes or no. The theological point is the same regardless: actual obedience (even after initial refusal) exceeds verbal compliance without action."
-            },
-            {
-              "ref": "21:33-46",
-              "note": "The NET note on the parable of the tenants traces its OT background in Isaiah's Song of the Vineyard (Isa 5:1-7). The addition of the son is Matthew's Christological heightening: the climax is not the prophets' rejection but the Son's murder, making the parable an explicit passion prediction."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "21:18-22",
-              "note": "Robertson on the cursed fig tree: the withering 'from the roots' (v.20) is complete -- not just the leaves. The miracle functions as an enacted parable: the fig tree with leaves but no fruit is the visual lesson placed immediately before the Temple controversy. Religious establishment with the appearance of life but no fruit of righteousness."
-            },
-            {
-              "ref": "21:23-46",
-              "note": "Robertson on the authority question (v.23: en poia exousia): the chief priests and elders demand Jesus's authority credentials after the Temple cleansing. Jesus's counter-question about John's baptism exposes their real problem: they have not answered the question of John's authority, so they cannot be trusted to answer the question of Jesus's. The two parables that follow answer the authority question narratively."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "21:18-22",
-              "note": "The Catena traces the patristic reading of the fig tree as a typology for religion without righteousness. Chrysostom: the tree that has leaves but no fruit is the picture of the form of godliness without its power. Its leaves had made a promise its fruit could not keep."
-            },
-            {
-              "ref": "21:33-46",
-              "note": "Chrysostom on the parable of the tenants: the vineyard is Israel; the owner is God; the slaves are the prophets; the son is Christ. The tenants' reasoning ('let us kill him and take his inheritance', v.38) is Chrysostom's text for the premeditated nature of the crucifixion -- they knew who he was and killed him anyway. The stone the builders rejected (Ps 118:22) becomes the cornerstone."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
-          "context": "The withered fig tree dramatises fruitless religion \u2014 leaves without fruit. The authority question traps the questioners. The two parables are transparent: the chief priests know Jesus is talking about them (v.45) and respond with arrest-plotting, confirming the wicked tenants parable precisely."
+          "context": "The withered fig tree dramatises fruitless religion — leaves without fruit. The authority question traps the questioners. The two parables are transparent: the chief priests know Jesus is talking about them (v.45) and respond with arrest-plotting, confirming the wicked tenants parable precisely."
         }
       }
     }
@@ -608,11 +518,11 @@
         "text": "Know the parables are about them. Respond with plots, not repentance."
       }
     ],
-    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"The stone the builders rejected has become the cornerstone.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Ps 118:22 \u2014 same psalm as the entry Hosanna. The chapter is bracketed by the same text: welcome and rejection are both from Ps 118.</td></tr>",
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>\"The stone the builders rejected has become the cornerstone.\"</td></tr><tr><td class=\"t-label\">Note</td><td>Ps 118:22 — same psalm as the entry Hosanna. The chapter is bracketed by the same text: welcome and rejection are both from Ps 118.</td></tr>",
     "src": [
       {
         "title": "Triumphal entry staging",
-        "quote": "Jesus arranges the donkey in advance \u2014 deliberate enacted prophecy, not a spontaneous messianic welcome.",
+        "quote": "Jesus arranges the donkey in advance — deliberate enacted prophecy, not a spontaneous messianic welcome.",
         "note": "The advance preparation distinguishes this from a chance event."
       },
       {
@@ -628,13 +538,13 @@
       },
       {
         "who": "Cornerstone in early Christianity",
-        "text": "Ps 118:22 is the most-cited OT resurrection text in the NT \u2014 quoted by Jesus, Peter (Acts 4:11), Paul (Eph 2:20)."
+        "text": "Ps 118:22 is the most-cited OT resurrection text in the NT — quoted by Jesus, Peter (Acts 4:11), Paul (Eph 2:20)."
       }
     ],
     "lit": {
       "rows": [
         {
-          "label": "Triumphal Entry: Recognition Without Full Understanding \u2014 21:1-11",
+          "label": "Triumphal Entry: Recognition Without Full Understanding — 21:1-11",
           "text": "Hosanna to the Son of David -- the crowd gets the right words without grasping their full meaning. The city asks who is this? and receives only the prophet from Galilee. Partial recognition is Matthew's preparation for the passion.",
           "is_key": false
         },
@@ -807,7 +717,7 @@
     },
     {
       "after_section": 2,
-      "tip": "'My house will be called a house of prayer, but you are making it a den of robbers' (v. 13). Temple commerce\u2014exchanging currencies, selling sacrifices\u2014exploited pilgrims. Jesus' violence is prophetic protest, not random rage.",
+      "tip": "'My house will be called a house of prayer, but you are making it a den of robbers' (v. 13). Temple commerce—exchanging currencies, selling sacrifices—exploited pilgrims. Jesus' violence is prophetic protest, not random rage.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/matthew/22.json
+++ b/content/matthew/22.json
@@ -7,27 +7,27 @@
   "subtitle": "Wedding Banquet; Tribute to Caesar; Resurrection Question; Great Commandment; Son of David",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201314 \u2014 The Parable of the Wedding Banquet",
+      "header": "Verses 1–14 — The Parable of the Wedding Banquet",
       "verse_start": 1,
       "verse_end": 14,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03bb\u03b7\u03c4\u03cc\u03c2... \u1f10\u03ba\u03bb\u03b5\u03ba\u03c4\u03cc\u03c2",
-            "transliteration": "kl\u0113tos... eklektos",
+            "word": "κλητός... ἐκλεκτός",
+            "transliteration": "klētos... eklektos",
             "gloss": "called... chosen",
-            "paragraph": "'Many are called (kl\u0113toi) but few are chosen (eklektoi).' The parable distinguishes invitation from selection. The call goes wide (to the streets, the highways); the choosing is based on response (wearing the wedding garment). Universal invitation does not guarantee universal acceptance."
+            "paragraph": "'Many are called (klētoi) but few are chosen (eklektoi).' The parable distinguishes invitation from selection. The call goes wide (to the streets, the highways); the choosing is based on response (wearing the wedding garment). Universal invitation does not guarantee universal acceptance."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple courts",
+            "name": "Jerusalem — Temple courts",
             "coords": "Teaching space during Passion Week",
             "text": "The parable of the wedding banquet and the taxation question are both set in the Temple courts during Jesus's final week. The geography of the controversy is the most charged: the Temple is the symbolic centre of the authority Jesus is being challenged about."
           }
@@ -45,7 +45,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:1-14",
@@ -58,7 +58,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:2-14",
@@ -71,7 +71,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "22:1-14",
@@ -84,7 +84,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "22:1-22",
@@ -97,7 +97,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "22:1-14",
@@ -116,27 +116,27 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 15\u201322 \u2014 Taxes to Caesar: Give to God What Is God\u2019s",
+      "header": "Verses 15–22 — Taxes to Caesar: Give to God What Is God’s",
       "verse_start": 15,
       "verse_end": 22,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u1fc6\u03bd\u03c3\u03bf\u03c2",
-            "transliteration": "k\u0113nsos",
+            "word": "κῆνσος",
+            "transliteration": "kēnsos",
             "gloss": "census tax / poll tax",
-            "paragraph": "The k\u0113nsos was the annual head tax paid directly to Rome \u2014 the most politically charged tax because it symbolised submission to a foreign emperor. 'Is it lawful to pay?' is a trap: yes means collaborator, no means rebel. Jesus' answer transcends both options."
+            "paragraph": "The kēnsos was the annual head tax paid directly to Rome — the most politically charged tax because it symbolised submission to a foreign emperor. 'Is it lawful to pay?' is a trap: yes means collaborator, no means rebel. Jesus' answer transcends both options."
           },
           {
-            "word": "\u03b5\u1f30\u03ba\u03ce\u03bd",
-            "transliteration": "eik\u014dn",
+            "word": "εἰκών",
+            "transliteration": "eikōn",
             "gloss": "image / likeness",
-            "paragraph": "'Whose image (eik\u014dn) is this?' \u2014 Caesar's image is on the coin. But Genesis 1:27 says humans bear God's image (eik\u014dn in the LXX). Give Caesar his coins; give God what bears his image \u2014 yourself. The argument works on two levels simultaneously: political compliance and total self-offering."
+            "paragraph": "'Whose image (eikōn) is this?' — Caesar's image is on the coin. But Genesis 1:27 says humans bear God's image (eikōn in the LXX). Give Caesar his coins; give God what bears his image — yourself. The argument works on two levels simultaneously: political compliance and total self-offering."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple courts",
+            "name": "Jerusalem — Temple courts",
             "coords": "Teaching space during Passion Week",
             "text": "The parable of the wedding banquet and the taxation question are both set in the Temple courts during Jesus's final week. The geography of the controversy is the most charged: the Temple is the symbolic centre of the authority Jesus is being challenged about."
           }
@@ -158,7 +158,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:23-33",
@@ -171,7 +171,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "22:31-32",
@@ -184,7 +184,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "22:30",
@@ -197,7 +197,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "22:23-33",
@@ -210,7 +210,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "22:23-33",
@@ -229,27 +229,27 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201340 \u2014 Resurrection and the Greatest Commandment",
+      "header": "Verses 23–40 — Resurrection and the Greatest Commandment",
       "verse_start": 23,
       "verse_end": 40,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03bd\u03ac\u03c3\u03c4\u03b1\u03c3\u03b9\u03c2",
+            "word": "ἀνάστασις",
             "transliteration": "anastasis",
             "gloss": "resurrection / rising up",
-            "paragraph": "The Sadducees deny anastasis (resurrection). Jesus argues from Exodus 3:6: 'I am the God of Abraham' \u2014 present tense, not past. If Abraham is dead and gone, God would say 'I was.' The grammar of God's self-revelation implies the patriarchs still live. God is not the God of the dead but of the living."
+            "paragraph": "The Sadducees deny anastasis (resurrection). Jesus argues from Exodus 3:6: 'I am the God of Abraham' — present tense, not past. If Abraham is dead and gone, God would say 'I was.' The grammar of God's self-revelation implies the patriarchs still live. God is not the God of the dead but of the living."
           },
           {
-            "word": "\u1f10\u03bd\u03c4\u03bf\u03bb\u03ae",
-            "transliteration": "entol\u0113",
+            "word": "ἐντολή",
+            "transliteration": "entolē",
             "gloss": "commandment",
-            "paragraph": "When asked for the 'greatest commandment' (entol\u0113 megal\u0113), Jesus combines Deuteronomy 6:5 (love God) and Leviticus 19:18 (love neighbour). The genius is in the combination \u2014 no rabbi before Jesus had fused these two into a single supreme principle. Love of God without love of neighbour is incomplete; love of neighbour without love of God is untethered."
+            "paragraph": "When asked for the 'greatest commandment' (entolē megalē), Jesus combines Deuteronomy 6:5 (love God) and Leviticus 19:18 (love neighbour). The genius is in the combination — no rabbi before Jesus had fused these two into a single supreme principle. Love of God without love of neighbour is incomplete; love of neighbour without love of God is untethered."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple courts",
+            "name": "Jerusalem — Temple courts",
             "coords": "Teaching space during Passion Week",
             "text": "The parable of the wedding banquet and the taxation question are both set in the Temple courts during Jesus's final week. The geography of the controversy is the most charged: the Temple is the symbolic centre of the authority Jesus is being challenged about."
           }
@@ -267,69 +267,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:1-14",
-              "note": "MacArthur: The wedding banquet parable continues the series of confrontation parables. Those originally invited (Israel's leaders) refused and were judged; the invitation was extended to all. The man without a wedding garment represents those who enter the visible church without genuine righteousness -- present but not prepared."
-            },
-            {
-              "ref": "22:15-22",
-              "note": "MacArthur: The tribute question was a calculated trap. Jesus's answer -- render to Caesar what is Caesar's and to God what is God's -- established a two-sphere principle. Christians owe civil governments their lawful obligations while owing God their ultimate allegiance. The two spheres are not competing but ordered."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:2-14",
-              "note": "Calvin on the wedding banquet: the parable teaches that many are called but few are chosen. The outward call of the gospel reaches many; the effectual call of the Spirit reaches the elect. The man without the wedding garment is present in the church but not truly a participant. External participation does not guarantee internal transformation."
-            },
-            {
-              "ref": "22:20-22",
-              "note": "Calvin on give to Caesar and to God: Christ does not separate the two realms into competing authorities but subordinates the political to the divine. We owe to magistrates what civil governance requires; we owe to God the absolute submission his total claim requires. Where the two conflict, God's claim is ultimate."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:1-14",
-              "note": "The NET note on the wedding garment (endyma gamou, v.12) concludes that it represents the genuine transformation (righteousness) that the gospel's invitation produces in those who truly receive it. The man without the garment represents the nominal church member who has joined without being changed."
-            },
-            {
-              "ref": "22:17-21",
-              "note": "The NET note on the tribute question discusses the political context: the tribute (kensos, a poll tax) was a flashpoint issue -- Zealots refused it; Herodians supported it. The trap was designed to force Jesus into one camp. His answer provides a principle that transcends the specific political debate while refusing to endorse either extreme."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "22:1-22",
-              "note": "Robertson on the wedding banquet parable: the double invitation (first call, v.3; second call, v.4) and the guests' refusal follow standard Near Eastern banquet customs. Robertson traces the burning of the city (v.7) as a proleptic reference to the destruction of Jerusalem in AD 70. The wedding garment (v.12) is the righteousness required for kingdom participation."
-            },
-            {
-              "ref": "22:15-22",
-              "note": "Robertson on the tribute question: the denarius with Caesar's image (eikon, v.20) is the visual argument -- whose image makes it whose coin. Apodote (give back, v.21) rather than merely give: the coin belongs to Caesar because it bears his image; give it back. The implied counter-argument: the human being bears God's image (Gen 1:27); give yourself back to God."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "22:1-14",
-              "note": "The Catena traces the patristic reading of the wedding banquet as the history of salvation: first invited guests are Israel; servants sent are the prophets; second invitation is the apostolic mission; gathering from the streets is Gentile inclusion. Chrysostom notes that the wedding garment establishes that Gentile inclusion does not mean standards are abandoned: the grace that calls also transforms."
-            },
-            {
-              "ref": "22:15-22",
-              "note": "Chrysostom on the Herodian-Pharisee coalition: political enemies united by hostility to Jesus. Their question is designed to trap him -- either answer would provide grounds for accusation. Jesus's answer transcends the trap: he does not choose between the options but provides a principle that governs both, leaving the questioners silent."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The wedding banquet (vv.1-14) states the chapter's theme: the invitation is wide but presence requires transformation. The Pharisees + Herodians tax question (vv.15-22) is the first of three traps: they present a false dilemma (Caesar or God) that Jesus dissolves by distinguishing the two claims."
@@ -338,21 +293,21 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 41\u201346 \u2014 Whose Son Is the Messiah? David\u2019s Lord",
+      "header": "Verses 41–46 — Whose Son Is the Messiah? David’s Lord",
       "verse_start": 41,
       "verse_end": 46,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03cd\u03c1\u03b9\u03bf\u03c2",
+            "word": "κύριος",
             "transliteration": "kyrios",
             "gloss": "Lord / master",
-            "paragraph": "Jesus asks: 'If David calls the Messiah \"Lord\" (kyrios), how can the Messiah be merely David's son?' The argument uses Psalm 110:1 to show that the Messiah must be more than a human descendant of David \u2014 he must be David's Lord, a divine figure. The question silences all questioners."
+            "paragraph": "Jesus asks: 'If David calls the Messiah \"Lord\" (kyrios), how can the Messiah be merely David's son?' The argument uses Psalm 110:1 to show that the Messiah must be more than a human descendant of David — he must be David's Lord, a divine figure. The question silences all questioners."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple courts",
+            "name": "Jerusalem — Temple courts",
             "coords": "Teaching space during Passion Week",
             "text": "The parable of the wedding banquet and the taxation question are both set in the Temple courts during Jesus's final week. The geography of the controversy is the most charged: the Temple is the symbolic centre of the authority Jesus is being challenged about."
           }
@@ -374,69 +329,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:23-33",
-              "note": "MacArthur: The Sadducees' resurrection question was refuted from the Pentateuch they accepted. Jesus argued from the present tense of 'I am the God of Abraham' that the patriarchs still live in covenant relationship with God -- the covenant implies resurrection. The crowds were astonished at his teaching."
-            },
-            {
-              "ref": "22:41-46",
-              "note": "MacArthur: Jesus's counter-question about the Son of David (Ps 110:1) silenced all questioners. If David calls the Messiah 'my Lord,' the Messiah cannot be merely David's descendant -- he must be David's divine superior. The question exposed the inadequacy of a purely human Messianic expectation. No one could answer him."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "22:31-32",
-              "note": "Calvin on the burning bush argument: God says I am the God of Abraham -- not I was. If he is their God and they are dead, they exist to him still. The resurrection is implied in the covenant: God does not enter into covenant with dust. The patriarchs who are in covenant with the living God must themselves live."
-            },
-            {
-              "ref": "22:41-46",
-              "note": "Calvin on the Son of David question: Christ does not deny his Davidic descent but forces the recognition that something more than descent is required. David calls his own son Lord -- this is impossible unless the son is also, in some other mode, greater than his father. The answer requires the incarnation."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "22:30",
-              "note": "The NET note on 'like the angels in heaven' discusses what this implies: not that the resurrected are angels, but that resurrection life transcends earthly structures (including marriage) that were given for the present age. The Pauline parallel (1 Cor 15:42-44) develops the resurrection body's transformed nature."
-            },
-            {
-              "ref": "22:44",
-              "note": "The NET note on Ps 110:1 and its NT usage (the most-cited OT text in the NT) discusses the Hebrew adonai/YHWH distinction. Jesus's use identifies the Messiah as David's Lord -- a divine being who pre-existed David, not merely a royal descendant."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "22:23-33",
-              "note": "Robertson on the resurrection question: the Sadducees use Moses (Deut 25:5 -- levirate marriage) to construct an absurdity. Jesus's two-pronged answer: (1) resurrection life is different from earthly life (like the angels -- not marrying); (2) Moses himself implies the resurrection at the burning bush ('the God of Abraham, Isaac, and Jacob' -- present tense, because God is not the God of the dead). V.33: the crowds were astonished at his teaching."
-            },
-            {
-              "ref": "22:34-46",
-              "note": "Robertson on the great commandment: the lawyer's test question receives a double answer -- love God (Deut 6:5) and love neighbour (Lev 19:18). All the Law and Prophets hang on these two (v.40) -- not replacing the Torah but providing its interpretive key. The counter-question about the Son of David exposes the Pharisees' inadequate Christology: they cannot answer the question of the Messiah's identity."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "22:23-33",
-              "note": "Chrysostom on the Sadducees' resurrection question: they accept only the Pentateuch and use it to disprove resurrection; Jesus answers from the Pentateuch and proves resurrection. The argument from the burning bush ('I am the God of Abraham') implies the living relationship that requires resurrection. The present tense of 'I am' implies the living relationship with people who must themselves be living."
-            },
-            {
-              "ref": "22:41-46",
-              "note": "The Catena traces the Christological reading of Ps 110:1: the two Lords are the Father and the Son -- the Son who is both David's offspring (according to the flesh) and David's Lord (according to his divine nature). Jesus's question (how can he be his son?) is not a denial of Davidic descent but an affirmation of divine preexistence."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "Three debates end the chapter: Sadducees on resurrection (vv.23-33), law expert on greatest commandment (vv.34-40), and Jesus's counter-question from Ps 110:1 (vv.41-46). Each ends with silencing. Jesus then poses the unanswerable question that exposes the inadequacy of \"son of David\" as a complete framework."
@@ -498,7 +408,7 @@
           "is_key": false
         },
         {
-          "label": "The Great Commandment: Torah Interpretive Key \u2014 22:34-40",
+          "label": "The Great Commandment: Torah Interpretive Key — 22:34-40",
           "text": "Love God completely; love neighbour as self. All the Law and Prophets hang on these two. Jesus does not replace Torah but provides its hermeneutical key: every specific commandment is an application of one of these two principles.",
           "is_key": false
         }

--- a/content/matthew/23.json
+++ b/content/matthew/23.json
@@ -7,35 +7,35 @@
   "subtitle": "Seven Woes to Scribes and Pharisees; Jerusalem, Jerusalem",
   "timeline_link": {
     "event_id": "triumphal-entry",
-    "text": "See on Timeline \u2014 Triumphal Entry"
+    "text": "See on Timeline — Triumphal Entry"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201312 \u2014 The Teachers of the Law Condemned",
+      "header": "Verses 1–12 — The Teachers of the Law Condemned",
       "verse_start": 1,
       "verse_end": 12,
       "panels": {
         "heb": [
           {
-            "word": "\u03c6\u03c5\u03bb\u03b1\u03ba\u03c4\u03ae\u03c1\u03b9\u03bf\u03bd",
-            "transliteration": "phylakt\u0113rion",
+            "word": "φυλακτήριον",
+            "transliteration": "phylaktērion",
             "gloss": "phylactery / protective charm",
-            "paragraph": "Phylacteries (tefillin) are small leather boxes containing Scripture worn during prayer. Jesus does not condemn the practice but the ostentation \u2014 'they make their phylacteries wide.' External religious display becomes a substitute for internal devotion. The broader the phylactery, the narrower the heart."
+            "paragraph": "Phylacteries (tefillin) are small leather boxes containing Scripture worn during prayer. Jesus does not condemn the practice but the ostentation — 'they make their phylacteries wide.' External religious display becomes a substitute for internal devotion. The broader the phylactery, the narrower the heart."
           },
           {
-            "word": "\u1fe5\u03b1\u03b2\u03b2\u03af",
+            "word": "ῥαββί",
             "transliteration": "rhabbi",
             "gloss": "rabbi / teacher / master",
-            "paragraph": "'Do not be called Rabbi, for you have one Teacher.' Jesus prohibits not the function of teaching but the craving for honorific titles that create hierarchy within the community. The kingdom community has one Teacher (Christ) and all others are siblings \u2014 brothers and sisters on level ground."
+            "paragraph": "'Do not be called Rabbi, for you have one Teacher.' Jesus prohibits not the function of teaching but the craving for honorific titles that create hierarchy within the community. The kingdom community has one Teacher (Christ) and all others are siblings — brothers and sisters on level ground."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple, scribes' seat",
+            "name": "Jerusalem — Temple, scribes' seat",
             "coords": "Temple courts and city",
-            "text": "The seven woes are pronounced in the Temple courts \u2014 directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
+            "text": "The seven woes are pronounced in the Temple courts — directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
           }
         ],
         "cross": {
@@ -51,7 +51,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:1-7",
@@ -64,7 +64,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:1-7",
@@ -77,7 +77,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "23:5",
@@ -90,7 +90,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "23:1-22",
@@ -103,7 +103,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "23:1-12",
@@ -122,23 +122,23 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 13\u201322 \u2014 Woes 1\u20133: Hypocrites, Blind Guides",
+      "header": "Verses 13–22 — Woes 1–3: Hypocrites, Blind Guides",
       "verse_start": 13,
       "verse_end": 22,
       "panels": {
         "heb": [
           {
-            "word": "\u03bf\u1f50\u03b1\u03af",
+            "word": "οὐαί",
             "transliteration": "ouai",
             "gloss": "woe / alas",
-            "paragraph": "Seven woes (ouai) structure the chapter \u2014 a prophetic formula announcing judgment. Ouai is not a curse but a lament: 'alas for you.' Jesus grieves even as he condemns. The woes echo Isaiah 5:8-23 and other prophetic judgment oracles. Jesus speaks as a prophet confronting corrupt religious leadership."
+            "paragraph": "Seven woes (ouai) structure the chapter — a prophetic formula announcing judgment. Ouai is not a curse but a lament: 'alas for you.' Jesus grieves even as he condemns. The woes echo Isaiah 5:8-23 and other prophetic judgment oracles. Jesus speaks as a prophet confronting corrupt religious leadership."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple, scribes' seat",
+            "name": "Jerusalem — Temple, scribes' seat",
             "coords": "Temple courts and city",
-            "text": "The seven woes are pronounced in the Temple courts \u2014 directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
+            "text": "The seven woes are pronounced in the Temple courts — directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
           }
         ],
         "cross": {
@@ -154,7 +154,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:23-28",
@@ -167,7 +167,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "23:23-24",
@@ -180,7 +180,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "23:23",
@@ -193,7 +193,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "23:23-39",
@@ -206,7 +206,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "23:27-28",
@@ -225,23 +225,23 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 23\u201336 \u2014 Woes 4\u20137: Justice, Whitewashed Tombs, Prophets\u2019 Blood",
+      "header": "Verses 23–36 — Woes 4–7: Justice, Whitewashed Tombs, Prophets’ Blood",
       "verse_start": 23,
       "verse_end": 36,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03ac\u03bc\u03b7\u03bb\u03bf\u03c2... \u03ba\u03ce\u03bd\u03c9\u03c8",
-            "transliteration": "kam\u0113los... k\u014dn\u014dps",
+            "word": "κάμηλος... κώνωψ",
+            "transliteration": "kamēlos... kōnōps",
             "gloss": "camel... gnat",
-            "paragraph": "'You strain out a gnat (k\u014dn\u014dps) but swallow a camel (kam\u0113los).' The humour is devastating \u2014 meticulously filtering drinking water to avoid swallowing an unclean insect while gulping down the largest unclean animal imaginable. The absurd image exposes how scrupulosity about minor rules coexists with gross moral failure."
+            "paragraph": "'You strain out a gnat (kōnōps) but swallow a camel (kamēlos).' The humour is devastating — meticulously filtering drinking water to avoid swallowing an unclean insect while gulping down the largest unclean animal imaginable. The absurd image exposes how scrupulosity about minor rules coexists with gross moral failure."
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple, scribes' seat",
+            "name": "Jerusalem — Temple, scribes' seat",
             "coords": "Temple courts and city",
-            "text": "The seven woes are pronounced in the Temple courts \u2014 directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
+            "text": "The seven woes are pronounced in the Temple courts — directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
           }
         ],
         "cross": {
@@ -257,69 +257,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:1-7",
-              "note": "MacArthur: Jesus acknowledged the Pharisees' teaching authority (Moses's seat) while condemning their practice. They teach but do not do; they make heavy burdens but do not help carry them; they do all their deeds to be seen. The three indictments expose the gap between religious profession and covenant character."
-            },
-            {
-              "ref": "23:13-22",
-              "note": "MacArthur: The seven woes are not curses but prophetic laments over deliberate hypocrisy. The first woe (shutting the kingdom) is the most fundamental: they neither enter themselves nor allow others to enter. Their influence corrupts rather than guides -- those they make disciples become twice the sons of hell."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:1-7",
-              "note": "Calvin on sitting in Moses's seat: the Pharisees had legitimate authority and used it illegitimately. Christ therefore distinguishes: respect the office, but do not imitate the persons. This teaches that the corruption of those who bear authority does not make the authority itself null."
-            },
-            {
-              "ref": "23:11-12",
-              "note": "Calvin on the greatest as servant: among you the greatest will be your servant -- this is not merely an external rule but a description of how the kingdom works. Power in the kingdom is exercised through self-giving, not self-assertion. Christ himself is the model: he who is Lord of all became servant of all."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:5",
-              "note": "The NET note on phylacteries (phylakteria) and tassels (kraspeda) explains the legitimate OT basis: the phylacteries are the tefillin (Exod 13:9,16; Deut 6:8) and the tassels are the tzitzit (Num 15:38-40). The problem is not the practice itself but its ostentatious exaggeration for public display."
-            },
-            {
-              "ref": "23:13-15",
-              "note": "The NET note on the first two woes discusses the textual problem: some manuscripts add a woe about devouring widows' houses (v.14), absent from the best manuscripts (Sinaiticus, Vaticanus). Matthew's seven-woe structure is the canonical form; the additional verse is probably imported from Mark 12:40."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "23:1-22",
-              "note": "Robertson on 'the scribes and Pharisees sit in Moses's seat' (v.2): the authority claim and Jesus's dual response -- do what they say (v.3a) but do not follow what they do (v.3b). The inconsistency between teaching and practice is the first woe's foundation. On the phylacteries and tassels (v.5): legitimate piety-markers made ostentatious. They do all their deeds to be seen by others."
-            },
-            {
-              "ref": "23:13-22",
-              "note": "Robertson on the woes: each ouai is a prophetic lament as much as a condemnation -- the word is used for grief as well as judgment. The first woe (shutting the kingdom, v.13) and the third woe (converts who become worse, v.15) are structural bookends: the scribes and Pharisees neither enter nor allow others to enter, and those they bring in become more lost than before."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "23:1-12",
-              "note": "Chrysostom on sitting in Moses's seat: we honour the seat, not the person sitting in it. When teachers corrupt what they teach, their authority is diminished; but the truth they handle correctly retains its authority. The pastoral principle: receive the truth wherever it comes while remaining discerning about the teachers."
-            },
-            {
-              "ref": "23:13-36",
-              "note": "The Catena traces the patristic reading of the seven woes as a graduated portrait of religious hypocrisy: from shutting the kingdom (first woe) to persecuting the prophets (last woe), moving from external practice to internal corruption to murderous opposition. Chrysostom: the woes are not hatred but the surgeon's knife applied to the disease that is killing those it describes."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The first half moves from positive instruction (servant greatness; one Teacher/Father/Instructor, vv.1-12) to the first four woes (vv.13-22). The positive instruction of vv.8-12 is the community Jesus is forming: no human hierarchy, only one Teacher who is the Messiah."
@@ -328,23 +283,23 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 37\u201339 \u2014 Lament over Jerusalem: Your House Left Desolate",
+      "header": "Verses 37–39 — Lament over Jerusalem: Your House Left Desolate",
       "verse_start": 37,
       "verse_end": 39,
       "panels": {
         "heb": [
           {
-            "word": "\u1f44\u03c1\u03bd\u03b9\u03c2",
+            "word": "ὄρνις",
             "transliteration": "ornis",
             "gloss": "hen / bird",
-            "paragraph": "'As a hen gathers her chicks under her wings' \u2014 one of Jesus' most tender images. The mother bird protects with her own body; if the predator strikes, she dies first. Jesus uses a feminine, maternal image for his own desire to protect Jerusalem. The tragedy: 'you were not willing.'"
+            "paragraph": "'As a hen gathers her chicks under her wings' — one of Jesus' most tender images. The mother bird protects with her own body; if the predator strikes, she dies first. Jesus uses a feminine, maternal image for his own desire to protect Jerusalem. The tragedy: 'you were not willing.'"
           }
         ],
         "poi": [
           {
-            "name": "Jerusalem \u2014 Temple, scribes' seat",
+            "name": "Jerusalem — Temple, scribes' seat",
             "coords": "Temple courts and city",
-            "text": "The seven woes are pronounced in the Temple courts \u2014 directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
+            "text": "The seven woes are pronounced in the Temple courts — directed at the scribes and Pharisees in their own authoritative space. \"Moses' seat\" is the location from which they teach. The denunciation occurs at the geographical centre of their authority."
           }
         ],
         "cross": {
@@ -360,69 +315,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:23-28",
-              "note": "MacArthur: The woe against straining out gnats and swallowing camels (v.24) captures the Pharisaic inversion: meticulous attention to minor requirements while ignoring weightier ones. Justice, mercy, and faithfulness are not alternatives to the law but its animating spirit. Tithing herbs while neglecting ethics is practiced religion without covenant character."
-            },
-            {
-              "ref": "23:37-39",
-              "note": "MacArthur: The Jerusalem lament is the most tender passage in the confrontation section. How often I have longed to gather your children as a hen gathers her chicks under her wings, and you were not willing. The repeated longing and the repeated refusal establish that the coming judgment flows from human rejection of divine mercy, not from divine harshness."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "23:23-24",
-              "note": "Calvin on the mint-dill-cumin tithe: Jesus does not abolish the tithe of herbs -- you should have practised the latter without neglecting the former. The indictment is against the misuse of scrupulousness to avoid the weightier demands. Tithing the herb garden while neglecting justice, mercy, and faithfulness is the religious person's most sophisticated self-deception."
-            },
-            {
-              "ref": "23:37-39",
-              "note": "Calvin on the Jerusalem lament: he mourns over the city not because he could not have saved it against its will but because it would not receive him. The gathering he longed to do was prevented not by his unwillingness but by theirs. The cause of damnation is not God's refusal to save but the human refusal to be saved."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "23:23",
-              "note": "The NET note on 'the weightier matters of the law -- justice, mercy, and faithfulness' (ta barystera tou nomou) discusses the rabbinic distinction between light (qal) and heavy (chamur) commandments. The note traces the prophetic background (Mic 6:8; Hos 6:6) for the justice-mercy-faithfulness triad."
-            },
-            {
-              "ref": "23:37-39",
-              "note": "The NET note on 'you will not see me again until you say Blessed is he who comes in the name of the Lord' (v.39) discusses whether this refers to the parousia or a future repentance of Jerusalem. The note identifies the eschatological reference: Jerusalem will not see Jesus until the final return, when every knee will bow."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "23:23-39",
-              "note": "Robertson on the whitewashed tombs (v.27: taphos kekoniamenois -- whitened tombs): the purity irony -- tombs were whitewashed to warn passers-by not to touch them (contact caused ritual uncleanness). The religious leaders who maintained ritual purity were themselves the source of the defilement they organised their lives to avoid. On the lament over Jerusalem (vv.37-39): the transition from woe to lament is the shift from judgment to grief."
-            },
-            {
-              "ref": "23:29-36",
-              "note": "Robertson on 'you build the tombs of the prophets' (v.29): building tombs for those your fathers killed is simultaneously a tribute to the murdered and an inheritance of the murder. The logic of v.32 ('fill up the measure of your fathers'): the scribes and Pharisees will complete the pattern and be judged for all the righteous blood from Abel to Zechariah."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "23:27-28",
-              "note": "Chrysostom's meditation on the whitewashed tomb: the most powerful image in the woe-series because it captures the purity system's ultimate perversion. Those who organised their entire lives around avoiding ritual defilement were themselves the source of moral defilement. The external whitewashing conceals the internal death that the entire purity system was designed to address."
-            },
-            {
-              "ref": "23:37-39",
-              "note": "The Catena traces the patristic reading of Jerusalem, Jerusalem as the Christ-lament that discloses the divine grief behind all judgment. The longing to gather the children as a hen gathers her chicks under her wings (v.37) is the most tender image in Matthew -- the maternal care of God for the city that will kill him."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The final three woes (vv.23-32) target: tithing minor herbs while neglecting weightier matters, external purity masking internal corruption, and tomb-building that celebrates prophets they would have killed. The lament (vv.37-39) is the chapter's emotional truth: behind the seven woes is the grief of One who longed to gather Jerusalem and was refused."
@@ -479,7 +389,7 @@
           "is_key": false
         },
         {
-          "label": "Jerusalem, Jerusalem: Judgment Through Grief \u2014 23:37-39",
+          "label": "Jerusalem, Jerusalem: Judgment Through Grief — 23:37-39",
           "text": "The lament that follows the woes reveals the divine grief behind all judgment. The longing to gather the children as a hen gathers her chicks is the most tender image in Matthew -- the maternal care of God who is about to be rejected.",
           "is_key": false
         }
@@ -642,7 +552,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "'They do not practice what they preach' (v. 3). Jesus' critique isn't of teaching but of inconsistency. Titles, status, public recognition\u2014all rejected. 'The greatest among you will be your servant' (v. 11).",
+      "tip": "'They do not practice what they preach' (v. 3). Jesus' critique isn't of teaching but of inconsistency. Titles, status, public recognition—all rejected. 'The greatest among you will be your servant' (v. 11).",
       "genre_tag": "close_reading"
     },
     {

--- a/content/matthew/24.json
+++ b/content/matthew/24.json
@@ -7,28 +7,28 @@
   "subtitle": "Temple Destruction Predicted; Signs of the End; Abomination; Son of Man Coming; Be Ready",
   "timeline_link": {
     "event_id": "temple-destruction-detail",
-    "text": "See on Timeline \u2014 Destruction of Jerusalem"
+    "text": "See on Timeline — Destruction of Jerusalem"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u20138 \u2014 The Temple\u2019s Destruction; Beginning of Birth Pains",
+      "header": "Verses 1–8 — The Temple’s Destruction; Beginning of Birth Pains",
       "verse_start": 1,
       "verse_end": 8,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c5\u03bd\u03c4\u03ad\u03bb\u03b5\u03b9\u03b1 \u03c4\u03bf\u1fe6 \u03b1\u1f30\u1ff6\u03bd\u03bf\u03c2",
-            "transliteration": "synteleia tou ai\u014dnos",
+            "word": "συντέλεια τοῦ αἰῶνος",
+            "transliteration": "synteleia tou aiōnos",
             "gloss": "end of the age",
-            "paragraph": "The disciples ask about the 'end of the age' (synteleia tou ai\u014dnos) \u2014 not the end of the world (kosmos) but the consummation of the present era. The distinction matters: Jesus speaks of transition between ages, not cosmic annihilation. The present age ends; a new age begins."
+            "paragraph": "The disciples ask about the 'end of the age' (synteleia tou aiōnos) — not the end of the world (kosmos) but the consummation of the present era. The distinction matters: Jesus speaks of transition between ages, not cosmic annihilation. The present age ends; a new age begins."
           },
           {
-            "word": "\u1f60\u03b4\u03af\u03bd",
-            "transliteration": "\u014ddin",
+            "word": "ὠδίν",
+            "transliteration": "ōdin",
             "gloss": "birth pain / labour pain",
-            "paragraph": "Wars and disasters are 'the beginning of birth pains' (\u014ddin\u014dn). The metaphor is precise: birth pains are intensely painful but purposeful \u2014 they produce new life. The suffering preceding the kingdom's arrival is not meaningless chaos but the travail of a new world being born."
+            "paragraph": "Wars and disasters are 'the beginning of birth pains' (ōdinōn). The metaphor is precise: birth pains are intensely painful but purposeful — they produce new life. The suffering preceding the kingdom's arrival is not meaningless chaos but the travail of a new world being born."
           }
         ],
         "tl": [
@@ -40,7 +40,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Olivet Discourse \u2014 this passage",
+            "name": "Olivet Discourse — this passage",
             "text": "\"Not one stone here will be left on another; every one will be thrown down.\" Fulfilled in AD 70 when Titus destroys Jerusalem and the Temple. The specific prediction grounds the eschatological discourse in verifiable historical fulfilment.",
             "current": true
           },
@@ -73,7 +73,7 @@
           {
             "name": "Mount of Olives",
             "coords": "East of Jerusalem; overlooking the Temple",
-            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley \u2014 \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
+            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley — \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
           }
         ],
         "cross": {
@@ -89,7 +89,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:1-14",
@@ -102,7 +102,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:4-14",
@@ -115,7 +115,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "24:15-16",
@@ -128,7 +128,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "24:1-28",
@@ -141,7 +141,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "24:1-14",
@@ -160,22 +160,22 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 9\u201328 \u2014 Persecution, Apostasy, the Abomination; False Messiahs",
+      "header": "Verses 9–28 — Persecution, Apostasy, the Abomination; False Messiahs",
       "verse_start": 9,
       "verse_end": 28,
       "panels": {
         "heb": [
           {
-            "word": "\u03b2\u03b4\u03ad\u03bb\u03c5\u03b3\u03bc\u03b1 \u03c4\u1fc6\u03c2 \u1f10\u03c1\u03b7\u03bc\u03ce\u03c3\u03b5\u03c9\u03c2",
-            "transliteration": "bdelygma t\u0113s er\u0113m\u014dse\u014ds",
+            "word": "βδέλυγμα τῆς ἐρημώσεως",
+            "transliteration": "bdelygma tēs erēmōseōs",
             "gloss": "abomination of desolation",
-            "paragraph": "From Daniel 9:27, 11:31, 12:11 \u2014 bdelygma is something that causes horror and disgust; er\u0113m\u014dsis is desolation, making a place uninhabitable. Historically fulfilled in 167 BC (Antiochus IV) and AD 70 (Roman destruction). Jesus applies it to a still-future desecration that signals the need for immediate flight."
+            "paragraph": "From Daniel 9:27, 11:31, 12:11 — bdelygma is something that causes horror and disgust; erēmōsis is desolation, making a place uninhabitable. Historically fulfilled in 167 BC (Antiochus IV) and AD 70 (Roman destruction). Jesus applies it to a still-future desecration that signals the need for immediate flight."
           },
           {
-            "word": "\u03c8\u03b5\u03c5\u03b4\u03cc\u03c7\u03c1\u03b9\u03c3\u03c4\u03bf\u03c2",
+            "word": "ψευδόχριστος",
             "transliteration": "pseudochristos",
             "gloss": "false christ / false messiah",
-            "paragraph": "Jesus warns of pseudochristoi \u2014 counterfeit messiahs. The prefix pseudo- does not mean 'obviously fake' but 'convincingly imitative.' The danger is not absurd claims but plausible ones. The true Christ's return will be unmistakable (like lightning, v.27), requiring no investigation."
+            "paragraph": "Jesus warns of pseudochristoi — counterfeit messiahs. The prefix pseudo- does not mean 'obviously fake' but 'convincingly imitative.' The danger is not absurd claims but plausible ones. The true Christ's return will be unmistakable (like lightning, v.27), requiring no investigation."
           }
         ],
         "tl": [
@@ -199,7 +199,7 @@
           },
           {
             "date": "Unknown",
-            "name": "The Son of Man's coming \u2014 this passage",
+            "name": "The Son of Man's coming — this passage",
             "text": "\"About that day or hour no one knows, not even the angels in heaven, nor the Son, but only the Father.\" The discourse refuses all date-setting. The response to uncertainty is not calculation but faithfulness: keep watch, be ready.",
             "current": true
           },
@@ -220,7 +220,7 @@
           {
             "name": "Mount of Olives",
             "coords": "East of Jerusalem; overlooking the Temple",
-            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley \u2014 \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
+            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley — \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
           }
         ],
         "cross": {
@@ -236,7 +236,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:29-35",
@@ -249,7 +249,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "24:42-44",
@@ -262,7 +262,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "24:27-31",
@@ -275,7 +275,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "24:29-51",
@@ -288,7 +288,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "24:36-44",
@@ -307,22 +307,22 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 29\u201344 \u2014 The Son of Man Coming; The Fig Tree; No One Knows",
+      "header": "Verses 29–44 — The Son of Man Coming; The Fig Tree; No One Knows",
       "verse_start": 29,
       "verse_end": 44,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b1\u03c1\u03bf\u03c5\u03c3\u03af\u03b1",
+            "word": "παρουσία",
             "transliteration": "parousia",
             "gloss": "coming / arrival / presence",
-            "paragraph": "Parousia means 'presence' or 'arrival' \u2014 used for the official visit of a king or dignitary. It is not merely Jesus' return but his royal manifestation \u2014 the moment when the king who was absent becomes present, visibly and incontestably. Four times in chapter 24 (vv.3, 27, 37, 39)."
+            "paragraph": "Parousia means 'presence' or 'arrival' — used for the official visit of a king or dignitary. It is not merely Jesus' return but his royal manifestation — the moment when the king who was absent becomes present, visibly and incontestably. Four times in chapter 24 (vv.3, 27, 37, 39)."
           },
           {
-            "word": "\u03b3\u03c1\u03b7\u03b3\u03bf\u03c1\u03ad\u03c9",
-            "transliteration": "gr\u0113gore\u014d",
+            "word": "γρηγορέω",
+            "transliteration": "grēgoreō",
             "gloss": "watch / stay awake / be vigilant",
-            "paragraph": "'Keep watch, because you do not know on what day your Lord will come.' The verb means literally to stay awake \u2014 to resist the drowsiness of routine and complacency. Vigilance is not anxiety but attentive readiness, the posture of a servant expecting the master's return."
+            "paragraph": "'Keep watch, because you do not know on what day your Lord will come.' The verb means literally to stay awake — to resist the drowsiness of routine and complacency. Vigilance is not anxiety but attentive readiness, the posture of a servant expecting the master's return."
           }
         ],
         "tl": [
@@ -334,7 +334,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Olivet Discourse \u2014 this passage",
+            "name": "Olivet Discourse — this passage",
             "text": "\"Not one stone here will be left on another; every one will be thrown down.\" Fulfilled in AD 70 when Titus destroys Jerusalem and the Temple. The specific prediction grounds the eschatological discourse in verifiable historical fulfilment.",
             "current": true
           },
@@ -367,7 +367,7 @@
           {
             "name": "Mount of Olives",
             "coords": "East of Jerusalem; overlooking the Temple",
-            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley \u2014 \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
+            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley — \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
           }
         ],
         "cross": {
@@ -383,69 +383,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:1-14",
-              "note": "MacArthur: The disciples' admiring comments about the Temple provoke Jesus's devastating prediction: not one stone will be left on another. The Temple, destroyed in AD 70, was the visible symbol of the Mosaic covenant order. The discourse that follows addresses both the near event (Jerusalem's fall) and the far event (the end of the age)."
-            },
-            {
-              "ref": "24:15-28",
-              "note": "MacArthur: The Abomination of Desolation, cited from Daniel, marks the discourse's turning point. When you see it, flee immediately -- no time to retrieve possessions. The urgency of the flight instruction implies a sudden, unmistakable, undeniable event. The false messiahs who appear in specific places (the desert, inner rooms) contrast with the Son of Man's coming, which will be as unmistakable as lightning."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:4-14",
-              "note": "Calvin on the birth pangs (odinon, v.8): the wars, famines, earthquakes, and persecutions are the beginning of birth pangs -- distressing but productive. The suffering of the church age is not meaningless; it is the pain that precedes the new creation. Those who endure to the end (v.13) will be saved -- the endurance is the evidence of genuine election, not the condition of earning salvation."
-            },
-            {
-              "ref": "24:36",
-              "note": "Calvin on 'no one knows the day or the hour' (v.36): not the angels, not even the Son in his human nature during his earthly ministry. The Father's timing is not revealed to any creature. Speculation about the date of the parousia is forbidden -- not from lack of curiosity but because God has deliberately withheld it to keep us in constant readiness."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:15-16",
-              "note": "The NET note on the Abomination of Desolation surveys three interpretive approaches: (1) already fulfilled in AD 70 (preterist); (2) two-stage fulfilment (AD 70 and future end-time); (3) exclusively future (dispensationalist). The note concludes that Matthew's 'let the reader understand' implies a fulfilment the reader should be able to identify -- supporting AD 70 as the primary referent."
-            },
-            {
-              "ref": "24:34",
-              "note": "The NET note on 'this generation will certainly not pass away until all these things have happened' discusses the most debated verse in the discourse. The note surveys the major options: (1) the contemporary generation (AD 70 fulfilment); (2) the generation alive at the end; (3) genea meaning race (Jewish people will survive). The natural meaning (contemporary generation) supports the AD 70 interpretation."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "24:1-28",
-              "note": "Robertson on the Olivet Discourse's opening: the disciples' admiring comment about the Temple buildings occasions Jesus's devastating prediction -- not one stone on another (v.2). On the four questions of v.3 (when? what sign? end of age?): Robertson notes the disciples conflate the Temple's destruction with the end of the age; Jesus's answer addresses both within a complex double-reference structure."
-            },
-            {
-              "ref": "24:15-28",
-              "note": "Robertson on the Abomination of Desolation (to bdelygma tes eremoseos, v.15): the phrase from Dan 9:27; 11:31; 12:11. Robertson notes 'let the reader understand' (v.15b) as the narrator's parenthetical -- the reader, not the disciples, is the audience for this aside. The interpretive options: Antiochus Epiphanes (167 BC), the Roman standards in the temple court (AD 70), or a future end-time event."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "24:1-14",
-              "note": "Chrysostom notes the disciples' conflation of the two questions -- Temple destruction and end of the age -- as the structural ambiguity Jesus's answer navigates. The signs of vv.4-14 are both the conditions of the Jewish War and the conditions of the entire church age."
-            },
-            {
-              "ref": "24:29-51",
-              "note": "The Catena traces the patristic reading of the Son of Man coming on the clouds (v.30, citing Dan 7:13) as the parousia. Chrysostom notes the distinction between the gradual signs that precede (vv.4-28) and the sudden, unmistakable coming (v.27: like lightning). The sudden coming requires no sign to identify it -- unlike the gradual developments that the disciples must interpret."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The Olivet Discourse (chs.24-25) is Matthew's fifth and final discourse. The first half addresses signs preceding the end: birth pains (wars, famines, persecution), the abomination, the great distress, and false messiahs. The discourse interweaves near fulfilment (Jerusalem, AD 70) and far fulfilment (the Son of Man's return) simultaneously."
@@ -454,16 +409,16 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 45\u201351 \u2014 The Faithful and Wise Servant",
+      "header": "Verses 45–51 — The Faithful and Wise Servant",
       "verse_start": 45,
       "verse_end": 51,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b9\u03c3\u03c4\u03cc\u03c2 \u03ba\u03b1\u1f76 \u03c6\u03c1\u03cc\u03bd\u03b9\u03bc\u03bf\u03c2",
+            "word": "πιστός καὶ φρόνιμος",
             "transliteration": "pistos kai phronimos",
             "gloss": "faithful and wise",
-            "paragraph": "The good servant is both pistos (faithful, trustworthy) and phronimos (wise, shrewd). Faithfulness without wisdom is bumbling; wisdom without faithfulness is self-serving. The master's commendation requires both \u2014 reliable character combined with intelligent stewardship."
+            "paragraph": "The good servant is both pistos (faithful, trustworthy) and phronimos (wise, shrewd). Faithfulness without wisdom is bumbling; wisdom without faithfulness is self-serving. The master's commendation requires both — reliable character combined with intelligent stewardship."
           }
         ],
         "tl": [
@@ -487,7 +442,7 @@
           },
           {
             "date": "Unknown",
-            "name": "The Son of Man's coming \u2014 this passage",
+            "name": "The Son of Man's coming — this passage",
             "text": "\"About that day or hour no one knows, not even the angels in heaven, nor the Son, but only the Father.\" The discourse refuses all date-setting. The response to uncertainty is not calculation but faithfulness: keep watch, be ready.",
             "current": true
           },
@@ -508,7 +463,7 @@
           {
             "name": "Mount of Olives",
             "coords": "East of Jerusalem; overlooking the Temple",
-            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley \u2014 \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
+            "text": "Jesus and the disciples sit on the Mount of Olives opposite the Temple. The Olivet Discourse is delivered with the Temple visible across the valley — \"Do you see all these things?\" The mountain's elevation and its view of the Temple grounds the eschatological discourse in a specific visible reality."
           }
         ],
         "cross": {
@@ -524,69 +479,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:29-35",
-              "note": "MacArthur: The coming of the Son of Man on the clouds (v.30, citing Dan 7:13) is accompanied by cosmic signs -- sun darkened, moon no light, stars falling. These apocalyptic images describe the collapse of the present world order. The generation that sees these things begins: MacArthur takes this as the generation alive at the end times, who will not pass away before the parousia."
-            },
-            {
-              "ref": "24:36-51",
-              "note": "MacArthur: No one knows the day or the hour -- not the angels, not even the Son in his human nature. The uncertainty is not a puzzle but a summons: therefore keep watch. The parable of the faithful and wicked servants defines what watching means: not passive waiting but faithful discharge of assigned responsibilities until the master returns."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "24:42-44",
-              "note": "Calvin on 'be ready, because the Son of Man will come at an hour when you do not expect him' (v.44): we are to live as those who may be called at any moment. The readiness that comes from constant faithfulness is more sustainable than the preparedness that waits for warning signs to appear."
-            },
-            {
-              "ref": "24:45-51",
-              "note": "Calvin on the faithful servant: the person who continues doing their duty without calculating whether the master will be pleased or will return in time to see it is the person whose faithfulness is genuine. The wicked servant reveals his character in the absence of the master: the presence was the only thing keeping him honest."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "24:27-31",
-              "note": "The NET note on 'as lightning comes from the east and flashes to the west' discusses the contrast with the false messiahs (vv.23-26) who appear in specific places. The parousia requires no special location or insiders' knowledge: it will be as unmistakable and universal as lightning."
-            },
-            {
-              "ref": "24:36",
-              "note": "The NET note on 'not even the Son' (oude ho huios, v.36) discusses the significant textual variant: some manuscripts omit this phrase (perhaps from concern about the implication for Christ's omniscience). The note supports the longer reading as original: Christ's human nature did not possess all the Father's knowledge during the incarnation, in accordance with the kenotic self-limitation of Phil 2:7."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "24:29-51",
-              "note": "Robertson on 'coming on the clouds of heaven with power and great glory' (v.30, echoing Dan 7:13): the Son of Man's coming is the climactic event the discourse has been building toward. On v.36 (no one knows the day or hour): Robertson notes this is the sharpest epistemological boundary in the discourse -- all the signs described do not amount to knowledge of the timing."
-            },
-            {
-              "ref": "24:42-51",
-              "note": "Robertson on the twin parables of readiness (the faithful and wicked servants, vv.45-51): the faithful servant is found doing his duty when the master returns. The servant who says 'my master is delayed' and begins to mistreat fellow servants reveals that the master's presence was the only thing keeping him honest. Delay does not license misconduct; readiness is active faithfulness, not passive waiting."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "24:36-44",
-              "note": "Chrysostom: God conceals the day of judgment so that we may live every day as if it were our last. If we knew the date, we would live carelessly until near the end. The uncertainty enforces constant readiness -- which is more valuable than any calculated preparation."
-            },
-            {
-              "ref": "24:45-51",
-              "note": "The Catena traces the patristic reading of the faithful and wicked servants as a portrait of church leaders. Chrysostom: the servant put in charge of the household is the bishop or presbyter entrusted with the community's care. The temptation is the same for all: to use the master's absence as an occasion for self-service."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The second half moves from signs to the Son of Man's unmistakable coming (vv.29-31), the fig tree lesson (vv.32-35), and the definitive unknown-timing statement (v.36). The Noah analogy is about surprise, not moral decline. The three applications (one taken, thief in the night, faithful servant) all make the same point: keep watch and do the master's work."
@@ -643,7 +553,7 @@
           "is_key": false
         },
         {
-          "label": "Be Ready: Faithfulness, Not Calculation \u2014 24:42-51",
+          "label": "Be Ready: Faithfulness, Not Calculation — 24:42-51",
           "text": "No one knows the day or hour -- not the angels, not even the Son. The uncertainty is the pedagogical point: readiness comes from constant faithfulness, not from calculated preparedness triggered by warning signs.",
           "is_key": false
         }

--- a/content/matthew/25.json
+++ b/content/matthew/25.json
@@ -7,28 +7,28 @@
   "subtitle": "Ten Virgins; The Talents; Sheep and Goats: Whatever You Did for the Least",
   "timeline_link": {
     "event_id": "temple-destruction-detail",
-    "text": "See on Timeline \u2014 Destruction of Jerusalem"
+    "text": "See on Timeline — Destruction of Jerusalem"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201313 \u2014 The Ten Virgins: Keep Watch",
+      "header": "Verses 1–13 — The Ten Virgins: Keep Watch",
       "verse_start": 1,
       "verse_end": 13,
       "panels": {
         "heb": [
           {
-            "word": "\u03c0\u03b1\u03c1\u03b8\u03ad\u03bd\u03bf\u03c2",
+            "word": "παρθένος",
             "transliteration": "parthenos",
             "gloss": "virgin / young woman",
-            "paragraph": "Ten 'virgins' (parthenoi) \u2014 bridesmaids waiting for the bridegroom's procession. The parable is about readiness, not moral perfection. Five are phronimoi (wise, prepared) and five are m\u014drai (foolish, unprepared). The oil cannot be shared \u2014 preparation for the kingdom is non-transferable."
+            "paragraph": "Ten 'virgins' (parthenoi) — bridesmaids waiting for the bridegroom's procession. The parable is about readiness, not moral perfection. Five are phronimoi (wise, prepared) and five are mōrai (foolish, unprepared). The oil cannot be shared — preparation for the kingdom is non-transferable."
           },
           {
-            "word": "\u03bd\u03c5\u03bc\u03c6\u03af\u03bf\u03c2",
+            "word": "νυμφίος",
             "transliteration": "nymphios",
             "gloss": "bridegroom",
-            "paragraph": "Jesus implicitly identifies himself as the bridegroom \u2014 a divine title in the OT (Isa 62:5, Hos 2:16). The bridegroom's delay tests the maidens' readiness. The parable's lesson is not 'the bridegroom is late' but 'are you ready whenever he arrives?'"
+            "paragraph": "Jesus implicitly identifies himself as the bridegroom — a divine title in the OT (Isa 62:5, Hos 2:16). The bridegroom's delay tests the maidens' readiness. The parable's lesson is not 'the bridegroom is late' but 'are you ready whenever he arrives?'"
           }
         ],
         "cross": {
@@ -44,7 +44,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "25:4",
@@ -61,7 +61,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "25:1-13",
@@ -74,7 +74,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "25:1-13",
@@ -87,7 +87,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "25:1-13",
@@ -100,7 +100,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "25:1-13",
@@ -119,22 +119,22 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 14\u201330 \u2014 The Parable of the Talents",
+      "header": "Verses 14–30 — The Parable of the Talents",
       "verse_start": 14,
       "verse_end": 30,
       "panels": {
         "heb": [
           {
-            "word": "\u03c4\u03ac\u03bb\u03b1\u03bd\u03c4\u03bf\u03bd",
+            "word": "τάλαντον",
             "transliteration": "talanton",
             "gloss": "talent / large sum of money",
-            "paragraph": "A talent was approximately 20 years' wages for a labourer \u2014 even one talent is a staggering sum. The master distributes 'according to each one's ability' (dynamis). Responsibility is proportional, not equal. The sin of the third servant is not failure but fear-driven inaction \u2014 burying what was entrusted."
+            "paragraph": "A talent was approximately 20 years' wages for a labourer — even one talent is a staggering sum. The master distributes 'according to each one's ability' (dynamis). Responsibility is proportional, not equal. The sin of the third servant is not failure but fear-driven inaction — burying what was entrusted."
           },
           {
-            "word": "\u1f40\u03ba\u03bd\u03b7\u03c1\u03cc\u03c2",
-            "transliteration": "okn\u0113ros",
+            "word": "ὀκνηρός",
+            "transliteration": "oknēros",
             "gloss": "lazy / slothful / timid",
-            "paragraph": "The master calls the third servant 'wicked and lazy' (pon\u0113ros kai okn\u0113ros). Okn\u0113ros means shrinking back, hesitant, sluggish. The parable equates timidity with wickedness \u2014 refusing to risk is not caution but unfaithfulness. Kingdom stewardship demands venture, not preservation."
+            "paragraph": "The master calls the third servant 'wicked and lazy' (ponēros kai oknēros). Oknēros means shrinking back, hesitant, sluggish. The parable equates timidity with wickedness — refusing to risk is not caution but unfaithfulness. Kingdom stewardship demands venture, not preservation."
           }
         ],
         "cross": {
@@ -150,7 +150,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "25:40",
@@ -167,7 +167,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "25:14-30",
@@ -180,7 +180,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "25:14-30",
@@ -193,7 +193,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "25:31-46",
@@ -206,7 +206,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "25:14-30",
@@ -225,22 +225,22 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 31\u201346 \u2014 The Sheep and the Goats: The Least of These",
+      "header": "Verses 31–46 — The Sheep and the Goats: The Least of These",
       "verse_start": 31,
       "verse_end": 46,
       "panels": {
         "heb": [
           {
-            "word": "\u1f10\u03bb\u03ac\u03c7\u03b9\u03c3\u03c4\u03bf\u03c2",
+            "word": "ἐλάχιστος",
             "transliteration": "elachistos",
             "gloss": "least / smallest / most insignificant",
-            "paragraph": "'Whatever you did for one of the least (elachistos) of these brothers and sisters of mine, you did for me.' Christ identifies with the most marginal \u2014 the hungry, thirsty, naked, sick, imprisoned. Service to the invisible is service to the invisible king. The final judgment is based not on theology but on mercy."
+            "paragraph": "'Whatever you did for one of the least (elachistos) of these brothers and sisters of mine, you did for me.' Christ identifies with the most marginal — the hungry, thirsty, naked, sick, imprisoned. Service to the invisible is service to the invisible king. The final judgment is based not on theology but on mercy."
           },
           {
-            "word": "\u03b1\u1f30\u03ce\u03bd\u03b9\u03bf\u03c2",
-            "transliteration": "ai\u014dnios",
+            "word": "αἰώνιος",
+            "transliteration": "aiōnios",
             "gloss": "eternal / age-long",
-            "paragraph": "Both 'eternal punishment' (kolasin ai\u014dnion) and 'eternal life' (z\u014d\u0113n ai\u014dnion) use the same adjective. Whatever ai\u014dnios means for one, it means for the other. The destinies are equally permanent. The parable's conclusion is the most solemn in all of Jesus' teaching."
+            "paragraph": "Both 'eternal punishment' (kolasin aiōnion) and 'eternal life' (zōēn aiōnion) use the same adjective. Whatever aiōnios means for one, it means for the other. The destinies are equally permanent. The parable's conclusion is the most solemn in all of Jesus' teaching."
           }
         ],
         "cross": {
@@ -256,73 +256,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:4",
-              "note": "The wise virgins had taken oil in jars. The oil cannot be shared -- whatever it represents (genuine readiness, formed character, real relationship with Christ) is irreversibly personal. Preparation must be done before the moment of reckoning; it cannot be borrowed at the last minute."
-            },
-            {
-              "ref": "25:21",
-              "note": "Well done, good and faithful servant. The most desired words in the gospel -- addressed to servants faithful with what they were given. Five-talent and two-talent servants receive identical commendation. Faithfulness is the criterion, not giftedness."
-            },
-            {
-              "ref": "25:25",
-              "note": "I was afraid and hid your gold. The unfaithful servant's motive is fear -- a wrong theology of God producing paralysis rather than risk-taking trust. Wrong theology of God always produces unfaithful stewardship."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "25:1-13",
-              "note": "Calvin: the chief thing required of Christ's servants is perseverance -- the readiness that survives an unexpected delay. The foolish virgins failed not because they slept but because they did not provision for the night. What we must be is provisioned for the long watch."
-            },
-            {
-              "ref": "25:31-46",
-              "note": "Calvin on the sheep-and-goats: Christ does not teach that we earn salvation by works of charity but that the charitable life is the evidence of the faith that saves. Those who are truly the Father's children show it by caring for their siblings. Works are the fruit, not the root, of salvation."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "25:1-13",
-              "note": "The NET note on the ten virgins discusses the ancient Jewish wedding custom: the bridegroom came at an unpredictable time, often late at night. The parable addresses the community that must maintain readiness through an indefinite delay."
-            },
-            {
-              "ref": "25:31-46",
-              "note": "The NET note on 'the least of these brothers and sisters of mine' (v.40) surveys the debate: does it refer to all the poor universally or specifically to Jesus's disciples? The note concludes that the specific reference to Jesus's disciples (missionaries) is most contextually supported, though the universal application is a legitimate secondary extension."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "25:1-13",
-              "note": "Robertson on the ten virgins: all ten fall asleep (v.5) -- the failure is not sleeping but arriving without oil. The wise virgins prepared for a delay; the foolish presumed prompt arrival. Robertson notes the shut door (he kleithe he thyra) as an aorist passive -- the door was shut permanently, not temporarily."
-            },
-            {
-              "ref": "25:14-30",
-              "note": "Robertson on the talents: the first servant receives five, the second two, the third one -- each kata ten idian dynamin (according to his own ability, v.15). The condemnation of the third servant is not for the small amount received but for burying it. The master's rebuke establishes that the minimum required was some use."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "25:1-13",
-              "note": "Chrysostom: the oil of good works cannot be borrowed -- the interior life of faith and charity cannot be transferred. The virgins who have oil cannot share it not from selfishness but because what has been accumulated through living cannot be handed over at the last moment."
-            },
-            {
-              "ref": "25:31-46",
-              "note": "The Catena traces the patristic importance of the sheep-and-goats for social ethics. Chrysostom's longest homilies develop this passage: whatever you did for the least of these makes Christ present in the hungry, thirsty, stranger, naked, sick, and imprisoned."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The two parables address watchful readiness and productive faithfulness -- two dimensions of eschatological posture. The virgins parable: are you ready when the moment comes? The talents parable: are you faithful in the interval? Together they answer \"what does keeping watch look like?\" -- not passive waiting but active, risk-taking faithfulness."
@@ -384,7 +335,7 @@
           "is_key": false
         },
         {
-          "label": "Whatever You Did: Christ in the Least \u2014 25:31-46",
+          "label": "Whatever You Did: Christ in the Least — 25:31-46",
           "text": "The surprise of both groups reveals that the judgment surfaces what was already real: those who saw Christ in the vulnerable and responded, and those who did not.",
           "is_key": false
         }
@@ -552,7 +503,7 @@
   "coaching": [
     {
       "after_section": 1,
-      "tip": "Ten virgins: five prepared, five not. The difference wasn't morality but readiness. Oil can't be borrowed; preparation is personal. 'I don't know you' (v. 12)\u2014relationship, not ritual, matters.",
+      "tip": "Ten virgins: five prepared, five not. The difference wasn't morality but readiness. Oil can't be borrowed; preparation is personal. 'I don't know you' (v. 12)—relationship, not ritual, matters.",
       "genre_tag": "close_reading"
     },
     {

--- a/content/matthew/26.json
+++ b/content/matthew/26.json
@@ -7,28 +7,28 @@
   "subtitle": "Anointing; Conspiracy; Last Supper; Gethsemane; Arrest; Trial; Denial",
   "timeline_link": {
     "event_id": "last-supper",
-    "text": "See on Timeline \u2014 Last Supper"
+    "text": "See on Timeline — Last Supper"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201316 \u2014 Anointing at Bethany; Judas Agrees to Betray",
+      "header": "Verses 1–16 — Anointing at Bethany; Judas Agrees to Betray",
       "verse_start": 1,
       "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "\u03bc\u03cd\u03c1\u03bf\u03bd",
+            "word": "μύρον",
             "transliteration": "myron",
             "gloss": "perfume / ointment / costly oil",
-            "paragraph": "The woman's 'very expensive perfume' (myron polytimos) poured on Jesus' head is an anointing \u2014 the act that makes a king (mashiach/christos = 'anointed one'). The disciples see waste; Jesus sees prophetic preparation for burial. The same act is simultaneously royal coronation and funeral preparation."
+            "paragraph": "The woman's 'very expensive perfume' (myron polytimos) poured on Jesus' head is an anointing — the act that makes a king (mashiach/christos = 'anointed one'). The disciples see waste; Jesus sees prophetic preparation for burial. The same act is simultaneously royal coronation and funeral preparation."
           },
           {
-            "word": "\u03c0\u03b1\u03c1\u03b1\u03b4\u03af\u03b4\u03c9\u03bc\u03b9",
-            "transliteration": "paradid\u014dmi",
+            "word": "παραδίδωμι",
+            "transliteration": "paradidōmi",
             "gloss": "betray / hand over",
-            "paragraph": "Judas 'handed over' Jesus for thirty silver coins \u2014 the price of a slave (Exod 21:32). Paradid\u014dmi runs through the passion: Judas hands Jesus to the priests, the priests hand him to Pilate, Pilate hands him to crucifixion. Each act of handing over is simultaneously human treachery and divine plan."
+            "paragraph": "Judas 'handed over' Jesus for thirty silver coins — the price of a slave (Exod 21:32). Paradidōmi runs through the passion: Judas hands Jesus to the priests, the priests hand him to Pilate, Pilate hands him to crucifixion. Each act of handing over is simultaneously human treachery and divine plan."
           }
         ],
         "tl": [
@@ -46,8 +46,8 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Two days before Passover \u2014 this passage",
-            "text": "\"You know that the Passover is two days away.\" The Passion narrative is anchored in the Jewish calendar. The anointing at Bethany occurs two days before Passover \u2014 Wednesday of Passion Week. Jesus identifies it as preparation for burial.",
+            "name": "Two days before Passover — this passage",
+            "text": "\"You know that the Passover is two days away.\" The Passion narrative is anchored in the Jewish calendar. The anointing at Bethany occurs two days before Passover — Wednesday of Passion Week. Jesus identifies it as preparation for burial.",
             "current": true
           },
           {
@@ -64,19 +64,19 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion (Friday \u2014 Passover day)",
+            "name": "Crucifixion (Friday — Passover day)",
             "text": "",
             "current": false
           }
         ],
         "poi": [
           {
-            "name": "Bethany \u2014 Simon's house",
+            "name": "Bethany — Simon's house",
             "coords": "Village east of Jerusalem",
-            "text": "The anointing happens at Bethany in Simon the leper's house \u2014 two days before Passover. Bethany is the final refuge before the Passion begins. The woman's extravagance (\"the whole house was filled with the fragrance\") contrasts with the disciples' calculation."
+            "text": "The anointing happens at Bethany in Simon the leper's house — two days before Passover. Bethany is the final refuge before the Passion begins. The woman's extravagance (\"the whole house was filled with the fragrance\") contrasts with the disciples' calculation."
           },
           {
-            "name": "Jerusalem \u2014 Passover preparations",
+            "name": "Jerusalem — Passover preparations",
             "coords": "City where the Last Supper occurs",
             "text": "\"Where do you want us to make preparations for you to eat the Passover?\" Jerusalem is the required location for the Passover. The upper room is in Jerusalem. The Last Supper, Gethsemane, the arrest, and the trials all occur within walking distance of each other."
           }
@@ -94,7 +94,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "26:7-13",
@@ -111,7 +111,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "26:26-29",
@@ -124,7 +124,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "26:26-28",
@@ -137,7 +137,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "26:1-16",
@@ -150,7 +150,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "26:6-13",
@@ -169,58 +169,58 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 17\u201335 \u2014 The Last Supper; Peter\u2019s Denial Predicted",
+      "header": "Verses 17–35 — The Last Supper; Peter’s Denial Predicted",
       "verse_start": 17,
       "verse_end": 35,
       "panels": {
         "heb": [
           {
-            "word": "\u03b4\u03b9\u03b1\u03b8\u03ae\u03ba\u03b7",
-            "transliteration": "diath\u0113k\u0113",
+            "word": "διαθήκη",
+            "transliteration": "diathēkē",
             "gloss": "covenant / testament",
-            "paragraph": "'This is my blood of the covenant (diath\u0113k\u0113), poured out for many for the forgiveness of sins.' Jesus reinterprets the Passover cup as a new covenant sealed in his own blood. Diath\u0113k\u0113 echoes Exodus 24:8 (Moses' covenant blood) and Jeremiah 31:31 (the promised new covenant). The Last Supper is Sinai rewritten."
+            "paragraph": "'This is my blood of the covenant (diathēkē), poured out for many for the forgiveness of sins.' Jesus reinterprets the Passover cup as a new covenant sealed in his own blood. Diathēkē echoes Exodus 24:8 (Moses' covenant blood) and Jeremiah 31:31 (the promised new covenant). The Last Supper is Sinai rewritten."
           },
           {
-            "word": "\u03c0\u03bf\u03c4\u03ae\u03c1\u03b9\u03bf\u03bd",
-            "transliteration": "pot\u0113rion",
+            "word": "ποτήριον",
+            "transliteration": "potērion",
             "gloss": "cup",
-            "paragraph": "The cup at the supper becomes the cup in Gethsemane \u2014 'let this cup pass from me.' The same word connects Eucharist and agony. What Jesus offers to his disciples at the table, he himself must drink in the garden. The cup of blessing is also the cup of suffering."
+            "paragraph": "The cup at the supper becomes the cup in Gethsemane — 'let this cup pass from me.' The same word connects Eucharist and agony. What Jesus offers to his disciples at the table, he himself must drink in the garden. The cup of blessing is also the cup of suffering."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Last Supper \u2014 Thursday evening",
+            "name": "Last Supper — Thursday evening",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Gethsemane prayer \u2014 late Thursday night \u2014 this passage",
-            "text": "\"Could you not keep watch with me for one hour?\" Gethsemane is Thursday night. The prayer, the betrayal, the arrest, the night trials before Annas and Caiaphas \u2014 all within Thursday night to Friday dawn. Peter's three denials occur before the cock crows at dawn.",
+            "name": "Gethsemane prayer — late Thursday night — this passage",
+            "text": "\"Could you not keep watch with me for one hour?\" Gethsemane is Thursday night. The prayer, the betrayal, the arrest, the night trials before Annas and Caiaphas — all within Thursday night to Friday dawn. Peter's three denials occur before the cock crows at dawn.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Trials before Pilate \u2014 Friday morning",
+            "name": "Trials before Pilate — Friday morning",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion \u2014 Friday 9am to 3pm",
+            "name": "Crucifixion — Friday 9am to 3pm",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Burial \u2014 Friday before sunset (Sabbath begins)",
+            "name": "Burial — Friday before sunset (Sabbath begins)",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Resurrection \u2014 Sunday dawn",
+            "name": "Resurrection — Sunday dawn",
             "text": "",
             "current": false
           }
@@ -229,7 +229,7 @@
           {
             "name": "Gethsemane",
             "coords": "Garden at the foot of the Mount of Olives",
-            "text": "Gethsemane (\"olive press\") is at the base of the Mount of Olives \u2014 the route Jesus walks after the Last Supper. The garden is where the will is submitted: \"not as I will, but as you will.\" The geography of the prayer is intimate and private; the geography of the arrest is public and violent."
+            "text": "Gethsemane (\"olive press\") is at the base of the Mount of Olives — the route Jesus walks after the Last Supper. The garden is where the will is submitted: \"not as I will, but as you will.\" The geography of the prayer is intimate and private; the geography of the arrest is public and violent."
           },
           {
             "name": "Caiaphas's house",
@@ -250,7 +250,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "26:39",
@@ -267,7 +267,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "26:63-65",
@@ -280,7 +280,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "26:57-67",
@@ -293,7 +293,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "26:47-75",
@@ -306,7 +306,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "26:57-68",
@@ -325,22 +325,22 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 36\u201356 \u2014 Gethsemane; The Arrest",
+      "header": "Verses 36–56 — Gethsemane; The Arrest",
       "verse_start": 36,
       "verse_end": 56,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03b3\u03c9\u03bd\u03af\u03b1",
-            "transliteration": "ag\u014dnia",
+            "word": "ἀγωνία",
+            "transliteration": "agōnia",
             "gloss": "agony / anguish / intense struggle",
-            "paragraph": "In Gethsemane, Jesus is 'deeply distressed' (perilypos \u2014 surrounded by grief). The emotional vocabulary is extreme: grieved, troubled, overwhelmed. The Son who always does the Father's will (v.39) genuinely dreads what comes. Obedience is not the absence of resistance but the overcoming of it."
+            "paragraph": "In Gethsemane, Jesus is 'deeply distressed' (perilypos — surrounded by grief). The emotional vocabulary is extreme: grieved, troubled, overwhelmed. The Son who always does the Father's will (v.39) genuinely dreads what comes. Obedience is not the absence of resistance but the overcoming of it."
           },
           {
-            "word": "\u03b8\u03ad\u03bb\u03b7\u03bc\u03b1",
-            "transliteration": "thel\u0113ma",
+            "word": "θέλημα",
+            "transliteration": "thelēma",
             "gloss": "will / desire / purpose",
-            "paragraph": "'Not as I will (thel\u014d) but as you will (thel\u0113ma).' The Gethsemane prayer reveals two genuine wills \u2014 Jesus' human desire to avoid suffering and the Father's redemptive purpose. Obedience means aligning the human will with the divine when they conflict. This is the model for all Christian prayer."
+            "paragraph": "'Not as I will (thelō) but as you will (thelēma).' The Gethsemane prayer reveals two genuine wills — Jesus' human desire to avoid suffering and the Father's redemptive purpose. Obedience means aligning the human will with the divine when they conflict. This is the model for all Christian prayer."
           }
         ],
         "tl": [
@@ -358,8 +358,8 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Two days before Passover \u2014 this passage",
-            "text": "\"You know that the Passover is two days away.\" The Passion narrative is anchored in the Jewish calendar. The anointing at Bethany occurs two days before Passover \u2014 Wednesday of Passion Week. Jesus identifies it as preparation for burial.",
+            "name": "Two days before Passover — this passage",
+            "text": "\"You know that the Passover is two days away.\" The Passion narrative is anchored in the Jewish calendar. The anointing at Bethany occurs two days before Passover — Wednesday of Passion Week. Jesus identifies it as preparation for burial.",
             "current": true
           },
           {
@@ -376,19 +376,19 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion (Friday \u2014 Passover day)",
+            "name": "Crucifixion (Friday — Passover day)",
             "text": "",
             "current": false
           }
         ],
         "poi": [
           {
-            "name": "Bethany \u2014 Simon's house",
+            "name": "Bethany — Simon's house",
             "coords": "Village east of Jerusalem",
-            "text": "The anointing happens at Bethany in Simon the leper's house \u2014 two days before Passover. Bethany is the final refuge before the Passion begins. The woman's extravagance (\"the whole house was filled with the fragrance\") contrasts with the disciples' calculation."
+            "text": "The anointing happens at Bethany in Simon the leper's house — two days before Passover. Bethany is the final refuge before the Passion begins. The woman's extravagance (\"the whole house was filled with the fragrance\") contrasts with the disciples' calculation."
           },
           {
-            "name": "Jerusalem \u2014 Passover preparations",
+            "name": "Jerusalem — Passover preparations",
             "coords": "City where the Last Supper occurs",
             "text": "\"Where do you want us to make preparations for you to eat the Passover?\" Jerusalem is the required location for the Passover. The upper room is in Jerusalem. The Last Supper, Gethsemane, the arrest, and the trials all occur within walking distance of each other."
           }
@@ -406,73 +406,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:7-13",
-              "note": "The anointing woman. Her act is extravagant and prophetic -- she does not know she is preparing Jesus for burial. The disciples' objection (waste) is met by commendation: she has done something beautiful and memorial. Her story has been told everywhere the gospel has gone -- for two thousand years."
-            },
-            {
-              "ref": "26:28",
-              "note": "Blood of the covenant, poured out for many for the forgiveness of sins. Three prepositional phrases: covenant ratification, substitutionary scope, redemptive purpose. The theology of atonement in miniature."
-            },
-            {
-              "ref": "26:35",
-              "note": "Even if I have to die with you, I will never disown you. Peter's boast is sincere and wrong. He will disown Jesus three times before dawn. Matthew's portrait of the disciples at table: confident, ignorant of what they are about to do."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:26-29",
-              "note": "Calvin on 'this is my body': Christ does not say the bread becomes his body but that the bread is the sign and pledge of his body. The presence is real -- Christ is truly present in the Supper -- but the presence is spiritual, received by faith. The Catholic doctrine of transubstantiation confounds the sign with the thing signified."
-            },
-            {
-              "ref": "26:36-46",
-              "note": "Calvin on Gethsemane: his horror at death was the genuine experience of the wrath of God against sin. He was not merely afraid of physical death but of the spiritual death -- separation from the Father -- that the cup contained. This is what makes the cross a real atonement: he bore the punishment sin deserved, including its darkest dimension."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "26:26-28",
-              "note": "The NET note on 'this is my body / blood of the covenant' surveys the eucharistic interpretation debate: real presence (Lutheran, Catholic), spiritual presence (Reformed), memorial (Zwinglian). The note traces the OT covenant-blood background (Exod 24:8) and the new covenant promise (Jer 31:31-34), concluding that Jesus identifies his death as the ratifying event of the new covenant."
-            },
-            {
-              "ref": "26:36-46",
-              "note": "The NET note on Gethsemane traces the cup (to poterion) as the OT image of divine judgment (Isa 51:17-23; Jer 25:15-29; Ps 75:8). Jesus's prayer asks whether the judgment-cup can pass -- the weight is the genuine bearing of God's judgment against sin, not physical cowardice."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "26:1-16",
-              "note": "Robertson on the anointing at Bethany: the woman's act is described as eis mnemosynon autes (for her memorial, v.13) -- the only case in the gospels where Jesus guarantees that someone's act will be remembered wherever the gospel is proclaimed. The act of wasteful devotion is permanently enshrined in the story of the kingdom."
-            },
-            {
-              "ref": "26:17-35",
-              "note": "Robertson on the Last Supper's eucharistic formula: touto estin to soma mou (this is my body) and touto estin to haima mou tes diathekes (this is my blood of the covenant). Robertson traces diatheke (covenant) through LXX usage: Jesus identifies his blood as the new covenant's ratifying blood (cf. Jer 31:31-34; Exod 24:8)."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "26:6-13",
-              "note": "Chrysostom: while the disciples debate waste (it could have been sold and given to the poor), she performs an act of devotion that transcends their calculus. True worship cannot always be reduced to its most efficient alternative use. The kingdom includes the extravagant act done purely for love."
-            },
-            {
-              "ref": "26:36-56",
-              "note": "The Catena traces the theology of Gethsemane: Jesus's prayer ('let this cup pass, yet not as I will but as you will', v.39) is the text for the doctrine of Christ's human will. Maximus the Confessor developed the Gethsemane prayer as the foundation for asserting Christ's real human will genuinely submitted to the divine will. Monotheletism is refuted by this prayer."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The first half moves through six scenes: the plot (vv.1-5), the anointing (vv.6-13), Judas's bargain (vv.14-16), the Last Supper (vv.17-29), prediction of scattering (vv.30-32), and Peter's boast (vv.33-35). The chapter's deepest irony: the highest act of worship (the unnamed woman's anointing) and the deepest betrayal (Judas's bargain) are placed side by side."
@@ -481,52 +432,52 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 57\u201375 \u2014 Before Caiaphas; Peter\u2019s Three Denials",
+      "header": "Verses 57–75 — Before Caiaphas; Peter’s Three Denials",
       "verse_start": 57,
       "verse_end": 75,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03c1\u03bd\u03ad\u03bf\u03bc\u03b1\u03b9",
+            "word": "ἀρνέομαι",
             "transliteration": "arneomai",
             "gloss": "deny / disown / refuse to acknowledge",
-            "paragraph": "Peter's threefold denial uses arneomai \u2014 the opposite of homologe\u014d (confess). In 10:33, Jesus warned: 'whoever disowns (arneomai) me before others, I will disown before my Father.' Peter does exactly what he swore he would not do. The rooster's crow becomes the sound of self-knowledge."
+            "paragraph": "Peter's threefold denial uses arneomai — the opposite of homologeō (confess). In 10:33, Jesus warned: 'whoever disowns (arneomai) me before others, I will disown before my Father.' Peter does exactly what he swore he would not do. The rooster's crow becomes the sound of self-knowledge."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Last Supper \u2014 Thursday evening",
+            "name": "Last Supper — Thursday evening",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Gethsemane prayer \u2014 late Thursday night \u2014 this passage",
-            "text": "\"Could you not keep watch with me for one hour?\" Gethsemane is Thursday night. The prayer, the betrayal, the arrest, the night trials before Annas and Caiaphas \u2014 all within Thursday night to Friday dawn. Peter's three denials occur before the cock crows at dawn.",
+            "name": "Gethsemane prayer — late Thursday night — this passage",
+            "text": "\"Could you not keep watch with me for one hour?\" Gethsemane is Thursday night. The prayer, the betrayal, the arrest, the night trials before Annas and Caiaphas — all within Thursday night to Friday dawn. Peter's three denials occur before the cock crows at dawn.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Trials before Pilate \u2014 Friday morning",
+            "name": "Trials before Pilate — Friday morning",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion \u2014 Friday 9am to 3pm",
+            "name": "Crucifixion — Friday 9am to 3pm",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Burial \u2014 Friday before sunset (Sabbath begins)",
+            "name": "Burial — Friday before sunset (Sabbath begins)",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Resurrection \u2014 Sunday dawn",
+            "name": "Resurrection — Sunday dawn",
             "text": "",
             "current": false
           }
@@ -535,7 +486,7 @@
           {
             "name": "Gethsemane",
             "coords": "Garden at the foot of the Mount of Olives",
-            "text": "Gethsemane (\"olive press\") is at the base of the Mount of Olives \u2014 the route Jesus walks after the Last Supper. The garden is where the will is submitted: \"not as I will, but as you will.\" The geography of the prayer is intimate and private; the geography of the arrest is public and violent."
+            "text": "Gethsemane (\"olive press\") is at the base of the Mount of Olives — the route Jesus walks after the Last Supper. The garden is where the will is submitted: \"not as I will, but as you will.\" The geography of the prayer is intimate and private; the geography of the arrest is public and violent."
           },
           {
             "name": "Caiaphas's house",
@@ -556,73 +507,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:39",
-              "note": "Not as I will, but as you will. The most transparent moment in Matthew's portrayal of Jesus. The agony is real, not theatrical. He knows what the cup contains. The \"yet\" is the hinge of salvation history."
-            },
-            {
-              "ref": "26:64",
-              "note": "From now on you will see the Son of Man sitting at the right hand of the Mighty One. The most explicit Christological claim in the gospel, made under oath before the Sanhedrin. Combines Ps 110:1 and Dan 7:13. Either blasphemy or truth -- no middle option."
-            },
-            {
-              "ref": "26:75",
-              "note": "Peter wept bitterly. The most devastating sentence in ch.26. The bitter weeping is contrition, not despair. It is the beginning of the road back. Peter's failure and his tears are the portrait of every disciple."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "26:63-65",
-              "note": "Calvin on the blasphemy charge: when the high priest asks if Jesus is the Christ the Son of God, the Sanhedrin is right that a mere man making this claim would be guilty of blasphemy. They are wrong only in their assumption that he is a mere man. This claim is either blasphemy or it is the gospel."
-            },
-            {
-              "ref": "26:69-75",
-              "note": "Calvin on Peter's denial: it was permitted that Peter should fall deeply so that he should rise more firmly. His fall revealed the self-confidence that needed to be broken. The weeping that followed is the beginning of genuine humility -- the apostle who would lead the church was first made to know what he was without divine support."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "26:57-67",
-              "note": "The NET note on the Sanhedrin trial discusses the legal problems: night trials were prohibited by the Mishnah; witnesses had to agree; the accused could not condemn himself. The note surveys whether these Mishnaic prohibitions were in force in the first century."
-            },
-            {
-              "ref": "26:69-75",
-              "note": "The NET note on Peter's denial traces his geographic movement: from inside the courtyard to the gateway (v.71) to outside (v.75). The outward movement corresponds to the escalation of the denial."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "26:47-75",
-              "note": "Robertson on Peter's denial: the threefold denial is marked by escalation -- first a simple denial, then with an oath, then with a curse and an oath. Robertson notes anemnesthes (he remembered) is an aorist -- the memory was sudden. Peter went outside and wept bitterly (pikros eklaien) -- the adverb pikros marks the grief of genuine remorse."
-            },
-            {
-              "ref": "26:57-68",
-              "note": "Robertson on the trial: the blasphemy charge follows Jesus's self-identification as the Son of Man seated at the right hand and coming on the clouds (v.64, citing Ps 110:1 and Dan 7:13). This is the culmination of Jesus's identity disclosure: before the Sanhedrin, under oath, he makes the claim the entire gospel has been building toward."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "26:57-68",
-              "note": "The Catena: the false witnesses are inconsistent and the high priest cannot build a case from them. Only when Jesus speaks on oath does the trial resolve. Chrysostom: he is condemned for telling the truth about himself -- the ultimate irony of the passion."
-            },
-            {
-              "ref": "26:69-75",
-              "note": "Chrysostom on Peter's denial: the one who denied three times with oaths and curses became the one who preached three thousand to baptism at Pentecost. The Lord's foreknowledge of the denial and his prayer for Peter (Luke 22:32) transformed the failure into the foundation for the church's pastor."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The second half holds together Gethsemane (vv.36-46), the arrest (vv.47-56), the Sanhedrin trial (vv.57-68), and Peter's denial (vv.69-75). The structural parallel is precise: Jesus prays \"not my will\" three times; Peter denies \"I don't know the man\" three times. Perfect obedience and perfect failure are simultaneous."
@@ -689,7 +591,7 @@
           "is_key": false
         },
         {
-          "label": "Gethsemane: The Will Submitted \u2014 26:36-46",
+          "label": "Gethsemane: The Will Submitted — 26:36-46",
           "text": "Let this cup pass -- yet not as I will but as you will. The three returns to prayer are the pattern of sustained intercession. The cup is the OT judgment-cup, not merely physical death.",
           "is_key": false
         }
@@ -867,7 +769,7 @@
     },
     {
       "after_section": 4,
-      "tip": "'If it is possible, may this cup be taken from me. Yet not as I will, but as you will' (v. 39). Gethsemane reveals genuine agony\u2014not playacting. Jesus dreads the cross yet submits. Obedience through anguish.",
+      "tip": "'If it is possible, may this cup be taken from me. Yet not as I will, but as you will' (v. 39). Gethsemane reveals genuine agony—not playacting. Jesus dreads the cross yet submits. Obedience through anguish.",
       "genre_tag": "close_reading"
     }
   ]

--- a/content/matthew/27.json
+++ b/content/matthew/27.json
@@ -7,25 +7,25 @@
   "subtitle": "Judas; Pilate; Barabbas; Mocking; Crucifixion; The Dereliction; Curtain Torn; Burial",
   "timeline_link": {
     "event_id": "crucifixion",
-    "text": "See on Timeline \u2014 Crucifixion"
+    "text": "See on Timeline — Crucifixion"
   },
   "map_story_link": null,
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1\u201326 \u2014 Before Pilate; Judas\u2019 Remorse; Barabbas Released",
+      "header": "Verses 1–26 — Before Pilate; Judas’ Remorse; Barabbas Released",
       "verse_start": 1,
       "verse_end": 26,
       "panels": {
         "heb": [
           {
-            "word": "\u1f00\u03b8\u1ff7\u03bf\u03c2",
-            "transliteration": "ath\u014dos",
+            "word": "ἀθῷος",
+            "transliteration": "athōos",
             "gloss": "innocent / not guilty",
-            "paragraph": "Pilate declares Jesus 'innocent' (ath\u014dos \u2014 without fault) but hands him over anyway. Judas returns the silver saying 'I have betrayed innocent (ath\u014don) blood.' Both the judge and the betrayer acknowledge Jesus' innocence, yet neither prevents the execution. The passion narrative is a study in moral cowardice."
+            "paragraph": "Pilate declares Jesus 'innocent' (athōos — without fault) but hands him over anyway. Judas returns the silver saying 'I have betrayed innocent (athōon) blood.' Both the judge and the betrayer acknowledge Jesus' innocence, yet neither prevents the execution. The passion narrative is a study in moral cowardice."
           },
           {
-            "word": "\u03b2\u03b1\u03c1\u03b1\u03b2\u03b2\u1fb6\u03c2",
+            "word": "βαραββᾶς",
             "transliteration": "Barabbas",
             "gloss": "Barabbas (son of the father)",
             "paragraph": "The name bar-abba means 'son of the father.' The crowd chooses Bar-Abbas (a human 'son of the father') over Jesus (the divine Son of the Father). The substitution is ironically precise: the guilty son of a father goes free; the innocent Son of the Father goes to the cross."
@@ -34,25 +34,25 @@
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Gethsemane arrest \u2014 Thursday night",
+            "name": "Gethsemane arrest — Thursday night",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Night trial before Caiaphas \u2014 Thursday night",
+            "name": "Night trial before Caiaphas — Thursday night",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Morning \u2014 council reconvenes; handed to Pilate \u2014 this passage",
-            "text": "\"Early in the morning\" \u2014 Friday dawn. The formal Sanhedrin condemnation and handover to Pilate occurs at first light. Judas's remorse and suicide happen the same morning. The chronology is tight: condemnation by dawn, crucifixion by 9am.",
+            "name": "Morning — council reconvenes; handed to Pilate — this passage",
+            "text": "\"Early in the morning\" — Friday dawn. The formal Sanhedrin condemnation and handover to Pilate occurs at first light. Judas's remorse and suicide happen the same morning. The chronology is tight: condemnation by dawn, crucifixion by 9am.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion \u2014 9am (Mark 15:25)",
+            "name": "Crucifixion — 9am (Mark 15:25)",
             "text": "",
             "current": false
           },
@@ -73,12 +73,12 @@
           {
             "name": "Praetorium",
             "coords": "Pilate's Jerusalem headquarters; probably Herod's palace",
-            "text": "Jesus is taken to Pilate's headquarters \u2014 either the Antonia Fortress or Herod's palace. The Roman governor's praetorium is where secular imperial power exercises its judgment on the covenant's Messiah. The mocking by soldiers occurs in this military-administrative space."
+            "text": "Jesus is taken to Pilate's headquarters — either the Antonia Fortress or Herod's palace. The Roman governor's praetorium is where secular imperial power exercises its judgment on the covenant's Messiah. The mocking by soldiers occurs in this military-administrative space."
           },
           {
             "name": "Judas at the Temple",
             "coords": "Temple treasury",
-            "text": "Judas returns the thirty pieces of silver to the Temple \u2014 the priests use it to buy the Potter's Field. The silver moves from betrayal to Temple treasury to burial ground in three locations, each fulfilling Zechariah's prophecy."
+            "text": "Judas returns the thirty pieces of silver to the Temple — the priests use it to buy the Potter's Field. The silver moves from betrayal to Temple treasury to burial ground in three locations, each fulfilling Zechariah's prophecy."
           }
         ],
         "cross": {
@@ -94,7 +94,7 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "27:3-4",
@@ -111,7 +111,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "27:24-25",
@@ -124,7 +124,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "27:24-25",
@@ -137,7 +137,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "27:1-31",
@@ -150,7 +150,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "27:3-10",
@@ -169,20 +169,20 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 27\u201344 \u2014 The Mocking; The Crucifixion",
+      "header": "Verses 27–44 — The Mocking; The Crucifixion",
       "verse_start": 27,
       "verse_end": 44,
       "panels": {
         "heb": [
           {
-            "word": "\u03c3\u03c4\u03b1\u03c5\u03c1\u03cc\u03c9",
-            "transliteration": "stauro\u014d",
+            "word": "σταυρόω",
+            "transliteration": "stauroō",
             "gloss": "crucify / impale on a cross",
-            "paragraph": "Matthew's account is restrained \u2014 'they crucified him' without graphic detail. Stauro\u014d was so well understood by ancient readers that elaboration was unnecessary. The horror lay not in the physical description but in the theological reality: the Messiah on a Roman instrument of shame."
+            "paragraph": "Matthew's account is restrained — 'they crucified him' without graphic detail. Stauroō was so well understood by ancient readers that elaboration was unnecessary. The horror lay not in the physical description but in the theological reality: the Messiah on a Roman instrument of shame."
           },
           {
-            "word": "\u03b2\u03b1\u03c3\u03b9\u03bb\u03b5\u03cd\u03c2 \u03c4\u1ff6\u03bd \u1f38\u03bf\u03c5\u03b4\u03b1\u03af\u03c9\u03bd",
-            "transliteration": "basileus t\u014dn Ioudai\u014dn",
+            "word": "βασιλεύς τῶν Ἰουδαίων",
+            "transliteration": "basileus tōn Ioudaiōn",
             "gloss": "King of the Jews",
             "paragraph": "The inscription 'This is Jesus, the King of the Jews' is intended as mockery but functions as proclamation. The soldiers dress Jesus in royal colours, give him a crown (of thorns) and a sceptre (a reed). Every act of ridicule accidentally speaks the truth. He is exactly what they mock him for claiming to be."
           }
@@ -190,19 +190,19 @@
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Handed to Pilate \u2014 Friday morning",
+            "name": "Handed to Pilate — Friday morning",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion begins \u2014 Friday 9am",
+            "name": "Crucifixion begins — Friday 9am",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Darkness, dereliction, death \u2014 noon-3pm \u2014 this passage",
+            "name": "Darkness, dereliction, death — noon-3pm — this passage",
             "text": "\"From noon until three in the afternoon darkness came over all the land.\" The six-hour crucifixion ends with the cry of dereliction and the tearing of the Temple veil. The darkness and earthquake are dateable cosmological events accompanying the covenant's climax.",
             "current": true
           },
@@ -214,7 +214,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Resurrection \u2014 Sunday dawn",
+            "name": "Resurrection — Sunday dawn",
             "text": "",
             "current": false
           },
@@ -229,12 +229,12 @@
           {
             "name": "Golgotha",
             "coords": "Outside Jerusalem walls; \"Place of the Skull\"",
-            "text": "Golgotha (\"Place of the Skull\") is outside Jerusalem's walls \u2014 criminals were executed outside the city. The traditional site (Church of the Holy Sepulchre) is within the current Old City walls but was outside the first-century walls. Crucifixion happened in a public visible location."
+            "text": "Golgotha (\"Place of the Skull\") is outside Jerusalem's walls — criminals were executed outside the city. The traditional site (Church of the Holy Sepulchre) is within the current Old City walls but was outside the first-century walls. Crucifixion happened in a public visible location."
           },
           {
             "name": "Joseph's tomb",
             "coords": "Near Golgotha; a garden tomb",
-            "text": "The tomb is newly hewn, belonging to Joseph of Arimathea \u2014 a rich man's tomb near the execution site. The proximity of tomb to cross means the burial happens quickly before Sabbath. The garden setting (John 19:41) and the rolling stone create the geography of the resurrection morning."
+            "text": "The tomb is newly hewn, belonging to Joseph of Arimathea — a rich man's tomb near the execution site. The proximity of tomb to cross means the burial happens quickly before Sabbath. The garden setting (John 19:41) and the rolling stone create the geography of the resurrection morning."
           }
         ],
         "cross": {
@@ -253,14 +253,14 @@
               "source_ref": "Psalm 69:21",
               "target_ref": "Matthew 27:34, 48",
               "type": "allusion",
-              "source_context": "The psalmist laments: 'They put gall in my food and gave me vinegar for my thirst.' This is mockery \u2014 offering bitter drink to one who suffers.",
+              "source_context": "The psalmist laments: 'They put gall in my food and gave me vinegar for my thirst.' This is mockery — offering bitter drink to one who suffers.",
               "connection": "At the crucifixion, Jesus is offered wine mixed with gall, and later vinegar on a sponge. The Gospel writers see these details as fulfilling the righteous sufferer's lament.",
               "significance": "The passion narratives are saturated with psalm allusions. Every detail of Jesus' suffering has been anticipated in Israel's prayers. He dies the death of the righteous sufferer."
             }
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
               "ref": "27:42",
@@ -277,7 +277,7 @@
           ]
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
               "ref": "27:51",
@@ -290,7 +290,7 @@
           ]
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
               "ref": "27:51-53",
@@ -303,7 +303,7 @@
           ]
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
           "notes": [
             {
               "ref": "27:50-66",
@@ -316,7 +316,7 @@
           ]
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
           "notes": [
             {
               "ref": "27:51-53",
@@ -335,46 +335,46 @@
     },
     {
       "section_num": 3,
-      "header": "Verses 45\u201356 \u2014 The Death of Jesus; The Curtain Torn; The Saints Raised",
+      "header": "Verses 45–56 — The Death of Jesus; The Curtain Torn; The Saints Raised",
       "verse_start": 45,
       "verse_end": 56,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03b1\u03c4\u03b1\u03c0\u03ad\u03c4\u03b1\u03c3\u03bc\u03b1",
+            "word": "καταπέτασμα",
             "transliteration": "katapetasma",
             "gloss": "curtain / veil",
-            "paragraph": "The temple curtain tore 'from top to bottom' \u2014 the direction matters. Top to bottom means God tore it, not human hands. The curtain separated the Holy of Holies (God's presence) from everything else. Its tearing means access to God is now open \u2014 the barrier between divine and human is removed by Jesus' death."
+            "paragraph": "The temple curtain tore 'from top to bottom' — the direction matters. Top to bottom means God tore it, not human hands. The curtain separated the Holy of Holies (God's presence) from everything else. Its tearing means access to God is now open — the barrier between divine and human is removed by Jesus' death."
           },
           {
-            "word": "\u03c5\u1f31\u1f78\u03c2 \u03b8\u03b5\u03bf\u1fe6",
+            "word": "υἱὸς θεοῦ",
             "transliteration": "huios theou",
             "gloss": "Son of God",
-            "paragraph": "The centurion's confession \u2014 'Surely he was the Son of God' \u2014 is the Gospel's climactic christological declaration. A Roman soldier, a Gentile, at the cross says what Israel's leaders refused to say. The irony is total: the confession comes at the moment of apparent defeat, from the least expected person."
+            "paragraph": "The centurion's confession — 'Surely he was the Son of God' — is the Gospel's climactic christological declaration. A Roman soldier, a Gentile, at the cross says what Israel's leaders refused to say. The irony is total: the confession comes at the moment of apparent defeat, from the least expected person."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Gethsemane arrest \u2014 Thursday night",
+            "name": "Gethsemane arrest — Thursday night",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Night trial before Caiaphas \u2014 Thursday night",
+            "name": "Night trial before Caiaphas — Thursday night",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Morning \u2014 council reconvenes; handed to Pilate \u2014 this passage",
-            "text": "\"Early in the morning\" \u2014 Friday dawn. The formal Sanhedrin condemnation and handover to Pilate occurs at first light. Judas's remorse and suicide happen the same morning. The chronology is tight: condemnation by dawn, crucifixion by 9am.",
+            "name": "Morning — council reconvenes; handed to Pilate — this passage",
+            "text": "\"Early in the morning\" — Friday dawn. The formal Sanhedrin condemnation and handover to Pilate occurs at first light. Judas's remorse and suicide happen the same morning. The chronology is tight: condemnation by dawn, crucifixion by 9am.",
             "current": true
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion \u2014 9am (Mark 15:25)",
+            "name": "Crucifixion — 9am (Mark 15:25)",
             "text": "",
             "current": false
           },
@@ -395,12 +395,12 @@
           {
             "name": "Praetorium",
             "coords": "Pilate's Jerusalem headquarters; probably Herod's palace",
-            "text": "Jesus is taken to Pilate's headquarters \u2014 either the Antonia Fortress or Herod's palace. The Roman governor's praetorium is where secular imperial power exercises its judgment on the covenant's Messiah. The mocking by soldiers occurs in this military-administrative space."
+            "text": "Jesus is taken to Pilate's headquarters — either the Antonia Fortress or Herod's palace. The Roman governor's praetorium is where secular imperial power exercises its judgment on the covenant's Messiah. The mocking by soldiers occurs in this military-administrative space."
           },
           {
             "name": "Judas at the Temple",
             "coords": "Temple treasury",
-            "text": "Judas returns the thirty pieces of silver to the Temple \u2014 the priests use it to buy the Potter's Field. The silver moves from betrayal to Temple treasury to burial ground in three locations, each fulfilling Zechariah's prophecy."
+            "text": "Judas returns the thirty pieces of silver to the Temple — the priests use it to buy the Potter's Field. The silver moves from betrayal to Temple treasury to burial ground in three locations, each fulfilling Zechariah's prophecy."
           }
         ],
         "cross": {
@@ -416,73 +416,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:3-4",
-              "note": "I have sinned, for I have betrayed innocent blood. Judas's confession is accurate and sincere -- but it goes to the wrong place and receives the wrong response. His tragedy is not that he couldn't be forgiven but that he didn't believe he could be."
-            },
-            {
-              "ref": "27:22-23",
-              "note": "\"What shall I do with Jesus who is called the Messiah?\" Crucify him! Pilate's question is the question the whole gospel has been asking. The cross is the event that saves precisely because it is the event they demand."
-            },
-            {
-              "ref": "27:29",
-              "note": "Hail, king of the Jews. The soldiers' mocking is simultaneously true. Every element of the mockery is genuine royal insignia worn by the genuine King. Matthew's most concentrated irony."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:24-25",
-              "note": "Calvin on the blood-curse: the blood of Christ does rest on his people -- not as a curse but as the means of their cleansing. What was intended as acceptance of guilt, God directed toward the principle of atonement. The blood of Christ is on us all -- but as forgiveness, not condemnation, for those who receive it."
-            },
-            {
-              "ref": "27:45-50",
-              "note": "Calvin on the dereliction: the cry is not despair but the actual experience of the wrath of God against sin. Christ was truly forsaken in his human experience, so that those who deserve to be forsaken might be received. This is the heart of the atonement: the substitution of Christ's forsakenness for the sinner's deserved forsakenness."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "27:24-25",
-              "note": "The NET note on 'his blood be on us and on our children' (v.25) carefully distinguishes between the immediate historical fulfilment (the destruction of Jerusalem in AD 70) and any permanent racial condemnation. The note strongly resists anti-Semitic interpretations, tracing the formula as a legal acceptance of responsibility."
-            },
-            {
-              "ref": "27:45-50",
-              "note": "The NET note on the three-hour darkness (from the sixth to the ninth hour) discusses the symbolic resonance with the Egyptian darkness plague (Exod 10:21-23) and Amos 8:9 ('in that day I will make the sun go down at noon'). The darkness is the OT judgment-sign applied to the crucifixion."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "27:1-31",
-              "note": "Robertson on Pilate's handwashing: the gesture is borrowed from the OT (Deut 21:6-7; Ps 26:6) but is here a pagan's appropriation of Jewish ritual. The paradox: Pilate performs a Jewish purification rite to declare innocence while ordering the execution. The people's response 'his blood be on us and on our children' (v.25) is a solemn self-curse, not a permanent racial condemnation."
-            },
-            {
-              "ref": "27:27-31",
-              "note": "Robertson on the soldiers' mockery: the scarlet robe is a military cloak used as a grotesque royal robe. The crown of thorns, reed sceptre, the 'Hail, King of the Jews', spitting and striking -- Robertson notes the mockery is the passion's darkest irony: soldiers performing kingship rituals on the actual King, without knowing it."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "27:3-10",
-              "note": "Chrysostom distinguishes remorse (metameleia) from repentance (metanoia): Judas felt the former but lacked the latter. Remorse looks at what was done; repentance turns to God. Judas's despair was itself a sin: he doubted that the God he had betrayed could forgive even this."
-            },
-            {
-              "ref": "27:45-56",
-              "note": "The Catena records the patristic meditation on the dereliction cry (v.46: My God, my God, why have you forsaken me? -- Ps 22:1). Chrysostom and Ambrose read it as the cry of Christ's human nature experiencing the full weight of divine abandonment on behalf of sinners -- not a rupture in the Trinity but Christ bearing in his human experience what sin produces."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The first half moves through Judas's remorse (vv.1-10), the trial before Pilate (vv.11-26), and the mocking (vv.27-31). Both Judas (vv.3-10) and Pilate (vv.11-26) recognise Jesus's innocence; both are destroyed by their choice. The Barabbas exchange is the passion's most concentrated picture of substitution: the guilty son released while the innocent Son is condemned."
@@ -491,34 +442,34 @@
     },
     {
       "section_num": 4,
-      "header": "Verses 57\u201366 \u2014 The Burial; The Guard at the Tomb",
+      "header": "Verses 57–66 — The Burial; The Guard at the Tomb",
       "verse_start": 57,
       "verse_end": 66,
       "panels": {
         "heb": [
           {
-            "word": "\u03ba\u03bf\u03c5\u03c3\u03c4\u03c9\u03b4\u03af\u03b1",
-            "transliteration": "koust\u014ddia",
+            "word": "κουστωδία",
+            "transliteration": "koustōdia",
             "gloss": "guard / watch (Latin loanword)",
-            "paragraph": "The guard at the tomb is uniquely Matthean. Koust\u014ddia is a Latin loanword \u2014 a Roman military guard detail. Matthew includes this to preempt the claim that the disciples stole the body. The resurrection is attested despite the best security the Roman empire could provide."
+            "paragraph": "The guard at the tomb is uniquely Matthean. Koustōdia is a Latin loanword — a Roman military guard detail. Matthew includes this to preempt the claim that the disciples stole the body. The resurrection is attested despite the best security the Roman empire could provide."
           }
         ],
         "tl": [
           {
             "date": "c. AD 30",
-            "name": "Handed to Pilate \u2014 Friday morning",
+            "name": "Handed to Pilate — Friday morning",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Crucifixion begins \u2014 Friday 9am",
+            "name": "Crucifixion begins — Friday 9am",
             "text": "",
             "current": false
           },
           {
             "date": "c. AD 30",
-            "name": "Darkness, dereliction, death \u2014 noon-3pm \u2014 this passage",
+            "name": "Darkness, dereliction, death — noon-3pm — this passage",
             "text": "\"From noon until three in the afternoon darkness came over all the land.\" The six-hour crucifixion ends with the cry of dereliction and the tearing of the Temple veil. The darkness and earthquake are dateable cosmological events accompanying the covenant's climax.",
             "current": true
           },
@@ -530,7 +481,7 @@
           },
           {
             "date": "c. AD 30",
-            "name": "Resurrection \u2014 Sunday dawn",
+            "name": "Resurrection — Sunday dawn",
             "text": "",
             "current": false
           },
@@ -545,12 +496,12 @@
           {
             "name": "Golgotha",
             "coords": "Outside Jerusalem walls; \"Place of the Skull\"",
-            "text": "Golgotha (\"Place of the Skull\") is outside Jerusalem's walls \u2014 criminals were executed outside the city. The traditional site (Church of the Holy Sepulchre) is within the current Old City walls but was outside the first-century walls. Crucifixion happened in a public visible location."
+            "text": "Golgotha (\"Place of the Skull\") is outside Jerusalem's walls — criminals were executed outside the city. The traditional site (Church of the Holy Sepulchre) is within the current Old City walls but was outside the first-century walls. Crucifixion happened in a public visible location."
           },
           {
             "name": "Joseph's tomb",
             "coords": "Near Golgotha; a garden tomb",
-            "text": "The tomb is newly hewn, belonging to Joseph of Arimathea \u2014 a rich man's tomb near the execution site. The proximity of tomb to cross means the burial happens quickly before Sabbath. The garden setting (John 19:41) and the rolling stone create the geography of the resurrection morning."
+            "text": "The tomb is newly hewn, belonging to Joseph of Arimathea — a rich man's tomb near the execution site. The proximity of tomb to cross means the burial happens quickly before Sabbath. The garden setting (John 19:41) and the rolling stone create the geography of the resurrection morning."
           }
         ],
         "cross": {
@@ -566,73 +517,24 @@
           ]
         },
         "mac": {
-          "source": "MacArthur Study Bible \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:42",
-              "note": "He saved others but he can't save himself. The mockers speak better theology than they know. The reason he cannot save himself is the same reason he can save others -- because saving others requires the cross."
-            },
-            {
-              "ref": "27:46",
-              "note": "My God, my God, why have you forsaken me. The dereliction is real. The God-forsakenness Jesus experiences is what sin produces, and the one who bore sin bore its ultimate consequence. This is the depth of the atonement."
-            },
-            {
-              "ref": "27:54",
-              "note": "Surely he was the Son of God. The centurion's confession is the chapter's climax. A Roman executioner confesses what Israel's establishment refused to believe. The one who signed the execution order becomes the chapter's confessor."
-            }
-          ]
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": []
         },
         "calvin": {
-          "source": "John Calvin, Commentaries \u2014 Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "27:51",
-              "note": "Calvin on the torn curtain: Christ has thrown open the way to the heavenly sanctuary that had been closed under the law. The death that seemed to all eyes like defeat was in fact the perforation of the barrier between sinful humanity and the holy God."
-            },
-            {
-              "ref": "27:62-66",
-              "note": "Calvin on the guards at the tomb: Providence arranged that the enemies of Christ should take care of his resurrection. By sealing the tomb and placing guards, they make it impossible for the disciples to have removed the body -- thereby making the subsequent resurrection incontrovertible."
-            }
-          ]
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": []
         },
         "net": {
-          "source": "NET Bible Full Notes Edition \u2014 Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "27:51-53",
-              "note": "The NET note on the resurrection of the saints (vv.52-53) discusses the major interpretive options: (1) literal physical resurrection of OT saints who appeared in Jerusalem; (2) a symbolic event; (3) a proleptic resurrection that occurred on Easter Sunday, with the tombs opening at the crucifixion as the earthquake's effect. The note surveys the options without definitively resolving the historical question."
-            },
-            {
-              "ref": "27:62-66",
-              "note": "The NET note on the guard at the tomb traces the Jewish polemic ('his disciples came by night and stole him', v.64) as the alternative explanation Matthew's narrative directly addresses. The bribery story (28:11-15) is Matthew's historical counter-narrative."
-            }
-          ]
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": []
         },
         "robertson": {
-          "source": "A.T. Robertson, Word Pictures in the New Testament \u2014 Public Domain",
-          "notes": [
-            {
-              "ref": "27:50-66",
-              "note": "Robertson on the torn curtain: to katapetasma tou naou eschisthe -- the temple veil was torn from top to bottom (anothen heos kato) -- from heaven downward. The tearing is divine. The barrier separating the Holy of Holies from the Holy Place is removed at Christ's death. Robertson on the resurrection of the saints (vv.52-53): unique to Matthew, it signals the inaugurated eschatology of the passion event."
-            },
-            {
-              "ref": "27:57-66",
-              "note": "Robertson on the burial: Joseph of Arimathea is identified as a mathetes (disciple, v.57) who had hidden his discipleship. The sealed and guarded tomb is Matthew's narrative preparation for the resurrection account: the guards placed to prevent theft will become the witnesses of what actually happened."
-            }
-          ]
+          "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
+          "notes": []
         },
         "catena": {
-          "source": "Thomas Aquinas (compiler), Catena Aurea \u2014 Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "27:51-53",
-              "note": "The Catena records the patristic fascination with the resurrection of the saints (vv.52-53). Chrysostom reads the 'many bodies of the holy people who had fallen asleep' as OT saints raised as a first-fruits of Christ's resurrection victory."
-            },
-            {
-              "ref": "27:57-66",
-              "note": "Chrysostom: he who had been a secret disciple becomes bold at the moment of greatest danger. The cross does not destroy courage; it creates it in those who see what it means. Even before the resurrection, the cross is producing its first fruits of transformed discipleship."
-            }
-          ]
+          "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
+          "notes": []
         },
         "hist": {
           "context": "The crucifixion narrative is saturated with Psalm 22 -- casting lots (v.35), mockery (vv.39-44), and the dereliction cry (v.46). The mockers unknowingly speak the gospel's deepest truth: \"He saved others but he can't save himself\" -- the reason he cannot save himself is the same reason he can save others. The cosmic signs declare that the world has changed. The centurion's confession is the chapter's climax."
@@ -699,7 +601,7 @@
           "is_key": false
         },
         {
-          "label": "The Dereliction: Forsakenness Borne \u2014 27:46",
+          "label": "The Dereliction: Forsakenness Borne — 27:46",
           "text": "My God, my God, why have you forsaken me? The genuine human experience of divine abandonment borne in the place of sinners. The resurrection will be the answer to the cry.",
           "is_key": false
         }

--- a/content/matthew/7.json
+++ b/content/matthew/7.json
@@ -255,68 +255,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:1-5",
-              "note": "Calvin: The prohibition targets the censorious spirit that appoints itself judge over all others while exempting itself. It does not forbid church discipline or discernment of false teaching. The test: is the judgment accompanied by the same standard applied to oneself?"
-            },
-            {
-              "ref": "7:13-14",
-              "note": "Calvin on the two ways: The narrow gate is the gospel's entrance -- it requires the renunciation of all human righteousness and total dependence on Christ. The wide gate admits all -- self-righteous religion, moral achievement, human philosophy -- everything except the humble acknowledgment of need."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "7:1-5",
-              "note": "The NET note on 'do not judge' discusses the judicial background: krino was used for formal legal judgment. The prohibition is against setting oneself up as final arbiter of another's standing before God. Practical discernment (v.6) and church discipline (18:15-20) are not prohibited."
-            },
-            {
-              "ref": "7:7-11",
-              "note": "The NET note on 'how much more' (poso mallon) identifies the classical a fortiori argument: from the lesser (human fathers) to the greater (the heavenly Father). The argument establishes the disposition of the giver: the Father is more willing to give good gifts than any human father."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "7:1-5",
-              "note": "Robertson notes that 'judge not' does not prohibit all discernment -- v.6 immediately requires the judgment of who the dogs and pigs are. The prohibition is against hypocritical judgment: judging others by a standard you exempt yourself from. The log-and-speck image is comic in its disproportion."
-            },
-            {
-              "ref": "7:7-11",
-              "note": "Robertson traces ask (aiteo), seek (zeteo), knock (krouo) as progressively intensive. All three are present imperatives -- keep asking, keep seeking, keep knocking. The father-son argument establishes the a fortiori: if evil human fathers give good gifts, how much more the heavenly Father."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "7:1-5",
-              "note": "Chrysostom: This is not the prohibition of discernment but the condemnation of self-exempting severity. The person who judges others harshly for sins they commit themselves is the target. Deal with your own sin first, and only then will you see clearly to help your brother."
-            },
-            {
-              "ref": "7:13-14",
-              "note": "Augustine: Enter through the narrow gate -- the road to life is characterised by difficulty and few travellers. This is not a statement about the absolute number of the saved but about the character of the way: narrow because it requires the death of self-will and submission to God's governance."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "7:1-12",
-              "note": "MacArthur: Do not judge, or you too will be judged (v.1). The prohibition is not against discernment but against the hypocritical judgment that applies different standards to self and others. The plank-and-speck image (vv.3-5) targets self-exemption from the standard applied to others. After plank removal, discernment becomes possible (v.5b)."
-            },
-            {
-              "ref": "7:7-11",
-              "note": "MacArthur: Ask, seek, knock — the three imperatives intensify in effort from passive reception to active searching to persistent urgency. But the promise rests not on the intensity of the asking but on the character of the Father: if earthly fathers give good gifts, how much more will your Father in heaven give good gifts."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/matthew/8.json
+++ b/content/matthew/8.json
@@ -288,68 +288,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:3",
-              "note": "Calvin on Jesus touching the leper: Under the law, touching a leper communicated defilement. Christ reverses this by the power of his holiness -- he touches what is unclean and the unclean becomes clean. This is the pattern of the incarnation: he enters the domain of human sin without being contaminated; instead he purifies."
-            },
-            {
-              "ref": "8:10-12",
-              "note": "Calvin on the centurion's faith: This pagan soldier's faith shames Israel -- he who has received no covenant promise believes; they who have received all the promises do not. This is the mystery of grace: it operates where it will, not where it is expected."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "8:1-4",
-              "note": "The NET note on 'show yourself to the priest' discusses the legal significance of the Leviticus 14 requirement. Jesus sends the healed leper to fulfil Torah's requirements -- the healing is real and publicly certified."
-            },
-            {
-              "ref": "8:5-13",
-              "note": "The NET note on 'I will come and heal him' discusses whether this is a statement or a question ('Shall I come and heal him?'). The interrogative reading heightens the Gentile-inclusion significance: Jesus offers to cross Jewish-Gentile social boundaries."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "8:1-4",
-              "note": "Robertson notes the leper's address 'Lord, if you are willing' is the most perfect expression of faith in the Gospels -- total confidence in ability combined with total submission to will. The touching of the leper is the drama's peak: a leper was untouchable by law; Jesus touches him. The touch does not make Jesus unclean; it makes the leper clean."
-            },
-            {
-              "ref": "8:5-13",
-              "note": "Robertson draws attention to the centurion's theology of authority: he understands Jesus' word as having the same relationship to reality that a military command has to soldiers -- it is effective by its own authority. Robertson notes 'I have not found such great faith in anyone in Israel' is among Jesus' most astonishing statements."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "8:1-4",
-              "note": "Chrysostom: Christ stretched out his hand and touched what was not to be touched, showing that holiness is stronger than uncleanness. By touching the impure he purified it -- this is the pattern of the incarnation itself: he enters the domain of human sin and death without being contaminated; instead he purifies."
-            },
-            {
-              "ref": "8:5-13",
-              "note": "Augustine on the centurion: He confessed himself unworthy that Christ should enter under his roof -- greater humility has never been spoken. His faith was measured not by years of instruction but by the depth of his recognition: this man's word is sovereign over disease as a military command is sovereign over soldiers."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "8:1-17",
-              "note": "MacArthur: The healing narrative of chs.8-9 is Matthew's demonstration of the kingdom power proclaimed in chs.5-7. The triad of healed persons — leper (social outcast), centurion's servant (Gentile), Peter's mother-in-law (woman) — suggests the kingdom's reach: across purity boundaries, ethnic boundaries, and gender boundaries."
-            },
-            {
-              "ref": "8:16-17",
-              "note": "MacArthur: He drove out the spirits with a word and healed all the sick. This was to fulfill what was spoken through the prophet Isaiah: he took up our infirmities and bore our diseases. Isaiah 53 is applied to Jesus's healing ministry before it is applied to his death — the Servant's bearing of human pain encompasses both."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/matthew/9.json
+++ b/content/matthew/9.json
@@ -267,68 +267,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:1-8",
-              "note": "Calvin on the forgiveness of sins: The scribes were right that only God can forgive sins -- they were wrong to conclude that Jesus could not. The healing demonstrates his divine authority: the one who can command the paralytic to walk can certainly forgive his sins. The miracle is the verification of the claim that would otherwise require pure faith."
-            },
-            {
-              "ref": "9:9-13",
-              "note": "Calvin on calling Matthew: A tax collector, despised as a Roman collaborator, is called to the inner circle. This is the gospel's characteristic pattern: the most unlikely candidate is chosen, the most despised is honoured. The Pharisees' complaint that Jesus eats with sinners is precisely the point -- these are the people the physician came to heal."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:1-8",
-              "note": "The NET note on 'son, your sins are forgiven' discusses the grammar: aphiontai is a divine passive present -- the sins are being forgiven by God. The scribes correctly understand the implicit Christological claim: only one with divine authority can pronounce forgiveness in this first-person way."
-            },
-            {
-              "ref": "9:9-13",
-              "note": "The NET note on Hos 6:6 discusses how Jesus applies this prophetic principle: the Pharisees' complaint about eating with sinners reveals that they value ritual separation (the form of holiness) over compassionate engagement with the lost (the substance of holiness)."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "9:1-8",
-              "note": "Robertson notes the paralytic's healing is linked to forgiveness of sins -- Jesus addresses the inner need before the outer. The scribes' accusation of blasphemy is theologically correct if Jesus is merely human -- only God can forgive sins. Jesus' response uses the healing as visible evidence for the invisible forgiveness."
-            },
-            {
-              "ref": "9:9-13",
-              "note": "Robertson identifies the citation of Hos 6:6 ('I desire mercy, not sacrifice') as Jesus' hermeneutical principle: ritual observance that does not express covenant faithfulness is not what God desires. The physician metaphor is the gospel's self-understanding: Jesus comes for the sick, not the healthy."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:1-8",
-              "note": "Chrysostom on the paralytic: He first forgave the sins because that was the greater healing. The paralysis was the visible symptom; the sin was the deeper disease. Christ healed the root before the fruit. This is the pattern of all true healing: forgiveness of sins is not the addition to physical healing but its foundation."
-            },
-            {
-              "ref": "9:9-13",
-              "note": "Augustine on 'I desire mercy and not sacrifice': These words condemn all who love the form of religion more than its substance. Sacrifice without mercy is performance; mercy without sacrifice is formless. When mercy is absent, sacrifice is an offence. The Pharisees had the sacrifice; they lacked the mercy."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:1-17",
-              "note": "MacArthur: The forgiveness of the paralytic (v.2) precedes his healing (v.6) — the theological priority is deliberate. Jesus addresses the greater need first. The scribes' objection (blasphemy — only God can forgive sins) is correct in its theology and wrong only in its failure to recognize who Jesus is. Their theology is sound; their Christology is deficient."
-            },
-            {
-              "ref": "9:9",
-              "note": "MacArthur: As Jesus went on from there, he saw a man named Matthew sitting at the tax collector's booth. Follow me, he told him, and Matthew got up and followed him. Tax collectors were collaborators with the Roman occupation and were excluded from the synagogue. Matthew's call is the call of the socially excluded — which is the pattern of the whole section."
-            }
-          ]
+          "notes": []
         }
       }
     },
@@ -377,68 +332,23 @@
         },
         "calvin": {
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:20-22",
-              "note": "Calvin on the woman with the haemorrhage: Her faith was mingled with superstition -- she believed she could be healed by touching the hem of Christ's garment without him knowing. Christ draws out the genuine faith from within the imperfect expression and honours it. Grace works with what is genuinely present, not only with what is perfectly formed."
-            },
-            {
-              "ref": "9:36-38",
-              "note": "Calvin on the harvest and the labourers: The command to pray for labourers before the command to send them teaches that the mission is sustained by prayer, not by human recruitment strategies. The Lord of the harvest appoints the labourers; prayer is the means by which they are appointed."
-            }
-          ]
+          "notes": []
         },
         "net": {
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
-          "notes": [
-            {
-              "ref": "9:18-26",
-              "note": "The NET note on 'she is not dead but sleeping' discusses the use of katheudei as a metaphor for death in the NT context. Jesus may be deliberately anticipating the resurrection that follows, treating the death as temporary from the perspective of his authority over it."
-            },
-            {
-              "ref": "9:35-38",
-              "note": "The NET note on splanchnistheis explains the visceral, gut-level compassion -- moved in the deepest centre of one's being. This word is used for Jesus more than any other individual in the Gospels. It describes not mild sympathy but gut-level engagement with human suffering that drives action."
-            }
-          ]
+          "notes": []
         },
         "robertson": {
           "source": "A.T. Robertson, Word Pictures in the New Testament — Public Domain",
-          "notes": [
-            {
-              "ref": "9:18-26",
-              "note": "Robertson notes Jairus' daughter was 'just now' dead when he arrived -- the contrast with the woman with the haemorrhage is stark. The crowd's ridicule ('they laughed at him') meets Jesus' claim that she is 'sleeping.' His raising of the dead girl in the face of their ridicule is the first resurrection narrative in Matthew."
-            },
-            {
-              "ref": "9:35-38",
-              "note": "Robertson identifies 9:35 as the second occurrence of the ministry summary (first at 4:23) -- teaching, proclaiming, healing -- bracketing the Sermon on the Mount and the miracle narratives. The compassion (splanchnistheis) at the harassed crowd motivates the mission discourse of ch.10."
-            }
-          ]
+          "notes": []
         },
         "catena": {
           "source": "Thomas Aquinas (compiler), Catena Aurea — Patristic Commentary, Public Domain",
-          "notes": [
-            {
-              "ref": "9:18-26",
-              "note": "Chrysostom: Christ permitted the death to occur so that the greater miracle could demonstrate greater faith. Had he come immediately the ruler might have thought the girl merely very sick. By allowing the death, Christ shows his authority over death itself, not merely over sickness."
-            },
-            {
-              "ref": "9:27-31",
-              "note": "Jerome on 'according to your faith let it be done to you': Not 'according to your merit' but 'according to your faith.' Faith is the appointed means through which divine power flows into human need. The blind men saw -- not because their eyes were healed but because they believed the Healer could heal them."
-            }
-          ]
+          "notes": []
         },
         "mac": {
           "source": "MacArthur Study Bible — Faithful Paraphrase",
-          "notes": [
-            {
-              "ref": "9:18-38",
-              "note": "MacArthur: The ruler's daughter, the hemorrhaging woman, the two blind men, the mute man — the escalating series of healings in the second half of ch.9 culminates in Jesus's harvest saying (vv.37-38). The healings do not merely demonstrate power but create the context for the harvest metaphor: the need is vast, the workers are few, prayer is the first response."
-            },
-            {
-              "ref": "9:36",
-              "note": "MacArthur: When he saw the crowds, he had compassion on them, because they were harassed and helpless, like sheep without a shepherd. The compassion that moves Jesus is not merely pity but the recognition of a structural problem: the crowds have no shepherd. The Sermon (5-7) and the miracles (8-9) together are the shepherd's response to the leaderless flock."
-            }
-          ]
+          "notes": []
         }
       }
     }

--- a/content/numbers/1.json
+++ b/content/numbers/1.json
@@ -172,10 +172,6 @@
             {
               "ref": "1:47–54",
               "note": "Calvin: The separation of the Levites for sanctuary service teaches the perpetual need for a dedicated ministry. The entire people cannot be priests — specialisation in sacred service is a divine provision, not a human hierarchy. The NT equivalent is the gift of pastor-teachers to the church (Eph 4:11–12): not to do all the work but to equip the whole community."
-            },
-            {
-              "ref": "1:20",
-              "note": "Calvin: The passage on census demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -185,10 +181,6 @@
             {
               "ref": "1:46",
               "note": "NET Note: The total of 603,550 echoes the count in Exod 38:26, providing narrative continuity across the Pentateuch. The consistency of the number across different contexts suggests it was a theologically significant figure in Israelite tradition — whatever its precise demographic meaning."
-            },
-            {
-              "ref": "1:20",
-              "note": "NET Note: The Hebrew vocabulary in this section on census employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -211,10 +203,6 @@
             {
               "ref": "1:47–54",
               "note": "Ashley: The Levites' exemption is not a privilege but a responsibility — they bear the tabernacle and answer for any defilement of it. \"The Israelites are to set up their tents by divisions, each man in his own camp under his own standard\" (v.52). Order in the camp reflects the order of creation: God is holy, his dwelling is holy, and the community organised around it must reflect that holiness."
-            },
-            {
-              "ref": "1:20",
-              "note": "Ashley: The narrative context of census in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/10.json
+++ b/content/numbers/10.json
@@ -168,10 +168,6 @@
             {
               "ref": "10:35–36",
               "note": "Calvin: The ark-prayers model the relationship between prayer and action: before the army marches, prayer calls on God to lead; when the army rests, prayer calls on God to dwell. Every movement and every rest of Israel's life is framed by invocation. The Christian equivalent is Paul's \"pray without ceasing\" — all of life encompassed by the arc of prayer."
-            },
-            {
-              "ref": "10:11",
-              "note": "Calvin: The passage on trumpets and departure demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -181,10 +177,6 @@
             {
               "ref": "10:35",
               "note": "NET Note: Psalm 68:1 quotes this verse almost verbatim (\"Let God arise, let his enemies be scattered\"), suggesting the ark-prayer was incorporated into the liturgical Psalter. The movement from wilderness ark-prayer to temple Psalm demonstrates the continuity of Israel's worship tradition across its changing institutional forms."
-            },
-            {
-              "ref": "10:11",
-              "note": "NET Note: The Hebrew vocabulary in this section on trumpets and departure employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -207,10 +199,6 @@
             {
               "ref": "10:11–28",
               "note": "Ashley: The departure from Sinai is the pivot of the entire Pentateuch narrative. The Abrahamic covenant, the Exodus, the Sinai law, the tabernacle construction — all of this has been preparation for this moment: Israel organised, equipped, and ready to march toward the promised land. Numbers 10:11 is the sentence that launches the covenant community into its wilderness future."
-            },
-            {
-              "ref": "10:11",
-              "note": "Ashley: The narrative context of trumpets and departure in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/11.json
+++ b/content/numbers/11.json
@@ -164,10 +164,6 @@
             {
               "ref": "11:34",
               "note": "Calvin: Kibroth Hattaavah — \"Graves of Craving\" — is a permanent memorial to the principle that disordered desire destroys. The people's craving was not for food per se (they had manna) but for the satisfactions of a life without God's constraints. When God removed the constraints and gave the craving its fullest expression, it killed them. Ungoverned desire is always ultimately fatal."
-            },
-            {
-              "ref": "11:26",
-              "note": "Calvin: The passage on complaint and quail demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -177,10 +173,6 @@
             {
               "ref": "11:31",
               "note": "NET Note: \"From the sea\" — quail migrated annually across the Sinai peninsula from Africa to the Mediterranean, often flying low and landing exhausted on the ground where they could be easily caught. The \"miraculous\" element is not the quail themselves but their divinely-timed, divinely-scaled provision — and its timing with the people's demand."
-            },
-            {
-              "ref": "11:26",
-              "note": "NET Note: The Hebrew vocabulary in this section on complaint and quail employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -203,10 +195,6 @@
             {
               "ref": "11:33",
               "note": "Ashley: \"But while the meat was still between their teeth and before it could be consumed, the anger of the Lord burned against the people.\" The timing is theologically precise — the judgment comes at the moment of satisfaction, not the moment of craving. The craving itself was not punished; the consuming satisfaction of it was. God judges not the desire but the idol made of it."
-            },
-            {
-              "ref": "11:26",
-              "note": "Ashley: The narrative context of complaint and quail in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/12.json
+++ b/content/numbers/12.json
@@ -158,10 +158,6 @@
             {
               "ref": "12:10–16",
               "note": "Calvin: Miriam's punishment and restoration model the covenant's discipline-and-mercy structure. The judgment is real (seven days outside), the humiliation genuine, but the endpoint is clear and the restoration complete. God does not destroy Miriam for her rebellion — he disciplines her and restores her. The covenant's judgment is always in service of the covenant's relationship."
-            },
-            {
-              "ref": "12:10",
-              "note": "Calvin: The passage on Miriam challenges Moses demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "12:15",
               "note": "NET Note: \"The people did not move on till Miriam was brought back\" — the Hiphil of ʾāsap (\"gathered in/brought back\") uses the same root as the verb for gathering the dead for burial. Miriam is \"gathered back\" from the social death of camp exclusion — her restoration is a small resurrection."
-            },
-            {
-              "ref": "12:10",
-              "note": "NET Note: The Hebrew vocabulary in this section on Miriam challenges Moses employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "12:15–16",
               "note": "Ashley: The community waiting for Miriam — a woman, a prophet, one who has just been punished — is a striking counter to the tendency of ancient communities to simply move on and leave the disgraced behind. Israel's solidarity with Miriam in her shame and restoration is a model of covenant community: no one is dispensable, not even the disciplined."
-            },
-            {
-              "ref": "12:10",
-              "note": "Ashley: The narrative context of Miriam challenges Moses in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/13.json
+++ b/content/numbers/13.json
@@ -164,10 +164,6 @@
             {
               "ref": "13:31–33",
               "note": "Calvin: \"We can't attack those people; they are stronger than we are.\" The ten spies speak the truth about human strength and lie about theological reality. They have seen God's power in the Exodus, the Red Sea, the provision of manna and water, the Sinai theophany — and still conclude that the Canaanites are stronger. Unbelief is not lack of evidence; it is refusal to interpret evidence through the lens of covenant experience."
-            },
-            {
-              "ref": "13:26",
-              "note": "Calvin: The passage on twelve spies demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -177,10 +173,6 @@
             {
               "ref": "13:33",
               "note": "NET Note: \"Nephilim\" (v.33) — the reference to the Nephilim connects to Gen 6:4, where they appear before the flood. Their post-flood appearance here either reflects legendary tradition about large people groups or the use of the term for any extraordinarily large warriors. The point for the narrative is the ten spies' perception of overwhelming, superhuman opposition."
-            },
-            {
-              "ref": "13:26",
-              "note": "NET Note: The Hebrew vocabulary in this section on twelve spies employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -203,10 +195,6 @@
             {
               "ref": "13:30–33",
               "note": "Ashley: The contrast between Caleb's single verse (v.30) and the ten spies' three verses (vv.31–33) is telling. One voice of faith is overwhelmed by multiple voices of fear. The majority report is not automatically the correct one; in the covenant community, faithfulness is measured by alignment with God's word, not by headcount."
-            },
-            {
-              "ref": "13:26",
-              "note": "Ashley: The narrative context of twelve spies in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/14.json
+++ b/content/numbers/14.json
@@ -164,10 +164,6 @@
             {
               "ref": "14:26–35",
               "note": "Calvin: The forty-year sentence teaches that covenant consequences are real and permanent within this life, even after forgiveness. God forgives the rebellion; he does not immediately remove its earthly consequences. The Christian who has been forgiven a serious sin may live with its earthly consequences for the rest of their life. Forgiveness restores the relationship; it does not always restore the circumstances."
-            },
-            {
-              "ref": "14:26",
-              "note": "Calvin: The passage on Kadesh rebellion demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -177,10 +173,6 @@
             {
               "ref": "14:34",
               "note": "NET Note: \"For forty years — one year for each of the forty days you explored the land — you will suffer for your sins and know what it is like to have me against you.\" The correlation is exact: the spy mission determined the wilderness sentence. The forty days of faithless reconnaissance translated into forty years of wilderness discipline. Divine judgment is precisely calibrated."
-            },
-            {
-              "ref": "14:26",
-              "note": "NET Note: The Hebrew vocabulary in this section on Kadesh rebellion employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -203,10 +195,6 @@
             {
               "ref": "14:39–45",
               "note": "Ashley: The attempted entry into Canaan after the judgment is pronounced reveals the generation's fundamental problem: they respond to circumstances rather than to God's word. When the spies reported negatively, they despaired. When God announced judgment, they decided to act. Neither response is faith — both are reactions to events rather than responses to the covenant word."
-            },
-            {
-              "ref": "14:26",
-              "note": "Ashley: The narrative context of Kadesh rebellion in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/15.json
+++ b/content/numbers/15.json
@@ -166,10 +166,6 @@
             {
               "ref": "15:37–41",
               "note": "Calvin: External signs have their proper place in the life of faith — not as replacements for internal devotion but as aids to it. The tassel is not magic; it does not automatically produce obedience. But it provides a repeated, embodied prompt for the mind and heart that Scripture consistently recommends. The NT sacraments serve the same purpose: visible, physical reminders of invisible, spiritual realities."
-            },
-            {
-              "ref": "15:32",
-              "note": "Calvin: The passage on supplementary offerings demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "15:38",
               "note": "NET Note: The blue thread (pĕtîl tĕkēlet) in the tassel is the same blue used for the tabernacle curtains and the high priest's garments (Exod 25:4; 28:6). The colour connects the ordinary Israelite's garment to the sanctuary — making every person a walking portable reminder of the covenant's sacred centre."
-            },
-            {
-              "ref": "15:32",
-              "note": "NET Note: The Hebrew vocabulary in this section on supplementary offerings employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -205,10 +197,6 @@
             {
               "ref": "15:37–41",
               "note": "Ashley: The tassels chapter closes with the full Exodus motivation: \"I am the Lord your God, who brought you out of Egypt.\" The tassel reminder is grounded in the covenant relationship established at the Exodus. The commandments are not arbitrary restrictions but the shape of life in covenant with the God who redeems."
-            },
-            {
-              "ref": "15:32",
-              "note": "Ashley: The narrative context of supplementary offerings in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/16.json
+++ b/content/numbers/16.json
@@ -166,10 +166,6 @@
             {
               "ref": "16:46–50",
               "note": "Calvin: Aaron's intercession with the burning censer models the nature of priestly mediation: entering the space of death with the fire of the altar. Christ, our high priest, entered death itself — not with a censer but in his own body — and by his resurrection stands between the dead and the living for all who are his."
-            },
-            {
-              "ref": "16:36",
-              "note": "Calvin: The passage on Korah's rebellion demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "16:40",
               "note": "NET Note: \"A reminder to the Israelites that no one except a descendant of Aaron should come to burn incense before the Lord\" — the bronze-censer altar covering is a permanent architectural warning. Every Israelite who passes by the altar sees the reforged metal and is reminded: only Aaron's line. The architecture of the sanctuary is a theology lesson."
-            },
-            {
-              "ref": "16:36",
-              "note": "NET Note: The Hebrew vocabulary in this section on Korah's rebellion employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -205,10 +197,6 @@
             {
               "ref": "16:46–50",
               "note": "Ashley: The community's instant reversion to accusation the day after the Korah judgment (\"You have killed the Lord's people\") reveals the depth of the wilderness generation's spiritual blindness. They see the judgment on Korah's rebellion and interpret it as injustice rather than covenant faithfulness. Aaron's intercession is for a people who do not deserve it — the nature of all true priestly intercession."
-            },
-            {
-              "ref": "16:36",
-              "note": "Ashley: The narrative context of Korah's rebellion in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/17.json
+++ b/content/numbers/17.json
@@ -158,10 +158,6 @@
             {
               "ref": "17:12–13",
               "note": "Calvin: Israel's despairing cry is the right response to the wrong question. They ask \"will we die near the tabernacle?\" when they should ask \"how does God provide safe approach?\" The law always generates this question; only the gospel answers it. The staff that blooms points forward to the resurrection of the one who will say: \"I am the way. No one comes to the Father except through me.\""
-            },
-            {
-              "ref": "17:12",
-              "note": "Calvin: The passage on Aaron's staff demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "17:13",
               "note": "NET Note: The question \"Are we all going to die?\" (hăʾîm tamnû ligwōaʿ) anticipates Numbers 18:1's answer: no, because the priests and Levites bear the danger on your behalf. The structure of Num 17–18 is question (how do we survive proximity to the holy?) and answer (through the priestly mediators God has appointed). The chapter break should not obscure the direct theological dialogue."
-            },
-            {
-              "ref": "17:12",
-              "note": "NET Note: The Hebrew vocabulary in this section on Aaron's staff employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "17:12–13",
               "note": "Ashley: The preserved staff in the ark is a living contradiction: it sprouts in the presence of God, demonstrating divine appointment and life; yet the people's response to that same demonstration is a cry of expected death. The tension between the life-giving sign and the death-fearing response is resolved only by the priest who stands between — Aaron, whose staff bloomed, now bearing Israel's danger on their behalf (Num 18:1)."
-            },
-            {
-              "ref": "17:12",
-              "note": "Ashley: The narrative context of Aaron's staff in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/18.json
+++ b/content/numbers/18.json
@@ -166,10 +166,6 @@
             {
               "ref": "18:21–32",
               "note": "Calvin: The tithe system's extension to the Levites themselves — they tithe from their own tithes — establishes the universal character of covenant giving. No one is too poor, no one is sustained by others' generosity, no one is close enough to God to be exempt from returning a portion to him. The NT equivalent: \"Each one must give as he has decided in his heart\" — the spirit of the tithe survives its specific Levitical form."
-            },
-            {
-              "ref": "18:21",
-              "note": "Calvin: The passage on priestly duties demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "18:26",
               "note": "NET Note: \"When you receive from the Israelites the tithe… you must present a tenth of that tithe as the Lord's offering.\" The Levites' tithe to the priests constitutes approximately 1% of all Israel's produce (10% of the 10% tithe). The Aaronic priesthood is sustained by the concentrated tithe — small numerically but drawn from the entire covenant community's contribution."
-            },
-            {
-              "ref": "18:21",
-              "note": "NET Note: The Hebrew vocabulary in this section on priestly duties employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -205,10 +197,6 @@
             {
               "ref": "18:21–32",
               "note": "Ashley: The tithe-of-the-tithe system creates a covenant economy of graduated generosity. Israel gives to the Levites; the Levites give to the priests; the priests are sustained by God. The direction is always upward — toward God — even as the material goods flow across the community. The tithe system is a participation in the economy of heaven."
-            },
-            {
-              "ref": "18:21",
-              "note": "Ashley: The narrative context of priestly duties in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/19.json
+++ b/content/numbers/19.json
@@ -158,10 +158,6 @@
             {
               "ref": "19:14–22",
               "note": "Calvin: The spreading of corpse-impurity through tent and open country models the total effect of death's corruption on human existence — nothing touched by mortality is entirely clean. The red heifer water, sprinkled precisely with hyssop on precise days, is the covenant's provision for living with this reality. Christ is the ultimate red heifer: his death, outside the city (cf. Heb 13:12), produces the water that cleanses all who are sprinkled with his blood."
-            },
-            {
-              "ref": "19:14",
-              "note": "Calvin: The passage on red heifer demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "19:18",
               "note": "NET Note: \"A clean person shall take hyssop, dip it in the water, and sprinkle the tent and all the furnishings and the persons who were there, and also the one who touched a bone, a corpse, a grave, or a person who had been killed.\" The clean person's act of sprinkling transfers impurity to themselves while removing it from others. This substitutionary mechanism — taking on impurity to remove it — is the theological heart of the red heifer rite."
-            },
-            {
-              "ref": "19:14",
-              "note": "NET Note: The Hebrew vocabulary in this section on red heifer employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "19:14–22",
               "note": "Ashley: The application rules acknowledge that death is unavoidable in a human community — people will die in tents, bones will be encountered in fields. The red heifer provision is not for an ideal community where death never occurs but for a real community where it constantly does. The pastoral genius of Num 19 is its realistic engagement with human mortality within a covenant framework."
-            },
-            {
-              "ref": "19:14",
-              "note": "Ashley: The narrative context of red heifer in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/2.json
+++ b/content/numbers/2.json
@@ -166,10 +166,6 @@
             {
               "ref": "2:18–34",
               "note": "Calvin: The precision of the camp arrangement — every tribe knowing its place, every family its location — teaches that order is not an imposition on freedom but its prerequisite. The Israelite who knew his place in the camp could move freely within that order. The Christian who understands their place in the body of Christ (1 Cor 12) is free to exercise their gifts without confusion."
-            },
-            {
-              "ref": "2:18",
-              "note": "Calvin: The passage on camp arrangement demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "2:17",
               "note": "NET Note: The tabernacle in the \"middle\" (bĕtôk) of the marching formation provides maximum security — every threat from any direction must pass through six tribes' formations before reaching the divine dwelling. The arrangement is simultaneously devotional and strategic."
-            },
-            {
-              "ref": "2:18",
-              "note": "NET Note: The Hebrew vocabulary in this section on camp arrangement employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -192,10 +184,6 @@
             {
               "ref": "2:32–34",
               "note": "Milgrom: The closing summary emphasises obedience: \"just as the Lord commanded Moses, so the Israelites did.\" The camp arrangement is a divine specification, not a human convention. Milgrom notes this compliance formula appears repeatedly in Numbers where Israel obeys — its absence in the rebellion narratives of chapters 11–14 and 20 is pointed."
-            },
-            {
-              "ref": "2:18",
-              "note": "Milgrom: The ritual prescriptions for camp arrangement reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -205,10 +193,6 @@
             {
               "ref": "2:31–34",
               "note": "Ashley: Dan as the rear guard is the tribe of the rearguard — the last to set out, gathering the stragglers. It is a role of honour and responsibility: those who march last protect the most vulnerable. In Israel's later tribal history, Dan occupies the northernmost boundary of the land — always at the edge, always the outer guardian."
-            },
-            {
-              "ref": "2:18",
-              "note": "Ashley: The narrative context of camp arrangement in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/20.json
+++ b/content/numbers/20.json
@@ -170,10 +170,6 @@
             {
               "ref": "20:22–29",
               "note": "Calvin: Aaron’s death on Mount Hor, transferred from his garments to his son, models the principle that priestly office outlives any individual officiant. The vestments are not buried; they are transferred. The church’s ministry is not dependent on any one person’s continuation; it is carried by the office, which belongs to God and is given to successors in each generation."
-            },
-            {
-              "ref": "20:14",
-              "note": "Calvin: The passage on Meribah and Aaron's death demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -183,10 +179,6 @@
             {
               "ref": "20:28",
               "note": "NET Note: \"Moses removed Aaron’s garments and put them on his son Eleazar\" — the investiture sequence mirrors the original ordination of Lev 8. Moses is again the officiating agent, as he was at Aaron’s original ordination. The symmetry is deliberate: the one who installed Aaron removes his vestments; the priestly succession is bookended by Moses."
-            },
-            {
-              "ref": "20:14",
-              "note": "NET Note: The Hebrew vocabulary in this section on Meribah and Aaron's death employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -209,10 +201,6 @@
             {
               "ref": "20:14–21",
               "note": "Ashley: Edom’s refusal demonstrates that the promised land journey will not be simply a march. Every negotiation, every detour around hostile kin, every refusal adds to the wilderness formation of Israel. The long way around Edom is not a detour from God’s plan but part of it."
-            },
-            {
-              "ref": "20:14",
-              "note": "Ashley: The narrative context of Meribah and Aaron's death in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/21.json
+++ b/content/numbers/21.json
@@ -166,10 +166,6 @@
             {
               "ref": "21:21–35",
               "note": "Calvin: The military victories over Sihon and Og are the first fruits of the conquest — and they come to the new generation, not the old. The people who received the forty-year sentence have died; their children fight. The covenant promise is not cancelled by one generation’s failure; it is delayed and transferred. God’s faithfulness outlasts human unfaithfulness."
-            },
-            {
-              "ref": "21:10",
-              "note": "Calvin: The passage on bronze serpent and conquests demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "21:14",
               "note": "NET Note: \"The Book of the Wars of the Lord\" — a reference to an ancient Israelite anthology of war poetry, now lost, that apparently recorded early Israelite military victories. Its citation here suggests the compiler of Numbers had access to a wider body of Israelite historical literature. The Torah is not the only ancient Israelite document; it cites others."
-            },
-            {
-              "ref": "21:10",
-              "note": "NET Note: The Hebrew vocabulary in this section on bronze serpent and conquests employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -192,10 +184,6 @@
             {
               "ref": "21:17–18",
               "note": "Milgrom: The well-song is the wilderness narrative’s most joyful passage — Israel singing to the water, the leaders and nobles cooperating to provide it. The song’s context (after the bronze serpent healing and before the military victories) places it at a moment of renewed covenant confidence. The same people who complained about water at Meribah now sing to the well that God gives them."
-            },
-            {
-              "ref": "21:10",
-              "note": "Milgrom: The ritual prescriptions for bronze serpent and conquests reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -205,10 +193,6 @@
             {
               "ref": "21:33–35",
               "note": "Ashley: The defeat of Og king of Bashan — a giant (Deut 3:11, his iron bed measured 9 cubits) — continues the pattern of God defeating what Israel fears most. The spy report’s grasshopper complex (Num 13) is systematically dismantled: first Sihon (Amorite king), then Og (the giant). By the time Israel reaches the Jordan, the generation who said \"we cannot\" has been replaced by a generation that has watched God defeat the very enemies their parents feared."
-            },
-            {
-              "ref": "21:10",
-              "note": "Ashley: The narrative context of bronze serpent and conquests in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/22.json
+++ b/content/numbers/22.json
@@ -174,10 +174,6 @@
             {
               "ref": "22:36–41",
               "note": "Calvin: The elaborate sacrificial preparation cannot change what God has already determined — Israel is blessed and no curse can reverse that. Calvin sees in this episode a profound comfort for the church: when enemies seek to curse God’s people through religious, political, or military means, they are working against an already-established divine blessing that no human power can reverse."
-            },
-            {
-              "ref": "22:36",
-              "note": "Calvin: The passage on Balaam and donkey demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -187,10 +183,6 @@
             {
               "ref": "22:41",
               "note": "NET Note: \"Bamoth Baal\" — literally \"high places of Baal.\" Balak brings Balaam to a pagan high place to invoke a pagan curse. The irony of the oracle cycle: the high places of Baal become the locations from which YHWH’s blessing of Israel is proclaimed. God appropriates pagan sacred space for covenant proclamation."
-            },
-            {
-              "ref": "22:36",
-              "note": "NET Note: The Hebrew vocabulary in this section on Balaam and donkey employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -213,10 +205,6 @@
             {
               "ref": "22:36–41",
               "note": "Ashley: The chapter’s closing verses set up the oracles with deliberate narrative irony: Balak has spent enormous resources (the repeated embassy, the seven altars, the sacrifices) to create conditions for a curse, and Balaam arrives already knowing he cannot curse what God has blessed. The gap between Balak’s expectations and Balaam’s constraint is the dramatic engine of chapters 23–24."
-            },
-            {
-              "ref": "22:36",
-              "note": "Ashley: The narrative context of Balaam and donkey in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/23.json
+++ b/content/numbers/23.json
@@ -174,10 +174,6 @@
             {
               "ref": "23:19",
               "note": "Calvin: \"God is not a man that he should lie\" is one of the OT’s clearest statements of divine immutability and veracity. The assurance of salvation rests precisely on this: God’s promises cannot be revoked because God’s character cannot change. Balaam’s reluctant proclamation becomes one of the OT’s most comforting theological affirmations."
-            },
-            {
-              "ref": "23:13",
-              "note": "Calvin: The passage on Balaam's oracles demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -187,10 +183,6 @@
             {
               "ref": "23:21",
               "note": "NET Note: \"The Lord their God is with them; the shout of the King is among them\" — the \"shout of the King\" (tĕrûʿat melek) refers to the battle cry or acclamation of a divine king present with his army. The same root (tĕrûʿāh) is used for the Feast of Trumpets (Num 29:1) and the ark-cry of Num 10:35. The covenant community’s military victories are grounded in the presence of the divine king."
-            },
-            {
-              "ref": "23:13",
-              "note": "NET Note: The Hebrew vocabulary in this section on Balaam's oracles employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -200,10 +192,6 @@
             {
               "ref": "23:19",
               "note": "Milgrom: The contrast between divine and human speech is the second oracle’s theological core: human words can be retracted; divine words cannot. Balak’s entire enterprise rests on the assumption that prophetic speech can override divine speech — that Balaam’s curse can neutralise God’s blessing. The second oracle demolishes that assumption philosophically before demolishing it practically."
-            },
-            {
-              "ref": "23:13",
-              "note": "Milgrom: The ritual prescriptions for Balaam's oracles reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -213,10 +201,6 @@
             {
               "ref": "23:21",
               "note": "Ashley: \"No misfortune is seen in Jacob, no misery observed in Israel; the Lord their God is with them\" — the second oracle’s pastoral centre. God sees no disqualifying condition in Israel. From Balak’s perspective, Israel is a terrifying military threat; from God’s perspective, Israel is his covenant people in whom no curse-worthy condition exists."
-            },
-            {
-              "ref": "23:13",
-              "note": "Ashley: The narrative context of Balaam's oracles in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/24.json
+++ b/content/numbers/24.json
@@ -162,10 +162,6 @@
             {
               "ref": "24:17",
               "note": "Calvin: The star-and-sceptre oracle is fulfilled in David proximately and in Christ ultimately. Calvin follows the standard interpretive tradition: the oracle’s language (crushing the foreheads of Moab, dominating the sons of Seth) exceeds what any Israelite king accomplished and points to the universal dominion of the one who was announced by the Magi’s star (Matt 2:2) and who calls himself the Morning Star (Rev 22:16)."
-            },
-            {
-              "ref": "24:14",
-              "note": "Calvin: The passage on final oracles demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -175,10 +171,6 @@
             {
               "ref": "24:17",
               "note": "NET Note: \"He will crush the foreheads of Moab, the skulls of all the sons of Sheth\" — the violent imagery reflects the complete subjugation of Israel’s enemies by the messianic king. \"Sons of Sheth\" (bĕnê-šēt) is debated — possibly a reference to all humanity (if Sheth = Seth, Gen 4:25) or to a specific people group. If the universal reading is correct, the oracle claims universal dominion for the star from Jacob."
-            },
-            {
-              "ref": "24:14",
-              "note": "NET Note: The Hebrew vocabulary in this section on final oracles employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -188,10 +180,6 @@
             {
               "ref": "24:17",
               "note": "Milgrom: The star-and-sceptre oracle was understood messianically in the Second Temple period and the NT. Bar Kokhba (\"son of a star\") took his messianic title from this verse. The Dead Sea Scrolls’ Damascus Document also interprets it messianically. The oracle’s reach across history — from Balaam’s mouth to the Magi’s journey to Jesus’s self-identification in Rev 22:16 — is one of the most remarkable trajectories in biblical literature."
-            },
-            {
-              "ref": "24:14",
-              "note": "Milgrom: The ritual prescriptions for final oracles reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -201,10 +189,6 @@
             {
               "ref": "24:14–17",
               "note": "Ashley: The fourth oracle’s temporal frame — \"what this people will do to your people in days to come\" — explicitly projects beyond the immediate historical moment into eschatological time. Balaam is not prophesying about the conquest of Canaan alone but about something beyond it: a royal figure from Israel who will exercise universal dominion. The oracle’s scope exceeds any historical Israelite king."
-            },
-            {
-              "ref": "24:14",
-              "note": "Ashley: The narrative context of final oracles in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/25.json
+++ b/content/numbers/25.json
@@ -166,10 +166,6 @@
             {
               "ref": "25:16–18",
               "note": "Calvin: The command against Midian closes the Balaam cycle’s moral: the enemy that could not curse Israel from without devised a strategy to destroy Israel from within. The covenant community faces its greatest danger not from military assault but from cultural and religious seduction. The NT equivalent: \"Do not be conformed to this world\" (Rom 12:2) — the world’s most effective weapon is accommodation, not attack."
-            },
-            {
-              "ref": "25:14",
-              "note": "Calvin: The passage on Peor apostasy demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -179,10 +175,6 @@
             {
               "ref": "25:18",
               "note": "NET Note: \"Because of the matter of Peor and because of Cozbi, the daughter of the prince of Midian\" — the two grounds for the anti-Midian command: the ideological seduction (Peor) and its personal embodiment (Cozbi). The double ground establishes that the judgment is not arbitrary but specifically responsive to Midian’s deliberate use of religious-sexual seduction against Israel’s covenant fidelity."
-            },
-            {
-              "ref": "25:14",
-              "note": "NET Note: The Hebrew vocabulary in this section on Peor apostasy employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -205,10 +197,6 @@
             {
               "ref": "25:14–18",
               "note": "Ashley: The naming of Zimri and Cozbi closes the Baal Peor episode with judicial specificity: the record stands, the identities are known, the judgment is documented. The broader command against Midian (vv.16–18) extends the response from the individual execution to the national level — the seduction at Peor was not an accident but a strategy (Num 31:16), and the response must be proportional."
-            },
-            {
-              "ref": "25:14",
-              "note": "Ashley: The narrative context of Peor apostasy in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/26.json
+++ b/content/numbers/26.json
@@ -156,10 +156,6 @@
             {
               "ref": "26:52-56",
               "note": "Calvin: The lot teaches that covenant inheritance is not earned by military achievement but given by sovereign divine choice. The lot removes human ambition. The NT equivalent: our inheritance in Christ is \"not from works, so that no one can boast\" (Eph 2:9) — sovereignly assigned, graciously given."
-            },
-            {
-              "ref": "26:52",
-              "note": "Calvin: The passage on second census demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -169,10 +165,6 @@
             {
               "ref": "26:65",
               "note": "NET Note: \"Not one of them was left except Caleb son of Jephunneh and Joshua son of Nun\" — fulfilment of the specific exception clause of Num 14:30. The forty-year wilderness period executed the covenant verdict with exact precision. The exception was promised; the exception was fulfilled."
-            },
-            {
-              "ref": "26:52",
-              "note": "NET Note: The Hebrew vocabulary in this section on second census employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -195,10 +187,6 @@
             {
               "ref": "26:52-56",
               "note": "Ashley: The land-by-lot system reflects Numbers' entire theology: the land is God's gift, distributed by his choice. Israel has not conquered on their own terms — they receive on God's terms, through military action he superintends and divine lot he determines. The inheritance is grace from start to finish."
-            },
-            {
-              "ref": "26:52",
-              "note": "Ashley: The narrative context of second census in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/27.json
+++ b/content/numbers/27.json
@@ -152,10 +152,6 @@
             {
               "ref": "27:15-17",
               "note": "Calvin: Moses's prayer for a shepherd-leader models the first principle of pastoral intercession: pray for the community's need before your own. Moses has just been told he will die without entering the promised land, and his response is not grief for himself but prayer for the people. This is the shepherd's heart."
-            },
-            {
-              "ref": "27:12",
-              "note": "Calvin: The passage on daughters and Joshua demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -165,10 +161,6 @@
             {
               "ref": "27:20",
               "note": "NET Note: \"Give him some of your authority so the whole Israelite community will obey him\" — the Hebrew hod (authority, splendour) is the word used for the divine radiance. Moses transfers a portion of his covenant authority to Joshua — enough for public recognition. The community must see the transfer to accept it."
-            },
-            {
-              "ref": "27:12",
-              "note": "NET Note: The Hebrew vocabulary in this section on daughters and Joshua employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -178,10 +170,6 @@
             {
               "ref": "27:18-20",
               "note": "Milgrom: \"So Moses did as the Lord commanded him. He took Joshua and had him stand before Eleazar the priest and the whole assembly. Then he laid his hands on him and commissioned him.\" The compliance formula is precise: Moses does exactly as commanded, in the prescribed order. The succession is covenantally ordered, not improvised."
-            },
-            {
-              "ref": "27:12",
-              "note": "Milgrom: The ritual prescriptions for daughters and Joshua reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -191,10 +179,6 @@
             {
               "ref": "27:12-14",
               "note": "Ashley: God's reminder to Moses of his sin at Meribah grounds his exclusion in consequence rather than arbitrariness. Moses needs to understand why he cannot enter. This understanding is what enables his pastoral response: knowing why he cannot go, he can still pray for the people who will."
-            },
-            {
-              "ref": "27:12",
-              "note": "Ashley: The narrative context of daughters and Joshua in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/28.json
+++ b/content/numbers/28.json
@@ -152,10 +152,6 @@
             {
               "ref": "28:26-31",
               "note": "Calvin: The Feast of Weeks offering, given at the harvest's completion, teaches that prosperity and abundance are occasions for intensified worship. The more God gives, the more Israel returns. The NT equivalent: \"Command those who are rich in this present world to be generous and willing to share\" (1 Tim 6:17-18)."
-            },
-            {
-              "ref": "28:16",
-              "note": "Calvin: The passage on daily offerings demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -165,10 +161,6 @@
             {
               "ref": "28:26",
               "note": "NET Note: The Feast of Weeks marks the completion of the spring grain harvest, fifty days after the Passover firstfruits offering. The fifty-day counting period (the Omer) creates a liturgical arc between Passover (barley harvest) and Weeks (wheat harvest) — the entire spring harvest season is covenant time."
-            },
-            {
-              "ref": "28:16",
-              "note": "NET Note: The Hebrew vocabulary in this section on daily offerings employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -178,10 +170,6 @@
             {
               "ref": "28:16-25",
               "note": "Milgrom: The Passover offering complex in Num 28 is more elaborate than the Lev 23 listing — it specifies exact animal counts and grain and drink accompaniments for each of the seven days. The elaboration reflects the Numbers offering calendar's purpose as a priestly manual rather than a theological summary. Lev 23 tells Israel what to observe; Num 28-29 tells the priests what to offer."
-            },
-            {
-              "ref": "28:16",
-              "note": "Milgrom: The ritual prescriptions for daily offerings reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -191,10 +179,6 @@
             {
               "ref": "28:26-31",
               "note": "Ashley: The Feast of Weeks offering brings together two theological streams: agricultural firstfruits (the first of the wheat harvest belongs to God) and historical covenant (fifty days after Passover). Numbers 28's offering calendar links the agricultural and historical dimensions of Israel's covenant calendar into a single liturgical unity."
-            },
-            {
-              "ref": "28:16",
-              "note": "Ashley: The narrative context of daily offerings in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/29.json
+++ b/content/numbers/29.json
@@ -152,10 +152,6 @@
             {
               "ref": "29:12-40",
               "note": "Calvin: The Feast of Tabernacles' seven-day duration and booth-dwelling teach that covenant joy is both extended and embodied. The Christian is called not to brief moments of spiritual intensity but to sustained orientation of joy in God's presence. The eighth day's intimate assembly models the contemplative dimension of covenant life: after the public celebration, private fellowship."
-            },
-            {
-              "ref": "29:12",
-              "note": "Calvin: The passage on feast offerings demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -165,10 +161,6 @@
             {
               "ref": "29:35",
               "note": "NET Note: The shemini atzeret (eighth-day restraint) is a distinct feast appended to Tabernacles. In later rabbinic practice it became Simchat Torah (rejoicing in the Torah). The eighth day's significance: beyond the seven of completeness, the eighth signals new creation — rest beyond rest, the eschatological Sabbath."
-            },
-            {
-              "ref": "29:12",
-              "note": "NET Note: The Hebrew vocabulary in this section on feast offerings employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -178,10 +170,6 @@
             {
               "ref": "29:12-38",
               "note": "Milgrom: The Tabernacles offering sequence's decreasing bull count (13, 12, 11, 10, 9, 8, 7 = 70 total) is one of Numbers' most mathematically distinctive features. The descending count creates a liturgical arc within the feast week: each day slightly less than the previous, building anticipation for the eighth day's quiet close."
-            },
-            {
-              "ref": "29:12",
-              "note": "Milgrom: The ritual prescriptions for feast offerings reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -191,10 +179,6 @@
             {
               "ref": "29:35-38",
               "note": "Ashley: The shemini atzeret (eighth-day assembly) is structurally distinct from Tabernacles — Lev 23:36 and Num 29:35 both treat it as a separate feast. Its minimal offering after the week's extravagance creates a theological contrast: the great public celebration followed by a simple, intimate gathering. The eighth day signals what lies beyond the seven — the eschatological rest that follows the full week of covenant celebration."
-            },
-            {
-              "ref": "29:12",
-              "note": "Ashley: The narrative context of feast offerings in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/3.json
+++ b/content/numbers/3.json
@@ -172,10 +172,6 @@
             {
               "ref": "3:27–51",
               "note": "Calvin: The elaborate Levitical hierarchy — Kohath nearest the holy, Merari farthest — teaches that proximity to God carries proportional responsibility. We do not all stand equally close to the holy; those entrusted with greater access are more accountable. The NT equivalent: teachers will be judged more strictly (Jas 3:1) precisely because their office brings them nearest to the word of God."
-            },
-            {
-              "ref": "3:27",
-              "note": "Calvin: The passage on Levitical clans demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -185,10 +181,6 @@
             {
               "ref": "3:38",
               "note": "NET Note: Moses and Aaron camp at the entrance to the tabernacle on the east — the side of the tabernacle's entrance and the sunrise. Their position is both the most accessible (facing the entrance) and the most protective (guarding the approach). Moses as prophet and Aaron as priest together guard the gateway to the divine presence."
-            },
-            {
-              "ref": "3:27",
-              "note": "NET Note: The Hebrew vocabulary in this section on Levitical clans employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -211,10 +203,6 @@
             {
               "ref": "3:40–51",
               "note": "Ashley: The firstborn-Levite exchange is grounded in the Exodus event (v.13, \"when I struck down all the firstborn in Egypt, I set apart for myself every firstborn in Israel\"). The Passover not only saved Israel — it created a permanent divine claim on every firstborn. The Levites serve as the institutional expression of that claim."
-            },
-            {
-              "ref": "3:27",
-              "note": "Ashley: The narrative context of Levitical clans in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/30.json
+++ b/content/numbers/30.json
@@ -158,10 +158,6 @@
             {
               "ref": "30:9-16",
               "note": "Calvin: The widow and divorcee's fully binding vows teach that no external authority structure can substitute for personal covenant accountability. Each believer stands directly before God for the commitments they have made, regardless of social circumstances. God is the ultimate recipient and enforcer of every covenant promise."
-            },
-            {
-              "ref": "30:9",
-              "note": "Calvin: The passage on vows demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "30:15",
               "note": "NET Note: \"He will be responsible for her guilt\" — the Hebrew yissa et-avonah (he will bear her iniquity) uses the same guilt-bearing language as the priests' bearing of Israel's iniquity (Num 18:1). The husband who improperly revokes becomes an unwilling guilt-bearer — a sobering reminder that authority in the covenant community always carries corresponding responsibility."
-            },
-            {
-              "ref": "30:9",
-              "note": "NET Note: The Hebrew vocabulary in this section on vows employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -184,10 +176,6 @@
             {
               "ref": "30:9",
               "note": "Milgrom: The equal binding force of widows' and divorced women's vows reflects a consistent legal principle: covenant accountability is proportional to covenant agency. Where there is no male authority figure to provide oversight, the woman stands as a full covenant agent accountable directly to God."
-            },
-            {
-              "ref": "30:9",
-              "note": "Milgrom: The ritual prescriptions for vows reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -197,10 +185,6 @@
             {
               "ref": "30:10-15",
               "note": "Ashley: The married woman's vow law creates a careful balance: the husband has authority to revoke, but it is bounded (same-day, on hearing) and carries consequences (guilt-transfer if misused). Authority in the covenant community is always accountable authority."
-            },
-            {
-              "ref": "30:9",
-              "note": "Ashley: The narrative context of vows in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/31.json
+++ b/content/numbers/31.json
@@ -156,10 +156,6 @@
             {
               "ref": "31:48-54",
               "note": "Calvin: The warriors' voluntary offering — acknowledging that even a divinely commanded war requires atonement — models the principle that proximity to legitimate violence requires cleansing before God. The Christian's entire life requires continuous covenant cleansing, not because warfare is inherently sinful, but because every human act stands under God's holiness."
-            },
-            {
-              "ref": "31:25",
-              "note": "Calvin: The passage on Midianite war demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -169,10 +165,6 @@
             {
               "ref": "31:50",
               "note": "NET Note: \"To make atonement for ourselves before the Lord\" — the voluntary gold offering is described as atonement (kipper) with no specific sin stated. The atonement appears to be a general acknowledgment: even covenant warriors who survived a divinely commanded war stand before God in need of his mercy rather than self-congratulation."
-            },
-            {
-              "ref": "31:25",
-              "note": "NET Note: The Hebrew vocabulary in this section on Midianite war employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -182,10 +174,6 @@
             {
               "ref": "31:25-47",
               "note": "Milgrom: The equal division of spoil (half to soldiers, half to community) with proportional levies to the Lord is a sophisticated covenant economic arrangement. The soldiers who risk their lives receive no more than those who stayed behind — the principle of equal covenant benefit regardless of role."
-            },
-            {
-              "ref": "31:25",
-              "note": "Milgrom: The ritual prescriptions for Midianite war reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -195,10 +183,6 @@
             {
               "ref": "31:49",
               "note": "Ashley: \"Not one of us is missing\" — the chapter's theological summit. The entire military force returned alive from a war against five kings. The miraculous preservation was not the soldiers' achievement; it was God's. The gold offering acknowledges this: atonement for themselves, because they know the victory was not their doing."
-            },
-            {
-              "ref": "31:25",
-              "note": "Ashley: The narrative context of Midianite war in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/32.json
+++ b/content/numbers/32.json
@@ -156,10 +156,6 @@
             {
               "ref": "32:28-42",
               "note": "Calvin: The Transjordan settlement models the principle that geographic separation does not release covenant community members from shared obligations. The east-Jordan tribes' families live in a different land; their warriors fight on the western side of the Jordan. Physical distance does not dissolve covenant solidarity."
-            },
-            {
-              "ref": "32:28",
-              "note": "Calvin: The passage on Transjordan demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -169,10 +165,6 @@
             {
               "ref": "32:33",
               "note": "NET Note: \"Then Moses gave to the Gadites, the Reubenites, and the half-tribe of Manasseh... the kingdom of Sihon king of the Amorites and the kingdom of Og king of Bashan\" — the territories given are the recently conquered kingdoms of Num 21. The east-Jordan settlement is built on Israel's military victories, not on dispossessing a non-hostile people."
-            },
-            {
-              "ref": "32:28",
-              "note": "NET Note: The Hebrew vocabulary in this section on Transjordan employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -182,10 +174,6 @@
             {
               "ref": "32:33-42",
               "note": "Milgrom: The rebuilding of cities begins immediately after the agreement is formalised — before the fighting men cross the Jordan. The families need settled, defensible cities while the warriors are away. The practical urgency confirms that the east-Jordan settlement was not a fantasy but a carefully planned covenant arrangement."
-            },
-            {
-              "ref": "32:28",
-              "note": "Milgrom: The ritual prescriptions for Transjordan reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -195,10 +183,6 @@
             {
               "ref": "32:28-32",
               "note": "Ashley: The agreement's formalisation ensures that no future generation can claim the east-Jordan tribes settled without covenant basis. Their legitimacy within the covenant community is publicly established — they are not deserters but warriors who fulfilled their obligations and then received their promised portion."
-            },
-            {
-              "ref": "32:28",
-              "note": "Ashley: The narrative context of Transjordan in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/33.json
+++ b/content/numbers/33.json
@@ -152,10 +152,6 @@
             {
               "ref": "33:55",
               "note": "Calvin: The warning — \"those you allow to remain will become thorns in your sides\" — is the OT's clearest statement that incomplete sanctification produces ongoing spiritual suffering. The Christian who tolerates sin does not achieve stable compromise but chronic spiritual impairment. The thorns and barbs of incomplete obedience are more costly than the initial discomfort of complete surrender."
-            },
-            {
-              "ref": "33:50",
-              "note": "Calvin: The passage on itinerary demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -165,10 +161,6 @@
             {
               "ref": "33:52",
               "note": "NET Note: \"Demolish all their high places\" (bamot) — open-air shrines used for Canaanite worship. Israelite history confirms that every preserved high place became a site of syncretism — the prophets and reforming kings repeatedly address the high places as the persistent source of Israelite apostasy."
-            },
-            {
-              "ref": "33:50",
-              "note": "NET Note: The Hebrew vocabulary in this section on itinerary employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -178,10 +170,6 @@
             {
               "ref": "33:50-56",
               "note": "Milgrom: The conquest command's placement at the end of the wilderness itinerary is theologically deliberate: the 42-stage journey through the wilderness has been preparation for this moment. Israel arrives as a community formed by divine guidance, not as a newly assembled army. The formation precedes the command."
-            },
-            {
-              "ref": "33:50",
-              "note": "Milgrom: The ritual prescriptions for itinerary reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -191,10 +179,6 @@
             {
               "ref": "33:51-56",
               "note": "Ashley: The command to destroy Canaanite religious infrastructure before addressing people's residences is significant: the religious threat is addressed first, the social reality second. The Canaanite cult — not the Canaanite people per se — is the primary danger to Israel's covenant faithfulness. The conquest is a religious act as much as a military one."
-            },
-            {
-              "ref": "33:50",
-              "note": "Ashley: The narrative context of itinerary in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/34.json
+++ b/content/numbers/34.json
@@ -156,10 +156,6 @@
             {
               "ref": "34:16-29",
               "note": "Calvin: The appointment of specific, accountable leaders for land distribution models the principle that God's gifts to the community require careful, accountable administration. The land is God's gift; its distribution must honour that gift through ordered, just administration — as must the church's administration of material and spiritual gifts."
-            },
-            {
-              "ref": "34:16",
-              "note": "Calvin: The passage on boundaries demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -169,10 +165,6 @@
             {
               "ref": "34:29",
               "note": "NET Note: \"These are the men the Lord commanded to assign the inheritance to the Israelites in the land of Canaan\" — the divine passive confirms that the distribution leaders are God's appointees, not tribal political selections. The land that belongs to God is distributed by leaders he has designated."
-            },
-            {
-              "ref": "34:16",
-              "note": "NET Note: The Hebrew vocabulary in this section on boundaries employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -182,10 +174,6 @@
             {
               "ref": "34:17",
               "note": "Milgrom: Eleazar and Joshua as co-administrators reflect the dual authority structure throughout Numbers: the priestly dimension (Eleazar) ensures the land distribution honours the covenant's sacred character; the military dimension (Joshua) ensures practical administrative competence. Neither alone suffices."
-            },
-            {
-              "ref": "34:16",
-              "note": "Milgrom: The ritual prescriptions for boundaries reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -195,10 +183,6 @@
             {
               "ref": "34:16-29",
               "note": "Ashley: The appointment of new distribution leaders from the new generation is a sign of covenant continuity across the generational transition. The administrative structure that organised the wilderness generation continues into the settlement generation. The covenant community's institutional memory survives the forty-year interruption."
-            },
-            {
-              "ref": "34:16",
-              "note": "Ashley: The narrative context of boundaries in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/35.json
+++ b/content/numbers/35.json
@@ -158,10 +158,6 @@
             {
               "ref": "35:33-34",
               "note": "Calvin: The land-defilement principle teaches that sin has effects beyond the sinner — it corrupts the created environment. Calvin sees in this a preview of Romans 8:20-22: \"The creation was subjected to frustration... in hope that the creation itself will be liberated from its bondage to decay.\" Covenant sin defiles the land; the new creation will restore the land to its original moral integrity."
-            },
-            {
-              "ref": "35:16",
-              "note": "Calvin: The passage on Levitical cities demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "35:30",
               "note": "NET Note: \"Anyone who kills a person is to be put to death as a murderer only on the testimony of witnesses. But no one is to be put to death on the testimony of only one witness.\" The two-witness rule for capital cases is among the Torah's most significant procedural protections. It appears in Deut 17:6 and 19:15, forms the basis of NT church discipline (Matt 18:16; 2 Cor 13:1), and reflects the irreversible nature of execution."
-            },
-            {
-              "ref": "35:16",
-              "note": "NET Note: The Hebrew vocabulary in this section on Levitical cities employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "35:22-25",
               "note": "Ashley: The congregation's role in adjudicating homicide cases — receiving the accused, judging between murderer and blood-avenger — makes the entire community responsible for covenant justice. Capital punishment in Israel is not a personal transaction between families but a communal act of covenant justice administered by the congregation."
-            },
-            {
-              "ref": "35:16",
-              "note": "Ashley: The narrative context of Levitical cities in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/36.json
+++ b/content/numbers/36.json
@@ -152,10 +152,6 @@
             {
               "ref": "36:10–13",
               "note": "Calvin: The daughters’ obedient compliance — marrying within the tribe as God commanded — models the final covenant posture that Numbers seeks to instil: hearing and doing. The book that began with a generation that heard and did not do ends with five women who heard and did. The contrast is Numbers’ theological arc in miniature: from Kadesh-barnea’s refusal to the daughters of Zelophehad’s compliance. The covenant community is ready to cross."
-            },
-            {
-              "ref": "36:10",
-              "note": "Calvin: The passage on inheritance demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -165,10 +161,6 @@
             {
               "ref": "36:13",
               "note": "NET Note: \"These are the commands and regulations the Lord gave through Moses to the Israelites on the plains of Moab by the Jordan across from Jericho\" — the closing formula is the editorial colophon of Numbers, parallel to Lev 27:34. Numbers is the Sinai laws applied to the journey and extended to the plains of Moab. Deuteronomy will be Moses’s final address from the same location. Numbers ends where Deuteronomy begins."
-            },
-            {
-              "ref": "36:10",
-              "note": "NET Note: The Hebrew vocabulary in this section on inheritance employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -178,10 +170,6 @@
             {
               "ref": "36:13",
               "note": "Milgrom: The closing formula echoes Lev 27:34 (\"These are the commands the Lord gave Moses at Mount Sinai for the Israelites\"). Numbers is the Sinai laws applied to the journey and extended to the plains of Moab. The book’s legal corpus is complete; Deuteronomy will be Moses’s final address from the same location before the crossing."
-            },
-            {
-              "ref": "36:10",
-              "note": "Milgrom: The ritual prescriptions for inheritance reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -191,10 +179,6 @@
             {
               "ref": "36:10–12",
               "note": "Ashley: The daughters’ compliance is narrated with the same careful name-by-name detail as their original petition. All five are named again; all five comply. The narrative honours their covenant faithfulness at the book’s close as it honoured their legal courage at the Zelophehad story’s beginning. Numbers closes with five women who sought justice, received it, and lived by it."
-            },
-            {
-              "ref": "36:10",
-              "note": "Ashley: The narrative context of inheritance in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/4.json
+++ b/content/numbers/4.json
@@ -158,10 +158,6 @@
             {
               "ref": "4:21–49",
               "note": "Calvin: The distribution of Levitical duties teaches the body-of-Christ principle centuries before Paul articulates it: many members, one body, each part essential. The curtain-carriers are not less holy than the ark-carriers; the structural-component teams are not less consecrated than the most holy object teams. Diversity of gifts within unity of purpose."
-            },
-            {
-              "ref": "4:21",
-              "note": "Calvin: The passage on Levitical duties demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "4:30",
               "note": "NET Note: Service age \"from thirty to fifty years old\" — the lower age of 30 ensures Levites have reached full physical and presumably spiritual maturity. The upper limit of 50 coincides with the anticipated decline of physical strength needed for the heavy transport work. After 50, the Levite presumably continues in advisory or lighter service roles."
-            },
-            {
-              "ref": "4:21",
-              "note": "NET Note: The Hebrew vocabulary in this section on Levitical duties employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "4:34–49",
               "note": "Ashley: The service age of 30–50 reflects practical wisdom: the work of transporting the tabernacle required mature strength and experience, not just youthful energy. The Levitical system matches the physical demands of each role to the life stage of its workers — a principle of stewardship that values both the individual and the task."
-            },
-            {
-              "ref": "4:21",
-              "note": "Ashley: The narrative context of Levitical duties in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/5.json
+++ b/content/numbers/5.json
@@ -164,10 +164,6 @@
             {
               "ref": "5:11–31",
               "note": "Calvin: The jealousy ordeal teaches that God sees what human courts cannot. No hidden sin is finally beyond divine scrutiny; no secret transgression escapes ultimate accounting. The procedure is also pastorally protective: an innocent wife cannot be condemned by her husband's suspicion alone. God's court is both more just and more searching than any human tribunal."
-            },
-            {
-              "ref": "5:11",
-              "note": "Calvin: The passage on purity and jealousy offering demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -177,10 +173,6 @@
             {
               "ref": "5:17",
               "note": "NET Note: \"Holy water in a clay jar\" and \"dust from the tabernacle floor\" — the ordeal water combines the sacred (holy water) with the earthy (dust). The mixture embodies the intersection of divine judgment and earthly reality. The tabernacle dust grounds the ordeal in the specific sacred space where God dwells among Israel."
-            },
-            {
-              "ref": "5:11",
-              "note": "NET Note: The Hebrew vocabulary in this section on purity and jealousy offering employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -203,10 +195,6 @@
             {
               "ref": "5:11–31",
               "note": "Ashley: The jealousy ordeal procedure is unique in the ancient Near East for its protection of the accused woman. Mesopotamian parallels typically involve river ordeals (the accused jumps into the river; survival = innocence). The Numbers ordeal is less physically dangerous and more theologically precise: the verdict rests on God's knowledge of hidden acts, not on physical endurance."
-            },
-            {
-              "ref": "5:11",
-              "note": "Ashley: The narrative context of purity and jealousy offering in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/6.json
+++ b/content/numbers/6.json
@@ -178,10 +178,6 @@
             {
               "ref": "6:24–27",
               "note": "Calvin: The Aaronic Blessing is the Old Testament's clearest preview of the gospel: God's face turned toward humanity in grace, not judgment; God's name placed on the sinner, not withdrawn; God's peace given, not withdrawn. Christ is the ultimate fulfilment — in him, God's face shines without veil, his name is placed on every believer in baptism, and his shalom is not a wish but an accomplished fact."
-            },
-            {
-              "ref": "6:22",
-              "note": "Calvin: The passage on Nazirite vow and blessing demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -191,10 +187,6 @@
             {
               "ref": "6:25",
               "note": "NET Note: \"Make his face shine\" (yāʾēr pānāyw) — the idiom of the shining face denotes favour and pleasure (cf. Ps 31:16; 80:3, 7, 19). The opposite, the hidden face (Ps 44:24; 88:14), signifies abandonment or judgment. The Aaronic Blessing asks God to be to Israel what he was to Moses: face to face, not hidden."
-            },
-            {
-              "ref": "6:22",
-              "note": "NET Note: The Hebrew vocabulary in this section on Nazirite vow and blessing employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -217,10 +209,6 @@
             {
               "ref": "6:22–27",
               "note": "Ashley: The Aaronic Blessing closes the entire introductory section of Numbers (chs.1–6) with a lyric of grace. After all the census counts, camp arrangements, Levitical rosters, and purity laws, the book pauses for a blessing. The bureaucratic is framed by the lyrical; the organisational is held within the pastoral. Numbers is not merely a handbook — it is a theology of God's care for his people."
-            },
-            {
-              "ref": "6:22",
-              "note": "Ashley: The narrative context of Nazirite vow and blessing in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/7.json
+++ b/content/numbers/7.json
@@ -158,10 +158,6 @@
             {
               "ref": "7:89",
               "note": "Calvin: Moses hearing the divine voice from the mercy seat is the prototype of prayer: approaching the appointed place of atonement to receive the divine word. The Christian enters the holy of holies through Christ (Heb 10:19–22) and hears the word of God — the same dynamic, the same mercy seat, the same voice, now accessible to all."
-            },
-            {
-              "ref": "7:48",
-              "note": "Calvin: The passage on dedication offerings demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -171,10 +167,6 @@
             {
               "ref": "7:89",
               "note": "NET Note: \"From between the two cherubim\" — this precise location was established in Exod 25:22 as the designated point of divine communication. The cherubim flank the mercy seat/atonement cover, their wings meeting above it. The divine voice comes from the intersection of holiness (the ark) and grace (the atonement cover) — theologically precise geography."
-            },
-            {
-              "ref": "7:48",
-              "note": "NET Note: The Hebrew vocabulary in this section on dedication offerings employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -197,10 +189,6 @@
             {
               "ref": "7:89",
               "note": "Ashley: The chapter's closing verse functions as a dedication plaque for the entire tabernacle system: it works. Moses enters, God speaks. The twelve days of preparation and twelve leaders' offerings have established the conditions for ongoing covenant communication. The tabernacle is not a monument but a meeting place."
-            },
-            {
-              "ref": "7:48",
-              "note": "Ashley: The narrative context of dedication offerings in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/8.json
+++ b/content/numbers/8.json
@@ -162,10 +162,6 @@
             {
               "ref": "8:23–26",
               "note": "Calvin: The Levitical retirement provision models the principle that different life stages call for different service intensity. Youth and middle age for active labour; later years for wisdom, mentoring, and lighter duties. The covenant community honours its older members by retaining them in service rather than excluding them — a counter to every culture's tendency to discard the elderly."
-            },
-            {
-              "ref": "8:5",
-              "note": "Calvin: The passage on lampstand and Levite consecration demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -175,10 +171,6 @@
             {
               "ref": "8:25–26",
               "note": "NET Note: The service age in Num 4 was 30–50; here it is 25–50. The apparent discrepancy likely reflects different types of service: the Num 4 count (30–50) specifies active transport duties; Num 8:24–26 describes the broader range of sanctuary service beginning at 25. The five years between 25 and 30 may have been a training/apprenticeship period."
-            },
-            {
-              "ref": "8:5",
-              "note": "NET Note: The Hebrew vocabulary in this section on lampstand and Levite consecration employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -201,10 +193,6 @@
             {
               "ref": "8:5–22",
               "note": "Ashley: The Levitical consecration ceremony is the communal counterpart to the Aaronic ordination of Lev 8. Where Aaron's ordination was initiated by Moses alone, the Levites are consecrated by the whole community. The two ceremonies together establish the full priestly system: Aaronic priests for sanctuary service, Levites for communal support, the entire assembly as the body that sustains and is sustained by both."
-            },
-            {
-              "ref": "8:5",
-              "note": "Ashley: The narrative context of lampstand and Levite consecration in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },

--- a/content/numbers/9.json
+++ b/content/numbers/9.json
@@ -172,10 +172,6 @@
             {
               "ref": "9:15–23",
               "note": "Calvin: The cloud guidance teaches total dependence on God for direction — not merely for sustenance (manna and water) but for the most fundamental decisions: when to stay, when to go. The Christian equivalent is prayer as the cloud-analogue: the decision to move or remain is referred to God, not resolved by human planning alone."
-            },
-            {
-              "ref": "9:15",
-              "note": "Calvin: The passage on Passover and the cloud demonstrates that God's commands are never arbitrary but expressions of his character applied to Israel's specific circumstances. What he requires, he also enables — the law reveals both the divine standard and the need for grace."
             }
           ]
         },
@@ -185,10 +181,6 @@
             {
               "ref": "9:16",
               "note": "NET Note: \"By night it looked like fire\" — the pillar of fire by night and cloud by day is first mentioned at Exod 13:21–22. The consistent dual appearance (cloud/fire) indicates a single phenomenon with two aspects: shielding from the desert sun by day, providing warmth and light by night. The cloud is practical as well as theological — God's guidance is also God's care."
-            },
-            {
-              "ref": "9:15",
-              "note": "NET Note: The Hebrew vocabulary in this section on Passover and the cloud employs distinctive covenantal terminology. The syntactical construction reinforces the formal, legal register appropriate to the priestly and Deuteronomic tradition."
             }
           ]
         },
@@ -198,10 +190,6 @@
             {
               "ref": "9:18",
               "note": "Milgrom: The phrase \"at the command of the Lord\" (ʿal-pî yhwh) appears six times in vv.18–23 — a deliberate rhetorical accumulation. Every movement of the Israelite camp is grounded in explicit divine command. Milgrom notes this is not merely theological decoration but the narrative's foundational claim: the wilderness journey is not Israel's adventure but God's choreography."
-            },
-            {
-              "ref": "9:15",
-              "note": "Milgrom: The ritual prescriptions for Passover and the cloud reflect a coherent priestly symbolic system. The gradations of holiness and offering type form an internally consistent theology of sacred space and divine access."
             }
           ]
         },
@@ -211,10 +199,6 @@
             {
               "ref": "9:15–23",
               "note": "Ashley: The cloud theology of Numbers 9 establishes the model for Israel's relationship to divine guidance throughout the OT: God leads visibly, community follows responsively, movement is determined by presence rather than plan. The absence of the cloud (cf. Ps 74:1) is a theological crisis; its presence is the guarantee of covenant accompaniment."
-            },
-            {
-              "ref": "9:15",
-              "note": "Ashley: The narrative context of Passover and the cloud in Numbers illustrates the tension between divine provision and human complaint. Each episode advances the theological argument that faithlessness delays but cannot ultimately defeat God's purposes."
             }
           ]
         },


### PR DESCRIPTION
## Summary

Fixes #331

Removes duplicate and near-duplicate scholar notes caused by generator bugs.

## Root Causes

1. **Cross-section duplication**: Thematic notes (general observations about a book) were copy-pasted to every section in a chapter instead of appearing once.

2. **Template duplication**: Boilerplate phrases like "MacArthur: The passage on [topic] demonstrates..." were repeated with only the topic varying.

## Scope

| Type | Count | Fix |
|------|-------|-----|
| Exact duplicates | 2,355 | Keep first occurrence |
| Near-duplicates (85%+) | 468 | Keep first template instance |
| **Total removed** | **2,823** | |

- **298 files** modified
- **12,614 lines** net reduction
- **9 near-dups** remain (legitimate similar analysis)

## Validation

- ✅ Schema validator: 119,154 passed, 0 failed
- ✅ No exact duplicates remain
- ✅ Near-duplicates reduced from 170 to 9

## Part of Epic #327