### PR TITLE
fix(content): Correct 4 chapters with verse overlap

### DIFF
--- a/content/genesis/45.json
+++ b/content/genesis/45.json
@@ -134,8 +134,8 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 9–28 — Instructions; Brothers Restored; Jacob Hears",
-      "verse_start": 9,
+      "header": "Verses 16–28 — Instructions; Brothers Restored; Jacob Hears",
+      "verse_start": 16,
       "verse_end": 28,
       "panels": {
         "heb": [

--- a/content/job/17.json
+++ b/content/job/17.json
@@ -13,9 +13,9 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1–16 — “My Spirit Is Broken”; Darkness as Companion",
+      "header": "Verses 1–9 — \"My Spirit Is Broken\"; Darkness as Companion",
       "verse_start": 1,
-      "verse_end": 16,
+      "verse_end": 9,
       "panels": {
         "heb": [
           {

--- a/content/job/18.json
+++ b/content/job/18.json
@@ -13,9 +13,9 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1–21 — Terrors, Snares, Disease, Death",
+      "header": "Verses 1–10 — Terrors, Snares, Disease, Death",
       "verse_start": 1,
-      "verse_end": 21,
+      "verse_end": 10,
       "panels": {
         "heb": [
           {

--- a/content/numbers/17.json
+++ b/content/numbers/17.json
@@ -13,9 +13,9 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1–13 — The Twelve Staffs; Aaron's Staff Produces Almonds",
+      "header": "Verses 1–11 — The Twelve Staffs; Aaron's Staff Produces Almonds",
       "verse_start": 1,
-      "verse_end": 13,
+      "verse_end": 11,
       "panels": {
         "heb": [
           {


### PR DESCRIPTION
## Summary

Fixes #558

4 chapters had sections with overlapping verse ranges (impossible state).

## Fixed Chapters

| Chapter | Issue | Fix |
|---------|-------|-----|
| genesis/45 | sec1 started at v9, prev ended v15 | sec1 verse_start 9→16 |
| job/17 | sec0 ended v16, sec1 started v10 | sec0 verse_end 16→9 |
| job/18 | sec0 ended v21, sec1 started v11 | sec0 verse_end 21→10 |
| numbers/17 | sec0 ended v13, sec1 started v12 | sec0 verse_end 13→11 |

## Validation

- ✅ No verse overlaps remain
- ✅ Headers updated to match corrected ranges

## Part of Epic #556