### PR TITLE
fix: Normalize 151 non-conforming debate topic tags (#322)

### DIFF
--- a/content/meta/debate-topics.json
+++ b/content/meta/debate-topics.json
@@ -4873,7 +4873,7 @@
     ],
     "tags": [
       "divine-name",
-      "YHWH",
+      "yhwh",
       "theology-proper",
       "burning-bush",
       "exodus-3"
@@ -5077,7 +5077,7 @@
       "Exodus 3:13-15"
     ],
     "tags": [
-      "YHWH",
+      "yhwh",
       "documentary-hypothesis",
       "source-criticism",
       "pentateuch",
@@ -12407,7 +12407,7 @@
     ],
     "tags": [
       "assurance",
-      "false prophets",
+      "false-prophets",
       "lordship",
       "obedience",
       "perseverance",
@@ -12471,7 +12471,7 @@
     "tags": [
       "healing",
       "atonement",
-      "Isaiah 53",
+      "isaiah-53",
       "miracles",
       "sickness",
       "faith"
@@ -12530,9 +12530,9 @@
       "Luke 8:26-39"
     ],
     "tags": [
-      "synoptic problem",
+      "synoptic-problem",
       "inerrancy",
-      "Jairus",
+      "jairus",
       "resurrection",
       "harmonisation"
     ]
@@ -12673,7 +12673,7 @@
       "discipleship",
       "salvation",
       "wisdom",
-      "Pharisees"
+      "pharisees"
     ]
   },
   {
@@ -12732,10 +12732,10 @@
     ],
     "tags": [
       "blasphemy",
-      "Holy Spirit",
-      "unforgivable sin",
-      "Pharisees",
-      "Beelzebul",
+      "holy-spirit",
+      "unforgivable-sin",
+      "pharisees",
+      "beelzebul",
       "impenitence"
     ]
   },
@@ -12798,7 +12798,7 @@
       "concealment",
       "revelation",
       "hardening",
-      "Isaiah 6",
+      "isaiah-6",
       "kingdom"
     ]
   },
@@ -12855,12 +12855,12 @@
       "Matthew 26:26-28"
     ],
     "tags": [
-      "feeding miracle",
-      "Eucharist",
-      "exodus typology",
+      "feeding-miracle",
+      "eucharist",
+      "exodus-typology",
       "bread",
       "manna",
-      "messianic banquet"
+      "messianic-banquet"
     ]
   },
   {
@@ -12921,11 +12921,11 @@
       "Isaiah 56:6-7"
     ],
     "tags": [
-      "Canaanite woman",
-      "Gentiles",
+      "canaanite-woman",
+      "gentiles",
       "faith",
-      "Israel",
-      "ethnic boundary",
+      "israel",
+      "ethnic-boundary",
       "dogs"
     ]
   },
@@ -13066,11 +13066,11 @@
     "tags": [
       "faith",
       "exorcism",
-      "mustard seed",
+      "mustard-seed",
       "prayer",
       "fasting",
-      "little faith",
-      "textual criticism"
+      "little-faith",
+      "textual-criticism"
     ]
   },
   {
@@ -13130,9 +13130,9 @@
       "Titus 3:10-11"
     ],
     "tags": [
-      "church discipline",
+      "church-discipline",
       "reconciliation",
-      "binding and loosing",
+      "binding-and-loosing",
       "ekklesia",
       "forgiveness",
       "conflict"
@@ -13275,10 +13275,10 @@
       "ransom",
       "atonement",
       "many",
-      "limited atonement",
+      "limited-atonement",
       "substitution",
-      "Calvinism",
-      "Arminianism"
+      "calvinism",
+      "arminianism"
     ]
   },
   {
@@ -13337,12 +13337,12 @@
       "Matthew 12:6"
     ],
     "tags": [
-      "temple cleansing",
-      "prophetic sign-act",
+      "temple-cleansing",
+      "prophetic-sign-act",
       "judgment",
       "worship",
-      "Gentiles",
-      "priestly corruption"
+      "gentiles",
+      "priestly-corruption"
     ]
   },
   {
@@ -13403,7 +13403,7 @@
       "Galatians 3:27"
     ],
     "tags": [
-      "wedding garment",
+      "wedding-garment",
       "righteousness",
       "kingdom",
       "judgment",
@@ -13469,12 +13469,12 @@
     ],
     "tags": [
       "woes",
-      "Pharisees",
+      "pharisees",
       "hypocrisy",
       "legalism",
-      "anti-Judaism",
-      "prophetic critique",
-      "church leadership"
+      "anti-judaism",
+      "prophetic-critique",
+      "church-leadership"
     ]
   },
   {
@@ -13881,10 +13881,10 @@
     "tags": [
       "resurrection",
       "body",
-      "spiritual body",
+      "spiritual-body",
       "physicality",
-      "Paul",
-      "empty tomb",
+      "paul",
+      "empty-tomb",
       "eschatology"
     ]
   },
@@ -14130,9 +14130,9 @@
       "parables",
       "concealment",
       "hardening",
-      "messianic secret",
-      "Isaiah 6",
-      "hina clause"
+      "messianic-secret",
+      "isaiah-6",
+      "hina-clause"
     ]
   },
   {
@@ -14188,10 +14188,10 @@
       "Daniel 12:2"
     ],
     "tags": [
-      "Jairus",
+      "jairus",
       "resurrection",
       "miracle",
-      "sleep metaphor",
+      "sleep-metaphor",
       "death",
       "rationalism"
     ]
@@ -14252,9 +14252,9 @@
       "Exodus 33:19-22"
     ],
     "tags": [
-      "walking on water",
+      "walking-on-water",
       "theophany",
-      "divine identity",
+      "divine-identity",
       "miracle",
       "sea",
       "christology"
@@ -14316,12 +14316,12 @@
       "Romans 1:16"
     ],
     "tags": [
-      "Syrophoenician woman",
-      "Gentiles",
+      "syrophoenician-woman",
+      "gentiles",
       "dogs",
       "faith",
-      "ethnic boundary",
-      "Israel first"
+      "ethnic-boundary",
+      "israel-first"
     ]
   },
   {
@@ -14379,12 +14379,12 @@
       "Mark 14:61-62"
     ],
     "tags": [
-      "Peter",
+      "peter",
       "confession",
-      "Caesarea Philippi",
+      "caesarea-philippi",
       "structure",
-      "messianic secret",
-      "passion prediction"
+      "messianic-secret",
+      "passion-prediction"
     ]
   },
   {
@@ -14440,10 +14440,10 @@
       "2 Peter 1:16-18"
     ],
     "tags": [
-      "Transfiguration",
-      "Mount Tabor",
-      "Mount Hermon",
-      "Sinai typology",
+      "transfiguration",
+      "mount-tabor",
+      "mount-hermon",
+      "sinai-typology",
       "theophany",
       "geography"
     ]
@@ -14508,8 +14508,8 @@
       "ransom",
       "atonement",
       "substitution",
-      "Christus Victor",
-      "Isaiah 53",
+      "christus-victor",
+      "isaiah-53",
       "anti",
       "liberation"
     ]
@@ -14573,9 +14573,9 @@
       "temple",
       "cleansing",
       "judgment",
-      "fig tree",
-      "prophetic sign-act",
-      "Markan sandwich"
+      "fig-tree",
+      "prophetic-sign-act",
+      "markan-sandwich"
     ]
   },
   {
@@ -14640,7 +14640,7 @@
       "exploitation",
       "generosity",
       "scribes",
-      "Markan sandwich"
+      "markan-sandwich"
     ]
   },
   {
@@ -14698,12 +14698,12 @@
       "1 Thessalonians 4:15-17"
     ],
     "tags": [
-      "Olivet Discourse",
-      "this generation",
-      "AD 70",
+      "olivet-discourse",
+      "this-generation",
+      "ad-70",
       "parousia",
       "eschatology",
-      "prophetic telescoping"
+      "prophetic-telescoping"
     ]
   },
   {
@@ -14762,11 +14762,11 @@
       "Exodus 12:1-14"
     ],
     "tags": [
-      "Last Supper",
-      "Passover",
+      "last-supper",
+      "passover",
       "chronology",
-      "Synoptic-Johannine",
-      "Eucharist",
+      "synoptic-johannine",
+      "eucharist",
       "calendar"
     ]
   },
@@ -14832,7 +14832,7 @@
       "judgment",
       "atonement",
       "centurion",
-      "Holy of Holies"
+      "holy-of-holies"
     ]
   },
   {
@@ -14888,12 +14888,12 @@
       "1 Corinthians 15:3-8"
     ],
     "tags": [
-      "Mark ending",
-      "textual criticism",
-      "longer ending",
-      "16:8",
+      "mark-ending",
+      "textual-criticism",
+      "longer-ending",
+      "168",
       "manuscripts",
-      "messianic secret"
+      "messianic-secret"
     ]
   },
   {
@@ -15461,9 +15461,9 @@
     ],
     "tags": [
       "kingdom",
-      "Transfiguration",
+      "transfiguration",
       "eschatology",
-      "AD 70",
+      "ad-70",
       "prophecy",
       "parousia"
     ]
@@ -15523,11 +15523,11 @@
       "Matthew 25:31-46"
     ],
     "tags": [
-      "Good Samaritan",
+      "good-samaritan",
       "allegory",
       "ethics",
       "neighbour",
-      "Samaritan",
+      "samaritan",
       "parable"
     ]
   },
@@ -15586,11 +15586,11 @@
       "Luke 24:46-47"
     ],
     "tags": [
-      "sign of Jonah",
+      "sign-of-jonah",
       "resurrection",
       "preaching",
       "repentance",
-      "Nineveh",
+      "nineveh",
       "judgment"
     ]
   },
@@ -15647,11 +15647,11 @@
       "Didache 8.2-3"
     ],
     "tags": [
-      "Lord's Prayer",
+      "lords-prayer",
       "prayer",
-      "Synoptic differences",
+      "synoptic-differences",
       "liturgy",
-      "Sermon on the Mount"
+      "sermon-on-the-mount"
     ]
   },
   {
@@ -15709,8 +15709,8 @@
     "tags": [
       "fire",
       "judgment",
-      "Pentecost",
-      "Spirit",
+      "pentecost",
+      "spirit",
       "division",
       "eschatology"
     ]
@@ -15770,9 +15770,9 @@
       "Hebrews 10:29"
     ],
     "tags": [
-      "degrees of punishment",
+      "degrees-of-punishment",
       "hell",
-      "proportional justice",
+      "proportional-justice",
       "knowledge",
       "accountability",
       "parable"
@@ -15833,12 +15833,12 @@
       "Zechariah 12:10"
     ],
     "tags": [
-      "Jerusalem",
+      "jerusalem",
       "lament",
-      "Palm Sunday",
+      "palm-sunday",
       "parousia",
-      "Psalm 118",
-      "Israel"
+      "psalm-118",
+      "israel"
     ]
   },
   {
@@ -15896,12 +15896,12 @@
       "Luke 4:25-27"
     ],
     "tags": [
-      "great banquet",
-      "Gentiles",
+      "great-banquet",
+      "gentiles",
       "outcasts",
-      "social ethics",
+      "social-ethics",
       "parable",
-      "Israel",
+      "israel",
       "hospitality"
     ]
   },
@@ -15962,12 +15962,12 @@
       "Romans 11:28-32"
     ],
     "tags": [
-      "prodigal son",
-      "elder brother",
-      "Pharisees",
+      "prodigal-son",
+      "elder-brother",
+      "pharisees",
       "grace",
       "legalism",
-      "open ending",
+      "open-ending",
       "invitation"
     ]
   },
@@ -16028,12 +16028,12 @@
       "Revelation 20:11-15"
     ],
     "tags": [
-      "rich man",
-      "Lazarus",
+      "rich-man",
+      "lazarus",
       "afterlife",
-      "Hades",
+      "hades",
       "parable",
-      "Scripture",
+      "scripture",
       "judgment"
     ]
   },
@@ -16093,12 +16093,12 @@
       "Matthew 12:28"
     ],
     "tags": [
-      "kingdom of God",
+      "kingdom-of-god",
       "within",
       "among",
       "entos",
-      "inaugurated eschatology",
-      "Pharisees"
+      "inaugurated-eschatology",
+      "pharisees"
     ]
   },
   {
@@ -16230,13 +16230,13 @@
       "Exodus 22:1-4"
     ],
     "tags": [
-      "Zacchaeus",
+      "zacchaeus",
       "conversion",
       "restitution",
-      "tax collector",
+      "tax-collector",
       "salvation",
-      "present tense",
-      "social justice"
+      "present-tense",
+      "social-justice"
     ]
   },
   {
@@ -16295,13 +16295,13 @@
       "Acts 5:29"
     ],
     "tags": [
-      "Caesar",
+      "caesar",
       "taxes",
-      "image of God",
-      "civil government",
+      "image-of-god",
+      "civil-government",
       "eikon",
       "idolatry",
-      "two kingdoms"
+      "two-kingdoms"
     ]
   },
   {
@@ -16432,9 +16432,9 @@
       "John 12:27"
     ],
     "tags": [
-      "Gethsemane",
-      "textual criticism",
-      "bloody sweat",
+      "gethsemane",
+      "textual-criticism",
+      "bloody-sweat",
       "angel",
       "manuscripts",
       "docetism"
@@ -16494,8 +16494,8 @@
       "Isaiah 53:12"
     ],
     "tags": [
-      "Father forgive them",
-      "textual criticism",
+      "father-forgive-them",
+      "textual-criticism",
       "forgiveness",
       "crucifixion",
       "manuscripts",
@@ -16557,12 +16557,12 @@
       "1 Corinthians 11:23-26"
     ],
     "tags": [
-      "Emmaus",
-      "breaking of bread",
-      "Eucharist",
+      "emmaus",
+      "breaking-of-bread",
+      "eucharist",
       "recognition",
       "resurrection",
-      "Word and sacrament"
+      "word-and-sacrament"
     ]
   },
   {
@@ -17015,9 +17015,9 @@
       "Acts 2:33"
     ],
     "tags": [
-      "living water",
-      "Tabernacles",
-      "Spirit",
+      "living-water",
+      "tabernacles",
+      "spirit",
       "temple",
       "punctuation",
       "christology"
@@ -17080,12 +17080,12 @@
       "Philippians 2:6"
     ],
     "tags": [
-      "I AM",
-      "ego eimi",
-      "deity of Christ",
+      "i-am",
+      "ego-eimi",
+      "deity-of-christ",
       "pre-existence",
-      "Exodus 3:14",
-      "divine name"
+      "exodus-314",
+      "divine-name"
     ]
   },
   {
@@ -17729,8 +17729,8 @@
       "victory",
       "cross",
       "tribulation",
-      "perfect tense",
-      "Farewell Discourse"
+      "perfect-tense",
+      "farewell-discourse"
     ]
   },
   {
@@ -17801,11 +17801,11 @@
     ],
     "tags": [
       "unity",
-      "High Priestly Prayer",
+      "high-priestly-prayer",
       "ecumenism",
-      "Trinity",
+      "trinity",
       "church",
-      "visible unity"
+      "visible-unity"
     ]
   },
   {
@@ -17958,10 +17958,10 @@
       "Exodus 12:22"
     ],
     "tags": [
-      "blood and water",
+      "blood-and-water",
       "crucifixion",
       "sacraments",
-      "Spirit",
+      "spirit",
       "atonement",
       "eyewitness"
     ]
@@ -18035,12 +18035,12 @@
       "Ezekiel 37:9-10"
     ],
     "tags": [
-      "Pentecost",
-      "Holy Spirit",
+      "pentecost",
+      "holy-spirit",
       "breathing",
-      "new creation",
+      "new-creation",
       "commissioning",
-      "John vs Acts"
+      "john-vs-acts"
     ]
   },
   {
@@ -18206,13 +18206,13 @@
       "Galatians 2:1-10"
     ],
     "tags": [
-      "Acts",
+      "acts",
       "historicity",
-      "Luke",
+      "luke",
       "archaeology",
       "historiography",
-      "Paul",
-      "we passages"
+      "paul",
+      "we-passages"
     ]
   },
   {


### PR DESCRIPTION
Lowercase, replace spaces with hyphens, strip non-alphanumeric chars, deduplicate per topic. 53 topics updated, 0 tag format warnings remain.

Examples: YHWH→yhwh, false prophets→false-prophets, Isaiah 53→isaiah-53, Holy Spirit→holy-spirit, AD 70→ad-70, Christus Victor→christus-victor

Closes #322

https://claude.ai/code/session_012iuiZXQvD4jD9oTbQoCZ6z