### PR TITLE
fix: Reconfigure stdout to UTF-8 on Windows for non-ASCII print output

### DIFF
--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -28,6 +28,10 @@ from pathlib import Path
 from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT = ROOT / 'content'
 META = CONTENT / 'meta'


### PR DESCRIPTION
Hebrew/Greek gloss characters in section 12 output cause UnicodeEncodeError on Windows where the console defaults to cp1252. Reconfigure sys.stdout to UTF-8 at startup.

https://claude.ai/code/session_01FGkib55aDzxzMYYMe3t1XD