### PR TITLE
fix: Add UTF-8 encoding to all _tools/ Python scripts for Windows

### DIFF
--- a/_tools/accuracy_auditor.py
+++ b/_tools/accuracy_auditor.py
@@ -28,6 +28,10 @@ import json
 import os
 import sys
 import time
+
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
 from collections import Counter, defaultdict
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -65,7 +69,7 @@ def load_chapter(book_dir: str, chapter_num: int) -> dict:
     path = CONTENT_DIR / book_dir / f"{chapter_num}.json"
     if not path.exists():
         return {}
-    return json.load(open(path))
+    return json.load(open(path, encoding='utf-8'))
 
 
 def iter_chapters(book_filter: str = None,
@@ -74,7 +78,7 @@ def iter_chapters(book_filter: str = None,
 
     Yields: (book_dir, chapter_num, chapter_data)
     """
-    books_meta = json.load(open(META_DIR / "books.json"))
+    books_meta = json.load(open(META_DIR / "books.json", encoding='utf-8'))
     chapters = []
 
     if chapter_filter:
@@ -105,7 +109,7 @@ def iter_chapters(book_filter: str = None,
                 ch_num = int(ch_file.stem)
             except ValueError:
                 continue
-            data = json.load(open(ch_file))
+            data = json.load(open(ch_file, encoding='utf-8'))
             if isinstance(data, dict):
                 chapters.append((book_id, ch_num, data))
 
@@ -134,7 +138,7 @@ def _parse_chapter_id(chapter_id: str, books_meta: list) -> tuple:
 
 def _get_testament(book_dir: str) -> str:
     """Get testament (ot/nt) for a book."""
-    books_meta = json.load(open(META_DIR / "books.json"))
+    books_meta = json.load(open(META_DIR / "books.json", encoding='utf-8'))
     for b in books_meta:
         if b["id"] == book_dir:
             return b.get("testament", "ot")
@@ -191,7 +195,7 @@ def score_chapter(results: list[VerificationResult],
 def load_matrix() -> dict:
     """Load existing reference matrix or create empty one."""
     if REFERENCE_MATRIX_PATH.exists():
-        return json.load(open(REFERENCE_MATRIX_PATH))
+        return json.load(open(REFERENCE_MATRIX_PATH, encoding='utf-8'))
     return {
         "metadata": {
             "version": "1.0",

--- a/_tools/build_strongs.py
+++ b/_tools/build_strongs.py
@@ -18,6 +18,10 @@ import os
 import re
 import sys
 import urllib.request
+
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
 from html.parser import HTMLParser
 from pathlib import Path
 

--- a/_tools/ci_content_check.py
+++ b/_tools/ci_content_check.py
@@ -32,6 +32,10 @@ import json
 import os
 import sys
 import time
+
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path

--- a/_tools/quality_scorer.py
+++ b/_tools/quality_scorer.py
@@ -23,6 +23,10 @@ import hashlib
 import os
 import re
 import sys
+
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
 import time
 from dataclasses import dataclass, field, asdict
 from difflib import SequenceMatcher
@@ -942,7 +946,7 @@ class QualityEvaluator:
         # From scholars.json meta
         meta_path = self.content_dir / "meta" / "scholars.json"
         if meta_path.exists():
-            scholars = json.loads(meta_path.read_text())
+            scholars = json.loads(meta_path.read_text(encoding='utf-8'))
             for s in scholars:
                 keys.add(s.get("panel_key", ""))
                 keys.add(s.get("id", ""))
@@ -965,7 +969,7 @@ class QualityEvaluator:
         cache_path = Path(__file__).resolve().parent / ".quality_cache.json"
         if cache_path.exists():
             try:
-                return json.loads(cache_path.read_text())
+                return json.loads(cache_path.read_text(encoding='utf-8'))
             except (json.JSONDecodeError, Exception):
                 pass
         return {}
@@ -982,7 +986,7 @@ class QualityEvaluator:
 
         verse_path = self.verse_dir / "niv" / f"{book_dir}.json"
         if verse_path.exists():
-            data = json.loads(verse_path.read_text())
+            data = json.loads(verse_path.read_text(encoding='utf-8'))
             self.verse_cache[book_dir] = data
             return data
 
@@ -992,7 +996,7 @@ class QualityEvaluator:
     def evaluate_chapter(self, chapter_path):
         """Score a single chapter file."""
         try:
-            data = json.loads(chapter_path.read_text())
+            data = json.loads(chapter_path.read_text(encoding='utf-8'))
         except (json.JSONDecodeError, Exception) as e:
             # Return a zero-score chapter
             ch_id = chapter_path.stem
@@ -1061,7 +1065,7 @@ class QualityEvaluator:
                     continue
                 for json_file in sorted(book_dir.glob("*.json")):
                     try:
-                        data = json.loads(json_file.read_text())
+                        data = json.loads(json_file.read_text(encoding='utf-8'))
                         if isinstance(data, dict) and data.get("chapter_id") == chapter:
                             score = self.evaluate_chapter(json_file)
                             report.chapters.append(score)
@@ -1088,7 +1092,7 @@ class QualityEvaluator:
             meta_path = self.content_dir / "meta" / "books.json"
             live_books = set()
             if meta_path.exists():
-                books = json.loads(meta_path.read_text())
+                books = json.loads(meta_path.read_text(encoding='utf-8'))
                 live_books = {b["id"] for b in books if b.get("is_live")}
 
             for book_dir in sorted(self.content_dir.iterdir()):


### PR DESCRIPTION
Windows defaults to cp1252 which can't handle Hebrew/Greek characters. Add sys.stdout.reconfigure(encoding='utf-8') and encoding='utf-8' to file read calls in accuracy_auditor, ci_content_check, quality_scorer, and build_strongs.

https://claude.ai/code/session_01FGkib55aDzxzMYYMe3t1XD