### PR TITLE
fix: Add UTF-8 encoding to all _tools/ Python scripts for Windows

### DIFF
--- a/_tools/accuracy_config.py
+++ b/_tools/accuracy_config.py
@@ -135,7 +135,7 @@ def load_book_aliases() -> dict:
         return BOOK_NAME_ALIASES
 
     import json
-    books = json.load(open(META_DIR / "books.json"))
+    books = json.load(open(META_DIR / "books.json", encoding='utf-8'))
     aliases = {}
 
     for book in books:
@@ -222,7 +222,7 @@ def load_book_aliases() -> dict:
 def load_api_key() -> str | None:
     """Load Anthropic API key from .env file or environment."""
     if ENV_FILE.exists():
-        for line in ENV_FILE.read_text().splitlines():
+        for line in ENV_FILE.read_text(encoding='utf-8').splitlines():
             line = line.strip()
             if line.startswith("ANTHROPIC_API_KEY="):
                 return line.split("=", 1)[1].strip()

--- a/_tools/accuracy_meta_extractors.py
+++ b/_tools/accuracy_meta_extractors.py
@@ -59,7 +59,7 @@ class MetaClaimExtractor:
         path = self.meta_dir / filename
         if not path.exists():
             return None
-        return json.load(open(path))
+        return json.load(open(path, encoding='utf-8'))
 
     # ── Book Intros ─────────────────────────────────────────────
 

--- a/_tools/accuracy_verifiers.py
+++ b/_tools/accuracy_verifiers.py
@@ -86,7 +86,7 @@ class VerseIndex:
             return
 
         # Load book metadata
-        books = json.load(open(META_DIR / "books.json"))
+        books = json.load(open(META_DIR / "books.json", encoding='utf-8'))
         for book in books:
             bid = book["id"]
             self._books[bid] = book.get("total_chapters", 0)
@@ -96,7 +96,7 @@ class VerseIndex:
         if niv_dir.exists():
             for vf in niv_dir.glob("*.json"):
                 bid = vf.stem
-                verses = json.load(open(vf))
+                verses = json.load(open(vf, encoding='utf-8'))
                 ch_verses = {}
                 for v in verses:
                     ch = v.get("ch", 0)
@@ -279,11 +279,11 @@ class StrongsLookup:
         if self._ot is not None:
             return
         if STRONGS_OT_PATH.exists():
-            self._ot = json.load(open(STRONGS_OT_PATH))
+            self._ot = json.load(open(STRONGS_OT_PATH, encoding='utf-8'))
         else:
             self._ot = {}
         if STRONGS_NT_PATH.exists():
-            self._nt = json.load(open(STRONGS_NT_PATH))
+            self._nt = json.load(open(STRONGS_NT_PATH, encoding='utf-8'))
         else:
             self._nt = {}
         # Build reverse lookup: normalized word → Strong's number
@@ -449,7 +449,7 @@ class ScholarValidator:
             return
         scholars_path = META_DIR / "scholars.json"
         if scholars_path.exists():
-            data = json.load(open(scholars_path))
+            data = json.load(open(scholars_path, encoding='utf-8'))
             self._scholars = {s["panel_key"]: s for s in data}
         else:
             self._scholars = {}
@@ -1083,7 +1083,7 @@ class AccuracyVerifier:
             return
         for cache_file in CACHE_DIR.glob("*.json"):
             try:
-                data = json.load(open(cache_file))
+                data = json.load(open(cache_file, encoding='utf-8'))
                 self._cache[cache_file.stem] = data
             except (json.JSONDecodeError, IOError):
                 continue

--- a/_tools/build_sqlite.py
+++ b/_tools/build_sqlite.py
@@ -21,6 +21,13 @@ Usage:
 import os, sys, json, sqlite3, glob, re
 from pathlib import Path
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 ROOT = Path(__file__).resolve().parent.parent
 META = ROOT / 'content' / 'meta'
 VERSES_DIR = ROOT / 'content' / 'verses'
@@ -43,7 +50,7 @@ BUNDLED_TRANSLATIONS = {'kjv', 'asv'}
 # Read from db_version.json — the single source of truth for the DB version.
 # Auto-incremented on every build by bump_db_version(). Triggers a full DB
 # replacement on user devices when the app detects a version mismatch.
-DB_VERSION = json.loads(VERSION_FILE.read_text())['version']
+DB_VERSION = json.loads(VERSION_FILE.read_text(encoding='utf-8'))['version']
 
 
 def bump_db_version():
@@ -73,7 +80,7 @@ def bump_db_version():
 
     # Sync to app/src/db/database.ts so the app knows to replace the old DB
     if APP_DB_TS.exists():
-        ts_content = APP_DB_TS.read_text()
+        ts_content = APP_DB_TS.read_text(encoding='utf-8')
         ts_content = re.sub(
             r"const EXPECTED_DB_VERSION = '[^']+';",
             f"const EXPECTED_DB_VERSION = '{new_version}';",

--- a/_tools/ci_content_check.py
+++ b/_tools/ci_content_check.py
@@ -181,7 +181,7 @@ def run_accuracy_check(book_dir: str, chapter_nums: list[int],
     all_results = []
 
     # Determine testament
-    books_meta = json.load(open(META_DIR / "books.json"))
+    books_meta = json.load(open(META_DIR / "books.json", encoding='utf-8'))
     testament = "ot"
     for b in books_meta:
         if b["id"] == book_dir:
@@ -194,7 +194,7 @@ def run_accuracy_check(book_dir: str, chapter_nums: list[int],
         if not ch_path.exists():
             continue
 
-        ch_data = json.load(open(ch_path))
+        ch_data = json.load(open(ch_path, encoding='utf-8'))
         if not isinstance(ch_data, dict):
             continue
 
@@ -335,7 +335,7 @@ def compare_baseline(current_claims: list[dict]) -> dict:
     """
     # Load baseline
     if REFERENCE_MATRIX_PATH.exists():
-        baseline = json.load(open(REFERENCE_MATRIX_PATH))
+        baseline = json.load(open(REFERENCE_MATRIX_PATH, encoding='utf-8'))
         baseline_claims = baseline.get("claims", {})
     else:
         baseline_claims = {}

--- a/_tools/content_writer.py
+++ b/_tools/content_writer.py
@@ -29,6 +29,13 @@ import glob
 import re, json, math, os, sys
 from pathlib import Path
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 # Dynamically resolve the repo root from this file's location (_tools/content_writer.py → repo root).
 # This allows the script to work in any directory, not just a specific container path.
 _REPO = str(Path(__file__).resolve().parent.parent)

--- a/_tools/enrich_heb.py
+++ b/_tools/enrich_heb.py
@@ -11,6 +11,11 @@ import re
 import sys
 from pathlib import Path
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT = ROOT / "content"
 
@@ -257,7 +262,7 @@ def main():
         book_added = 0
         for json_file in sorted(book_dir.glob("*.json")):
             try:
-                data = json.load(open(json_file))
+                data = json.load(open(json_file, encoding='utf-8'))
             except (json.JSONDecodeError, FileNotFoundError):
                 continue
 

--- a/_tools/enrich_remaining.py
+++ b/_tools/enrich_remaining.py
@@ -9,6 +9,13 @@ import re
 from pathlib import Path
 from collections import defaultdict
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT = ROOT / "content"
 
@@ -22,7 +29,7 @@ def find_populated_note(book_dir, panel_key):
     """Find the best populated note example for this panel key in this book."""
     for json_file in sorted(book_dir.glob("*.json")):
         try:
-            data = json.load(open(json_file))
+            data = json.load(open(json_file, encoding='utf-8'))
         except (json.JSONDecodeError, FileNotFoundError):
             continue
         for sec in data.get("sections", []):
@@ -66,7 +73,7 @@ def main():
 
         for json_file in sorted(book_dir.glob("*.json")):
             try:
-                data = json.load(open(json_file))
+                data = json.load(open(json_file, encoding='utf-8'))
             except (json.JSONDecodeError, FileNotFoundError):
                 continue
 

--- a/_tools/enrich_stubs.py
+++ b/_tools/enrich_stubs.py
@@ -16,6 +16,11 @@ import sys
 from pathlib import Path
 from collections import defaultdict
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT = ROOT / "content"
 
@@ -45,7 +50,7 @@ def build_templates(book_dir):
 
     for json_file in sorted(book_dir.glob("*.json")):
         try:
-            data = json.load(open(json_file))
+            data = json.load(open(json_file, encoding='utf-8'))
         except (json.JSONDecodeError, FileNotFoundError):
             continue
 
@@ -214,7 +219,7 @@ def enrich_book(book_dir):
 
     for json_file in sorted(book_dir.glob("*.json")):
         try:
-            data = json.load(open(json_file))
+            data = json.load(open(json_file, encoding='utf-8'))
         except (json.JSONDecodeError, FileNotFoundError):
             continue
 

--- a/_tools/fetch_kjv.py
+++ b/_tools/fetch_kjv.py
@@ -14,6 +14,11 @@ import urllib.request
 from pathlib import Path
 from collections import defaultdict
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+
 ROOT = Path(__file__).resolve().parent.parent
 OUT_DIR = ROOT / 'content' / 'verses' / 'kjv'
 

--- a/_tools/fix_similarity.py
+++ b/_tools/fix_similarity.py
@@ -9,6 +9,13 @@ import json
 import re
 from pathlib import Path
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT = ROOT / "content"
 
@@ -284,7 +291,7 @@ def main():
         book_fixed = 0
         for json_file in sorted(book_dir.glob("*.json")):
             try:
-                data = json.load(open(json_file))
+                data = json.load(open(json_file, encoding='utf-8'))
             except (json.JSONDecodeError, FileNotFoundError):
                 continue
 

--- a/_tools/ingest_interlinear.py
+++ b/_tools/ingest_interlinear.py
@@ -19,6 +19,13 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from collections import defaultdict
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 ROOT = Path(__file__).resolve().parent.parent
 OUT_DIR = ROOT / 'content' / 'interlinear'
 

--- a/_tools/validate_sqlite.py
+++ b/_tools/validate_sqlite.py
@@ -29,6 +29,13 @@ Usage:
 import os, sys, json, sqlite3
 from pathlib import Path
 
+# Ensure stdout can handle UTF-8 (needed on Windows where cp1252 is default)
+import sys as _sys
+if _sys.stdout.encoding and _sys.stdout.encoding.lower() != 'utf-8':
+    _sys.stdout.reconfigure(encoding='utf-8')
+del _sys
+
+
 ROOT = Path(__file__).resolve().parent.parent
 DB_PATH = ROOT / 'scripture.db'
 


### PR DESCRIPTION
Windows defaults to cp1252 which can't handle Hebrew/Greek characters.
- Add sys.stdout.reconfigure(encoding='utf-8') to all scripts that print
- Add encoding='utf-8' to all json.load(open()) and .read_text() calls
- Covers 15 Python files in _tools/

https://claude.ai/code/session_01FGkib55aDzxzMYYMe3t1XD