### PR TITLE
fix: prevent Discovery not found when secondary queries fail

### DIFF
--- a/app/src/hooks/useArchaeology.ts
+++ b/app/src/hooks/useArchaeology.ts
@@ -84,8 +84,8 @@ export function useArchaeologyDetail(discoveryId: string): ArchaeologyDetailData
     setLoading(true);
     Promise.all([
       getDiscovery(discoveryId),
-      getDiscoveryVerseLinks(discoveryId),
-      getDiscoveryImages(discoveryId),
+      getDiscoveryVerseLinks(discoveryId).catch(() => [] as ArchaeologyVerseLink[]),
+      getDiscoveryImages(discoveryId).catch(() => [] as ArchaeologyImage[]),
     ])
       .then(([d, vl, imgs]) => {
         if (mountedRef.current) {


### PR DESCRIPTION
The useArchaeologyDetail hook used Promise.all for getDiscovery, getDiscoveryVerseLinks, and getDiscoveryImages. If any query failed (e.g. archaeology_images table missing on devices with cached older DB), the entire Promise.all rejected and the catch handler silently set loading=false without setting discovery, showing "Discovery not found".

Now catch errors on verse-link and image queries individually so they gracefully degrade to empty arrays without blocking the main discovery.

https://claude.ai/code/session_01U8QkCMkiNXawNKpTZbRmPC