### PR TITLE
fix: Add retry logic and error handling to Tier 2 verification

### DIFF
--- a/_tools/accuracy_verifiers.py
+++ b/_tools/accuracy_verifiers.py
@@ -768,8 +768,19 @@ class Tier2Verifier:
             # Rate limiting: simple delay
             time.sleep(1.2)  # ~50 RPM
 
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                result = json.load(resp)
+            # Retry with backoff for transient network errors
+            last_err = None
+            for attempt in range(3):
+                try:
+                    with urllib.request.urlopen(req, timeout=90) as resp:
+                        result = json.load(resp)
+                    break
+                except (urllib.error.URLError, OSError, TimeoutError) as e:
+                    last_err = e
+                    if attempt < 2:
+                        time.sleep(2 ** (attempt + 1))
+            else:
+                raise last_err
 
             self._call_count += 1
 
@@ -845,7 +856,17 @@ class Tier2Verifier:
         all_results = []
         for i in range(0, len(claims), self.BATCH_SIZE):
             batch = claims[i:i + self.BATCH_SIZE]
-            results = self.verify_batch(batch, book_name, chapter_num)
+            try:
+                results = self.verify_batch(batch, book_name, chapter_num)
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as e:
+                now = datetime.now(timezone.utc).isoformat()
+                results = [VerificationResult(
+                    claim_id=c.id, status=STATUS_UNVERIFIED, confidence=0,
+                    notes=f"Tier 2 batch error: {str(e)[:100]}",
+                    verified_at=now, tier=2,
+                ) for c in batch]
             all_results.extend(results)
         return all_results
 


### PR DESCRIPTION
- Add 3 retries with exponential backoff for transient network errors in verify_batch (timeout increased to 90s)
- Wrap verify_claims_batched to catch exceptions per-batch instead of crashing the entire run — failed batches return UNVERIFIED results
- Allows the auditor to complete and save results even when individual API calls fail

https://claude.ai/code/session_01FGkib55aDzxzMYYMe3t1XD