### PR TITLE
debug: add console.log to archaeology detail hook for image diagnosis

### DIFF
--- a/app/src/hooks/useArchaeology.ts
+++ b/app/src/hooks/useArchaeology.ts
@@ -108,10 +108,18 @@ export function useArchaeologyDetail(discoveryId: string): ArchaeologyDetailData
     ])
       .then(([d, vl, imgs]) => {
         if (mountedRef.current) {
+          const finalImages = imgs.length > 0 ? imgs : parseInlineImages(d);
+          console.log('[ArchDetail]', discoveryId, {
+            discoveryFound: !!d,
+            hasImagesJson: !!d?.images_json,
+            imagesTableCount: imgs.length,
+            inlineParseCount: parseInlineImages(d).length,
+            finalCount: finalImages.length,
+          });
           setDiscovery(d);
           setVerseLinks(vl);
           // Prefer images from the separate table; fall back to inline JSON
-          setImages(imgs.length > 0 ? imgs : parseInlineImages(d));
+          setImages(finalImages);
           setLoading(false);
         }
       })


### PR DESCRIPTION
Temporary logging to diagnose why images aren't rendering on device. Logs discovery presence, images_json availability, table query count, inline parse count, and final image count.

https://claude.ai/code/session_01U8QkCMkiNXawNKpTZbRmPC