### PR TITLE
fix: add User-Agent header to archaeology image requests

### DIFF
--- a/app/src/components/DiscoveryImageGallery.tsx
+++ b/app/src/components/DiscoveryImageGallery.tsx
@@ -76,7 +76,12 @@ function GalleryImage({ image, width }: ImageItemProps) {
           </View>
         )}
         <Image
-          source={{ uri: image.url }}
+          source={{
+            uri: image.url,
+            headers: {
+              'User-Agent': 'ScriptureDeepDive/1.0 (https://companionstudy.app; contact@companionstudy.app)',
+            },
+          }}
           style={styles.image}
           resizeMode="contain"
           onLoad={handleLoad}


### PR DESCRIPTION
Wikimedia Commons blocks image requests without a proper User-Agent header, causing all Shroud of Turin images to show "Image unavailable". Add a descriptive User-Agent per Wikimedia's API etiquette policy.

https://claude.ai/code/session_01U8QkCMkiNXawNKpTZbRmPC