### PR TITLE
Fix evidence card subtitle text overlapping card boundaries

### DIFF
--- a/app/src/components/ArchaeologyCard.tsx
+++ b/app/src/components/ArchaeologyCard.tsx
@@ -121,6 +121,7 @@ const styles = StyleSheet.create({
   meta: {
     fontFamily: fontFamily.ui,
     fontSize: 11,
+    flexShrink: 1,
   },
   significance: {
     fontFamily: fontFamily.body,


### PR DESCRIPTION
Add flexShrink: 1 to meta text style so location/date text truncates properly within the metaRow flex container instead of overflowing.

https://claude.ai/code/session_012mJU8pkhgoJcaRt4kYX8KK