### PR TITLE
revert: remove back buttons from Map and Timeline screens

### DIFF
--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -8,9 +8,8 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { View, TouchableOpacity, StyleSheet, useWindowDimensions } from 'react-native';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ArrowLeft } from 'lucide-react-native';
 import MapView, { PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
 
 import { usePlaces } from '../hooks/usePlaces';
@@ -192,16 +191,6 @@ function MapScreen({ route, navigation }: {
         )}
       </MapView>
 
-      {/* Floating back button */}
-      <TouchableOpacity
-        onPress={() => navigation.goBack()}
-        accessibilityRole="button"
-        accessibilityLabel="Go back"
-        style={[styles.backButton, { top: insets.top + 8, backgroundColor: base.bgElevated }]}
-      >
-        <ArrowLeft size={20} color={base.gold} />
-      </TouchableOpacity>
-
       {/* Era filter — overlaid at top below status bar */}
       <View style={[styles.topControls, { paddingTop: insets.top }]} pointerEvents="box-none">
         <EraFilterBar activeEra={activeEra} onSelect={handleEraChange} />
@@ -264,21 +253,6 @@ const styles = StyleSheet.create({
   },
   loadingPad: {
     padding: spacing.lg,
-  },
-  backButton: {
-    position: 'absolute',
-    left: 12,
-    zIndex: 15,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 3,
-    elevation: 4,
   },
   topControls: {
     position: 'absolute',

--- a/app/src/screens/TimelineScreen.tsx
+++ b/app/src/screens/TimelineScreen.tsx
@@ -13,7 +13,6 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef, useReducer } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ArrowLeft } from 'lucide-react-native';
 import Svg, {
   Defs, LinearGradient, Stop,
   Rect, Line, Circle, G, Text as SvgText,
@@ -158,15 +157,6 @@ function TimelineScreen() {
   return (
     <View style={[styles.container, { backgroundColor: base.bg }]}>
       <View style={{ paddingTop: insets.top }}>
-        {/* Back button */}
-        <TouchableOpacity
-          onPress={() => navigation.goBack()}
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-          style={[styles.backButton, { backgroundColor: base.bgElevated }]}
-        >
-          <ArrowLeft size={20} color={base.gold} />
-        </TouchableOpacity>
         <EraFilterBar activeEra={filterEra} onSelect={handleEraChange} />
 
         {/* Category toggles */}
@@ -413,22 +403,6 @@ function TimelineScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  backButton: {
-    position: 'absolute',
-    left: 12,
-    top: 8,
-    zIndex: 15,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 3,
-    elevation: 4,
   },
   loadingPad: {
     padding: spacing.lg,


### PR DESCRIPTION
The floating back buttons didn't work well on these fullscreen experiences. Users can navigate away via the bottom tab bar instead.

https://claude.ai/code/session_01U8QkCMkiNXawNKpTZbRmPC