### PR TITLE
Fix content accuracy bugs: catena alias + 2 Chr cross-reference

### DIFF
--- a/_tools/accuracy_verifiers.py
+++ b/_tools/accuracy_verifiers.py
@@ -460,6 +460,7 @@ class ScholarValidator:
             "netbible": "net",
             "mar": "marcus",
             "cat": "catena",
+            "catena": "cat",
             "rho": "rhoads",
             # These scholars exist in content but not yet in scholars.json
             # They self-alias so the validator doesn't flag them as unknown

--- a/content/2_chronicles/2.json
+++ b/content/2_chronicles/2.json
@@ -24,8 +24,8 @@
               "note": "The Kings parallel. The Chronicler expands Solomon’s theological reasoning and adds specifications."
             },
             {
-              "ref": "2 Chr 1:18–2:1 (LXX)",
-              "note": "The LXX versification differs from the MT here, placing Solomon's labour conscription in the previous chapter. Cross-referencing both systems is essential for comparative study."
+              "ref": "2 Chr 2:1",
+              "note": "The LXX versification differs from the MT here — what is 2 Chr 2:1 in English translations appears as 1:18 in the LXX/MT numbering. Cross-referencing both systems is essential for comparative study."
             },
             {
               "ref": "Exod 25:1–9",


### PR DESCRIPTION
1. Add bidirectional alias "catena" → "cat" in ScholarValidator so content files using "catena" as the panel key are recognized. The alias map had "cat" → "catena" but not the reverse, causing 157 false positives across 30 chapters (all NT catena panels).

2. Fix invalid cross-reference in 2 Chr 2 that cited "2 Chr 1:18" (chapter 1 only has 17 verses). The reference was using LXX/MT versification; updated to use the English verse number with an explanatory note about the versification difference.

https://claude.ai/code/session_012mJU8pkhgoJcaRt4kYX8KK