### PR TITLE
Content: Add coaching tips to 287 OT Narrative chapters (#294)

### DIFF
--- a/content/1_chronicles/10.json
+++ b/content/1_chronicles/10.json
@@ -358,5 +358,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Chronicler covers Saul's entire reign in one chapter — just his death and its theological explanation: 'Saul died because he was unfaithful to the LORD.' No Goliath, no Jonathan, no David's fugitive years. Everything before David is prelude; the real story starts now.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/11.json
+++ b/content/1_chronicles/11.json
@@ -363,5 +363,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David becomes king of all Israel immediately in Chronicles — no seven-year civil war, no Ishbosheth, no Abner negotiations. The Chronicler streamlines the messy political process into a unified coronation. His David is idealized: the way Israel should have received its king.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/12.json
+++ b/content/1_chronicles/12.json
@@ -344,5 +344,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'All Israel' gathers to make David king, and they celebrate for three days. The Chronicler devotes an entire chapter to the unity of this moment — warriors from every tribe, including Benjamin (Saul's tribe). The coronation feast is the theological ideal: one people, one king, one purpose.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/13.json
+++ b/content/1_chronicles/13.json
@@ -361,5 +361,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Uzzah's death when the ark is transported on a cart — rather than carried by Levites as prescribed — is kept in Chronicles despite the Chronicler's positive portrait of David. The lesson is too important to omit: good intentions with wrong methods do not equal obedience.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/14.json
+++ b/content/1_chronicles/14.json
@@ -344,5 +344,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David inquires of God before each battle and receives different tactics each time. The second battle requires waiting for 'the sound of marching in the tops of the poplar trees.' Obedience is not a formula to be repeated but a relationship to be maintained — each situation requires fresh guidance.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/15.json
+++ b/content/1_chronicles/15.json
@@ -371,5 +371,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David corrects the Uzzah disaster: this time Levites carry the ark with poles, as Moses commanded. David says explicitly: 'It was because you, the Levites, did not bring it up the first time that the LORD our God broke out in anger.' Learning from failure is itself an act of faithfulness.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_chronicles/16.json
+++ b/content/1_chronicles/16.json
@@ -387,5 +387,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David's psalm of thanksgiving (vv. 8-36) is a composite drawn from Psalms 105, 96, and 106. The Chronicler places psalm-singing at the center of David's achievement — not military conquest but liturgical innovation. David's legacy is worship, not war.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/17.json
+++ b/content/1_chronicles/17.json
@@ -355,5 +355,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Davidic covenant in Chronicles parallels 2 Samuel 7 but with a notable omission: the warning 'when he does wrong, I will punish him' is softened. The Chronicler's version emphasizes the unconditional promise. For a post-exilic audience, the permanence of the covenant matters more than the discipline clause.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/18.json
+++ b/content/1_chronicles/18.json
@@ -360,5 +360,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David's military victories are summarized rapidly — the Chronicler is less interested in battles than in what David does with the spoils: dedicating them to the LORD. Conquest serves worship. The warrior-king's real purpose is funding the temple his son will build.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/19.json
+++ b/content/1_chronicles/19.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Ammonite war narrative parallels 2 Samuel 10-11 but the Chronicler omits the Bathsheba episode entirely. David stays unblemished in Chronicles. The omission is not ignorance — it is editorial theology: the Chronicler presents the David his audience needs for temple legitimacy.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/2.json
+++ b/content/1_chronicles/2.json
@@ -345,5 +345,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The genealogy traces Judah's line first — before the other tribes — because the Chronicler is building toward David. The genealogical order is theological, not chronological. Judah leads because the Davidic dynasty matters most to the post-exilic community.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_chronicles/20.json
+++ b/content/1_chronicles/20.json
@@ -352,5 +352,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The brief note that 'David took the crown from the head of their king' skips directly from war to spoils. Between 2 Samuel 11:1 and 12:31, the Bathsheba-Uriah catastrophe unfolds. Here: silence. The gap in the Chronicler's narrative is louder than any accusation.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_chronicles/21.json
+++ b/content/1_chronicles/21.json
@@ -384,5 +384,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "In Chronicles, 'Satan rose up against Israel and incited David to take a census.' In 2 Samuel 24:1, 'the anger of the LORD burned against Israel, and he incited David.' The theological development between the two texts — attributing the incitement to Satan rather than God — reflects deepening Israelite theology about evil's agency.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_chronicles/22.json
+++ b/content/1_chronicles/22.json
@@ -359,5 +359,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David tells Solomon: 'You are to build a house for my Name because you will be a man of peace.' David's disqualification — 'you have shed much blood' — is not a moral condemnation but a liturgical one. The temple requires a builder whose reign symbolizes shalom. War and worship need different hands.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/23.json
+++ b/content/1_chronicles/23.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David organizes the Levites into divisions for temple service — 24,000 supervisors, 6,000 officials, 4,000 gatekeepers, 4,000 musicians. The Chronicler's David is an administrator of worship infrastructure. Organizational planning is presented as spiritual work.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_chronicles/24.json
+++ b/content/1_chronicles/24.json
@@ -368,5 +368,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The 24 priestly divisions — determined by lot — ensure every family serves in rotation. The system prevents monopoly and guarantees access. When Zechariah (Luke 1:5) serves 'in the division of Abijah,' he is operating within the system David established here.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_chronicles/25.json
+++ b/content/1_chronicles/25.json
@@ -358,5 +358,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Temple musicians are described as those who 'prophesied with lyres, harps, and cymbals.' Music is classified as prophecy — a form of divine communication, not mere entertainment. The Chronicler collapses the distinction between worship leader and prophet.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/26.json
+++ b/content/1_chronicles/26.json
@@ -357,5 +357,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Gatekeepers receive detailed attention because controlling access to the temple is a sacred responsibility. Who enters, when, and how — these are theological decisions, not merely logistical ones. The gate is the boundary between holy and common.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/27.json
+++ b/content/1_chronicles/27.json
@@ -363,5 +363,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The military divisions serve in monthly rotation — 24,000 per month. David's army is organized like his priesthood: structured, rotational, comprehensive. The Chronicler presents the ideal Israelite state as a society where military and liturgical systems mirror each other.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_chronicles/28.json
+++ b/content/1_chronicles/28.json
@@ -374,5 +374,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David gives Solomon the plans for the temple 'that the Spirit had put in his mind.' The temple blueprints are treated as divinely revealed — like the tabernacle plans given to Moses. David is not designing; he is receiving. Architecture is revelation.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_chronicles/29.json
+++ b/content/1_chronicles/29.json
@@ -377,5 +377,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David's final prayer — 'Everything comes from you, and we have given you only what comes from your hand' — reframes all human generosity as returning God's own gifts. Giving is not sacrifice; it is acknowledgment. The theology of stewardship begins with this prayer.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/3.json
+++ b/content/1_chronicles/3.json
@@ -367,5 +367,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David's sons are listed in detail, then the line continues through the exile into the post-exilic period. The Chronicler traces the Davidic line to his own day — a quiet argument that the dynasty still exists and the covenant is still active, even without a throne.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_chronicles/4.json
+++ b/content/1_chronicles/4.json
@@ -364,5 +364,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jabez's prayer — 'Oh, that you would bless me and enlarge my territory!' — appears unexpectedly in a genealogy. His name means 'pain,' but he prays his way out of his name's destiny. The insertion says: identity is not fixed by birth. Prayer can rewrite a name.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/5.json
+++ b/content/1_chronicles/5.json
@@ -369,5 +369,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Transjordan tribes 'were unfaithful to the God of their ancestors and prostituted themselves to the gods of the peoples of the land.' The Chronicler explains their exile as a direct consequence. Every genealogical note in Chronicles carries a theological verdict.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/6.json
+++ b/content/1_chronicles/6.json
@@ -376,5 +376,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Levitical genealogy is the most detailed in Chronicles — far more space than any tribe except Judah. The Chronicler writes for a community rebuilding the temple. Priests and worship leaders are not peripheral; they are the institutional backbone of restoration.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_chronicles/7.json
+++ b/content/1_chronicles/7.json
@@ -324,5 +324,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The northern tribes receive briefer genealogies but they are included. The Chronicler's vision of 'all Israel' encompasses tribes that no longer exist as political units. The genealogical register is an act of faith — claiming a unity that history has shattered.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_chronicles/8.json
+++ b/content/1_chronicles/8.json
@@ -360,5 +360,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Benjamin's genealogy is expanded here because Saul comes from Benjamin. The Chronicler needs to introduce Saul's line before his death in chapter 10 — even though the entire Saul narrative is compressed to a single chapter. Benjamin matters only as David's predecessor.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_chronicles/9.json
+++ b/content/1_chronicles/9.json
@@ -379,5 +379,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "This chapter lists the first returnees from exile — 'the first to resettle on their own property in their own towns.' The genealogies that began in chapter 1 with Adam arrive at the Chronicler's own community. Nine chapters of names are the bridge from creation to restoration.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/10.json
+++ b/content/1_kings/10.json
@@ -454,5 +454,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Queen of Sheba declares 'Not even half was told me.' Solomon's wealth is cataloged in dazzling detail — gold, ivory, apes, peacocks. But the narrator is building toward chapter 11. The more impressive the zenith, the more devastating the fall.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/1_kings/11.json
+++ b/content/1_kings/11.json
@@ -493,5 +493,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'King Solomon loved many foreign women.' The verb 'loved' echoes his earlier love of the LORD (3:3). The same capacity that once drove him to God now drives him to apostasy. Solomon does not abandon faith dramatically — he drifts, one alliance and one altar at a time.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/12.json
+++ b/content/1_kings/12.json
@@ -503,5 +503,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Rehoboam rejects the elders' counsel and follows his peers: 'My little finger is thicker than my father's waist.' One arrogant speech tears the kingdom in two. The narrator adds: 'this turn of events was from the LORD' — fulfilling Ahijah's prophecy (11:31). Human folly serves divine purpose.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/13.json
+++ b/content/1_kings/13.json
@@ -449,5 +449,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The man of God obeys God's word, then disobeys it when an older prophet lies to him. A lion kills him on the road. The episode is disturbing because the punishment seems disproportionate. But the narrative's point is precise: obedience to God's direct word cannot be overridden by another prophet's claim, however credible.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/14.json
+++ b/content/1_kings/14.json
@@ -452,5 +452,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ahijah tells Jeroboam's wife that God will 'uproot Israel from this good land' — the first explicit prediction of exile in Kings. It appears this early, during the very first generation of the divided monarchy. The ending is announced at the beginning.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/15.json
+++ b/content/1_kings/15.json
@@ -442,5 +442,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Asa 'did what was right in the eyes of the LORD, as his father David had done.' David becomes the permanent benchmark — every king is measured against him. Yet even David was deeply flawed. The standard is not perfection but covenant loyalty.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/16.json
+++ b/content/1_kings/16.json
@@ -457,5 +457,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ahab 'did more to arouse the anger of the LORD, the God of Israel, than did all the kings of Israel before him.' The superlative marks a new low. His marriage to Jezebel imports Baal worship at state level. The Elijah cycle that follows is the response to this nadir.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/1_kings/17.json
+++ b/content/1_kings/17.json
@@ -486,5 +486,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God sends Elijah to a widow in Zarephath — Sidon, Jezebel's homeland. The prophet of Israel is sustained by a Gentile woman in Baal territory. Jesus cites this episode (Luke 4:25-26) to make the provocative point that God's provision crosses ethnic and religious boundaries.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/18.json
+++ b/content/1_kings/18.json
@@ -593,5 +593,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Elijah's challenge — 'How long will you waver between two opinions?' — uses a Hebrew verb (pāsaḥ) that means 'to limp' or 'to hop.' He is mocking their indecision as a limping dance between Yahweh and Baal. The people respond with silence. The silence is the diagnosis.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Elijah drenches the altar with water — twelve jars, three times — then prays a simple prayer. No theatrics, no ritual cutting (as the Baal prophets did). Fire falls. The contrast between Baal's frantic prophets and Elijah's calm confidence is the theological argument made visible.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/19.json
+++ b/content/1_kings/19.json
@@ -498,5 +498,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "After his greatest victory, Elijah collapses into suicidal despair: 'Take my life.' God does not rebuke him. Instead: food, sleep, more food, more sleep. Before any theology, before any recommissioning, God addresses the prophet's physical needs. Depression gets bread before it gets answers.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 2,
+      "tip": "God is not in the wind, earthquake, or fire — but in the 'gentle whisper' (qôl demāmāh daqqāh, literally 'a sound of thin silence'). After the spectacle of Carmel, God reverses the mode of revelation. Power was demonstrated on the mountain; intimacy is offered in the cave.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_kings/2.json
+++ b/content/1_kings/2.json
@@ -508,5 +508,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David's deathbed instructions mix spiritual counsel ('walk in obedience') with political hits — settle scores with Joab and Shimei. The blend is unsettling. David's final words reveal a man who is simultaneously a man of faith and a calculating power broker. The Bible gives you both.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_kings/20.json
+++ b/content/1_kings/20.json
@@ -457,5 +457,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "A prophet condemns Ahab for releasing Ben-Hadad: 'You have set free a man I had determined should die.' Ahab's mercy toward an enemy king is not praised — it is judged as disobedience. The episode complicates simple readings: sometimes what looks like grace is actually a failure to follow divine command.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/21.json
+++ b/content/1_kings/21.json
@@ -486,5 +486,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Naboth refuses to sell his vineyard: 'The LORD forbid that I should give you the inheritance of my ancestors.' The refusal is theological, not economic — ancestral land in Israel was a covenant gift. Jezebel's response — frame Naboth, execute him, seize the property — represents the collision between Israelite covenant theology and Phoenician royal absolutism.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/22.json
+++ b/content/1_kings/22.json
@@ -496,5 +496,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Four hundred prophets say 'Go up and fight'; Micaiah alone says 'I saw all Israel scattered on the hills like sheep without a shepherd.' The lone dissenting voice against institutional consensus is a recurring pattern — Jeremiah against the temple prophets, Jesus against the Sanhedrin. Truth is not determined by vote.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/3.json
+++ b/content/1_kings/3.json
@@ -482,5 +482,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Solomon asks for 'a discerning heart to govern' rather than wealth or long life. God is 'pleased that Solomon asked for this.' The request reveals Solomon's priorities at this moment — wisdom for service, not power for self. The tragedy of the book is watching these priorities invert.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/4.json
+++ b/content/1_kings/4.json
@@ -477,5 +477,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Solomon's wisdom is measured in proverbs (3,000), songs (1,005), and botanical/zoological knowledge. The text presents wisdom as encyclopedic — not just moral advice but a comprehensive engagement with the created order. Israel's golden age is an intellectual renaissance.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_kings/5.json
+++ b/content/1_kings/5.json
@@ -476,5 +476,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The temple project requires 30,000 laborers in monthly rotations plus 150,000 workers. Solomon's forced labor corps will later become a grievance that splits the kingdom (12:4). The glory of the temple and the seed of the kingdom's destruction grow from the same root.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/6.json
+++ b/content/1_kings/6.json
@@ -472,5 +472,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "God's word interrupts the architectural description: 'As for this temple you are building — if you follow my decrees... I will live among the Israelites.' The conditional promise embedded in the building narrative warns that the structure is not the point. Obedience is. Stones without faithfulness are just stones.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_kings/7.json
+++ b/content/1_kings/7.json
@@ -470,5 +470,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Solomon spends seven years on the temple and thirteen on his own palace. The narrator states this without comment, but the contrast does its own work. The proportions reveal something about where Solomon's real investment lies.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_kings/8.json
+++ b/content/1_kings/8.json
@@ -621,5 +621,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "When the ark enters the temple, 'the cloud filled the temple of the LORD.' Solomon declares: 'The LORD has said he would dwell in a dark cloud.' God's presence is real but not visible — glory manifests as concealment. The theology of divine hiddenness begins here.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 2,
+      "tip": "Solomon's prayer anticipates exile: 'When they sin against you — for there is no one who does not sin — and you become angry... if they turn back to you... then hear from heaven.' The dedication prayer already assumes the temple will be destroyed. Hope is built into the architecture of failure.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_kings/9.json
+++ b/content/1_kings/9.json
@@ -470,5 +470,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "God's second appearance to Solomon carries an explicit threat: 'If you or your descendants turn away... I will cut off Israel from the land... and this temple will become a heap of rubble.' The conditional covenant hangs over every subsequent chapter like a suspended sentence.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/10.json
+++ b/content/1_samuel/10.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "When the lot falls on Saul, he is hiding among the baggage. The narrator presents this without comment, but the image is unforgettable: Israel's first king must be dragged out of hiding to accept the crown. His reluctance will later curdle into something worse — not humility but insecurity.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/11.json
+++ b/content/1_samuel/11.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "After the Jabesh-Gilead victory, some want to execute those who opposed Saul's kingship. Saul refuses: 'No one shall be put to death today, for this day the LORD has rescued Israel.' This is Saul at his best — generous, God-centered, restrained. The contrast with his later paranoia makes the decline more painful.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/12.json
+++ b/content/1_samuel/12.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Samuel's farewell speech parallels Joshua 24 — covenant review, challenge, warning. Samuel adds thunder and rain during wheat harvest (meteorologically impossible) as a sign. The prophet steps aside but makes clear that kingship does not replace prophetic accountability. Kings will answer to prophets.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/13.json
+++ b/content/1_samuel/13.json
@@ -498,5 +498,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul offers the sacrifice himself rather than waiting for Samuel. His excuse — 'I felt compelled' — reveals the core issue. Saul acts from pressure rather than obedience. Samuel's verdict — 'your kingdom will not endure' — seems disproportionate until you see the pattern it establishes: partial obedience is disobedience.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/14.json
+++ b/content/1_samuel/14.json
@@ -502,5 +502,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jonathan says 'Nothing can hinder the LORD from saving, whether by many or by few.' Compare this to Saul's anxious head-counting in the previous chapter. Father and son represent two postures toward the same God — one calculates odds, the other trusts regardless of them.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/15.json
+++ b/content/1_samuel/15.json
@@ -498,5 +498,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul claims he spared the best animals 'to sacrifice to the LORD.' Samuel's response — 'Does the LORD delight in burnt offerings and sacrifices as much as in obeying the LORD?' — becomes one of the Old Testament's most quoted principles. Religious activity without obedience is not worship; it is performance.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "Samuel tells Saul 'the LORD has torn the kingdom of Israel from you today.' Saul's response: 'I have sinned. But please honor me before the elders.' Even in repentance, Saul's primary concern is public reputation. The confession is real but shallow — he grieves the loss of status more than the loss of God's favor.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/16.json
+++ b/content/1_samuel/16.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God tells Samuel 'The LORD does not look at the things people look at. People look at the outward appearance, but the LORD looks at the heart.' Seven sons pass before Samuel. David, the youngest, is not even invited to the lineup. God's choice confounds every human assumption about who qualifies.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/17.json
+++ b/content/1_samuel/17.json
@@ -498,5 +498,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David refuses Saul's armor — 'I cannot go in these, because I am not used to them.' He fights with what he knows: a sling and five stones. The detail is not quaint; slingers were lethal in ancient warfare. David is not naive — he is choosing his actual competence over borrowed prestige.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/18.json
+++ b/content/1_samuel/18.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'Saul has slain his thousands, and David his tens of thousands.' The song enrages Saul not because it is false but because it is true. From this point, Saul's fear of David drives every decision. The king's downfall is not a single failure but an unchecked emotion — jealousy — that colonizes his entire being.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/19.json
+++ b/content/1_samuel/19.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul sends men to capture David, but they encounter prophets and begin prophesying themselves. Saul goes personally — and he too prophesies, stripping off his clothes. The Spirit overrides the king's murderous intent. 'Is Saul also among the prophets?' is asked again (cf. 10:11), but now it is ironic rather than hopeful.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/2.json
+++ b/content/1_samuel/2.json
@@ -498,5 +498,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Hannah's prayer (vv. 1-10) moves from personal thanksgiving to cosmic theology — God raises the poor, guards the faithful, shatters the mighty. The final word mentions 'his king' and 'his anointed' — remarkable since Israel has no king yet. Hannah's song anticipates the entire book's trajectory.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 2,
+      "tip": "Eli's sons take the meat before it is offered to God and sleep with women at the tabernacle entrance. The narrator calls them 'scoundrels' who 'had no regard for the LORD.' Priestly corruption is presented as the systemic failure that necessitates a new kind of leadership.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/20.json
+++ b/content/1_samuel/20.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jonathan and David's covenant is remarkable: the crown prince voluntarily cedes his claim to the throne. Jonathan recognizes what Saul refuses to accept — that God has chosen David. Loyalty to God's purposes overrides loyalty to family dynasty. It costs Jonathan everything.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/21.json
+++ b/content/1_samuel/21.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David eats the consecrated bread at Nob — bread reserved for priests. Jesus cites this episode (Mark 2:25-26) to argue that human need can override ritual law. The incident becomes a permanent reference point in the debate about law versus mercy.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/22.json
+++ b/content/1_samuel/22.json
@@ -420,5 +420,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul massacres 85 priests at Nob because they helped David. Only Abiathar escapes. The man anointed to protect Israel slaughters its priesthood. Saul has become the very threat the king was supposed to guard against. His trajectory from reluctant king to priestly murderer is complete.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/23.json
+++ b/content/1_samuel/23.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David inquires of the LORD before every move — twice in this chapter alone. Saul has no such practice. The contrast between the fugitive who prays and the king who doesn't is the quiet engine driving the narrative toward its conclusion.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/24.json
+++ b/content/1_samuel/24.json
@@ -411,5 +411,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David cuts Saul's robe in the cave and is immediately 'conscience-stricken.' He refuses to kill the LORD's anointed even when handed the perfect opportunity. David's restraint is not pragmatic — it is theological. He will not seize by force what God has promised to give by providence.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/25.json
+++ b/content/1_samuel/25.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Abigail intercepts David's vengeance raid with food, wisdom, and a speech that reads like prophecy: 'The LORD will certainly make a lasting dynasty for my lord.' She saves David from himself — from becoming the kind of man who avenges personal insults with massacre. Without Abigail, David's story could have ended at Nabal's doorstep.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/26.json
+++ b/content/1_samuel/26.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David spares Saul a second time, taking his spear and water jug as proof. The repetition (after ch. 24) is not redundant — it deepens the portrait. David's mercy is not a one-time impulse but a settled conviction. Saul responds with tears both times, but changes nothing. The gap between feeling and transformation is the tragedy.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/27.json
+++ b/content/1_samuel/27.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David lives among the Philistines and deceives Achish about his raids. The future king of Israel is hiding, lying, and serving Israel's enemies. The narrative presents this without moralizing — David is surviving. But the moral ambiguity is deliberate: even the chosen king is compromised by circumstances.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/28.json
+++ b/content/1_samuel/28.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul consults the medium at Endor — violating his own decree against necromancy. Samuel's ghost delivers the final verdict: 'Tomorrow you and your sons will be with me.' The king who began by prophesying (10:10) ends by consulting the dead. His spiritual trajectory is a complete inversion.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/29.json
+++ b/content/1_samuel/29.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Philistine commanders refuse to let David fight alongside them — 'He must not go with us into battle, or he will turn against us.' Their suspicion saves David from the impossible position of fighting against his own people. Providence operates through enemy distrust.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/3.json
+++ b/content/1_samuel/3.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'In those days the word of the LORD was rare; there were not many visions.' The sentence explains why Samuel does not recognize God's voice — he has no frame of reference. The spiritual famine is institutional: the priesthood has failed to mediate divine communication.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/30.json
+++ b/content/1_samuel/30.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David 'strengthened himself in the LORD his God' (v. 6) when his own men talk of stoning him. Then he inquires of the Lord and pursues. This is the David pattern at its clearest: distress → worship → guidance → action. It contrasts with Saul's pattern: distress → panic → self-reliance → disaster.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/31.json
+++ b/content/1_samuel/31.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul falls on his own sword — Israel's first king dies by his own hand on Mount Gilboa. The Philistines display his body on the walls of Beth Shan. The men of Jabesh-Gilead, whom Saul saved in his finest hour (ch. 11), retrieve the body. His beginning and his end are connected by the loyalty of one town.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/1_samuel/4.json
+++ b/content/1_samuel/4.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Israel treats the ark as a talisman — bring it to the battlefield and God must fight. They lose anyway. The ark is captured. Eli's daughter-in-law names her son Ichabod: 'The glory has departed from Israel.' The name becomes a verdict on the entire era.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/5.json
+++ b/content/1_samuel/5.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Dagon falls face down before the ark — twice. The second time his head and hands break off. The scene is darkly comic: the Philistine god literally prostrates himself before Israel's God, then disintegrates. The ark needs no army to defend itself.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/1_samuel/6.json
+++ b/content/1_samuel/6.json
@@ -420,5 +420,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Philistines design an experiment: put the ark on a cart pulled by cows that have never been yoked, with their calves penned up. If the cows walk toward Israel against their natural instinct, it proves God's hand. The pagan priests apply empirical reasoning to theology — and get the right answer.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/1_samuel/7.json
+++ b/content/1_samuel/7.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Samuel sets up a stone called Ebenezer — 'Thus far the LORD has helped us.' The name acknowledges both past faithfulness and present incompleteness. 'Thus far' means the journey is not over. Monuments mark progress, not arrival.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/8.json
+++ b/content/1_samuel/8.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "God tells Samuel: 'It is not you they have rejected, but they have rejected me as their king.' Israel wants to be 'like all the other nations' — the exact opposite of their calling to be distinct. The demand for a king is not inherently sinful (Deuteronomy 17 anticipated it), but the motivation is.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/1_samuel/9.json
+++ b/content/1_samuel/9.json
@@ -428,5 +428,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Saul is looking for lost donkeys when God directs him to Samuel. The mundane errand becomes the vehicle for divine appointment. Saul's kingship begins with an accident he did not seek — a detail that will become tragically ironic as he clings to the throne he never wanted.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/2_chronicles/10.json
+++ b/content/2_chronicles/10.json
@@ -340,5 +340,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The division of the kingdom is attributed to divine causation: 'This turn of events was from God, to fulfill the word the LORD had spoken.' The Chronicler, like Kings, sees political catastrophe as prophetic fulfillment. History is not random — it is narrated covenant.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/11.json
+++ b/content/2_chronicles/11.json
@@ -326,5 +326,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Priests and Levites from all Israel migrate south to Judah when Jeroboam installs illegitimate worship. The brain drain strengthens Judah spiritually. The Chronicler argues that true Israel — defined by legitimate worship, not geography — reconstitutes in the south.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/12.json
+++ b/content/2_chronicles/12.json
@@ -336,5 +336,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Rehoboam and the leaders humble themselves when Shishak invades: 'The LORD is just.' God's response: 'they have humbled themselves; I will not destroy them.' The pattern of 2 Chronicles 7:14 activates immediately. Humility triggers deliverance. This becomes the Chronicler's recurring engine.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/13.json
+++ b/content/2_chronicles/13.json
@@ -326,5 +326,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Abijah's speech before battle claims legitimacy based on temple worship: 'We have the priests... we observe the requirements of the LORD.' Judah wins despite being outnumbered because proper worship is treated as a military advantage. The Chronicler equates liturgical faithfulness with national security.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/14.json
+++ b/content/2_chronicles/14.json
@@ -326,5 +326,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Asa faces an army of a million Cushites. His prayer: 'LORD, there is no one like you to help the powerless against the mighty.' God gives victory. The prayer's theology is precise: God's power is most visible when human resources are most inadequate.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/15.json
+++ b/content/2_chronicles/15.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Azariah prophesies: 'For a long time Israel was without the true God, without a priest to teach, and without the law.' The description fits the Judges period — but the Chronicler's audience would hear it as describing their own post-exilic experience. The past narrates the present.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/16.json
+++ b/content/2_chronicles/16.json
@@ -334,5 +334,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Asa, who trusted God against a million Cushites (ch. 14), now pays Aram to fight Israel — trusting a treaty instead of God. The seer Hanani rebukes him: 'Because you relied on the king of Aram and not on the LORD your God.' Asa imprisons the prophet. The king who began in faith ends in angry self-reliance.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/17.json
+++ b/content/2_chronicles/17.json
@@ -338,5 +338,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jehoshaphat sends officials with Levites and priests throughout Judah carrying the Book of the Law to teach the people. This is the first recorded public education program in Judah — a king who understands that national reform requires catechesis, not just royal decree.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/18.json
+++ b/content/2_chronicles/18.json
@@ -326,5 +326,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "This chapter parallels 1 Kings 22 nearly verbatim — Micaiah vs. 400 prophets. The Chronicler retains it because it illustrates Jehoshaphat's critical flaw: allying with wicked kings despite personal faithfulness. Good theology combined with bad alliances produces disaster.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/19.json
+++ b/content/2_chronicles/19.json
@@ -322,5 +322,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jehoshaphat instructs judges: 'Consider carefully what you do, because you are not judging for mere mortals but for the LORD.' The judicial reform establishes a principle that runs through biblical ethics: every human institution operates under divine accountability.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/2.json
+++ b/content/2_chronicles/2.json
@@ -342,5 +342,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Solomon tells Hiram 'The temple I am going to build will be great, because our God is greater than all other gods.' The temple's grandeur is theological argument — the building physically proclaims divine supremacy. Architecture is a form of confession.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/20.json
+++ b/content/2_chronicles/20.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Facing a vast army, Jehoshaphat prays: 'We do not know what to do, but our eyes are on you.' Then he sends singers ahead of the army. The battle plan is worship-first, fight-second — and the enemies destroy each other before Judah arrives. The Chronicler's ideal warfare is liturgical.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/21.json
+++ b/content/2_chronicles/21.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jehoram receives a posthumous letter from Elijah predicting his intestinal disease. He dies in 'great pain' and 'departed with no one's regret.' The final phrase is the Chronicler's harshest epitaph — a king so worthless that no one mourned. Legacy is measured by grief at departure.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/22.json
+++ b/content/2_chronicles/22.json
@@ -342,5 +342,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Athaliah destroys the royal family, but Jehosheba hides baby Joash in the temple. The Davidic line survives through the temple — the institution David envisioned now protects David's line. The mutual dependence of dynasty and temple is the Chronicler's central thesis.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/23.json
+++ b/content/2_chronicles/23.json
@@ -331,5 +331,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jehoiada the priest orchestrates a coup, restores the Davidic king, and renews the covenant. The priest saves the monarchy. In the Chronicler's vision, when kings fail, priests hold the line. The institutional church preserves what the political state cannot.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/24.json
+++ b/content/2_chronicles/24.json
@@ -330,5 +330,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "After Jehoiada dies, Joash abandons the temple and kills Jehoiada's own son Zechariah when he prophesies against him. The king's faithfulness lasted exactly as long as his mentor's life. Borrowed convictions collapse when the lender dies. Joash had Jehoiada's influence but not Jehoiada's character.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/25.json
+++ b/content/2_chronicles/25.json
@@ -326,5 +326,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Amaziah hires Israelite mercenaries, then dismisses them on prophetic instruction. They raid Judean towns on their way home. Amaziah wins the battle but brings back Edomite gods and worships them. A prophet asks the obvious: 'Why do you consult the gods of a people who could not save their own people?' The logic is airtight; Amaziah ignores it.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/26.json
+++ b/content/2_chronicles/26.json
@@ -338,5 +338,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Uzziah's reign is summed up: 'After Uzziah became powerful, his pride led to his downfall.' He enters the temple to burn incense — a priestly prerogative. Eighty priests confront him; he rages; leprosy breaks out on his forehead. Success breeds entitlement, and entitlement crosses sacred boundaries.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/27.json
+++ b/content/2_chronicles/27.json
@@ -336,5 +336,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jotham 'grew powerful because he walked steadfastly before the LORD his God.' The chapter is brief — a quiet, faithful reign without dramatic events. The Chronicler shows that not every good king needs a crisis to prove his faith. Consistency is its own story.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/28.json
+++ b/content/2_chronicles/28.json
@@ -335,5 +335,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ahaz closes the temple doors — literally shutting God out. It is the Chronicler's ultimate anti-king act: the temple that Solomon opened, Ahaz padlocks. Every subsequent reform will begin by reopening these doors. The symbolic weight of a locked temple is immense.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/29.json
+++ b/content/2_chronicles/29.json
@@ -344,5 +344,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Hezekiah reopens the temple doors in the first month of his first year — his very first royal act. He tells the Levites: 'Our parents were unfaithful... they shut the doors.' Reform begins with naming what went wrong. Honesty about the past is the precondition for change.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/3.json
+++ b/content/2_chronicles/3.json
@@ -364,5 +364,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Chronicler specifies that Solomon builds the temple on Mount Moriah — 'where the LORD had appeared to his father David... on the threshing floor of Araunah.' The site connects three moments: Abraham's near-sacrifice of Isaac, David's altar during plague, and Solomon's temple. Sacred geography accumulates meaning.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/30.json
+++ b/content/2_chronicles/30.json
@@ -340,5 +340,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Hezekiah invites the northern tribes to Jerusalem for Passover — 'all Israel, from Beersheba to Dan.' Some laugh and mock the invitation; others come. The Chronicler's 'all Israel' vision extends even to the fallen north. Unity is always offered, even when rejected.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/31.json
+++ b/content/2_chronicles/31.json
@@ -335,5 +335,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The tithes pile up so abundantly that Hezekiah has to prepare storerooms. The Chronicler shows the tangible result of spiritual renewal: generosity overflows. When worship is restored, provision follows. The economics of faithfulness are portrayed as self-evident.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/32.json
+++ b/content/2_chronicles/32.json
@@ -339,5 +339,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Sennacherib's taunts are theological: 'No god of any nation or kingdom has been able to deliver his people from my hand.' Hezekiah and Isaiah pray. An angel destroys the Assyrian army. The Chronicler frames geopolitics as theological contest — which god delivers?",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/33.json
+++ b/content/2_chronicles/33.json
@@ -330,5 +330,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Chronicler adds material not in Kings: Manasseh repents in Babylonian captivity. 'He humbled himself greatly before the God of his ancestors.' Even the worst king in Judah's history can be restored through humility. 2 Chronicles 7:14 applies universally — no one is beyond its reach.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/34.json
+++ b/content/2_chronicles/34.json
@@ -335,5 +335,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Josiah begins seeking God at sixteen, starts reform at twenty, finds the Book of the Law at twenty-six. The Chronicler's timeline shows reform preceded the book's discovery — Josiah was already faithful before he had the text. Character drove the search, not the other way around.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/35.json
+++ b/content/2_chronicles/35.json
@@ -342,5 +342,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Josiah ignores Neco's warning — 'God has told me to hurry; so stop opposing God, or he will destroy you.' The Chronicler says these words were 'from the mouth of God.' Josiah, the most faithful king, dies because he cannot accept that God might speak through an Egyptian pharaoh. The source of truth is not always the source you expect.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/36.json
+++ b/content/2_chronicles/36.json
@@ -334,5 +334,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Chronicles ends with Cyrus's decree: 'The LORD, the God of heaven, has given me all the kingdoms of the earth and he has appointed me to build a temple for him at Jerusalem. Any of his people among you may go up.' The last word is not exile but invitation. The entire book — from Adam's genealogy to this moment — builds toward a single verb: go up.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_chronicles/4.json
+++ b/content/2_chronicles/4.json
@@ -348,5 +348,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The bronze Sea holds approximately 17,500 gallons and rests on twelve bulls. The scale is deliberately overwhelming — worship space should dwarf the worshiper. The furnishings communicate proportion: humanity is small; God is vast; the gap between them is the space the temple fills.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/5.json
+++ b/content/2_chronicles/5.json
@@ -353,5 +353,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "When the musicians and singers praise as one, 'the temple of the LORD was filled with the cloud.' Unified worship triggers divine manifestation. The Chronicler's theology is consistent: worship brings presence. The cloud does not descend on silence or individual prayer but on corporate, musical praise.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/6.json
+++ b/content/2_chronicles/6.json
@@ -353,5 +353,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Solomon's prayer repeatedly uses the phrase 'hear from heaven.' The temple is not God's residence — it is the earthly connection point for heavenly hearing. Solomon explicitly states: 'The heavens, even the highest heavens, cannot contain you. How much less this temple I have built!' The theology prevents idolatry of the building.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_chronicles/7.json
+++ b/content/2_chronicles/7.json
@@ -364,5 +364,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'If my people, who are called by my name, will humble themselves and pray and seek my face and turn from their wicked ways, then I will hear from heaven' (v. 14). This verse — perhaps the most quoted in Chronicles — is God's response to Solomon's prayer. Four conditions: humility, prayer, seeking, turning. The order matters.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/8.json
+++ b/content/2_chronicles/8.json
@@ -329,5 +329,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Solomon's administrative achievements are cataloged without the critical edge found in Kings. No forced labor controversy, no complaint about palace costs. The Chronicler presents Solomon's reign as the golden age — the model of how Israel should function when worship is central.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_chronicles/9.json
+++ b/content/2_chronicles/9.json
@@ -345,5 +345,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Queen of Sheba's visit is the apex — foreign recognition of Israelite wisdom and worship. The Chronicler ends Solomon's story here, omitting his apostasy entirely. Solomon's legacy in Chronicles is pure: builder of the temple, paragon of wisdom. The fall belongs to another book.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/10.json
+++ b/content/2_kings/10.json
@@ -399,5 +399,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jehu destroys Baal worship but 'did not turn away from the sins of Jeroboam' — the golden calves remain. His reform is partial. The narrator gives a split verdict: commended for executing judgment on Ahab's house, condemned for perpetuating the original national sin. Zeal against one evil does not excuse tolerance of another.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/11.json
+++ b/content/2_kings/11.json
@@ -405,5 +405,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Athaliah is the only woman to rule Judah — and she does it by massacring the royal family. Baby Joash is hidden in the temple for six years. The Davidic line survives through a single child sheltered by a priest. The covenant promise hangs by a thread, but the thread holds.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/12.json
+++ b/content/2_kings/12.json
@@ -389,5 +389,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joash repairs the temple but buys off Hazael by emptying the temple treasury. He saves the building by gutting its contents. The pattern repeats through Kings: kings raiding the temple to pay off threats, each time diminishing the glory they claim to protect.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/13.json
+++ b/content/2_kings/13.json
@@ -431,5 +431,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Elisha on his deathbed tells Joash to strike the ground with arrows. Joash strikes three times and stops. Elisha is angry: 'You should have struck five or six times.' Half-hearted obedience produces half-hearted results. The number of strikes determines the number of victories. Effort correlates with outcome.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/14.json
+++ b/content/2_kings/14.json
@@ -394,5 +394,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Amaziah challenges Israel to battle after defeating Edom. Joash responds with a fable: the thistle challenges the cedar and gets trampled. Pride from one victory leads to a catastrophic defeat. Amaziah's trajectory — obedience, success, arrogance, destruction — is a miniature of Israel's national pattern.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/2_kings/15.json
+++ b/content/2_kings/15.json
@@ -399,5 +399,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Five kings in Israel within two decades — two assassinated, one deported. The rapid succession contrasts with Judah's relative stability under Uzziah/Azariah (52 years). The northern kingdom is disintegrating from within before Assyria delivers the final blow.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/2_kings/16.json
+++ b/content/2_kings/16.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ahaz copies a pagan altar he saw in Damascus and installs it in the temple, moving the bronze altar aside. He redesigns God's worship space to match foreign aesthetics. The syncretism is architectural — the temple itself is remodeled to reflect divided loyalties.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/17.json
+++ b/content/2_kings/17.json
@@ -558,5 +558,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The narrator devotes an extended theological essay to explaining why Samaria fell: 'All this took place because the Israelites had sinned against the LORD their God.' The explanation is not military (Assyria was stronger) but moral. History is interpreted through covenant theology.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/18.json
+++ b/content/2_kings/18.json
@@ -431,5 +431,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Rabshakeh speaks in Hebrew so the people on the walls can hear: 'Has any god ever delivered his land from the king of Assyria?' It is sophisticated psychological warfare — attack the people's faith in God, not just their walls. The enemy understands that Israel's real defense is theological.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/19.json
+++ b/content/2_kings/19.json
@@ -433,5 +433,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Hezekiah spreads Sennacherib's letter before the LORD — literally lays it out in the temple. The gesture is prayer made physical: here is the threat; what will you do? God's response through Isaiah promises deliverance, and 185,000 Assyrians die overnight. The contrast with Ahaz's panic (ch. 16) could not be sharper.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/2.json
+++ b/content/2_kings/2.json
@@ -491,5 +491,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Elijah's departure — chariot of fire, whirlwind, ascension — echoes Enoch ('God took him,' Genesis 5:24). Elisha's cry 'My father! My father! The chariots and horsemen of Israel!' identifies Elijah as Israel's true defense. The prophet, not the army, was the nation's real military asset.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/20.json
+++ b/content/2_kings/20.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Hezekiah shows Babylonian envoys everything in his treasury. Isaiah warns that Babylon will carry it all away. Hezekiah's response: 'The word of the LORD you have spoken is good... there will be peace and security in my lifetime.' The king accepts national disaster as long as it falls on future generations. Shortsightedness has rarely been stated more bluntly.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/21.json
+++ b/content/2_kings/21.json
@@ -421,5 +421,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Manasseh reigns 55 years — the longest reign in Judah — and reverses every reform. He 'shed so much innocent blood that he filled Jerusalem from end to end.' The narrator makes Manasseh the point of no return: 'because of all Manasseh had done' (24:3), exile becomes inevitable. One king's sins outweigh generations of reform.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/22.json
+++ b/content/2_kings/22.json
@@ -436,5 +436,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Book of the Law is 'found' in the temple during repairs — it had been lost, forgotten, buried under debris. The detail is devastating: the nation responsible for God's word did not know where it was. Josiah's anguished response — tearing his robes — shows he understands how far they have drifted.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/23.json
+++ b/content/2_kings/23.json
@@ -422,5 +422,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Josiah's reform is the most thorough in Kings: altars demolished, Asherah poles burned, mediums expelled, high places defiled. The narrator says 'Neither before nor after Josiah was there a king like him.' Yet it is not enough — God's anger over Manasseh remains. The greatest reform in history cannot undo accumulated covenant violation.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/24.json
+++ b/content/2_kings/24.json
@@ -449,5 +449,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Nebuchadnezzar carries off the temple treasures and deports 10,000 — 'only the poorest people of the land were left.' The exile begins not with total destruction but with systematic extraction. First the wealth and skill leave; then the destruction follows. Judgment arrives in stages.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/25.json
+++ b/content/2_kings/25.json
@@ -556,5 +556,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The final paragraph — Jehoiachin released from prison in Babylon, given a seat at the king's table — is a thin thread of hope in the darkest chapter. The Davidic line survives, eating at a foreign king's table. It is not restoration, but it is not extinction. Kings ends not with a period but with an ellipsis.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_kings/3.json
+++ b/content/2_kings/3.json
@@ -461,5 +461,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Mesha king of Moab sacrifices his own son on the city wall, and 'great fury came upon Israel, and they withdrew.' The text leaves the theology ambiguous — whose fury? The episode resists easy explanation, presenting the reader with the same bewilderment the Israelite army experienced.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/4.json
+++ b/content/2_kings/4.json
@@ -568,5 +568,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The widow's oil multiplies until she runs out of vessels. The miracle is limited not by God's supply but by human preparation — she should have borrowed more jars. The principle applies broadly: God's provision often scales to the size of our expectation and effort.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/5.json
+++ b/content/2_kings/5.json
@@ -467,5 +467,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Naaman expects a dramatic healing ritual; Elisha tells him to wash in the muddy Jordan. Naaman's servants reason with him: 'If the prophet had told you to do some great thing, would you not have done it?' The barrier to healing is not complexity but simplicity. Pride wants spectacular; God offers ordinary.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/6.json
+++ b/content/2_kings/6.json
@@ -526,5 +526,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Elisha prays 'Open his eyes, LORD' and the servant sees hills full of horses and chariots of fire. The invisible reality is more populated than the visible threat. The prayer is not for rescue but for sight — the protection was already there.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/7.json
+++ b/content/2_kings/7.json
@@ -407,5 +407,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Four lepers reason: 'Why sit here until we die? If they kill us, we die; if we don't go, we die.' Their logic of desperation leads them to the abandoned Aramean camp and Samaria's deliverance. God uses the most marginalized figures — outcasts with nothing to lose — as the agents of salvation.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_kings/8.json
+++ b/content/2_kings/8.json
@@ -434,5 +434,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Hazael weeps when Elisha tells him what he will do to Israel — burning, killing, dashing children. 'How could your servant, a mere dog, do such a thing?' He cannot imagine himself capable of such violence. The next day he murders his master and becomes exactly what he denied. Self-knowledge is rarely as accurate as we think.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_kings/9.json
+++ b/content/2_kings/9.json
@@ -447,5 +447,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jezebel paints her eyes and arranges her hair before Jehu arrives — she faces death with royal defiance, not submission. Her final words taunt Jehu by comparing him to Zimri, a usurper who lasted seven days. Even in death, she is formidable. The narrator respects her courage while condemning her legacy.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/10.json
+++ b/content/2_samuel/10.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David sends envoys to comfort the Ammonite king; they are humiliated. The misread act of kindness triggers a war that sets the stage for chapter 11. The narrator is arranging events — it is during 'the time when kings go off to war' that David stays home, and everything falls apart.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/2_samuel/11.json
+++ b/content/2_samuel/11.json
@@ -519,5 +519,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The narrative structure is devastating in its restraint. David sees, sends, takes, sleeps. Four verbs, no commentary. Then the cover-up escalates: summon Uriah, get him drunk, send him home. When nothing works, arrange his death. Each step is more calculated than the last. The text lets the facts speak.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "The chapter's final sentence — 'But the thing David had done displeased the LORD' — arrives after two sections of David's meticulous scheming. The divine verdict is withheld until the end, letting the reader sit with the full weight of what the man after God's own heart has done.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/2_samuel/12.json
+++ b/content/2_samuel/12.json
@@ -498,5 +498,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Nathan's parable about the rich man stealing the poor man's lamb traps David into pronouncing his own sentence: 'The man who did this must die!' Then: 'You are the man.' The prophetic confrontation works because David's moral intuition is intact — he can see injustice everywhere except in himself.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "David's response — 'I have sinned against the LORD' — is immediate and unqualified. No excuses, no blame-shifting, no 'but I felt compelled' (contrast Saul in 1 Samuel 13). The difference between Saul and David is not the absence of sin but the quality of repentance.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/13.json
+++ b/content/2_samuel/13.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Amnon's 'love' for Tamar turns to hatred 'greater than the love' immediately after the assault. The text exposes the dynamic precisely: what Amnon called love was possession. When satisfied, it inverts. David is 'furious' but does nothing — a pattern of parental paralysis that will cost him Absalom.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/14.json
+++ b/content/2_samuel/14.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joab engineers Absalom's return through the wise woman of Tekoa — another parable designed to trap the king (echoing Nathan's in ch. 12). David recognizes Joab's hand immediately. The king permits Absalom's return but refuses to see him. Half-measures in reconciliation create the conditions for rebellion.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/2_samuel/15.json
+++ b/content/2_samuel/15.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David flees Jerusalem weeping, barefoot, head covered. The anointed king ascending the Mount of Olives in humiliation prefigures another anointed one who will ascend the same mount in anguish (Luke 22:39). David's exile from Jerusalem because of sin within his house foreshadows the larger pattern of exile in Israel's story.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/16.json
+++ b/content/2_samuel/16.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Shimei curses David: 'Get out, you murderer!' David forbids his men from retaliating: 'The LORD has told him to curse David. Who can ask, Why do you do this?' David accepts the cursing as possibly deserved — a remarkable act of self-awareness from a man mid-crisis. Even in flight, he is more spiritually lucid than Saul ever was.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/17.json
+++ b/content/2_samuel/17.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ahithophel's counsel is described as 'like that of one who inquires of God' — yet Hushai's inferior plan prevails because 'the LORD had determined to frustrate the good advice of Ahithophel.' God works through the counselor's ego and Absalom's vanity. Providence operates through flawed human psychology.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/18.json
+++ b/content/2_samuel/18.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'O my son Absalom! My son, my son Absalom! If only I had died instead of you!' David's grief is the emotional center of the entire narrative. The father who could not discipline his son now cannot stop mourning him. Nathan's prophecy — 'the sword will never depart from your house' — is fulfilled in the king's own tears.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/19.json
+++ b/content/2_samuel/19.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David's restoration requires navigating competing loyalties: Judah vs. Israel, old friends vs. former enemies, justice vs. mercy. Shimei is pardoned, Mephibosheth's claim is split, Barzillai is honored. Every decision is a political calculation layered on genuine emotion. Kingship is exhausting.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/2.json
+++ b/content/2_samuel/2.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David is anointed king of Judah only — not all Israel. Seven and a half years of civil war follow. God's promise does not arrive in a single moment. David's path to the full throne is gradual, contested, and politically messy.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/20.json
+++ b/content/2_samuel/20.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Sheba's revolt — 'We have no share in David!' — exposes the fragility of the united monarchy. The tribal fracture line between Judah and Israel that Sheba exploits is the same one that will permanently split the kingdom under Rehoboam. The seeds of 1 Kings 12 are already germinating.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/21.json
+++ b/content/2_samuel/21.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Rizpah guards the exposed bodies of her sons from birds and beasts — for months, from harvest until the rains come. Her vigil of maternal grief is one of the most haunting images in the Old Testament. When David hears of it, he finally buries Saul and Jonathan's bones properly. A mother's devotion shames the king into action.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/22.json
+++ b/content/2_samuel/22.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David's psalm of thanksgiving (nearly identical to Psalm 18) places this cosmic poetry — mountains shaking, divine warrior descending — in the mouth of a man whose reign included adultery, murder, and family disintegration. The psalm is not denial; it is the claim that God's faithfulness persists despite the psalmist's failures.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/23.json
+++ b/content/2_samuel/23.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David's mighty men risk their lives to bring him water from the well at Bethlehem. David pours it out as an offering to God: 'Is it not the blood of men who went at the risk of their lives?' He refuses to drink what cost others their safety. The gesture transforms water into sacrament.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/24.json
+++ b/content/2_samuel/24.json
@@ -498,5 +498,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David insists on paying full price for Araunah's threshing floor: 'I will not sacrifice to the LORD my God burnt offerings that cost me nothing.' The principle embedded here — worship must cost the worshiper something — will echo through the prophets' critique of empty ritual.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "The threshing floor David purchases becomes the site of Solomon's temple (2 Chronicles 3:1). The book ends where the temple begins — on a piece of ground bought during judgment, consecrated by sacrifice. Disaster becomes holy ground.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/3.json
+++ b/content/2_samuel/3.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joab murders Abner during peace negotiations — a blood-feud killing disguised as justice. David publicly curses Joab but does not punish him. This pattern — David condemning violence he cannot control — will haunt his reign. The king is morally clear but politically constrained.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/4.json
+++ b/content/2_samuel/4.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "When Ishbosheth's assassins bring his head to David expecting reward, David executes them instead. Like his refusal to kill Saul, David will not build his kingdom on murder — even murder that benefits him. Legitimacy matters more than expediency.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/5.json
+++ b/content/2_samuel/5.json
@@ -498,5 +498,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David captures Jerusalem — a neutral city belonging to neither Judah nor the northern tribes. The political genius is evident: the capital belongs to the king alone, avoiding tribal jealousy. Jerusalem becomes 'the City of David' — not the city of any tribe.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/2_samuel/6.json
+++ b/content/2_samuel/6.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David dances before the ark 'with all his might,' wearing a linen ephod. Michal despises him from the window. The contrast is sharp: the king humbles himself in worship while the queen cares about royal dignity. Michal's contempt costs her children — barrenness is the narrator's verdict on her priorities.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/2_samuel/7.json
+++ b/content/2_samuel/7.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "David wants to build God a house (temple); God responds by building David a house (dynasty). The wordplay on 'house' (bayit) drives the entire chapter. The Davidic covenant — 'your throne will be established forever' — becomes the foundation of messianic expectation through the rest of Scripture.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/2_samuel/8.json
+++ b/content/2_samuel/8.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The summary of David's victories ends with: 'The LORD gave David victory wherever he went.' The refrain appears twice (vv. 6, 14). The military catalog is framed theologically — David's empire is presented as divine gift, not human achievement.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/2_samuel/9.json
+++ b/content/2_samuel/9.json
@@ -416,5 +416,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "David seeks out Mephibosheth — Jonathan's crippled son — and restores Saul's estate to him. 'He will always eat at my table.' This is not political calculation; it is covenant loyalty to Jonathan. The lame grandson of David's enemy dines permanently at the king's table. Grace has a seat.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/esther/10.json
+++ b/content/esther/10.json
@@ -422,5 +422,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The book ends with Mordecai as second-in-command of the Persian empire — a Jewish exile at the pinnacle of Gentile power. The trajectory from sackcloth at the gate (4:1) to royal authority parallels Joseph in Egypt and Daniel in Babylon. Diaspora faithfulness leads to improbable influence.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/esther/2.json
+++ b/content/esther/2.json
@@ -548,5 +548,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Mordecai tells Esther to conceal her Jewish identity. The instruction reflects diaspora survival strategy — assimilation as protective camouflage. The tension between hiddenness and revelation drives the entire plot. Esther's identity is a secret that, once spoken, will change everything.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/esther/3.json
+++ b/content/esther/3.json
@@ -487,5 +487,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Haman's fury at one man's refusal to bow leads him to plan genocide against an entire people. The escalation from personal insult to national destruction is terrifyingly plausible. Haman does not merely want Mordecai punished — he wants the category of person Mordecai represents eliminated.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/esther/4.json
+++ b/content/esther/4.json
@@ -455,5 +455,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'Who knows but that you have come to your royal position for such a time as this?' Mordecai's argument is not certainty but possibility — 'who knows.' The call to courageous action operates on hope, not guarantees. Esther must act without knowing the outcome, which is what makes it courage rather than calculation.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/esther/5.json
+++ b/content/esther/5.json
@@ -444,5 +444,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Esther does not immediately present her request — she invites the king and Haman to a banquet, then another. The delay is strategic patience. She builds anticipation, creates the right atmosphere, and lets Haman's arrogance ripen. Timing is as important as the petition itself.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/esther/6.json
+++ b/content/esther/6.json
@@ -536,5 +536,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The king cannot sleep, reads the chronicles, discovers Mordecai was never rewarded for foiling an assassination. The 'coincidence' is the book's invisible theology. Esther never mentions God, but the timing is too precise to be accidental. Providence operates through insomnia and bureaucratic records.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/esther/7.json
+++ b/content/esther/7.json
@@ -440,5 +440,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Haman falls on the couch where Esther is reclining and the king interprets it as assault. The reversal is complete in a single moment — from the king's favorite to condemned criminal. The book's architecture of reversal reaches its climax: the man who built a gallows will hang on it.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/esther/8.json
+++ b/content/esther/8.json
@@ -460,5 +460,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Persian law cannot revoke Haman's decree, so a counter-decree is issued: Jews may defend themselves. The solution is not cancellation of danger but authorization of resistance. Even in deliverance, the threat remains real. The Jews must still fight — they are simply given permission to do so.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/esther/9.json
+++ b/content/esther/9.json
@@ -475,5 +475,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Purim is established as a perpetual festival — 'these days should be remembered and observed in every generation.' The story becomes liturgy. Esther moves from narrative to ritual, ensuring that a community that nearly perished will annually rehearse its survival. Memory is mandated because forgetting is lethal.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/ezra/10.json
+++ b/content/ezra/10.json
@@ -511,5 +511,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The mass divorce of foreign wives is the most uncomfortable passage in Ezra. The text records it without triumphalism — a brief note mentions children involved. Modern readers rightly struggle with this. The tension between covenant purity and human cost is left unresolved in the text itself.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/ezra/2.json
+++ b/content/ezra/2.json
@@ -609,5 +609,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The returning exiles are listed by family — 42,360 people plus 7,337 servants. The meticulous census echoes Numbers: God's people are counted before entering the land, both at Sinai and after Babylon. Return from exile is framed as a second exodus.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/ezra/3.json
+++ b/content/ezra/3.json
@@ -510,5 +510,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "When the foundation is laid, older people who remember Solomon's temple weep while younger ones shout for joy. The two sounds are indistinguishable from a distance. Restoration is simultaneously grief and celebration — the new thing is real, but it is not the old thing.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/ezra/4.json
+++ b/content/ezra/4.json
@@ -510,5 +510,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Opponents offer to help build — 'Let us help you build because, like you, we seek your God.' Zerubbabel refuses: 'You have no part with us in building a temple to our God.' The refusal seems harsh, but the offer was political co-option disguised as cooperation. Not every offer of help serves the mission.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/ezra/5.json
+++ b/content/ezra/5.json
@@ -492,5 +492,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "When the governor asks 'Who authorized you to rebuild?', the elders answer by citing Cyrus's original decree. They appeal to imperial law, not prophetic authority. The returnees have learned to navigate pagan bureaucracy — using the empire's own systems to advance God's purposes.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/ezra/6.json
+++ b/content/ezra/6.json
@@ -510,5 +510,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Darius not only confirms Cyrus's decree but orders the opponents to fund the construction from royal revenue. The temple is rebuilt with Persian tax money. God uses the empire that destroyed Jerusalem to finance its restoration. The irony is the theology.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/ezra/7.json
+++ b/content/ezra/7.json
@@ -496,5 +496,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Ezra 'had devoted himself to the study and observance of the Law of the LORD, and to teaching its decrees.' Study, practice, then teaching — the order is deliberate. Ezra does not teach what he has not first studied and lived. The sequence is his credential.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/ezra/8.json
+++ b/content/ezra/8.json
@@ -504,5 +504,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ezra is ashamed to ask the king for soldiers to protect the caravan: 'The gracious hand of our God is on everyone who looks to him.' He had already told the king God protects his people. Now he must live that theology. The fast at the Ahava Canal is the cost of his own words.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/ezra/9.json
+++ b/content/ezra/9.json
@@ -517,5 +517,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ezra's prayer does not say 'they have sinned' but 'we have sinned.' He includes himself in the guilt though he personally has not intermarried. Corporate confession — owning communal sin as personal — is a prophetic posture that runs from Ezra through Daniel to Nehemiah.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/10.json
+++ b/content/genesis/10.json
@@ -681,5 +681,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Nimrod is described as a 'mighty hunter before the LORD' — but the Hebrew gibor can also mean 'warrior' or 'tyrant.' His kingdom includes Babel and cities in Assyria. The Table of Nations quietly introduces the empires that will later oppress Israel.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "This genealogy maps the known world from an Israelite perspective. It isn't trying to be exhaustive — it's showing that all nations trace back to one family. The theological point precedes the historical one: human diversity is real, but human unity is more fundamental.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/11.json
+++ b/content/genesis/11.json
@@ -798,5 +798,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Babel story is built on wordplay. The builders want to 'make a name' (shem) for themselves. God responds by scattering them and confusing their language (balal). They name the city Babel — which sounds like balal but in Babylonian means 'gate of God.' The city that claimed divine access became the byword for confusion.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "After Babel's dispersion, the narrative suddenly narrows from all humanity to one family line: Shem to Terah to Abram. The genealogy is a literary bridge — God's response to Babel isn't just judgment but election. He will bless the nations through one nation.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/12.json
+++ b/content/genesis/12.json
@@ -568,5 +568,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God's call to Abram requires him to leave three things: country, people, and father's household. Each circle is more intimate than the last. The command moves inward, stripping away every source of identity and security except the promise itself.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "Abram has barely arrived in the land of promise before famine drives him to Egypt, where he immediately lies about Sarai. The patriarch who just received God's grand covenant acts out of fear and self-preservation. Genesis never airbrushes its heroes.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/13.json
+++ b/content/genesis/13.json
@@ -617,5 +617,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Lot 'looked up and saw that the whole plain of the Jordan was well watered' — the text compares it to 'the garden of the LORD' and to Egypt. Lot chooses based on what his eyes see, just as Eve saw the fruit was 'pleasing to the eye.' The echo is intentional: choosing by sight over faith is a recurring Genesis pattern.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 3,
+      "tip": "After Lot takes the apparent best land, God tells Abram to look in every direction — the same verb Lot used. But where Lot's looking led to self-interested choice, Abram's looking receives divine promise. The contrast frames the entire chapter.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/14.json
+++ b/content/genesis/14.json
@@ -634,5 +634,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "This is the only chapter in Genesis where Abram acts as a military leader. With 318 trained men from his household, he defeats a coalition of kings. The number tells us something about Abram's wealth and power — he is no wandering nomad but a significant regional figure.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Melchizedek appears without genealogy, without context — king of Salem (likely Jerusalem), priest of 'God Most High' (El Elyon). He blesses Abram and receives a tenth. The New Testament will build an entire Christological argument on this mysterious figure's sudden appearance (Hebrews 7).",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/15.json
+++ b/content/genesis/15.json
@@ -657,5 +657,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Verse 6 — 'Abram believed the LORD, and he credited it to him as righteousness' — is one of the most theologically loaded sentences in the Bible. Paul builds his doctrine of justification by faith on this verse (Romans 4, Galatians 3). James uses the same verse to argue faith requires works (James 2:23). Same text, different angles.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 3,
+      "tip": "In the covenant ceremony, God alone passes between the animal pieces as a 'smoking firepot and blazing torch.' Normally both parties walk through, pledging 'may I be torn apart like these animals if I break covenant.' God takes the oath unilaterally — the obligation falls entirely on him.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/16.json
+++ b/content/genesis/16.json
@@ -476,5 +476,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Sarai's plan — using Hagar as a surrogate — follows standard Mesopotamian legal practice (attested in the Code of Hammurabi and Nuzi texts). The text doesn't condemn the practice as illegal; it shows how even culturally acceptable solutions can generate suffering when they substitute for trusting the promise.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "The 'angel of the LORD' appears for the first time in Scripture — to a foreign slave woman fleeing in the wilderness. Before any covenant with Israel, before the law, God seeks out the marginalized. Hagar is the first person in the Bible to give God a name: El Roi, 'the God who sees me.'",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/17.json
+++ b/content/genesis/17.json
@@ -679,5 +679,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God changes Abram's name to Abraham ('father of many') when he has exactly one son by a servant and no legitimate heir. The new name is a promise worn as an identity — every time someone addresses him, they speak the covenant over him before it is fulfilled.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "Abraham laughs when told Sarah will bear a son (v. 17), and Sarah will laugh too (18:12). Their son's name — Isaac (Yitzhak, 'he laughs') — memorializes the incredulity. The promised child carries the parents' disbelief in his very name, transformed from doubt into joy (21:6).",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/18.json
+++ b/content/genesis/18.json
@@ -492,5 +492,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Abraham sees 'three men' but addresses them as 'my Lord' (singular). The text alternates between plural visitors and singular divine speech throughout. Early church fathers read this as a Trinitarian encounter; Jewish interpreters saw God with two angels. The ambiguity appears to be deliberate.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "Abraham's intercession for Sodom negotiates from fifty righteous down to ten. The bargaining structure reveals something about prayer: it is not merely submission but genuine dialogue. God permits — even invites — Abraham to press. The negotiation stops at ten, but Abraham stops asking, not God refusing.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/19.json
+++ b/content/genesis/19.json
@@ -627,5 +627,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Lot's offer of his daughters to the mob is deeply disturbing to modern readers, and the text does not frame it as virtuous. It reveals how deeply Sodom's corruption has affected even the one 'righteous' resident. Living among wickedness has warped Lot's moral compass — hospitality at the expense of his own children.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "Lot's wife 'looked back' — the same directional language used when Lot first 'looked' toward Sodom (13:10). Her backward glance mirrors his initial choice. The family's attachment to Sodom runs deeper than geography; it is a spiritual orientation that ultimately costs everything.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/20.json
+++ b/content/genesis/20.json
@@ -477,5 +477,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Abraham repeats the wife-sister deception from chapter 12 — same lie, different king. The repetition is not sloppy editing; it shows that Abram's character flaw persists despite years of covenant relationship with God. Growth in faith does not mean the immediate death of every weakness.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 2,
+      "tip": "Abimelek emerges as more morally upright than Abraham in this episode — he acts with integrity, fears God, and is vindicated in a dream. The pagan king shames the covenant patriarch. Genesis consistently resists the idea that election equals moral superiority.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/21.json
+++ b/content/genesis/21.json
@@ -645,5 +645,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Sarah says 'God has brought me laughter, and everyone who hears about this will laugh with me' (v. 6). The Hebrew wordplay is dense: Isaac's name (yitzhak) turns Sarah's earlier laugh of disbelief (18:12) into communal joy. The promise-fulfillment arc transforms the same emotion from mockery to worship.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "Hagar and Ishmael's expulsion parallels their earlier flight (ch. 16) — wilderness, despair, divine intervention, a well. But this time God's promise to Hagar is national: 'I will make him into a great nation.' Two covenant lines emerge from Abraham's household, and God cares for both.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/22.json
+++ b/content/genesis/22.json
@@ -679,5 +679,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Hebrew for 'tested' (nissah) appears here for the first time in the Bible. It does not mean 'tempted' — God already knows what Abraham will do. A test reveals character to the one being tested and to the audience. Abraham's obedience here completes the arc that began with his initial call in chapter 12.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "Isaac carries the wood up the mountain while Abraham carries the fire and the knife — the boy bears the instrument of his own sacrifice. The parallel to Jesus carrying his cross is one of the most recognized typological connections in all of Scripture.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/23.json
+++ b/content/genesis/23.json
@@ -466,5 +466,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Abraham insists on paying full price for the burial cave rather than accepting it as a gift. This is not stubbornness — in ancient Near Eastern culture, accepting a gift created an obligation. By paying, Abraham secures undisputed legal title. His only real estate in the promised land is a grave.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/genesis/24.json
+++ b/content/genesis/24.json
@@ -610,5 +610,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The servant's prayer is remarkably specific: the right woman will not only give him water but volunteer to water ten camels. A thirsty camel drinks 25 gallons. This is a request for extravagant, unsolicited generosity — the servant is testing for character, not beauty.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Rebekah is asked 'Will you go with this man?' and answers 'I will go' — the same decisive language God used with Abraham in chapter 12. She leaves family and homeland on faith. The narrative frames her as a true counterpart to Abraham.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/25.json
+++ b/content/genesis/25.json
@@ -659,5 +659,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 3,
+      "tip": "Esau 'despised his birthright' — the Hebrew verb bazah implies treating something as worthless. The birthright carried the covenant promises, the double inheritance, and the family leadership. Esau trades his future for a single meal. The text presents this as a character verdict, not just a bad deal.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/genesis/26.json
+++ b/content/genesis/26.json
@@ -608,5 +608,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Isaac repeats Abraham's wife-sister lie (12:13, 20:2) — third time in Genesis. The pattern is now generational. The promise passes to the next patriarch, but so does the character flaw. Election does not automatically break family dysfunction.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 2,
+      "tip": "The well disputes are not just about water rights — in an arid land, wells represent life itself. Isaac names one well Rehoboth ('room') saying 'Now the LORD has given us room.' The naming turns a property dispute into a theological statement about divine provision.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/27.json
+++ b/content/genesis/27.json
@@ -607,5 +607,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Isaac's blessing, once spoken, cannot be revoked — 'I blessed him, and indeed he will be blessed.' In the ancient world, a spoken blessing was not merely a wish but a performative utterance that released real power. Words, once launched, take on a life of their own.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Rebekah engineers the deception, yet the text never records God condemning her. The narrative tension is sharper than that: God had already told Rebekah 'the older will serve the younger' (25:23). She is right about the outcome but wrong about the method — a distinction Genesis forces the reader to sit with.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/28.json
+++ b/content/genesis/28.json
@@ -482,5 +482,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jacob's ladder vision features angels 'ascending and descending' — ascending first, meaning they were already on earth. God's messengers were present before Jacob knew it. The revelation at Bethel does not create God's presence; it unveils a presence that was already there. 'Surely the LORD is in this place, and I was not aware of it.'",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/29.json
+++ b/content/genesis/29.json
@@ -648,5 +648,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The deceiver gets deceived. Jacob tricked his father by pretending to be the firstborn; now Laban substitutes the firstborn daughter for the younger. The literary justice is exact. 'It is not our custom here to give the younger daughter in marriage before the older one' — a rebuke that lands on multiple levels.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/30.json
+++ b/content/genesis/30.json
@@ -621,5 +621,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The naming of each son encodes the rivalry between Rachel and Leah. Leah names her sons with cries for love ('surely my husband will love me now'). Rachel's surrogate-born sons carry names of vindication ('God has vindicated me'). The children's names are a transcript of marital pain.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/genesis/31.json
+++ b/content/genesis/31.json
@@ -656,5 +656,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Rachel steals Laban's household gods (teraphim) and hides them by sitting on them, claiming she cannot rise because 'the way of women is upon me.' The scene is bitterly comic — the gods are literally sat upon, helpless. The narrative mocks idolatry through physical farce.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/32.json
+++ b/content/genesis/32.json
@@ -547,5 +547,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jacob wrestles an unnamed figure until daybreak and receives a new name: Israel, meaning 'he struggles with God.' The patriarch who spent his life grasping — grabbing Esau's heel, grasping the birthright, grasping the blessing — is finally grasped by God. He prevails but walks away limping. Victory and wound arrive together.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/33.json
+++ b/content/genesis/33.json
@@ -489,5 +489,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jacob tells Esau 'to see your face is like seeing the face of God' (v. 10). He has just seen God's face at Peniel (32:30). The reconciliation with his brother is framed as a mirror of the divine encounter — the horizontal relationship echoing the vertical one.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/34.json
+++ b/content/genesis/34.json
@@ -512,5 +512,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Simeon and Levi's massacre at Shechem uses circumcision — the sign of the covenant — as a weapon. They pervert a sacred rite into a military tactic. Jacob condemns them, and in his deathbed blessing (49:5-7) he curses their anger. The text treats this as a profound violation, not heroic vengeance.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/35.json
+++ b/content/genesis/35.json
@@ -532,5 +532,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God sends Jacob back to Bethel — full circle to the place of his ladder vision (ch. 28). Jacob commands his household to 'put away the foreign gods.' The return to Bethel requires a purification that should have happened long before. God's patience with Jacob's slow obedience is itself a theological statement.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/36.json
+++ b/content/genesis/36.json
@@ -482,5 +482,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Esau's genealogy gets a full chapter — a generous literary allotment for the non-chosen line. Genesis consistently refuses to erase the rejected brother. Ishmael got his genealogy (25:12-18), and now Esau gets his. God's covenant narrows, but God's care does not.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/37.json
+++ b/content/genesis/37.json
@@ -659,5 +659,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Joseph's dreams always feature others bowing to him. Jacob rebukes Joseph ('Will your mother and I actually come and bow down?') but then 'kept the matter in mind.' The narrator signals that Jacob recognizes something real in the dreams even while resisting their implications.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "The brothers dip Joseph's robe in goat blood to deceive Jacob — who once used goat skins to deceive his own father Isaac. The goat is the instrument of deception across generations. Jacob who tricked is now tricked by the same animal.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/38.json
+++ b/content/genesis/38.json
@@ -522,5 +522,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "This chapter seems to interrupt the Joseph story, but it is deliberately placed. Judah, who suggested selling Joseph, now faces his own moral reckoning. Tamar's 'more righteous than I' verdict (v. 26) begins Judah's transformation — the arc that climaxes in his self-sacrificing speech in chapter 44.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/39.json
+++ b/content/genesis/39.json
@@ -518,5 +518,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The refrain 'the LORD was with Joseph' appears four times in this chapter (vv. 2, 3, 21, 23). Yet Joseph is falsely accused, imprisoned, and forgotten. The narrative insists that divine presence does not mean exemption from suffering. 'The LORD was with him' — in the pit, in the prison, in the waiting.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/4.json
+++ b/content/genesis/4.json
@@ -708,5 +708,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Cain and Abel both bring offerings, but the text never says God rejected Cain's because it was grain rather than animal. The issue is subtler — 'Cain brought some of the fruits' while Abel brought 'fat portions from the firstborn.' One gave generically; the other gave the best of the best.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "God's question to Cain — 'Where is your brother?' — echoes the question to Adam: 'Where are you?' Both are rhetorical. God already knows. The pattern of divine interrogation after human sin becomes a recurring motif through Genesis.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/40.json
+++ b/content/genesis/40.json
@@ -495,5 +495,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joseph asks the cupbearer to 'remember me' — but 'the chief cupbearer did not remember Joseph; he forgot him.' Two full years pass (41:1). The delay is not incidental; it ensures that Joseph's rise comes from God's timing, not human networking. Every human avenue of rescue fails first.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/41.json
+++ b/content/genesis/41.json
@@ -645,5 +645,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joseph tells Pharaoh 'I cannot do it, but God will give Pharaoh the answer' (v. 16). Compare this to Daniel's identical stance before Nebuchadnezzar (Daniel 2:27-28). Both refuse credit. The pattern — foreign ruler, impossible dream, humble interpreter — becomes a biblical template for how God's people serve pagan power.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/42.json
+++ b/content/genesis/42.json
@@ -500,5 +500,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The brothers say 'Surely we are being punished because of our brother' (v. 21) — twenty years after selling Joseph. Guilt has been silently working. Reuben adds 'Didn't I tell you not to sin against the boy?' The conversation Joseph overhears, unrecognized, confirms both their guilt and their growth.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/genesis/43.json
+++ b/content/genesis/43.json
@@ -492,5 +492,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Judah pledges himself as surety for Benjamin: 'I myself will guarantee his safety; you can hold me personally responsible.' This is the same Judah who proposed selling Joseph (37:26). The transformation is underway — from brother-seller to brother-guarantor.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/44.json
+++ b/content/genesis/44.json
@@ -479,5 +479,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Judah's speech (vv. 18-34) is the emotional climax of the entire Joseph cycle. He offers himself as a slave in Benjamin's place — the exact reversal of selling Joseph into slavery. The man who traded one brother for profit now trades himself for another. Genesis rarely announces its moral lessons; it shows them.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/45.json
+++ b/content/genesis/45.json
@@ -500,5 +500,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'You intended to harm me, but God intended it for good' (50:20) is anticipated here: 'It was to save lives that God sent me ahead of you' (v. 5). Joseph interprets his entire suffering through a theological lens — not denying the brothers' guilt but seeing a larger purpose operating through it.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/46.json
+++ b/content/genesis/46.json
@@ -473,5 +473,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God says 'Do not be afraid to go down to Egypt' — echoing 15:13 where God told Abraham his descendants would be strangers in a foreign land for 400 years. Jacob's descent into Egypt sets the stage for Exodus. The promise is simultaneously fulfilled (the family grows) and endangered (they enter captivity).",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/47.json
+++ b/content/genesis/47.json
@@ -656,5 +656,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jacob tells Pharaoh 'My years have been few and difficult' (v. 9) — at 130 years old. Compared to his ancestors (Abraham lived 175, Isaac 180), he is telling the truth. But the word 'difficult' (ra'im, literally 'evil') is the real weight: deception, exile, Dinah, Joseph's loss. The patriarch summarizes his life in one bitter adjective.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/genesis/48.json
+++ b/content/genesis/48.json
@@ -470,5 +470,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jacob crosses his hands to place the right hand on the younger son Ephraim rather than the firstborn Manasseh. The reversal of primogeniture — younger over older — is Genesis's most persistent pattern: Isaac over Ishmael, Jacob over Esau, now Ephraim over Manasseh. It is the signature move of a God who overturns human assumptions about who comes first.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/49.json
+++ b/content/genesis/49.json
@@ -503,5 +503,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Judah oracle (vv. 8-12) — 'The scepter shall not depart from Judah' — is the first explicit prediction of royal dynasty in the Bible. It plants the seed that will grow through David to the messianic expectation. Genesis ends not with Joseph (the immediate hero) but with Judah (the long-term lineage).",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/5.json
+++ b/content/genesis/5.json
@@ -873,5 +873,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "This genealogy restates that humanity was made 'in the likeness of God' (v. 1), then immediately notes Adam fathered Seth 'in his own likeness.' The subtle shift — from divine image to human copy — tracks the deterioration that Genesis 3–4 introduced.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Enoch 'walked with God; then he was no more, because God took him' breaks the relentless death refrain ('and then he died') that governs every other entry. In a chapter saturated with mortality, one life escapes the pattern — a quiet signal that death is not the final word.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/50.json
+++ b/content/genesis/50.json
@@ -677,5 +677,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'You intended to harm me, but God intended it for good, to accomplish what is now being done, the saving of many lives' (v. 20). This verse is the theological thesis statement of the entire Joseph cycle — and arguably of Genesis itself. Human evil is real; divine sovereignty is larger. Both are affirmed without either being minimized.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "Genesis ends with a coffin in Egypt. Joseph's bones await transport to the promised land — a journey that won't happen for 400 years (Exodus 13:19). The book of beginnings closes with an unfinished ending, pointing forward. Every ending in Genesis is really a setup for the next act.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/6.json
+++ b/content/genesis/6.json
@@ -851,5 +851,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The phrase 'sons of God' (bene elohim) has generated centuries of debate. In the ancient Near East, this language typically described divine council members. The text presents their boundary-crossing union with human women as the catalyst for divine judgment — a violation of the created order.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "Noah is described as 'righteous' and 'blameless among the people of his time' — that qualifier 'among the people of his time' is doing real work. Later rabbis debated whether it was a compliment (righteous despite a wicked generation) or a qualification (only righteous by comparison).",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/genesis/7.json
+++ b/content/genesis/7.json
@@ -814,5 +814,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The detail that 'the LORD shut him in' (v. 16) is often overlooked. Noah doesn't seal the ark himself — God does. It is simultaneously an act of protection (sealing Noah in safety) and judgment (sealing the world out). One action, two meanings.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "The flood narrative uses a chiastic structure: the waters rise for 150 days, then recede for 150 days, with 'God remembered Noah' at the center (8:1). The literary architecture places divine memory — not destruction — at the heart of the story.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/genesis/8.json
+++ b/content/genesis/8.json
@@ -818,5 +818,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The raven flies 'back and forth' endlessly, while the dove returns, then returns with an olive leaf, then doesn't return at all. The dove's three missions create a narrative arc of their own — a miniature story of restoration nested inside the larger one.",
+      "genre_tag": "literary_pattern"
+    },
+    {
+      "after_section": 4,
+      "tip": "Noah's first act on dry ground is worship — he builds an altar and offers sacrifices. God's response ('Never again will I curse the ground') echoes but reverses the curse of Genesis 3:17. The flood narrative ends where creation began: with divine blessing.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/genesis/9.json
+++ b/content/genesis/9.json
@@ -670,5 +670,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God's commission to Noah — 'Be fruitful and multiply' — deliberately echoes Genesis 1:28. But there is a significant addition: 'the fear and dread of you will fall on all the beasts.' The post-flood world is recognizably the same creation, but the relationship between humanity and nature has fundamentally changed.",
+      "genre_tag": "canonical_thread"
+    },
+    {
+      "after_section": 3,
+      "tip": "The curse on Canaan (not Ham directly) has been catastrophically misused throughout history to justify slavery and racism. The text itself is narrowly focused: it anticipates Israel's later conflict with the Canaanite nations. Reading it as a statement about race imports a framework the author never intended.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/jonah/2.json
+++ b/content/jonah/2.json
@@ -451,5 +451,12 @@
         "context"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Jonah's psalm from the fish's belly quotes or echoes multiple psalms — it is a collage of Israel's worship language, prayed from inside a sea creature. The prophet who fled God's word cannot escape God's liturgy. Even in rebellion, his prayer is formed by Scripture.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/jonah/3.json
+++ b/content/jonah/3.json
@@ -471,5 +471,12 @@
         "context"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Nineveh repents — from king to cattle, everyone fasts in sackcloth. It is the most dramatic mass repentance in the entire Bible, and it comes from Israel's worst enemy. The pagan city responds more fully to God's warning than Israel ever did to its own prophets. The comparison is the indictment.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/jonah/4.json
+++ b/content/jonah/4.json
@@ -505,5 +505,12 @@
         "context"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "God's final question — 'Should I not have concern for the great city of Nineveh, in which there are more than 120,000 people who cannot tell their right hand from their left?' — is left unanswered. The book ends with a question mark. Jonah never responds. The reader must answer instead: does God's compassion have ethnic limits? The silence demands a verdict.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/10.json
+++ b/content/joshua/10.json
@@ -495,5 +495,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The sun standing still (v. 13) has generated endless scientific debate, but the text's own concern is theological: 'There has never been a day like it before or since, a day when the LORD listened to a human being.' The miracle's significance is relational — God responds to Joshua's prayer — not cosmological.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/11.json
+++ b/content/joshua/11.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The summary statement — 'So Joshua took the entire land... Then the land had rest from war' — creates a theological tension that the rest of Judges will expose. The land was 'taken' in principle but not fully possessed in practice. Joshua's conquest is complete and incomplete simultaneously.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/joshua/12.json
+++ b/content/joshua/12.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Thirty-one kings defeated — the catalog reads like a military ledger. But the literary function is doxological: this is what God accomplished through Joshua. The list exists not to glorify Israel's army but to enumerate divine faithfulness.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/joshua/13.json
+++ b/content/joshua/13.json
@@ -408,5 +408,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'You are now very old, and there are still very large areas of land to be taken over.' The honest assessment — Joshua is aging and the task is unfinished — sets up the tension that defines the rest of the Old Testament. The promise is sure; the fulfillment is gradual and incomplete.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/14.json
+++ b/content/joshua/14.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Caleb at 85 says 'I am still as strong today as the day Moses sent me out' and asks for the hill country where the giants live. The man who gave a good report 45 years ago (Numbers 14) still wants the hardest assignment. His faith has not diminished with age — it has compounded.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/15.json
+++ b/content/joshua/15.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The final verse — 'Judah could not dislodge the Jebusites who were living in Jerusalem; to this day the Jebusites live there' — is a quiet admission of failure that will persist until David captures the city centuries later (2 Samuel 5). The allotment chapters are honest about gaps between promise and reality.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/16.json
+++ b/content/joshua/16.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ephraim 'did not dislodge the Canaanites living in Gezer; to this day the Canaanites live among the people of Ephraim but are required to do forced labor.' The pattern of incomplete conquest — toleration followed by coexistence followed by assimilation — is Judges' origin story, planted right here in Joshua.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/17.json
+++ b/content/joshua/17.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The tribe of Joseph complains they have too little land. Joshua's response is sharp: 'If you are so numerous, go up into the forest and clear land.' They protest there are iron chariots in the valley. Joshua says go anyway. Entitlement meets challenge — and loses.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/joshua/18.json
+++ b/content/joshua/18.json
@@ -403,5 +403,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Joshua rebukes seven tribes: 'How long will you wait before you begin to take possession of the land?' The promised land requires active participation. Passivity is not trust — it is a failure to respond to what God has already given.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/19.json
+++ b/content/joshua/19.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joshua receives his own allotment last — after every other tribe is settled. The leader serves before he receives. The pattern recurs: Moses never enters the land, David waits years for his throne, Jesus takes the lowest seat. Biblical leadership is characterized by deferred reward.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/2.json
+++ b/content/joshua/2.json
@@ -477,5 +477,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Rahab's confession — 'the LORD your God is God in heaven above and on the earth below' — is one of the most theologically precise statements in Joshua, and it comes from a Canaanite prostitute. She recognizes what Israel's own spies at Kadesh did not (Numbers 13-14). Faith appears where you least expect it.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 2,
+      "tip": "The scarlet cord in the window echoes the blood on the doorposts at Passover. In both cases, a visible sign marks a household for deliverance while judgment falls around it. Rahab's salvation replays the Exodus in miniature.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/20.json
+++ b/content/joshua/20.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Cities of refuge protect the accidental killer from blood vengeance until a fair trial. The system institutionalizes the distinction between intent and outcome — a remarkably sophisticated legal principle embedded in an ancient text. Justice requires knowing not just what happened but why.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/21.json
+++ b/content/joshua/21.json
@@ -413,5 +413,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'Not one of all the LORD's good promises to Israel failed; every one was fulfilled' (v. 45). This is Joshua's thesis statement. Whatever complications the allotment chapters revealed, the narrator insists the covenant was honored. The summary does not deny the gaps — it affirms the trajectory.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/22.json
+++ b/content/joshua/22.json
@@ -490,5 +490,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Israel nearly goes to civil war over an altar — but sends a delegation first. The Phinehas embassy discovers the altar is a memorial, not an act of apostasy. The near-disaster illustrates both the danger of assumptions and the value of asking before attacking.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/joshua/23.json
+++ b/content/joshua/23.json
@@ -408,5 +408,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Joshua's farewell warning — 'if you turn away and ally yourselves with the survivors of these nations... they will become snares and traps' — reads like a preview of Judges. The speech is both warning and prophecy. Joshua knows what Israel will do even as he pleads against it.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/24.json
+++ b/content/joshua/24.json
@@ -485,5 +485,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'Choose for yourselves this day whom you will serve.' The people respond enthusiastically. Joshua pushes back: 'You are not able to serve the LORD.' He is not doubting God's grace — he is testing the depth of their commitment. Cheap enthusiasm is worse than honest uncertainty.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Joshua is buried; Joseph's bones are finally buried at Shechem (fulfilling Genesis 50:25); Eleazar the priest dies. Three burials close the book — the era of the conquest generation is over. What comes next has no guaranteed leader. The transition to Judges begins with a void.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/3.json
+++ b/content/joshua/3.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Jordan crossing deliberately mirrors the Red Sea crossing. The waters 'stand up in a heap' (same Hebrew phrase as Exodus 15:8). Joshua is being established as Moses' successor not by title but by parallel event — God does for Joshua what he did for Moses.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/4.json
+++ b/content/joshua/4.json
@@ -408,5 +408,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The memorial stones serve a specific pedagogical purpose: 'When your children ask... tell them.' Israel's worship is built on children's questions. The monument exists not as decoration but as a conversation starter across generations.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/5.json
+++ b/content/joshua/5.json
@@ -495,5 +495,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Mass circumcision at Gilgal makes the army militarily vulnerable — recovering men cannot fight. God requires a posture of total dependence before the first battle. The conquest begins not with strategy but with covenant renewal.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "The commander of the LORD's army answers Joshua's question 'Are you for us or for our enemies?' with 'Neither.' God does not join Israel's side — Israel must join God's side. The distinction matters enormously and recurs throughout the prophets.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/joshua/6.json
+++ b/content/joshua/6.json
@@ -485,5 +485,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The battle plan for Jericho is militarily absurd: march silently for six days, then shout. Every element strips away human agency. The victory cannot be attributed to tactics, numbers, or weaponry. The method is the message: this land is a gift, not a conquest.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "Rahab is 'brought out' and 'lives among the Israelites to this day.' She appears in Matthew's genealogy of Jesus (Matthew 1:5). The Canaanite prostitute becomes an ancestor of the Messiah — a detail that demolishes any ethnic purity reading of the conquest narratives.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/7.json
+++ b/content/joshua/7.json
@@ -408,5 +408,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Achan's sin is described as Israel's sin — 'the Israelites were unfaithful.' One person's hidden disobedience affects the entire community. The corporate solidarity principle operating here is foreign to modern individualism but fundamental to how the Old Testament understands covenant.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/joshua/8.json
+++ b/content/joshua/8.json
@@ -490,5 +490,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 3,
+      "tip": "After Ai's capture, Joshua builds an altar on Mount Ebal and reads the entire law — blessings from Gerizim, curses from Ebal, exactly as Moses commanded (Deuteronomy 27). The conquest pauses for covenant ceremony. Military progress is subordinated to liturgical obedience.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/joshua/9.json
+++ b/content/joshua/9.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The Gibeonites deceive Israel with moldy bread and worn sandals. The text pointedly notes that Israel 'did not inquire of the LORD' (v. 14). The failure is not military but spiritual — they trusted their own investigation instead of consulting God. Discernment without prayer is just guessing.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/judges/10.json
+++ b/content/judges/10.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "God's response to Israel's latest cry for help is unprecedented: 'Go and cry out to the gods you have chosen. Let them save you.' God refuses to rescue on autopilot. Israel must actually repent, not just perform the cry-out step of the cycle. Even divine patience has a pedagogical edge.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/11.json
+++ b/content/judges/11.json
@@ -499,5 +499,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 3,
+      "tip": "Jephthah's vow — offering whatever comes out of his house first — is rash, tragic, and never endorsed by the narrator. The text records it without approval. God gives the victory despite the vow, not because of it. Judges does not confuse God's sovereignty with God's endorsement of every human decision.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/12.json
+++ b/content/judges/12.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "'Say Shibboleth' — a pronunciation test that identifies Ephraimites by their dialect. 42,000 die over a single consonant. The episode illustrates how tribal identity hardens into lethal tribalism. Israel's internal violence now rivals the external threats Judges began with.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/judges/13.json
+++ b/content/judges/13.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Samson's birth announcement follows the pattern of Isaac, Samuel, and John the Baptist — barren mother, divine messenger, special child. The setup promises a deliverer. The story that follows will systematically subvert every expectation the birth narrative creates.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/judges/14.json
+++ b/content/judges/14.json
@@ -438,5 +438,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Samson wants a Philistine wife; his parents object. The narrator interjects: 'His parents did not know that this was from the LORD, who was seeking an occasion to confront the Philistines.' God works through Samson's worst impulses. The instrument is flawed; the purpose is not.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/15.json
+++ b/content/judges/15.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "After killing a thousand Philistines with a donkey's jawbone, Samson is desperately thirsty and cries out to God — his first prayer in the narrative. It takes physical extremity to produce spiritual dependence. Even then, the prayer is more demand than worship.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/judges/16.json
+++ b/content/judges/16.json
@@ -499,5 +499,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Delilah asks the same question four times, and Samson keeps answering. The repetition is not about her cleverness but his arrogance — he believes he can play with the boundary and never cross it. 'He did not know that the LORD had left him' (v. 20) is the most chilling sentence in Judges.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Samson's final prayer — 'remember me, O God, just once more' — is his most genuine moment. Blind, humiliated, chained between pillars, he finally prays with nothing left to leverage. His greatest act of faith and his death arrive simultaneously. Judges' strongest hero is at his best only at the end.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/17.json
+++ b/content/judges/17.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Micah hires a Levite as his personal priest and declares 'Now I know that the LORD will be good to me, since this Levite has become my priest.' He treats the priesthood as a good luck charm. The corruption is not dramatic — it is casual, domestic, and completely sincere. That is what makes it terrifying.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/18.json
+++ b/content/judges/18.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Danites steal Micah's idol and his priest, then conquer Laish — a peaceful, unsuspecting city. The tribe of Dan, allocated land in Joshua's distribution, takes someone else's instead. The 'conquest' is a robbery, and the religion they establish is a theft. Everything in these final chapters is counterfeit.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/19.json
+++ b/content/judges/19.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The atrocity at Gibeah deliberately echoes Sodom (Genesis 19) — a mob demands a male guest, a host offers women instead. But this time it happens inside Israel, not in a foreign city. The narrator's point is devastating: Israel has become Sodom. The covenant people have sunk to the level of the cities God destroyed.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/judges/2.json
+++ b/content/judges/2.json
@@ -417,5 +417,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The angel's speech at Bokim delivers the verdict Joshua's farewell warned about: 'You have disobeyed me. Why have you done this?' Israel weeps — the name Bokim means 'weepers' — but weeping without change is just sentiment. The tears produce no reform.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 2,
+      "tip": "The Judges cycle is stated explicitly here: apostasy → oppression → crying out → deliverance → relapse. This four-beat pattern will repeat with escalating severity through the entire book. Each cycle descends further. Judges is not a flat loop — it is a downward spiral.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/judges/20.json
+++ b/content/judges/20.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Israel assembles 400,000 men against Benjamin's 26,700 — and loses twice before winning. God authorizes the attack but does not guarantee easy victory. The civil war costs 65,000 lives total. Justice is served, but at a price that nearly destroys a tribe. The 'solution' creates new problems.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/21.json
+++ b/content/judges/21.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "'In those days Israel had no king; everyone did what was right in his own eyes.' This final sentence is not just a diagnosis — it is an argument. The book's downward spiral points toward the need for a king, setting up the monarchy narratives of Samuel. Judges ends by creating a vacuum that only kingship can fill.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/judges/3.json
+++ b/content/judges/3.json
@@ -507,5 +507,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Othniel is the 'ideal' judge — brief, successful, faithful. Every detail matches the pattern perfectly. He exists as a benchmark against which every subsequent judge will be measured and found wanting.",
+      "genre_tag": "structure_guide"
+    },
+    {
+      "after_section": 2,
+      "tip": "Ehud's assassination of Eglon is told with grotesque physical detail — the fat closing over the blade, the intestinal release. The narrator is not squeamish; the graphic realism serves a literary purpose, depicting the messiness of deliverance in a fallen world.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/judges/4.json
+++ b/content/judges/4.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Barak refuses to go without Deborah. She agrees but warns: 'the honor will not be yours, for the LORD will deliver Sisera into the hands of a woman.' The expected male warrior is sidelined; a woman (Jael, not even an Israelite) delivers the decisive blow. Judges consistently subverts expectations about who God uses.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/5.json
+++ b/content/judges/5.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Song of Deborah is one of the oldest texts in the Bible. It ends not with Israel's triumph but with Sisera's mother peering through a window, wondering why her son's chariot is late. The shift to the enemy mother's perspective is devastating — victory for one side is grief for the other. The poem refuses to let war be simple.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/judges/6.json
+++ b/content/judges/6.json
@@ -499,5 +499,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Gideon's response to God's call — 'But Lord, how can I save Israel? My clan is the weakest in Manasseh, and I am the least in my family' — echoes Moses' objections (Exodus 3-4). God's pattern of choosing the least qualified is not accidental; it ensures the credit goes to the right place.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/judges/7.json
+++ b/content/judges/7.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "God reduces Gideon's army from 32,000 to 300 — a 99% reduction. The stated reason: 'Israel might boast against me that her own strength has saved her.' The military logic is absurd; the theological logic is precise. Dependence is engineered through deliberate weakness.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/8.json
+++ b/content/judges/8.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Gideon refuses the crown — 'I will not rule over you... The LORD will rule over you' — then immediately makes a gold ephod that becomes an idol. His words are right; his actions contradict them. Judges shows that even the best leaders in this era carry the seeds of the next apostasy.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/judges/9.json
+++ b/content/judges/9.json
@@ -417,5 +417,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Jotham's fable — trees seeking a king, only the thornbush accepting — is the Bible's sharpest political parable. The worthy trees (olive, fig, vine) refuse to stop being productive to rule. Only the useless thornbush wants power. The fable is anti-monarchical satire embedded in the narrative.",
+      "genre_tag": "literary_pattern"
+    }
   ]
 }

--- a/content/nehemiah/10.json
+++ b/content/nehemiah/10.json
@@ -423,5 +423,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The community binds itself by written covenant — specifying intermarriage prohibitions, Sabbath observance, temple tax, wood offering, firstfruits, and tithes. The covenant is remarkably specific. Vague commitments produce vague obedience. Nehemiah understands that reform requires concrete, measurable pledges.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/11.json
+++ b/content/nehemiah/11.json
@@ -419,5 +419,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The people cast lots to determine who will live in Jerusalem — one in ten. Living in the holy city is presented as a sacrifice, not a privilege. The city needs population, and the 'volunteers' are commended. Sometimes faithfulness means moving where the need is, not where comfort is.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/12.json
+++ b/content/nehemiah/12.json
@@ -559,5 +559,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The wall dedication features two great choirs walking in opposite directions atop the wall until they meet at the temple. The sound carries far. The celebration is architectural, musical, and theological at once — the wall exists for worship, and worship validates the wall.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/nehemiah/13.json
+++ b/content/nehemiah/13.json
@@ -691,5 +691,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Nehemiah returns from Persia to find every reform undone: Tobiah has a room in the temple, tithes have stopped, Sabbath is violated, intermarriage has resumed. His response is furious — he throws out furniture, rebukes officials, even pulls out hair. The book ends not with triumph but with the exhausting reality that reform requires constant vigilance.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/2.json
+++ b/content/nehemiah/2.json
@@ -596,5 +596,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "Nehemiah prays before answering the king — 'I prayed to the God of heaven' — in the space between question and response. The prayer is instantaneous, mid-conversation. Nehemiah does not choose between prayer and action; he embeds prayer inside action.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/nehemiah/3.json
+++ b/content/nehemiah/3.json
@@ -467,5 +467,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The wall-building roster lists every section with its builder — priests, goldsmiths, perfume-makers, merchants, daughters. Everyone builds, regardless of profession. The project succeeds because participation is universal, not specialized. Sacred construction is not reserved for professionals.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/4.json
+++ b/content/nehemiah/4.json
@@ -589,5 +589,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Workers hold a tool in one hand and a weapon in the other: 'Those who carried materials did their work with one hand and held a weapon in the other.' The image is the book's central metaphor — building and defending simultaneously. Restoration always faces opposition; readiness is not paranoia but wisdom.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/nehemiah/5.json
+++ b/content/nehemiah/5.json
@@ -598,5 +598,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Nehemiah confronts wealthy Jews who are enslaving their own people through debt. He demands cancellation of loans and return of property. The governor who fights external enemies also fights internal exploitation. Justice within the community is as urgent as walls around it.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/6.json
+++ b/content/nehemiah/6.json
@@ -571,5 +571,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Sanballat invites Nehemiah to a 'meeting' four times. Nehemiah's refusal is iconic: 'I am carrying on a great project and cannot go down.' He recognizes that distraction is a tactic. Every invitation to leave the work is an attack disguised as diplomacy.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/nehemiah/7.json
+++ b/content/nehemiah/7.json
@@ -452,5 +452,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The genealogical registry in this chapter nearly duplicates Ezra 2. The repetition is not editorial laziness — it is a theological claim. The community that returned is the community that rebuilt. Identity must be verified; not everyone who claims belonging actually belongs.",
+      "genre_tag": "structure_guide"
+    }
   ]
 }

--- a/content/nehemiah/8.json
+++ b/content/nehemiah/8.json
@@ -566,5 +566,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ezra reads the Law from dawn until noon. The Levites 'made it clear and gave the meaning so that the people could understand.' The people weep, but Nehemiah says 'Do not grieve, for the joy of the LORD is your strength.' Conviction leads to grief; grief is redirected toward joy. The sequence matters.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/nehemiah/9.json
+++ b/content/nehemiah/9.json
@@ -554,5 +554,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "The Levites' prayer recounts all of Israel's history — from creation through Abraham, Egypt, wilderness, conquest, kings, and exile. The prayer is a theological narrative: God was faithful at every point; Israel was unfaithful at every point. The asymmetry is the basis for hope, not despair.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }

--- a/content/ruth/2.json
+++ b/content/ruth/2.json
@@ -567,5 +567,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Boaz tells Ruth 'I've been told all about what you have done for your mother-in-law since the death of your husband.' Her reputation precedes her. In a book full of quiet faithfulness, Boaz recognizes Ruth's character before anything else. The love story begins with respect, not attraction.",
+      "genre_tag": "close_reading"
+    },
+    {
+      "after_section": 3,
+      "tip": "Boaz instructs his workers to 'pull out some stalks for her from the bundles and leave them for her.' He goes beyond the law's minimum requirement (gleaning rights) to active, hidden generosity. Grace exceeds obligation — a theme that runs from Ruth through the entire biblical narrative.",
+      "genre_tag": "theological_insight"
+    }
   ]
 }

--- a/content/ruth/3.json
+++ b/content/ruth/3.json
@@ -575,5 +575,12 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 2,
+      "tip": "Ruth asks Boaz to 'spread your garment over me' (literally 'spread your wing'). The Hebrew kānāp is the same word Boaz used in 2:12: 'under whose wings you have come to take refuge.' Ruth essentially says: you prayed for God to shelter me — now you be the answer to your own prayer.",
+      "genre_tag": "close_reading"
+    }
   ]
 }

--- a/content/ruth/4.json
+++ b/content/ruth/4.json
@@ -590,5 +590,17 @@
         "cross"
       ]
     }
+  ],
+  "coaching": [
+    {
+      "after_section": 1,
+      "tip": "The nearer kinsman is willing to redeem the land but not to marry Ruth — it would 'endanger my own estate.' He calculates cost. Boaz calculates covenant. The contrast between the unnamed redeemer and Boaz is a study in two responses to obligation: minimal compliance versus wholehearted embrace.",
+      "genre_tag": "theological_insight"
+    },
+    {
+      "after_section": 3,
+      "tip": "The genealogy ending — Perez to David — transforms a small-town love story into royal history. Ruth the Moabitess, from a nation born of incest (Genesis 19:37), becomes David's great-grandmother. The line that produces Israel's greatest king runs through a foreign widow who chose loyalty over safety.",
+      "genre_tag": "canonical_thread"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Complete coaching expansion for all 15 OT Narrative books (287 chapters updated).

All 343 OT Narrative chapters now have coaching tips.

| Book | Chapters Added |
|------|---------------|
| Genesis | 47 (4-50) |
| Joshua | 23 (2-24) |
| Judges | 20 (2-21) |
| Ruth | 3 (2-4) |
| 1 Samuel | 30 (2-31) |
| 2 Samuel | 23 (2-24) |
| 1 Kings | 21 (2-22) |
| 2 Kings | 24 (2-25) |
| 1 Chronicles | 28 (2-29) |
| 2 Chronicles | 35 (2-36) |
| Ezra | 9 (2-10) |
| Nehemiah | 12 (2-13) |
| Esther | 9 (2-10) |
| Jonah | 3 (2-4) |

Tags: close_reading, theological_insight, canonical_thread, literary_pattern, structure_guide

Closes #294