### PR TITLE
fix: skip historical_interpretations dir in schema validator

### DIFF
--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -108,7 +108,7 @@ def main():
     books_found = Counter()
 
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             total_files += 1
@@ -193,7 +193,7 @@ def main():
     valid_css = {'vhl-divine', 'vhl-place', 'vhl-person', 'vhl-time', 'vhl-key'}
     bad_css = set()
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             with open(json_file, encoding='utf-8') as f:
@@ -540,7 +540,7 @@ def main():
         tl_checked = 0
         tl_invalid = 0
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -568,7 +568,7 @@ def main():
 
     dup_count = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -605,7 +605,7 @@ def main():
 
     oob_tips = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -631,7 +631,7 @@ def main():
     if scopes_path_11.exists():
         scopes_data = json.loads(scopes_path_11.read_text(encoding='utf-8'))
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -662,7 +662,7 @@ def main():
 
     word_glosses = defaultdict(set)
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -706,7 +706,7 @@ def main():
         }
         unregistered = []
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -728,7 +728,7 @@ def main():
 
     overlaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -758,7 +758,7 @@ def main():
 
     gaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:


### PR DESCRIPTION
The new eras.json file (from Time-Travel Reader, #821) is an array not a chapter object, causing schema_validator to crash with "'list' object has no attribute 'get'". Add historical_interpretations to the skip list alongside meta, verses, interlinear, etc.

https://claude.ai/code/session_01U8QkCMkiNXawNKpTZbRmPC