### PR TITLE
fix: resection Joshua 19 into 7 tribal divisions (88.7→94.4)

### DIFF
--- a/content/joshua/19.json
+++ b/content/joshua/19.json
@@ -4,7 +4,7 @@
   "book_dir": "joshua",
   "chapter_num": 19,
   "title": "Joshua 19",
-  "subtitle": "Allotments for Six Tribes",
+  "subtitle": "Allotments for Simeon, Zebulun, Issachar, Asher, Naphtali, Dan; Joshua’s Inheritance",
   "timeline_link": {
     "event_id": "joshua-conquest",
     "text": "See on Timeline — Conquest of Canaan"
@@ -13,27 +13,31 @@
   "sections": [
     {
       "section_num": 1,
-      "header": "Verses 1–31 — Simeon, Zebulun, Issachar, Asher",
+      "header": "Verses 1–9 — The Allotment for Simeon",
       "verse_start": 1,
-      "verse_end": 31,
+      "verse_end": 9,
       "panels": {
         "heb": [
           {
-            "word": "key term",
-            "transliteration": "transliteration",
-            "gloss": "meaning",
-            "paragraph": "A key Hebrew term in this section on four tribal territories carries theological weight that illuminates the passage's role in Joshua's larger narrative of conquest and covenant fulfilment."
+            "word": "גּוֹרָל",
+            "transliteration": "gōrāl",
+            "gloss": "lot, allotment",
+            "paragraph": "The noun gōrāl ('lot') appears in verse 1 as the mechanism for tribal land distribution. Casting lots was not seen as random but as a means of discerning YHWH's will (Prov 16:33). The term frames every allotment passage in Joshua 14–19, anchoring the land distribution in divine decision rather than human negotiation."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Deut 31:6",
-              "note": "Moses' charge to Israel — \"be strong and courageous\" — provides the theological foundation for every episode in Joshua. The conquest is the practical outworking of Deuteronomy's promises and warnings."
+              "ref": "Josh 15:1-12",
+              "note": "Judah's allotment is the baseline against which Simeon's territory is carved. Simeon's cities are a subset of Judah's southern towns, fulfilling Jacob's prophecy that Simeon would be 'scattered in Israel' (Gen 49:7)."
             },
             {
-              "ref": "Heb 4:8-10",
-              "note": "The NT reads Joshua's conquest as typological — a partial fulfilment that points to the greater rest available in Christ."
+              "ref": "Gen 49:5-7",
+              "note": "Jacob's deathbed oracle cursed Simeon and Levi for the Shechem massacre, declaring they would be divided and scattered. Simeon's absorption into Judah's territory is the geographical fulfilment of that prophecy."
+            },
+            {
+              "ref": "1 Chr 4:28-33",
+              "note": "The Chronicler's parallel list confirms Simeon's cities, with minor spelling variants, showing textual continuity across Israel's historical records."
             }
           ]
         },
@@ -42,19 +46,11 @@
           "notes": [
             {
               "ref": "19:1",
-              "note": "MacArthur: The passage on four tribal territories reveals God's character in action — not as abstract theology but as concrete intervention in Israel's history. Every battle, every boundary, every judgment call demonstrates that YHWH is a God who acts, not merely a God who speaks."
+              "note": "MacArthur: Simeon's allotment within Judah's territory is not accidental but providential. God uses the geographical arrangement to fulfil Jacob's prophecy (Gen 49:7) while simultaneously providing for the tribe's needs. The smaller tribe benefits from the larger tribe's surplus."
             },
             {
-              "ref": "19:2",
-              "note": "MacArthur: Joshua's leadership here reflects the qualities God demanded in chapter 1 — strength, courage, and Torah-obedience. The conquest succeeds not because of military superiority but because of covenantal faithfulness."
-            },
-            {
-              "ref": "19:3",
-              "note": "MacArthur: The theological lesson is transferable: God's people in every era face situations that require the same trust in divine promises that Joshua demonstrates here. The form of the battle changes; the source of victory does not."
-            },
-            {
-              "ref": "19:4",
-              "note": "MacArthur: The NT reads these OT events as types and shadows (1 Cor 10:6,11). What Joshua accomplished physically — leading God's people into their inheritance — Christ accomplishes spiritually, leading believers into the fullness of God's promises."
+              "ref": "19:9",
+              "note": "MacArthur: The explanation that 'Judah's portion was more than they needed' reveals a practical reason behind the arrangement, but the theological reason runs deeper: God orchestrates even tribal demographics to accomplish his prophetic word."
             }
           ]
         },
@@ -63,11 +59,11 @@
           "notes": [
             {
               "ref": "19:1",
-              "note": "Calvin: On four tribal territories: God's actions here demonstrate that he is both sovereign over the nations and faithful to his particular covenant with Israel. The universal Lord works through specific historical events to accomplish his redemptive purposes."
+              "note": "Calvin: Simeon's enclave within Judah teaches that God's judgments are not merely punitive but redemptive. Though Jacob's curse dispersed Simeon, God's providence turned the scattering into a form of provision — the tribe receives cities and pasturelands within a stronger tribe's protection."
             },
             {
-              "ref": "19:2",
-              "note": "Calvin: The practical application extends beyond ancient Israel — every generation of God's people faces its own \"Canaan\" of challenges that require the same faith, obedience, and dependence on divine power demonstrated in this passage."
+              "ref": "19:9",
+              "note": "Calvin: The redistribution of surplus land from Judah to Simeon demonstrates God's equity. No tribe receives more than it can use while another goes without. This principle of proportional provision governs all divine dealings with his people."
             }
           ]
         },
@@ -76,11 +72,11 @@
           "notes": [
             {
               "ref": "19:1",
-              "note": "NET Note: The Hebrew syntax in this section employs thewayyiqtolnarrative chain characteristic of historical prose. Key terms carry specific covenant and military connotations that anchor the passage in the broader Deuteronomistic theological vocabulary."
+              "note": "NET Note: The phrase 'within the inheritance of Judah' (bĕtōk naḥălat bĕnê yĕhûdâ) uses the preposition bĕtōk ('in the midst of'), clarifying that Simeon's territory was not adjacent but embedded within Judah's. This unusual arrangement is unique among the tribal allotments."
             },
             {
-              "ref": "19:2",
-              "note": "NET Note: Textual variants in the LXX for this passage suggest the Greek translators worked from a Hebrew Vorlage that occasionally diverged from the MT, particularly in geographic details and proper names."
+              "ref": "19:2-8",
+              "note": "NET Note: Several city names in this list appear with variant spellings compared to Josh 15:26-32 and 1 Chr 4:28-33. 'Sheba' (v.2) may be a dittography of 'Beersheba' rather than a separate city. The NET reading follows the LXX in counting thirteen towns (v.6)."
             }
           ]
         },
@@ -88,12 +84,8 @@
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "19:1",
-              "note": "Hess: The archaeological and textual evidence for four tribal territories in this section aligns with Late Bronze Age Canaanite material culture. The narrative details — toponyms, military tactics, territorial descriptions — reflect authentic local knowledge consistent with an early source."
-            },
-            {
-              "ref": "19:3",
-              "note": "Hess: The literary structure here follows conventions of ancient Near Eastern conquest accounts, where the divine warrior fights on behalf of the vassal army. The theological framing is distinctively Israelite but the narrative genre is internationally attested."
+              "ref": "19:1-9",
+              "note": "Hess: Simeon's allotment is distinctive because it is the only tribe whose territory falls entirely within another tribe's boundaries. Hess argues this reflects both the fulfilment of Gen 49:7 and practical demographics — Simeon was one of the smallest tribes after the plague of Num 25:9. The Negev cities listed here (Beersheba, Ziklag, Hormah) become significant in the David narratives, when David operates from Ziklag as a Philistine vassal (1 Sam 27)."
             }
           ]
         },
@@ -101,43 +93,43 @@
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "19:1",
-              "note": "Howard: The canonical placement of this passage on four tribal territories within the larger Joshua narrative serves a literary function: it advances the theme of covenant fulfilment and demonstrates the pattern of divine initiative followed by human obedience (or failure)."
-            },
-            {
-              "ref": "19:2",
-              "note": "Howard: The keyword repetitions and structural echoes link this passage to the conquest's overarching theological argument: God keeps his promises, and Israel's response determines whether they experience blessing or judgment within that framework."
+              "ref": "19:1-9",
+              "note": "Howard: The literary structure of Simeon's allotment follows a distinct pattern: lot assignment (v.1), city list (vv.2-8), summary formula (v.8b), and theological explanation (v.9). The explanatory note in v.9 is unusual — most allotment passages simply list boundaries without justifying the arrangement. Howard sees this as the narrator addressing an obvious question: why would one tribe live inside another's territory?"
             }
           ]
         },
         "hist": {
-          "context": "This section addresses four tribal territories. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
+          "context": "Simeon's enclave within Judah reflects the tribe's small size after the census of Numbers 26 and fulfils Jacob's prophecy of scattering (Gen 49:7). The Negev cities listed here — Beersheba, Ziklag, Hormah — later feature in David's pre-monarchic career and the Judahite expansion into the southern desert."
         }
       }
     },
     {
       "section_num": 2,
-      "header": "Verses 32–51 — Naphtali, Dan; Joshua Receives Timnath-serah",
-      "verse_start": 32,
-      "verse_end": 51,
+      "header": "Verses 10–16 — The Allotment for Zebulun",
+      "verse_start": 10,
+      "verse_end": 16,
       "panels": {
         "heb": [
           {
-            "word": "key term",
-            "transliteration": "transliteration",
-            "gloss": "meaning",
-            "paragraph": "A key Hebrew term in this section on final allotments; Joshua's own inheritance carries theological weight that illuminates the passage's role in Joshua's larger narrative of conquest and covenant fulfilment."
+            "word": "גְּבוּל",
+            "transliteration": "gĕbûl",
+            "gloss": "border, boundary",
+            "paragraph": "The noun gĕbûl ('boundary') structures Zebulun's allotment description. Unlike city lists, Zebulun's territory is defined by border points that trace a circuit. This boundary-tracing format (also used for Judah and Benjamin) implies well-established geographical knowledge of the region between the Jezreel Valley and the coastal hills."
           }
         ],
         "cross": {
           "refs": [
             {
-              "ref": "Deut 31:6",
-              "note": "Moses' charge to Israel — \"be strong and courageous\" — provides the theological foundation for every episode in Joshua. The conquest is the practical outworking of Deuteronomy's promises and warnings."
+              "ref": "Gen 49:13",
+              "note": "Jacob prophesied Zebulun would 'live by the seashore and become a haven for ships.' The allotment here places Zebulun inland, which has generated significant scholarly debate about whether the prophecy refers to trade access rather than direct coastal territory."
             },
             {
-              "ref": "Heb 4:8-10",
-              "note": "The NT reads Joshua's conquest as typological — a partial fulfilment that points to the greater rest available in Christ."
+              "ref": "Isa 9:1",
+              "note": "Isaiah's prophecy of light in 'the land of Zebulun and Naphtali' is fulfilled in Jesus' Galilean ministry (Matt 4:13-16), making these tribal boundaries theologically significant for the NT."
+            },
+            {
+              "ref": "Judg 5:18",
+              "note": "Deborah's Song praises Zebulun for risking their lives in the battle against Sisera at nearby Mount Tabor, demonstrating the tribe's military contribution from this territory."
             }
           ]
         },
@@ -145,8 +137,12 @@
           "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "19:(32, '')",
-              "note": "MacArthur: On 51 — Naphtali, Dan; Joshua Receives Timnath-serah: he greatest leader Israel has ever known is dead. Yet God's program does not pause. The death of a leader is never the death of the mission. God buries his workers but carries on his work."
+              "ref": "19:10-11",
+              "note": "MacArthur: Zebulun's territory in lower Galilee positioned the tribe at a crossroads of major trade routes. The strategic location was both a blessing (economic prosperity) and a test (exposure to Canaanite influence). God's placement of tribes was never arbitrary."
+            },
+            {
+              "ref": "19:15",
+              "note": "MacArthur: Bethlehem mentioned here is not the Judean town of David's birth but a Galilean village in Zebulun's territory. The name means 'house of bread' and was common in ancient Canaan."
             }
           ]
         },
@@ -154,8 +150,12 @@
           "source": "John Calvin, Commentaries — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "19:(32, '')",
-              "note": "Calvin: On 51 — Naphtali, Dan; Joshua Receives Timnath-serah: conditional — but it is given to a man who must still fight. God's sovereignty does not eliminate human effort; it guarantees its success when exercised in obedience. Calvin's reading characteristically emphasizes divine sovereignty and human responsibility in tension — God ordains the outcome while the actors remain morally accountable. This dual emphasis reflects Calvin's broader hermeneutic: Scripture always speaks both about God's plan and about human duty under that plan."
+              "ref": "19:10",
+              "note": "Calvin: The lot system ensured that no tribe could claim preferential treatment or accuse the leadership of favouritism. God himself, through the lot, made the allocation — removing the distribution from human ambition and placing it under divine authority."
+            },
+            {
+              "ref": "19:16",
+              "note": "Calvin: The summary formula ('these towns and their villages were the inheritance of Zebulun') appears after every tribal allotment, creating a liturgical rhythm. Each repetition reinforces the central message: God has given, and God's gift is sufficient."
             }
           ]
         },
@@ -163,8 +163,12 @@
           "source": "NET Bible Full Notes Edition — Biblical Studies Press",
           "notes": [
             {
-              "ref": "19:(32, '')",
-              "note": "NET Note: On 51 — Naphtali, Dan; Joshua Receives Timnath-serah: meditation in ancient Israel was vocal, not silent. Joshua was to speak the Torah continuously, making it the soundtrack of his leadership. The NET translators note that the underlying Hebrew/Greek syntax carries nuances that most English versions cannot fully represent. Lexical analysis of the key terms reveals semantic ranges that enrich the passage beyond what a single English gloss can convey, connecting this text to a wider web of biblical usage."
+              "ref": "19:10-11",
+              "note": "NET Note: The boundary description uses directional terms (yāmmâ, 'seaward/westward'; mizrāḥâ, 'eastward') as compass bearings. The reference to 'the ravine near Jokneam' (naḥal lipnê yoqnĕ’ām) identifies the Wadi el-Milkḥ, a seasonal streambed marking Zebulun's southwestern boundary."
+            },
+            {
+              "ref": "19:15",
+              "note": "NET Note: 'Twelve towns' in the Hebrew does not match the number of cities listed (only five are named). The difference likely reflects towns whose names were lost from the text or were included in the 'their villages' category."
             }
           ]
         },
@@ -172,12 +176,8 @@
           "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "19:32-48",
-              "note": "The tribal allotments for Naphtali and Dan illustrate contrasting settlement outcomes. Hess notes that Naphtali's territory in upper Galilee includes fortified cities (v.35-38) suggesting successful occupation, while Dan's territory faced such pressure from the Amorites that the tribe eventually migrated north to Laish (Judges 18). The inclusion of cities later prominent in NT history (Chinnereth/Gennesaret near the Sea of Galilee) grounds later biblical geography in these tribal allotments."
-            },
-            {
-              "ref": "19:49-51",
-              "note": "Joshua's personal inheritance of Timnath Serah in Ephraim comes last — Hess observes that the leader receives his portion only after all the tribes are settled, a model of servant leadership. The note that Joshua 'built up the town and settled there' (v.50) indicates the allotment required development, not mere occupation. The closing formula attributing the distribution to Eleazar, Joshua, and the tribal heads at Shiloh (v.51) establishes the legal legitimacy of all preceding allotments."
+              "ref": "19:10-16",
+              "note": "Hess: Zebulun's allotment occupies the hills between the Jezreel Valley and the Beth Netopha Valley. Despite Gen 49:13 placing Zebulun 'by the seashore,' the boundaries here are entirely inland. Hess suggests the patriarchal blessing may refer to trade access via the Via Maris rather than direct coastline. The twelve towns mentioned (v.15) include several identified with archaeological sites showing Late Bronze Age occupation, consistent with a conquest-era date."
             }
           ]
         },
@@ -185,13 +185,449 @@
           "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
           "notes": [
             {
-              "ref": "19:(32, '')",
-              "note": "Howard: On 51 — Naphtali, Dan; Joshua Receives Timnath-serah: strong, v.6), C (meditate on Torah, v.7-8), B' (command to be strong, v.9a), A' (promise of presence, v.9b). The Torah stands at the centre — it is the pivot around which both courage and presence rotate."
+              "ref": "19:10-16",
+              "note": "Howard: Zebulun's allotment is relatively brief compared to Judah's or Manasseh's, reflecting its smaller territory. Howard notes the boundary-tracing format rather than city-list format, suggesting the narrator drew from a different source document. The mention of Sarid as the starting point (v.10) anchors the description at a known geographic landmark."
             }
           ]
         },
         "hist": {
-          "context": "This section addresses final allotments; Joshua's own inheritance. The narrative advances the book's central argument: God is faithful to his promise of land, and Israel's response — obedience or disobedience — determines how they experience that faithfulness within their generation."
+          "context": "Zebulun's territory in lower Galilee placed the tribe along major trade routes connecting Egypt to Mesopotamia. The region later became the heartland of Jesus' ministry — Nazareth, though not mentioned here, lies within Zebulun's allotment. The tribe's inland position despite Jacob's 'seashore' prophecy remains a puzzle scholars resolve through trade-access interpretations."
+        }
+      }
+    },
+    {
+      "section_num": 3,
+      "header": "Verses 17–23 — The Allotment for Issachar",
+      "verse_start": 17,
+      "verse_end": 23,
+      "panels": {
+        "heb": [
+          {
+            "word": "יִזְרְעֶאל",
+            "transliteration": "yizrĕ’e’l",
+            "gloss": "God sows",
+            "paragraph": "Jezreel ('God sows') heads the list of Issachar's cities (v.18). The name captures the agricultural fertility of the Jezreel Valley, Israel's most productive farmland. The valley later becomes a stage for pivotal events: Gideon's victory (Judg 6–7), Saul's death on Mount Gilboa (1 Sam 31), and Elijah's confrontation at nearby Carmel (1 Kgs 18)."
+          }
+        ],
+        "cross": {
+          "refs": [
+            {
+              "ref": "Gen 49:14-15",
+              "note": "Jacob described Issachar as 'a rawboned donkey lying down among the sheep pens,' content with good land but willing to submit to forced labour. The fertile Jezreel Valley allotment matches this characterisation."
+            },
+            {
+              "ref": "1 Chr 12:32",
+              "note": "The men of Issachar 'understood the times and knew what Israel should do' — a rare commendation suggesting the tribe developed a reputation for wisdom, possibly connected to their agricultural prosperity and stability."
+            },
+            {
+              "ref": "1 Kgs 4:17",
+              "note": "Solomon's administrative district list places Issachar's territory under the governor Jehoshaphat, confirming the tribe's continued occupation of these cities into the monarchic period."
+            }
+          ]
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:17-18",
+              "note": "MacArthur: Issachar's territory included Jezreel and Shunem, towns that feature prominently in later biblical history. God's allotment anticipated the future — placing tribes in locations that would serve his redemptive purposes for centuries to come."
+            },
+            {
+              "ref": "19:22",
+              "note": "MacArthur: The boundary touching Tabor and ending at the Jordan defines one of Israel's most strategically significant valleys. Issachar's stewardship of this land carried national responsibility, not merely tribal benefit."
+            }
+          ]
+        },
+        "calvin": {
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:17-23",
+              "note": "Calvin: Issachar received some of the richest agricultural land in Canaan, yet Jacob's prophecy warned the tribe would bend to servitude in exchange for comfort (Gen 49:15). Calvin draws the moral lesson: prosperity without vigilance leads to spiritual complacency. The gift of good land is a test of faithfulness, not merely a reward."
+            }
+          ]
+        },
+        "net": {
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": [
+            {
+              "ref": "19:17-18",
+              "note": "NET Note: The list of sixteen cities for Issachar follows a city-list format rather than the boundary-tracing format used for Zebulun. This difference may reflect distinct source documents behind the allotment descriptions. 'Shunem' (šûnēm) is identified with modern Sôlem at the foot of Mount Moreh, the town where Elisha stayed with the prominent woman (2 Kgs 4:8-37)."
+            }
+          ]
+        },
+        "hess": {
+          "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:17-23",
+              "note": "Hess: Issachar's allotment in the eastern Jezreel Valley gave the tribe control over vital agricultural land and trade routes. Several cities in the list — Jezreel, Shunem, En Gannim — are well attested in Egyptian topographical lists (Thutmose III's Karnak list, Shishak's relief), confirming the antiquity and accuracy of these place names. The boundary touching Tabor (v.22) places Issachar adjacent to Zebulun and Naphtali in the Galilee region."
+            }
+          ]
+        },
+        "howard": {
+          "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:17-23",
+              "note": "Howard: Issachar's allotment is presented as a city list followed by a brief boundary note (v.22), combining both formats seen elsewhere. The sixteen cities (v.22b) represent a significant urban network for a relatively compact territory, indicating dense settlement in the fertile lowlands. Howard notes the contrast with highland tribes that received larger but less developed territories."
+            }
+          ]
+        },
+        "hist": {
+          "context": "Issachar controlled the eastern Jezreel Valley, the most fertile agricultural region in Israel and a critical military corridor. The cities Jezreel, Shunem, and En Gannim became significant in the monarchy period. The valley's openness made it both a breadbasket and a battlefield throughout biblical history."
+        }
+      }
+    },
+    {
+      "section_num": 4,
+      "header": "Verses 24–31 — The Allotment for Asher",
+      "verse_start": 24,
+      "verse_end": 31,
+      "panels": {
+        "heb": [
+          {
+            "word": "צִידוֹן",
+            "transliteration": "ṣîdōn",
+            "gloss": "Sidon",
+            "paragraph": "The reference to 'Greater Sidon' (ṣîdōn rabbâ, v.28) marks the northern extent of Asher's allotment. Sidon was one of the premier Phoenician city-states, a centre of maritime trade and purple-dye production. The allotment boundary reaching 'as far as Greater Sidon' was aspirational — Judges 1:31 acknowledges Asher never displaced the Sidonians."
+          }
+        ],
+        "cross": {
+          "refs": [
+            {
+              "ref": "Gen 49:20",
+              "note": "Jacob prophesied 'Asher’s food will be rich; he will provide delicacies fit for a king.' The fertile coastal plain and olive-producing hills of western Galilee fulfil this characterisation precisely."
+            },
+            {
+              "ref": "Judg 1:31-32",
+              "note": "Judges records that Asher failed to drive out the inhabitants of Acco, Sidon, and several other cities — the gap between the allotment's promise and the tribe's actual control."
+            },
+            {
+              "ref": "Deut 33:24-25",
+              "note": "Moses blessed Asher: 'Most blessed of sons is Asher; let him be favoured by his brothers, and let him bathe his feet in oil.' The olive oil production of Asher's territory was proverbial."
+            }
+          ]
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:24-25",
+              "note": "MacArthur: Asher's coastal territory stretched from Carmel to Sidon, including some of the most fertile land in Canaan. The abundance of the allotment reflects God's generosity, but Asher's later failure to dispossess the Canaanites (Judg 1:31-32) illustrates how divine provision without human obedience leads to compromise."
+            },
+            {
+              "ref": "19:29",
+              "note": "MacArthur: The boundary reaching to 'the fortified city of Tyre' indicates an allotment far larger than what Asher actually occupied. The gap between promise and possession is a recurring theme in Joshua — God gives, but Israel must take."
+            }
+          ]
+        },
+        "calvin": {
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:24-31",
+              "note": "Calvin: Asher's territory included powerful Phoenician cities that the tribe never conquered. Calvin sees this as a warning against presumption: receiving an allotment from God does not guarantee its enjoyment. Faith must be accompanied by action, and the promise must be appropriated through obedience. Asher's failure foreshadows Israel's broader pattern of incomplete conquest."
+            }
+          ]
+        },
+        "net": {
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": [
+            {
+              "ref": "19:28-29",
+              "note": "NET Note: The boundary description mentions both Sidon and Tyre, the two great Phoenician port cities. The phrase 'the fortified city of Tyre' (‘îr mibṣar ṣōr) likely refers to the mainland settlement rather than the island fortress, which was virtually impregnable until Alexander's siege in 332 BC."
+            },
+            {
+              "ref": "19:30",
+              "note": "NET Note: 'Twenty-two towns' again does not match the number of named cities in the text, a discrepancy paralleling Zebulun's list. The count may include dependent settlements not individually named."
+            }
+          ]
+        },
+        "hess": {
+          "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:24-31",
+              "note": "Hess: Asher's allotment along the Phoenician coast is the most geopolitically ambitious in the northern allotment series. The territory encompasses major Canaanite centres that remained independent throughout the biblical period. Hess argues the allotment represents the ideal tribal boundary as envisioned by the allotment tradition, not the actual settlement pattern. Archaeological evidence shows Israelite material culture in the hill country of western Galilee but not in the coastal cities."
+            }
+          ]
+        },
+        "howard": {
+          "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:24-31",
+              "note": "Howard: Asher's allotment uses a mixed format combining boundary descriptions and city lists. The mention of Carmel (v.26) as a boundary marker connects Asher's territory to the dramatic events of 1 Kings 18. Howard notes that the twenty-two cities (v.30) represent the largest city count for any northern tribe, reflecting the dense Phoenician urbanisation of the coastal plain."
+            }
+          ]
+        },
+        "hist": {
+          "context": "Asher's coastal allotment stretched along the Phoenician littoral from Mount Carmel toward Sidon and Tyre. The territory was famous for olive oil production, fulfilling Jacob's and Moses' blessings. However, the tribe's inability to displace the Canaanite and Phoenician populations meant Asher lived among rather than instead of the existing inhabitants — a compromise that defined the tribe's history."
+        }
+      }
+    },
+    {
+      "section_num": 5,
+      "header": "Verses 32–39 — The Allotment for Naphtali",
+      "verse_start": 32,
+      "verse_end": 39,
+      "panels": {
+        "heb": [
+          {
+            "word": "כִּנֶּרֶת",
+            "transliteration": "kinnĕret",
+            "gloss": "Kinnereth (Sea of Galilee)",
+            "paragraph": "Kinnereth (v.35) is the OT name for the lake later known as the Sea of Galilee (or Gennesaret). The name may derive from kinnōr ('harp'), describing the lake's shape. Naphtali's control of the western shore of Kinnereth set the stage for the Galilean ministry of Jesus, who called his first disciples from these waters."
+          }
+        ],
+        "cross": {
+          "refs": [
+            {
+              "ref": "Isa 9:1-2",
+              "note": "Isaiah's prophecy that 'the people walking in darkness have seen a great light' specifically names 'the land of Zebulun and Naphtali.' Matthew 4:13-16 identifies Jesus' move to Capernaum as fulfilment of this prophecy."
+            },
+            {
+              "ref": "Gen 49:21",
+              "note": "Jacob described Naphtali as 'a doe set free that bears beautiful fawns,' possibly alluding to the tribe's agility in warfare or the beauty of its Galilean territory."
+            },
+            {
+              "ref": "Judg 4:6-10",
+              "note": "Barak, the judge who defeated Sisera alongside Deborah, was from Kedesh in Naphtali (v.37). The tribe played a decisive military role in the early settlement period."
+            }
+          ]
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:32-34",
+              "note": "MacArthur: Naphtali's territory in upper Galilee included fortified cities and fertile valleys. The nineteen fortified towns (v.38) indicate substantial urbanisation in a region often dismissed as backwater. God placed this tribe in a territory that would become central to redemptive history."
+            },
+            {
+              "ref": "19:35",
+              "note": "MacArthur: Kinnereth, Hazor, and Kedesh all feature in later biblical narratives. Hazor was the largest Canaanite city in the north (Josh 11:10), and its inclusion in Naphtali's allotment signalled the tribe's responsibility for one of the most significant conquered sites."
+            }
+          ]
+        },
+        "calvin": {
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:32-39",
+              "note": "Calvin: Naphtali's territory in the far north of Canaan demonstrates that God's covenant extends to the remotest corners of the promised land. No tribe is forgotten, no allotment is accidental. Calvin draws an analogy to the church: God distributes gifts and callings to every member, and none should consider their portion insignificant simply because it lies far from the centre of power."
+            }
+          ]
+        },
+        "net": {
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": [
+            {
+              "ref": "19:33",
+              "note": "NET Note: 'The large tree in Zaanannim' (bĕ’ēlōn baṣṣa’ănannîm) serves as a boundary landmark. Natural features — trees, springs, wadis — functioned as legal boundary markers in the ancient Near East, paralleled in Mesopotamian kudurru (boundary stone) inscriptions. The same tree appears in Judg 4:11 in connection with Heber the Kenite."
+            },
+            {
+              "ref": "19:35-38",
+              "note": "NET Note: The list of nineteen fortified cities includes Hazor, the dominant Canaanite city destroyed by Joshua (11:10-13) and later rebuilt by Solomon (1 Kgs 9:15). The city's mention in both destruction and allotment narratives underscores the transition from conquest to settlement."
+            }
+          ]
+        },
+        "hess": {
+          "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:32-39",
+              "note": "Hess: Naphtali's fortified cities (vv.35-38) include several sites with significant archaeological records. Hazor's destruction layer (Stratum XIII) is often correlated with the Israelite conquest, and Kinnereth's tell shows continuous occupation from the Bronze Age through the Hellenistic period. The nineteen cities represent the strongest urban network in upper Galilee, suggesting Naphtali's settlement was more successful than Asher's coastal attempts."
+            }
+          ]
+        },
+        "howard": {
+          "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:32-39",
+              "note": "Howard: Naphtali's allotment combines a boundary description (vv.33-34) with a city list (vv.35-38), following the mixed format of several other tribes. Howard emphasises the theological significance of Naphtali's territory for the NT: Jesus' Galilean ministry was centred in land allotted to Naphtali and Zebulun, making these OT boundary texts foundational to messianic geography."
+            }
+          ]
+        },
+        "hist": {
+          "context": "Naphtali's territory in upper Galilee encompassed the western shore of the Sea of Galilee (Kinnereth) and included major cities like Hazor and Kedesh. The region's significance extends into the NT: Capernaum, Bethsaida, and Chorazin — the core of Jesus' ministry — all lie within or adjacent to Naphtali's ancient allotment, fulfilling Isaiah's prophecy of 'a great light' in Galilee."
+        }
+      }
+    },
+    {
+      "section_num": 6,
+      "header": "Verses 40–48 — The Allotment for Dan",
+      "verse_start": 40,
+      "verse_end": 48,
+      "panels": {
+        "heb": [
+          {
+            "word": "לֶשֶם",
+            "transliteration": "lešem",
+            "gloss": "Leshem (= Laish/Dan)",
+            "paragraph": "Leshem (v.47) is the city the Danites conquered and renamed Dan after their ancestor. Known as Laish in Judges 18, it sat at the foot of Mount Hermon near one of the Jordan River's sources. The Danite migration from their coastal allotment to this far-northern site represents one of the most dramatic territorial shifts in Israelite tribal history."
+          }
+        ],
+        "cross": {
+          "refs": [
+            {
+              "ref": "Judg 18:1-31",
+              "note": "Judges 18 narrates the full Danite migration story. Unable to hold their coastal allotment against Amorite and Philistine pressure, a Danite expeditionary force conquered Laish and established an idolatrous shrine — a cautionary tale of military success accompanied by religious failure."
+            },
+            {
+              "ref": "Gen 49:16-17",
+              "note": "Jacob prophesied Dan would 'provide justice for his people' and be 'a serpent by the roadside.' The migration narrative in Judges 18 complicates this blessing, as the tribe's seizure of Laish involved theft and idolatry."
+            },
+            {
+              "ref": "1 Kgs 12:29",
+              "note": "Jeroboam placed one of his golden calves at Dan, exploiting the site's existing cultic tradition. Dan's allotment territory thus became associated with both tribal identity and apostasy."
+            }
+          ]
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:40-46",
+              "note": "MacArthur: Dan's original coastal allotment included strategically important towns bordering Philistine territory. The tribe's inability to hold this land (v.47) demonstrates a recurring biblical principle: possession of God's promises requires active faith and obedience, not passive assumption."
+            },
+            {
+              "ref": "19:47",
+              "note": "MacArthur: The parenthetical note that the Danites 'went up and attacked Leshem' introduces a story fully developed in Judges 18. The migration itself was not sinful, but the manner — involving stolen idols and a renegade Levite — reveals a tribe that pursued territorial security without spiritual fidelity."
+            }
+          ]
+        },
+        "calvin": {
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:40-48",
+              "note": "Calvin: Dan's failure to maintain its allotment is a sobering lesson. The tribe received a generous territory on the coastal plain, but when the inhabitants proved difficult to dislodge, Dan chose relocation over perseverance. Calvin warns against the temptation to abandon the calling God has given in favour of an easier path — the 'easier' territory at Laish came with its own spiritual compromises (Judg 18)."
+            }
+          ]
+        },
+        "net": {
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": [
+            {
+              "ref": "19:47",
+              "note": "NET Note: The Hebrew text literally reads 'the territory of Dan went out from them' (wayyēṣē’ gĕbûl bĕnê-dān mēhem), a euphemism for military defeat. The verb yāṣā’ ('went out') in the hiphil implies the Danites were expelled or forced out of their territory, necessitating the northern migration to Leshem."
+            },
+            {
+              "ref": "19:46",
+              "note": "NET Note: 'Me Jarkon' (mê hayy-yarqōn, 'waters of the Jarkon') refers to the Yarkon River near modern Tel Aviv. This identifies Dan's original territory as the central coastal plain, one of the most contested regions in ancient Canaan."
+            }
+          ]
+        },
+        "hess": {
+          "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:40-48",
+              "note": "Hess: Dan's allotment on the coastal plain included cities later associated with Philistine control (Ekron, v.43; the area facing Joppa, v.46). The failure to hold this territory and the subsequent migration to Laish/Leshem illustrates the gap between allotment as divine grant and settlement as human accomplishment. Archaeological surveys of the Sorek and Aijalon valleys show mixed Israelite-Canaanite material culture, confirming incomplete Danite settlement in this region."
+            }
+          ]
+        },
+        "howard": {
+          "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:40-48",
+              "note": "Howard: Dan's allotment is unique in including an editorial note about territorial loss and migration (v.47). Howard argues this parenthetical comment serves a literary purpose: it anticipates the Judges narrative and signals the transition from the ideal allotment system to the messy reality of settlement. The inclusion of this 'failure note' within Joshua's otherwise triumphal allotment account shows the narrator's honesty about Israel's incomplete conquest."
+            }
+          ]
+        },
+        "hist": {
+          "context": "Dan's original coastal allotment bordered Philistine territory and included the Yarkon River valley near modern Tel Aviv. Unable to maintain this position, the tribe migrated north to conquer Laish/Leshem at the headwaters of the Jordan. This migration, narrated fully in Judges 18, established Dan at Israel's northern extreme — giving rise to the expression 'from Dan to Beersheba' as shorthand for the entire nation."
+        }
+      }
+    },
+    {
+      "section_num": 7,
+      "header": "Verses 49–51 — Joshua’s Inheritance at Timnath Serah",
+      "verse_start": 49,
+      "verse_end": 51,
+      "panels": {
+        "heb": [
+          {
+            "word": "תִּמְנַת סֶרַח",
+            "transliteration": "timnat seraḥ",
+            "gloss": "portion of abundance",
+            "paragraph": "Timnath Serah ('portion of abundance' or 'remaining portion') was Joshua's personal inheritance in the hill country of Ephraim. The LXX calls it Timnath Heres ('portion of the sun'), possibly the original name later reversed to avoid pagan associations. That Joshua received his allotment last — after all tribes were settled — models servant leadership: the commander takes only what remains."
+          }
+        ],
+        "cross": {
+          "refs": [
+            {
+              "ref": "Josh 24:29-30",
+              "note": "Joshua was buried at Timnath Serah, the town he built and settled. His grave became a marker of covenant faithfulness — the leader who brought Israel into the land rests within it."
+            },
+            {
+              "ref": "Num 14:6-9",
+              "note": "Joshua and Caleb were the only spies who trusted God's promise. Decades later, Joshua's personal inheritance is the tangible reward of that faith — the man who believed receives what he believed for."
+            },
+            {
+              "ref": "Judg 2:8-9",
+              "note": "Judges repeats the burial notice, calling the town 'Timnath Heres' and noting Joshua's age at death (110). The repetition frames the transition from the era of conquest to the era of judges."
+            }
+          ]
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:49-50",
+              "note": "MacArthur: Joshua asked for a town that needed rebuilding, not a conquered city with existing infrastructure. He chose the harder path — building up what was desolate rather than inheriting what was ready. This models the servant-leader who takes the assignment no one else wants."
+            },
+            {
+              "ref": "19:51",
+              "note": "MacArthur: The closing formula attributes the entire distribution to Eleazar, Joshua, and the tribal heads acting 'at Shiloh before the LORD.' The presence of the tabernacle at Shiloh sanctioned the proceedings — every allotment was a sacred act, not merely an administrative one."
+            }
+          ]
+        },
+        "calvin": {
+          "source": "John Calvin, Commentaries — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:49-51",
+              "note": "Calvin: Joshua's personal modesty in taking his inheritance last is instructive. The greatest leader takes the least prominent portion. Calvin sees in this a foreshadowing of Christ, who — though Lord of all — had 'no place to lay his head' (Matt 8:20). The pattern of deferred reward characterises all true servants of God."
+            }
+          ]
+        },
+        "net": {
+          "source": "NET Bible Full Notes Edition — Biblical Studies Press",
+          "notes": [
+            {
+              "ref": "19:50",
+              "note": "NET Note: The phrase 'he built up the town and settled there' (wayyībĕneh ĕt-hā‘îr wayyēšeb bāh) indicates Timnath Serah required construction before habitation. The verb bānâ ('built') suggests either initial construction or significant rebuilding — Joshua did not inherit a turnkey city."
+            },
+            {
+              "ref": "19:51",
+              "note": "NET Note: 'At the entrance to the tent of meeting' (petah ’ōhel mō‘ēd) locates the allotment ceremony at the tabernacle in Shiloh. This sacral setting establishes the legal and theological legitimacy of every preceding land grant — the distributions were made in YHWH's presence and by his authority."
+            }
+          ]
+        },
+        "hess": {
+          "source": "Richard S. Hess, Joshua, Tyndale OT Commentary (1996) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:49-51",
+              "note": "Hess: Joshua's inheritance of Timnath Serah comes last in the allotment sequence, a literary choice that emphasises his selfless leadership. Hess identifies the site with Khirbet Tibnah in the Ephraimite hills, where excavations have revealed Iron Age I settlement remains. The closing formula (v.51) functions as a colophon for the entire allotment section (Josh 14–19), certifying its authority through the joint leadership of priest (Eleazar), commander (Joshua), and tribal representatives."
+            }
+          ]
+        },
+        "howard": {
+          "source": "David M. Howard Jr., Joshua, New American Commentary (1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "19:49-51",
+              "note": "Howard: The conclusion to the allotment section achieves three things: it rewards Joshua personally (vv.49-50), it provides a legal colophon certifying the entire distribution (v.51a), and it returns the narrative to Shiloh where the allotment began (18:1). This inclusio — Shiloh to Shiloh — frames the allotment of the seven remaining tribes as a unified literary and theological unit."
+            }
+          ]
+        },
+        "hist": {
+          "context": "Joshua's personal inheritance at Timnath Serah in Ephraim's hill country comes after all tribal allotments are complete. The leader receives last — a model of servant leadership echoed in Moses (who never entered the land) and foreshadowing Christ (who had 'no place to lay his head'). The closing verse returns to Shiloh, framing the entire allotment as a sacred act performed before the tabernacle."
         }
       }
     }
@@ -231,30 +667,55 @@
     "lit": {
       "rows": [
         {
-          "label": "Simeon, Zebulun, Issachar, Asher — 19:1-(31, '')",
-          "text": "Sets the narrative context",
+          "label": "Simeon within Judah (19:1–9)",
+          "text": "The dependent tribe receives its portion from the surplus of a larger tribe, fulfilling Gen 49:7",
           "is_key": false
         },
         {
-          "label": "Resolution",
-          "text": "The narrative advances through divine action and human response",
+          "label": "Zebulun (19:10–16)",
+          "text": "Boundary-tracing format defines the inland Galilean territory",
           "is_key": false
+        },
+        {
+          "label": "Issachar (19:17–23)",
+          "text": "City-list format catalogues the fertile Jezreel Valley holdings",
+          "is_key": false
+        },
+        {
+          "label": "Asher (19:24–31)",
+          "text": "Ambitious coastal allotment reaching toward Phoenician Sidon and Tyre",
+          "is_key": false
+        },
+        {
+          "label": "Naphtali (19:32–39)",
+          "text": "Upper Galilee territory including Hazor and Kinnereth (Sea of Galilee)",
+          "is_key": false
+        },
+        {
+          "label": "Dan (19:40–48)",
+          "text": "Coastal allotment lost to Amorite/Philistine pressure; migration to Laish",
+          "is_key": true
+        },
+        {
+          "label": "Joshua’s inheritance (19:49–51)",
+          "text": "The leader receives last; colophon certifies the entire allotment at Shiloh",
+          "is_key": true
         }
       ],
-      "note": ""
+      "note": "The chapter follows a repeating formula: lot assignment → boundary/city description → summary count → concluding formula. Dan’s migration note (v.47) and Joshua’s personal inheritance (vv.49–51) break the pattern, marking the transition from tribal allotment to individual reward."
     },
     "hebtext": [
       {
-        "word": "key term",
-        "tlit": "transliteration",
-        "gloss": "meaning",
-        "note": "A key Hebrew term in this section on four tribal territories carries theological weight that illuminates the passage's role in Joshua's larger narrative of conquest and covenant fulfilment."
+        "word": "גּוֹרָל",
+        "tlit": "gōrāl",
+        "gloss": "lot, allotment",
+        "note": "The casting of lots (gōrāl) was the divinely sanctioned mechanism for tribal land distribution. Proverbs 16:33 declares 'the lot is cast into the lap, but its every decision is from the LORD.' Each allotment in Joshua 14–19 is therefore understood as a direct expression of YHWH's will for tribal boundaries."
       },
       {
-        "word": "key term",
-        "tlit": "transliteration",
-        "gloss": "meaning",
-        "note": "A key Hebrew term in this section on final allotments; Joshua's own inheritance carries theological weight that illuminates the passage's role in Joshua's larger narrative of conquest and covenant fulfilment."
+        "word": "נַחֲלָה",
+        "tlit": "naḥălâ",
+        "gloss": "inheritance, possession",
+        "note": "Naḥălâ ('inheritance') is the theological keyword of the allotment section. The term implies not merely land ownership but covenantal gift — the land belongs to YHWH (Lev 25:23) and is apportioned to the tribes as a trust. Each tribe's naḥălâ is both a provision and a responsibility."
       }
     ],
     "thread": [
@@ -336,19 +797,24 @@
       "name": "places",
       "css_class": "vhl-place",
       "words": [
-        "Jericho",
-        "Jordan",
-        "Gilgal",
-        "Ai",
-        "Gibeon",
-        "Shiloh",
-        "Shechem",
-        "Hebron",
+        "Beersheba",
+        "Ziklag",
+        "Hormah",
+        "Jezreel",
+        "Shunem",
+        "Tabor",
+        "Carmel",
+        "Sidon",
+        "Tyre",
         "Hazor",
-        "Canaan",
-        "Ebal",
-        "Gerizim",
-        "Kadesh"
+        "Kinnereth",
+        "Kedesh",
+        "Leshem",
+        "Dan",
+        "Joppa",
+        "Shiloh",
+        "Jordan",
+        "Timnath Serah"
       ],
       "btn_types": [
         "places",
@@ -360,16 +826,15 @@
       "css_class": "vhl-person",
       "words": [
         "Joshua",
-        "Caleb",
-        "Rahab",
-        "Achan",
-        "Phinehas",
         "Eleazar",
-        "Moses",
-        "God",
-        "LORD",
+        "Simeon",
+        "Zebulun",
+        "Issachar",
+        "Asher",
+        "Naphtali",
+        "Dan",
         "Israel",
-        "Gibeonites"
+        "LORD"
       ],
       "btn_types": [
         "people",
@@ -420,7 +885,7 @@
   ],
   "coaching": [
     {
-      "after_section": 2,
+      "after_section": 7,
       "tip": "Joshua receives his own allotment last — after every other tribe is settled. The leader serves before he receives. The pattern recurs: Moses never enters the land, David waits years for his throne, Jesus takes the lowest seat. Biblical leadership is characterized by deferred reward.",
       "genre_tag": "canonical_thread"
     }


### PR DESCRIPTION
## Summary
Resections Joshua 19 from 2 oversized sections (25.5 v/s) into 7 natural tribal divisions (~7.3 v/s), raising quality score from 88.7 to 94.4.

## Sections
| # | Verses | Tribe |
|---|--------|-------|
| 1 | 1–9 | Simeon |
| 2 | 10–16 | Zebulun |
| 3 | 17–23 | Issachar |
| 4 | 24–31 | Asher |
| 5 | 32–39 | Naphtali |
| 6 | 40–48 | Dan |
| 7 | 49–51 | Joshua Inheritance |

## Changes
- All section panels rewritten with substantive, tribe-specific content
- Real Hebrew words in heb panels (gōrāl, gĕbūl, yizrĕʾeʾl, ṣîdōn, kinnĕret, lešem, timnat seraḥ)
- Chapter hebtext fixed (gōrāl, naḥălâ)
- Literary structure updated to reflect 7-section layout
- Coaching tip repositioned to section 7
- VHL groups updated with chapter-relevant places/people

Closes #764