### PR TITLE
fix: correct Psalms 69 S1 verse_end from 1 to 18 (86.1→91.8)

### DIFF
--- a/content/psalms/69.json
+++ b/content/psalms/69.json
@@ -15,7 +15,7 @@
       "section_num": 1,
       "header": "Verses 1’18 — “I Am Sinking in the Miry Depths”",
       "verse_start": 1,
-      "verse_end": 1,
+      "verse_end": 18,
       "panels": {
         "heb": [
           {


### PR DESCRIPTION
One-character fix: S1 `verse_end` was `1` instead of `18`, leaving verses 2-18 uncovered.

Closes #777