### PR TITLE
fix(content): Psalm 95 verse coverage — section 2 range 8-11

### DIFF
--- a/content/psalms/95.json
+++ b/content/psalms/95.json
@@ -65,9 +65,9 @@
     },
     {
       "section_num": 2,
-      "header": "Verses 7b–11 — “Today, If Only You Would Hear His Voice”",
-      "verse_start": 7,
-      "verse_end": 7,
+      "header": "Verses 8–11 — \"Today, If Only You Would Hear His Voice\"",
+      "verse_start": 8,
+      "verse_end": 11,
       "panels": {
         "heb": [
           {


### PR DESCRIPTION
## Summary
Fixes #778 — Psalm 95 quality score below 90 floor.

## Problem
- Section 2 was incorrectly set to verses 7–7 (single verse)
- Verses 8–11 were uncovered
- Verse 7 overlapped between sections

## Fix
Changed section 2 from `verse_start: 7, verse_end: 7` to `verse_start: 8, verse_end: 11`.

Verse 7 contains a mid-verse transition (praise in 7a, warning in 7b), but our system uses whole verses. Section 1 now covers praise (vv. 1–7), section 2 covers warning (vv. 8–11).

## Quality Score
- **Before:** 83.9 / 100 (Grade B)
- **After:** 93.3 / 100 (Grade A)
- Breakdown: D:19 V:25 C:24 R:25

## Testing
- [x]  passes
- [x]  succeeds
- [x]  passes
