### PR TITLE
Add prayer prompts for Genesis 2-50 and Exodus 2-40 (#849)

### DIFF
--- a/content/exodus/10.json
+++ b/content/exodus/10.json
@@ -485,5 +485,6 @@
       "tip": "Three days of darkness 'that can be felt' (v. 21). Ra, the sun god, goes dark. Egypt's supreme deity is eclipsed. The escalation is theological: YHWH defeats not just Pharaoh but Pharaoh's god.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the plague of darkness so thick it could be felt, consider asking God whether there are areas of spiritual darkness in your life that you have grown accustomed to — and what it would take for you to long for the light again."
 }

--- a/content/exodus/11.json
+++ b/content/exodus/11.json
@@ -483,5 +483,6 @@
       "tip": "Israel leaves with Egyptian silver, gold, and clothing (v. 2). They 'plunder' Egypt without a battle. Four hundred years of slave labor receives back payment. Justice looks like irony.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the dreadful finality of the tenth plague announced, consider asking God to help you take His warnings seriously the first time — not to wait until the consequences are irreversible before you respond."
 }

--- a/content/exodus/12.json
+++ b/content/exodus/12.json
@@ -715,5 +715,6 @@
       "tip": "'The blood will be a sign for you' (v. 13)—for Israel, not God. God doesn't need a visual cue; Israel needs assurance. The lamb's blood marks households, but more deeply, it marks trust. Faith makes the sign effective.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the Passover lamb's blood on the doorposts — protection not by merit but by obedience — consider asking God whether you are trusting in your own goodness or in the covering He has provided, and what it means to eat in haste, ready to move."
 }

--- a/content/exodus/13.json
+++ b/content/exodus/13.json
@@ -544,5 +544,6 @@
       "tip": "God leads them the long way, avoiding Philistine territory (v. 17). 'If they face war, they might change their minds.' God knows their fragility. The wilderness route isn't punishment—it's protection. Discipleship often takes detours.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on God leading Israel by a pillar of cloud and fire rather than by the shortest route, consider asking the Lord whether His detours in your life have been protections in disguise — and whether you are following His presence or your own map."
 }

--- a/content/exodus/14.json
+++ b/content/exodus/14.json
@@ -533,5 +533,6 @@
       "tip": "'The Egyptians you see today you will never see again' (v. 13). The sea swallows the army—chariots, horses, riders (v. 28). Egypt's military pride drowns in the corridor of Israel's salvation. Liberation and judgment share the same waters.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Israel trapped between the sea and Pharaoh's army, consider asking God to help you stand still in your own impossible situations — to believe that the God who parts seas is not limited by your lack of options."
 }

--- a/content/exodus/15.json
+++ b/content/exodus/15.json
@@ -521,5 +521,6 @@
       "tip": "Three days from the sea, they grumble at Marah's bitter water (v. 24). The Red Sea high crashes fast. Memory fades; thirst doesn't. Faith tested by scarcity reveals what abundance conceals.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Israel singing in triumph at the sea and then grumbling three days later at Marah's bitter water, consider asking God how quickly your own worship turns to complaint — and whether you can trust Him to sweeten what is bitter."
 }

--- a/content/exodus/16.json
+++ b/content/exodus/16.json
@@ -588,5 +588,6 @@
       "tip": "'What is it?' they ask (v. 15)—Hebrew מָן הוּא (man hu), giving manna its name. The bread defies categories. Israel learns: God's provision doesn't always fit familiar boxes. Expect the strange from the faithful God.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God providing manna daily — enough for the day but no more — consider asking the Lord to free you from the anxiety of hoarding and to teach you the discipline of daily dependence."
 }

--- a/content/exodus/17.json
+++ b/content/exodus/17.json
@@ -527,5 +527,6 @@
       "tip": "Moses's raised hands determine battle outcome (vv. 11-12). When he tires, Aaron and Hur hold them up. Leadership isn't solo performance. Even Moses needs support. Victory is communal.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Moses' arms growing heavy during the battle with Amalek and needing Aaron and Hur to hold them up, consider asking God to show you who is holding up your arms — and whose arms you should be supporting."
 }

--- a/content/exodus/18.json
+++ b/content/exodus/18.json
@@ -514,5 +514,6 @@
       "tip": "'What you are doing is not good. You will only wear yourself out' (vv. 17-18). Moses's father-in-law sees burnout coming. Delegation isn't weakness—it's wisdom. God's work doesn't require one person's exhaustion.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jethro's counsel to Moses — that leading alone would wear him out — consider asking God whether you are trying to carry responsibilities He designed to be shared, and whether pride or fear is keeping you from delegating."
 }

--- a/content/exodus/19.json
+++ b/content/exodus/19.json
@@ -589,5 +589,6 @@
       "tip": "Thunder, lightning, thick cloud, trumpet blast, smoke, earthquake (vv. 16-18). Sinai overwhelms the senses. God's approach terrifies. 'Do not let the people break through to see the LORD, or many of them will perish' (v. 21). Holiness protects by creating distance.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Israel standing at the foot of Sinai while the mountain shook with God's presence, consider asking the Lord whether your relationship with Him still has a sense of holy awe — or whether familiarity has dulled your reverence."
 }

--- a/content/exodus/2.json
+++ b/content/exodus/2.json
@@ -859,5 +859,6 @@
       "tip": "Moses kills an Egyptian, hides the body, flees to Midian (vv. 11-15). His first act of deliverance is violent, impulsive, and fails. Forty years of shepherding will precede his calling. God's deliverers often need breaking before they're ready.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Moses rescued from the Nile by the very household that ordered Hebrew babies killed, consider asking God to show you how He has placed you in unlikely situations — even hostile ones — as part of His rescue plan for others."
 }

--- a/content/exodus/20.json
+++ b/content/exodus/20.json
@@ -626,5 +626,6 @@
       "tip": "The people stand 'at a distance' while Moses approaches (v. 21). They want Moses to mediate: 'Speak to us yourself... but do not have God speak to us' (v. 19). Intimacy with God terrifies. They prefer secondhand revelation.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the Ten Commandments beginning with 'I am the LORD your God, who brought you out of Egypt,' consider asking God to help you see His commands not as restrictions but as the boundaries of freedom — given by a deliverer, not a tyrant."
 }

--- a/content/exodus/21.json
+++ b/content/exodus/21.json
@@ -643,5 +643,6 @@
       "tip": "'Eye for eye, tooth for tooth' (v. 24). Not vengeance permission but limitation: punishment must match, not exceed, the crime. Lex talionis restrains escalation. Justice is proportional, not unlimited.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on laws governing Hebrew servants and personal injury, consider asking God whether you treat the people under your authority — at work, at home, in the church — with the dignity and limits these laws demanded."
 }

--- a/content/exodus/22.json
+++ b/content/exodus/22.json
@@ -485,5 +485,6 @@
       "tip": "'Do not mistreat or oppress a foreigner, for you were foreigners in Egypt' (v. 21). Memory shapes ethics. Israel's Egyptian experience becomes moral instruction: you know vulnerability; don't inflict it.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God's laws protecting the vulnerable — foreigners, widows, orphans — consider asking the Lord whether your definition of justice extends to the people most easily ignored in your community."
 }

--- a/content/exodus/23.json
+++ b/content/exodus/23.json
@@ -485,5 +485,6 @@
       "tip": "Three annual festivals structure Israel's year: Unleavened Bread, Harvest, Ingathering (v. 14-17). Worship rhythms mark time. The calendar itself confesses: life belongs to God, punctuated by remembrance and gratitude.",
       "genre_tag": "structure_guide"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the command not to spread false reports or follow the crowd in doing wrong, consider asking God whether you have the courage to stand for truth when the consensus is moving in the opposite direction."
 }

--- a/content/exodus/24.json
+++ b/content/exodus/24.json
@@ -537,5 +537,6 @@
       "tip": "Seventy elders 'saw God, and they ate and drank' (v. 11). Theophany plus feast—God's presence doesn't destroy but hosts. The vision of God doesn't end in death but in communion. Astonishing intimacy.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the elders of Israel seeing God and eating a meal in His presence, consider asking the Lord whether you approach Him expecting encounter or merely performing ritual — and what it would look like to dine with God rather than just talk at Him."
 }

--- a/content/exodus/25.json
+++ b/content/exodus/25.json
@@ -615,5 +615,6 @@
       "tip": "'Make this tabernacle... exactly like the pattern I will show you' (v. 9). The design isn't arbitrary—it reflects heavenly reality. Hebrews 8:5 calls the earthly tent 'a copy and shadow.' Worship connects realms.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the detailed instructions for the ark, the table, and the lampstand, consider asking God whether you bring the same care and intentionality to creating space for His presence in your daily life — or whether worship has become haphazard."
 }

--- a/content/exodus/26.json
+++ b/content/exodus/26.json
@@ -569,5 +569,6 @@
       "tip": "The Most Holy Place measures a perfect cube: ten cubits in each dimension (v. 33-34). Revelation 21:16 describes the New Jerusalem identically—a cube. Sacred geometry persists from tabernacle to eternity.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the layered coverings of the tabernacle — each material serving a purpose — consider asking God what layers of protection, beauty, and structure He has placed around the sacred things in your life, and whether you value them."
 }

--- a/content/exodus/27.json
+++ b/content/exodus/27.json
@@ -499,5 +499,6 @@
       "tip": "Pure olive oil keeps the lamps burning 'from evening till morning' (v. 20-21). Light never fails in God's house. The priests tend what the people provide—communal generosity sustains divine worship.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the bronze altar at the entrance of the courtyard — the first thing encountered — consider asking God whether you approach His presence through sacrifice or try to skip past the cost of drawing near."
 }

--- a/content/exodus/28.json
+++ b/content/exodus/28.json
@@ -595,5 +595,6 @@
       "tip": "Twelve stones on the breastpiece, each engraved with a tribe's name (vv. 17-21). Aaron carries Israel over his heart into God's presence. The priest represents the people—literally bearing them.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the priest carrying the names of the twelve tribes on his breastpiece over his heart, consider asking God who He has placed on your heart to carry before Him in prayer — and whether you are faithfully bearing their names."
 }

--- a/content/exodus/29.json
+++ b/content/exodus/29.json
@@ -629,5 +629,6 @@
       "tip": "'I will dwell among the Israelites and be their God' (v. 45). The tabernacle's purpose stated plainly: divine presence. All the gold, linen, and ritual serve one end—God living with his people.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the elaborate ordination ceremony — blood on the ear, thumb, and toe — consider asking God to consecrate your hearing, your work, and your walk so that every part of your life is set apart for His purposes."
 }

--- a/content/exodus/3.json
+++ b/content/exodus/3.json
@@ -834,5 +834,6 @@
       "tip": "'Take off your sandals, for the place where you are standing is holy ground' (v. 5). Holiness isn't the bush—it's God's presence. Any ground becomes sacred when God shows up. Moses learns: approach matters before assignment.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Moses turning aside to see the burning bush, consider asking God whether there is something He is doing right now that you have been too busy or too afraid to turn aside and examine — and whether 'I AM' is enough of an answer for the questions you are carrying."
 }

--- a/content/exodus/30.json
+++ b/content/exodus/30.json
@@ -629,5 +629,6 @@
       "tip": "The half-shekel census tax is identical for rich and poor (v. 15). 'The rich are not to give more than a half shekel and the poor are not to give less.' Before God, economic distinctions collapse.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the incense altar and the command that its fragrance rise continually, consider asking God whether your prayers have become sporadic rather than sustained — and what a life of continual communion with Him might look like."
 }

--- a/content/exodus/31.json
+++ b/content/exodus/31.json
@@ -495,5 +495,6 @@
       "tip": "'The Sabbath will be a sign between me and you' (v. 13). Rest identifies Israel: they stop when others don't. Identity is marked not by what they do but by what they refuse to do. Sabbath is counter-cultural confession.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on God filling Bezalel with His Spirit specifically for craftsmanship and artistry, consider asking the Lord whether you have limited the work of His Spirit to 'spiritual' activities and failed to see your creative or professional skills as Spirit-empowered callings."
 }

--- a/content/exodus/32.json
+++ b/content/exodus/32.json
@@ -677,5 +677,6 @@
       "tip": "Moses intercedes: 'Turn from your fierce anger; relent' (v. 12). He argues from God's reputation, not Israel's merit. 'What will the Egyptians say?' (v. 12). Intercessors use any leverage available.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Israel building a golden calf while Moses was receiving the law on the mountain, consider asking God whether impatience has led you to construct substitutes for His presence — and whether you have the courage of Moses to intercede for people who have failed spectacularly."
 }

--- a/content/exodus/33.json
+++ b/content/exodus/33.json
@@ -612,5 +612,6 @@
       "tip": "'You cannot see my face, for no one may see me and live' (v. 20). God grants Moses a glimpse—of his back, after passing by. Glory is deadly; even friendship with God has limits. Yet Moses sees more than any before.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Moses refusing to go forward without God's presence — even when God offered an angel instead — consider asking the Lord whether you would notice if His presence withdrew from your life, or whether you would keep going on momentum alone."
 }

--- a/content/exodus/34.json
+++ b/content/exodus/34.json
@@ -697,5 +697,6 @@
       "tip": "Moses's face radiates so brightly he veils it (v. 33-35). Proximity transforms. Paul reads this as the difference between old and new covenants (2 Cor 3:7-18). Unveiled faces behold and become.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God proclaiming His own name — compassionate, gracious, slow to anger, abounding in love — consider asking God to help you receive this self-description as the truest thing about Him, especially when your circumstances suggest otherwise."
 }

--- a/content/exodus/35.json
+++ b/content/exodus/35.json
@@ -563,5 +563,6 @@
       "tip": "'Everyone who was willing and whose heart moved them' (v. 21). Offerings for the tabernacle are voluntary—no compulsion. Generosity flows from hearts, not quotas. Worship flourishes on willing sacrifice.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the people giving so generously for the tabernacle that Moses had to tell them to stop, consider asking God whether your giving has ever approached that kind of overflow — and what would change if you gave out of delight rather than duty."
 }

--- a/content/exodus/36.json
+++ b/content/exodus/36.json
@@ -462,5 +462,6 @@
       "tip": "The detailed execution (vv. 8-38) mirrors the earlier blueprint. Repetition isn't redundancy—it's testimony. The craftsmen didn't improvise; they followed the pattern. Faithfulness looks like precision.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the skilled workers beginning construction exactly as God designed, consider asking the Lord whether you are building your life according to His blueprint or improvising your own design and hoping He approves."
 }

--- a/content/exodus/37.json
+++ b/content/exodus/37.json
@@ -481,5 +481,6 @@
       "tip": "Table, lampstand, incense altar—each piece serves the priests serving God. Light to see, bread to eat, incense to offer. The holy place sustains ministry. God provides what worship requires.",
       "genre_tag": "structure_guide"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the mercy seat crafted above the ark — the place where God's presence would dwell between the cherubim — consider asking God whether you have a place in your life where mercy and justice meet, and whether you go there often enough."
 }

--- a/content/exodus/38.json
+++ b/content/exodus/38.json
@@ -486,5 +486,6 @@
       "tip": "The material inventory: nearly a ton of gold, three tons of silver, two and a half tons of bronze (vv. 24-29). Precise accounting. God's house is built with auditable generosity. Stewardship requires records.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the careful accounting of every talent and shekel used in the tabernacle, consider asking God whether you steward the resources He has given you with the same transparency and accountability — and whether anything is unaccounted for."
 }

--- a/content/exodus/39.json
+++ b/content/exodus/39.json
@@ -485,5 +485,6 @@
       "tip": "Moses inspects and blesses: 'they had done it just as the LORD had commanded' (v. 43). Completion brings blessing. The work isn't finished until leadership confirms fidelity. Accountability closes the loop.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Moses inspecting the completed work and blessing the people because they did it 'just as the LORD commanded,' consider asking God whether the work of your hands would pass His inspection — and whether obedience to His design matters more to you than your own creative preferences."
 }

--- a/content/exodus/4.json
+++ b/content/exodus/4.json
@@ -504,5 +504,6 @@
       "tip": "'The LORD met Moses and was about to kill him' (v. 24). Bizarre and terrifying: God nearly kills the man he just commissioned. Zipporah's quick circumcision saves him. Even deliverers must bear covenant marks. Uncircumcised Moses can't lead circumcised Israel.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Moses' repeated objections — 'Who am I? What if they don't listen? I can't speak well' — consider asking God to reveal which of your excuses He has already answered, and whether you are stalling out of genuine inadequacy or simple fear."
 }

--- a/content/exodus/40.json
+++ b/content/exodus/40.json
@@ -677,5 +677,6 @@
       "tip": "'The glory of the LORD filled the tabernacle' (v. 34). Moses cannot enter—the glory is too intense. What began at a burning bush ends in blazing presence. God has moved in. Mission accomplished.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the glory of the LORD filling the tabernacle so powerfully that even Moses could not enter, consider asking God whether you have left room for His presence to overwhelm your carefully arranged life — and whether you are willing to stand outside your own plans when His glory fills the space."
 }

--- a/content/exodus/5.json
+++ b/content/exodus/5.json
@@ -483,5 +483,6 @@
       "tip": "Moses's first intervention makes things worse: no straw, same quota, beatings (vv. 6-14). Deliverance often deepens crisis before resolving it. The foremen blame Moses; Moses blames God (v. 22). Honest prayer includes complaint.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Pharaoh doubling the workload after Moses' first demand, consider asking God to sustain your faith when obedience makes things worse before they get better — and whether you are tempted to blame the messenger when liberation is costly."
 }

--- a/content/exodus/6.json
+++ b/content/exodus/6.json
@@ -501,5 +501,6 @@
       "tip": "The genealogy (vv. 14-25) interrupts the narrative—why? It establishes Moses and Aaron's credentials: Levites, positioned between Reuben and Judah. Deliverers need pedigree. Israel must know who speaks for God.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God reminding Moses of His covenant name — 'I am the LORD' — consider asking whether you have reduced God to what He can do for you rather than knowing Him by who He is, and what it would mean to anchor your faith in His character rather than His performance."
 }

--- a/content/exodus/7.json
+++ b/content/exodus/7.json
@@ -459,5 +459,6 @@
       "tip": "Aaron's staff becomes a serpent—but so do the magicians' staffs (v. 12). Egypt's gods compete, initially matching YHWH's power. The plagues escalate until the magicians concede: 'This is the finger of God' (8:19). Contest, not mere punishment.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the Nile turning to blood — Egypt's source of life becoming a source of death — consider asking God to reveal the systems you depend on that He is willing to disrupt in order to get your attention."
 }

--- a/content/exodus/8.json
+++ b/content/exodus/8.json
@@ -479,5 +479,6 @@
       "tip": "'I will deal differently with the land of Goshen' (v. 22). From the flies onward, Israel is exempt. The plagues discriminate: judgment falls on Egypt, not on God's people. Distinction becomes the point.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Pharaoh begging for relief during each plague and then hardening his heart the moment the pressure lifted, consider asking God whether you have a pattern of crying out in crisis and then forgetting your promises when the pain subsides."
 }

--- a/content/exodus/9.json
+++ b/content/exodus/9.json
@@ -478,5 +478,6 @@
       "tip": "'I have raised you up for this very purpose, that I might show you my power' (v. 16). Paul quotes this in Romans 9:17. Pharaoh serves God's purposes even in rebellion. Divine sovereignty encompasses human resistance.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the plagues striking Egypt while Goshen remained untouched, consider asking God whether you recognize the distinction He has made in your life — the protections you take for granted — and what gratitude for that distinction looks like."
 }

--- a/content/genesis/10.json
+++ b/content/genesis/10.json
@@ -693,5 +693,6 @@
       "tip": "This genealogy maps the known world from an Israelite perspective. It isn't trying to be exhaustive — it's showing that all nations trace back to one family. The theological point precedes the historical one: human diversity is real, but human unity is more fundamental.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you trace the spread of nations from Noah's three sons, consider asking God to broaden your vision beyond your own tribe — and to help you see every language and culture as part of His deliberate design for filling the earth."
 }

--- a/content/genesis/11.json
+++ b/content/genesis/11.json
@@ -810,5 +810,6 @@
       "tip": "After Babel's dispersion, the narrative suddenly narrows from all humanity to one family line: Shem to Terah to Abram. The genealogy is a literary bridge — God's response to Babel isn't just judgment but election. He will bless the nations through one nation.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider humanity's attempt to build a tower to make a name for themselves, consider asking God to reveal the towers you are building — the projects, reputations, or platforms motivated more by your glory than His."
 }

--- a/content/genesis/12.json
+++ b/content/genesis/12.json
@@ -580,5 +580,6 @@
       "tip": "Abram has barely arrived in the land of promise before famine drives him to Egypt, where he immediately lies about Sarai. The patriarch who just received God's grand covenant acts out of fear and self-preservation. Genesis never airbrushes its heroes.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Abram leaving everything familiar at God's call, consider asking the Lord whether there is something He is asking you to leave — a comfort zone, a certainty, a plan — and whether you are willing to go without knowing the destination."
 }

--- a/content/genesis/13.json
+++ b/content/genesis/13.json
@@ -629,5 +629,6 @@
       "tip": "After Lot takes the apparent best land, God tells Abram to look in every direction — the same verb Lot used. But where Lot's looking led to self-interested choice, Abram's looking receives divine promise. The contrast frames the entire chapter.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider how Abram let Lot choose the best land first, consider asking God to free you from the need to grasp — to trust that what He has promised you cannot be taken by someone else's choice."
 }

--- a/content/genesis/14.json
+++ b/content/genesis/14.json
@@ -646,5 +646,6 @@
       "tip": "Melchizedek appears without genealogy, without context — king of Salem (likely Jerusalem), priest of 'God Most High' (El Elyon). He blesses Abram and receives a tenth. The New Testament will build an entire Christological argument on this mysterious figure's sudden appearance (Hebrews 7).",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Melchizedek blessing Abram and Abram giving him a tenth of everything, consider asking God to show you the king-priests He has placed in your life — people of mysterious authority — and whether your generosity matches Abram's gratitude."
 }

--- a/content/genesis/15.json
+++ b/content/genesis/15.json
@@ -669,5 +669,6 @@
       "tip": "In the covenant ceremony, God alone passes between the animal pieces as a 'smoking firepot and blazing torch.' Normally both parties walk through, pledging 'may I be torn apart like these animals if I break covenant.' God takes the oath unilaterally — the obligation falls entirely on him.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Abram's honest question — 'What can you give me since I remain childless?' — consider asking God whether you have stopped bringing Him your honest doubts, and whether He is inviting you, like Abram, to look up and count what only faith can see."
 }

--- a/content/genesis/16.json
+++ b/content/genesis/16.json
@@ -488,5 +488,6 @@
       "tip": "The 'angel of the LORD' appears for the first time in Scripture — to a foreign slave woman fleeing in the wilderness. Before any covenant with Israel, before the law, God seeks out the marginalized. Hagar is the first person in the Bible to give God a name: El Roi, 'the God who sees me.'",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hagar alone in the desert, seen by a God who called Himself El Roi — the God who sees — consider asking God to make you aware of His gaze on you in your loneliest moments, and to help you see the overlooked people around you."
 }

--- a/content/genesis/17.json
+++ b/content/genesis/17.json
@@ -691,5 +691,6 @@
       "tip": "Abraham laughs when told Sarah will bear a son (v. 17), and Sarah will laugh too (18:12). Their son's name — Isaac (Yitzhak, 'he laughs') — memorializes the incredulity. The promised child carries the parents' disbelief in his very name, transformed from doubt into joy (21:6).",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God changing Abram's name to Abraham — father of many — when he had one child by a slave woman, consider asking God whether He has spoken a new identity over you that you have not yet grown into, and what it would take to start living as though His renaming were already true."
 }

--- a/content/genesis/18.json
+++ b/content/genesis/18.json
@@ -504,5 +504,6 @@
       "tip": "Abraham's intercession for Sodom negotiates from fifty righteous down to ten. The bargaining structure reveals something about prayer: it is not merely submission but genuine dialogue. God permits — even invites — Abraham to press. The negotiation stops at ten, but Abraham stops asking, not God refusing.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Abraham bargaining with God for the sake of Sodom, consider asking the Lord to give you that same boldness in prayer — the courage to intercede persistently for people and places that seem beyond saving."
 }

--- a/content/genesis/19.json
+++ b/content/genesis/19.json
@@ -639,5 +639,6 @@
       "tip": "Lot's wife 'looked back' — the same directional language used when Lot first 'looked' toward Sodom (13:10). Her backward glance mirrors his initial choice. The family's attachment to Sodom runs deeper than geography; it is a spiritual orientation that ultimately costs everything.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Lot's wife looking back at the city she was told to leave, consider asking God to reveal what you keep looking back toward — the comforts, habits, or attachments He has already told you to walk away from."
 }

--- a/content/genesis/2.json
+++ b/content/genesis/2.json
@@ -920,5 +920,6 @@
       "tip": "The command \"you may freely eat of every tree\" comes before the prohibition. God's first word to humanity is generous permission, not restriction. The one boundary (\"but of the tree of knowledge…\") is set inside an ocean of freedom. Keep this ratio in mind when the serpent reframes it in chapter 3.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider how God placed Adam in the garden to work and keep it, consider asking the Lord to show you where He has planted you — and whether you are tending the relationships and responsibilities He has entrusted to you with the same intentionality He showed in Eden."
 }

--- a/content/genesis/20.json
+++ b/content/genesis/20.json
@@ -489,5 +489,6 @@
       "tip": "Abimelek emerges as more morally upright than Abraham in this episode — he acts with integrity, fears God, and is vindicated in a dream. The pagan king shames the covenant patriarch. Genesis consistently resists the idea that election equals moral superiority.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Abraham repeating the same deception about Sarah — even after years of walking with God — consider asking the Lord to expose the recurring sins you have never fully surrendered, the patterns you keep cycling through."
 }

--- a/content/genesis/21.json
+++ b/content/genesis/21.json
@@ -657,5 +657,6 @@
       "tip": "Hagar and Ishmael's expulsion parallels their earlier flight (ch. 16) — wilderness, despair, divine intervention, a well. But this time God's promise to Hagar is national: 'I will make him into a great nation.' Two covenant lines emerge from Abraham's household, and God cares for both.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Sarah's laughter turning from disbelief to joy at Isaac's birth, consider asking God whether there is a promise in your life that you have stopped expecting Him to fulfill — and whether He is about to surprise you with laughter."
 }

--- a/content/genesis/22.json
+++ b/content/genesis/22.json
@@ -691,5 +691,6 @@
       "tip": "Isaac carries the wood up the mountain while Abraham carries the fire and the knife — the boy bears the instrument of his own sacrifice. The parallel to Jesus carrying his cross is one of the most recognized typological connections in all of Scripture.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Abraham's willingness to offer Isaac on the altar, consider asking God to reveal the Isaac in your life — the thing He gave you that you love so much it has become harder to hold loosely — and whether you trust Him enough to lay it down."
 }

--- a/content/genesis/23.json
+++ b/content/genesis/23.json
@@ -473,5 +473,6 @@
       "tip": "Abraham insists on paying full price for the burial cave rather than accepting it as a gift. This is not stubbornness — in ancient Near Eastern culture, accepting a gift created an obligation. By paying, Abraham secures undisputed legal title. His only real estate in the promised land is a grave.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Abraham weeping for Sarah and then carefully negotiating a burial plot, consider asking God to help you grieve with both honesty and dignity — and to see that even ordinary acts like purchasing land can be expressions of covenant faithfulness."
 }

--- a/content/genesis/24.json
+++ b/content/genesis/24.json
@@ -622,5 +622,6 @@
       "tip": "Rebekah is asked 'Will you go with this man?' and answers 'I will go' — the same decisive language God used with Abraham in chapter 12. She leaves family and homeland on faith. The narrative frames her as a true counterpart to Abraham.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Abraham's servant praying for specific guidance at the well, consider asking God to show you how to bring your practical decisions — not just your crises — before Him with the same specificity and expectation."
 }

--- a/content/genesis/25.json
+++ b/content/genesis/25.json
@@ -666,5 +666,6 @@
       "tip": "Esau 'despised his birthright' — the Hebrew verb bazah implies treating something as worthless. The birthright carried the covenant promises, the double inheritance, and the family leadership. Esau trades his future for a single meal. The text presents this as a character verdict, not just a bad deal.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the rivalry between Jacob and Esau beginning in the womb, consider asking God to reveal any places where you have traded something of lasting value for an immediate appetite — selling your birthright for a bowl of stew."
 }

--- a/content/genesis/26.json
+++ b/content/genesis/26.json
@@ -620,5 +620,6 @@
       "tip": "The well disputes are not just about water rights — in an arid land, wells represent life itself. Isaac names one well Rehoboth ('room') saying 'Now the LORD has given us room.' The naming turns a property dispute into a theological statement about divine provision.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Isaac re-digging the wells his father Abraham had dug, consider asking God whether there are spiritual wells in your family's history — prayers, faithfulness, callings — that need to be uncovered and reopened in your generation."
 }

--- a/content/genesis/27.json
+++ b/content/genesis/27.json
@@ -619,5 +619,6 @@
       "tip": "Rebekah engineers the deception, yet the text never records God condemning her. The narrative tension is sharper than that: God had already told Rebekah 'the older will serve the younger' (25:23). She is right about the outcome but wrong about the method — a distinction Genesis forces the reader to sit with.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob's elaborate deception of his blind father, consider asking God whether you have ever manipulated circumstances to obtain something He may have intended to give you anyway — and what that manipulation cost your relationships."
 }

--- a/content/genesis/28.json
+++ b/content/genesis/28.json
@@ -489,5 +489,6 @@
       "tip": "Jacob's ladder vision features angels 'ascending and descending' — ascending first, meaning they were already on earth. God's messengers were present before Jacob knew it. The revelation at Bethel does not create God's presence; it unveils a presence that was already there. 'Surely the LORD is in this place, and I was not aware of it.'",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Jacob fleeing in shame and encountering God in a dream at Bethel, consider asking the Lord whether He has met you in unexpected places — perhaps your lowest moments — and whether you recognized His presence or walked right past it."
 }

--- a/content/genesis/29.json
+++ b/content/genesis/29.json
@@ -655,5 +655,6 @@
       "tip": "The deceiver gets deceived. Jacob tricked his father by pretending to be the firstborn; now Laban substitutes the firstborn daughter for the younger. The literary justice is exact. 'It is not our custom here to give the younger daughter in marriage before the older one' — a rebuke that lands on multiple levels.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob working seven years for Rachel only to be deceived by Laban, consider asking God what it means that the deceiver was himself deceived — and whether there are consequences of your own choices that you have mistaken for unfair treatment."
 }

--- a/content/genesis/3.json
+++ b/content/genesis/3.json
@@ -911,5 +911,6 @@
       "tip": "Verse 15 — \"he shall bruise your head, and you shall bruise his heel\" — is the first messianic hint in the Bible (the protoevangelium). The conflict announced here between the serpent's offspring and the woman's offspring becomes a thread running through the entire biblical narrative. Every genealogy that follows is, in part, tracing this promise.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the serpent's question — 'Did God really say?' — consider asking God to reveal the places where you have been tempted to doubt His word or redefine His boundaries, and to give you the honesty to stop hiding and come into the open before Him."
 }

--- a/content/genesis/30.json
+++ b/content/genesis/30.json
@@ -628,5 +628,6 @@
       "tip": "The naming of each son encodes the rivalry between Rachel and Leah. Leah names her sons with cries for love ('surely my husband will love me now'). Rachel's surrogate-born sons carry names of vindication ('God has vindicated me'). The children's names are a transcript of marital pain.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the painful rivalry between Rachel and Leah — one loved but barren, the other fertile but unloved — consider asking God to free you from measuring your worth by what someone else has that you lack."
 }

--- a/content/genesis/31.json
+++ b/content/genesis/31.json
@@ -663,5 +663,6 @@
       "tip": "Rachel steals Laban's household gods (teraphim) and hides them by sitting on them, claiming she cannot rise because 'the way of women is upon me.' The scene is bitterly comic — the gods are literally sat upon, helpless. The narrative mocks idolatry through physical farce.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob finally leaving Laban after twenty years of exploitation, consider asking God whether there are situations you have stayed in too long out of fear — and whether He is telling you it is time to move."
 }

--- a/content/genesis/32.json
+++ b/content/genesis/32.json
@@ -554,5 +554,6 @@
       "tip": "Jacob wrestles an unnamed figure until daybreak and receives a new name: Israel, meaning 'he struggles with God.' The patriarch who spent his life grasping — grabbing Esau's heel, grasping the birthright, grasping the blessing — is finally grasped by God. He prevails but walks away limping. Victory and wound arrive together.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Jacob wrestling with God all night and refusing to let go until he received a blessing, consider asking the Lord whether you have the tenacity to keep holding on in prayer when the struggle has gone on longer than you expected — and whether you are willing to walk away limping if it means being renamed."
 }

--- a/content/genesis/33.json
+++ b/content/genesis/33.json
@@ -496,5 +496,6 @@
       "tip": "Jacob tells Esau 'to see your face is like seeing the face of God' (v. 10). He has just seen God's face at Peniel (32:30). The reconciliation with his brother is framed as a mirror of the divine encounter — the horizontal relationship echoing the vertical one.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob bowing before Esau and finding forgiveness instead of vengeance, consider asking God whether there is a relationship you need to approach with humility — not knowing the outcome — trusting that He can change hearts you thought were hardened."
 }

--- a/content/genesis/34.json
+++ b/content/genesis/34.json
@@ -519,5 +519,6 @@
       "tip": "Simeon and Levi's massacre at Shechem uses circumcision — the sign of the covenant — as a weapon. They pervert a sacred rite into a military tactic. Jacob condemns them, and in his deathbed blessing (49:5-7) he curses their anger. The text treats this as a profound violation, not heroic vengeance.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the violence at Shechem and Jacob's silence during the crisis, consider asking God to give you the wisdom to know when action is required and when restraint is cowardice disguised as patience."
 }

--- a/content/genesis/35.json
+++ b/content/genesis/35.json
@@ -539,5 +539,6 @@
       "tip": "God sends Jacob back to Bethel — full circle to the place of his ladder vision (ch. 28). Jacob commands his household to 'put away the foreign gods.' The return to Bethel requires a purification that should have happened long before. God's patience with Jacob's slow obedience is itself a theological statement.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God calling Jacob back to Bethel — the place where he first met God — consider asking the Lord whether there is a spiritual starting point He is calling you to return to, and what household idols you need to bury before you go."
 }

--- a/content/genesis/36.json
+++ b/content/genesis/36.json
@@ -489,5 +489,6 @@
       "tip": "Esau's genealogy gets a full chapter — a generous literary allotment for the non-chosen line. Genesis consistently refuses to erase the rejected brother. Ishmael got his genealogy (25:12-18), and now Esau gets his. God's covenant narrows, but God's care does not.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you trace the genealogy of Esau and the kings of Edom, consider asking God to help you see His sovereignty over all peoples and nations — even those outside the covenant line — and to trust that no one falls outside His providential oversight."
 }

--- a/content/genesis/37.json
+++ b/content/genesis/37.json
@@ -671,5 +671,6 @@
       "tip": "The brothers dip Joseph's robe in goat blood to deceive Jacob — who once used goat skins to deceive his own father Isaac. The goat is the instrument of deception across generations. Jacob who tricked is now tricked by the same animal.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Joseph's dreams and his brothers' hatred, consider asking God whether there is a calling or vision He has given you that others have resented — and whether you have been wise or reckless in how you have shared it."
 }

--- a/content/genesis/38.json
+++ b/content/genesis/38.json
@@ -529,5 +529,6 @@
       "tip": "This chapter seems to interrupt the Joseph story, but it is deliberately placed. Judah, who suggested selling Joseph, now faces his own moral reckoning. Tamar's 'more righteous than I' verdict (v. 26) begins Judah's transformation — the arc that climaxes in his self-sacrificing speech in chapter 44.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Judah's failures and Tamar's desperate righteousness, consider asking God to show you the unexpected people in your life who are pursuing justice in ways you have not recognized — and whether your own blind spots need exposing."
 }

--- a/content/genesis/39.json
+++ b/content/genesis/39.json
@@ -525,5 +525,6 @@
       "tip": "The refrain 'the LORD was with Joseph' appears four times in this chapter (vv. 2, 3, 21, 23). Yet Joseph is falsely accused, imprisoned, and forgotten. The narrative insists that divine presence does not mean exemption from suffering. 'The LORD was with him' — in the pit, in the prison, in the waiting.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Joseph's faithfulness in Potiphar's house — rewarded with false accusation and prison — consider asking God to sustain your integrity when doing the right thing makes your situation worse rather than better."
 }

--- a/content/genesis/4.json
+++ b/content/genesis/4.json
@@ -720,5 +720,6 @@
       "tip": "God's question to Cain — 'Where is your brother?' — echoes the question to Adam: 'Where are you?' Both are rhetorical. God already knows. The pattern of divine interrogation after human sin becomes a recurring motif through Genesis.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Cain's anger when his offering was not accepted, consider asking God whether there is resentment in your heart toward someone whose life seems more blessed — and whether, like Cain, you are letting bitterness crouch at the door rather than mastering it."
 }

--- a/content/genesis/40.json
+++ b/content/genesis/40.json
@@ -502,5 +502,6 @@
       "tip": "Joseph asks the cupbearer to 'remember me' — but 'the chief cupbearer did not remember Joseph; he forgot him.' Two full years pass (41:1). The delay is not incidental; it ensures that Joseph's rise comes from God's timing, not human networking. Every human avenue of rescue fails first.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Joseph interpreting the dreams of the cupbearer and baker and then being forgotten for two years, consider asking God for the grace to serve faithfully even when no one remembers your contribution — trusting His timing over human gratitude."
 }

--- a/content/genesis/41.json
+++ b/content/genesis/41.json
@@ -652,5 +652,6 @@
       "tip": "Joseph tells Pharaoh 'I cannot do it, but God will give Pharaoh the answer' (v. 16). Compare this to Daniel's identical stance before Nebuchadnezzar (Daniel 2:27-28). Both refuse credit. The pattern — foreign ruler, impossible dream, humble interpreter — becomes a biblical template for how God's people serve pagan power.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Joseph's sudden elevation from prison to second-in-command over Egypt, consider asking God whether there is a season of preparation you are in right now that feels pointless — and whether He is building in you the competence that authority requires."
 }

--- a/content/genesis/42.json
+++ b/content/genesis/42.json
@@ -507,5 +507,6 @@
       "tip": "The brothers say 'Surely we are being punished because of our brother' (v. 21) — twenty years after selling Joseph. Guilt has been silently working. Reuben adds 'Didn't I tell you not to sin against the boy?' The conversation Joseph overhears, unrecognized, confirms both their guilt and their growth.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Joseph testing his brothers to see whether they have changed, consider asking God whether He is testing you in similar ways — creating situations designed to reveal whether old patterns of jealousy, deception, or self-preservation still control you."
 }

--- a/content/genesis/43.json
+++ b/content/genesis/43.json
@@ -499,5 +499,6 @@
       "tip": "Judah pledges himself as surety for Benjamin: 'I myself will guarantee his safety; you can hold me personally responsible.' This is the same Judah who proposed selling Joseph (37:26). The transformation is underway — from brother-seller to brother-guarantor.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Judah pledging his own life for Benjamin, consider asking God to show you the growth that suffering has produced in you — the ways you have become someone who protects others rather than protecting yourself."
 }

--- a/content/genesis/44.json
+++ b/content/genesis/44.json
@@ -486,5 +486,6 @@
       "tip": "Judah's speech (vv. 18-34) is the emotional climax of the entire Joseph cycle. He offers himself as a slave in Benjamin's place — the exact reversal of selling Joseph into slavery. The man who traded one brother for profit now trades himself for another. Genesis rarely announces its moral lessons; it shows them.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Judah's great speech — offering himself in Benjamin's place — consider asking God whether you have ever loved someone enough to take their consequences upon yourself, and what that willingness reveals about the gospel."
 }

--- a/content/genesis/45.json
+++ b/content/genesis/45.json
@@ -507,5 +507,6 @@
       "tip": "'You intended to harm me, but God intended it for good' (50:20) is anticipated here: 'It was to save lives that God sent me ahead of you' (v. 5). Joseph interprets his entire suffering through a theological lens — not denying the brothers' guilt but seeing a larger purpose operating through it.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Joseph weeping and revealing himself to his brothers with the words 'I am Joseph,' consider asking God to give you Joseph's extraordinary perspective — the ability to see divine purpose behind human cruelty without minimizing the pain."
 }

--- a/content/genesis/46.json
+++ b/content/genesis/46.json
@@ -480,5 +480,6 @@
       "tip": "God says 'Do not be afraid to go down to Egypt' — echoing 15:13 where God told Abraham his descendants would be strangers in a foreign land for 400 years. Jacob's descent into Egypt sets the stage for Exodus. The promise is simultaneously fulfilled (the family grows) and endangered (they enter captivity).",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the aged Jacob finally reunited with Joseph after decades of grief, consider asking God whether there are long-held sorrows in your life that He is preparing to resolve — and whether you can receive joy after so much loss."
 }

--- a/content/genesis/47.json
+++ b/content/genesis/47.json
@@ -663,5 +663,6 @@
       "tip": "Jacob tells Pharaoh 'My years have been few and difficult' (v. 9) — at 130 years old. Compared to his ancestors (Abraham lived 175, Isaac 180), he is telling the truth. But the word 'difficult' (ra'im, literally 'evil') is the real weight: deception, exile, Dinah, Joseph's loss. The patriarch summarizes his life in one bitter adjective.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob standing before Pharaoh and describing his years as 'few and difficult,' consider asking God to help you hold the full truth of your life — both the hardship and the blessing — without letting either one define the whole story."
 }

--- a/content/genesis/48.json
+++ b/content/genesis/48.json
@@ -477,5 +477,6 @@
       "tip": "Jacob crosses his hands to place the right hand on the younger son Ephraim rather than the firstborn Manasseh. The reversal of primogeniture — younger over older — is Genesis's most persistent pattern: Isaac over Ishmael, Jacob over Esau, now Ephraim over Manasseh. It is the signature move of a God who overturns human assumptions about who comes first.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the aging Jacob crossing his hands to bless the younger Ephraim over the firstborn Manasseh, consider asking God whether His plans for your life have defied the expected order — and whether you can trust His reversals."
 }

--- a/content/genesis/49.json
+++ b/content/genesis/49.json
@@ -510,5 +510,6 @@
       "tip": "The Judah oracle (vv. 8-12) — 'The scepter shall not depart from Judah' — is the first explicit prediction of royal dynasty in the Bible. It plants the seed that will grow through David to the messianic expectation. Genesis ends not with Joseph (the immediate hero) but with Judah (the long-term lineage).",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jacob's final blessings over his twelve sons — some painfully honest, some richly prophetic — consider asking God what He would say over your life if He summed it up in a single blessing, and whether you are living into it."
 }

--- a/content/genesis/5.json
+++ b/content/genesis/5.json
@@ -885,5 +885,6 @@
       "tip": "Enoch 'walked with God; then he was no more, because God took him' breaks the relentless death refrain ('and then he died') that governs every other entry. In a chapter saturated with mortality, one life escapes the pattern — a quiet signal that death is not the final word.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you read through the repeated refrain 'and then he died,' consider asking God to give you an honest reckoning with your own mortality — and to help you live, like Enoch, in such close fellowship with Him that death loses its finality."
 }

--- a/content/genesis/50.json
+++ b/content/genesis/50.json
@@ -689,5 +689,6 @@
       "tip": "Genesis ends with a coffin in Egypt. Joseph's bones await transport to the promised land — a journey that won't happen for 400 years (Exodus 13:19). The book of beginnings closes with an unfinished ending, pointing forward. Every ending in Genesis is really a setup for the next act.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Joseph's declaration — 'You intended to harm me, but God intended it for good' — consider asking God to give you the faith to say the same about the deepest wounds in your story, not to excuse what was done but to trust that He wastes nothing."
 }

--- a/content/genesis/6.json
+++ b/content/genesis/6.json
@@ -863,5 +863,6 @@
       "tip": "Noah is described as 'righteous' and 'blameless among the people of his time' — that qualifier 'among the people of his time' is doing real work. Later rabbis debated whether it was a compliment (righteous despite a wicked generation) or a qualification (only righteous by comparison).",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider a world so corrupted that God grieved making humanity, consider asking whether the culture around you has dulled your sense of what grieves God — and whether, like Noah, you are willing to be different even when no one else is."
 }

--- a/content/genesis/7.json
+++ b/content/genesis/7.json
@@ -826,5 +826,6 @@
       "tip": "The flood narrative uses a chiastic structure: the waters rise for 150 days, then recede for 150 days, with 'God remembered Noah' at the center (8:1). The literary architecture places divine memory — not destruction — at the heart of the story.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the image of God Himself shutting Noah inside the ark, consider asking the Lord to deepen your trust that when He closes a door around you, it is for your protection — even when the storm outside is terrifying."
 }

--- a/content/genesis/8.json
+++ b/content/genesis/8.json
@@ -830,5 +830,6 @@
       "tip": "Noah's first act on dry ground is worship — he builds an altar and offers sacrifices. God's response ('Never again will I curse the ground') echoes but reverses the curse of Genesis 3:17. The flood narrative ends where creation began: with divine blessing.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Noah's patient waiting as the waters receded — months of silence before the dove returned with an olive leaf — consider asking God for the grace to wait on His timing rather than forcing your way out of seasons of uncertainty."
 }

--- a/content/genesis/9.json
+++ b/content/genesis/9.json
@@ -682,5 +682,6 @@
       "tip": "The curse on Canaan (not Ham directly) has been catastrophically misused throughout history to justify slavery and racism. The text itself is narrowly focused: it anticipates Israel's later conflict with the Canaanite nations. Reading it as a statement about race imports a framework the author never intended.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on God's covenant promise never to destroy the earth again by flood, consider asking the Lord to help you see the signs of His faithfulness in your own life — the rainbows after your storms — and to trust that His promises stand even when the sky darkens."
 }


### PR DESCRIPTION
## Prayer Prompts: Pentateuch Narrative

Closes #849 | Epic #848

### Changes
- 88 chapters updated with prayer prompts (Genesis 2-50, Exodus 2-40)
- Genesis 1 and Exodus 1 already had prompts — skipped
- All prompts use invitational "Consider asking..." pattern
- Each prompt references specific chapter content (names, events, themes)
- Genre-aware tone (theological narrative)

### Validation
- `schema_validator.py`: 119,571 passed, 0 failed
- `validate_sqlite.py`: 67 passed, 0 failed
- `build_sqlite.py`: clean build