### PR TITLE
Add prayer prompts for 1-2 Samuel and 1-2 Kings (#852)

### DIFF
--- a/content/1_kings/10.json
+++ b/content/1_kings/10.json
@@ -461,5 +461,6 @@
       "tip": "The Queen of Sheba declares 'Not even half was told me.' Solomon's wealth is cataloged in dazzling detail — gold, ivory, apes, peacocks. But the narrator is building toward chapter 11. The more impressive the zenith, the more devastating the fall.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the Queen of Sheba declaring that Solomon's wisdom exceeded the reports, consider asking God whether the way you live causes people to say 'It's even better than I heard' — or whether reality falls short of what you project."
 }

--- a/content/1_kings/11.json
+++ b/content/1_kings/11.json
@@ -500,5 +500,6 @@
       "tip": "'King Solomon loved many foreign women.' The verb 'loved' echoes his earlier love of the LORD (3:3). The same capacity that once drove him to God now drives him to apostasy. Solomon does not abandon faith dramatically — he drifts, one alliance and one altar at a time.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Solomon's heart being turned away by foreign wives in his old age, consider asking God whether there are attachments in your life that are slowly bending your loyalties — not suddenly but gradually, over years."
 }

--- a/content/1_kings/12.json
+++ b/content/1_kings/12.json
@@ -510,5 +510,6 @@
       "tip": "Rehoboam rejects the elders' counsel and follows his peers: 'My little finger is thicker than my father's waist.' One arrogant speech tears the kingdom in two. The narrator adds: 'this turn of events was from the LORD' — fulfilling Ahijah's prophecy (11:31). Human folly serves divine purpose.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Rehoboam rejecting the counsel of the elders in favor of his peers' harsh advice, consider asking God whether you listen to wise voices or comfortable ones — and whether your leadership burdens or blesses the people under you."
 }

--- a/content/1_kings/13.json
+++ b/content/1_kings/13.json
@@ -456,5 +456,6 @@
       "tip": "The man of God obeys God's word, then disobeys it when an older prophet lies to him. A lion kills him on the road. The episode is disturbing because the punishment seems disproportionate. But the narrative's point is precise: obedience to God's direct word cannot be overridden by another prophet's claim, however credible.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the man of God who obeyed God's word perfectly and then was deceived by an old prophet, consider asking God whether you are vulnerable to spiritual authority figures who contradict what God has clearly told you."
 }

--- a/content/1_kings/14.json
+++ b/content/1_kings/14.json
@@ -459,5 +459,6 @@
       "tip": "Ahijah tells Jeroboam's wife that God will 'uproot Israel from this good land' — the first explicit prediction of exile in Kings. It appears this early, during the very first generation of the divided monarchy. The ending is announced at the beginning.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jeroboam's wife disguising herself to consult the prophet Ahijah, consider asking God whether you have ever tried to get a word from Him while hiding who you really are — and what it means that He sees through every disguise."
 }

--- a/content/1_kings/15.json
+++ b/content/1_kings/15.json
@@ -449,5 +449,6 @@
       "tip": "Asa 'did what was right in the eyes of the LORD, as his father David had done.' David becomes the permanent benchmark — every king is measured against him. Yet even David was deeply flawed. The standard is not perfection but covenant loyalty.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the contrast between faithless kings and Asa who did what was right, consider asking God whether you are content to be faithful in an unfaithful generation — even if your reforms are incomplete and your courage imperfect."
 }

--- a/content/1_kings/16.json
+++ b/content/1_kings/16.json
@@ -464,5 +464,6 @@
       "tip": "Ahab 'did more to arouse the anger of the LORD, the God of Israel, than did all the kings of Israel before him.' The superlative marks a new low. His marriage to Jezebel imports Baal worship at state level. The Elijah cycle that follows is the response to this nadir.",
       "genre_tag": "structure_guide"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the rapid succession of kings, each worse than the last, culminating in Ahab, consider asking God whether you can see the downward trajectory in patterns of compromise — and whether you are willing to break the cycle before it reaches bottom."
 }

--- a/content/1_kings/17.json
+++ b/content/1_kings/17.json
@@ -493,5 +493,6 @@
       "tip": "God sends Elijah to a widow in Zarephath — Sidon, Jezebel's homeland. The prophet of Israel is sustained by a Gentile woman in Baal territory. Jesus cites this episode (Luke 4:25-26) to make the provocative point that God's provision crosses ethnic and religious boundaries.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Elijah fed by ravens and then sustained through a widow's last handful of flour, consider asking God whether you trust Him to provide through unconventional means — and whether you would share your last meal with a stranger who asked."
 }

--- a/content/1_kings/18.json
+++ b/content/1_kings/18.json
@@ -605,5 +605,6 @@
       "tip": "Elijah drenches the altar with water — twelve jars, three times — then prays a simple prayer. No theatrics, no ritual cutting (as the Baal prophets did). Fire falls. The contrast between Baal's frantic prophets and Elijah's calm confidence is the theological argument made visible.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Elijah's challenge on Mount Carmel — 'How long will you waver between two opinions?' — consider asking God whether there is a decision you have been straddling, trying to serve two masters, and what it would take to choose."
 }

--- a/content/1_kings/19.json
+++ b/content/1_kings/19.json
@@ -510,5 +510,6 @@
       "tip": "God is not in the wind, earthquake, or fire — but in the 'gentle whisper' (qôl demāmāh daqqāh, literally 'a sound of thin silence'). After the spectacle of Carmel, God reverses the mode of revelation. Power was demonstrated on the mountain; intimacy is offered in the cave.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Elijah fleeing Jezebel's threat and collapsing under a broom tree just one day after his greatest victory, consider asking God whether exhaustion and fear have distorted your view of reality — and whether what you need is not a rebuke but rest, food, and His quiet voice."
 }

--- a/content/1_kings/2.json
+++ b/content/1_kings/2.json
@@ -515,5 +515,6 @@
       "tip": "David's deathbed instructions mix spiritual counsel ('walk in obedience') with political hits — settle scores with Joab and Shimei. The blend is unsettling. David's final words reveal a man who is simultaneously a man of faith and a calculating power broker. The Bible gives you both.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David's final charge to Solomon — 'Be strong, act like a man, and observe what the LORD requires' — consider asking God what charge the generation before you has left, and whether you are honoring it or ignoring it."
 }

--- a/content/1_kings/20.json
+++ b/content/1_kings/20.json
@@ -464,5 +464,6 @@
       "tip": "A prophet condemns Ahab for releasing Ben-Hadad: 'You have set free a man I had determined should die.' Ahab's mercy toward an enemy king is not praised — it is judged as disobedience. The episode complicates simple readings: sometimes what looks like grace is actually a failure to follow divine command.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Ahab's victories over Ben-Hadad followed by his foolish mercy toward a defeated enemy God had devoted to destruction, consider asking God whether your compassion is sometimes misplaced — sparing what He said to release."
 }

--- a/content/1_kings/21.json
+++ b/content/1_kings/21.json
@@ -493,5 +493,6 @@
       "tip": "Naboth refuses to sell his vineyard: 'The LORD forbid that I should give you the inheritance of my ancestors.' The refusal is theological, not economic — ancestral land in Israel was a covenant gift. Jezebel's response — frame Naboth, execute him, seize the property — represents the collision between Israelite covenant theology and Phoenician royal absolutism.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Ahab coveting Naboth's vineyard and Jezebel arranging a judicial murder to obtain it, consider asking God whether there is something you want badly enough that you have allowed or tolerated injustice to get it."
 }

--- a/content/1_kings/22.json
+++ b/content/1_kings/22.json
@@ -503,5 +503,6 @@
       "tip": "Four hundred prophets say 'Go up and fight'; Micaiah alone says 'I saw all Israel scattered on the hills like sheep without a shepherd.' The lone dissenting voice against institutional consensus is a recurring pattern — Jeremiah against the temple prophets, Jesus against the Sanhedrin. Truth is not determined by vote.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Micaiah standing alone against four hundred prophets who told the king what he wanted to hear, consider asking God whether you have the courage to speak truth when everyone in the room is saying the opposite."
 }

--- a/content/1_kings/3.json
+++ b/content/1_kings/3.json
@@ -489,5 +489,6 @@
       "tip": "Solomon asks for 'a discerning heart to govern' rather than wealth or long life. God is 'pleased that Solomon asked for this.' The request reveals Solomon's priorities at this moment — wisdom for service, not power for self. The tragedy of the book is watching these priorities invert.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Solomon asking God for wisdom rather than wealth or long life, consider asking the Lord what you would request if He offered you one thing — and whether your answer reveals what you value most."
 }

--- a/content/1_kings/4.json
+++ b/content/1_kings/4.json
@@ -484,5 +484,6 @@
       "tip": "Solomon's wisdom is measured in proverbs (3,000), songs (1,005), and botanical/zoological knowledge. The text presents wisdom as encyclopedic — not just moral advice but a comprehensive engagement with the created order. Israel's golden age is an intellectual renaissance.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Solomon's extraordinary prosperity and wisdom, consider asking God whether abundance in your life has drawn you closer to Him or slowly made you feel less dependent on Him."
 }

--- a/content/1_kings/5.json
+++ b/content/1_kings/5.json
@@ -483,5 +483,6 @@
       "tip": "The temple project requires 30,000 laborers in monthly rotations plus 150,000 workers. Solomon's forced labor corps will later become a grievance that splits the kingdom (12:4). The glory of the temple and the seed of the kingdom's destruction grow from the same root.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Solomon's alliance with Hiram to gather materials for the temple, consider asking God whether you have the humility to seek outside help for the things He has called you to build — or whether pride keeps you working alone."
 }

--- a/content/1_kings/6.json
+++ b/content/1_kings/6.json
@@ -479,5 +479,6 @@
       "tip": "God's word interrupts the architectural description: 'As for this temple you are building — if you follow my decrees... I will live among the Israelites.' The conditional promise embedded in the building narrative warns that the structure is not the point. Obedience is. Stones without faithfulness are just stones.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the seven years Solomon spent building the temple — every stone cut offsite so no hammer was heard — consider asking God what sacred work in your life requires that kind of quiet, patient, invisible craftsmanship."
 }

--- a/content/1_kings/7.json
+++ b/content/1_kings/7.json
@@ -477,5 +477,6 @@
       "tip": "Solomon spends seven years on the temple and thirteen on his own palace. The narrator states this without comment, but the contrast does its own work. The proportions reveal something about where Solomon's real investment lies.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Solomon spending thirteen years building his own palace compared to seven for God's temple, consider asking God honestly where your time and resources reveal your true priorities."
 }

--- a/content/1_kings/8.json
+++ b/content/1_kings/8.json
@@ -633,5 +633,6 @@
       "tip": "Solomon's prayer anticipates exile: 'When they sin against you — for there is no one who does not sin — and you become angry... if they turn back to you... then hear from heaven.' The dedication prayer already assumes the temple will be destroyed. Hope is built into the architecture of failure.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Solomon's prayer at the temple dedication — acknowledging that even the highest heaven cannot contain God — consider asking the Lord whether your picture of Him has become too small, too domesticated, too containable."
 }

--- a/content/1_kings/9.json
+++ b/content/1_kings/9.json
@@ -477,5 +477,6 @@
       "tip": "God's second appearance to Solomon carries an explicit threat: 'If you or your descendants turn away... I will cut off Israel from the land... and this temple will become a heap of rubble.' The conditional covenant hangs over every subsequent chapter like a suspended sentence.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on God's conditional promise to Solomon — 'if you walk faithfully, I will establish your throne; if you turn away, I will cut off Israel' — consider asking God whether you take His warnings as seriously as His promises."
 }

--- a/content/1_samuel/10.json
+++ b/content/1_samuel/10.json
@@ -423,5 +423,6 @@
       "tip": "When the lot falls on Saul, he is hiding among the baggage. The narrator presents this without comment, but the image is unforgettable: Israel's first king must be dragged out of hiding to accept the crown. His reluctance will later curdle into something worse — not humility but insecurity.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the Spirit of God coming upon Saul and changing him into a different person, consider asking the Lord whether you are living in the power He gave you or have settled back into who you were before He called you."
 }

--- a/content/1_samuel/11.json
+++ b/content/1_samuel/11.json
@@ -423,5 +423,6 @@
       "tip": "After the Jabesh-Gilead victory, some want to execute those who opposed Saul's kingship. Saul refuses: 'No one shall be put to death today, for this day the LORD has rescued Israel.' This is Saul at his best — generous, God-centered, restrained. The contrast with his later paranoia makes the decline more painful.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul's decisive action to rescue Jabesh Gilead, consider asking God whether there are moments of boldness He is offering you right now — situations that require immediate courage rather than endless deliberation."
 }

--- a/content/1_samuel/12.json
+++ b/content/1_samuel/12.json
@@ -423,5 +423,6 @@
       "tip": "Samuel's farewell speech parallels Joshua 24 — covenant review, challenge, warning. Samuel adds thunder and rain during wheat harvest (meteorologically impossible) as a sign. The prophet steps aside but makes clear that kingship does not replace prophetic accountability. Kings will answer to prophets.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Samuel's farewell — reminding Israel of God's faithfulness across generations — consider asking God to help you remember His track record in your own life, especially when the future feels uncertain."
 }

--- a/content/1_samuel/13.json
+++ b/content/1_samuel/13.json
@@ -505,5 +505,6 @@
       "tip": "Saul offers the sacrifice himself rather than waiting for Samuel. His excuse — 'I felt compelled' — reveals the core issue. Saul acts from pressure rather than obedience. Samuel's verdict — 'your kingdom will not endure' — seems disproportionate until you see the pattern it establishes: partial obedience is disobedience.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul offering the sacrifice himself rather than waiting for Samuel, consider asking God whether impatience has led you to take matters into your own hands in areas where He asked you to wait — and what that presumption cost."
 }

--- a/content/1_samuel/14.json
+++ b/content/1_samuel/14.json
@@ -509,5 +509,6 @@
       "tip": "Jonathan says 'Nothing can hinder the LORD from saving, whether by many or by few.' Compare this to Saul's anxious head-counting in the previous chapter. Father and son represent two postures toward the same God — one calculates odds, the other trusts regardless of them.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Jonathan climbing the cliff at Michmash with only his armor-bearer, saying 'Nothing can hinder the LORD from saving,' consider asking God whether your faith is bold enough to act on what you believe — or whether you wait for safer odds."
 }

--- a/content/1_samuel/15.json
+++ b/content/1_samuel/15.json
@@ -510,5 +510,6 @@
       "tip": "Samuel tells Saul 'the LORD has torn the kingdom of Israel from you today.' Saul's response: 'I have sinned. But please honor me before the elders.' Even in repentance, Saul's primary concern is public reputation. The confession is real but shallow — he grieves the loss of status more than the loss of God's favor.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul keeping the best of the Amalekite plunder and calling it obedience, consider asking God whether you have ever redefined partial obedience as enough — keeping what He told you to surrender and dressing it up as devotion."
 }

--- a/content/1_samuel/16.json
+++ b/content/1_samuel/16.json
@@ -423,5 +423,6 @@
       "tip": "God tells Samuel 'The LORD does not look at the things people look at. People look at the outward appearance, but the LORD looks at the heart.' Seven sons pass before Samuel. David, the youngest, is not even invited to the lineup. God's choice confounds every human assumption about who qualifies.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on God choosing David — the youngest, the overlooked shepherd — while Samuel was impressed by the older brothers, consider asking God whether you are evaluating yourself or others by appearance when He is looking at the heart."
 }

--- a/content/1_samuel/17.json
+++ b/content/1_samuel/17.json
@@ -505,5 +505,6 @@
       "tip": "David refuses Saul's armor — 'I cannot go in these, because I am not used to them.' He fights with what he knows: a sling and five stones. The detail is not quaint; slingers were lethal in ancient warfare. David is not naive — he is choosing his actual competence over borrowed prestige.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David facing Goliath with a sling and five stones while Saul's army cowered, consider asking God what giant in your life you have been waiting for someone else to fight — and whether He has already equipped you with what you need."
 }

--- a/content/1_samuel/18.json
+++ b/content/1_samuel/18.json
@@ -423,5 +423,6 @@
       "tip": "'Saul has slain his thousands, and David his tens of thousands.' The song enrages Saul not because it is false but because it is true. From this point, Saul's fear of David drives every decision. The king's downfall is not a single failure but an unchecked emotion — jealousy — that colonizes his entire being.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Saul's jealousy when the women sang 'Saul has slain his thousands, and David his tens of thousands,' consider asking God whether comparison has poisoned any of your relationships — and whether you can genuinely celebrate another's success."
 }

--- a/content/1_samuel/19.json
+++ b/content/1_samuel/19.json
@@ -423,5 +423,6 @@
       "tip": "Saul sends men to capture David, but they encounter prophets and begin prophesying themselves. Saul goes personally — and he too prophesies, stripping off his clothes. The Spirit overrides the king's murderous intent. 'Is Saul also among the prophets?' is asked again (cf. 10:11), but now it is ironic rather than hopeful.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul hunting David despite knowing David had done nothing wrong, consider asking God for the grace to endure unjust treatment without becoming bitter — and to trust Him to vindicate you in His own time."
 }

--- a/content/1_samuel/2.json
+++ b/content/1_samuel/2.json
@@ -510,5 +510,6 @@
       "tip": "Eli's sons take the meat before it is offered to God and sleep with women at the tabernacle entrance. The narrator calls them 'scoundrels' who 'had no regard for the LORD.' Priestly corruption is presented as the systemic failure that necessitates a new kind of leadership.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hannah's song — exalting a God who lifts the poor from the dust and seats them with princes — consider asking God whether you truly believe He reverses the world's hierarchies, and whether your life reflects that conviction."
 }

--- a/content/1_samuel/20.json
+++ b/content/1_samuel/20.json
@@ -423,5 +423,6 @@
       "tip": "Jonathan and David's covenant is remarkable: the crown prince voluntarily cedes his claim to the throne. Jonathan recognizes what Saul refuses to accept — that God has chosen David. Loyalty to God's purposes overrides loyalty to family dynasty. It costs Jonathan everything.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the covenant between David and Jonathan — a friendship that cost Jonathan his own throne — consider asking God whether you have a friendship marked by that kind of sacrificial loyalty, and what it would take to build one."
 }

--- a/content/1_samuel/21.json
+++ b/content/1_samuel/21.json
@@ -423,5 +423,6 @@
       "tip": "David eats the consecrated bread at Nob — bread reserved for priests. Jesus cites this episode (Mark 2:25-26) to argue that human need can override ritual law. The incident becomes a permanent reference point in the debate about law versus mercy.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David fleeing to Nob and then pretending to be insane before the king of Gath, consider asking God whether fear has ever driven you to compromise your integrity — and whether desperation justifies deception."
 }

--- a/content/1_samuel/22.json
+++ b/content/1_samuel/22.json
@@ -427,5 +427,6 @@
       "tip": "Saul massacres 85 priests at Nob because they helped David. Only Abiathar escapes. The man anointed to protect Israel slaughters its priesthood. Saul has become the very threat the king was supposed to guard against. His trajectory from reluctant king to priestly murderer is complete.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David gathering the distressed, the indebted, and the discontented in the cave of Adullam, consider asking God whether He is calling you to lead or shelter people the world has discarded."
 }

--- a/content/1_samuel/23.json
+++ b/content/1_samuel/23.json
@@ -423,5 +423,6 @@
       "tip": "David inquires of the LORD before every move — twice in this chapter alone. Saul has no such practice. The contrast between the fugitive who prays and the king who doesn't is the quiet engine driving the narrative toward its conclusion.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David rescuing Keilah and then learning that the very people he saved would betray him, consider asking God for the strength to do the right thing even when the people you help cannot be trusted to reciprocate."
 }

--- a/content/1_samuel/24.json
+++ b/content/1_samuel/24.json
@@ -418,5 +418,6 @@
       "tip": "David cuts Saul's robe in the cave and is immediately 'conscience-stricken.' He refuses to kill the LORD's anointed even when handed the perfect opportunity. David's restraint is not pragmatic — it is theological. He will not seize by force what God has promised to give by providence.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David cutting Saul's robe in the cave but refusing to kill the man who was trying to kill him, consider asking God whether you can distinguish between opportunities and temptations — and whether you trust His timing over your own advantage."
 }

--- a/content/1_samuel/25.json
+++ b/content/1_samuel/25.json
@@ -423,5 +423,6 @@
       "tip": "Abigail intercepts David's vengeance raid with food, wisdom, and a speech that reads like prophecy: 'The LORD will certainly make a lasting dynasty for my lord.' She saves David from himself — from becoming the kind of man who avenges personal insults with massacre. Without Abigail, David's story could have ended at Nabal's doorstep.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Abigail's wisdom in defusing David's rage against Nabal, consider asking God whether there is a situation in your life where a wise voice is trying to prevent you from doing something you would regret."
 }

--- a/content/1_samuel/26.json
+++ b/content/1_samuel/26.json
@@ -423,5 +423,6 @@
       "tip": "David spares Saul a second time, taking his spear and water jug as proof. The repetition (after ch. 24) is not redundant — it deepens the portrait. David's mercy is not a one-time impulse but a settled conviction. Saul responds with tears both times, but changes nothing. The gap between feeling and transformation is the tragedy.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David sparing Saul a second time — even when his own men urged him to strike — consider asking God whether you are as committed to restraint the second time as you were the first, or whether your patience is wearing thin."
 }

--- a/content/1_samuel/27.json
+++ b/content/1_samuel/27.json
@@ -423,5 +423,6 @@
       "tip": "David lives among the Philistines and deceives Achish about his raids. The future king of Israel is hiding, lying, and serving Israel's enemies. The narrative presents this without moralizing — David is surviving. But the moral ambiguity is deliberate: even the chosen king is compromised by circumstances.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David living among the Philistines and deceiving King Achish about his raids, consider asking God whether you have ever found yourself living a double life — surviving by telling different stories to different people."
 }

--- a/content/1_samuel/28.json
+++ b/content/1_samuel/28.json
@@ -423,5 +423,6 @@
       "tip": "Saul consults the medium at Endor — violating his own decree against necromancy. Samuel's ghost delivers the final verdict: 'Tomorrow you and your sons will be with me.' The king who began by prophesying (10:10) ends by consulting the dead. His spiritual trajectory is a complete inversion.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Saul consulting the medium at Endor after God stopped answering him, consider asking God whether His silence in your life is driving you toward illegitimate sources of guidance — and whether repentance would reopen the conversation."
 }

--- a/content/1_samuel/29.json
+++ b/content/1_samuel/29.json
@@ -423,5 +423,6 @@
       "tip": "The Philistine commanders refuse to let David fight alongside them — 'He must not go with us into battle, or he will turn against us.' Their suspicion saves David from the impossible position of fighting against his own people. Providence operates through enemy distrust.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David being dismissed from the Philistine army before he had to fight against his own people, consider asking God whether He has ever rescued you from a situation you created — removing you before the consequences fully landed."
 }

--- a/content/1_samuel/3.json
+++ b/content/1_samuel/3.json
@@ -423,5 +423,6 @@
       "tip": "'In those days the word of the LORD was rare; there were not many visions.' The sentence explains why Samuel does not recognize God's voice — he has no frame of reference. The spiritual famine is institutional: the priesthood has failed to mediate divine communication.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the young Samuel learning to recognize God's voice in the night, consider asking the Lord whether you have cultivated the stillness to hear Him — and whether, like Samuel, you are willing to say 'Speak, for your servant is listening' even before you know what He will ask."
 }

--- a/content/1_samuel/30.json
+++ b/content/1_samuel/30.json
@@ -423,5 +423,6 @@
       "tip": "David 'strengthened himself in the LORD his God' (v. 6) when his own men talk of stoning him. Then he inquires of the Lord and pursues. This is the David pattern at its clearest: distress → worship → guidance → action. It contrasts with Saul's pattern: distress → panic → self-reliance → disaster.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's men weeping until they had no strength left at Ziklag and then David strengthening himself in the LORD, consider asking God to show you how to find strength in Him when everyone around you — including you — is exhausted."
 }

--- a/content/1_samuel/31.json
+++ b/content/1_samuel/31.json
@@ -423,5 +423,6 @@
       "tip": "Saul falls on his own sword — Israel's first king dies by his own hand on Mount Gilboa. The Philistines display his body on the walls of Beth Shan. The men of Jabesh-Gilead, whom Saul saved in his finest hour (ch. 11), retrieve the body. His beginning and his end are connected by the loyalty of one town.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul's tragic end on Mount Gilboa — falling on his own sword — consider asking God to help you see the full arc of a life that began with promise and ended in ruin, and to examine honestly whether you are drifting toward a similar trajectory."
 }

--- a/content/1_samuel/4.json
+++ b/content/1_samuel/4.json
@@ -423,5 +423,6 @@
       "tip": "Israel treats the ark as a talisman — bring it to the battlefield and God must fight. They lose anyway. The ark is captured. Eli's daughter-in-law names her son Ichabod: 'The glory has departed from Israel.' The name becomes a verdict on the entire era.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Israel treating the ark like a lucky charm and losing it in battle, consider asking God whether you have ever confused His presence with a prop — reducing worship to a formula for getting what you want."
 }

--- a/content/1_samuel/5.json
+++ b/content/1_samuel/5.json
@@ -423,5 +423,6 @@
       "tip": "Dagon falls face down before the ark — twice. The second time his head and hands break off. The scene is darkly comic: the Philistine god literally prostrates himself before Israel's God, then disintegrates. The ark needs no army to defend itself.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the idol Dagon falling face-down before the ark, consider asking God whether there are idols in your life that He has already toppled — things you keep propping back up that He keeps knocking down."
 }

--- a/content/1_samuel/6.json
+++ b/content/1_samuel/6.json
@@ -427,5 +427,6 @@
       "tip": "The Philistines design an experiment: put the ark on a cart pulled by cows that have never been yoked, with their calves penned up. If the cows walk toward Israel against their natural instinct, it proves God's hand. The pagan priests apply empirical reasoning to theology — and get the right answer.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the Philistines sending the ark back on an untended cart, consider asking God whether you have ever tried to return something sacred to its rightful place while keeping your distance from the God who owns it."
 }

--- a/content/1_samuel/7.json
+++ b/content/1_samuel/7.json
@@ -423,5 +423,6 @@
       "tip": "Samuel sets up a stone called Ebenezer — 'Thus far the LORD has helped us.' The name acknowledges both past faithfulness and present incompleteness. 'Thus far' means the journey is not over. Monuments mark progress, not arrival.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Samuel calling Israel to put away their foreign gods and return to the LORD with all their hearts, consider asking God what needs to be put away in your own life before genuine repentance can begin."
 }

--- a/content/1_samuel/8.json
+++ b/content/1_samuel/8.json
@@ -423,5 +423,6 @@
       "tip": "God tells Samuel: 'It is not you they have rejected, but they have rejected me as their king.' Israel wants to be 'like all the other nations' — the exact opposite of their calling to be distinct. The demand for a king is not inherently sinful (Deuteronomy 17 anticipated it), but the motivation is.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Israel demanding a king 'like all the other nations,' consider asking God whether you have ever wanted something not because it was good but because everyone else seemed to have it — and what that desire cost you."
 }

--- a/content/1_samuel/9.json
+++ b/content/1_samuel/9.json
@@ -435,5 +435,6 @@
       "tip": "Saul is looking for lost donkeys when God directs him to Samuel. The mundane errand becomes the vehicle for divine appointment. Saul's kingship begins with an accident he did not seek — a detail that will become tragically ironic as he clings to the throne he never wanted.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Saul searching for lost donkeys and finding a kingdom instead, consider asking God whether He is doing something far larger with your ordinary errands than you can see — and whether you are paying attention to the unexpected turns."
 }

--- a/content/2_kings/10.json
+++ b/content/2_kings/10.json
@@ -406,5 +406,6 @@
       "tip": "Jehu destroys Baal worship but 'did not turn away from the sins of Jeroboam' — the golden calves remain. His reform is partial. The narrator gives a split verdict: commended for executing judgment on Ahab's house, condemned for perpetuating the original national sin. Zeal against one evil does not excuse tolerance of another.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Jehu destroying Baal worship but not departing from the sins of Jeroboam, consider asking God whether your reforms have been thorough or selective — tearing down the sins you despise while preserving the ones that serve you."
 }

--- a/content/2_kings/11.json
+++ b/content/2_kings/11.json
@@ -412,5 +412,6 @@
       "tip": "Athaliah is the only woman to rule Judah — and she does it by massacring the royal family. Baby Joash is hidden in the temple for six years. The Davidic line survives through a single child sheltered by a priest. The covenant promise hangs by a thread, but the thread holds.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jehosheba hiding the infant Joash from Athaliah's massacre, preserving the Davidic line by a thread, consider asking God to show you the small, hidden acts of faithfulness that protect what He has promised."
 }

--- a/content/2_kings/12.json
+++ b/content/2_kings/12.json
@@ -396,5 +396,6 @@
       "tip": "Joash repairs the temple but buys off Hazael by emptying the temple treasury. He saves the building by gutting its contents. The pattern repeats through Kings: kings raiding the temple to pay off threats, each time diminishing the glory they claim to protect.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Joash repairing the temple but later stripping its gold to buy off an invader, consider asking God whether the things you have built for Him are resources you would sacrifice the moment pressure arrives."
 }

--- a/content/2_kings/13.json
+++ b/content/2_kings/13.json
@@ -438,5 +438,6 @@
       "tip": "Elisha on his deathbed tells Joash to strike the ground with arrows. Joash strikes three times and stops. Elisha is angry: 'You should have struck five or six times.' Half-hearted obedience produces half-hearted results. The number of strikes determines the number of victories. Effort correlates with outcome.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Elisha on his deathbed telling King Jehoash to strike the ground with arrows, and the king stopping after three strikes, consider asking God whether you pursue His promises with half-hearted effort when He intended full commitment."
 }

--- a/content/2_kings/14.json
+++ b/content/2_kings/14.json
@@ -401,5 +401,6 @@
       "tip": "Amaziah challenges Israel to battle after defeating Edom. Joash responds with a fable: the thistle challenges the cedar and gets trampled. Pride from one victory leads to a catastrophic defeat. Amaziah's trajectory — obedience, success, arrogance, destruction — is a miniature of Israel's national pattern.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Amaziah's partial faithfulness and Jeroboam II's prosperous but spiritually hollow reign, consider asking God whether external success in your life is masking internal decay."
 }

--- a/content/2_kings/15.json
+++ b/content/2_kings/15.json
@@ -406,5 +406,6 @@
       "tip": "Five kings in Israel within two decades — two assassinated, one deported. The rapid succession contrasts with Judah's relative stability under Uzziah/Azariah (52 years). The northern kingdom is disintegrating from within before Assyria delivers the final blow.",
       "genre_tag": "structure_guide"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the rapid succession of assassinated kings in Israel's final decades, consider asking God whether the instability in any area of your life is the fruit of unaddressed sin rather than bad luck."
 }

--- a/content/2_kings/16.json
+++ b/content/2_kings/16.json
@@ -424,5 +424,6 @@
       "tip": "Ahaz copies a pagan altar he saw in Damascus and installs it in the temple, moving the bronze altar aside. He redesigns God's worship space to match foreign aesthetics. The syncretism is architectural — the temple itself is remodeled to reflect divided loyalties.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Ahaz dismantling the temple furnishings to appease the king of Assyria, consider asking God whether you have ever traded sacred things for political or social survival."
 }

--- a/content/2_kings/17.json
+++ b/content/2_kings/17.json
@@ -565,5 +565,6 @@
       "tip": "The narrator devotes an extended theological essay to explaining why Samaria fell: 'All this took place because the Israelites had sinned against the LORD their God.' The explanation is not military (Assyria was stronger) but moral. History is interpreted through covenant theology.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the narrator's summary of why Israel fell — 'They worshiped other gods, they followed the practices of the nations' — consider asking God with unflinching honesty which practices of the surrounding culture you have adopted as your own."
 }

--- a/content/2_kings/18.json
+++ b/content/2_kings/18.json
@@ -438,5 +438,6 @@
       "tip": "The Rabshakeh speaks in Hebrew so the people on the walls can hear: 'Has any god ever delivered his land from the king of Assyria?' It is sophisticated psychological warfare — attack the people's faith in God, not just their walls. The enemy understands that Israel's real defense is theological.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hezekiah's trust in the LORD — 'There was no one like him among all the kings of Judah' — consider asking God what wholehearted trust would look like in your specific circumstances, and what half-measures you need to abandon."
 }

--- a/content/2_kings/19.json
+++ b/content/2_kings/19.json
@@ -440,5 +440,6 @@
       "tip": "Hezekiah spreads Sennacherib's letter before the LORD — literally lays it out in the temple. The gesture is prayer made physical: here is the threat; what will you do? God's response through Isaiah promises deliverance, and 185,000 Assyrians die overnight. The contrast with Ahaz's panic (ch. 16) could not be sharper.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Hezekiah spreading Sennacherib's threatening letter before the LORD, consider asking God whether you bring your most intimidating problems directly to Him — literally laying them out — or try to solve them on your own first."
 }

--- a/content/2_kings/2.json
+++ b/content/2_kings/2.json
@@ -498,5 +498,6 @@
       "tip": "Elijah's departure — chariot of fire, whirlwind, ascension — echoes Enoch ('God took him,' Genesis 5:24). Elisha's cry 'My father! My father! The chariots and horsemen of Israel!' identifies Elijah as Israel's true defense. The prophet, not the army, was the nation's real military asset.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Elisha refusing to leave Elijah's side and then asking for a double portion of his spirit, consider asking God whether you are pursuing spiritual inheritance with that kind of tenacity — or whether you settle for what comes easily."
 }

--- a/content/2_kings/20.json
+++ b/content/2_kings/20.json
@@ -424,5 +424,6 @@
       "tip": "Hezekiah shows Babylonian envoys everything in his treasury. Isaiah warns that Babylon will carry it all away. Hezekiah's response: 'The word of the LORD you have spoken is good... there will be peace and security in my lifetime.' The king accepts national disaster as long as it falls on future generations. Shortsightedness has rarely been stated more bluntly.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hezekiah showing Babylon's envoys everything in his treasury, consider asking God whether there are things you display out of pride that will eventually become vulnerabilities — and whether discretion is a form of wisdom you have neglected."
 }

--- a/content/2_kings/21.json
+++ b/content/2_kings/21.json
@@ -428,5 +428,6 @@
       "tip": "Manasseh reigns 55 years — the longest reign in Judah — and reverses every reform. He 'shed so much innocent blood that he filled Jerusalem from end to end.' The narrator makes Manasseh the point of no return: 'because of all Manasseh had done' (24:3), exile becomes inevitable. One king's sins outweigh generations of reform.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Manasseh's fifty-five-year reign of unchecked evil that sealed Judah's fate, consider asking God whether the duration of your influence carries a proportional responsibility — and what legacy you are building with the years He has given you."
 }

--- a/content/2_kings/22.json
+++ b/content/2_kings/22.json
@@ -443,5 +443,6 @@
       "tip": "The Book of the Law is 'found' in the temple during repairs — it had been lost, forgotten, buried under debris. The detail is devastating: the nation responsible for God's word did not know where it was. Josiah's anguished response — tearing his robes — shows he understands how far they have drifted.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Josiah's response to hearing the Book of the Law — tearing his robes in grief — consider asking God when Scripture last grieved you, convicted you, or made you feel the weight of how far you have drifted from what it says."
 }

--- a/content/2_kings/23.json
+++ b/content/2_kings/23.json
@@ -429,5 +429,6 @@
       "tip": "Josiah's reform is the most thorough in Kings: altars demolished, Asherah poles burned, mediums expelled, high places defiled. The narrator says 'Neither before nor after Josiah was there a king like him.' Yet it is not enough — God's anger over Manasseh remains. The greatest reform in history cannot undo accumulated covenant violation.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Josiah's sweeping reforms — tearing down every high place, desecrating every altar — and the narrator's note that no king before or after turned to the LORD as he did, consider asking God whether radical obedience is something you admire in others or practice yourself."
 }

--- a/content/2_kings/24.json
+++ b/content/2_kings/24.json
@@ -456,5 +456,6 @@
       "tip": "Nebuchadnezzar carries off the temple treasures and deports 10,000 — 'only the poorest people of the land were left.' The exile begins not with total destruction but with systematic extraction. First the wealth and skill leave; then the destruction follows. Judgment arrives in stages.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Judah's final kings reigning as vassals to Babylon, consider asking God whether there are areas of your life where you have already been carried into captivity without realizing it — living under powers you once would have resisted."
 }

--- a/content/2_kings/25.json
+++ b/content/2_kings/25.json
@@ -563,5 +563,6 @@
       "tip": "The final paragraph — Jehoiachin released from prison in Babylon, given a seat at the king's table — is a thin thread of hope in the darkest chapter. The Davidic line survives, eating at a foreign king's table. It is not restoration, but it is not extinction. Kings ends not with a period but with an ellipsis.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the destruction of Jerusalem — the temple burned, the walls broken, the people exiled — consider asking God to sit with you in the ruins of whatever has collapsed in your life, and to help you trust that exile is not the end of His story."
 }

--- a/content/2_kings/3.json
+++ b/content/2_kings/3.json
@@ -468,5 +468,6 @@
       "tip": "Mesha king of Moab sacrifices his own son on the city wall, and 'great fury came upon Israel, and they withdrew.' The text leaves the theology ambiguous — whose fury? The episode resists easy explanation, presenting the reader with the same bewilderment the Israelite army experienced.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the kings seeking Elisha's help against Moab only because they were desperate, consider asking God whether you seek Him primarily in crisis or as a matter of daily practice."
 }

--- a/content/2_kings/4.json
+++ b/content/2_kings/4.json
@@ -575,5 +575,6 @@
       "tip": "The widow's oil multiplies until she runs out of vessels. The miracle is limited not by God's supply but by human preparation — she should have borrowed more jars. The principle applies broadly: God's provision often scales to the size of our expectation and effort.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Elisha's miracles among ordinary people — oil multiplied, a child raised, poison neutralized — consider asking God whether you believe He cares about your everyday crises as much as the dramatic ones."
 }

--- a/content/2_kings/5.json
+++ b/content/2_kings/5.json
@@ -474,5 +474,6 @@
       "tip": "Naaman expects a dramatic healing ritual; Elisha tells him to wash in the muddy Jordan. Naaman's servants reason with him: 'If the prophet had told you to do some great thing, would you not have done it?' The barrier to healing is not complexity but simplicity. Pride wants spectacular; God offers ordinary.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Naaman's initial outrage at being told to wash in the Jordan — expecting something more dramatic — consider asking God whether you have rejected His provision because it came in a form you considered beneath you."
 }

--- a/content/2_kings/6.json
+++ b/content/2_kings/6.json
@@ -533,5 +533,6 @@
       "tip": "Elisha prays 'Open his eyes, LORD' and the servant sees hills full of horses and chariots of fire. The invisible reality is more populated than the visible threat. The prayer is not for rescue but for sight — the protection was already there.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Elisha's prayer — 'Open his eyes, LORD, so that he may see' — and the servant seeing the hills full of horses and chariots of fire, consider asking God to open your eyes to the invisible resources surrounding your most frightening situation."
 }

--- a/content/2_kings/7.json
+++ b/content/2_kings/7.json
@@ -414,5 +414,6 @@
       "tip": "Four lepers reason: 'Why sit here until we die? If they kill us, we die; if we don't go, we die.' Their logic of desperation leads them to the abandoned Aramean camp and Samaria's deliverance. God uses the most marginalized figures — outcasts with nothing to lose — as the agents of salvation.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the four lepers at the gate who discovered the abandoned Aramean camp and said 'This is a day of good news and we are keeping it to ourselves,' consider asking God whether there is good news in your life you are hoarding instead of sharing."
 }

--- a/content/2_kings/8.json
+++ b/content/2_kings/8.json
@@ -441,5 +441,6 @@
       "tip": "Hazael weeps when Elisha tells him what he will do to Israel — burning, killing, dashing children. 'How could your servant, a mere dog, do such a thing?' He cannot imagine himself capable of such violence. The next day he murders his master and becomes exactly what he denied. Self-knowledge is rarely as accurate as we think.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hazael's shocked response — 'How could your servant, a mere dog, accomplish such a thing?' — and then doing exactly what Elisha predicted, consider asking God whether you underestimate what you are capable of in both good and evil."
 }

--- a/content/2_kings/9.json
+++ b/content/2_kings/9.json
@@ -454,5 +454,6 @@
       "tip": "Jezebel paints her eyes and arranges her hair before Jehu arrives — she faces death with royal defiance, not submission. Her final words taunt Jehu by comparing him to Zimri, a usurper who lasted seven days. Even in death, she is formidable. The narrator respects her courage while condemning her legacy.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Jehu's violent revolution against the house of Ahab, consider asking God to help you discern the difference between zeal for His purposes and zeal that feeds your own appetite for power."
 }

--- a/content/2_samuel/10.json
+++ b/content/2_samuel/10.json
@@ -423,5 +423,6 @@
       "tip": "David sends envoys to comfort the Ammonite king; they are humiliated. The misread act of kindness triggers a war that sets the stage for chapter 11. The narrator is arranging events — it is during 'the time when kings go off to war' that David stays home, and everything falls apart.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Hanun humiliating David's ambassadors, consider asking God whether you have ever misread someone's genuine goodwill as a threat — and what that suspicion cost the relationship."
 }

--- a/content/2_samuel/11.json
+++ b/content/2_samuel/11.json
@@ -531,5 +531,6 @@
       "tip": "The chapter's final sentence — 'But the thing David had done displeased the LORD' — arrives after two sections of David's meticulous scheming. The divine verdict is withheld until the end, letting the reader sit with the full weight of what the man after God's own heart has done.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David's fall — from an idle rooftop glance to adultery to murder — consider asking God to show you the first small step in any chain of compromise you are currently on, before the consequences become irreversible."
 }

--- a/content/2_samuel/12.json
+++ b/content/2_samuel/12.json
@@ -510,5 +510,6 @@
       "tip": "David's response — 'I have sinned against the LORD' — is immediate and unqualified. No excuses, no blame-shifting, no 'but I felt compelled' (contrast Saul in 1 Samuel 13). The difference between Saul and David is not the absence of sin but the quality of repentance.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Nathan's parable and the devastating words 'You are the man,' consider asking God whether there is a truth about yourself that everyone around you can see but you — and whether you would receive it if someone had the courage to say it."
 }

--- a/content/2_samuel/13.json
+++ b/content/2_samuel/13.json
@@ -423,5 +423,6 @@
       "tip": "Amnon's 'love' for Tamar turns to hatred 'greater than the love' immediately after the assault. The text exposes the dynamic precisely: what Amnon called love was possession. When satisfied, it inverts. David is 'furious' but does nothing — a pattern of parental paralysis that will cost him Absalom.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the horror of Amnon's assault on Tamar and David's failure to act, consider asking God whether your silence in the face of injustice — especially within your own family or community — has allowed harm to fester."
 }

--- a/content/2_samuel/14.json
+++ b/content/2_samuel/14.json
@@ -423,5 +423,6 @@
       "tip": "Joab engineers Absalom's return through the wise woman of Tekoa — another parable designed to trap the king (echoing Nathan's in ch. 12). David recognizes Joab's hand immediately. The king permits Absalom's return but refuses to see him. Half-measures in reconciliation create the conditions for rebellion.",
       "genre_tag": "literary_pattern"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Joab's scheme to manipulate David into restoring Absalom, consider asking God whether reconciliation in your life has been genuine or merely political — a surface arrangement that left the real wounds untreated."
 }

--- a/content/2_samuel/15.json
+++ b/content/2_samuel/15.json
@@ -423,5 +423,6 @@
       "tip": "David flees Jerusalem weeping, barefoot, head covered. The anointed king ascending the Mount of Olives in humiliation prefigures another anointed one who will ascend the same mount in anguish (Luke 22:39). David's exile from Jerusalem because of sin within his house foreshadows the larger pattern of exile in Israel's story.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David fleeing Jerusalem barefoot and weeping as his own son usurps the throne, consider asking God to give you David's posture in crisis — grief without rage, humility without collapse, trust without passivity."
 }

--- a/content/2_samuel/16.json
+++ b/content/2_samuel/16.json
@@ -429,5 +429,6 @@
       "tip": "Shimei curses David: 'Get out, you murderer!' David forbids his men from retaliating: 'The LORD has told him to curse David. Who can ask, Why do you do this?' David accepts the cursing as possibly deserved — a remarkable act of self-awareness from a man mid-crisis. Even in flight, he is more spiritually lucid than Saul ever was.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Shimei cursing David and David refusing to silence him, consider asking God whether there is a harsh voice in your life that, painful as it is, He may be allowing because it carries a truth you need to hear."
 }

--- a/content/2_samuel/17.json
+++ b/content/2_samuel/17.json
@@ -423,5 +423,6 @@
       "tip": "Ahithophel's counsel is described as 'like that of one who inquires of God' — yet Hushai's inferior plan prevails because 'the LORD had determined to frustrate the good advice of Ahithophel.' God works through the counselor's ego and Absalom's vanity. Providence operates through flawed human psychology.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Hushai's counsel defeating Ahithophel's — a human strategy overturned by God's invisible hand — consider asking God whether you trust His providence to work through ordinary people and circumstances even when the enemy's plan looks airtight."
 }

--- a/content/2_samuel/18.json
+++ b/content/2_samuel/18.json
@@ -423,5 +423,6 @@
       "tip": "'O my son Absalom! My son, my son Absalom! If only I had died instead of you!' David's grief is the emotional center of the entire narrative. The father who could not discipline his son now cannot stop mourning him. Nathan's prophecy — 'the sword will never depart from your house' — is fulfilled in the king's own tears.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's anguished cry — 'O my son Absalom! If only I had died instead of you!' — consider asking God to help you hold the tension between justice and grief, between consequences deserved and love that wishes it could absorb them."
 }

--- a/content/2_samuel/19.json
+++ b/content/2_samuel/19.json
@@ -423,5 +423,6 @@
       "tip": "David's restoration requires navigating competing loyalties: Judah vs. Israel, old friends vs. former enemies, justice vs. mercy. Shimei is pardoned, Mephibosheth's claim is split, Barzillai is honored. Every decision is a political calculation layered on genuine emotion. Kingship is exhausting.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the complexity of David's restoration — forgiving some, restraining others, navigating tribal jealousy — consider asking God for wisdom in your own seasons of rebuilding, where not everyone who hurt you needs the same response."
 }

--- a/content/2_samuel/2.json
+++ b/content/2_samuel/2.json
@@ -423,5 +423,6 @@
       "tip": "David is anointed king of Judah only — not all Israel. Seven and a half years of civil war follow. God's promise does not arrive in a single moment. David's path to the full throne is gradual, contested, and politically messy.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on the civil war between David's men and Ish-Bosheth's forces, consider asking God whether you are fighting battles He has not authorized — competing for positions He would have given you in time without bloodshed."
 }

--- a/content/2_samuel/20.json
+++ b/content/2_samuel/20.json
@@ -423,5 +423,6 @@
       "tip": "Sheba's revolt — 'We have no share in David!' — exposes the fragility of the united monarchy. The tribal fracture line between Judah and Israel that Sheba exploits is the same one that will permanently split the kingdom under Rehoboam. The seeds of 1 Kings 12 are already germinating.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on Sheba's revolt erupting just as David was restored, consider asking God whether you expect seasons of victory to be uninterrupted — and whether you have the resilience to face the next crisis before the last one has fully healed."
 }

--- a/content/2_samuel/21.json
+++ b/content/2_samuel/21.json
@@ -423,5 +423,6 @@
       "tip": "Rizpah guards the exposed bodies of her sons from birds and beasts — for months, from harvest until the rains come. Her vigil of maternal grief is one of the most haunting images in the Old Testament. When David hears of it, he finally buries Saul and Jonathan's bones properly. A mother's devotion shames the king into action.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider the famine caused by Saul's broken treaty with the Gibeonites, consider asking God whether there are broken promises in your past — or your community's past — whose consequences are still creating drought in the present."
 }

--- a/content/2_samuel/22.json
+++ b/content/2_samuel/22.json
@@ -423,5 +423,6 @@
       "tip": "David's psalm of thanksgiving (nearly identical to Psalm 18) places this cosmic poetry — mountains shaking, divine warrior descending — in the mouth of a man whose reign included adultery, murder, and family disintegration. The psalm is not denial; it is the claim that God's faithfulness persists despite the psalmist's failures.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's great song of deliverance, consider asking God to help you compose your own — to recount the specific ways He has been your rock, your fortress, and your deliverer, not in general terms but from your actual story."
 }

--- a/content/2_samuel/23.json
+++ b/content/2_samuel/23.json
@@ -423,5 +423,6 @@
       "tip": "David's mighty men risk their lives to bring him water from the well at Bethlehem. David pours it out as an offering to God: 'Is it not the blood of men who went at the risk of their lives?' He refuses to drink what cost others their safety. The gesture transforms water into sacrament.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David's mighty men — warriors defined by extraordinary loyalty and courage — consider asking God who your mighty men are, and whether you are the kind of leader worth that level of devotion."
 }

--- a/content/2_samuel/24.json
+++ b/content/2_samuel/24.json
@@ -510,5 +510,6 @@
       "tip": "The threshing floor David purchases becomes the site of Solomon's temple (2 Chronicles 3:1). The book ends where the temple begins — on a piece of ground bought during judgment, consecrated by sacrifice. Disaster becomes holy ground.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's census and his choice to fall into God's hands rather than human hands when judgment came, consider asking God whether you trust His discipline more than people's mercy — and what that trust reveals about how you know Him."
 }

--- a/content/2_samuel/3.json
+++ b/content/2_samuel/3.json
@@ -423,5 +423,6 @@
       "tip": "Joab murders Abner during peace negotiations — a blood-feud killing disguised as justice. David publicly curses Joab but does not punish him. This pattern — David condemning violence he cannot control — will haunt his reign. The king is morally clear but politically constrained.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider Abner's defection and Joab's revenge murder, consider asking God whether there are people in your circle whose loyalty comes with a violent edge — and whether you have the courage to publicly grieve what they have done."
 }

--- a/content/2_samuel/4.json
+++ b/content/2_samuel/4.json
@@ -423,5 +423,6 @@
       "tip": "When Ishbosheth's assassins bring his head to David expecting reward, David executes them instead. Like his refusal to kill Saul, David will not build his kingdom on murder — even murder that benefits him. Legitimacy matters more than expediency.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's refusal to reward the men who murdered Ish-Bosheth, consider asking God whether you have ever been tempted to benefit from someone else's wrongdoing while keeping your own hands technically clean."
 }

--- a/content/2_samuel/5.json
+++ b/content/2_samuel/5.json
@@ -505,5 +505,6 @@
       "tip": "David captures Jerusalem — a neutral city belonging to neither Judah nor the northern tribes. The political genius is evident: the capital belongs to the king alone, avoiding tribal jealousy. Jerusalem becomes 'the City of David' — not the city of any tribe.",
       "genre_tag": "close_reading"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David finally becoming king of all Israel after years of waiting, consider asking God whether the delays in your life are His way of preparing not just you but the people around you for what He has planned."
 }

--- a/content/2_samuel/6.json
+++ b/content/2_samuel/6.json
@@ -423,5 +423,6 @@
       "tip": "David dances before the ark 'with all his might,' wearing a linen ephod. Michal despises him from the window. The contrast is sharp: the king humbles himself in worship while the queen cares about royal dignity. Michal's contempt costs her children — barrenness is the narrator's verdict on her priorities.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David dancing before the ark with all his might, consider asking God whether your worship has ever been that uninhibited — and whether Michal's contempt for David's abandon mirrors a voice inside you that calls passionate devotion undignified."
 }

--- a/content/2_samuel/7.json
+++ b/content/2_samuel/7.json
@@ -423,5 +423,6 @@
       "tip": "David wants to build God a house (temple); God responds by building David a house (dynasty). The wordplay on 'house' (bayit) drives the entire chapter. The Davidic covenant — 'your throne will be established forever' — becomes the foundation of messianic expectation through the rest of Scripture.",
       "genre_tag": "canonical_thread"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider God's promise to establish David's throne forever, consider asking the Lord whether you are trying to build something for God that He never asked for — and whether you can receive what He wants to build through you instead."
 }

--- a/content/2_samuel/8.json
+++ b/content/2_samuel/8.json
@@ -423,5 +423,6 @@
       "tip": "The summary of David's victories ends with: 'The LORD gave David victory wherever he went.' The refrain appears twice (vv. 6, 14). The military catalog is framed theologically — David's empire is presented as divine gift, not human achievement.",
       "genre_tag": "structure_guide"
     }
-  ]
+  ],
+  "prayer_prompt": "As you reflect on David's military victories and the note that 'the LORD gave David victory wherever he went,' consider asking God whether you acknowledge His hand in your successes or have begun to believe they are products of your own ability."
 }

--- a/content/2_samuel/9.json
+++ b/content/2_samuel/9.json
@@ -423,5 +423,6 @@
       "tip": "David seeks out Mephibosheth — Jonathan's crippled son — and restores Saul's estate to him. 'He will always eat at my table.' This is not political calculation; it is covenant loyalty to Jonathan. The lame grandson of David's enemy dines permanently at the king's table. Grace has a seat.",
       "genre_tag": "theological_insight"
     }
-  ]
+  ],
+  "prayer_prompt": "As you consider David seeking out Mephibosheth — Jonathan's crippled son — to show him kindness, consider asking God who in your life deserves kindness not because of their own merit but because of a covenant you made with someone else."
 }


### PR DESCRIPTION
## Prayer Prompts: OT Narrative — Samuel through Kings

Closes #852 | Epic #848

### Changes
- 98 chapters updated with prayer prompts
- 1 Samuel 2-31, 2 Samuel 2-24, 1 Kings 2-22, 2 Kings 2-25
- Ch 1 of each book already had prompts — skipped
- All prompts use invitational "Consider asking..." pattern
- Genre-aware tone (theological narrative: leadership, faithfulness, judgment)

### Validation
- schema_validator: 119,571 passed, 0 failed
- validate_sqlite: 67 passed, 0 failed
- build_sqlite: clean build