### PR TITLE
fix: prevent vertical scroll capture on dictionary AlphabetBar

### DIFF
--- a/app/src/components/AlphabetBar.tsx
+++ b/app/src/components/AlphabetBar.tsx
@@ -25,6 +25,7 @@ export function AlphabetBar({ activeLetter, availableLetters, onSelect }: Props)
       horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.container}
+      style={styles.scrollView}
       scrollEventThrottle={16}
       directionalLockEnabled
       alwaysBounceVertical={false}
@@ -66,11 +67,14 @@ export function AlphabetBar({ activeLetter, availableLetters, onSelect }: Props)
 }
 
 const styles = StyleSheet.create({
+  scrollView: {
+    flexGrow: 0,
+    height: 36,
+  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 8,
-    height: 36,
   },
   letterBtn: {
     width: 28,


### PR DESCRIPTION
Move height constraint from contentContainerStyle to the ScrollView's own style so it has a fixed outer height. Without this, the horizontal ScrollView could expand vertically and intercept vertical drag gestures meant for the SectionList below.

https://claude.ai/code/session_019V7zhgQ8d1AAF9wKpRQTLF