### PR TITLE
Add unified dev startup script and auto-build DB if missing

### DIFF
--- a/app/scripts/setup.js
+++ b/app/scripts/setup.js
@@ -1,25 +1,44 @@
 #!/usr/bin/env node
 /**
- * scripts/setup.js — Copy scripture.db into assets/ for Expo bundling.
+ * scripts/setup.js — Ensure scripture.db is ready for Expo bundling.
  *
  * Run: npm run setup (or: node scripts/setup.js)
  * Must be run from the app/ directory.
  *
  * The canonical scripture.db lives at the repo root. This script copies it
  * into app/assets/ where metro can bundle it as a require()-able asset.
+ *
+ * If the root DB doesn't exist, it runs build_sqlite.py to generate it.
  * Always copies — a 35MB file copy takes <100ms and eliminates stale DB bugs.
  */
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
-const SRC = path.resolve(__dirname, '..', '..', 'scripture.db');
+const ROOT = path.resolve(__dirname, '..', '..');
+const SRC = path.join(ROOT, 'scripture.db');
 const DST = path.resolve(__dirname, '..', 'assets', 'scripture.db');
+const BUILD_SCRIPT = path.join(ROOT, '_tools', 'build_sqlite.py');
 
-// Check source exists
+// Build DB if it doesn't exist
 if (!fs.existsSync(SRC)) {
-  console.error(`❌ scripture.db not found at ${SRC}`);
-  console.error('   Run: cd .. && python3 _tools/build_sqlite.py');
+  console.log('📦 scripture.db not found — building from content...');
+  try {
+    execSync(`python3 "${BUILD_SCRIPT}"`, { cwd: ROOT, stdio: 'inherit' });
+  } catch {
+    // Try 'python' on Windows if 'python3' isn't available
+    try {
+      execSync(`python "${BUILD_SCRIPT}"`, { cwd: ROOT, stdio: 'inherit' });
+    } catch (e) {
+      console.error('❌ Failed to build scripture.db. Is Python 3 installed?');
+      process.exit(1);
+    }
+  }
+}
+
+if (!fs.existsSync(SRC)) {
+  console.error(`❌ scripture.db still not found at ${SRC} after build attempt`);
   process.exit(1);
 }
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# dev.sh — Pull, rebuild DB if needed, and launch Expo.
+#
+# Usage: ./dev.sh            (normal start)
+#        ./dev.sh --clear    (clear metro cache)
+#        ./dev.sh --rebuild  (force DB rebuild even if it exists)
+#
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+# ── 1. Pull latest changes ──────────────────────────────────────
+echo "⬇  Pulling latest changes..."
+git pull origin "$(git branch --show-current)" || echo "⚠  Pull failed (offline?) — continuing with local"
+
+# ── 2. Build scripture.db if missing (or --rebuild) ─────────────
+if [[ "$*" == *"--rebuild"* ]] || [ ! -f "$ROOT/scripture.db" ]; then
+  echo "📦 Building scripture.db..."
+  python3 "$ROOT/_tools/build_sqlite.py" 2>/dev/null \
+    || python "$ROOT/_tools/build_sqlite.py"
+else
+  echo "✓  scripture.db exists (use --rebuild to force)"
+fi
+
+# ── 3. Launch Expo ──────────────────────────────────────────────
+cd "$ROOT/app"
+
+EXPO_ARGS=""
+if [[ "$*" == *"--clear"* ]]; then
+  EXPO_ARGS="--clear"
+fi
+
+echo "🚀 Starting Expo..."
+npx expo start $EXPO_ARGS


### PR DESCRIPTION
- dev.sh: Single command to pull, build DB if needed, and launch Expo. Supports --clear (metro cache) and --rebuild (force DB rebuild).
- setup.js: Now auto-runs build_sqlite.py when scripture.db is missing instead of failing with an error. Tries python3 then python for Windows compatibility.

Usage: ./dev.sh

https://claude.ai/code/session_012mJU8pkhgoJcaRt4kYX8KK