### PR TITLE
Add clickable verse_ref pill to Time-Travel interpretation cards

### DIFF
--- a/app/src/components/interpretations/InterpretationCard.tsx
+++ b/app/src/components/interpretations/InterpretationCard.tsx
@@ -3,16 +3,18 @@
  * quote, source, and era badge. Uses church era colors from theme.
  */
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme, spacing, radii, fontFamily, churchEras } from '../../theme';
 import type { HistoricalInterpretation } from '../../types';
 
 interface Props {
   interpretation: HistoricalInterpretation;
+  onVersePress?: (verseRef: string) => void;
 }
 
 export const InterpretationCard = React.memo(function InterpretationCard({
   interpretation,
+  onVersePress,
 }: Props) {
   const { base } = useTheme();
   const eraColor = churchEras[interpretation.era] ?? base.gold;
@@ -24,12 +26,27 @@ export const InterpretationCard = React.memo(function InterpretationCard({
         { backgroundColor: base.bgElevated, borderColor: eraColor + '30' },
       ]}
     >
-      {/* Era badge */}
-      <View style={[styles.eraBadge, { backgroundColor: eraColor + '25' }]}>
-        <View style={[styles.eraDot, { backgroundColor: eraColor }]} />
-        <Text style={[styles.eraLabel, { color: eraColor }]}>
-          {interpretation.era_label}
-        </Text>
+      {/* Era badge + verse ref row */}
+      <View style={styles.badgeRow}>
+        <View style={[styles.eraBadge, { backgroundColor: eraColor + '25' }]}>
+          <View style={[styles.eraDot, { backgroundColor: eraColor }]} />
+          <Text style={[styles.eraLabel, { color: eraColor }]}>
+            {interpretation.era_label}
+          </Text>
+        </View>
+        {interpretation.verse_ref && onVersePress ? (
+          <TouchableOpacity
+            onPress={() => onVersePress(interpretation.verse_ref)}
+            style={[styles.verseRefPill, { backgroundColor: base.gold + '18', borderColor: base.gold + '35' }]}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`Go to ${interpretation.verse_ref}`}
+          >
+            <Text style={[styles.verseRefText, { color: base.gold }]}>
+              {interpretation.verse_ref}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
       </View>
 
       {/* Author line */}
@@ -74,15 +91,30 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     marginBottom: spacing.sm,
   },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
   eraBadge: {
     flexDirection: 'row',
     alignItems: 'center',
-    alignSelf: 'flex-start',
     gap: 4,
     borderRadius: radii.pill,
     paddingHorizontal: 8,
     paddingVertical: 3,
-    marginBottom: spacing.sm,
+  },
+  verseRefPill: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  verseRefText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 0.3,
   },
   eraDot: {
     width: 6,

--- a/app/src/screens/TimeTravelDetailScreen.tsx
+++ b/app/src/screens/TimeTravelDetailScreen.tsx
@@ -6,10 +6,10 @@
  * 1-2 eras visible for free users, all eras for premium.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useCallback } from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -20,6 +20,7 @@ import { useVerseInterpretations } from '../hooks/useInterpretations';
 import { usePremium } from '../hooks/usePremium';
 import { useTheme, spacing, fontFamily, churchEras } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { parseReference } from '../utils/verseResolver';
 import type { HistoricalInterpretation } from '../types';
 
 /** Number of free eras visible to non-premium users. */
@@ -33,6 +34,38 @@ function TimeTravelDetailScreen() {
 
   const { data: interpretations, loading } = useVerseInterpretations(verseRef);
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
+
+  const scrollRef = useRef<ScrollView>(null);
+  const cardYMap = useRef<Record<string, number>>({});
+  const lastPressedCardId = useRef<string | null>(null);
+
+  // Restore scroll position when returning from chapter view
+  const handleScrollRestore = useCallback(() => {
+    const id = lastPressedCardId.current;
+    if (id && cardYMap.current[id] != null) {
+      setTimeout(() => {
+        scrollRef.current?.scrollTo({ y: Math.max(0, cardYMap.current[id] - 80), animated: true });
+      }, 150);
+    }
+  }, []);
+
+  const handleVersePress = useCallback((refStr: string, cardId: string) => {
+    const parsed = parseReference(refStr);
+    if (!parsed) return;
+    lastPressedCardId.current = cardId;
+    navigation.push('Chapter', {
+      bookId: parsed.bookId,
+      chapterNum: parsed.chapter,
+      verseNum: parsed.verseStart,
+    });
+  }, [navigation]);
+
+  // Restore scroll position when returning from chapter view
+  useFocusEffect(
+    useCallback(() => {
+      handleScrollRestore();
+    }, [handleScrollRestore])
+  );
 
   // Group interpretations by era, preserving display_order
   const groupedByEra = useMemo(() => {
@@ -88,7 +121,7 @@ function TimeTravelDetailScreen() {
         <Text style={[styles.verseRef, { color: base.gold }]}>{verseRef}</Text>
       </View>
 
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+      <ScrollView ref={scrollRef} style={styles.scroll} contentContainerStyle={styles.scrollContent}>
         {interpretations.length === 0 ? (
           <View style={styles.emptyState}>
             <Text style={[styles.emptyText, { color: base.textMuted }]}>
@@ -112,7 +145,17 @@ function TimeTravelDetailScreen() {
                     style={[styles.timelineLine, { borderLeftColor: eraColor + '40' }]}
                   >
                     {group.items.map((interp) => (
-                      <InterpretationCard key={interp.id} interpretation={interp} />
+                      <View
+                        key={interp.id}
+                        onLayout={(e) => {
+                          cardYMap.current[interp.id] = e.nativeEvent.layout.y;
+                        }}
+                      >
+                        <InterpretationCard
+                          interpretation={interp}
+                          onVersePress={(ref) => handleVersePress(ref, interp.id)}
+                        />
+                      </View>
                     ))}
                   </View>
                 </View>


### PR DESCRIPTION
- InterpretationCard: Add verse reference pill button on the right side of the era badge row. Gold-tinted outline pill that navigates to the referenced verse when tapped.
- TimeTravelDetailScreen: Wire up verse press to push Chapter screen with bookId, chapterNum, and verseNum (auto-scrolls to verse). Track card positions via onLayout and restore scroll position when returning via back button using useFocusEffect.

https://claude.ai/code/session_012mJU8pkhgoJcaRt4kYX8KK