### PR TITLE
Fix dev.sh: detect stale DB and support older Git versions

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -14,15 +14,32 @@ cd "$ROOT"
 
 # ── 1. Pull latest changes ──────────────────────────────────────
 echo "⬇  Pulling latest changes..."
-git pull origin "$(git branch --show-current)" || echo "⚠  Pull failed (offline?) — continuing with local"
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "master")
+git pull origin "$BRANCH" || echo "⚠  Pull failed (offline?) — continuing with local"
 
-# ── 2. Build scripture.db if missing (or --rebuild) ─────────────
-if [[ "$*" == *"--rebuild"* ]] || [ ! -f "$ROOT/scripture.db" ]; then
+# ── 2. Build scripture.db if missing, stale, or --rebuild ───────
+NEED_BUILD=false
+
+if [[ "$*" == *"--rebuild"* ]]; then
+  NEED_BUILD=true
+elif [ ! -f "$ROOT/scripture.db" ]; then
+  NEED_BUILD=true
+else
+  # Rebuild if any content or build tool file is newer than the DB
+  STALE=$(find "$ROOT/content" "$ROOT/_tools/build_sqlite.py" \
+    -newer "$ROOT/scripture.db" -print -quit 2>/dev/null)
+  if [ -n "$STALE" ]; then
+    echo "📦 Content changed since last build — rebuilding..."
+    NEED_BUILD=true
+  fi
+fi
+
+if [ "$NEED_BUILD" = true ]; then
   echo "📦 Building scripture.db..."
   python3 "$ROOT/_tools/build_sqlite.py" 2>/dev/null \
     || python "$ROOT/_tools/build_sqlite.py"
 else
-  echo "✓  scripture.db exists (use --rebuild to force)"
+  echo "✓  scripture.db is up to date"
 fi
 
 # ── 3. Launch Expo ──────────────────────────────────────────────


### PR DESCRIPTION
- Use git rev-parse --abbrev-ref instead of git branch --show-current for compatibility with Git < 2.22 (Windows Git Bash)
- Auto-rebuild scripture.db when any content file or build_sqlite.py is newer than the existing DB, not just when the DB is missing

https://claude.ai/code/session_012mJU8pkhgoJcaRt4kYX8KK