### PR TITLE
ci: add R2 upload step to content pipeline

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -54,6 +54,20 @@ jobs:
         run: |
           python3 _tools/validate_sqlite.py 2>&1 | tee validate_db.log
 
+      # ── Upload to R2 (master only) ───────────────────────────
+
+      - name: Upload to CloudFlare R2
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+        run: |
+          pip install boto3
+          python3 _tools/upload_to_r2.py
+
       # ── Stage 2: Detect changed chapters ─────────────────────
 
       - name: Detect changed content


### PR DESCRIPTION
## Summary
Adds automatic R2 upload after successful DB build on master merges.

Implements #1179. Part of epic #758.

## What This Does
After `validate_sqlite.py` succeeds on a push to master:
1. Installs boto3
2. Runs `upload_to_r2.py`
3. Uploads scripture.db and manifest.json to R2

## Conditions
- Only runs on `push` events (not PRs)
- Only runs on `master` branch
- Only runs if previous steps succeed

## Secrets Required (already configured ✓)
- `R2_ACCOUNT_ID`
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_BUCKET_NAME`
- `R2_PUBLIC_URL`
