### PR TITLE
feat: add R2 upload step to content pipeline for #1179

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -54,6 +54,19 @@ jobs:
         run: |
           python3 _tools/validate_sqlite.py 2>&1 | tee validate_db.log
 
+      # ── Stage 1.5: Upload to R2 (master only) ───────────────
+      - name: Upload to R2
+        if: github.ref == 'refs/heads/master' && success()
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+        run: |
+          pip install boto3
+          python3 _tools/upload_to_r2.py
+
       # ── Stage 2: Detect changed chapters ─────────────────────
 
       - name: Detect changed content


### PR DESCRIPTION
Add upload step after DB build/validation that runs only on master merges. Installs boto3 and runs upload_to_r2.py with R2 credentials from GitHub secrets.

https://claude.ai/code/session_01G4QtimXKScdS3VsxsM8BdT