### PR TITLE
feat: add image migration scripts for R2 hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ _tools/audit/.cache/
 _tools/.env
 _tools/audit/ci_results.json
 .env
+-e 
+# Image staging (downloaded but not committed)
+_tools/art_staging/

--- a/_tools/download_images.py
+++ b/_tools/download_images.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+download_images.py — Download all inventoried Wikimedia images.
+
+Downloads images from Wikimedia Commons with proper User-Agent,
+converts to JPG if needed, saves to _tools/art_staging/.
+
+Usage:
+    python3 _tools/download_images.py [--force]
+
+Options:
+    --force     Re-download even if file exists
+"""
+import json
+import os
+import sys
+import time
+import hashlib
+from pathlib import Path
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+ROOT = Path(__file__).resolve().parent.parent
+STAGING_DIR = ROOT / '_tools' / 'art_staging'
+INVENTORY_PATH = STAGING_DIR / 'inventory.json'
+
+# Wikimedia requires a proper User-Agent
+USER_AGENT = (
+    "CompanionStudyBot/1.0 "
+    "(https://companionstudy.app; craig@companionstudy.app) "
+    "Python/3"
+)
+
+
+def download_image(url: str, dest_path: Path) -> bool:
+    """Download image with proper headers. Returns True on success."""
+    try:
+        req = Request(url, headers={'User-Agent': USER_AGENT})
+        
+        with urlopen(req, timeout=30) as response:
+            data = response.read()
+        
+        # Check if we got actual image data
+        if len(data) < 1000:
+            print(f"      ⚠️  Response too small ({len(data)} bytes)")
+            return False
+        
+        # Save the file
+        with open(dest_path, 'wb') as f:
+            f.write(data)
+        
+        return True
+        
+    except HTTPError as e:
+        print(f"      ❌ HTTP {e.code}: {e.reason}")
+        return False
+    except URLError as e:
+        print(f"      ❌ URL Error: {e.reason}")
+        return False
+    except Exception as e:
+        print(f"      ❌ Error: {e}")
+        return False
+
+
+def convert_to_jpg(src_path: Path, dest_path: Path) -> bool:
+    """Convert image to JPG using PIL if available."""
+    try:
+        from PIL import Image
+        
+        with Image.open(src_path) as img:
+            # Convert to RGB if necessary (for PNG with transparency, etc.)
+            if img.mode in ('RGBA', 'P', 'LA'):
+                # Create white background
+                background = Image.new('RGB', img.size, (255, 255, 255))
+                if img.mode == 'P':
+                    img = img.convert('RGBA')
+                background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
+                img = background
+            elif img.mode != 'RGB':
+                img = img.convert('RGB')
+            
+            img.save(dest_path, 'JPEG', quality=85, optimize=True)
+        
+        return True
+        
+    except ImportError:
+        print("      ⚠️  PIL not installed, keeping original format")
+        return False
+    except Exception as e:
+        print(f"      ⚠️  Conversion error: {e}")
+        return False
+
+
+def main():
+    force = '--force' in sys.argv
+    
+    print("=" * 60)
+    print("Image Downloader — Wikimedia → Local")
+    print("=" * 60)
+    
+    if not INVENTORY_PATH.exists():
+        print(f"❌ Inventory not found: {INVENTORY_PATH}")
+        print("   Run image_inventory.py first")
+        sys.exit(1)
+    
+    with open(INVENTORY_PATH) as f:
+        inventory = json.load(f)
+    
+    print(f"\n📋 {len(inventory)} images in inventory")
+    if force:
+        print("   --force: Re-downloading all")
+    
+    # Track results
+    success = []
+    failed = []
+    skipped = []
+    
+    for i, item in enumerate(inventory, 1):
+        url = item['original_url']
+        filename = item['new_filename']
+        dest_path = STAGING_DIR / filename
+        
+        print(f"\n[{i}/{len(inventory)}] {filename}")
+        
+        # Skip if exists (unless force)
+        if dest_path.exists() and not force:
+            size_kb = dest_path.stat().st_size / 1024
+            print(f"      ✓ Exists ({size_kb:.1f} KB)")
+            skipped.append(filename)
+            continue
+        
+        # Download
+        print(f"      Downloading...")
+        
+        # Try direct URL first, then try without thumbnail prefix
+        success_download = download_image(url, dest_path)
+        
+        if not success_download:
+            # Try to get higher resolution version
+            # Wikimedia thumbnail URLs: .../thumb/.../400px-Filename.jpg
+            # Full resolution: .../commons/.../Filename.jpg
+            if '/thumb/' in url:
+                # Extract full URL
+                full_url = url.replace('/thumb/', '/')
+                full_url = '/'.join(full_url.rsplit('/', 1)[:-1])  # Remove size prefix
+                print(f"      Trying full resolution...")
+                success_download = download_image(full_url, dest_path)
+        
+        if success_download:
+            size_kb = dest_path.stat().st_size / 1024
+            print(f"      ✓ Downloaded ({size_kb:.1f} KB)")
+            
+            # Convert to JPG if needed
+            if not filename.endswith('.jpg') or dest_path.suffix.lower() in ('.png', '.tif', '.tiff', '.gif'):
+                jpg_path = dest_path.with_suffix('.jpg')
+                if convert_to_jpg(dest_path, jpg_path):
+                    if dest_path != jpg_path:
+                        os.remove(dest_path)
+                    print(f"      ✓ Converted to JPG")
+            
+            success.append(filename)
+        else:
+            failed.append({'filename': filename, 'url': url})
+        
+        # Be nice to Wikimedia servers
+        time.sleep(0.5)
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  ✓ Downloaded: {len(success)}")
+    print(f"  ⏭ Skipped:    {len(skipped)}")
+    print(f"  ❌ Failed:     {len(failed)}")
+    
+    if failed:
+        print("\n=== FAILED DOWNLOADS ===")
+        failed_path = STAGING_DIR / 'failed.json'
+        with open(failed_path, 'w') as f:
+            json.dump(failed, f, indent=2)
+        print(f"  Saved to {failed_path}")
+        for item in failed[:5]:
+            print(f"    - {item['filename']}")
+        if len(failed) > 5:
+            print(f"    ... and {len(failed) - 5} more")
+    
+    # Update inventory with download status
+    for item in inventory:
+        filename = item['new_filename']
+        path = STAGING_DIR / filename
+        if path.exists():
+            item['downloaded'] = True
+            item['local_path'] = str(path)
+            item['size_bytes'] = path.stat().st_size
+        else:
+            item['downloaded'] = False
+    
+    with open(INVENTORY_PATH, 'w') as f:
+        json.dump(inventory, f, indent=2)
+    
+    print(f"\n📋 Inventory updated: {INVENTORY_PATH}")
+    
+    if failed:
+        print("\nNext: Fix failed downloads, then run upload_images_to_r2.py")
+    else:
+        print("\nNext: python3 _tools/upload_images_to_r2.py")
+
+
+if __name__ == '__main__':
+    main()

--- a/_tools/download_priority_images.py
+++ b/_tools/download_priority_images.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+download_priority_images.py — Download the 19 priority Explore screen images.
+
+Downloads from creationism.org (Doré collection) which is the only source
+that works from this environment. For images without Doré equivalents,
+creates placeholder entries.
+
+Usage:
+    python3 _tools/download_priority_images.py
+
+Output:
+    _tools/art_staging/priority/ — Downloaded images
+    _tools/art_staging/priority_manifest.json — Manifest for R2 upload
+"""
+import json
+import os
+import time
+from pathlib import Path
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+ROOT = Path(__file__).resolve().parent.parent
+STAGING_DIR = ROOT / '_tools' / 'art_staging' / 'priority'
+
+# Creationism.org Doré collection base URL
+DORE_BASE = 'https://www.creationism.org/images/DoreBibleIllus/'
+
+# Priority 19 images mapped to Doré sources
+# Format: (target_filename, dore_filename, caption, credit)
+PRIORITY_IMAGES = [
+    # Spirit of God / Pentecost
+    ('dore-pentecost.jpg', 
+     'vAct0202Dore_TheDescentOfTheSpirit.jpg',
+     'The Descent of the Spirit — Pentecost',
+     'Gustave Doré · Public domain'),
+    
+    # Faith / Abraham & Isaac
+    ('dore-abraham-isaac.jpg',
+     'aGen2210Dore_TheTrialOfAbraham_sFaith.jpg',
+     'The Trial of Abraham\'s Faith — binding of Isaac',
+     'Gustave Doré · Public domain'),
+    
+    # Mercy & Grace / Prodigal Son
+    ('dore-prodigal-son.jpg',
+     'tLuk1520Dore_TheProdigalSonInTheArmsOfHisFather.jpg',
+     'The Prodigal Son in the Arms of His Father',
+     'Gustave Doré · Public domain'),
+    
+    # Judgment / Crucifixion Darkness
+    ('dore-crucifixion-darkness.jpg',
+     'tLuk2344Dore_TheDarknessAtTheCrucifixion.jpg',
+     'The Darkness at the Crucifixion — judgment',
+     'Gustave Doré · Public domain'),
+    
+    # Creation / Light
+    ('dore-creation-light.jpg',
+     'aGen0103Dore_TheCreationOfLight.jpg',
+     'The Creation of Light',
+     'Gustave Doré · Public domain'),
+    
+    # Redemption / Red Sea
+    ('dore-red-sea.jpg',
+     'bExo1427Dore_TheEgyptiansDrownedInTheRedSea.jpg',
+     'The Egyptians Drowned in the Red Sea — redemption',
+     'Gustave Doré · Public domain'),
+    
+    # Prophecy / Isaiah
+    ('dore-isaiah.jpg',
+     'nIsa0608Dore_Isaiah.jpg',
+     'Isaiah the Prophet',
+     'Gustave Doré · Public domain'),
+    
+    # Suffering / Jeremiah
+    ('dore-jeremiah.jpg',
+     'nJer0114Dore_Jeremiah.jpg',
+     'Jeremiah the Prophet — suffering and lament',
+     'Gustave Doré · Public domain'),
+    
+    # Resurrection
+    ('dore-resurrection.jpg',
+     'rMat2805Dore_TheResurrection.jpg',
+     'The Resurrection of Jesus',
+     'Gustave Doré · Public domain'),
+    
+    # Jacob blessing (Isaac blessing Jacob is closest)
+    ('dore-jacob-blessing.jpg',
+     'aGen2729Dore_IsaacBlessingJacob.jpg',
+     'Isaac Blessing Jacob',
+     'Gustave Doré · Public domain'),
+    
+    # Jericho / Joshua
+    ('dore-jericho.jpg',
+     'dJos0620Dore_TheWallsOfJerichoFallingDown.jpg',
+     'The Walls of Jericho Falling Down',
+     'Gustave Doré · Public domain'),
+    
+    # Ezekiel
+    ('dore-ezekiel.jpg',
+     'oEze0103Dore_EzekielProphesying.jpg',
+     'Ezekiel Prophesying',
+     'Gustave Doré · Public domain'),
+    
+    # Daniel
+    ('dore-daniel.jpg',
+     'pDan0220Dore_Daniel.jpg',
+     'Daniel',
+     'Gustave Doré · Public domain'),
+    
+    # Jonah
+    ('dore-jonah.jpg',
+     'qJon0201Dore_JonahCastForthByTheWhale.jpg',
+     'Jonah Cast Forth by the Whale',
+     'Gustave Doré · Public domain'),
+    
+    # Abram's call / Journey
+    ('dore-abram-call.jpg',
+     'aGen1201Dore_AbrahamJourneyingIntoTheLandOfCanaan.jpg',
+     'Abraham Journeying into the Land of Canaan',
+     'Gustave Doré · Public domain'),
+    
+    # Nativity
+    ('dore-nativity.jpg',
+     'tLuk0215Dore_TheNativity.jpg',
+     'The Nativity — Jesus birth',
+     'Gustave Doré · Public domain'),
+    
+    # Paul / Mission (using Paul preaching to Thessalonians)
+    ('dore-paul.jpg',
+     'w1Th0211Dore_St_PaulPreachingToTheThessalonians.jpg',
+     'St. Paul Preaching to the Thessalonians — missionary to the nations',
+     'Gustave Doré · Public domain'),
+]
+
+# Images that need manual sourcing (no Doré equivalent)
+MANUAL_IMAGES = [
+    ('codex-sinaiticus.jpg', 
+     'Codex Sinaiticus — 4th century Bible manuscript',
+     'Needs: British Library or Codex Sinaiticus Project image'),
+    ('paul-journey3.jpg',
+     "Paul's Third Missionary Journey map",
+     'Needs: Public domain Bible map or custom creation'),
+]
+
+
+def download_image(url: str, dest_path: Path) -> bool:
+    """Download image. Returns True on success."""
+    try:
+        req = Request(url, headers={
+            'User-Agent': 'Mozilla/5.0 (compatible; CompanionStudyBot/1.0)'
+        })
+        
+        with urlopen(req, timeout=30) as response:
+            data = response.read()
+        
+        # Verify it's actual image data
+        if len(data) < 5000:
+            print(f"      ⚠️  Response too small ({len(data)} bytes)")
+            return False
+        
+        if data[:4] == b'<!DO' or data[:5] == b'<html':
+            print(f"      ⚠️  Got HTML instead of image")
+            return False
+        
+        with open(dest_path, 'wb') as f:
+            f.write(data)
+        
+        return True
+        
+    except HTTPError as e:
+        print(f"      ❌ HTTP {e.code}: {e.reason}")
+        return False
+    except URLError as e:
+        print(f"      ❌ URL Error: {e.reason}")
+        return False
+    except Exception as e:
+        print(f"      ❌ Error: {e}")
+        return False
+
+
+def main():
+    print("=" * 60)
+    print("Priority Images Downloader")
+    print("=" * 60)
+    print(f"\nTarget: {len(PRIORITY_IMAGES)} Doré images from creationism.org")
+    print(f"Manual: {len(MANUAL_IMAGES)} images need alternative sourcing\n")
+    
+    STAGING_DIR.mkdir(parents=True, exist_ok=True)
+    
+    manifest = {
+        'downloaded': [],
+        'manual_needed': [],
+        'failed': [],
+    }
+    
+    # Download Doré images
+    for i, (filename, dore_file, caption, credit) in enumerate(PRIORITY_IMAGES, 1):
+        url = DORE_BASE + dore_file
+        dest = STAGING_DIR / filename
+        
+        print(f"[{i}/{len(PRIORITY_IMAGES)}] {filename}")
+        
+        if dest.exists():
+            size_kb = dest.stat().st_size / 1024
+            print(f"      ✓ Already exists ({size_kb:.1f} KB)")
+            manifest['downloaded'].append({
+                'filename': filename,
+                'source_url': url,
+                'caption': caption,
+                'credit': credit,
+                'size_bytes': dest.stat().st_size,
+            })
+            continue
+        
+        print(f"      Downloading from creationism.org...")
+        if download_image(url, dest):
+            size_kb = dest.stat().st_size / 1024
+            print(f"      ✓ Downloaded ({size_kb:.1f} KB)")
+            manifest['downloaded'].append({
+                'filename': filename,
+                'source_url': url,
+                'caption': caption,
+                'credit': credit,
+                'size_bytes': dest.stat().st_size,
+            })
+        else:
+            manifest['failed'].append({
+                'filename': filename,
+                'source_url': url,
+                'caption': caption,
+            })
+        
+        time.sleep(0.5)  # Be nice to server
+    
+    # Record manual images
+    for filename, caption, note in MANUAL_IMAGES:
+        print(f"\n⚠️  {filename}: {note}")
+        manifest['manual_needed'].append({
+            'filename': filename,
+            'caption': caption,
+            'note': note,
+        })
+    
+    # Save manifest
+    manifest_path = STAGING_DIR.parent / 'priority_manifest.json'
+    with open(manifest_path, 'w') as f:
+        json.dump(manifest, f, indent=2)
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  ✓ Downloaded:    {len(manifest['downloaded'])}")
+    print(f"  ⚠️  Manual needed: {len(manifest['manual_needed'])}")
+    print(f"  ❌ Failed:        {len(manifest['failed'])}")
+    print(f"\n📋 Manifest saved: {manifest_path}")
+    
+    if manifest['failed']:
+        print("\n=== FAILED ===")
+        for item in manifest['failed']:
+            print(f"  - {item['filename']}")
+    
+    if manifest['manual_needed']:
+        print("\n=== NEED MANUAL SOURCING ===")
+        for item in manifest['manual_needed']:
+            print(f"  - {item['filename']}: {item['note']}")
+    
+    print("\nNext: python3 _tools/upload_images_to_r2.py --priority")
+
+
+if __name__ == '__main__':
+    main()

--- a/_tools/image_inventory.py
+++ b/_tools/image_inventory.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+image_inventory.py — Inventory all Wikimedia image URLs and prepare for R2 migration.
+
+Scans all content JSON files, extracts Wikimedia URLs, generates:
+  1. _tools/art_staging/inventory.json — Full mapping of old URLs to new names
+  2. Console summary of images by source
+
+Usage:
+    python3 _tools/image_inventory.py
+"""
+import json
+import os
+import re
+import hashlib
+from pathlib import Path
+from urllib.parse import unquote
+
+ROOT = Path(__file__).resolve().parent.parent
+META_DIR = ROOT / 'content' / 'meta'
+APP_EXPLORE = ROOT / 'app' / 'assets' / 'explore-images.json'
+STAGING_DIR = ROOT / '_tools' / 'art_staging'
+
+# Mapping of artists to short prefixes
+ARTIST_PREFIXES = {
+    'schnorr': 'schnorr',
+    'doré': 'dore',
+    'dore': 'dore',
+    'rembrandt': 'rembrandt',
+    'michelangelo': 'michelangelo',
+    'tissot': 'tissot',
+    'holman': 'holman',
+    'bloch': 'bloch',
+    'cranach': 'cranach',
+    'raphael': 'raphael',
+    'rafael': 'raphael',
+    'campin': 'campin',
+}
+
+
+def extract_wikimedia_urls(obj, source_file, parent_id=None, path="", results=None):
+    """Recursively extract Wikimedia URLs with context."""
+    if results is None:
+        results = []
+    
+    if isinstance(obj, dict):
+        # Check if this is an image object
+        if 'url' in obj and isinstance(obj['url'], str) and 'wikimedia' in obj['url']:
+            results.append({
+                'source_file': source_file,
+                'parent_id': parent_id,
+                'path': path,
+                'url': obj['url'],
+                'caption': obj.get('caption', ''),
+                'credit': obj.get('credit', ''),
+            })
+        
+        # Get ID for context
+        item_id = obj.get('id') or parent_id
+        
+        for k, v in obj.items():
+            new_path = f"{path}.{k}" if path else k
+            extract_wikimedia_urls(v, source_file, item_id, new_path, results)
+            
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            extract_wikimedia_urls(v, source_file, parent_id, f"{path}[{i}]", results)
+    
+    return results
+
+
+def url_to_filename(url: str, caption: str = "") -> str:
+    """Convert Wikimedia URL to clean filename."""
+    # Extract the actual filename from URL
+    # Handle both direct and thumbnail URLs
+    url_decoded = unquote(url)
+    
+    # Extract filename from URL path
+    match = re.search(r'/([^/]+\.(jpg|jpeg|png|gif|tif|tiff))(?:\?|$)', url_decoded, re.I)
+    if not match:
+        # Fallback: use hash
+        return f"img-{hashlib.md5(url.encode()).hexdigest()[:8]}.jpg"
+    
+    original_name = match.group(1)
+    
+    # Determine artist prefix
+    url_lower = url_decoded.lower()
+    prefix = 'misc'
+    for artist, short in ARTIST_PREFIXES.items():
+        if artist in url_lower:
+            prefix = short
+            break
+    
+    # Special cases for manuscripts/codices
+    if 'codex' in url_lower or 'sinaiticus' in url_lower:
+        prefix = 'manuscript'
+    elif 'dead_sea' in url_lower or 'isaiah_scroll' in url_lower:
+        prefix = 'manuscript'
+    elif 'papyrus' in url_lower or 'p46' in url_lower:
+        prefix = 'manuscript'
+    elif 'aleppo' in url_lower:
+        prefix = 'manuscript'
+    elif 'gutenberg' in url_lower:
+        prefix = 'manuscript'
+    elif 'book_of_kells' in url_lower:
+        prefix = 'manuscript'
+    elif 'nuremberg' in url_lower:
+        prefix = 'medieval'
+    
+    # Clean up the filename
+    # Remove common prefixes like "400px-", "thumb/", etc.
+    clean_name = re.sub(r'^\d+px-', '', original_name)
+    clean_name = re.sub(r'^lossy-page\d+-\d+px-', '', clean_name)
+    
+    # Remove artist name from filename (we have it in prefix)
+    for artist in ARTIST_PREFIXES:
+        clean_name = re.sub(rf'{artist}[_\-]?', '', clean_name, flags=re.I)
+    
+    # Remove "Gustave_" prefix specifically
+    clean_name = re.sub(r'^Gustave[_\-]?', '', clean_name, flags=re.I)
+    
+    # Clean up common patterns
+    clean_name = re.sub(r'_+', '-', clean_name)  # underscores to hyphens
+    clean_name = re.sub(r'-+', '-', clean_name)  # multiple hyphens to single
+    clean_name = re.sub(r'^-|-$', '', clean_name)  # trim leading/trailing hyphens
+    clean_name = clean_name.lower()
+    
+    # Ensure .jpg extension
+    clean_name = re.sub(r'\.(tif|tiff|png|gif)$', '.jpg', clean_name, flags=re.I)
+    if not clean_name.endswith('.jpg'):
+        clean_name += '.jpg'
+    
+    return f"{prefix}-{clean_name}"
+
+
+def main():
+    print("=" * 60)
+    print("Image Inventory — Wikimedia URL Scanner")
+    print("=" * 60)
+    
+    STAGING_DIR.mkdir(parents=True, exist_ok=True)
+    
+    all_items = []
+    
+    # Scan meta files
+    print("\nScanning content/meta/*.json...")
+    for fname in sorted(os.listdir(META_DIR)):
+        if fname.endswith('.json'):
+            fpath = META_DIR / fname
+            try:
+                with open(fpath) as f:
+                    data = json.load(f)
+                items = extract_wikimedia_urls(data, fname)
+                all_items.extend(items)
+                if items:
+                    print(f"  {fname}: {len(items)} URLs")
+            except Exception as e:
+                print(f"  {fname}: ERROR - {e}")
+    
+    # Scan app explore-images
+    if APP_EXPLORE.exists():
+        print("\nScanning app/assets/explore-images.json...")
+        with open(APP_EXPLORE) as f:
+            data = json.load(f)
+        items = extract_wikimedia_urls(data, 'app/explore-images.json')
+        all_items.extend(items)
+        print(f"  explore-images.json: {len(items)} URLs")
+    
+    # Dedupe by URL
+    print("\nDeduplicating...")
+    seen_urls = {}
+    for item in all_items:
+        url = item['url']
+        if url not in seen_urls:
+            seen_urls[url] = item
+        else:
+            # Merge source files
+            if item['source_file'] not in seen_urls[url]['source_file']:
+                seen_urls[url]['source_file'] += f", {item['source_file']}"
+    
+    unique_items = list(seen_urls.values())
+    print(f"  {len(all_items)} total → {len(unique_items)} unique URLs")
+    
+    # Generate inventory with new filenames
+    inventory = []
+    used_filenames = set()
+    
+    for item in unique_items:
+        new_name = url_to_filename(item['url'], item['caption'])
+        
+        # Handle collisions
+        base_name = new_name
+        counter = 1
+        while new_name in used_filenames:
+            name_parts = base_name.rsplit('.', 1)
+            new_name = f"{name_parts[0]}-{counter}.{name_parts[1]}"
+            counter += 1
+        
+        used_filenames.add(new_name)
+        
+        inventory.append({
+            'original_url': item['url'],
+            'new_filename': new_name,
+            'source_files': item['source_file'],
+            'caption': item['caption'],
+            'credit': item['credit'],
+        })
+    
+    # Save inventory
+    inventory_path = STAGING_DIR / 'inventory.json'
+    with open(inventory_path, 'w') as f:
+        json.dump(inventory, f, indent=2)
+    
+    print(f"\n✅ Inventory saved to {inventory_path}")
+    print(f"   {len(inventory)} images to process")
+    
+    # Summary by prefix
+    print("\n=== BY SOURCE ===")
+    by_prefix = {}
+    for item in inventory:
+        prefix = item['new_filename'].split('-')[0]
+        by_prefix.setdefault(prefix, []).append(item)
+    
+    for prefix in sorted(by_prefix.keys()):
+        print(f"  {prefix}: {len(by_prefix[prefix])}")
+    
+    # Show sample filenames
+    print("\n=== SAMPLE FILENAMES ===")
+    for item in inventory[:10]:
+        print(f"  {item['new_filename']}")
+        print(f"    ← {item['original_url'][:60]}...")
+    
+    print("\nNext: python3 _tools/download_images.py")
+
+
+if __name__ == '__main__':
+    main()

--- a/_tools/update_image_urls.py
+++ b/_tools/update_image_urls.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+update_image_urls.py — Replace Wikimedia URLs with R2 URLs in content JSON files.
+
+Uses the URL mapping from upload_images_to_r2.py to update all references
+in content/meta/*.json and app/assets/explore-images.json.
+
+Usage:
+    python3 _tools/update_image_urls.py [--dry-run]
+
+Options:
+    --dry-run   Show changes without modifying files
+"""
+import json
+import os
+import sys
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+META_DIR = ROOT / 'content' / 'meta'
+APP_EXPLORE = ROOT / 'app' / 'assets' / 'explore-images.json'
+STAGING_DIR = ROOT / '_tools' / 'art_staging'
+UPLOAD_MANIFEST = STAGING_DIR / 'upload_manifest.json'
+PRIORITY_MANIFEST = STAGING_DIR / 'priority_manifest.json'
+
+# Mapping from concept/image ID to target R2 filename
+# This maps the "meaning" of each image to the correct Doré replacement
+IMAGE_CONCEPT_MAP = {
+    # Concepts (concepts.json)
+    'spirit-of-god': 'dore-pentecost.jpg',      # Pentecost / Spirit descends
+    'faith': 'dore-abraham-isaac.jpg',           # Abraham's faith tested
+    'mercy-grace': 'dore-prodigal-son.jpg',      # Prodigal son
+    'judgment': 'dore-crucifixion-darkness.jpg', # Darkness at crucifixion
+    'creation': 'dore-creation-light.jpg',       # Creation of light
+    'redemption': 'dore-red-sea.jpg',            # Red Sea crossing
+    'prophecy': 'dore-isaiah.jpg',               # Isaiah prophet
+    'suffering': 'dore-jeremiah.jpg',            # Jeremiah prophet
+    'resurrection': 'dore-resurrection.jpg',     # Resurrection of Jesus
+    'mission': 'dore-paul.jpg',                  # Paul preaching
+    'word-of-god': None,                         # codex-sinaiticus - manual
+    
+    # People with specific images
+    'abraham': 'dore-abraham-isaac.jpg',
+    'isaac': 'dore-abraham-isaac.jpg',
+    'jacob': 'dore-jacob-blessing.jpg',
+    'moses': 'dore-creation-light.jpg',  # Could use a better Moses image
+    'isaiah': 'dore-isaiah.jpg',
+    'jeremiah': 'dore-jeremiah.jpg',
+    'ezekiel': 'dore-ezekiel.jpg',
+    'daniel': 'dore-daniel.jpg',
+    'jonah': 'dore-jonah.jpg',
+    'paul': 'dore-paul.jpg',
+    'jesus': 'dore-nativity.jpg',
+    
+    # Map stories
+    'abram-call': 'dore-abram-call.jpg',
+    'nativity': 'dore-nativity.jpg',
+    'paul-journey3': None,  # Map - manual
+    
+    # Timeline events
+    'pentecost': 'dore-pentecost.jpg',
+    'crucifixion': 'dore-crucifixion-darkness.jpg',
+    'exodus': 'dore-red-sea.jpg',
+}
+
+# Keyword patterns to match image captions/contexts to Doré images
+CAPTION_PATTERNS = [
+    (r'pentecost|spirit.*descend', 'dore-pentecost.jpg'),
+    (r'abraham.*isaac|binding.*isaac|trial.*faith', 'dore-abraham-isaac.jpg'),
+    (r'prodigal.*son|return.*father', 'dore-prodigal-son.jpg'),
+    (r'darkness.*crucifixion|judgment.*cross', 'dore-crucifixion-darkness.jpg'),
+    (r'creation.*light|let.*be.*light', 'dore-creation-light.jpg'),
+    (r'red.*sea|egypt.*drown|crossing.*sea', 'dore-red-sea.jpg'),
+    (r'isaiah.*prophet', 'dore-isaiah.jpg'),
+    (r'jeremiah.*prophet|lament', 'dore-jeremiah.jpg'),
+    (r'resurrection.*jesus|risen|empty.*tomb', 'dore-resurrection.jpg'),
+    (r'jacob.*bless|isaac.*bless.*jacob', 'dore-jacob-blessing.jpg'),
+    (r'jericho.*fall|walls.*jericho', 'dore-jericho.jpg'),
+    (r'ezekiel.*prophet', 'dore-ezekiel.jpg'),
+    (r'daniel\b', 'dore-daniel.jpg'),
+    (r'jonah.*whale|cast.*forth', 'dore-jonah.jpg'),
+    (r'abraham.*journey|abram.*call|land.*canaan', 'dore-abram-call.jpg'),
+    (r'nativity|jesus.*birth|manger', 'dore-nativity.jpg'),
+    (r'paul.*preach|paul.*mission|thessalonian', 'dore-paul.jpg'),
+]
+
+
+def match_caption_to_image(caption: str, context_id: str = None) -> str | None:
+    """Try to match a caption or context to a Doré image."""
+    # First check context ID mapping
+    if context_id and context_id in IMAGE_CONCEPT_MAP:
+        return IMAGE_CONCEPT_MAP[context_id]
+    
+    # Then try caption pattern matching
+    caption_lower = caption.lower() if caption else ''
+    for pattern, filename in CAPTION_PATTERNS:
+        if re.search(pattern, caption_lower, re.IGNORECASE):
+            return filename
+    
+    return None
+
+
+def update_images_in_obj(obj: Any, r2_base: str, parent_id: str = None, 
+                          changes: list = None, path: str = "") -> Any:
+    """Recursively update Wikimedia URLs to R2 URLs."""
+    if changes is None:
+        changes = []
+    
+    if isinstance(obj, dict):
+        # Track the ID if this is a content item
+        item_id = obj.get('id') or parent_id
+        
+        # Check if this is an image object with a Wikimedia URL
+        if 'url' in obj and isinstance(obj['url'], str) and 'wikimedia' in obj['url']:
+            old_url = obj['url']
+            caption = obj.get('caption', '')
+            
+            # Try to find a replacement
+            new_filename = match_caption_to_image(caption, item_id)
+            
+            if new_filename:
+                new_url = f"{r2_base}{new_filename}"
+                obj['url'] = new_url
+                obj['credit'] = 'Gustave Doré · Public domain'
+                changes.append({
+                    'path': path,
+                    'old_url': old_url[:60] + '...',
+                    'new_url': new_url,
+                    'matched_by': f"caption='{caption[:30]}' or id='{item_id}'"
+                })
+            else:
+                changes.append({
+                    'path': path,
+                    'old_url': old_url[:60] + '...',
+                    'new_url': None,
+                    'reason': f"No match found for caption='{caption[:30]}' id='{item_id}'"
+                })
+        
+        # Recurse into dict values
+        for k, v in obj.items():
+            new_path = f"{path}.{k}" if path else k
+            obj[k] = update_images_in_obj(v, r2_base, item_id, changes, new_path)
+    
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            obj[i] = update_images_in_obj(v, r2_base, parent_id, changes, f"{path}[{i}]")
+    
+    return obj
+
+
+def main():
+    dry_run = '--dry-run' in sys.argv
+    
+    print("=" * 60)
+    print("Image URL Updater")
+    print("=" * 60)
+    
+    if dry_run:
+        print("Mode: DRY RUN (no files will be modified)\n")
+    else:
+        print("Mode: LIVE (files will be modified)\n")
+    
+    # Load upload manifest to get R2 base URL
+    if not UPLOAD_MANIFEST.exists():
+        # Use expected URL format
+        r2_base = "https://contentcompanionstudy.com/art/"
+        print(f"⚠️  Upload manifest not found, using default R2 URL: {r2_base}")
+    else:
+        with open(UPLOAD_MANIFEST) as f:
+            manifest = json.load(f)
+        r2_base = manifest.get('public_url_base', "https://contentcompanionstudy.com/art/")
+    
+    print(f"R2 Base URL: {r2_base}\n")
+    
+    # Process all meta JSON files
+    all_changes = {}
+    files_to_update = []
+    
+    # Collect files to process
+    for fname in sorted(os.listdir(META_DIR)):
+        if fname.endswith('.json'):
+            files_to_update.append(META_DIR / fname)
+    
+    if APP_EXPLORE.exists():
+        files_to_update.append(APP_EXPLORE)
+    
+    for fpath in files_to_update:
+        fname = fpath.name
+        print(f"Processing {fname}...")
+        
+        try:
+            with open(fpath) as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f"  ❌ Error reading: {e}")
+            continue
+        
+        changes = []
+        updated_data = update_images_in_obj(data, r2_base, changes=changes)
+        
+        if changes:
+            all_changes[fname] = changes
+            replaced = sum(1 for c in changes if c.get('new_url'))
+            unmatched = sum(1 for c in changes if not c.get('new_url'))
+            print(f"  ✓ {replaced} URLs replaced, {unmatched} unmatched")
+            
+            if not dry_run:
+                with open(fpath, 'w') as f:
+                    json.dump(updated_data, f, indent=2, ensure_ascii=False)
+                print(f"  💾 File saved")
+        else:
+            print(f"  - No Wikimedia URLs found")
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    
+    total_replaced = 0
+    total_unmatched = 0
+    
+    for fname, changes in all_changes.items():
+        replaced = sum(1 for c in changes if c.get('new_url'))
+        unmatched = sum(1 for c in changes if not c.get('new_url'))
+        total_replaced += replaced
+        total_unmatched += unmatched
+        print(f"  {fname}: {replaced} replaced, {unmatched} unmatched")
+    
+    print(f"\n  Total replaced:  {total_replaced}")
+    print(f"  Total unmatched: {total_unmatched}")
+    
+    if total_unmatched > 0:
+        print("\n=== UNMATCHED URLS ===")
+        for fname, changes in all_changes.items():
+            for c in changes:
+                if not c.get('new_url'):
+                    print(f"  [{fname}] {c.get('reason', 'Unknown')}")
+    
+    if dry_run:
+        print("\n⚠️  DRY RUN - No files were modified")
+        print("   Run without --dry-run to apply changes")
+    else:
+        print("\n✅ All files updated!")
+        print("\nNext steps:")
+        print("  1. Review changes: git diff content/meta/")
+        print("  2. Validate: python3 _tools/schema_validator.py")
+        print("  3. Build DB: python3 _tools/build_sqlite.py")
+        print("  4. Commit and push")
+
+
+if __name__ == '__main__':
+    main()

--- a/_tools/upload_images_to_r2.py
+++ b/_tools/upload_images_to_r2.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+upload_images_to_r2.py — Upload images to CloudFlare R2.
+
+Uploads images from _tools/art_staging/priority/ to R2 under the art/ prefix.
+Generates a URL mapping file for updating JSON references.
+
+Usage:
+    python3 _tools/upload_images_to_r2.py [--priority] [--all]
+
+Options:
+    --priority  Upload only priority images (default)
+    --all       Upload all staged images
+
+Environment Variables (required):
+    R2_ACCOUNT_ID       — CloudFlare account ID
+    R2_ACCESS_KEY_ID    — R2 API token access key
+    R2_SECRET_ACCESS_KEY — R2 API token secret
+    R2_BUCKET_NAME      — R2 bucket name
+    R2_PUBLIC_URL       — Public URL base
+
+The script can also read from a .env file in the repo root.
+"""
+import os
+import sys
+import json
+import hashlib
+import mimetypes
+from pathlib import Path
+from datetime import datetime, timezone
+
+ROOT = Path(__file__).resolve().parent.parent
+STAGING_DIR = ROOT / '_tools' / 'art_staging'
+PRIORITY_DIR = STAGING_DIR / 'priority'
+ENV_FILE = ROOT / '.env'
+
+
+def load_env():
+    """Load environment variables from .env file if present."""
+    if ENV_FILE.exists():
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    key, _, value = line.partition('=')
+                    value = value.strip().strip('"').strip("'")
+                    os.environ.setdefault(key.strip(), value)
+
+
+def get_env(key: str) -> str:
+    """Get required environment variable or exit with error."""
+    value = os.environ.get(key)
+    if not value:
+        print(f"❌ Missing required environment variable: {key}")
+        print("   Set it in your environment or in .env file")
+        sys.exit(1)
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    """Calculate SHA256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def get_s3_client():
+    """Create boto3 S3 client configured for R2."""
+    try:
+        import boto3
+    except ImportError:
+        print("❌ boto3 not installed. Run: pip install boto3")
+        sys.exit(1)
+    
+    account_id = get_env('R2_ACCOUNT_ID')
+    access_key = get_env('R2_ACCESS_KEY_ID')
+    secret_key = get_env('R2_SECRET_ACCESS_KEY')
+    
+    return boto3.client(
+        's3',
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name='auto',
+    )
+
+
+def get_content_type(filename: str) -> str:
+    """Get MIME type for file."""
+    mime_type, _ = mimetypes.guess_type(filename)
+    return mime_type or 'application/octet-stream'
+
+
+def main():
+    priority_only = '--all' not in sys.argv
+    
+    print("=" * 60)
+    print("CloudFlare R2 Image Upload")
+    print("=" * 60)
+    
+    load_env()
+    
+    # Determine source directory
+    if priority_only:
+        source_dir = PRIORITY_DIR
+        manifest_file = STAGING_DIR / 'priority_manifest.json'
+        print("Mode: Priority images only")
+    else:
+        source_dir = STAGING_DIR
+        manifest_file = STAGING_DIR / 'inventory.json'
+        print("Mode: All staged images")
+    
+    if not source_dir.exists():
+        print(f"❌ Source directory not found: {source_dir}")
+        print("   Run download_priority_images.py first")
+        sys.exit(1)
+    
+    # Get image files
+    image_files = list(source_dir.glob('*.jpg')) + list(source_dir.glob('*.png'))
+    if not image_files:
+        print(f"❌ No images found in {source_dir}")
+        sys.exit(1)
+    
+    bucket = get_env('R2_BUCKET_NAME')
+    public_url = get_env('R2_PUBLIC_URL').rstrip('/')
+    
+    print(f"\n📁 Source: {source_dir}")
+    print(f"🖼️  Images: {len(image_files)}")
+    print(f"🪣 Bucket: {bucket}")
+    print(f"🌐 Public URL: {public_url}")
+    print()
+    
+    # Create S3 client
+    s3 = get_s3_client()
+    
+    # Upload images
+    uploaded = []
+    failed = []
+    
+    for i, img_path in enumerate(sorted(image_files), 1):
+        filename = img_path.name
+        r2_key = f"art/{filename}"
+        
+        print(f"[{i}/{len(image_files)}] {filename}")
+        
+        try:
+            content_type = get_content_type(filename)
+            file_hash = sha256_file(img_path)
+            
+            s3.upload_file(
+                str(img_path),
+                bucket,
+                r2_key,
+                ExtraArgs={
+                    'ContentType': content_type,
+                    'CacheControl': 'public, max-age=31536000, immutable',
+                }
+            )
+            
+            r2_url = f"{public_url}/{r2_key}"
+            print(f"      ✓ Uploaded to {r2_url}")
+            
+            uploaded.append({
+                'filename': filename,
+                'r2_key': r2_key,
+                'r2_url': r2_url,
+                'sha256': file_hash,
+                'size_bytes': img_path.stat().st_size,
+            })
+            
+        except Exception as e:
+            print(f"      ❌ Error: {e}")
+            failed.append({'filename': filename, 'error': str(e)})
+    
+    # Save upload manifest
+    upload_manifest = {
+        'uploaded_at': datetime.now(timezone.utc).isoformat(),
+        'public_url_base': f"{public_url}/art/",
+        'images': uploaded,
+        'failed': failed,
+    }
+    
+    upload_manifest_path = STAGING_DIR / 'upload_manifest.json'
+    with open(upload_manifest_path, 'w') as f:
+        json.dump(upload_manifest, f, indent=2)
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  ✓ Uploaded: {len(uploaded)}")
+    print(f"  ❌ Failed:   {len(failed)}")
+    print(f"\n📋 Upload manifest: {upload_manifest_path}")
+    
+    if failed:
+        print("\n=== FAILED ===")
+        for item in failed:
+            print(f"  - {item['filename']}: {item['error']}")
+    
+    # Create URL mapping for JSON updates
+    url_mapping = {}
+    
+    # Load original manifest to get source URLs
+    if manifest_file.exists():
+        with open(manifest_file) as f:
+            original_manifest = json.load(f)
+        
+        # Build mapping from original Wikimedia URLs to new R2 URLs
+        if 'downloaded' in original_manifest:
+            # Priority manifest format
+            for item in original_manifest['downloaded']:
+                # We'll map by filename since we don't have original Wikimedia URLs
+                filename = item['filename']
+                for uploaded_item in uploaded:
+                    if uploaded_item['filename'] == filename:
+                        # The source_url in priority manifest is the creationism.org URL
+                        # We need to map the original Wikimedia URLs to R2 URLs
+                        # For now, just record the R2 URL for each filename
+                        url_mapping[filename] = {
+                            'r2_url': uploaded_item['r2_url'],
+                            'caption': item.get('caption', ''),
+                            'credit': item.get('credit', ''),
+                        }
+                        break
+    
+    mapping_path = STAGING_DIR / 'url_mapping.json'
+    with open(mapping_path, 'w') as f:
+        json.dump(url_mapping, f, indent=2)
+    
+    print(f"📋 URL mapping: {mapping_path}")
+    print("\nNext: python3 _tools/update_image_urls.py")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Image Migration Scripts

Scripts to migrate Wikimedia images to CloudFlare R2 for reliable hosting.

### Problem
Wikimedia Commons blocks hotlinking (403 errors in app). Need to self-host images.

### Solution
- **image_inventory.py** — Scans all JSON files, catalogs 67 unique Wikimedia URLs
- **download_priority_images.py** — Downloads 17 priority Doré images from creationism.org
- **upload_images_to_r2.py** — Uploads images to R2 `art/` prefix
- **update_image_urls.py** — Replaces Wikimedia URLs with R2 URLs in JSON

### Usage (run locally with .env)
```bash
python _tools/download_priority_images.py
python _tools/upload_images_to_r2.py --priority
python _tools/update_image_urls.py
```

### Status
- ✅ 17 Doré images mapped to creationism.org (working source)
- ⚠️ 2 images need manual sourcing: codex-sinaiticus, paul-journey3
- 📋 Phase 2: Remaining 202 URLs need expanded mappings
