### PR TITLE
fix: Windows console encoding compatibility

### DIFF
--- a/_tools/download_images.py
+++ b/_tools/download_images.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-download_images.py — Download all inventoried Wikimedia images.
+download_images.py - Download all inventoried Wikimedia images.
 
 Downloads images from Wikimedia Commons with proper User-Agent,
 converts to JPG if needed, saves to _tools/art_staging/.
@@ -42,7 +42,7 @@ def download_image(url: str, dest_path: Path) -> bool:
         
         # Check if we got actual image data
         if len(data) < 1000:
-            print(f"      ⚠️  Response too small ({len(data)} bytes)")
+            print(f"      [!]  Response too small ({len(data)} bytes)")
             return False
         
         # Save the file
@@ -52,13 +52,13 @@ def download_image(url: str, dest_path: Path) -> bool:
         return True
         
     except HTTPError as e:
-        print(f"      ❌ HTTP {e.code}: {e.reason}")
+        print(f"      [X] HTTP {e.code}: {e.reason}")
         return False
     except URLError as e:
-        print(f"      ❌ URL Error: {e.reason}")
+        print(f"      [X] URL Error: {e.reason}")
         return False
     except Exception as e:
-        print(f"      ❌ Error: {e}")
+        print(f"      [X] Error: {e}")
         return False
 
 
@@ -84,10 +84,10 @@ def convert_to_jpg(src_path: Path, dest_path: Path) -> bool:
         return True
         
     except ImportError:
-        print("      ⚠️  PIL not installed, keeping original format")
+        print("      [!]  PIL not installed, keeping original format")
         return False
     except Exception as e:
-        print(f"      ⚠️  Conversion error: {e}")
+        print(f"      [!]  Conversion error: {e}")
         return False
 
 
@@ -95,18 +95,18 @@ def main():
     force = '--force' in sys.argv
     
     print("=" * 60)
-    print("Image Downloader — Wikimedia → Local")
+    print("Image Downloader - Wikimedia -> Local")
     print("=" * 60)
     
     if not INVENTORY_PATH.exists():
-        print(f"❌ Inventory not found: {INVENTORY_PATH}")
+        print(f"[X] Inventory not found: {INVENTORY_PATH}")
         print("   Run image_inventory.py first")
         sys.exit(1)
     
     with open(INVENTORY_PATH) as f:
         inventory = json.load(f)
     
-    print(f"\n📋 {len(inventory)} images in inventory")
+    print(f"\n-- {len(inventory)} images in inventory")
     if force:
         print("   --force: Re-downloading all")
     
@@ -125,7 +125,7 @@ def main():
         # Skip if exists (unless force)
         if dest_path.exists() and not force:
             size_kb = dest_path.stat().st_size / 1024
-            print(f"      ✓ Exists ({size_kb:.1f} KB)")
+            print(f"      [OK] Exists ({size_kb:.1f} KB)")
             skipped.append(filename)
             continue
         
@@ -148,7 +148,7 @@ def main():
         
         if success_download:
             size_kb = dest_path.stat().st_size / 1024
-            print(f"      ✓ Downloaded ({size_kb:.1f} KB)")
+            print(f"      [OK] Downloaded ({size_kb:.1f} KB)")
             
             # Convert to JPG if needed
             if not filename.endswith('.jpg') or dest_path.suffix.lower() in ('.png', '.tif', '.tiff', '.gif'):
@@ -156,7 +156,7 @@ def main():
                 if convert_to_jpg(dest_path, jpg_path):
                     if dest_path != jpg_path:
                         os.remove(dest_path)
-                    print(f"      ✓ Converted to JPG")
+                    print(f"      [OK] Converted to JPG")
             
             success.append(filename)
         else:
@@ -169,9 +169,9 @@ def main():
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    print(f"  ✓ Downloaded: {len(success)}")
-    print(f"  ⏭ Skipped:    {len(skipped)}")
-    print(f"  ❌ Failed:     {len(failed)}")
+    print(f"  [OK] Downloaded: {len(success)}")
+    print(f"  >> Skipped:    {len(skipped)}")
+    print(f"  [X] Failed:     {len(failed)}")
     
     if failed:
         print("\n=== FAILED DOWNLOADS ===")
@@ -198,7 +198,7 @@ def main():
     with open(INVENTORY_PATH, 'w') as f:
         json.dump(inventory, f, indent=2)
     
-    print(f"\n📋 Inventory updated: {INVENTORY_PATH}")
+    print(f"\n-- Inventory updated: {INVENTORY_PATH}")
     
     if failed:
         print("\nNext: Fix failed downloads, then run upload_images_to_r2.py")

--- a/_tools/download_priority_images.py
+++ b/_tools/download_priority_images.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-download_priority_images.py — Download the 19 priority Explore screen images.
+download_priority_images.py - Download the 19 priority Explore screen images.
 
 Downloads from creationism.org (Doré collection) which is the only source
 that works from this environment. For images without Doré equivalents,
@@ -10,8 +10,8 @@ Usage:
     python3 _tools/download_priority_images.py
 
 Output:
-    _tools/art_staging/priority/ — Downloaded images
-    _tools/art_staging/priority_manifest.json — Manifest for R2 upload
+    _tools/art_staging/priority/ - Downloaded images
+    _tools/art_staging/priority_manifest.json - Manifest for R2 upload
 """
 import json
 import os
@@ -32,110 +32,110 @@ PRIORITY_IMAGES = [
     # Spirit of God / Pentecost
     ('dore-pentecost.jpg', 
      'vAct0202Dore_TheDescentOfTheSpirit.jpg',
-     'The Descent of the Spirit — Pentecost',
-     'Gustave Doré · Public domain'),
+     'The Descent of the Spirit - Pentecost',
+     'Gustave Doré - Public domain'),
     
     # Faith / Abraham & Isaac
     ('dore-abraham-isaac.jpg',
      'aGen2210Dore_TheTrialOfAbraham_sFaith.jpg',
-     'The Trial of Abraham\'s Faith — binding of Isaac',
-     'Gustave Doré · Public domain'),
+     'The Trial of Abraham\'s Faith - binding of Isaac',
+     'Gustave Doré - Public domain'),
     
     # Mercy & Grace / Prodigal Son
     ('dore-prodigal-son.jpg',
      'tLuk1520Dore_TheProdigalSonInTheArmsOfHisFather.jpg',
      'The Prodigal Son in the Arms of His Father',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Judgment / Crucifixion Darkness
     ('dore-crucifixion-darkness.jpg',
      'tLuk2344Dore_TheDarknessAtTheCrucifixion.jpg',
-     'The Darkness at the Crucifixion — judgment',
-     'Gustave Doré · Public domain'),
+     'The Darkness at the Crucifixion - judgment',
+     'Gustave Doré - Public domain'),
     
     # Creation / Light
     ('dore-creation-light.jpg',
      'aGen0103Dore_TheCreationOfLight.jpg',
      'The Creation of Light',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Redemption / Red Sea
     ('dore-red-sea.jpg',
      'bExo1427Dore_TheEgyptiansDrownedInTheRedSea.jpg',
-     'The Egyptians Drowned in the Red Sea — redemption',
-     'Gustave Doré · Public domain'),
+     'The Egyptians Drowned in the Red Sea - redemption',
+     'Gustave Doré - Public domain'),
     
     # Prophecy / Isaiah
     ('dore-isaiah.jpg',
      'nIsa0608Dore_Isaiah.jpg',
      'Isaiah the Prophet',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Suffering / Jeremiah
     ('dore-jeremiah.jpg',
      'nJer0114Dore_Jeremiah.jpg',
-     'Jeremiah the Prophet — suffering and lament',
-     'Gustave Doré · Public domain'),
+     'Jeremiah the Prophet - suffering and lament',
+     'Gustave Doré - Public domain'),
     
     # Resurrection
     ('dore-resurrection.jpg',
      'rMat2805Dore_TheResurrection.jpg',
      'The Resurrection of Jesus',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Jacob blessing (Isaac blessing Jacob is closest)
     ('dore-jacob-blessing.jpg',
      'aGen2729Dore_IsaacBlessingJacob.jpg',
      'Isaac Blessing Jacob',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Jericho / Joshua
     ('dore-jericho.jpg',
      'dJos0620Dore_TheWallsOfJerichoFallingDown.jpg',
      'The Walls of Jericho Falling Down',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Ezekiel
     ('dore-ezekiel.jpg',
      'oEze0103Dore_EzekielProphesying.jpg',
      'Ezekiel Prophesying',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Daniel
     ('dore-daniel.jpg',
      'pDan0220Dore_Daniel.jpg',
      'Daniel',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Jonah
     ('dore-jonah.jpg',
      'qJon0201Dore_JonahCastForthByTheWhale.jpg',
      'Jonah Cast Forth by the Whale',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Abram's call / Journey
     ('dore-abram-call.jpg',
      'aGen1201Dore_AbrahamJourneyingIntoTheLandOfCanaan.jpg',
      'Abraham Journeying into the Land of Canaan',
-     'Gustave Doré · Public domain'),
+     'Gustave Doré - Public domain'),
     
     # Nativity
     ('dore-nativity.jpg',
      'tLuk0215Dore_TheNativity.jpg',
-     'The Nativity — Jesus birth',
-     'Gustave Doré · Public domain'),
+     'The Nativity - Jesus birth',
+     'Gustave Doré - Public domain'),
     
     # Paul / Mission (using Paul preaching to Thessalonians)
     ('dore-paul.jpg',
      'w1Th0211Dore_St_PaulPreachingToTheThessalonians.jpg',
-     'St. Paul Preaching to the Thessalonians — missionary to the nations',
-     'Gustave Doré · Public domain'),
+     'St. Paul Preaching to the Thessalonians - missionary to the nations',
+     'Gustave Doré - Public domain'),
 ]
 
 # Images that need manual sourcing (no Doré equivalent)
 MANUAL_IMAGES = [
     ('codex-sinaiticus.jpg', 
-     'Codex Sinaiticus — 4th century Bible manuscript',
+     'Codex Sinaiticus - 4th century Bible manuscript',
      'Needs: British Library or Codex Sinaiticus Project image'),
     ('paul-journey3.jpg',
      "Paul's Third Missionary Journey map",
@@ -155,11 +155,11 @@ def download_image(url: str, dest_path: Path) -> bool:
         
         # Verify it's actual image data
         if len(data) < 5000:
-            print(f"      ⚠️  Response too small ({len(data)} bytes)")
+            print(f"      [!]  Response too small ({len(data)} bytes)")
             return False
         
         if data[:4] == b'<!DO' or data[:5] == b'<html':
-            print(f"      ⚠️  Got HTML instead of image")
+            print(f"      [!]  Got HTML instead of image")
             return False
         
         with open(dest_path, 'wb') as f:
@@ -168,13 +168,13 @@ def download_image(url: str, dest_path: Path) -> bool:
         return True
         
     except HTTPError as e:
-        print(f"      ❌ HTTP {e.code}: {e.reason}")
+        print(f"      [X] HTTP {e.code}: {e.reason}")
         return False
     except URLError as e:
-        print(f"      ❌ URL Error: {e.reason}")
+        print(f"      [X] URL Error: {e.reason}")
         return False
     except Exception as e:
-        print(f"      ❌ Error: {e}")
+        print(f"      [X] Error: {e}")
         return False
 
 
@@ -202,7 +202,7 @@ def main():
         
         if dest.exists():
             size_kb = dest.stat().st_size / 1024
-            print(f"      ✓ Already exists ({size_kb:.1f} KB)")
+            print(f"      [OK] Already exists ({size_kb:.1f} KB)")
             manifest['downloaded'].append({
                 'filename': filename,
                 'source_url': url,
@@ -215,7 +215,7 @@ def main():
         print(f"      Downloading from creationism.org...")
         if download_image(url, dest):
             size_kb = dest.stat().st_size / 1024
-            print(f"      ✓ Downloaded ({size_kb:.1f} KB)")
+            print(f"      [OK] Downloaded ({size_kb:.1f} KB)")
             manifest['downloaded'].append({
                 'filename': filename,
                 'source_url': url,
@@ -234,7 +234,7 @@ def main():
     
     # Record manual images
     for filename, caption, note in MANUAL_IMAGES:
-        print(f"\n⚠️  {filename}: {note}")
+        print(f"\n[!]  {filename}: {note}")
         manifest['manual_needed'].append({
             'filename': filename,
             'caption': caption,
@@ -250,10 +250,10 @@ def main():
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    print(f"  ✓ Downloaded:    {len(manifest['downloaded'])}")
-    print(f"  ⚠️  Manual needed: {len(manifest['manual_needed'])}")
-    print(f"  ❌ Failed:        {len(manifest['failed'])}")
-    print(f"\n📋 Manifest saved: {manifest_path}")
+    print(f"  [OK] Downloaded:    {len(manifest['downloaded'])}")
+    print(f"  [!]  Manual needed: {len(manifest['manual_needed'])}")
+    print(f"  [X] Failed:        {len(manifest['failed'])}")
+    print(f"\n-- Manifest saved: {manifest_path}")
     
     if manifest['failed']:
         print("\n=== FAILED ===")

--- a/_tools/image_inventory.py
+++ b/_tools/image_inventory.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-image_inventory.py — Inventory all Wikimedia image URLs and prepare for R2 migration.
+image_inventory.py - Inventory all Wikimedia image URLs and prepare for R2 migration.
 
 Scans all content JSON files, extracts Wikimedia URLs, generates:
-  1. _tools/art_staging/inventory.json — Full mapping of old URLs to new names
+  1. _tools/art_staging/inventory.json - Full mapping of old URLs to new names
   2. Console summary of images by source
 
 Usage:
@@ -135,7 +135,7 @@ def url_to_filename(url: str, caption: str = "") -> str:
 
 def main():
     print("=" * 60)
-    print("Image Inventory — Wikimedia URL Scanner")
+    print("Image Inventory - Wikimedia URL Scanner")
     print("=" * 60)
     
     STAGING_DIR.mkdir(parents=True, exist_ok=True)
@@ -179,7 +179,7 @@ def main():
                 seen_urls[url]['source_file'] += f", {item['source_file']}"
     
     unique_items = list(seen_urls.values())
-    print(f"  {len(all_items)} total → {len(unique_items)} unique URLs")
+    print(f"  {len(all_items)} total -> {len(unique_items)} unique URLs")
     
     # Generate inventory with new filenames
     inventory = []

--- a/_tools/update_image_urls.py
+++ b/_tools/update_image_urls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-update_image_urls.py — Replace Wikimedia URLs with R2 URLs in content JSON files.
+update_image_urls.py - Replace Wikimedia URLs with R2 URLs in content JSON files.
 
 Uses the URL mapping from upload_images_to_r2.py to update all references
 in content/meta/*.json and app/assets/explore-images.json.
@@ -123,7 +123,7 @@ def update_images_in_obj(obj: Any, r2_base: str, parent_id: str = None,
             if new_filename:
                 new_url = f"{r2_base}{new_filename}"
                 obj['url'] = new_url
-                obj['credit'] = 'Gustave Doré · Public domain'
+                obj['credit'] = 'Gustave Doré - Public domain'
                 changes.append({
                     'path': path,
                     'old_url': old_url[:60] + '...',
@@ -166,7 +166,7 @@ def main():
     if not UPLOAD_MANIFEST.exists():
         # Use expected URL format
         r2_base = "https://contentcompanionstudy.com/art/"
-        print(f"⚠️  Upload manifest not found, using default R2 URL: {r2_base}")
+        print(f"[!]  Upload manifest not found, using default R2 URL: {r2_base}")
     else:
         with open(UPLOAD_MANIFEST) as f:
             manifest = json.load(f)
@@ -194,7 +194,7 @@ def main():
             with open(fpath) as f:
                 data = json.load(f)
         except Exception as e:
-            print(f"  ❌ Error reading: {e}")
+            print(f"  [X] Error reading: {e}")
             continue
         
         changes = []
@@ -204,12 +204,12 @@ def main():
             all_changes[fname] = changes
             replaced = sum(1 for c in changes if c.get('new_url'))
             unmatched = sum(1 for c in changes if not c.get('new_url'))
-            print(f"  ✓ {replaced} URLs replaced, {unmatched} unmatched")
+            print(f"  [OK] {replaced} URLs replaced, {unmatched} unmatched")
             
             if not dry_run:
                 with open(fpath, 'w') as f:
                     json.dump(updated_data, f, indent=2, ensure_ascii=False)
-                print(f"  💾 File saved")
+                print(f"  -- File saved")
         else:
             print(f"  - No Wikimedia URLs found")
     
@@ -239,7 +239,7 @@ def main():
                     print(f"  [{fname}] {c.get('reason', 'Unknown')}")
     
     if dry_run:
-        print("\n⚠️  DRY RUN - No files were modified")
+        print("\n[!]  DRY RUN - No files were modified")
         print("   Run without --dry-run to apply changes")
     else:
         print("\n✅ All files updated!")

--- a/_tools/upload_images_to_r2.py
+++ b/_tools/upload_images_to_r2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-upload_images_to_r2.py — Upload images to CloudFlare R2.
+upload_images_to_r2.py - Upload images to CloudFlare R2.
 
 Uploads images from _tools/art_staging/priority/ to R2 under the art/ prefix.
 Generates a URL mapping file for updating JSON references.
@@ -13,11 +13,11 @@ Options:
     --all       Upload all staged images
 
 Environment Variables (required):
-    R2_ACCOUNT_ID       — CloudFlare account ID
-    R2_ACCESS_KEY_ID    — R2 API token access key
-    R2_SECRET_ACCESS_KEY — R2 API token secret
-    R2_BUCKET_NAME      — R2 bucket name
-    R2_PUBLIC_URL       — Public URL base
+    R2_ACCOUNT_ID       - CloudFlare account ID
+    R2_ACCESS_KEY_ID    - R2 API token access key
+    R2_SECRET_ACCESS_KEY - R2 API token secret
+    R2_BUCKET_NAME      - R2 bucket name
+    R2_PUBLIC_URL       - Public URL base
 
 The script can also read from a .env file in the repo root.
 """
@@ -51,7 +51,7 @@ def get_env(key: str) -> str:
     """Get required environment variable or exit with error."""
     value = os.environ.get(key)
     if not value:
-        print(f"❌ Missing required environment variable: {key}")
+        print(f"[X] Missing required environment variable: {key}")
         print("   Set it in your environment or in .env file")
         sys.exit(1)
     return value
@@ -71,7 +71,7 @@ def get_s3_client():
     try:
         import boto3
     except ImportError:
-        print("❌ boto3 not installed. Run: pip install boto3")
+        print("[X] boto3 not installed. Run: pip install boto3")
         sys.exit(1)
     
     account_id = get_env('R2_ACCOUNT_ID')
@@ -113,23 +113,23 @@ def main():
         print("Mode: All staged images")
     
     if not source_dir.exists():
-        print(f"❌ Source directory not found: {source_dir}")
+        print(f"[X] Source directory not found: {source_dir}")
         print("   Run download_priority_images.py first")
         sys.exit(1)
     
     # Get image files
     image_files = list(source_dir.glob('*.jpg')) + list(source_dir.glob('*.png'))
     if not image_files:
-        print(f"❌ No images found in {source_dir}")
+        print(f"[X] No images found in {source_dir}")
         sys.exit(1)
     
     bucket = get_env('R2_BUCKET_NAME')
     public_url = get_env('R2_PUBLIC_URL').rstrip('/')
     
-    print(f"\n📁 Source: {source_dir}")
-    print(f"🖼️  Images: {len(image_files)}")
-    print(f"🪣 Bucket: {bucket}")
-    print(f"🌐 Public URL: {public_url}")
+    print(f"\n-- Source: {source_dir}")
+    print(f"--  Images: {len(image_files)}")
+    print(f"-- Bucket: {bucket}")
+    print(f"-- Public URL: {public_url}")
     print()
     
     # Create S3 client
@@ -160,7 +160,7 @@ def main():
             )
             
             r2_url = f"{public_url}/{r2_key}"
-            print(f"      ✓ Uploaded to {r2_url}")
+            print(f"      [OK] Uploaded to {r2_url}")
             
             uploaded.append({
                 'filename': filename,
@@ -171,7 +171,7 @@ def main():
             })
             
         except Exception as e:
-            print(f"      ❌ Error: {e}")
+            print(f"      [X] Error: {e}")
             failed.append({'filename': filename, 'error': str(e)})
     
     # Save upload manifest
@@ -190,9 +190,9 @@ def main():
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    print(f"  ✓ Uploaded: {len(uploaded)}")
-    print(f"  ❌ Failed:   {len(failed)}")
-    print(f"\n📋 Upload manifest: {upload_manifest_path}")
+    print(f"  [OK] Uploaded: {len(uploaded)}")
+    print(f"  [X] Failed:   {len(failed)}")
+    print(f"\n-- Upload manifest: {upload_manifest_path}")
     
     if failed:
         print("\n=== FAILED ===")
@@ -229,7 +229,7 @@ def main():
     with open(mapping_path, 'w') as f:
         json.dump(url_mapping, f, indent=2)
     
-    print(f"📋 URL mapping: {mapping_path}")
+    print(f"-- URL mapping: {mapping_path}")
     print("\nNext: python3 _tools/update_image_urls.py")
 
 


### PR DESCRIPTION
## Fix Windows Console Encoding

Windows cp1252 encoding cannot display Unicode symbols. Scripts were failing with:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2713'
```

### Changes
Replaced Unicode symbols with ASCII equivalents in all 5 image migration scripts:
- `✓` → `[OK]`
- `❌` → `[X]`
- `→` → `->`
- `—` → `-`
- `·` → `-`
