### PR TITLE
fix: add grammar to schema_validator skip directories

### DIFF
--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -111,7 +111,7 @@ def main():
     books_found = Counter()
 
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             total_files += 1
@@ -253,7 +253,7 @@ def main():
     valid_css = {'vhl-divine', 'vhl-place', 'vhl-person', 'vhl-time', 'vhl-key'}
     bad_css = set()
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             with open(json_file, encoding='utf-8') as f:
@@ -769,7 +769,7 @@ def main():
         tl_checked = 0
         tl_invalid = 0
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -873,7 +873,7 @@ def main():
 
     dup_count = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -910,7 +910,7 @@ def main():
 
     oob_tips = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -937,7 +937,7 @@ def main():
     if scopes_path_11.exists():
         scopes_data = json.loads(scopes_path_11.read_text(encoding='utf-8'))
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -968,7 +968,7 @@ def main():
 
     word_glosses = defaultdict(set)
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1012,7 +1012,7 @@ def main():
         }
         unregistered = []
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -1034,7 +1034,7 @@ def main():
 
     overlaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1064,7 +1064,7 @@ def main():
 
     gaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations'):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar'):
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:


### PR DESCRIPTION
The `content/grammar/` directory was being scanned as chapter files, causing validation to fail.