### PR TITLE
feat: migrate all images to expo-image with disk caching

### DIFF
--- a/app/src/components/ContentImageGallery.tsx
+++ b/app/src/components/ContentImageGallery.tsx
@@ -3,7 +3,7 @@
  *
  * Features:
  * - Snap-to-item horizontal scroll with page indicator dots
- * - Cached remote images via React Native Image
+ * - Cached remote images via expo-image with disk caching
  * - Loading skeleton per image
  * - Graceful fallback on load failure (hides broken image)
  * - Caption and credit text below each image
@@ -18,7 +18,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import {
   View,
-  Image,
   Text,
   ScrollView,
   Modal,
@@ -30,6 +29,7 @@ import {
   type NativeSyntheticEvent,
   type NativeScrollEvent,
 } from 'react-native';
+import { Image } from 'expo-image';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -111,7 +111,8 @@ function GalleryImageItem({ image, width, height, onPress }: ImageItemProps) {
           <Image
             source={{ uri: image.url, headers: IMAGE_HEADERS }}
             style={styles.image}
-            resizeMode="contain"
+            contentFit="contain"
+            cachePolicy="disk"
             onLoad={handleLoad}
             onError={handleError}
           />
@@ -241,7 +242,8 @@ function ZoomViewer({ image, visible, onClose }: ZoomViewerProps) {
               <Image
                 source={{ uri: image.url, headers: IMAGE_HEADERS }}
                 style={styles.zoomImage}
-                resizeMode="contain"
+                contentFit="contain"
+                cachePolicy="disk"
               />
             </Animated.View>
           </GestureDetector>

--- a/app/src/components/ContinueReadingHero.tsx
+++ b/app/src/components/ContinueReadingHero.tsx
@@ -106,6 +106,7 @@ export function ContinueReadingHero({ mostRecent, onPress }: Props) {
             source={{ uri: currentImage.url }}
             style={styles.image}
             contentFit="cover"
+            cachePolicy="disk"
             transition={500}
             onError={() => setFailedUrls((prev) => new Set(prev).add(currentImage.url))}
             recyclingKey={currentImage.url}

--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -104,6 +104,7 @@ export function FeatureCard({
               source={{ uri: currentImage.url }}
               style={styles.image}
               contentFit="cover"
+              cachePolicy="disk"
               transition={400}
               onError={() => setFailedUrls((prev) => new Set(prev).add(currentImage.url))}
               recyclingKey={currentImage.url}

--- a/app/src/components/RecommendedCard.tsx
+++ b/app/src/components/RecommendedCard.tsx
@@ -122,6 +122,7 @@ export function RecommendedCard({
               source={{ uri: currentImage.url }}
               style={styles.image}
               contentFit="cover"
+              cachePolicy="disk"
               transition={400}
               onError={() => setFailedUrls((prev) => new Set(prev).add(currentImage.url))}
               recyclingKey={currentImage.url}

--- a/app/src/components/RelatedContentCard.tsx
+++ b/app/src/components/RelatedContentCard.tsx
@@ -9,8 +9,9 @@
 
 import React, { useState } from 'react';
 import {
-  View, Text, TouchableOpacity, Image, StyleSheet,
+  View, Text, TouchableOpacity, StyleSheet,
 } from 'react-native';
+import { Image } from 'expo-image';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 
 export interface RelatedContentItem {
@@ -51,7 +52,8 @@ export function RelatedContentCard({ item, onPress }: Props) {
           source={{ uri: item.imageUrl! }}
           style={styles.image}
           onError={() => setImgError(true)}
-          resizeMode="cover"
+          contentFit="cover"
+          cachePolicy="disk"
         />
       ) : (
         <View style={[styles.image, { backgroundColor: item.color + '20' }]}>


### PR DESCRIPTION
Replace React Native Image with expo-image in ContentImageGallery and RelatedContentCard (the last two holdouts). Add cachePolicy="disk" to every expo-image instance across the codebase for persistent offline image storage.

Closes #1208

https://claude.ai/code/session_01A2XpUBqBakJSixWK1LGaiS