### PR TITLE
feat: add blanket image credit attribution to detail screens

### DIFF
--- a/app/src/components/ContentImageGallery.tsx
+++ b/app/src/components/ContentImageGallery.tsx
@@ -41,6 +41,7 @@ import {
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { ImageCredit } from './ImageCredit';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 const GALLERY_PADDING = spacing.md;
@@ -119,9 +120,7 @@ function GalleryImageItem({ image, width, height, onPress }: ImageItemProps) {
         {image.caption ? (
           <Text style={[styles.caption, { color: base.textDim }]}>{image.caption}</Text>
         ) : null}
-        {image.credit ? (
-          <Text style={[styles.credit, { color: base.textMuted }]}>{image.credit}</Text>
-        ) : null}
+        <ImageCredit credit={image.credit} />
       </View>
     </TouchableOpacity>
   );
@@ -247,16 +246,16 @@ function ZoomViewer({ image, visible, onClose }: ZoomViewerProps) {
           </GestureDetector>
 
           {/* Caption overlay */}
-          {image.caption ? (
-            <TouchableWithoutFeedback onPress={handleClose}>
-              <View style={styles.captionOverlay}>
+          <TouchableWithoutFeedback onPress={handleClose}>
+            <View style={styles.captionOverlay}>
+              {image.caption ? (
                 <Text style={styles.captionOverlayText}>{image.caption}</Text>
-                {image.credit ? (
-                  <Text style={styles.creditOverlayText}>{image.credit}</Text>
-                ) : null}
-              </View>
-            </TouchableWithoutFeedback>
-          ) : null}
+              ) : null}
+              <Text style={styles.creditOverlayText}>
+                Image: {image.credit || 'Public domain via Wikimedia Commons'}
+              </Text>
+            </View>
+          </TouchableWithoutFeedback>
         </View>
       </GestureHandlerRootView>
     </Modal>
@@ -384,11 +383,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 17,
     marginTop: spacing.xs,
-  },
-  credit: {
-    fontFamily: fontFamily.ui,
-    fontSize: 10,
-    marginTop: 2,
   },
   dotsRow: {
     flexDirection: 'row',

--- a/app/src/components/ImageCredit.tsx
+++ b/app/src/components/ImageCredit.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { useTheme, fontFamily } from '../theme';
+
+interface ImageCreditProps {
+  credit?: string | null;
+}
+
+const DEFAULT_CREDIT = 'Public domain via Wikimedia Commons';
+
+export function ImageCredit({ credit }: ImageCreditProps) {
+  const { base } = useTheme();
+  const displayText = credit || DEFAULT_CREDIT;
+
+  return (
+    <Text style={[styles.credit, { color: base.textMuted }]}>
+      Image: {displayText}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  credit: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    fontStyle: 'italic',
+    marginTop: 4,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
Create reusable ImageCredit component that displays per-image credit from the DB when available, falling back to "Public domain via Wikimedia Commons". Integrate it into ContentImageGallery so all 6 detail screens (Concept, WordStudy, Archaeology, Timeline, Scholar, Prophecy) automatically show credit lines below every image, including in the fullscreen zoom modal.

Closes #1209

https://claude.ai/code/session_01A2XpUBqBakJSixWK1LGaiS