### PR TITLE
Home screen: holiday overrides for verse + encouragement

### DIFF
--- a/app/__tests__/utils/computeMovableHolidays.test.ts
+++ b/app/__tests__/utils/computeMovableHolidays.test.ts
@@ -1,0 +1,54 @@
+import { computeMovableHolidays } from '../../src/utils/computeMovableHolidays';
+
+describe('computeMovableHolidays', () => {
+  it('computes correct Easter 2026 (April 5)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('04-05')).toBe('easter');
+  });
+
+  it('computes correct Good Friday 2026 (April 3)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('04-03')).toBe('good_friday');
+  });
+
+  it('computes correct Palm Sunday 2026 (March 29)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('03-29')).toBe('palm_sunday');
+  });
+
+  it('computes correct Ascension 2026 (May 14)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('05-14')).toBe('ascension');
+  });
+
+  it('computes correct Pentecost 2026 (May 24)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('05-24')).toBe('pentecost');
+  });
+
+  it('computes Thanksgiving 2026 (Nov 26)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('11-26')).toBe('thanksgiving');
+  });
+
+  it('computes Mothers Day 2026 (May 10)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('05-10')).toBe('mothers_day');
+  });
+
+  it('computes Fathers Day 2026 (June 21)', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.get('06-21')).toBe('fathers_day');
+  });
+
+  it('returns 8 movable holidays', () => {
+    const holidays = computeMovableHolidays(2026);
+    expect(holidays.size).toBe(8);
+  });
+
+  // Verify the algorithm works for a different year (Easter 2025 = April 20)
+  it('computes correct Easter 2025 (April 20)', () => {
+    const holidays = computeMovableHolidays(2025);
+    expect(holidays.get('04-20')).toBe('easter');
+  });
+});

--- a/app/src/data/holidayOverrides.ts
+++ b/app/src/data/holidayOverrides.ts
@@ -1,0 +1,151 @@
+/**
+ * holidayOverrides.ts — Special-day overrides for verse + encouragement.
+ *
+ * Two maps:
+ *   fixedHolidays  — keyed by 'MM-DD' (same date every year)
+ *   movableHolidays — keyed by holiday ID (dates computed at runtime)
+ *
+ * When today matches a holiday, both the verse of the day and the
+ * encouragement subtitle are replaced with the holiday-specific content.
+ */
+
+export interface HolidayContent {
+  name: string;
+  encouragement: string;
+  verse: {
+    ref: string;
+    bookId: string;
+    chapter: number;
+    text: string;
+  };
+}
+
+// ── Fixed holidays (same date every year) ─────────────────────────
+
+export const fixedHolidays: Record<string, HolidayContent> = {
+  '01-01': {
+    name: 'New Year\'s Day',
+    encouragement: 'A new year, a fresh page — His mercies begin again today',
+    verse: {
+      ref: 'Lamentations 3:22–23',
+      bookId: 'lamentations',
+      chapter: 3,
+      text: 'Because of the LORD\'s great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.',
+    },
+  },
+  '01-06': {
+    name: 'Epiphany',
+    encouragement: 'The light has come — and it shines for you',
+    verse: {
+      ref: 'Matthew 2:11',
+      bookId: 'matthew',
+      chapter: 2,
+      text: 'On coming to the house, they saw the child with his mother Mary, and they bowed down and worshiped him. Then they opened their treasures and presented him with gifts of gold, frankincense and myrrh.',
+    },
+  },
+  '10-31': {
+    name: 'Reformation Day',
+    encouragement: 'The righteous shall live by faith — sola fide',
+    verse: {
+      ref: 'Romans 1:17',
+      bookId: 'romans',
+      chapter: 1,
+      text: 'For in the gospel the righteousness of God is revealed — a righteousness that is by faith from first to last, just as it is written: "The righteous will live by faith."',
+    },
+  },
+  '12-25': {
+    name: 'Christmas',
+    encouragement: 'The Word became flesh and dwelt among us — Merry Christmas',
+    verse: {
+      ref: 'Luke 2:10–11',
+      bookId: 'luke',
+      chapter: 2,
+      text: 'But the angel said to them, "Do not be afraid. I bring you good news that will cause great joy for all the people. Today in the town of David a Savior has been born to you; he is the Messiah, the Lord."',
+    },
+  },
+};
+
+// ── Movable holidays (keyed by ID, dates computed at runtime) ─────
+
+export const movableHolidays: Record<string, HolidayContent> = {
+  palm_sunday: {
+    name: 'Palm Sunday',
+    encouragement: 'Blessed is He who comes in the name of the Lord',
+    verse: {
+      ref: 'Matthew 21:9',
+      bookId: 'matthew',
+      chapter: 21,
+      text: 'The crowds that went ahead of him and those that followed shouted, "Hosanna to the Son of David!" "Blessed is he who comes in the name of the Lord!" "Hosanna in the highest heaven!"',
+    },
+  },
+  good_friday: {
+    name: 'Good Friday',
+    encouragement: 'By His wounds, we are healed',
+    verse: {
+      ref: 'Isaiah 53:5',
+      bookId: 'isaiah',
+      chapter: 53,
+      text: 'But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.',
+    },
+  },
+  easter: {
+    name: 'Easter',
+    encouragement: 'He is risen — death has lost its sting',
+    verse: {
+      ref: '1 Corinthians 15:55–57',
+      bookId: '1_corinthians',
+      chapter: 15,
+      text: '"Where, O death, is your victory? Where, O death, is your sting?" The sting of death is sin, and the power of sin is the law. But thanks be to God! He gives us the victory through our Lord Jesus Christ.',
+    },
+  },
+  ascension: {
+    name: 'Ascension Day',
+    encouragement: 'He ascended far above all — and fills all things',
+    verse: {
+      ref: 'Acts 1:9–11',
+      bookId: 'acts',
+      chapter: 1,
+      text: 'After he said this, he was taken up before their very eyes, and a cloud hid him from their sight. They were looking intently up into the sky as he was going, when suddenly two men dressed in white stood beside them.',
+    },
+  },
+  pentecost: {
+    name: 'Pentecost',
+    encouragement: 'The Spirit was poured out — and still moves today',
+    verse: {
+      ref: 'Acts 2:4',
+      bookId: 'acts',
+      chapter: 2,
+      text: 'All of them were filled with the Holy Spirit and began to speak in other tongues as the Spirit enabled them.',
+    },
+  },
+  thanksgiving: {
+    name: 'Thanksgiving',
+    encouragement: 'Give thanks in all circumstances — this is God\'s will for you',
+    verse: {
+      ref: '1 Thessalonians 5:16–18',
+      bookId: '1_thessalonians',
+      chapter: 5,
+      text: 'Rejoice always, pray continually, give thanks in all circumstances; for this is God\'s will for you in Christ Jesus.',
+    },
+  },
+  mothers_day: {
+    name: 'Mother\'s Day',
+    encouragement: 'Her children rise up and call her blessed',
+    verse: {
+      ref: 'Proverbs 31:28–29',
+      bookId: 'proverbs',
+      chapter: 31,
+      text: 'Her children arise and call her blessed; her husband also, and he praises her: "Many women do noble things, but you surpass them all."',
+    },
+  },
+  fathers_day: {
+    name: 'Father\'s Day',
+    encouragement: 'A father\'s instruction is a fountain of life',
+    verse: {
+      ref: 'Proverbs 4:1–2',
+      bookId: 'proverbs',
+      chapter: 4,
+      text: 'Listen, my sons, to a father\'s instruction; pay attention and gain understanding. I give you sound learning, so do not forsake my teaching.',
+    },
+  },
+};

--- a/app/src/hooks/useHomeData.ts
+++ b/app/src/hooks/useHomeData.ts
@@ -11,7 +11,9 @@ import { getContentStats, type ContentStats } from '../db/content';
 import { getRecentChapters, getReadingStats, type ReadingStats } from '../db/user';
 import type { RecentChapter } from '../types';
 import { logger } from '../utils/logger';
+import { computeMovableHolidays } from '../utils/computeMovableHolidays';
 import dailyEncouragements from '../data/dailyEncouragements';
+import { fixedHolidays, movableHolidays, type HolidayContent } from '../data/holidayOverrides';
 
 // ── Verse of the Day ───────────────────────────────────────────────
 
@@ -67,7 +69,36 @@ function getDayOfYear(): number {
   return Math.floor(diff / (1000 * 60 * 60 * 24));
 }
 
+// ── Holiday detection ─────────────────────────────────────────────
+
+/** Cache movable holidays for the current year to avoid recomputing. */
+let _movableCache: { year: number; map: Map<string, string> } | null = null;
+
+function getTodayHoliday(): HolidayContent | null {
+  const now = new Date();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const key = `${mm}-${dd}`;
+
+  // Check fixed holidays first
+  if (fixedHolidays[key]) return fixedHolidays[key];
+
+  // Check movable holidays (compute once per year)
+  const year = now.getFullYear();
+  if (!_movableCache || _movableCache.year !== year) {
+    _movableCache = { year, map: computeMovableHolidays(year) };
+  }
+  const holidayId = _movableCache.map.get(key);
+  if (holidayId && movableHolidays[holidayId]) {
+    return movableHolidays[holidayId];
+  }
+
+  return null;
+}
+
 function getVerseOfDay(): VerseOfDay {
+  const holiday = getTodayHoliday();
+  if (holiday) return holiday.verse;
   return FEATURED_VERSES[getDayOfYear() % FEATURED_VERSES.length];
 }
 
@@ -86,6 +117,8 @@ function getSubtitle(readingStats: ReadingStats | null): string {
   if (!readingStats || readingStats.totalChapters === 0) {
     return 'Learn to read the Bible the way it was written';
   }
+  const holiday = getTodayHoliday();
+  if (holiday) return holiday.encouragement;
   return dailyEncouragements[getDayOfYear() % dailyEncouragements.length];
 }
 

--- a/app/src/utils/computeMovableHolidays.ts
+++ b/app/src/utils/computeMovableHolidays.ts
@@ -1,0 +1,82 @@
+/**
+ * computeMovableHolidays.ts — Compute dates for holidays that shift each year.
+ *
+ * Returns a Map<string, string> keyed by 'MM-DD' → holiday ID.
+ * Called once per app launch with the current year.
+ */
+
+/**
+ * Anonymous Gregorian Easter algorithm (Meeus/Jones/Butcher).
+ * Returns the Date of Easter Sunday for the given year.
+ */
+function getEasterDate(year: number): Date {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31); // 3 = March, 4 = April
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(year, month - 1, day);
+}
+
+/** Shift a date by N days (positive = forward, negative = backward). */
+function offsetDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+/**
+ * Nth weekday of a month (e.g., 4th Thursday of November).
+ * @param year  Calendar year
+ * @param month 0-indexed month (0 = Jan, 10 = Nov)
+ * @param weekday 0 = Sunday, 4 = Thursday, etc.
+ * @param n Which occurrence (1-based)
+ */
+function nthWeekdayOfMonth(year: number, month: number, weekday: number, n: number): Date {
+  const first = new Date(year, month, 1);
+  const firstWeekday = first.getDay();
+  const day = 1 + ((weekday - firstWeekday + 7) % 7) + (n - 1) * 7;
+  return new Date(year, month, day);
+}
+
+/** Format a Date as 'MM-DD'. */
+function toKey(date: Date): string {
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${mm}-${dd}`;
+}
+
+/**
+ * Build a map of movable holiday dates for the given year.
+ * Keys are 'MM-DD', values are holiday IDs matching holidayOverrides.
+ */
+export function computeMovableHolidays(year: number): Map<string, string> {
+  const easter = getEasterDate(year);
+  const map = new Map<string, string>();
+
+  map.set(toKey(offsetDays(easter, -7)),  'palm_sunday');
+  map.set(toKey(offsetDays(easter, -2)),  'good_friday');
+  map.set(toKey(easter),                  'easter');
+  map.set(toKey(offsetDays(easter, 39)),  'ascension');
+  map.set(toKey(offsetDays(easter, 49)),  'pentecost');
+
+  // Thanksgiving: 4th Thursday of November
+  map.set(toKey(nthWeekdayOfMonth(year, 10, 4, 4)), 'thanksgiving');
+
+  // Mother's Day: 2nd Sunday of May
+  map.set(toKey(nthWeekdayOfMonth(year, 4, 0, 2)), 'mothers_day');
+
+  // Father's Day: 3rd Sunday of June
+  map.set(toKey(nthWeekdayOfMonth(year, 5, 0, 3)), 'fathers_day');
+
+  return map;
+}


### PR DESCRIPTION
Adds holiday-aware overrides so both the verse of the day and the encouragement subtitle show curated content on special days.

**12 holidays total:**
- Fixed (4): New Year, Epiphany, Reformation Day, Christmas
- Movable (8): Palm Sunday, Good Friday, Easter, Ascension, Pentecost, Thanksgiving, Mother's Day, Father's Day

Easter computed via the Anonymous Gregorian algorithm. Movable dates cached per year. Holiday check runs before the daily rotation fallback. First-launch onboarding copy unaffected.

Lives in JS bundle — updateable via `eas update`. Adding a new holiday is one entry in `holidayOverrides.ts`.