### PR TITLE
Fix 4 explore screen bugs (Periods, Story, Timeline, People)

### DIFF
--- a/app/src/hooks/useExploreImages.ts
+++ b/app/src/hooks/useExploreImages.ts
@@ -20,7 +20,7 @@ import rawManifest from '../../assets/explore-images.json';
 // ── Deep-link resolver: content_type + content_id → screen + params ──
 
 const CONTENT_TYPE_TO_SCREEN: Record<string, { screen: string; paramKey: string }> = {
-  people: { screen: 'PersonDetail', paramKey: 'personId' },
+  people: { screen: 'GenealogyTree', paramKey: 'personId' },
   timeline: { screen: 'Timeline', paramKey: 'eventId' },
   map_story: { screen: 'Map', paramKey: 'storyId' },
   concept: { screen: 'ConceptDetail', paramKey: 'conceptId' },

--- a/app/src/hooks/useRedemptiveArc.ts
+++ b/app/src/hooks/useRedemptiveArc.ts
@@ -10,7 +10,7 @@ export interface ParsedRedemptiveAct {
   name: string;
   tagline: string | null;
   summary: string | null;
-  key_verse: string | null;
+  key_verse: { ref: string; text: string } | null;
   era_ids: string[];
   book_range: string | null;
   threads: string[];
@@ -20,6 +20,7 @@ export interface ParsedRedemptiveAct {
 function parseAct(row: RedemptiveAct): ParsedRedemptiveAct {
   return {
     ...row,
+    key_verse: safeParse<{ ref: string; text: string } | null>(row.key_verse, null, 'useRedemptiveArc.key_verse'),
     era_ids: safeParse<string[]>(row.era_ids, [], 'useRedemptiveArc.era_ids'),
     threads: safeParse<string[]>(row.threads, [], 'useRedemptiveArc.threads'),
     prophecy_chains: safeParse<string[]>(row.prophecy_chains, [], 'useRedemptiveArc.chains'),

--- a/app/src/screens/PeriodsScreen.tsx
+++ b/app/src/screens/PeriodsScreen.tsx
@@ -122,86 +122,88 @@ function EraCard({ era, isLast, nextEra, base, onPersonPress, onBookPress }: Era
   const accentColor = era.hex ?? base.gold;
 
   return (
-    <View style={styles.eraCardWrapper}>
-      {/* Timeline dot + line */}
-      <View style={styles.timelineTrack}>
-        <View style={[styles.timelineDot, { backgroundColor: accentColor }]} />
-        {!isLast && <View style={[styles.timelineLine, { backgroundColor: base.border }]} />}
-      </View>
+    <>
+      <View style={styles.eraCardWrapper}>
+        {/* Timeline dot + line */}
+        <View style={styles.timelineTrack}>
+          <View style={[styles.timelineDot, { backgroundColor: accentColor }]} />
+          {!isLast && <View style={[styles.timelineLine, { backgroundColor: base.border }]} />}
+        </View>
 
-      {/* Card body */}
-      <View style={[styles.eraCard, { backgroundColor: base.bgElevated, borderColor: accentColor + '40' }]}>
-        {/* Header: name + date range + pill */}
-        <View style={styles.eraHeader}>
-          <View style={styles.eraHeaderLeft}>
-            <Text style={[styles.eraName, { color: base.text }]}>{era.name}</Text>
-            <Text style={[styles.eraRange, { color: base.textDim }]}>
-              {formatYear(era.range_start)} – {formatYear(era.range_end)}
-            </Text>
+        {/* Card body */}
+        <View style={[styles.eraCard, { backgroundColor: base.bgElevated, borderColor: accentColor + '40' }]}>
+          {/* Header: name + date range + pill */}
+          <View style={styles.eraHeader}>
+            <View style={styles.eraHeaderLeft}>
+              <Text style={[styles.eraName, { color: base.text }]}>{era.name}</Text>
+              <Text style={[styles.eraRange, { color: base.textDim }]}>
+                {formatYear(era.range_start)} – {formatYear(era.range_end)}
+              </Text>
+            </View>
+            {era.pill && (
+              <View style={[styles.eraPill, { backgroundColor: accentColor + '25' }]}>
+                <Text style={[styles.eraPillText, { color: accentColor }]}>{era.pill}</Text>
+              </View>
+            )}
           </View>
-          {era.pill && (
-            <View style={[styles.eraPill, { backgroundColor: accentColor + '25' }]}>
-              <Text style={[styles.eraPillText, { color: accentColor }]}>{era.pill}</Text>
+
+          {/* Summary */}
+          {era.summary && (
+            <Text style={[styles.eraSummary, { color: base.textDim }]}>{era.summary}</Text>
+          )}
+
+          {/* Key People */}
+          {era.key_people.length > 0 && (
+            <View style={styles.eraRow}>
+              <Text style={[styles.eraRowLabel, { color: base.gold }]}>KEY PEOPLE</Text>
+              <View style={styles.chipRow}>
+                {era.key_people.map((pid) => (
+                  <TouchableOpacity
+                    key={pid}
+                    onPress={() => onPersonPress(pid)}
+                    style={[styles.personChip, { backgroundColor: base.gold + '15' }]}
+                    accessibilityRole="button"
+                  >
+                    <Text style={[styles.personChipText, { color: base.gold }]}>
+                      {pid.replace(/_/g, ' ')}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {/* Books */}
+          {era.books.length > 0 && (
+            <View style={styles.eraRow}>
+              <Text style={[styles.eraRowLabel, { color: base.gold }]}>BOOKS</Text>
+              <View style={styles.chipRow}>
+                {era.books.map((bk) => (
+                  <TouchableOpacity
+                    key={bk}
+                    onPress={() => onBookPress(bk)}
+                    style={[styles.bookChip, { backgroundColor: base.bgSurface ?? base.bg }]}
+                    accessibilityRole="button"
+                  >
+                    <Text style={[styles.bookChipText, { color: base.text }]}>
+                      {bk.replace(/_/g, ' ')}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {/* Geographic region */}
+          {era.geographic_center && (
+            <View style={styles.eraRow}>
+              <BadgeChip label={era.geographic_center} color={base.textDim} />
             </View>
           )}
         </View>
-
-        {/* Summary */}
-        {era.summary && (
-          <Text style={[styles.eraSummary, { color: base.textDim }]}>{era.summary}</Text>
-        )}
-
-        {/* Key People */}
-        {era.key_people.length > 0 && (
-          <View style={styles.eraRow}>
-            <Text style={[styles.eraRowLabel, { color: base.gold }]}>KEY PEOPLE</Text>
-            <View style={styles.chipRow}>
-              {era.key_people.map((pid) => (
-                <TouchableOpacity
-                  key={pid}
-                  onPress={() => onPersonPress(pid)}
-                  style={[styles.personChip, { backgroundColor: base.gold + '15' }]}
-                  accessibilityRole="button"
-                >
-                  <Text style={[styles.personChipText, { color: base.gold }]}>
-                    {pid.replace(/_/g, ' ')}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-          </View>
-        )}
-
-        {/* Books */}
-        {era.books.length > 0 && (
-          <View style={styles.eraRow}>
-            <Text style={[styles.eraRowLabel, { color: base.gold }]}>BOOKS</Text>
-            <View style={styles.chipRow}>
-              {era.books.map((bk) => (
-                <TouchableOpacity
-                  key={bk}
-                  onPress={() => onBookPress(bk)}
-                  style={[styles.bookChip, { backgroundColor: base.bgSurface ?? base.bg }]}
-                  accessibilityRole="button"
-                >
-                  <Text style={[styles.bookChipText, { color: base.text }]}>
-                    {bk.replace(/_/g, ' ')}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-          </View>
-        )}
-
-        {/* Geographic region */}
-        {era.geographic_center && (
-          <View style={styles.eraRow}>
-            <BadgeChip label={era.geographic_center} color={base.textDim} />
-          </View>
-        )}
       </View>
 
-      {/* Transition arrow to next era */}
+      {/* Transition arrow to next era — outside the row for proper flow */}
       {!isLast && era.transition_to_next && nextEra && (
         <View style={[styles.transitionBlock, { borderColor: base.border }]}>
           <Text style={[styles.transitionText, { color: base.textMuted }]}>
@@ -209,7 +211,7 @@ function EraCard({ era, isLast, nextEra, base, onPersonPress, onBookPress }: Era
           </Text>
         </View>
       )}
-    </View>
+    </>
   );
 }
 
@@ -327,14 +329,13 @@ const styles = StyleSheet.create({
   },
   /* Transition arrow */
   transitionBlock: {
-    position: 'absolute',
-    left: 36,
-    right: 0,
-    bottom: -2,
+    marginLeft: 36,
     borderTopWidth: 1,
     borderStyle: 'dashed',
     paddingTop: spacing.xs,
     paddingLeft: spacing.sm,
+    paddingBottom: spacing.sm,
+    marginBottom: spacing.xs,
   },
   transitionText: {
     fontFamily: fontFamily.bodyItalic,

--- a/app/src/screens/RedemptiveArcScreen.tsx
+++ b/app/src/screens/RedemptiveArcScreen.tsx
@@ -83,7 +83,8 @@ function RedemptiveArcScreen() {
             {/* Key verse */}
             {act.key_verse && (
               <View style={[styles.keyVerseRow, { borderColor: base.gold + '20' }]}>
-                <Text style={[styles.keyVerseText, { color: base.text }]}>{act.key_verse}</Text>
+                <Text style={[styles.keyVerseText, { color: base.text }]}>{act.key_verse.text}</Text>
+                <Text style={[styles.keyVerseRef, { color: base.goldDim }]}>{act.key_verse.ref}</Text>
               </View>
             )}
 
@@ -217,6 +218,11 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.bodyItalic ?? fontFamily.body,
     fontSize: 13,
     lineHeight: 20,
+  },
+  keyVerseRef: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    marginTop: 3,
   },
   metaRow: {
     flexDirection: 'row',

--- a/app/src/screens/TimelineScreen.tsx
+++ b/app/src/screens/TimelineScreen.tsx
@@ -144,9 +144,16 @@ function TimelineScreen() {
         e.id === `evt_${initialEventId}` ||
         e.id === `bk_${initialEventId}`
       );
-      if (evt) handleSelectEvent(evt);
+      if (evt) {
+        // Scroll to centre the event horizontally
+        const scrollTarget = Math.max(0, evt.x - screenWidth / 2);
+        setTimeout(() => {
+          timelineScrollRef.current?.scrollTo({ x: scrollTarget, animated: true });
+        }, 100);
+        handleSelectEvent(evt);
+      }
     }
-  }, [initialEventId, positioned.length, handleSelectEvent]);
+  }, [initialEventId, positioned.length, handleSelectEvent, screenWidth]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
**Bug 1 — Periods: jumbled transition text**
Transition text used `position: absolute` inside a flex row, causing overlap with the next card. Moved outside the row wrapper into normal vertical flow with proper margin.

**Bug 2 — Story of the Bible: raw JSON in key_verse**
`key_verse` stored as JSON (`{"ref":"...","text":"..."}`) but `parseAct()` didn't deserialize it. Added `safeParse`, updated the type, and render text + ref attribution separately.

**Bug 3 — Timeline: deep link didn't scroll to event**
`handleSelectEvent` opened the bottom sheet but left the timeline at scroll position 0. Added `scrollTo` centering on the event's x coordinate.

**Bug 4 — People carousel: wrong navigation target**
Image tap navigated to `PersonDetail` directly on the Explore screen. Changed deep link to `GenealogyTree` which already handles `personId` with auto-centre + bio open. Closing the bio leaves the user on the tree focused on that person.