### PR TITLE
Add life topics: Same-Sex Marriage + LGBTQ+ and the Bible

### DIFF
--- a/content/life_topics/topics/lgbtq_and_the_bible.json
+++ b/content/life_topics/topics/lgbtq_and_the_bible.json
@@ -1,0 +1,85 @@
+{
+  "id": "lgbtq_and_the_bible",
+  "category_id": "identity",
+  "title": "LGBTQ+ and the Bible",
+  "subtitle": "What the Bible Says About Sexual Orientation and Gender Identity",
+  "summary": "Scripture distinguishes between the experience of temptation and the act of sin, offering hope for those who experience same-sex attraction or gender dysphoria while calling all believers to align their identity and behavior with God's created design.",
+  "body": "The modern categories of sexual orientation and gender identity did not exist in the ancient world, but Scripture addresses the underlying realities. The Bible's teaching unfolds in three movements: creation design, the recognition of brokenness, and the call to faithfulness.\n\nGenesis establishes that God created humanity male and female, and that this sexual differentiation is intentional, not incidental [verse:gen.1.27]. The body is not a prison or a mistake but a gift that reflects God's purposes. When David writes that he was 'fearfully and wonderfully made,' he is affirming that his embodied existence — including his biological sex — is the product of divine craftsmanship [verse:ps.139.13-14].\n\nThe experience of same-sex attraction is not itself condemned in Scripture. The Bible distinguishes between temptation and sin — Jesus himself was tempted in every way yet did not sin [verse:heb.4.15]. What Scripture prohibits is acting on desires that fall outside God's design for sexual expression, which is exclusively within heterosexual marriage. This applies equally to heterosexual lust, fornication, and adultery. The standard is high for everyone.\n\nPaul's words in 1 Corinthians 6 are often quoted for their prohibition, but the passage does not end there. 'And that is what some of you were. But you were washed, you were sanctified, you were justified in the name of the Lord Jesus Christ' [verse:1cor.6.11]. The early church included people whose past involved same-sex behavior — and they were welcomed into new identity in Christ.\n\nOn gender, Scripture offers no support for the idea that one's internal sense of gender can override biological sex. The prohibition against cross-dressing in Deuteronomy 22:5 reflects a broader principle: the intentional blurring of male-female distinctions dishonors the Creator's design [verse:deut.22.5]. Paul's teaching that the body is a temple of the Holy Spirit reinforces that we are stewards, not owners, of our physical selves [verse:1cor.6.19-20].\n\nNone of this means the church should be hostile to those who experience same-sex attraction or gender dysphoria. These are real struggles, often accompanied by deep pain. The call is not to deny the struggle but to find identity in Christ rather than in sexuality or gender — and to pursue faithfulness within the boundaries God has set, trusting that his design is good even when it is costly.",
+  "display_order": 2,
+  "verses": [
+    {
+      "verse_ref": "gen.1.27",
+      "verse_order": 1,
+      "annotation": "God creates humanity male and female — sexual differentiation as intentional design.",
+      "is_primary": true
+    },
+    {
+      "verse_ref": "ps.139.13-14",
+      "verse_order": 2,
+      "annotation": "The body as fearfully and wonderfully made — embodied existence is a divine gift, not an accident.",
+      "is_primary": true
+    },
+    {
+      "verse_ref": "heb.4.15",
+      "verse_order": 3,
+      "annotation": "Jesus was tempted in every way yet without sin — temptation itself is not sin.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "1cor.6.11",
+      "verse_order": 4,
+      "annotation": "Past behavior does not define present identity: 'that is what some of you were.'",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "deut.22.5",
+      "verse_order": 5,
+      "annotation": "The prohibition against cross-dressing reflects the principle of honoring created sexual distinctions.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "1cor.6.19-20",
+      "verse_order": 6,
+      "annotation": "The body as temple — we are stewards, not owners, of our physical selves.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "2cor.5.17",
+      "verse_order": 7,
+      "annotation": "In Christ, the old has gone and the new has come — identity transformation is possible.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "matt.16.24",
+      "verse_order": 8,
+      "annotation": "Following Jesus requires self-denial and cross-bearing — discipleship costs everyone something.",
+      "is_primary": false
+    }
+  ],
+  "scholars": [
+    {
+      "scholar_id": "schreiner",
+      "quote": "Schreiner emphasizes that the New Testament's sexual ethic is grounded in creation, not culture. Paul's appeals to 'nature' in Romans 1 echo Genesis 1-2, meaning the prohibitions are not arbitrary rules but flow from God's design for human flourishing.",
+      "source": "Romans (Schreiner, BECNT, 1998)",
+      "display_order": 1
+    },
+    {
+      "scholar_id": "fee",
+      "quote": "Fee observes that Paul's 'and such were some of you' in 1 Corinthians 6:11 indicates the early church included converts whose past involved the behaviors listed — including same-sex activity. The grammar emphasizes decisive break: not 'you are improving' but 'you were washed.'",
+      "source": "The First Epistle to the Corinthians (Fee, NICNT, 1987)",
+      "display_order": 2
+    },
+    {
+      "scholar_id": "keener",
+      "quote": "Keener notes that Jesus' call to take up one's cross daily (Luke 9:23) was not metaphorical to first-century hearers — it meant real suffering and self-denial. Following Christ has always required surrendering personal desires to God's will, whatever form that takes.",
+      "source": "A Commentary on the Gospel of Matthew (Keener, 1999)",
+      "display_order": 3
+    }
+  ],
+  "related": [
+    "same_sex_marriage",
+    "identity_in_christ",
+    "sexual_temptation",
+    "self_acceptance"
+  ]
+}

--- a/content/life_topics/topics/same_sex_marriage.json
+++ b/content/life_topics/topics/same_sex_marriage.json
@@ -1,0 +1,79 @@
+{
+  "id": "same_sex_marriage",
+  "category_id": "relationships",
+  "title": "Same-Sex Marriage",
+  "subtitle": "What the Bible Says About Same-Sex Marriage",
+  "summary": "Scripture consistently presents marriage as a covenant union between one man and one woman, rooted in creation's design and reaffirmed by Jesus himself as the exclusive context for sexual union.",
+  "body": "The biblical teaching on marriage begins not with prohibitions but with design. Genesis presents God creating humanity as male and female, then declaring that a man will leave his parents and be united to his wife, becoming one flesh [verse:gen.2.24]. This anatomical and relational complementarity is not incidental — it is presented as the foundation of marriage itself.\n\nWhen Jesus was asked about divorce, he did not simply cite the Law but reached back to creation. He quoted Genesis directly: 'Have you not read that from the beginning the Creator made them male and female?' [verse:matt.19.4-6]. For Jesus, the male-female structure of marriage was not a cultural accommodation but an original design that human traditions should not override.\n\nThe Levitical code explicitly prohibits same-sex sexual activity, calling it an abomination in the context of holiness laws that set Israel apart [verse:lev.18.22]. Some argue these laws are obsolete, but the New Testament reaffirms the sexual ethic while setting aside ceremonial requirements. Paul addresses same-sex relations directly in Romans 1, describing them as 'contrary to nature' — language that echoes the creation order rather than mere cultural convention [verse:rom.1.26-27].\n\nPaul's vice list in 1 Corinthians includes the Greek term arsenokoitai, a compound word he likely coined from the Septuagint's rendering of Leviticus 18 and 20 [verse:1cor.6.9-10]. The term refers to men who engage in sexual activity with other men. Significantly, the passage does not end with condemnation but with redemption: 'And that is what some of you were. But you were washed, you were sanctified' [verse:1cor.6.11].\n\nThe consistent biblical witness — from Genesis through the Gospels to Paul — presents marriage as a male-female covenant. This is not arbitrary restriction but purposeful design, meant to reflect something larger than human preference.",
+  "display_order": 3,
+  "verses": [
+    {
+      "verse_ref": "gen.2.24",
+      "verse_order": 1,
+      "annotation": "The foundational definition: a man leaves his parents and is united to his wife, becoming one flesh.",
+      "is_primary": true
+    },
+    {
+      "verse_ref": "matt.19.4-6",
+      "verse_order": 2,
+      "annotation": "Jesus grounds marriage in creation's male-female design, not cultural convention.",
+      "is_primary": true
+    },
+    {
+      "verse_ref": "lev.18.22",
+      "verse_order": 3,
+      "annotation": "The Levitical prohibition on same-sex sexual activity within the holiness code.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "rom.1.26-27",
+      "verse_order": 4,
+      "annotation": "Paul describes same-sex relations as 'contrary to nature,' echoing creation order.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "1cor.6.9-11",
+      "verse_order": 5,
+      "annotation": "Vice list including arsenokoitai, followed immediately by the hope of redemption.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "gen.1.27",
+      "verse_order": 6,
+      "annotation": "God created humanity male and female — sexual differentiation as part of the original design.",
+      "is_primary": false
+    },
+    {
+      "verse_ref": "eph.5.31-32",
+      "verse_order": 7,
+      "annotation": "Paul reveals that marriage images Christ and the church — a mystery requiring the male-female structure.",
+      "is_primary": false
+    }
+  ],
+  "scholars": [
+    {
+      "scholar_id": "moo",
+      "quote": "Moo argues that Paul's language in Romans 1:26-27 is grounded in creation theology, not cultural convention. The phrase 'contrary to nature' (para physin) refers to the created order established in Genesis, making the prohibition transcultural rather than situational.",
+      "source": "The Epistle to the Romans (Moo, NICNT, 1996)",
+      "display_order": 1
+    },
+    {
+      "scholar_id": "fee",
+      "quote": "Fee explains that arsenokoitai in 1 Corinthians 6:9 is almost certainly a Pauline coinage derived from Leviticus 18:22 and 20:13 in the Septuagint, where 'lying with a male' (arsenos koiten) is prohibited. The term refers to the active partner in male same-sex intercourse.",
+      "source": "The First Epistle to the Corinthians (Fee, NICNT, 1987)",
+      "display_order": 2
+    },
+    {
+      "scholar_id": "keener",
+      "quote": "Keener notes that Jesus' appeal to Genesis 1-2 in Matthew 19 was not merely about divorce but about the essential nature of marriage itself. By grounding his teaching in creation rather than Mosaic concession, Jesus established male-female union as the normative and permanent structure.",
+      "source": "A Commentary on the Gospel of Matthew (Keener, 1999)",
+      "display_order": 3
+    }
+  ],
+  "related": [
+    "marriage",
+    "lgbtq_and_the_bible",
+    "sexual_temptation",
+    "singleness"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds two new life topics covering sexuality and identity from a traditional biblical perspective with pastoral nuance.

## New Topics

### 1. Same-Sex Marriage (`relationships` category)
- **Focus**: What Scripture says about marriage as male-female union
- **Key passages**: Gen 2:24, Matt 19:4-6, Lev 18:22, Rom 1:26-27, 1 Cor 6:9-11
- **Scholars**: Moo (Romans), Fee (1 Corinthians), Keener (Matthew)
- **Tone**: Traditional apologetic — presents historic Christian position with scholarly depth

### 2. LGBTQ+ and the Bible (`identity` category)
- **Focus**: Orientation vs. behavior distinction; gender identity; identity in Christ
- **Key passages**: Gen 1:27, Ps 139:13-14, Heb 4:15, 1 Cor 6:11, Deut 22:5
- **Scholars**: Schreiner (Romans), Fee (1 Corinthians), Keener (Matthew)
- **Tone**: Pastoral — acknowledges real struggles while upholding biblical sexual ethic

## Changes
- `content/life_topics/topics/same_sex_marriage.json` (new)
- `content/life_topics/topics/lgbtq_and_the_bible.json` (new)
- `scripture.db` rebuilt

## Validation
- Schema validation: ✅
- SQLite build: ✅
- SQLite validation: ✅ (83 passed, 0 failed)

Total life topics: 69 → 71
