### PR TITLE
Fix flaky PersonDetailScreen test

### DIFF
--- a/app/__tests__/screens/PersonDetailScreen.test.tsx
+++ b/app/__tests__/screens/PersonDetailScreen.test.tsx
@@ -3,6 +3,14 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
 import PersonDetailScreen from '@/screens/PersonDetailScreen';
 
+// ── Modal mock (renders children inline so testing-library can query them) ──
+jest.mock('react-native/Libraries/Modal/Modal', () => {
+  const { createElement } = require('react');
+  const { View } = jest.requireActual('react-native');
+  const MockModal = (props: any) => props.visible ? createElement(View, null, props.children) : null;
+  return { __esModule: true, default: MockModal };
+});
+
 // ── Navigation mocks ────────────────────────────────────────
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -76,8 +84,8 @@ beforeEach(() => {
 
 describe('PersonDetailScreen', () => {
   it('renders person bio via PersonSidebar', async () => {
-    const { findByText } = renderWithProviders(<PersonDetailScreen />);
-    expect(await findByText('Abraham')).toBeTruthy();
+    const { getByText } = renderWithProviders(<PersonDetailScreen />);
+    await waitFor(() => expect(getByText('Abraham')).toBeTruthy(), { timeout: 3000 });
   });
 
   it('displays person role', async () => {


### PR DESCRIPTION
Two issues:
1. React Native `Modal` renders in a portal that testing-library can't query into. Added a mock that renders children inline when `visible=true`.
2. The first test used `findByText` which timed out before the `getPerson` mock resolved and triggered the state update. Switched to `waitFor` + `getByText` with a 3s timeout.

All 5 tests pass reliably now.