### PR TITLE
Fix R2 sync check on Windows

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -50,7 +50,9 @@ if [ -f "$ROOT/scripture.db" ]; then
       || echo "$MANIFEST_JSON" | python -c "import sys,json; print(json.load(sys.stdin).get('full_db_sha256',''))" 2>/dev/null)
     if [ -n "$REMOTE_SHA" ]; then
       LOCAL_SHA=$(sha256sum "$ROOT/scripture.db" 2>/dev/null | cut -d' ' -f1 \
-        || shasum -a 256 "$ROOT/scripture.db" 2>/dev/null | cut -d' ' -f1)
+        || shasum -a 256 "$ROOT/scripture.db" 2>/dev/null | cut -d' ' -f1 \
+        || python3 -c "import hashlib;print(hashlib.sha256(open('$ROOT/scripture.db','rb').read()).hexdigest())" 2>/dev/null \
+        || python -c "import hashlib;print(hashlib.sha256(open('$ROOT/scripture.db','rb').read()).hexdigest())" 2>/dev/null)
       if [ -n "$LOCAL_SHA" ] && [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
         echo ""
         echo "⚠️  R2 is out of sync with local DB"


### PR DESCRIPTION
## Problem
The R2 out-of-sync warning in `dev.sh` was silently failing on Windows because neither `sha256sum` nor `shasum` exist in MINGW64/Git Bash.

## Fix
Added Python fallback for SHA256 calculation, which works cross-platform:
```bash
LOCAL_SHA=$(sha256sum ... || shasum ... || python3 -c "import hashlib;..." || python -c "import hashlib;...")
```

## Result
After this fix, running `./dev.sh` on Windows will properly show:
```
⚠️  R2 is out of sync with local DB
   Local:  99087a364aa44781...
   Remote: d2cae990e63694d9...
   Run:    python _tools/upload_to_r2.py
```
