### PR TITLE
Fix ContentUpdater to use content_hash key in db_meta

### DIFF
--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -118,7 +118,7 @@ class ContentUpdaterService {
   }
 
   /**
-   * Read the installed DB version from the db_meta table.
+   * Read the installed DB content hash from the db_meta table.
    * Returns null if the table doesn't exist or the DB isn't present.
    */
   async getInstalledVersion(): Promise<string | null> {
@@ -126,7 +126,7 @@ class ContentUpdaterService {
     try {
       tempDb = await SQLite.openDatabaseAsync('scripture.db');
       const row = await tempDb.getFirstAsync<{ value: string }>(
-        "SELECT value FROM db_meta WHERE key = 'version'",
+        "SELECT value FROM db_meta WHERE key = 'content_hash'",
       );
       return row?.value ?? null;
     } catch {
@@ -186,9 +186,9 @@ class ContentUpdaterService {
         await updateDb.execAsync('BEGIN TRANSACTION');
         await updateDb.execAsync(sql);
 
-        // Update version in db_meta
+        // Update content_hash in db_meta
         await updateDb.runAsync(
-          "INSERT OR REPLACE INTO db_meta (key, value) VALUES ('version', ?)",
+          "INSERT OR REPLACE INTO db_meta (key, value) VALUES ('content_hash', ?)",
           delta.to_version,
         );
         await updateDb.execAsync('COMMIT');
@@ -262,16 +262,16 @@ class ContentUpdaterService {
       await FileSystem.deleteAsync(DB_PATH, { idempotent: true });
       await FileSystem.moveAsync({ from: tempPath, to: DB_PATH });
 
-      // Verify the new DB can be opened and has the expected version
+      // Verify the new DB can be opened and has the expected content_hash
       let verifyDb: SQLite.SQLiteDatabase | null = null;
       try {
         verifyDb = await SQLite.openDatabaseAsync('scripture.db');
         const row = await verifyDb.getFirstAsync<{ value: string }>(
-          "SELECT value FROM db_meta WHERE key = 'version'",
+          "SELECT value FROM db_meta WHERE key = 'content_hash'",
         );
         if (row?.value !== manifest.current_version) {
           throw new Error(
-            `Version mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
+            `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
         }
       } catch (err) {


### PR DESCRIPTION
## Problem

ContentUpdater.ts was still querying db_meta for `key = 'version'` but the content-hash versioning refactor changed this to `key = 'content_hash'`.

This caused `getInstalledVersion()` to return `null`, which made the app think no version was installed and triggered an unnecessary R2 download every time.

## Fix

Updated three locations in ContentUpdater.ts:
- `getInstalledVersion()`: query for `content_hash`
- `applyDelta()`: write `content_hash` key
- `downloadFullDb()`: verify `content_hash` key

## After merge

```bash
git pull origin master
./dev.sh --rebuild
python _tools/upload_to_r2.py
```

Then restart the app — the ContentUpdater should see matching hashes and skip the download.
