### PR TITLE
Remove @sentry/react-native/expo plugin until SDK is installed

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -57,8 +57,7 @@
         }
       ],
       "expo-asset",
-      "expo-sqlite",
-      "@sentry/react-native/expo"
+      "expo-sqlite"
     ],
     "updates": {
       "url": "https://u.expo.dev/105f31ba-3cfb-4d35-8509-4abbe6ab132d",


### PR DESCRIPTION
The Expo plugin requires the native module to be installed. Since Craig will install the SDK later (phase-14), the plugin crashes Expo Go with "Failed to resolve plugin". The sentry.ts init is already a no-op without a DSN, so the plugin isn't needed yet.

https://claude.ai/code/session_014TyV9xtSj7zJtjwmPYLUpB