### PR TITLE
Defer @sentry/react-native to runtime require — remove from dependencies

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -185,7 +185,7 @@ function App() {
   );
 }
 
-export default DSN ? Sentry.wrap(App) : App;
+export default DSN && Sentry ? Sentry.wrap(App) : App;
 
 const appStyles = StyleSheet.create({
   splashContainer: {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,7 +15,6 @@
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.2.10",
-        "@sentry/react-native": "^6.5.0",
         "d3-hierarchy": "^3.1.2",
         "expo": "^54.0.0",
         "expo-asset": "~12.0.12",
@@ -3859,324 +3858,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.0.tgz",
-      "integrity": "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.0.tgz",
-      "integrity": "sha512-cP3BD/Q6pquVQ+YL+rwCnorKuTXiS9KXW8HNKu4nmmBAyf7urjs+F6Hr1k9MXP5yQ8W3yK7jRWd09Yu6DHWOiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.0.tgz",
-      "integrity": "sha512-roCDEGkORwolxBn8xAKedybY+Jlefq3xYmgN2fr3BTnsXjSYOPC7D1/mYqINBat99nDtvgFvNfRcZPiwwZ1hSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.0.tgz",
-      "integrity": "sha512-nIkfgRWk1091zHdu4NbocQsxZF1rv1f7bbp3tTIlZYbrH62XVZosx5iHAuZG0Zc48AETLE7K4AX9VGjvQj8i9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.2.0.tgz",
-      "integrity": "sha512-GFpS3REqaHuyX4LCNqlneAQZIKyHb5ePiI1802n0fhtYjk68I1DTQ3PnbzYi50od/vAsTQVCknaS5F6tidNqTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.0.tgz",
-      "integrity": "sha512-1A31mCEWCjaMxJt6qGUK+aDnLDcK6AwLAZnqpSchNysGni1pSn1RWSmk9TBF8qyTds5FH8B31H480uxMPUJ7Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry-internal/feedback": "8.55.0",
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry-internal/replay-canvas": "8.55.0",
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/cli": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.53.0.tgz",
-      "integrity": "sha512-n2ZNb+5Z6AZKQSI0SusQ7ZzFL637mfw3Xh4C3PEyVSn9LiF683fX0TTq8OeGmNZQS4maYfS95IFD+XpydU0dEA==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@sentry/cli-darwin": "2.53.0",
-        "@sentry/cli-linux-arm": "2.53.0",
-        "@sentry/cli-linux-arm64": "2.53.0",
-        "@sentry/cli-linux-i686": "2.53.0",
-        "@sentry/cli-linux-x64": "2.53.0",
-        "@sentry/cli-win32-arm64": "2.53.0",
-        "@sentry/cli-win32-i686": "2.53.0",
-        "@sentry/cli-win32-x64": "2.53.0"
-      }
-    },
-    "node_modules/@sentry/cli-darwin": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.53.0.tgz",
-      "integrity": "sha512-NNPfpILMwKgpHiyJubHHuauMKltkrgLQ5tvMdxNpxY60jBNdo5VJtpESp4XmXlnidzV4j1z61V4ozU6ttDgt5Q==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.53.0.tgz",
-      "integrity": "sha512-NdRzQ15Ht83qG0/Lyu11ciy/Hu/oXbbtJUgwzACc7bWvHQA8xEwTsehWexqn1529Kfc5EjuZ0Wmj3MHmp+jOWw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.53.0.tgz",
-      "integrity": "sha512-xY/CZ1dVazsSCvTXzKpAgXaRqfljVfdrFaYZRUaRPf1ZJRGa3dcrivoOhSIeG/p5NdYtMvslMPY9Gm2MT0M83A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.53.0.tgz",
-      "integrity": "sha512-0REmBibGAB4jtqt9S6JEsFF4QybzcXHPcHtJjgMi5T0ueh952uG9wLzjSxQErCsxTKF+fL8oG0Oz5yKBuCwCCQ==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.53.0.tgz",
-      "integrity": "sha512-9UGJL+Vy5N/YL1EWPZ/dyXLkShlNaDNrzxx4G7mTS9ywjg+BIuemo6rnN7w43K1NOjObTVO6zY0FwumJ1pCyLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.53.0.tgz",
-      "integrity": "sha512-G1kjOjrjMBY20rQcJV2GA8KQE74ufmROCDb2GXYRfjvb1fKAsm4Oh8N5+Tqi7xEHdjQoLPkE4CNW0aH68JSUDQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.53.0.tgz",
-      "integrity": "sha512-qbGTZUzesuUaPtY9rPXdNfwLqOZKXrJRC1zUFn52hdo6B+Dmv0m/AHwRVFHZP53Tg1NCa8bDei2K/uzRN0dUZw==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.53.0.tgz",
-      "integrity": "sha512-1TXYxYHtwgUq5KAJt3erRzzUtPqg7BlH9T7MdSPHjJatkrr/kwZqnVe2H6Arr/5NH891vOlIeSPHBdgJUAD69g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
-      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/react": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.0.tgz",
-      "integrity": "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "8.55.0",
-        "@sentry/core": "8.55.0",
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "node_modules/@sentry/react-native": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-6.22.0.tgz",
-      "integrity": "sha512-Xt8ZuYa7YsMTG7hFU8awfNpVWijH6kWdyqykML6qVohBmP2OS57oSAd4fAdCmbtaIbHs8Drux+uPtb/SdOy2Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "4.2.0",
-        "@sentry/browser": "8.55.0",
-        "@sentry/cli": "2.53.0",
-        "@sentry/core": "8.55.0",
-        "@sentry/react": "8.55.0",
-        "@sentry/types": "8.55.0",
-        "@sentry/utils": "8.55.0"
-      },
-      "bin": {
-        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
-      },
-      "peerDependencies": {
-        "expo": ">=49.0.0",
-        "react": ">=17.0.0",
-        "react-native": ">=0.65.0"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.55.0.tgz",
-      "integrity": "sha512-6LRT0+r6NWQ+RtllrUW2yQfodST0cJnkOmdpHA75vONgBUhpKwiJ4H7AmgfoTET8w29pU6AnntaGOe0LJbOmog==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.55.0.tgz",
-      "integrity": "sha512-cYcl39+xcOivBpN9d8ZKbALl+DxZKo/8H0nueJZ0PO4JA+MJGhSm6oHakXxLPaiMoNLTX7yor8ndnQIuFg+vmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.55.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -4918,6 +4599,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -8731,6 +8413,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -11708,26 +11391,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -12565,12 +12228,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -14473,12 +14130,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -14907,12 +14558,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -14941,16 +14586,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/whatwg-url-without-unicode": {

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,6 @@
     "@expo-google-fonts/eb-garamond": "^0.2.3",
     "@expo-google-fonts/source-sans-3": "^0.2.3",
     "@gorhom/bottom-sheet": "^5.1.1",
-    "@sentry/react-native": "^6.5.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.2.10",

--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -1,14 +1,35 @@
-import * as Sentry from '@sentry/react-native';
+/**
+ * lib/sentry.ts — Crash reporting via Sentry (conditional).
+ *
+ * The @sentry/react-native package is NOT installed until Craig creates
+ * the Sentry project and runs `npx expo install @sentry/react-native`.
+ * All access is deferred via try/require so the app works without it.
+ */
 import Constants from 'expo-constants';
 
 const DSN = Constants.expoConfig?.extra?.sentryDsn as string | undefined;
 
-if (DSN) {
-  Sentry.init({
-    dsn: DSN,
-    enableAutoSessionTracking: true,
-    tracesSampleRate: 0.2,
-  });
+// Lazy-load Sentry — returns a no-op stub if the package isn't installed or no DSN
+let _sentry: {
+  init: (opts: Record<string, unknown>) => void;
+  wrap: <T>(component: T) => T;
+  captureException: (err: unknown) => void;
+  captureMessage: (msg: string, level?: string) => void;
+  setUser: (user: { id: string } | null) => void;
+} | null = null;
+
+try {
+  if (DSN) {
+    _sentry = require('@sentry/react-native');
+    _sentry!.init({
+      dsn: DSN,
+      enableAutoSessionTracking: true,
+      tracesSampleRate: 0.2,
+    });
+  }
+} catch {
+  // @sentry/react-native not installed — Sentry disabled
 }
 
-export { Sentry, DSN };
+export const Sentry = _sentry;
+export { DSN };

--- a/app/src/stores/authStore.ts
+++ b/app/src/stores/authStore.ts
@@ -138,7 +138,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       const supabase = getAuth().getSupabase();
       if (supabase) await supabase.auth.signOut();
       await clearAuthProfile();
-      if (DSN) Sentry.setUser(null);
+      if (DSN && Sentry) Sentry.setUser(null);
       set({ user: null });
     } catch (err) {
       logger.error('authStore', 'Sign out failed', err);
@@ -163,7 +163,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
 /** Sync Supabase user info to local SQLite profile + Sentry context. */
 async function syncProfile(user: AuthUser) {
-  if (DSN) Sentry.setUser({ id: user.id });
+  if (DSN && Sentry) Sentry.setUser({ id: user.id });
   try {
     await upsertAuthProfile(
       user.id,

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -20,7 +20,7 @@ export const logger = {
   /** Recoverable issue — always logged. */
   warn(tag: string, msg: string, data?: unknown): void {
     console.warn(`[${tag}] ${msg}`, data ?? '');
-    if (DSN) {
+    if (DSN && Sentry) {
       Sentry.captureMessage(`[${tag}] ${msg}`, 'warning');
     }
   },
@@ -28,7 +28,7 @@ export const logger = {
   /** Unrecoverable error — always logged. */
   error(tag: string, msg: string, err?: unknown): void {
     console.error(`[${tag}] ${msg}`, err ?? '');
-    if (DSN) {
+    if (DSN && Sentry) {
       Sentry.captureException(err instanceof Error ? err : new Error(`[${tag}] ${msg}`));
     }
   },


### PR DESCRIPTION
Metro/Expo crash if @sentry/react-native is in package.json but not installed. Since Craig will install the SDK later, remove the dep and use a try/require pattern in sentry.ts so the app runs without it.

- Remove @sentry/react-native from package.json and lock file
- Convert sentry.ts to lazy require with try/catch fallback
- Add null guards (DSN && Sentry) in logger.ts, authStore.ts, App.tsx

https://claude.ai/code/session_014TyV9xtSj7zJtjwmPYLUpB