### PR TITLE
Fix Metro bundler failing to resolve optional @sentry/react-native

### DIFF
--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -20,7 +20,9 @@ let _sentry: {
 
 try {
   if (DSN) {
-    _sentry = require('@sentry/react-native');
+    // Indirect require so Metro doesn't resolve the module at bundle time
+    const pkg = '@sentry/react-native';
+    _sentry = require(pkg);
     _sentry!.init({
       dsn: DSN,
       enableAutoSessionTracking: true,


### PR DESCRIPTION
Use indirect require via a variable so Metro's static analysis doesn't try to resolve the module at bundle time. The package was intentionally removed from dependencies — the try/catch already handles the missing-module case at runtime.

https://claude.ai/code/session_015ATyueVtKmWGMpSVakYhYL