### PR TITLE
Remove offline connectivity banner

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -15,9 +15,7 @@ import { useSettingsStore, useAuthStore, usePremiumStore } from './src/stores';
 import { pruneEvents } from './src/services/analytics';
 import { checkAndScheduleReengagement } from './src/services/reengagement';
 import { syncPremiumStatus } from './src/services/purchases';
-import { startMonitoring } from './src/services/connectivity';
 import { flushQueue } from './src/services/syncQueue';
-import ConnectivityBanner from './src/components/ConnectivityBanner';
 import { RootNavigator } from './src/navigation';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
@@ -106,7 +104,6 @@ function AppShell() {
           <RootNavigator />
         </ErrorBoundary>
       </NavigationContainer>
-      <ConnectivityBanner />
       <StatusBar style={statusBarStyle === 'light-content' ? 'light' : 'dark'} />
     </>
   );
@@ -127,7 +124,6 @@ function App() {
         await useAuthStore.getState().hydrate();
         await usePremiumStore.getState().hydrate();
         pruneEvents(90); // Clean up old analytics (fire-and-forget)
-        startMonitoring(); // Begin network connectivity monitoring
       } catch (e) {
         console.error('Init error:', e);
       } finally {


### PR DESCRIPTION
## Summary
Removes the "You're offline" banner that was showing incorrectly even when connected.

## Problem
The connectivity service used a polling fallback (pinging `clients3.google.com`) which can fail on certain networks (firewalls, DNS issues, corporate networks) even when the device is actually online. This caused the offline banner to appear incorrectly.

## Solution
Remove the banner entirely. The offline sync queue (`flushQueue`) is still triggered when the app comes to foreground via `AppState`, so offline mutations will still sync when the user returns to the app.

## Changes
- Removed `ConnectivityBanner` import and render from `App.tsx`
- Removed `startMonitoring()` call from app initialization

## Future Consideration
If we want to bring back offline indication, consider:
1. Making it dismissible
2. Using a more reliable detection method (NetInfo in dev builds works fine)
3. Making it opt-in via settings
