### PR TITLE
Make dev.sh work for first-time setup and fix setup.js timestamps

### DIFF
--- a/app/scripts/setup.js
+++ b/app/scripts/setup.js
@@ -22,23 +22,45 @@ const DST = path.resolve(__dirname, '..', 'assets', 'scripture.db');
 const BUILD_SCRIPT = path.join(ROOT, '_tools', 'build_sqlite.py');
 
 /**
- * Check if any file under `dir` is newer than `refPath`.
- * Returns true if the DB should be rebuilt.
+ * Compute content hash from source files (same algorithm as build_sqlite.py).
+ * Returns null on failure.
  */
-function hasNewerContent(dir, refPath) {
-  const refMtime = fs.statSync(refPath).mtimeMs;
+function computeContentHash() {
   try {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (hasNewerContent(full, refPath)) return true;
-      } else {
-        if (fs.statSync(full).mtimeMs > refMtime) return true;
-      }
-    }
-  } catch { /* dir doesn't exist — not stale */ }
-  return false;
+    const result = execSync(`python3 -c "
+import hashlib
+from pathlib import Path
+content_dir = Path('content')
+json_files = sorted(content_dir.rglob('*.json'))
+json_files = [f for f in json_files if 'verses' not in f.parts]
+h = hashlib.sha256()
+for f in json_files:
+    h.update(str(f.relative_to(content_dir)).encode())
+    h.update(f.read_bytes())
+print(h.hexdigest()[:16])
+"`, { cwd: ROOT, encoding: 'utf8' }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the content hash from the DB's db_meta table. Returns null on failure.
+ */
+function getDbHash() {
+  try {
+    const result = execSync(`python3 -c "
+import sqlite3
+db = sqlite3.connect('scripture.db')
+row = db.execute(\\"SELECT value FROM db_meta WHERE key='content_hash'\\").fetchone()
+print(row[0] if row else '')
+db.close()
+"`, { cwd: ROOT, encoding: 'utf8' }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
 }
 
 function buildDb() {
@@ -54,16 +76,17 @@ function buildDb() {
   }
 }
 
-// Build DB if it doesn't exist
+// Build DB if it doesn't exist or content has changed
 if (!fs.existsSync(SRC)) {
   console.log('📦 scripture.db not found — building from content...');
   buildDb();
-} else if (
-  hasNewerContent(path.join(ROOT, 'content'), SRC) ||
-  fs.statSync(path.join(ROOT, '_tools', 'build_sqlite.py')).mtimeMs > fs.statSync(SRC).mtimeMs
-) {
-  console.log('📦 Content changed since last build — rebuilding scripture.db...');
-  buildDb();
+} else {
+  const contentHash = computeContentHash();
+  const dbHash = getDbHash();
+  if (contentHash && contentHash !== dbHash) {
+    console.log(`📦 Content changed (${dbHash || 'none'} → ${contentHash}) — rebuilding scripture.db...`);
+    buildDb();
+  }
 }
 
 if (!fs.existsSync(SRC)) {

--- a/dev.sh
+++ b/dev.sh
@@ -57,12 +57,17 @@ fi
 
 if [ "$NEED_BUILD" = true ]; then
   echo "📦 Building scripture.db..."
-  python3 "$ROOT/_tools/build_sqlite.py" 2>/dev/null \
+  python3 "$ROOT/_tools/build_sqlite.py" \
     || python "$ROOT/_tools/build_sqlite.py"
   # Re-read hash after build
   DB_HASH=$CONTENT_HASH
 else
   echo "✓  scripture.db is up to date ($DB_HASH)"
+  # Ensure the asset copy exists even when build is skipped
+  if [ ! -f "$ROOT/app/assets/scripture.db" ]; then
+    cp "$ROOT/scripture.db" "$ROOT/app/assets/scripture.db"
+    echo "✓  Copied scripture.db → app/assets/"
+  fi
 fi
 
 # ── 2b. Check if R2 manifest is in sync with local DB ──────────
@@ -86,8 +91,15 @@ if [ -n "$DB_HASH" ]; then
   fi
 fi
 
-# ── 3. Launch Expo ──────────────────────────────────────────────
+# ── 3. Install dependencies if needed ──────────────────────────
 cd "$ROOT/app"
+
+if [ ! -d "node_modules" ]; then
+  echo "📥 Installing dependencies..."
+  npm install
+fi
+
+# ── 4. Launch Expo ──────────────────────────────────────────────
 
 EXPO_ARGS=""
 if [[ "$*" == *"--clear"* ]]; then


### PR DESCRIPTION
dev.sh:
- Add npm install step when node_modules is missing
- Ensure app/assets/scripture.db exists even when build is skipped
- Remove 2>/dev/null from build_sqlite.py call so build output is visible

setup.js:
- Replace timestamp-based hasNewerContent check with content hash comparison (same algorithm as dev.sh and build_sqlite.py). File timestamps are unreliable after git clone/pull.

https://claude.ai/code/session_015ATyueVtKmWGMpSVakYhYL