### PR TITLE
feat: universal search with reference parsing

### DIFF
--- a/app/__tests__/hooks/useSearch.test.ts
+++ b/app/__tests__/hooks/useSearch.test.ts
@@ -1,22 +1,45 @@
-import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 
 const mockSearchVerses = jest.fn().mockResolvedValue([]);
 const mockSearchPeople = jest.fn().mockResolvedValue([]);
-const mockGetAllWordStudies = jest.fn().mockResolvedValue([]);
-const mockSearchDiscoveries = jest.fn().mockResolvedValue([]);
+const mockGetLiveBooks = jest.fn().mockResolvedValue([]);
+const mockGetAllConcepts = jest.fn().mockResolvedValue([]);
+const mockGetMapStories = jest.fn().mockResolvedValue([]);
+const mockGetAllTimelineEntries = jest.fn().mockResolvedValue([]);
+const mockGetAllDifficultPassages = jest.fn().mockResolvedValue([]);
+const mockSearchLifeTopics = jest.fn().mockResolvedValue([]);
 
 jest.mock('@/db/content', () => ({
   searchVerses: (...args: any[]) => mockSearchVerses(...args),
   searchPeople: (...args: any[]) => mockSearchPeople(...args),
-  getAllWordStudies: (...args: any[]) => mockGetAllWordStudies(...args),
-  searchDiscoveries: (...args: any[]) => mockSearchDiscoveries(...args),
+  getLiveBooks: (...args: any[]) => mockGetLiveBooks(...args),
+  getAllConcepts: (...args: any[]) => mockGetAllConcepts(...args),
+  getMapStories: (...args: any[]) => mockGetMapStories(...args),
+  getAllTimelineEntries: (...args: any[]) => mockGetAllTimelineEntries(...args),
+  getAllDifficultPassages: (...args: any[]) => mockGetAllDifficultPassages(...args),
+  searchLifeTopics: (...args: any[]) => mockSearchLifeTopics(...args),
+}));
+
+jest.mock('@/utils/verseResolver', () => ({
+  getBookByName: (name: string) => {
+    const books: Record<string, any> = {
+      genesis: { id: 'genesis', name: 'Genesis', short: 'Gen', chapters: 50, testament: 'ot', aliases: [] },
+      gen: { id: 'genesis', name: 'Genesis', short: 'Gen', chapters: 50, testament: 'ot', aliases: [] },
+      romans: { id: 'romans', name: 'Romans', short: 'Rom', chapters: 16, testament: 'nt', aliases: [] },
+      rom: { id: 'romans', name: 'Romans', short: 'Rom', chapters: 16, testament: 'nt', aliases: [] },
+      psalms: { id: 'psalms', name: 'Psalms', short: 'Ps', chapters: 150, testament: 'ot', aliases: [] },
+      psalm: { id: 'psalms', name: 'Psalms', short: 'Ps', chapters: 150, testament: 'ot', aliases: [] },
+    };
+    return books[name.toLowerCase().trim()] ?? null;
+  },
 }));
 
 jest.mock('@/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
-import { useSearch } from '@/hooks/useSearch';
+import { useSearch, buildOrderedGroups } from '@/hooks/useSearch';
+import type { UniversalSearchResults } from '@/hooks/useSearch';
 
 describe('useSearch', () => {
   beforeEach(() => {
@@ -24,18 +47,21 @@ describe('useSearch', () => {
     jest.clearAllMocks();
     mockSearchVerses.mockResolvedValue([]);
     mockSearchPeople.mockResolvedValue([]);
-    mockGetAllWordStudies.mockResolvedValue([]);
-    mockSearchDiscoveries.mockResolvedValue([]);
+    mockGetLiveBooks.mockResolvedValue([]);
+    mockGetAllConcepts.mockResolvedValue([]);
+    mockGetMapStories.mockResolvedValue([]);
+    mockGetAllTimelineEntries.mockResolvedValue([]);
+    mockGetAllDifficultPassages.mockResolvedValue([]);
+    mockSearchLifeTopics.mockResolvedValue([]);
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
+  afterEach(() => jest.useRealTimers());
 
   it('returns empty results for short query', () => {
     const { result } = renderHook(() => useSearch('a'));
     expect(result.current.results.verses).toEqual([]);
     expect(result.current.results.people).toEqual([]);
+    expect(result.current.results.reference).toBeNull();
     expect(result.current.isLoading).toBe(false);
   });
 
@@ -56,7 +82,6 @@ describe('useSearch', () => {
       ({ q }: { q: string }) => useSearch(q),
       { initialProps: { q: 'creation' } },
     );
-
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -65,18 +90,53 @@ describe('useSearch', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('passes testament filter to searchVerses', async () => {
-    const { result } = renderHook(() => useSearch('love', 'nt'));
+  it('parses "Gen 3:15" as a reference', async () => {
+    const { result } = renderHook(() => useSearch('Gen 3:15'));
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockSearchVerses).toHaveBeenCalledWith('love', 20, 'nt', undefined);
+
+    expect(result.current.results.reference).not.toBeNull();
+    expect(result.current.results.reference!.bookId).toBe('genesis');
+    expect(result.current.results.reference!.chapter).toBe(3);
+    expect(result.current.results.reference!.verse).toBe(15);
+    expect(result.current.results.reference!.display).toBe('Genesis 3:15');
   });
 
-  it('passes bookId filter to searchVerses', async () => {
-    const { result } = renderHook(() => useSearch('love', null, 'genesis'));
+  it('parses chapter-only reference "Psalm 23"', async () => {
+    const { result } = renderHook(() => useSearch('Psalm 23'));
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockSearchVerses).toHaveBeenCalledWith('love', 20, null, 'genesis');
+
+    expect(result.current.results.reference).not.toBeNull();
+    expect(result.current.results.reference!.bookId).toBe('psalms');
+    expect(result.current.results.reference!.chapter).toBe(23);
+    expect(result.current.results.reference!.verse).toBeUndefined();
+  });
+
+  it('parses lowercase reference "romans 8"', async () => {
+    const { result } = renderHook(() => useSearch('romans 8'));
+    jest.advanceTimersByTime(350);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.results.reference).not.toBeNull();
+    expect(result.current.results.reference!.bookId).toBe('romans');
+    expect(result.current.results.reference!.chapter).toBe(8);
+  });
+
+  it('returns null reference for invalid chapter', async () => {
+    const { result } = renderHook(() => useSearch('Gen 999'));
+    jest.advanceTimersByTime(350);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.results.reference).toBeNull();
+  });
+
+  it('returns null reference for non-reference text', async () => {
+    const { result } = renderHook(() => useSearch('love'));
+    jest.advanceTimersByTime(350);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.results.reference).toBeNull();
   });
 
   it('sorts people by relevance — exact match first', async () => {
@@ -92,49 +152,55 @@ describe('useSearch', () => {
     expect(result.current.results.people[0].name).toBe('adam');
   });
 
-  it('filters word studies from cache', async () => {
-    mockGetAllWordStudies.mockResolvedValue([
-      { id: 'charis', transliteration: 'charis', original: 'χάρις' },
-      { id: 'agape', transliteration: 'agape', original: 'ἀγάπη' },
+  it('filters books from cache by name', async () => {
+    mockGetLiveBooks.mockResolvedValue([
+      { id: 'genesis', name: 'Genesis', testament: 'ot', total_chapters: 50 },
+      { id: 'exodus', name: 'Exodus', testament: 'ot', total_chapters: 40 },
     ]);
 
-    const { result } = renderHook(() => useSearch('charis'));
+    const { result } = renderHook(() => useSearch('genesis'));
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.results.wordStudies).toHaveLength(1);
-    expect(result.current.results.wordStudies[0].id).toBe('charis');
+    expect(result.current.results.books).toHaveLength(1);
+    expect(result.current.results.books[0].name).toBe('Genesis');
   });
 
-  it('reuses word study cache on subsequent searches', async () => {
-    mockGetAllWordStudies.mockResolvedValue([
-      { id: 'charis', transliteration: 'charis', original: 'χάρις' },
+  it('filters concepts by name', async () => {
+    mockGetAllConcepts.mockResolvedValue([
+      { id: 'covenant', name: 'Covenant', description: 'Divine agreement' },
+      { id: 'atonement', name: 'Atonement', description: 'Covering for sin' },
     ]);
+
+    const { result } = renderHook(() => useSearch('covenant'));
+    jest.advanceTimersByTime(350);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.results.concepts).toHaveLength(1);
+    expect(result.current.results.concepts[0].name).toBe('Covenant');
+  });
+
+  it('reuses static caches on subsequent searches', async () => {
+    mockGetLiveBooks.mockResolvedValue([]);
+    mockGetAllConcepts.mockResolvedValue([]);
+    mockGetMapStories.mockResolvedValue([]);
+    mockGetAllTimelineEntries.mockResolvedValue([]);
+    mockGetAllDifficultPassages.mockResolvedValue([]);
 
     const { result, rerender } = renderHook(
       ({ q }: { q: string }) => useSearch(q),
-      { initialProps: { q: 'charis' } },
+      { initialProps: { q: 'first' } },
     );
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // Second search should reuse cache
-    rerender({ q: 'agape' });
+    rerender({ q: 'second' });
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // getAllWordStudies should only be called once
-    expect(mockGetAllWordStudies).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns discoveries in results', async () => {
-    mockSearchDiscoveries.mockResolvedValue([{ id: 'dss', title: 'Dead Sea Scrolls' }]);
-
-    const { result } = renderHook(() => useSearch('Dead Sea'));
-    jest.advanceTimersByTime(350);
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    expect(result.current.results.discoveries).toHaveLength(1);
+    // Static cache loaders should only be called once
+    expect(mockGetLiveBooks).toHaveBeenCalledTimes(1);
+    expect(mockGetAllConcepts).toHaveBeenCalledTimes(1);
   });
 
   it('handles search errors gracefully', async () => {
@@ -144,7 +210,6 @@ describe('useSearch', () => {
     jest.advanceTimersByTime(350);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // Should return empty results, not throw
     expect(result.current.results.verses).toEqual([]);
   });
 
@@ -154,20 +219,41 @@ describe('useSearch', () => {
       { initialProps: { q: 'genesis' } },
     );
 
-    // Before debounce fires, change query
     jest.advanceTimersByTime(100);
     rerender({ q: 'exodus' });
     jest.advanceTimersByTime(350);
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    // searchVerses should have been called with 'exodus', not 'genesis'
-    expect(mockSearchVerses).toHaveBeenCalledWith('exodus', 20, undefined, undefined);
+    expect(mockSearchVerses).toHaveBeenCalledWith('exodus', 50);
+  });
+});
+
+describe('buildOrderedGroups', () => {
+  const base: UniversalSearchResults = {
+    reference: null,
+    verses: [], people: [], books: [], concepts: [],
+    mapStories: [], timelineEvents: [], lifeTopics: [], difficultPassages: [],
+  };
+
+  it('returns empty array when no results', () => {
+    expect(buildOrderedGroups(base, 'test')).toEqual([]);
   });
 
-  it('trims whitespace from query', async () => {
-    const { result } = renderHook(() => useSearch('  love  '));
-    jest.advanceTimersByTime(350);
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockSearchVerses).toHaveBeenCalledWith('love', 20, undefined, undefined);
+  it('puts exact name match group first', () => {
+    const results: UniversalSearchResults = {
+      ...base,
+      people: [{ name: 'Moses' } as any],
+      books: [{ name: 'Exodus' } as any],
+      concepts: [{ name: 'Moses' } as any], // not the query
+    };
+    const groups = buildOrderedGroups(results, 'Moses');
+    expect(groups[0].key).toBe('people');
+  });
+
+  it('skips empty groups', () => {
+    const results: UniversalSearchResults = { ...base, books: [{ name: 'Genesis' } as any] };
+    const groups = buildOrderedGroups(results, 'gen');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('books');
   });
 });

--- a/app/__tests__/screens/SearchScreen.test.tsx
+++ b/app/__tests__/screens/SearchScreen.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent } from '@testing-library/react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
 import SearchScreen from '@/screens/SearchScreen';
 
-// ── Navigation mock ───────────────────────────────────────────────
-
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
@@ -21,15 +19,24 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
-// ── Hooks ─────────────────────────────────────────────────────────
-
 const mockSearchResults = {
-  results: { people: [] as any[], wordStudies: [] as any[], verses: [] as any[], discoveries: [] as any[] },
+  results: {
+    reference: null as any,
+    people: [] as any[],
+    verses: [] as any[],
+    books: [] as any[],
+    concepts: [] as any[],
+    mapStories: [] as any[],
+    timelineEvents: [] as any[],
+    lifeTopics: [] as any[],
+    difficultPassages: [] as any[],
+  },
   isLoading: false,
 };
 
 jest.mock('@/hooks/useSearch', () => ({
   useSearch: () => mockSearchResults,
+  buildOrderedGroups: jest.fn().mockReturnValue([]),
 }));
 
 jest.mock('@/components/SearchInput', () => ({
@@ -45,16 +52,14 @@ jest.mock('@/components/SearchInput', () => ({
   },
 }));
 
-jest.mock('@/components/SearchFilterChips', () => ({
-  SearchFilterChips: () => null,
-}));
-
-// ── Tests ─────────────────────────────────────────────────────────
-
 describe('SearchScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSearchResults.results = { people: [], wordStudies: [], verses: [], discoveries: [] };
+    mockSearchResults.results = {
+      reference: null,
+      people: [], verses: [], books: [], concepts: [],
+      mapStories: [], timelineEvents: [], lifeTopics: [], difficultPassages: [],
+    };
     mockSearchResults.isLoading = false;
   });
 
@@ -70,57 +75,25 @@ describe('SearchScreen', () => {
 
   it('shows idle state message when no query entered', () => {
     const { getByText } = renderWithProviders(<SearchScreen />);
-    expect(getByText('Search verses, people, evidence, and more')).toBeTruthy();
+    expect(getByText('Search books, people, concepts, verses, and more')).toBeTruthy();
   });
 
-  it('shows search input with correct placeholder', () => {
+  it('shows reference-aware placeholder', () => {
     const { getByPlaceholderText } = renderWithProviders(<SearchScreen />);
-    expect(getByPlaceholderText('Search verses, people, evidence...')).toBeTruthy();
-  });
-
-  it('renders results sections when people data is available', () => {
-    mockSearchResults.results = {
-      people: [{ id: 'moses', name: 'Moses', role: 'Prophet', era: 'exodus' }],
-      wordStudies: [],
-      verses: [],
-      discoveries: [],
-    };
-    // The SectionList needs a query with length >= 2 to render,
-    // but since useSearch is mocked, the results will be available.
-    // The component checks trimmed.length < 2 internally from its own state.
-    const { toJSON } = renderWithProviders(<SearchScreen />);
-    expect(toJSON()).toBeTruthy();
-  });
-
-  it('renders results sections when verse data is available', () => {
-    mockSearchResults.results = {
-      people: [],
-      wordStudies: [],
-      verses: [
-        { id: 1, book_id: 'genesis', chapter_num: 1, verse_num: 1, text: 'In the beginning', book_name: 'Genesis' },
-      ],
-      discoveries: [],
-    };
-    const { toJSON } = renderWithProviders(<SearchScreen />);
-    expect(toJSON()).toBeTruthy();
-  });
-
-  it('renders results sections when word studies data is available', () => {
-    mockSearchResults.results = {
-      people: [],
-      wordStudies: [{ id: 'w1', original: '\u05D7\u05B6\u05E1\u05B6\u05D3', transliteration: 'chesed' }],
-      verses: [],
-      discoveries: [],
-    };
-    const { toJSON } = renderWithProviders(<SearchScreen />);
-    expect(toJSON()).toBeTruthy();
+    expect(getByPlaceholderText(/reference like Gen 3:15/)).toBeTruthy();
   });
 
   it('updates query when user types in search input', () => {
     const { getByTestId } = renderWithProviders(<SearchScreen />);
     const input = getByTestId('search-input');
     fireEvent.changeText(input, 'love');
-    // No crash, query state updated internally
     expect(input).toBeTruthy();
+  });
+
+  it('renders without filter chips (removed)', () => {
+    const { queryByText } = renderWithProviders(<SearchScreen />);
+    // The old All/OT/NT filter buttons should not exist
+    expect(queryByText('OT')).toBeNull();
+    expect(queryByText('NT')).toBeNull();
   });
 });

--- a/app/src/hooks/useSearch.ts
+++ b/app/src/hooks/useSearch.ts
@@ -1,36 +1,198 @@
 /**
- * hooks/useSearch.ts — Combined search across verses, people, and word studies.
- * Debounced at 300ms to avoid hammering FTS on every keystroke.
+ * hooks/useSearch.ts — Universal search across all content types.
+ * Debounced at 300ms. Searches verses, people, books, concepts,
+ * map stories, timeline events, life topics, and difficult passages.
+ *
+ * Includes reference parsing: typing "Gen 3:15" or "Romans 8" produces
+ * a direct-navigation result at the top of the list.
+ *
+ * Results are grouped by type. Groups are ordered by relevance:
+ * groups with direct name/title matches rank highest.
  */
 
 import { useState, useEffect, useRef } from 'react';
-import { searchVerses, searchPeople, getAllWordStudies, searchDiscoveries } from '../db/content';
-import type { Verse, Person, WordStudy, ArchaeologicalDiscovery } from '../types';
+import {
+  searchVerses, searchPeople, getLiveBooks, getAllConcepts,
+  getMapStories, getAllTimelineEntries, getAllDifficultPassages,
+  searchLifeTopics,
+} from '../db/content';
+import { getBookByName } from '../utils/verseResolver';
+import type { Verse, Person, Book, MapStory, TimelineEntry, DifficultPassage, Concept, LifeTopic } from '../types';
 import { logger } from '../utils/logger';
 
-interface SearchResults {
-  verses: Verse[];
-  people: Person[];
-  wordStudies: WordStudy[];
-  discoveries: ArchaeologicalDiscovery[];
+// ── Result types ────────────────────────────────────────────────────
+
+export interface ParsedReference {
+  bookId: string;
+  bookName: string;
+  chapter: number;
+  verse?: number;
+  display: string; // e.g. "Genesis 3:15"
 }
 
-export function useSearch(
+export interface UniversalSearchResults {
+  reference: ParsedReference | null;
+  verses: Verse[];
+  people: Person[];
+  books: Book[];
+  concepts: Concept[];
+  mapStories: MapStory[];
+  timelineEvents: TimelineEntry[];
+  lifeTopics: LifeTopic[];
+  difficultPassages: DifficultPassage[];
+}
+
+const EMPTY: UniversalSearchResults = {
+  reference: null,
+  verses: [], people: [], books: [], concepts: [],
+  mapStories: [], timelineEvents: [], lifeTopics: [], difficultPassages: [],
+};
+
+// ── Reference parsing ───────────────────────────────────────────────
+
+/**
+ * Parse a search query as a scripture reference.
+ * Case-insensitive. Handles: "Gen 3", "genesis 3:15", "1 Cor 13", "Psalm 23:1"
+ */
+const REF_INPUT_PATTERN = /^(\d?\s*[A-Za-z][A-Za-z .]+?)\s+(\d+)(?::(\d+))?$/;
+
+function parseSearchReference(query: string): ParsedReference | null {
+  const trimmed = query.trim();
+  const m = trimmed.match(REF_INPUT_PATTERN);
+  if (!m) return null;
+
+  const bookStr = m[1].trim();
+  const book = getBookByName(bookStr);
+  if (!book) return null;
+
+  const chapter = parseInt(m[2], 10);
+  if (chapter < 1 || chapter > book.chapters) return null;
+
+  const verse = m[3] ? parseInt(m[3], 10) : undefined;
+  const display = verse
+    ? `${book.name} ${chapter}:${verse}`
+    : `${book.name} ${chapter}`;
+
+  return { bookId: book.id, bookName: book.name, chapter, verse, display };
+}
+
+// ── Group ordering ──────────────────────────────────────────────────
+
+/** Default section order when relevance scores tie. */
+const DEFAULT_ORDER: (keyof Omit<UniversalSearchResults, 'reference'>)[] = [
+  'books', 'people', 'concepts', 'difficultPassages',
+  'mapStories', 'timelineEvents', 'lifeTopics', 'verses',
+];
+
+const GROUP_LABELS: Record<string, string> = {
+  books: 'Books',
+  people: 'People',
+  concepts: 'Concepts',
+  difficultPassages: 'Difficult Passages',
+  mapStories: 'Map Stories',
+  timelineEvents: 'Timeline',
+  lifeTopics: 'Life Topics',
+  verses: 'Verses',
+};
+
+function nameScore(name: string, lower: string): number {
+  const n = name.toLowerCase();
+  if (n === lower) return 3;
+  if (n.startsWith(lower)) return 2;
+  if (n.includes(lower)) return 1;
+  return 0;
+}
+
+function groupScore(items: Record<string, any>[], lower: string): number {
+  let best = 0;
+  for (const item of items) {
+    const field: string = item.name ?? item.title ?? '';
+    best = Math.max(best, nameScore(field, lower));
+    if (best === 3) return best;
+  }
+  return best;
+}
+
+export interface SearchResultGroup {
+  key: string;
+  label: string;
+  data: any[];
+}
+
+/** Return non-empty result groups ordered by relevance. */
+export function buildOrderedGroups(
+  results: UniversalSearchResults,
   query: string,
-  testament?: 'ot' | 'nt' | null,
-  bookId?: string | null,
-) {
-  const [results, setResults] = useState<SearchResults>({ verses: [], people: [], wordStudies: [], discoveries: [] });
+): SearchResultGroup[] {
+  const lower = query.trim().toLowerCase();
+
+  const groups: SearchResultGroup[] = DEFAULT_ORDER
+    .filter((k) => results[k].length > 0)
+    .map((k) => ({ key: k, label: GROUP_LABELS[k], data: results[k] }));
+
+  // Stable sort: higher group relevance score → earlier position
+  groups.sort((a, b) => {
+    const sa = groupScore(a.data, lower);
+    const sb = groupScore(b.data, lower);
+    return sb - sa;
+  });
+
+  return groups;
+}
+
+// ── Caches for small, static datasets ─────────────────────────────
+
+interface StaticCaches {
+  books: Book[];
+  concepts: Concept[];
+  mapStories: MapStory[];
+  timelineEvents: TimelineEntry[];
+  difficultPassages: DifficultPassage[];
+}
+
+async function loadCaches(
+  cache: React.MutableRefObject<StaticCaches | null>,
+): Promise<StaticCaches> {
+  if (cache.current) return cache.current;
+  const [books, concepts, mapStories, timelineEvents, difficultPassages] =
+    await Promise.all([
+      getLiveBooks(),
+      getAllConcepts(),
+      getMapStories(),
+      getAllTimelineEntries(),
+      getAllDifficultPassages(),
+    ]);
+  cache.current = { books, concepts, mapStories, timelineEvents, difficultPassages };
+  return cache.current;
+}
+
+function filterByFields<T extends Record<string, any>>(
+  items: T[],
+  lower: string,
+  fields: (keyof T)[],
+): T[] {
+  return items.filter((item) =>
+    fields.some((f) => {
+      const val = item[f];
+      return typeof val === 'string' && val.toLowerCase().includes(lower);
+    }),
+  );
+}
+
+// ── Hook ────────────────────────────────────────────────────────────
+
+export function useSearch(query: string) {
+  const [results, setResults] = useState<UniversalSearchResults>(EMPTY);
   const [isLoading, setIsLoading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const wordStudyCache = useRef<WordStudy[]>([]);
+  const cacheRef = useRef<StaticCaches | null>(null);
 
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
 
     const trimmed = query.trim();
     if (trimmed.length < 2) {
-      setResults({ verses: [], people: [], wordStudies: [], discoveries: [] });
+      setResults(EMPTY);
       setIsLoading(false);
       return;
     }
@@ -38,47 +200,42 @@ export function useSearch(
     setIsLoading(true);
     timerRef.current = setTimeout(async () => {
       try {
-        // Lazy-load word studies cache
-        if (wordStudyCache.current.length === 0) {
-          wordStudyCache.current = await getAllWordStudies();
-        }
-
         const lower = trimmed.toLowerCase();
-        const [verses, rawPeople, discoveries] = await Promise.all([
-          searchVerses(trimmed, 20, testament, bookId),
+
+        // Reference parsing — instant, no DB call
+        const reference = parseSearchReference(trimmed);
+
+        const caches = await loadCaches(cacheRef);
+
+        // FTS queries + client-side filters in parallel
+        const [verses, rawPeople, lifeTopics] = await Promise.all([
+          searchVerses(trimmed, 50),
           searchPeople(trimmed),
-          searchDiscoveries(trimmed),
+          searchLifeTopics(trimmed).catch(() => [] as LifeTopic[]),
         ]);
 
-        // Sort people by relevance: direct name match → name contains → role/bio match
-        const people = rawPeople.sort((a, b) => {
-          const aName = a.name.toLowerCase();
-          const bName = b.name.toLowerCase();
-          const aExact = aName === lower;
-          const bExact = bName === lower;
-          if (aExact && !bExact) return -1;
-          if (!aExact && bExact) return 1;
-          const aStarts = aName.startsWith(lower);
-          const bStarts = bName.startsWith(lower);
-          if (aStarts && !bStarts) return -1;
-          if (!aStarts && bStarts) return 1;
-          const aContains = aName.includes(lower);
-          const bContains = bName.includes(lower);
-          if (aContains && !bContains) return -1;
-          if (!aContains && bContains) return 1;
-          return 0; // both are role/bio matches — keep FTS order
-        });
-
-        // Filter word studies client-side (only 14 entries — no FTS needed)
-        const wordStudies = wordStudyCache.current.filter((ws) =>
-          ws.transliteration.toLowerCase().includes(lower) ||
-          ws.original.includes(trimmed) ||
-          ws.id.toLowerCase().includes(lower)
+        // Sort people by relevance
+        const people = rawPeople.sort(
+          (a, b) => nameScore(b.name, lower) - nameScore(a.name, lower),
         );
 
-        setResults({ verses, people, wordStudies, discoveries });
+        // Client-side filters on cached data
+        const books = filterByFields(caches.books, lower, ['name', 'id']);
+        const concepts = filterByFields(caches.concepts, lower, ['name', 'description']);
+        const mapStories = filterByFields(caches.mapStories, lower, ['name', 'summary']);
+        const timelineEvents = filterByFields(caches.timelineEvents, lower, ['name', 'summary']);
+        const difficultPassages = filterByFields(
+          caches.difficultPassages, lower, ['title', 'question'],
+        );
+
+        setResults({
+          reference,
+          verses, people, books, concepts,
+          mapStories, timelineEvents, lifeTopics, difficultPassages,
+        });
       } catch (err) {
-        setResults({ verses: [], people: [], wordStudies: [], discoveries: [] });
+        logger.error('Search', 'Universal search failed', err);
+        setResults(EMPTY);
       } finally {
         setIsLoading(false);
       }
@@ -87,7 +244,7 @@ export function useSearch(
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [query, testament, bookId]);
+  }, [query]);
 
   return { results, isLoading };
 }

--- a/app/src/screens/SearchScreen.tsx
+++ b/app/src/screens/SearchScreen.tsx
@@ -1,109 +1,307 @@
 /**
- * SearchScreen — Full FTS5 search across verses, people, word studies,
- * and archaeological evidence.
+ * SearchScreen — Universal search across all content types.
  *
- * Fixes from Phase 4A:
- *   - Verse results show book display name (via joined book_name)
- *   - Empty state when no results match
- *   - "Load more" button when verses are sliced at 20
+ * Searches: verses, people, books, concepts, map stories,
+ * timeline events, life topics, and difficult passages.
+ * Includes reference parsing for direct chapter/verse navigation.
+ * Groups ordered by relevance — best name matches first.
  */
 
-import React, { useState, useRef, useMemo } from 'react';
-import { View, Text, TextInput, TouchableOpacity, SectionList, StyleSheet } from 'react-native';
+import React, { useState, useRef, useMemo, useCallback } from 'react';
+import { View, Text, TouchableOpacity, SectionList, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
-// Navigation types imported from types but using any for cross-tab navigation
-import { useScrollToTop } from '@react-navigation/native';
-import { Search as SearchIcon } from 'lucide-react-native';
-import { useSearch } from '../hooks/useSearch';
+import { useNavigation, useScrollToTop } from '@react-navigation/native';
+import {
+  Search as SearchIcon, BookOpen, Users, Compass, MapPin,
+  Clock, Heart, HelpCircle, ArrowRight,
+} from 'lucide-react-native';
+import { useSearch, buildOrderedGroups } from '../hooks/useSearch';
+import type { SearchResultGroup, ParsedReference } from '../hooks/useSearch';
 import { SearchInput } from '../components/SearchInput';
-import { SearchFilterChips, type SearchFilter } from '../components/SearchFilterChips';
 import { useTheme, spacing, radii, fontFamily, panels } from '../theme';
-import type { Person, WordStudy, Verse, ArchaeologicalDiscovery } from '../types';
+import type { Person, Book, MapStory, TimelineEntry, Verse, DifficultPassage, Concept, LifeTopic } from '../types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 const INITIAL_VERSE_LIMIT = 20;
 const LOAD_MORE_INCREMENT = 30;
+
+// ── Section icons & colors by group key ─────────────────────────────
+
+const GROUP_META: Record<string, { Icon: any; colorKey: string }> = {
+  books:              { Icon: BookOpen,   colorKey: 'gold' },
+  people:             { Icon: Users,      colorKey: 'gold' },
+  concepts:           { Icon: Compass,    colorKey: 'gold' },
+  difficultPassages:  { Icon: HelpCircle, colorKey: 'gold' },
+  mapStories:         { Icon: MapPin,     colorKey: 'gold' },
+  timelineEvents:     { Icon: Clock,      colorKey: 'gold' },
+  lifeTopics:         { Icon: Heart,      colorKey: 'gold' },
+  verses:             { Icon: BookOpen,   colorKey: 'gold' },
+};
 
 function SearchScreen() {
   const { base, eras } = useTheme();
   const navigation = useNavigation<any>();
   const [query, setQuery] = useState('');
   const [verseLimit, setVerseLimit] = useState(INITIAL_VERSE_LIMIT);
-  const [filter, setFilter] = useState<SearchFilter>({ testament: 'all', bookId: null, bookName: null });
-  const testament = filter.testament === 'all' ? null : filter.testament;
-  const { results, isLoading } = useSearch(query, testament, filter.bookId);
+  const { results, isLoading } = useSearch(query);
   const listRef = useRef<SectionList>(null);
   useScrollToTop(listRef);
 
-  // Reset limit when query changes
-  const handleQueryChange = (text: string) => {
+  const handleQueryChange = useCallback((text: string) => {
     setQuery(text);
     setVerseLimit(INITIAL_VERSE_LIMIT);
-  };
-
-  const displayedVerses = results.verses.slice(0, verseLimit);
-  const hasMoreVerses = results.verses.length > verseLimit;
-
-  const sections = useMemo(() => [
-    ...(results.people.length ? [{
-      title: 'People',
-      data: results.people.map((p) => ({ type: 'person' as const, item: p })),
-    }] : []),
-    ...(results.discoveries.length ? [{
-      title: 'Archaeological Evidence',
-      data: results.discoveries.map((d) => ({ type: 'discovery' as const, item: d })),
-    }] : []),
-    ...(results.wordStudies.length ? [{
-      title: 'Word Studies',
-      data: results.wordStudies.map((w) => ({ type: 'word' as const, item: w })),
-    }] : []),
-    ...(displayedVerses.length ? [{
-      title: 'Verses',
-      data: [
-        ...displayedVerses.map((v) => ({ type: 'verse' as const, item: v })),
-        ...(hasMoreVerses ? [{ type: 'loadMore' as const, item: null }] : []),
-      ],
-    }] : []),
-  ], [results.people, results.discoveries, results.wordStudies, displayedVerses, hasMoreVerses]);
+  }, []);
 
   const trimmed = query.trim();
-  const hasResults = results.people.length > 0 || results.wordStudies.length > 0 || results.verses.length > 0 || results.discoveries.length > 0;
+
+  // Build ordered groups, cap verses at verseLimit
+  const groups = useMemo(() => {
+    const ordered = buildOrderedGroups(results, trimmed);
+    return ordered.map((g) => {
+      if (g.key === 'verses') {
+        const sliced = g.data.slice(0, verseLimit);
+        const hasMore = g.data.length > verseLimit;
+        return {
+          ...g,
+          data: [
+            ...sliced.map((v: Verse) => ({ type: g.key, item: v })),
+            ...(hasMore ? [{ type: 'loadMore', item: null }] : []),
+          ],
+        };
+      }
+      return { ...g, data: g.data.map((item: any) => ({ type: g.key, item })) };
+    });
+  }, [results, trimmed, verseLimit]);
+
+  // Prepend reference result as its own section
+  const sections = useMemo(() => {
+    const s: { title: string; key: string; data: any[] }[] = [];
+    if (results.reference) {
+      s.push({
+        title: 'Go To',
+        key: 'reference',
+        data: [{ type: 'reference', item: results.reference }],
+      });
+    }
+    for (const g of groups) {
+      s.push({ title: g.label, key: g.key, data: g.data });
+    }
+    return s;
+  }, [results.reference, groups]);
+
+  const hasResults = sections.length > 0;
+
+  // ── Navigation handlers ─────────────────────────────────────────
+
+  const goToChapter = useCallback((bookId: string, chapterNum: number, verseNum?: number) => {
+    navigation.navigate('ReadTab', {
+      screen: 'Chapter',
+      params: { bookId, chapterNum, verseNum },
+    });
+  }, [navigation]);
+
+  const goToExplore = useCallback((screen: string, params: Record<string, any>) => {
+    navigation.navigate('ExploreTab', { screen, params });
+  }, [navigation]);
+
+  // ── Render items ────────────────────────────────────────────────
+
+  const renderItem = useCallback(({ item: { type, item } }: { item: { type: string; item: any } }) => {
+    if (type === 'loadMore') {
+      return (
+        <TouchableOpacity
+          onPress={() => setVerseLimit((prev) => prev + LOAD_MORE_INCREMENT)}
+          style={styles.loadMoreButton}
+          accessibilityRole="button"
+          accessibilityLabel="Load more verses"
+        >
+          <Text style={[styles.loadMoreText, { color: base.gold }]}>Load more verses</Text>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'reference') {
+      const ref = item as ParsedReference;
+      return (
+        <TouchableOpacity
+          onPress={() => goToChapter(ref.bookId, ref.chapter, ref.verse)}
+          style={[styles.refRow, { backgroundColor: base.gold + '12', borderColor: base.gold + '30' }]}
+          accessibilityRole="button"
+          accessibilityLabel={`Go to ${ref.display}`}
+        >
+          <ArrowRight size={16} color={base.gold} />
+          <Text style={[styles.refText, { color: base.gold }]}>{ref.display}</Text>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'books') {
+      const b = item as Book;
+      return (
+        <TouchableOpacity
+          onPress={() => navigation.navigate('ReadTab', { screen: 'ChapterList', params: { bookId: b.id } })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Open ${b.name}`}
+        >
+          <BookOpen size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{b.name}</Text>
+            <Text style={[styles.rowSub, { color: base.textMuted }]}>
+              {b.total_chapters} chapters · {b.testament === 'ot' ? 'Old Testament' : 'New Testament'}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'people') {
+      const p = item as Person;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('PersonDetail', { personId: p.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`View ${p.name}`}
+        >
+          <View style={[styles.eraDot, { backgroundColor: p.era ? (eras[p.era] ?? base.textMuted) : base.textMuted }]} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{p.name}</Text>
+            {p.role ? <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{p.role}</Text> : null}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'concepts') {
+      const c = item as Concept;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('ConceptDetail', { conceptId: c.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Concept: ${c.name}`}
+        >
+          <Compass size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{c.name}</Text>
+            {c.description ? <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{c.description}</Text> : null}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'difficultPassages') {
+      const d = item as DifficultPassage;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('DifficultPassageDetail', { passageId: d.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Difficult passage: ${d.title}`}
+        >
+          <HelpCircle size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{d.title}</Text>
+            <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{d.passage}</Text>
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'mapStories') {
+      const ms = item as MapStory;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('Map', { storyId: ms.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Map story: ${ms.name}`}
+        >
+          <MapPin size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{ms.name}</Text>
+            {ms.summary ? <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{ms.summary}</Text> : null}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'timelineEvents') {
+      const t = item as TimelineEntry;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('Timeline', { eventId: t.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Timeline: ${t.name}`}
+        >
+          <Clock size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{t.name}</Text>
+            <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>
+              {t.year != null ? `${Math.abs(t.year)} ${t.year < 0 ? 'BC' : 'AD'}` : ''}{t.summary ? ` · ${t.summary}` : ''}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'lifeTopics') {
+      const lt = item as LifeTopic;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('LifeTopicDetail', { topicId: lt.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Life topic: ${lt.title}`}
+        >
+          <Heart size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{lt.title}</Text>
+            {lt.subtitle ? <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{lt.subtitle}</Text> : null}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    // Verses (default)
+    const v = item as Verse;
+    const displayName = (v as any).book_name ?? v.book_id;
+    return (
+      <TouchableOpacity
+        onPress={() => goToChapter(v.book_id, v.chapter_num, v.verse_num)}
+        style={styles.verseRow}
+        accessibilityRole="button"
+        accessibilityLabel={`Go to ${displayName} ${v.chapter_num}:${v.verse_num}`}
+      >
+        <Text style={[styles.verseRef, { color: base.gold }]}>
+          {displayName} {v.chapter_num}:{v.verse_num}
+        </Text>
+        <Text style={[styles.verseText, { color: base.textDim }]} numberOfLines={2}>{v.text}</Text>
+      </TouchableOpacity>
+    );
+  }, [base, eras, goToChapter, goToExplore, navigation]);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      {/* Search input */}
       <View style={styles.inputWrapper}>
         <SearchInput
           value={query}
           onChangeText={handleQueryChange}
-          placeholder="Search verses, people, evidence..."
+          placeholder="Search anything — or type a reference like Gen 3:15"
           autoFocus
         />
       </View>
 
-      {/* Filter chips (show when query is active) */}
-      {query.trim().length >= 2 && (
-        <SearchFilterChips
-          filter={filter}
-          onFilterChange={(f) => { setFilter(f); setVerseLimit(INITIAL_VERSE_LIMIT); }}
-          onBookPickerOpen={() => {
-            // For now, cycle through a simple book picker approach
-            // A full book picker modal can be added in a future iteration
-          }}
-        />
-      )}
-
       {trimmed.length < 2 ? (
-        /* Idle state */
         <View style={styles.emptyCenter}>
           <SearchIcon size={28} color={base.textMuted + '60'} />
           <Text style={[styles.emptyText, { color: base.textMuted }]}>
-            Search verses, people, evidence, and more
+            Search books, people, concepts, verses, and more
           </Text>
         </View>
       ) : !hasResults && !isLoading ? (
-        /* No results */
         <View style={styles.emptyCenter}>
           <Text style={[styles.emptyText, { color: base.textMuted }]}>
             No results found for "{trimmed}"
@@ -115,6 +313,7 @@ function SearchScreen() {
           sections={sections}
           keyExtractor={(item, i) => `${item.type}-${i}`}
           contentContainerStyle={styles.listContent}
+          stickySectionHeadersEnabled={false}
           renderSectionHeader={({ section }) => (
             <View style={[styles.sectionHeader, { backgroundColor: base.bg }]}>
               <Text style={[styles.sectionTitle, { color: base.textMuted }]}>
@@ -122,101 +321,7 @@ function SearchScreen() {
               </Text>
             </View>
           )}
-          renderItem={({ item: { type, item } }) => {
-            if (type === 'loadMore') {
-              return (
-                <TouchableOpacity
-                  onPress={() => setVerseLimit((prev) => prev + LOAD_MORE_INCREMENT)}
-                  style={styles.loadMoreButton}
-                  accessibilityRole="button"
-                  accessibilityLabel="Load more verses"
-                >
-                  <Text style={[styles.loadMoreText, { color: base.gold }]}>Load more verses</Text>
-                </TouchableOpacity>
-              );
-            }
-            if (type === 'person') {
-              const p = item as Person;
-              return (
-                <TouchableOpacity
-                  onPress={() => navigation.navigate('ExploreTab', {
-                    screen: 'PersonDetail',
-                    params: { personId: p.id },
-                  })}
-                  style={styles.personRow}
-                  accessibilityRole="button"
-                  accessibilityLabel={`View person: ${p.name}`}
-                >
-                  <View style={[
-                    styles.eraDot,
-                    { backgroundColor: p.era ? (eras[p.era] ?? base.textMuted) : base.textMuted },
-                  ]} />
-                  <View style={styles.personText}>
-                    <Text style={[styles.personName, { color: base.text }]}>{p.name}</Text>
-                    <Text style={[styles.personRole, { color: base.textMuted }]} numberOfLines={1}>{p.role}</Text>
-                  </View>
-                </TouchableOpacity>
-              );
-            }
-            if (type === 'discovery') {
-              const d = item as ArchaeologicalDiscovery;
-              return (
-                <TouchableOpacity
-                  onPress={() => navigation.navigate('ExploreTab', {
-                    screen: 'ArchaeologyDetail',
-                    params: { discoveryId: d.id },
-                  })}
-                  style={styles.discoveryRow}
-                  accessibilityRole="button"
-                  accessibilityLabel={`View evidence: ${d.name}`}
-                >
-                  <Text style={styles.discoveryEmoji}>🏛</Text>
-                  <View style={styles.discoveryText}>
-                    <Text style={[styles.discoveryName, { color: base.text }]} numberOfLines={1}>{d.name}</Text>
-                    <Text style={[styles.discoveryMeta, { color: base.textMuted }]} numberOfLines={1}>
-                      {[d.category, d.location].filter(Boolean).join(' · ')}
-                    </Text>
-                  </View>
-                </TouchableOpacity>
-              );
-            }
-            if (type === 'word') {
-              const w = item as WordStudy;
-              return (
-                <TouchableOpacity
-                  onPress={() => navigation.navigate('ExploreTab', {
-                    screen: 'WordStudyDetail',
-                    params: { wordId: w.id },
-                  })}
-                  style={styles.wordRow}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Word study: ${w.transliteration}`}
-                >
-                  <Text style={styles.wordOriginal}>{w.original}</Text>
-                  <Text style={[styles.wordTranslit, { color: base.goldDim }]}>{w.transliteration}</Text>
-                </TouchableOpacity>
-              );
-            }
-            // Verse
-            const v = item as Verse;
-            const displayName = (v as any).book_name ?? v.book_id;
-            return (
-              <TouchableOpacity
-                onPress={() => navigation.navigate('ReadTab', {
-                  screen: 'Chapter',
-                  params: { bookId: v.book_id, chapterNum: v.chapter_num, verseNum: v.verse_num },
-                })}
-                style={styles.verseRow}
-                accessibilityRole="button"
-                accessibilityLabel={`Go to ${displayName} ${v.chapter_num}:${v.verse_num}`}
-              >
-                <Text style={[styles.verseRef, { color: base.gold }]}>
-                  {displayName} {v.chapter_num}:{v.verse_num}
-                </Text>
-                <Text style={[styles.verseText, { color: base.textDim }]} numberOfLines={2}>{v.text}</Text>
-              </TouchableOpacity>
-            );
-          }}
+          renderItem={renderItem}
         />
       )}
     </SafeAreaView>
@@ -254,8 +359,22 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.bodyItalic,
     fontSize: 15,
   },
-  // Person
-  personRow: {
+  // Reference row
+  refRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    borderWidth: 1,
+  },
+  refText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 15,
+  },
+  // Generic content row
+  row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
@@ -266,52 +385,19 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
   },
-  personText: {
+  rowText: {
     flex: 1,
   },
-  personName: {
+  rowTitle: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 14,
   },
-  personRole: {
+  rowSub: {
     fontFamily: fontFamily.ui,
     fontSize: 11,
+    marginTop: 1,
   },
-  // Word study
-  wordRow: {
-    paddingVertical: spacing.sm,
-  },
-  wordOriginal: {
-    color: panels.heb.accent,
-    fontFamily: fontFamily.bodyMedium,
-    fontSize: 16,
-  },
-  wordTranslit: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 12,
-  },
-  // Discovery
-  discoveryRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-    paddingVertical: spacing.sm,
-  },
-  discoveryEmoji: {
-    fontSize: 18,
-  },
-  discoveryText: {
-    flex: 1,
-  },
-  discoveryName: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 14,
-  },
-  discoveryMeta: {
-    fontFamily: fontFamily.ui,
-    fontSize: 11,
-  },
-  // Verse
+  // Verse row
   verseRow: {
     paddingVertical: spacing.xs,
   },


### PR DESCRIPTION
## What

Rearchitects the main search from a verse-centric 4-type search into a universal 8-type search with scripture reference parsing.

### Universal search (8 content types)
- **FTS**: Verses, People, Life Topics
- **Cached + client-side**: Books, Concepts, Map Stories, Timeline Events, Difficult Passages

### Reference parsing
- Typing "Gen 3:15" or "romans 8" shows a Go To row for direct navigation
- Case-insensitive, validates chapter range

### Group ordering
- Groups with exact name matches rank first
- Default: Books > People > Concepts > Difficult Passages > Map Stories > Timeline > Life Topics > Verses

### Removed: SearchFilterChips (All/OT/NT/Book)
- Verse-only, malformed on text input, irrelevant for universal search

### Fixed: search not returning results
- Old hook passed testament/bookId filters from broken chips
