### PR TITLE
Fix: Search screen crash — concepts table column mismatch

### DIFF
--- a/app/src/db/content/features.ts
+++ b/app/src/db/content/features.ts
@@ -47,13 +47,13 @@ export async function getProphecyChainsForChapter(
 
 export async function getAllConcepts(): Promise<Concept[]> {
   return getDb().getAllAsync<Concept>(
-    'SELECT * FROM concepts ORDER BY name'
+    'SELECT *, title AS name FROM concepts ORDER BY title'
   );
 }
 
 export async function getConcept(id: string): Promise<Concept | null> {
   return getDb().getFirstAsync<Concept>(
-    'SELECT * FROM concepts WHERE id = ?',
+    'SELECT *, title AS name FROM concepts WHERE id = ?',
     [id]
   );
 }


### PR DESCRIPTION
## Bug
Search screen crashes on load with:
```
[Search] Universal search failed Error: Calling the 'prepareAsync' function has failed
→ Caused by: Error code 1: no such column: name
```

## Root Cause
`getAllConcepts()` in `features.ts` ran `SELECT * FROM concepts ORDER BY name`, but the `concepts` table uses `title` not `name`. The `prepareAsync` call fails immediately because SQLite can't find the column.

## Fix
Alias `title AS name` in both `getAllConcepts()` and `getConcept()` queries so the TypeScript `Concept` type (which expects `.name`) receives the correct field:
```sql
-- Before (crashes)
SELECT * FROM concepts ORDER BY name

-- After (works)
SELECT *, title AS name FROM concepts ORDER BY title
```

## Why alias instead of renaming the type?
The `Concept.name` property is used in `SearchScreen.tsx`, `useSearch.ts`, and `useTopicDetail.ts`. Aliasing in the two query functions is a 2-line change vs touching 5+ files. The `useConceptData.ts` hook already handles the mismatch manually by mapping `conceptRow.title` to the type.

## Impact
- **Before:** Search screen is completely broken — any keystroke crashes
- **After:** Search works, concepts appear in results with correct titles