### PR TITLE
Fix: searchLifeTopics silently broken + Concept type mismatch

### DIFF
--- a/app/src/db/content/lifeTopics.ts
+++ b/app/src/db/content/lifeTopics.ts
@@ -31,14 +31,29 @@ export async function getLifeTopic(id: string): Promise<LifeTopic | null> {
   );
 }
 
+/**
+ * Sanitize user input for FTS5 MATCH queries.
+ * Strips special characters, wraps each term in quotes, drops single-char terms.
+ */
+function sanitizeFtsQuery(query: string): string {
+  return query
+    .replace(/["*(){}[\]^~:]/g, '')
+    .split(/\s+/)
+    .filter((w) => w.length >= 2)
+    .map((w) => `"${w}"`)
+    .join(' ');
+}
+
 export async function searchLifeTopics(query: string): Promise<LifeTopic[]> {
+  const ftsQuery = sanitizeFtsQuery(query);
+  if (!ftsQuery) return [];
   return getDb().getAllAsync<LifeTopic>(
-    `SELECT lt.* FROM life_topics_fts fts
-     JOIN life_topics_official lt ON lt.id = fts.rowid
-     WHERE fts MATCH ?
+    `SELECT lt.* FROM life_topics_fts
+     JOIN life_topics_official lt ON lt.rowid = life_topics_fts.rowid
+     WHERE life_topics_fts MATCH ?
      ORDER BY rank
      LIMIT 30`,
-    [query]
+    [ftsQuery]
   );
 }
 

--- a/app/src/types/explore.ts
+++ b/app/src/types/explore.ts
@@ -51,7 +51,7 @@ export interface Concept {
   thread_ids_json: string | null;
   prophecy_chain_ids_json: string | null;
   people_tags_json: string | null;
-  search_terms_json: string | null;
+  tags_json: string | null;
 }
 
 /** Parsed from DifficultPassage.responses_json */


### PR DESCRIPTION
## Bugs Fixed

### searchLifeTopics() — 3 bugs, completely non-functional
Life Topics have **never appeared** in search results. The `.catch(() => [])` in `useSearch.ts` silently swallowed all errors.

**Bug 1:** `WHERE fts MATCH ?` — FTS5 MATCH doesn't resolve table aliases. SQLite throws 'no such column: fts'. Fixed: use actual table name `life_topics_fts`.

**Bug 2:** `JOIN ... ON lt.id = fts.rowid` — `life_topics_official.id` is TEXT ('grief-and-loss'), `fts.rowid` is INTEGER (1). Join never matches. Fixed: `ON lt.rowid = life_topics_fts.rowid`.

**Bug 3:** Raw unsanitized query passed directly to FTS5 MATCH. Any special characters (`"`, `*`, `:`, etc.) crash the query. Fixed: added `sanitizeFtsQuery()` matching the pattern in `search.ts`.

### Concept type mismatch
`Concept.search_terms_json` in TypeScript but DB column is `tags_json`. Fixed type to match DB. Not a runtime bug (field was never read) but incorrect type definition.

## Related
- PR #1251 fixed the concepts `ORDER BY name` crash
- This PR fixes the remaining bugs found during search audit