### PR TITLE
Add archaeological discoveries to search + category filter chips

### DIFF
--- a/app/src/db/content/archaeology.ts
+++ b/app/src/db/content/archaeology.ts
@@ -59,9 +59,9 @@ export async function searchDiscoveries(
   const ftsQuery = sanitizeFtsQuery(query);
   if (!ftsQuery) return [];
   return getDb().getAllAsync<ArchaeologicalDiscovery>(
-    `SELECT d.* FROM archaeology_fts fts
-     JOIN archaeological_discoveries d ON d.rowid = fts.rowid
-     WHERE fts MATCH ?
+    `SELECT d.* FROM archaeology_fts
+     JOIN archaeological_discoveries d ON d.rowid = archaeology_fts.rowid
+     WHERE archaeology_fts MATCH ?
      ORDER BY rank
      LIMIT 30`,
     [ftsQuery]

--- a/app/src/hooks/useSearch.ts
+++ b/app/src/hooks/useSearch.ts
@@ -14,10 +14,10 @@ import { useState, useEffect, useRef } from 'react';
 import {
   searchVerses, searchPeople, getLiveBooks, getAllConcepts,
   getMapStories, getAllTimelineEntries, getAllDifficultPassages,
-  searchLifeTopics,
+  searchLifeTopics, searchDiscoveries,
 } from '../db/content';
 import { getBookByName } from '../utils/verseResolver';
-import type { Verse, Person, Book, MapStory, TimelineEntry, DifficultPassage, Concept, LifeTopic } from '../types';
+import type { Verse, Person, Book, MapStory, TimelineEntry, DifficultPassage, Concept, LifeTopic, ArchaeologicalDiscovery } from '../types';
 import { logger } from '../utils/logger';
 
 // ── Result types ────────────────────────────────────────────────────
@@ -40,12 +40,14 @@ export interface UniversalSearchResults {
   timelineEvents: TimelineEntry[];
   lifeTopics: LifeTopic[];
   difficultPassages: DifficultPassage[];
+  archaeology: ArchaeologicalDiscovery[];
 }
 
 const EMPTY: UniversalSearchResults = {
   reference: null,
   verses: [], people: [], books: [], concepts: [],
   mapStories: [], timelineEvents: [], lifeTopics: [], difficultPassages: [],
+  archaeology: [],
 };
 
 // ── Reference parsing ───────────────────────────────────────────────
@@ -80,7 +82,7 @@ function parseSearchReference(query: string): ParsedReference | null {
 
 /** Default section order when relevance scores tie. */
 const DEFAULT_ORDER: (keyof Omit<UniversalSearchResults, 'reference'>)[] = [
-  'books', 'people', 'concepts', 'difficultPassages',
+  'books', 'people', 'concepts', 'archaeology', 'difficultPassages',
   'mapStories', 'timelineEvents', 'lifeTopics', 'verses',
 ];
 
@@ -88,6 +90,7 @@ const GROUP_LABELS: Record<string, string> = {
   books: 'Books',
   people: 'People',
   concepts: 'Concepts',
+  archaeology: 'Archaeological Evidence',
   difficultPassages: 'Difficult Passages',
   mapStories: 'Map Stories',
   timelineEvents: 'Timeline',
@@ -208,10 +211,11 @@ export function useSearch(query: string) {
         const caches = await loadCaches(cacheRef);
 
         // FTS queries + client-side filters in parallel
-        const [verses, rawPeople, lifeTopics] = await Promise.all([
+        const [verses, rawPeople, lifeTopics, archaeology] = await Promise.all([
           searchVerses(trimmed, 50),
           searchPeople(trimmed),
           searchLifeTopics(trimmed).catch(() => [] as LifeTopic[]),
+          searchDiscoveries(trimmed).catch(() => [] as ArchaeologicalDiscovery[]),
         ]);
 
         // Sort people by relevance
@@ -232,6 +236,7 @@ export function useSearch(query: string) {
           reference,
           verses, people, books, concepts,
           mapStories, timelineEvents, lifeTopics, difficultPassages,
+          archaeology,
         });
       } catch (err) {
         logger.error('Search', 'Universal search failed', err);

--- a/app/src/screens/SearchScreen.tsx
+++ b/app/src/screens/SearchScreen.tsx
@@ -8,18 +8,18 @@
  */
 
 import React, { useState, useRef, useMemo, useCallback } from 'react';
-import { View, Text, TouchableOpacity, SectionList, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, SectionList, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useScrollToTop } from '@react-navigation/native';
 import {
   Search as SearchIcon, BookOpen, Users, Compass, MapPin,
-  Clock, Heart, HelpCircle, ArrowRight,
+  Clock, Heart, HelpCircle, ArrowRight, Landmark,
 } from 'lucide-react-native';
 import { useSearch, buildOrderedGroups } from '../hooks/useSearch';
 import type { SearchResultGroup, ParsedReference } from '../hooks/useSearch';
 import { SearchInput } from '../components/SearchInput';
 import { useTheme, spacing, radii, fontFamily, panels } from '../theme';
-import type { Person, Book, MapStory, TimelineEntry, Verse, DifficultPassage, Concept, LifeTopic } from '../types';
+import type { Person, Book, MapStory, TimelineEntry, Verse, DifficultPassage, Concept, LifeTopic, ArchaeologicalDiscovery } from '../types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 const INITIAL_VERSE_LIMIT = 20;
@@ -31,6 +31,7 @@ const GROUP_META: Record<string, { Icon: any; colorKey: string }> = {
   books:              { Icon: BookOpen,   colorKey: 'gold' },
   people:             { Icon: Users,      colorKey: 'gold' },
   concepts:           { Icon: Compass,    colorKey: 'gold' },
+  archaeology:        { Icon: Landmark,   colorKey: 'gold' },
   difficultPassages:  { Icon: HelpCircle, colorKey: 'gold' },
   mapStories:         { Icon: MapPin,     colorKey: 'gold' },
   timelineEvents:     { Icon: Clock,      colorKey: 'gold' },
@@ -43,6 +44,7 @@ function SearchScreen() {
   const navigation = useNavigation<any>();
   const [query, setQuery] = useState('');
   const [verseLimit, setVerseLimit] = useState(INITIAL_VERSE_LIMIT);
+  const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const { results, isLoading } = useSearch(query);
   const listRef = useRef<SectionList>(null);
   useScrollToTop(listRef);
@@ -50,6 +52,7 @@ function SearchScreen() {
   const handleQueryChange = useCallback((text: string) => {
     setQuery(text);
     setVerseLimit(INITIAL_VERSE_LIMIT);
+    setActiveFilter(null);
   }, []);
 
   const trimmed = query.trim();
@@ -76,7 +79,7 @@ function SearchScreen() {
   // Prepend reference result as its own section
   const sections = useMemo(() => {
     const s: { title: string; key: string; data: any[] }[] = [];
-    if (results.reference) {
+    if (results.reference && !activeFilter) {
       s.push({
         title: 'Go To',
         key: 'reference',
@@ -84,10 +87,23 @@ function SearchScreen() {
       });
     }
     for (const g of groups) {
+      if (activeFilter && g.key !== activeFilter) continue;
       s.push({ title: g.label, key: g.key, data: g.data });
     }
     return s;
-  }, [results.reference, groups]);
+  }, [results.reference, groups, activeFilter]);
+
+  // Build chip data from groups (only categories with results)
+  const chips = useMemo(() => {
+    if (groups.length === 0) return [];
+    return groups.map((g) => ({
+      key: g.key,
+      label: g.label,
+      count: g.key === 'verses'
+        ? (results as any).verses?.length ?? g.data.length
+        : g.data.filter((d: any) => d.type !== 'loadMore').length,
+    }));
+  }, [groups, results]);
 
   const hasResults = sections.length > 0;
 
@@ -186,6 +202,24 @@ function SearchScreen() {
           <View style={styles.rowText}>
             <Text style={[styles.rowTitle, { color: base.text }]}>{c.name}</Text>
             {c.description ? <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{c.description}</Text> : null}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (type === 'archaeology') {
+      const a = item as ArchaeologicalDiscovery;
+      return (
+        <TouchableOpacity
+          onPress={() => goToExplore('ArchaeologyDetail', { discoveryId: a.id })}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Archaeological evidence: ${a.name}`}
+        >
+          <Landmark size={14} color={base.textMuted} />
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: base.text }]}>{a.name}</Text>
+            <Text style={[styles.rowSub, { color: base.textMuted }]} numberOfLines={1}>{a.category} · {a.date_range}</Text>
           </View>
         </TouchableOpacity>
       );
@@ -294,6 +328,56 @@ function SearchScreen() {
         />
       </View>
 
+      {/* ── Category filter chips ──────────────────────────────── */}
+      {trimmed.length >= 2 && chips.length > 1 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.chipRow}
+          keyboardShouldPersistTaps="handled"
+        >
+          <TouchableOpacity
+            onPress={() => setActiveFilter(null)}
+            style={[
+              styles.chip,
+              !activeFilter
+                ? { backgroundColor: base.gold + '20', borderColor: base.gold }
+                : { backgroundColor: 'transparent', borderColor: base.textMuted + '30' },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Show all results"
+            accessibilityState={{ selected: !activeFilter }}
+          >
+            <Text style={[styles.chipLabel, { color: !activeFilter ? base.gold : base.textMuted }]}>All</Text>
+          </TouchableOpacity>
+          {chips.map((c) => {
+            const active = activeFilter === c.key;
+            return (
+              <TouchableOpacity
+                key={c.key}
+                onPress={() => setActiveFilter(active ? null : c.key)}
+                style={[
+                  styles.chip,
+                  active
+                    ? { backgroundColor: base.gold + '20', borderColor: base.gold }
+                    : { backgroundColor: 'transparent', borderColor: base.textMuted + '30' },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter by ${c.label}`}
+                accessibilityState={{ selected: active }}
+              >
+                <Text style={[styles.chipLabel, { color: active ? base.gold : base.textMuted }]}>
+                  {c.label}
+                </Text>
+                <Text style={[styles.chipCount, { color: active ? base.gold + 'BB' : base.textMuted + '80' }]}>
+                  {c.count}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      )}
+
       {trimmed.length < 2 ? (
         <View style={styles.emptyCenter}>
           <SearchIcon size={28} color={base.textMuted + '60'} />
@@ -358,6 +442,30 @@ const styles = StyleSheet.create({
   emptyText: {
     fontFamily: fontFamily.bodyItalic,
     fontSize: 15,
+  },
+  // Filter chips
+  chipRow: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.sm,
+    gap: spacing.xs,
+    flexDirection: 'row',
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+  },
+  chipLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  chipCount: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
   },
   // Reference row
   refRow: {


### PR DESCRIPTION
## What
Two features in one PR — archaeology in search, and dynamic filter chips to manage multi-category results.

### 1. Archaeological Discoveries in Search
Wires the existing `archaeology_fts` FTS5 index into the search pipeline.

- **`archaeology.ts`** — Fixed FTS5 alias bug in `searchDiscoveries()`
- **`useSearch.ts`** — Added `searchDiscoveries` to parallel Promise.all, `archaeology` to results interface/EMPTY/DEFAULT_ORDER/GROUP_LABELS
- **`SearchScreen.tsx`** — Landmark icon, render block with category + date_range subtitle, navigates to `ArchaeologyDetail`

### 2. Dynamic Category Filter Chips
Horizontal scrollable chip row between search input and results.

**Behavior:**
- Appears only when results span 2+ categories
- "All" chip always first, followed by each category that has hits
- Each chip shows label + result count (e.g. `People 12`)
- Tap a chip → isolate that category. Tap again or tap "All" → show everything
- Filter resets automatically when query text changes
- Reference "Go To" row hidden when a category filter is active
- Verse count shows full count (not the paginated slice)

**Design:**
- Active chip: `gold + '20'` bg, `gold` border/text
- Inactive chip: transparent bg, `textMuted + '30'` border, `textMuted` text
- 32px height, `borderRadius: 16`, horizontal ScrollView
- Uses `fontFamily.uiMedium` for labels, `fontFamily.ui` for counts

## Example
Searching 'David' shows chips: `All` `People 3` `Timeline 12` `Books 1` `Archaeological Evidence 1` `Verses 50`

Tapping `People` isolates to just the People section. Tapping `All` returns to full results.

## Depends on
- #1252 (life topics FTS fix — same alias pattern)