### PR TITLE
Fix: 4 failing tests from search PRs #1252 and #1253

### DIFF
--- a/app/__tests__/db/content/lifeTopics.test.ts
+++ b/app/__tests__/db/content/lifeTopics.test.ts
@@ -55,12 +55,17 @@ describe('db/content/lifeTopics', () => {
   });
 
   describe('searchLifeTopics', () => {
-    it('uses FTS MATCH', async () => {
+    it('uses FTS MATCH with sanitized query', async () => {
       await searchLifeTopics('prayer');
       expect(getMockDb().getAllAsync).toHaveBeenCalledWith(
         expect.stringContaining('MATCH'),
-        ['prayer'],
+        ['"prayer"'],
       );
+    });
+
+    it('returns empty for short query', async () => {
+      const result = await searchLifeTopics('x');
+      expect(result).toEqual([]);
     });
   });
 

--- a/app/__tests__/hooks/useSearch.test.ts
+++ b/app/__tests__/hooks/useSearch.test.ts
@@ -8,6 +8,7 @@ const mockGetMapStories = jest.fn().mockResolvedValue([]);
 const mockGetAllTimelineEntries = jest.fn().mockResolvedValue([]);
 const mockGetAllDifficultPassages = jest.fn().mockResolvedValue([]);
 const mockSearchLifeTopics = jest.fn().mockResolvedValue([]);
+const mockSearchDiscoveries = jest.fn().mockResolvedValue([]);
 
 jest.mock('@/db/content', () => ({
   searchVerses: (...args: any[]) => mockSearchVerses(...args),
@@ -18,6 +19,7 @@ jest.mock('@/db/content', () => ({
   getAllTimelineEntries: (...args: any[]) => mockGetAllTimelineEntries(...args),
   getAllDifficultPassages: (...args: any[]) => mockGetAllDifficultPassages(...args),
   searchLifeTopics: (...args: any[]) => mockSearchLifeTopics(...args),
+  searchDiscoveries: (...args: any[]) => mockSearchDiscoveries(...args),
 }));
 
 jest.mock('@/utils/verseResolver', () => ({
@@ -53,6 +55,7 @@ describe('useSearch', () => {
     mockGetAllTimelineEntries.mockResolvedValue([]);
     mockGetAllDifficultPassages.mockResolvedValue([]);
     mockSearchLifeTopics.mockResolvedValue([]);
+    mockSearchDiscoveries.mockResolvedValue([]);
   });
 
   afterEach(() => jest.useRealTimers());
@@ -233,6 +236,7 @@ describe('buildOrderedGroups', () => {
     reference: null,
     verses: [], people: [], books: [], concepts: [],
     mapStories: [], timelineEvents: [], lifeTopics: [], difficultPassages: [],
+    archaeology: [],
   };
 
   it('returns empty array when no results', () => {

--- a/app/__tests__/unit/dbLifeTopics.test.ts
+++ b/app/__tests__/unit/dbLifeTopics.test.ts
@@ -59,13 +59,19 @@ describe('getLifeTopic', () => {
 });
 
 describe('searchLifeTopics', () => {
-  it('searches via FTS MATCH', async () => {
+  it('searches via FTS MATCH with sanitized query', async () => {
     getMockDb().getAllAsync.mockResolvedValue([]);
     await searchLifeTopics('forgive');
     expect(getMockDb().getAllAsync).toHaveBeenCalledWith(
       expect.stringContaining('life_topics_fts'),
-      ['forgive'],
+      ['"forgive"'],
     );
+  });
+
+  it('returns empty for single-char query', async () => {
+    const result = await searchLifeTopics('a');
+    expect(result).toEqual([]);
+    expect(getMockDb().getAllAsync).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Root Cause
PRs #1252 and #1253 introduced changes that broke 4 tests across 3 files.

### Test failures from #1253 (archaeology in search)
**`useSearch.test.ts` line 232** — `buildOrderedGroups` test mock was missing `archaeology: []` in the `UniversalSearchResults` base object. TypeScript compilation failed with TS2741, blocking both lint and test CI jobs.

**Fix:** Added `archaeology: []` to base mock, added `mockSearchDiscoveries` to jest.mock and beforeEach reset.

### Test failures from #1252 (life topics FTS fix)
**`dbLifeTopics.test.ts`** and **`db/content/lifeTopics.test.ts`** — both test `searchLifeTopics()` and expected raw query strings (`'forgive'`, `'prayer'`), but #1252 added `sanitizeFtsQuery()` which wraps terms in quotes (`'"forgive"'`, `'"prayer"'`).

**Fix:** Updated assertions to expect the sanitized format. Added test for short query returning empty array.

## Files Changed
- `app/__tests__/hooks/useSearch.test.ts` — add archaeology mock
- `app/__tests__/unit/dbLifeTopics.test.ts` — fix expected query format
- `app/__tests__/db/content/lifeTopics.test.ts` — fix expected query format