### PR TITLE
Fix: filter chips stretching to fill vertical space

### DIFF
--- a/app/src/screens/SearchScreen.tsx
+++ b/app/src/screens/SearchScreen.tsx
@@ -333,6 +333,7 @@ function SearchScreen() {
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
+          style={styles.chipScroll}
           contentContainerStyle={styles.chipRow}
           keyboardShouldPersistTaps="handled"
         >
@@ -444,6 +445,9 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   // Filter chips
+  chipScroll: {
+    flexGrow: 0,
+  },
   chipRow: {
     paddingHorizontal: spacing.md,
     paddingBottom: spacing.sm,


### PR DESCRIPTION
The horizontal ScrollView for filter chips was a flex child that grew to fill available space, making chips absurdly tall when few results were present.

**Fix:** `flexGrow: 0` on the ScrollView style.

**Before:** Chips fill half the screen
**After:** Chips are compact pills at their natural content height