### PR TITLE
feat: Surface person & concept journeys on Explore screen

### DIFF
--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -242,5 +242,18 @@
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
+  },
+  "JourneyBrowse": {
+    "count": 50,
+    "noun": "journeys",
+    "contentType": "people",
+    "featured": [
+      "abraham",
+      "moses",
+      "david",
+      "paul",
+      "jesus",
+      "daniel"
+    ]
   }
 }

--- a/app/src/components/JourneyBrowseSection.tsx
+++ b/app/src/components/JourneyBrowseSection.tsx
@@ -1,0 +1,295 @@
+/**
+ * JourneyBrowseSection — Journeys section for ExploreMenuScreen.
+ *
+ * Two horizontal rows:
+ *   Row A: Person Journeys — avatar-style cards (30 people)
+ *   Row B: Concept Journeys — text-forward cards (20 concepts)
+ *
+ * Part of Journeys on Explore feature.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  View, Text, TouchableOpacity, ScrollView, StyleSheet,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { ChevronRight } from 'lucide-react-native';
+import type { ScreenNavProp } from '../navigation/types';
+import { useJourneyBrowse, type PersonJourneyEntry, type ConceptJourneyEntry } from '../hooks/useJourneyBrowse';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+
+// ── Person Card ────────────────────────────────────────────────────
+
+function PersonJourneyCard({
+  entry,
+  eraColor,
+  onPress,
+}: {
+  entry: PersonJourneyEntry;
+  eraColor: string;
+  onPress: () => void;
+}) {
+  const { base } = useTheme();
+
+  return (
+    <TouchableOpacity
+      style={[styles.personCard, { backgroundColor: base.bgElevated, borderColor: eraColor + '20' }]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${entry.name} journey, ${entry.stageCount} stages`}
+    >
+      {/* Avatar circle with initial */}
+      <View style={[styles.avatar, { backgroundColor: eraColor + '30', borderColor: eraColor + '40' }]}>
+        <Text style={[styles.avatarText, { color: eraColor }]}>
+          {entry.name.charAt(0)}
+        </Text>
+      </View>
+      <Text style={[styles.personName, { color: base.text }]} numberOfLines={1}>
+        {entry.name}
+      </Text>
+      {entry.role ? (
+        <Text style={[styles.personRole, { color: base.textMuted }]} numberOfLines={1}>
+          {entry.role}
+        </Text>
+      ) : null}
+      <Text style={[styles.stageCount, { color: eraColor }]}>
+        {entry.stageCount} stages
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+// ── Concept Card ───────────────────────────────────────────────────
+
+function ConceptJourneyCard({
+  entry,
+  onPress,
+}: {
+  entry: ConceptJourneyEntry;
+  onPress: () => void;
+}) {
+  const { base } = useTheme();
+
+  const rangeText = entry.firstLabel && entry.lastLabel
+    ? `${entry.firstLabel} → ${entry.lastLabel}`
+    : '';
+
+  return (
+    <TouchableOpacity
+      style={[styles.conceptCard, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${entry.title} journey, ${entry.stopCount} stops`}
+    >
+      <Text style={[styles.conceptTitle, { color: base.gold }]} numberOfLines={1}>
+        {entry.title}
+      </Text>
+      {rangeText ? (
+        <Text style={[styles.conceptRange, { color: base.textMuted }]} numberOfLines={1}>
+          {rangeText}
+        </Text>
+      ) : null}
+      <Text style={[styles.stageCount, { color: base.textDim }]}>
+        {entry.stopCount} stops
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+// ── Section Component ──────────────────────────────────────────────
+
+export function JourneyBrowseSection() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'ExploreMenu'>>();
+  const { personJourneys, conceptJourneys, isLoading } = useJourneyBrowse();
+
+  const handlePersonPress = useCallback((personId: string) => {
+    navigation.navigate('PersonJourney', { personId });
+  }, [navigation]);
+
+  const handleConceptPress = useCallback((conceptId: string) => {
+    navigation.navigate('ConceptDetail', { conceptId, initialTab: 'journey' });
+  }, [navigation]);
+
+  const handleBrowseAll = useCallback((tab?: 'people' | 'concepts') => {
+    navigation.navigate('JourneyBrowse', { tab });
+  }, [navigation]);
+
+  if (isLoading || (personJourneys.length === 0 && conceptJourneys.length === 0)) {
+    return null;
+  }
+
+  // Map era strings to theme era colors
+  const getEraColor = (era: string | null): string => {
+    if (!era) return base.gold;
+    // The eras record is in theme/colors but we use the palette-transformed version
+    return base.gold; // Simplified — the era badge handles its own color
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* ── Person Journeys Row ── */}
+      {personJourneys.length > 0 && (
+        <View style={styles.rowContainer}>
+          <View style={styles.rowHeader}>
+            <Text style={[styles.rowLabel, { color: base.textMuted }]}>
+              PEOPLE
+            </Text>
+            <TouchableOpacity
+              onPress={() => handleBrowseAll('people')}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Browse all ${personJourneys.length} person journeys`}
+            >
+              <Text style={[styles.browseAll, { color: base.gold }]}>
+                {personJourneys.length} journeys ›
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+          >
+            {personJourneys.map((entry) => (
+              <PersonJourneyCard
+                key={entry.personId}
+                entry={entry}
+                eraColor={getEraColor(entry.era)}
+                onPress={() => handlePersonPress(entry.personId)}
+              />
+            ))}
+          </ScrollView>
+        </View>
+      )}
+
+      {/* ── Concept Journeys Row ── */}
+      {conceptJourneys.length > 0 && (
+        <View style={styles.rowContainer}>
+          <View style={styles.rowHeader}>
+            <Text style={[styles.rowLabel, { color: base.textMuted }]}>
+              CONCEPTS
+            </Text>
+            <TouchableOpacity
+              onPress={() => handleBrowseAll('concepts')}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Browse all ${conceptJourneys.length} concept journeys`}
+            >
+              <Text style={[styles.browseAll, { color: base.gold }]}>
+                {conceptJourneys.length} journeys ›
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+          >
+            {conceptJourneys.map((entry) => (
+              <ConceptJourneyCard
+                key={entry.conceptId}
+                entry={entry}
+                onPress={() => handleConceptPress(entry.conceptId)}
+              />
+            ))}
+          </ScrollView>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ── Styles ──────────────────────────────────────────────────────────
+
+const PERSON_CARD_WIDTH = 120;
+const CONCEPT_CARD_WIDTH = 160;
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  rowContainer: {
+    gap: spacing.sm,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  rowLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.5,
+  },
+  browseAll: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  carouselContent: {
+    paddingHorizontal: 20,
+    gap: spacing.sm,
+  },
+
+  // Person card
+  personCard: {
+    width: PERSON_CARD_WIDTH,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    padding: spacing.sm + 2,
+    alignItems: 'center',
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.xs,
+  },
+  avatarText: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 18,
+  },
+  personName: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  personRole: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+  stageCount: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    marginTop: spacing.xs,
+  },
+
+  // Concept card
+  conceptCard: {
+    width: CONCEPT_CARD_WIDTH,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    padding: spacing.sm + 4,
+  },
+  conceptTitle: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+    marginBottom: 2,
+  },
+  conceptRange: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    lineHeight: 14,
+    marginBottom: spacing.xs,
+  },
+});

--- a/app/src/db/content/index.ts
+++ b/app/src/db/content/index.ts
@@ -16,7 +16,7 @@ export {
 export { getAllScholars, getScholar, getScholarsForBook } from './scholars';
 export {
   getAllPeople, getPerson, getPersonChildren, getSpousesOf,
-  getPersonJourney, getPersonLegacyRefs, hasPersonJourney,
+  getPersonJourney, getPersonLegacyRefs, hasPersonJourney, getPeopleWithJourneys,
 } from './people';
 export { getPlaces, getPlace, getMapStories, getMapStory } from './places';
 export {

--- a/app/src/db/content/people.ts
+++ b/app/src/db/content/people.ts
@@ -47,6 +47,20 @@ export async function getPersonLegacyRefs(personId: string): Promise<PersonLegac
   );
 }
 
+/** Get all people who have journey data (for Explore browse). */
+export async function getPeopleWithJourneys(): Promise<
+  { person_id: string; name: string; era: string | null; role: string | null; stage_count: number }[]
+> {
+  return getDb().getAllAsync(
+    `SELECT p.id as person_id, p.name, p.era, p.role,
+            COUNT(pj.id) as stage_count
+     FROM people p
+     JOIN people_journeys pj ON pj.person_id = p.id
+     GROUP BY p.id
+     ORDER BY stage_count DESC`,
+  );
+}
+
 /** Check if a person has a journey (fast count query). */
 export async function hasPersonJourney(personId: string): Promise<boolean> {
   const row = await getDb().getFirstAsync<{ c: number }>(

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -57,3 +57,4 @@ export { useMySubmissions } from './useMySubmissions';
 export { useEras } from './useEras';
 export { useRedemptiveArc, useRedemptiveActDetail } from './useRedemptiveArc';
 export { usePersonJourney } from './usePersonJourney';
+export { useJourneyBrowse } from './useJourneyBrowse';

--- a/app/src/hooks/useJourneyBrowse.ts
+++ b/app/src/hooks/useJourneyBrowse.ts
@@ -1,0 +1,79 @@
+/**
+ * useJourneyBrowse — Data for the Journeys section on ExploreMenuScreen.
+ *
+ * Loads person journeys (from people_journeys table) and concept journeys
+ * (from concepts table, filtered to those with journey_stops) in parallel.
+ *
+ * Part of Journeys on Explore feature.
+ */
+
+import { useState, useEffect } from 'react';
+import { getPeopleWithJourneys } from '../db/content';
+import { useConcepts, type Concept } from './useConceptData';
+import { logger } from '../utils/logger';
+
+export interface PersonJourneyEntry {
+  personId: string;
+  name: string;
+  era: string | null;
+  role: string | null;
+  stageCount: number;
+}
+
+export interface ConceptJourneyEntry {
+  conceptId: string;
+  title: string;
+  stopCount: number;
+  firstLabel: string;
+  lastLabel: string;
+}
+
+export interface JourneyBrowseData {
+  personJourneys: PersonJourneyEntry[];
+  conceptJourneys: ConceptJourneyEntry[];
+  isLoading: boolean;
+}
+
+export function useJourneyBrowse(): JourneyBrowseData {
+  const [personJourneys, setPersonJourneys] = useState<PersonJourneyEntry[]>([]);
+  const [isLoadingPeople, setIsLoadingPeople] = useState(true);
+  const { concepts, loading: conceptsLoading } = useConcepts();
+
+  // Load person journeys
+  useEffect(() => {
+    getPeopleWithJourneys()
+      .then((rows) => {
+        setPersonJourneys(
+          rows.map((r) => ({
+            personId: r.person_id,
+            name: r.name,
+            era: r.era,
+            role: r.role,
+            stageCount: r.stage_count,
+          })),
+        );
+      })
+      .catch((err) => {
+        logger.warn('useJourneyBrowse', 'Failed to load person journeys', err);
+      })
+      .finally(() => setIsLoadingPeople(false));
+  }, []);
+
+  // Derive concept journeys from the concepts hook (already loaded)
+  const conceptJourneys: ConceptJourneyEntry[] = concepts
+    .filter((c: Concept) => c.journey_stops && c.journey_stops.length > 0)
+    .map((c: Concept) => ({
+      conceptId: c.id,
+      title: c.title,
+      stopCount: c.journey_stops.length,
+      firstLabel: c.journey_stops[0]?.label ?? '',
+      lastLabel: c.journey_stops[c.journey_stops.length - 1]?.label ?? '',
+    }))
+    .sort((a, b) => b.stopCount - a.stopCount);
+
+  return {
+    personJourneys,
+    conceptJourneys,
+    isLoading: isLoadingPeople || conceptsLoading,
+  };
+}

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -13,6 +13,7 @@ const TimelineScreen = React.lazy(() => import('../screens/TimelineScreen'));
 const PeriodsScreen = React.lazy(() => import('../screens/PeriodsScreen'));
 const RedemptiveArcScreen = React.lazy(() => import('../screens/RedemptiveArcScreen'));
 const PersonJourneyScreen = React.lazy(() => import('../screens/PersonJourneyScreen'));
+const JourneyBrowseScreen = React.lazy(() => import('../screens/JourneyBrowseScreen'));
 const WordStudyBrowseScreen = React.lazy(() => import('../screens/WordStudyBrowseScreen'));
 const WordStudyDetailScreen = React.lazy(() => import('../screens/WordStudyDetailScreen'));
 const ScholarBrowseScreen = React.lazy(() => import('../screens/ScholarBrowseScreen'));
@@ -85,6 +86,7 @@ export function ExploreStack() {
         <Stack.Screen name="Periods" component={PeriodsScreen} />
         <Stack.Screen name="RedemptiveArc" component={RedemptiveArcScreen} />
         <Stack.Screen name="PersonJourney" component={PersonJourneyScreen} />
+        <Stack.Screen name="JourneyBrowse" component={JourneyBrowseScreen} />
         <Stack.Screen name="WordStudyBrowse" component={WordStudyBrowseScreen} />
         <Stack.Screen name="WordStudyDetail" component={WordStudyDetailScreen} />
         <Stack.Screen name="ScholarBrowse" component={ScholarBrowseScreen} />

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -69,7 +69,7 @@ export type ExploreStackParamList = {
   ProphecyBrowse: undefined;
   ProphecyDetail: { chainId: string };
   ConceptBrowse: undefined;
-  ConceptDetail: { conceptId: string };
+  ConceptDetail: { conceptId: string; initialTab?: 'overview' | 'journey' };
   DifficultPassagesBrowse: undefined;
   DifficultPassageDetail: { passageId: string };
   DictionaryBrowse: undefined;
@@ -94,6 +94,7 @@ export type ExploreStackParamList = {
   Periods: undefined;
   RedemptiveArc: undefined;
   PersonJourney: { personId: string };
+  JourneyBrowse: { tab?: 'people' | 'concepts' } | undefined;
   Concordance: {
     strongs?: string;
     original?: string;

--- a/app/src/screens/ConceptDetailScreen.tsx
+++ b/app/src/screens/ConceptDetailScreen.tsx
@@ -36,7 +36,7 @@ function ConceptDetailScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<Nav>();
   const route = useRoute<Route>();
-  const { conceptId } = route.params;
+  const { conceptId, initialTab: paramInitialTab } = route.params;
 
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
 
@@ -61,7 +61,9 @@ function ConceptDetailScreen() {
   };
 
   const hasJourney = (concept?.journey_stops?.length ?? 0) > 0;
-  const [activeTab, setActiveTab] = useState<'overview' | 'journey'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'journey'>(
+    paramInitialTab === 'journey' ? 'journey' : 'overview',
+  );
 
   if (loading) {
     return (

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -23,6 +23,7 @@ import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../components/Fea
 import { RecommendedCard } from '../components/RecommendedCard';
 import { StartHereBanner } from '../components/StartHereBanner';
 import { UpgradePrompt } from '../components/UpgradePrompt';
+import { JourneyBrowseSection } from '../components/JourneyBrowseSection';
 import { getReadingStats, getPreference, setPreference } from '../db/user';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
@@ -61,6 +62,10 @@ const SECTIONS: FeatureSection[] = [
       { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
       { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
     ],
+  },
+  {
+    id: 'journeys', label: 'Journeys', subtitle: 'Follow a life or trace an idea across Scripture',
+    features: [], // Custom renderer — uses JourneyBrowseSection instead of FeatureCards
   },
   {
     id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
@@ -242,6 +247,10 @@ function ExploreMenuScreen() {
               <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
               <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
 
+              {/* Journeys section uses a custom component instead of FeatureCards */}
+              {section.id === 'journeys' ? (
+                <JourneyBrowseSection />
+              ) : (
               <ScrollView
                 horizontal
                 showsHorizontalScrollIndicator={false}
@@ -266,6 +275,7 @@ function ExploreMenuScreen() {
                   );
                 })}
               </ScrollView>
+              )}
             </View>
           </View>
         ))}

--- a/app/src/screens/JourneyBrowseScreen.tsx
+++ b/app/src/screens/JourneyBrowseScreen.tsx
@@ -1,0 +1,246 @@
+/**
+ * JourneyBrowseScreen — Full-screen list of all person + concept journeys.
+ *
+ * Two tabs: People (30 entries) and Concepts (20 entries).
+ * Each row shows name, stage/stop count, era/range, and chevron.
+ * Taps navigate to PersonJourney or ConceptDetail (journey tab).
+ *
+ * Part of Journeys on Explore feature.
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  View, Text, TouchableOpacity, FlatList, StyleSheet,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { ChevronRight } from 'lucide-react-native';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { useJourneyBrowse, type PersonJourneyEntry, type ConceptJourneyEntry } from '../hooks/useJourneyBrowse';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+
+type Tab = 'people' | 'concepts';
+
+function JourneyBrowseScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'JourneyBrowse'>>();
+  const route = useRoute<ScreenRouteProp<'Explore', 'JourneyBrowse'>>();
+  const initialTab = route.params?.tab ?? 'people';
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+  const { personJourneys, conceptJourneys, isLoading } = useJourneyBrowse();
+
+  const handlePersonPress = useCallback((personId: string) => {
+    navigation.navigate('PersonJourney', { personId });
+  }, [navigation]);
+
+  const handleConceptPress = useCallback((conceptId: string) => {
+    navigation.navigate('ConceptDetail', { conceptId, initialTab: 'journey' });
+  }, [navigation]);
+
+  const renderPersonItem = useCallback(({ item }: { item: PersonJourneyEntry }) => (
+    <TouchableOpacity
+      style={[styles.row, { borderBottomColor: base.border }]}
+      onPress={() => handlePersonPress(item.personId)}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.name}, ${item.stageCount} stages`}
+    >
+      <View style={[styles.avatar, { backgroundColor: base.gold + '18', borderColor: base.gold + '30' }]}>
+        <Text style={[styles.avatarText, { color: base.gold }]}>
+          {item.name.charAt(0)}
+        </Text>
+      </View>
+      <View style={styles.rowCenter}>
+        <Text style={[styles.rowTitle, { color: base.text }]}>{item.name}</Text>
+        <Text style={[styles.rowSubtitle, { color: base.textMuted }]}>
+          {[item.role, item.era].filter(Boolean).join(' · ')}
+        </Text>
+      </View>
+      <View style={styles.rowRight}>
+        <Text style={[styles.countBadge, { color: base.gold }]}>
+          {item.stageCount} stages
+        </Text>
+        <ChevronRight size={14} color={base.textMuted} />
+      </View>
+    </TouchableOpacity>
+  ), [base, handlePersonPress]);
+
+  const renderConceptItem = useCallback(({ item }: { item: ConceptJourneyEntry }) => (
+    <TouchableOpacity
+      style={[styles.row, { borderBottomColor: base.border }]}
+      onPress={() => handleConceptPress(item.conceptId)}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.title}, ${item.stopCount} stops`}
+    >
+      <View style={[styles.conceptIcon, { backgroundColor: base.gold + '12' }]}>
+        <Text style={styles.conceptIconText}>◆</Text>
+      </View>
+      <View style={styles.rowCenter}>
+        <Text style={[styles.rowTitle, { color: base.text }]}>{item.title}</Text>
+        {item.firstLabel && item.lastLabel ? (
+          <Text style={[styles.rowSubtitle, { color: base.textMuted }]} numberOfLines={1}>
+            {item.firstLabel} → {item.lastLabel}
+          </Text>
+        ) : null}
+      </View>
+      <View style={styles.rowRight}>
+        <Text style={[styles.countBadge, { color: base.gold }]}>
+          {item.stopCount} stops
+        </Text>
+        <ChevronRight size={14} color={base.textMuted} />
+      </View>
+    </TouchableOpacity>
+  ), [base, handleConceptPress]);
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <ScreenHeader title="Journeys" />
+        <View style={styles.loadingPad}>
+          <LoadingSkeleton lines={8} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScreenHeader title="Journeys" />
+
+      {/* Tab bar */}
+      <View style={[styles.tabBar, { borderBottomColor: base.border }]}>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'people' && [styles.tabActive, { backgroundColor: base.gold + '15' }]]}
+          onPress={() => setActiveTab('people')}
+          accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'people' }}
+        >
+          <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'people' && { color: base.gold }]}>
+            People ({personJourneys.length})
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'concepts' && [styles.tabActive, { backgroundColor: base.gold + '15' }]]}
+          onPress={() => setActiveTab('concepts')}
+          accessibilityRole="tab"
+          accessibilityState={{ selected: activeTab === 'concepts' }}
+        >
+          <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'concepts' && { color: base.gold }]}>
+            Concepts ({conceptJourneys.length})
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* List */}
+      {activeTab === 'people' ? (
+        <FlatList
+          data={personJourneys}
+          keyExtractor={(item) => item.personId}
+          renderItem={renderPersonItem}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+        />
+      ) : (
+        <FlatList
+          data={conceptJourneys}
+          keyExtractor={(item) => item.conceptId}
+          renderItem={renderConceptItem}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+export default withErrorBoundary(JourneyBrowseScreen);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingPad: {
+    padding: spacing.lg,
+  },
+
+  // Tab bar
+  tabBar: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    paddingHorizontal: spacing.lg,
+  },
+  tab: {
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.sm,
+    marginBottom: -1,
+  },
+  tabActive: {
+    borderRadius: radii.sm,
+  },
+  tabText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+
+  // List
+  listContent: {
+    paddingBottom: spacing.xxl,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm + 4,
+    paddingHorizontal: spacing.lg,
+    borderBottomWidth: 1,
+    gap: spacing.sm + 2,
+  },
+  avatar: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 16,
+  },
+  conceptIcon: {
+    width: 38,
+    height: 38,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  conceptIconText: {
+    fontSize: 14,
+    color: '#bfa050', // Uses gold directly for the icon — matches brand
+  },
+  rowCenter: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+  },
+  rowSubtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    marginTop: 1,
+  },
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  countBadge: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+});

--- a/app/src/screens/JourneyBrowseScreen.tsx
+++ b/app/src/screens/JourneyBrowseScreen.tsx
@@ -99,7 +99,7 @@ function JourneyBrowseScreen() {
   if (isLoading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-        <ScreenHeader title="Journeys" />
+        <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
         <View style={styles.loadingPad}>
           <LoadingSkeleton lines={8} />
         </View>
@@ -109,7 +109,7 @@ function JourneyBrowseScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScreenHeader title="Journeys" />
+      <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
 
       {/* Tab bar */}
       <View style={[styles.tabBar, { borderBottomColor: base.border }]}>


### PR DESCRIPTION
## What

Surfaces 30 person journeys (176 stages) and 20 concept journeys (162 stops) on the Explore screen. Previously this content was only reachable 3-4 taps deep through individual detail screens.

## New Files
- `JourneyBrowseSection.tsx` — Custom Explore section with two horizontal carousels (people avatar cards + concept text cards)
- `JourneyBrowseScreen.tsx` — Full browse screen with People/Concepts tabs
- `useJourneyBrowse.ts` — Hook combining person + concept journey data

## Changes
- `people.ts` — Add `getPeopleWithJourneys()` query
- `types.ts` — Add `JourneyBrowse` route + `ConceptDetail.initialTab` param
- `ExploreStack.tsx` — Register `JourneyBrowseScreen`
- `ExploreMenuScreen.tsx` — Add Journeys section between Themes and Language with custom renderer
- `ConceptDetailScreen.tsx` — Accept `initialTab` param for deep-linking to journey tab
- `explore-images.json` — Add `JourneyBrowse` manifest entry

## Navigation Paths (new)
- Explore → Journeys → tap person card → `PersonJourneyScreen`
- Explore → Journeys → tap concept card → `ConceptDetailScreen` (journey tab)
- Explore → Journeys → "30 journeys ›" → `JourneyBrowseScreen` (people tab)
- Explore → Journeys → "20 journeys ›" → `JourneyBrowseScreen` (concepts tab)

## No DB/pipeline changes
All data already exists in `people_journeys` table and `concepts.journey_stops_json` column.