### PR TITLE
fix: per-screen Suspense boundaries + journey navigation

### DIFF
--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -1,130 +1,116 @@
-import React, { Suspense } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import ExploreMenuScreen from '../screens/ExploreMenuScreen';
 import { useTheme } from '../theme';
 import type { ExploreStackParamList } from './types';
+import { lazySuspense } from './lazySuspense';
 
-// Lazy-loaded screens — only imported on first navigation
-const GenealogyTreeScreen = React.lazy(() => import('../screens/GenealogyTreeScreen'));
-const PersonDetailScreen = React.lazy(() => import('../screens/PersonDetailScreen'));
-const MapScreen = React.lazy(() => import('../screens/MapScreen'));
-const TimelineScreen = React.lazy(() => import('../screens/TimelineScreen'));
-const PeriodsScreen = React.lazy(() => import('../screens/PeriodsScreen'));
-const RedemptiveArcScreen = React.lazy(() => import('../screens/RedemptiveArcScreen'));
-const PersonJourneyScreen = React.lazy(() => import('../screens/PersonJourneyScreen'));
-const JourneyBrowseScreen = React.lazy(() => import('../screens/JourneyBrowseScreen'));
-const WordStudyBrowseScreen = React.lazy(() => import('../screens/WordStudyBrowseScreen'));
-const WordStudyDetailScreen = React.lazy(() => import('../screens/WordStudyDetailScreen'));
-const ScholarBrowseScreen = React.lazy(() => import('../screens/ScholarBrowseScreen'));
-const ScholarBioScreen = React.lazy(() => import('../screens/ScholarBioScreen'));
-const ParallelPassageScreen = React.lazy(() => import('../screens/ParallelPassageScreen'));
-const ParallelDetailScreen = React.lazy(() => import('../screens/ParallelDetailScreen'));
-const HarmonyBrowseScreen = React.lazy(() => import('../screens/HarmonyBrowseScreen'));
-const HarmonyDetailScreen = React.lazy(() => import('../screens/HarmonyDetailScreen'));
-const TopicBrowseScreen = React.lazy(() => import('../screens/TopicBrowseScreen'));
-const TopicDetailScreen = React.lazy(() => import('../screens/TopicDetailScreen'));
-const ProphecyBrowseScreen = React.lazy(() => import('../screens/ProphecyBrowseScreen'));
-const ProphecyDetailScreen = React.lazy(() => import('../screens/ProphecyDetailScreen'));
-const ConceptBrowseScreen = React.lazy(() => import('../screens/ConceptBrowseScreen'));
-const ConceptDetailScreen = React.lazy(() => import('../screens/ConceptDetailScreen'));
-const DifficultPassagesBrowseScreen = React.lazy(() => import('../screens/DifficultPassagesBrowseScreen'));
-const DifficultPassageDetailScreen = React.lazy(() => import('../screens/DifficultPassageDetailScreen'));
-const ConcordanceScreen = React.lazy(() => import('../screens/ConcordanceScreen'));
-const ContentLibraryScreen = React.lazy(() => import('../screens/ContentLibraryScreen'));
-const DictionaryBrowseScreen = React.lazy(() => import('../screens/DictionaryBrowseScreen'));
-const DictionaryDetailScreen = React.lazy(() => import('../screens/DictionaryDetailScreen'));
-const DebateBrowseScreen = React.lazy(() => import('../screens/DebateBrowseScreen'));
-const DebateDetailScreen = React.lazy(() => import('../screens/DebateDetailScreen'));
-const LifeTopicsScreen = React.lazy(() => import('../screens/LifeTopicsScreen'));
-const LifeTopicDetailScreen = React.lazy(() => import('../screens/LifeTopicDetailScreen'));
-const LensBrowseScreen = React.lazy(() => import('../screens/LensBrowseScreen'));
-const ArchaeologyBrowseScreen = React.lazy(() => import('../screens/ArchaeologyBrowseScreen'));
-const ArchaeologyDetailScreen = React.lazy(() => import('../screens/ArchaeologyDetailScreen'));
-const TimeTravelBrowseScreen = React.lazy(() => import('../screens/TimeTravelBrowseScreen'));
-const TimeTravelDetailScreen = React.lazy(() => import('../screens/TimeTravelDetailScreen'));
-const GrammarBrowseScreen = React.lazy(() => import('../screens/GrammarBrowseScreen'));
-const GrammarArticleScreen = React.lazy(() => import('../screens/GrammarArticleScreen'));
-const ThreadBrowseScreen = React.lazy(() => import('../screens/ThreadBrowseScreen'));
-const ThreadDetailScreen = React.lazy(() => import('../screens/ThreadDetailScreen'));
-const SubmissionFlowScreen = React.lazy(() => import('../screens/SubmissionFlowScreen'));
-const SubmissionDetailScreen = React.lazy(() => import('../screens/SubmissionDetailScreen'));
-const SubmissionFeedScreen = React.lazy(() => import('../screens/SubmissionFeedScreen'));
-const ChapterScreen = React.lazy(() => import('../screens/ChapterScreen'));
+// Lazy-loaded screens — each wrapped in its own Suspense boundary
+const GenealogyTreeScreen = lazySuspense(() => import('../screens/GenealogyTreeScreen'));
+const PersonDetailScreen = lazySuspense(() => import('../screens/PersonDetailScreen'));
+const MapScreen = lazySuspense(() => import('../screens/MapScreen'));
+const TimelineScreen = lazySuspense(() => import('../screens/TimelineScreen'));
+const PeriodsScreen = lazySuspense(() => import('../screens/PeriodsScreen'));
+const RedemptiveArcScreen = lazySuspense(() => import('../screens/RedemptiveArcScreen'));
+const PersonJourneyScreen = lazySuspense(() => import('../screens/PersonJourneyScreen'));
+const JourneyBrowseScreen = lazySuspense(() => import('../screens/JourneyBrowseScreen'));
+const WordStudyBrowseScreen = lazySuspense(() => import('../screens/WordStudyBrowseScreen'));
+const WordStudyDetailScreen = lazySuspense(() => import('../screens/WordStudyDetailScreen'));
+const ScholarBrowseScreen = lazySuspense(() => import('../screens/ScholarBrowseScreen'));
+const ScholarBioScreen = lazySuspense(() => import('../screens/ScholarBioScreen'));
+const ParallelPassageScreen = lazySuspense(() => import('../screens/ParallelPassageScreen'));
+const ParallelDetailScreen = lazySuspense(() => import('../screens/ParallelDetailScreen'));
+const HarmonyBrowseScreen = lazySuspense(() => import('../screens/HarmonyBrowseScreen'));
+const HarmonyDetailScreen = lazySuspense(() => import('../screens/HarmonyDetailScreen'));
+const TopicBrowseScreen = lazySuspense(() => import('../screens/TopicBrowseScreen'));
+const TopicDetailScreen = lazySuspense(() => import('../screens/TopicDetailScreen'));
+const ProphecyBrowseScreen = lazySuspense(() => import('../screens/ProphecyBrowseScreen'));
+const ProphecyDetailScreen = lazySuspense(() => import('../screens/ProphecyDetailScreen'));
+const ConceptBrowseScreen = lazySuspense(() => import('../screens/ConceptBrowseScreen'));
+const ConceptDetailScreen = lazySuspense(() => import('../screens/ConceptDetailScreen'));
+const DifficultPassagesBrowseScreen = lazySuspense(() => import('../screens/DifficultPassagesBrowseScreen'));
+const DifficultPassageDetailScreen = lazySuspense(() => import('../screens/DifficultPassageDetailScreen'));
+const ConcordanceScreen = lazySuspense(() => import('../screens/ConcordanceScreen'));
+const ContentLibraryScreen = lazySuspense(() => import('../screens/ContentLibraryScreen'));
+const DictionaryBrowseScreen = lazySuspense(() => import('../screens/DictionaryBrowseScreen'));
+const DictionaryDetailScreen = lazySuspense(() => import('../screens/DictionaryDetailScreen'));
+const DebateBrowseScreen = lazySuspense(() => import('../screens/DebateBrowseScreen'));
+const DebateDetailScreen = lazySuspense(() => import('../screens/DebateDetailScreen'));
+const LifeTopicsScreen = lazySuspense(() => import('../screens/LifeTopicsScreen'));
+const LifeTopicDetailScreen = lazySuspense(() => import('../screens/LifeTopicDetailScreen'));
+const LensBrowseScreen = lazySuspense(() => import('../screens/LensBrowseScreen'));
+const ArchaeologyBrowseScreen = lazySuspense(() => import('../screens/ArchaeologyBrowseScreen'));
+const ArchaeologyDetailScreen = lazySuspense(() => import('../screens/ArchaeologyDetailScreen'));
+const TimeTravelBrowseScreen = lazySuspense(() => import('../screens/TimeTravelBrowseScreen'));
+const TimeTravelDetailScreen = lazySuspense(() => import('../screens/TimeTravelDetailScreen'));
+const GrammarBrowseScreen = lazySuspense(() => import('../screens/GrammarBrowseScreen'));
+const GrammarArticleScreen = lazySuspense(() => import('../screens/GrammarArticleScreen'));
+const ThreadBrowseScreen = lazySuspense(() => import('../screens/ThreadBrowseScreen'));
+const ThreadDetailScreen = lazySuspense(() => import('../screens/ThreadDetailScreen'));
+const SubmissionFlowScreen = lazySuspense(() => import('../screens/SubmissionFlowScreen'));
+const SubmissionDetailScreen = lazySuspense(() => import('../screens/SubmissionDetailScreen'));
+const SubmissionFeedScreen = lazySuspense(() => import('../screens/SubmissionFeedScreen'));
+const ChapterScreen = lazySuspense(() => import('../screens/ChapterScreen'));
 
 const Stack = createStackNavigator<ExploreStackParamList>();
-
-function SuspenseFallback() {
-  return (
-    <View style={fallbackStyles.container}>
-      <ActivityIndicator color="#bfa050" size="large" />
-    </View>
-  );
-}
-
-const fallbackStyles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-});
 
 export function ExploreStack() {
   const { base } = useTheme();
 
   return (
-    <Suspense fallback={<SuspenseFallback />}>
-      <Stack.Navigator
-        screenOptions={{
-          headerShown: false,
-          cardStyle: { backgroundColor: base.bg },
-          gestureEnabled: true,
-        }}
-      >
-        <Stack.Screen name="ExploreMenu" component={ExploreMenuScreen} />
-        <Stack.Screen name="GenealogyTree" component={GenealogyTreeScreen} options={{ gestureEnabled: false }} />
-        <Stack.Screen name="PersonDetail" component={PersonDetailScreen} />
-        <Stack.Screen name="Map" component={MapScreen} options={{ gestureEnabled: false }} />
-        <Stack.Screen name="Timeline" component={TimelineScreen} options={{ gestureEnabled: false }} />
-        <Stack.Screen name="Periods" component={PeriodsScreen} />
-        <Stack.Screen name="RedemptiveArc" component={RedemptiveArcScreen} />
-        <Stack.Screen name="PersonJourney" component={PersonJourneyScreen} />
-        <Stack.Screen name="JourneyBrowse" component={JourneyBrowseScreen} />
-        <Stack.Screen name="WordStudyBrowse" component={WordStudyBrowseScreen} />
-        <Stack.Screen name="WordStudyDetail" component={WordStudyDetailScreen} />
-        <Stack.Screen name="ScholarBrowse" component={ScholarBrowseScreen} />
-        <Stack.Screen name="ScholarBio" component={ScholarBioScreen} />
-        <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
-        <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
-        <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
-        <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
-        <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
-        <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
-        <Stack.Screen name="ProphecyBrowse" component={ProphecyBrowseScreen} />
-        <Stack.Screen name="ProphecyDetail" component={ProphecyDetailScreen} />
-        <Stack.Screen name="ConceptBrowse" component={ConceptBrowseScreen} />
-        <Stack.Screen name="ConceptDetail" component={ConceptDetailScreen} />
-        <Stack.Screen name="DifficultPassagesBrowse" component={DifficultPassagesBrowseScreen} />
-        <Stack.Screen name="DifficultPassageDetail" component={DifficultPassageDetailScreen} />
-        <Stack.Screen name="Concordance" component={ConcordanceScreen} />
-        <Stack.Screen name="ContentLibrary" component={ContentLibraryScreen} />
-        <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
-        <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
-        <Stack.Screen name="DebateBrowse" component={DebateBrowseScreen} />
-        <Stack.Screen name="DebateDetail" component={DebateDetailScreen} />
-        <Stack.Screen name="LifeTopics" component={LifeTopicsScreen} />
-        <Stack.Screen name="LifeTopicDetail" component={LifeTopicDetailScreen} />
-        <Stack.Screen name="LensBrowse" component={LensBrowseScreen} />
-        <Stack.Screen name="ArchaeologyBrowse" component={ArchaeologyBrowseScreen} />
-        <Stack.Screen name="ArchaeologyDetail" component={ArchaeologyDetailScreen} />
-        <Stack.Screen name="TimeTravelBrowse" component={TimeTravelBrowseScreen} />
-        <Stack.Screen name="TimeTravelDetail" component={TimeTravelDetailScreen} />
-        <Stack.Screen name="GrammarBrowse" component={GrammarBrowseScreen} />
-        <Stack.Screen name="GrammarArticle" component={GrammarArticleScreen} />
-        <Stack.Screen name="ThreadBrowse" component={ThreadBrowseScreen} />
-        <Stack.Screen name="ThreadDetail" component={ThreadDetailScreen} />
-        <Stack.Screen name="SubmissionFlow" component={SubmissionFlowScreen} />
-        <Stack.Screen name="SubmissionDetail" component={SubmissionDetailScreen} />
-        <Stack.Screen name="SubmissionFeed" component={SubmissionFeedScreen} />
-        <Stack.Screen name="Chapter" component={ChapterScreen} />
-      </Stack.Navigator>
-    </Suspense>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        cardStyle: { backgroundColor: base.bg },
+        gestureEnabled: true,
+      }}
+    >
+      <Stack.Screen name="ExploreMenu" component={ExploreMenuScreen} />
+      <Stack.Screen name="GenealogyTree" component={GenealogyTreeScreen} options={{ gestureEnabled: false }} />
+      <Stack.Screen name="PersonDetail" component={PersonDetailScreen} />
+      <Stack.Screen name="Map" component={MapScreen} options={{ gestureEnabled: false }} />
+      <Stack.Screen name="Timeline" component={TimelineScreen} options={{ gestureEnabled: false }} />
+      <Stack.Screen name="Periods" component={PeriodsScreen} />
+      <Stack.Screen name="RedemptiveArc" component={RedemptiveArcScreen} />
+      <Stack.Screen name="PersonJourney" component={PersonJourneyScreen} />
+      <Stack.Screen name="JourneyBrowse" component={JourneyBrowseScreen} />
+      <Stack.Screen name="WordStudyBrowse" component={WordStudyBrowseScreen} />
+      <Stack.Screen name="WordStudyDetail" component={WordStudyDetailScreen} />
+      <Stack.Screen name="ScholarBrowse" component={ScholarBrowseScreen} />
+      <Stack.Screen name="ScholarBio" component={ScholarBioScreen} />
+      <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
+      <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
+      <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
+      <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
+      <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
+      <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
+      <Stack.Screen name="ProphecyBrowse" component={ProphecyBrowseScreen} />
+      <Stack.Screen name="ProphecyDetail" component={ProphecyDetailScreen} />
+      <Stack.Screen name="ConceptBrowse" component={ConceptBrowseScreen} />
+      <Stack.Screen name="ConceptDetail" component={ConceptDetailScreen} />
+      <Stack.Screen name="DifficultPassagesBrowse" component={DifficultPassagesBrowseScreen} />
+      <Stack.Screen name="DifficultPassageDetail" component={DifficultPassageDetailScreen} />
+      <Stack.Screen name="Concordance" component={ConcordanceScreen} />
+      <Stack.Screen name="ContentLibrary" component={ContentLibraryScreen} />
+      <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
+      <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
+      <Stack.Screen name="DebateBrowse" component={DebateBrowseScreen} />
+      <Stack.Screen name="DebateDetail" component={DebateDetailScreen} />
+      <Stack.Screen name="LifeTopics" component={LifeTopicsScreen} />
+      <Stack.Screen name="LifeTopicDetail" component={LifeTopicDetailScreen} />
+      <Stack.Screen name="LensBrowse" component={LensBrowseScreen} />
+      <Stack.Screen name="ArchaeologyBrowse" component={ArchaeologyBrowseScreen} />
+      <Stack.Screen name="ArchaeologyDetail" component={ArchaeologyDetailScreen} />
+      <Stack.Screen name="TimeTravelBrowse" component={TimeTravelBrowseScreen} />
+      <Stack.Screen name="TimeTravelDetail" component={TimeTravelDetailScreen} />
+      <Stack.Screen name="GrammarBrowse" component={GrammarBrowseScreen} />
+      <Stack.Screen name="GrammarArticle" component={GrammarArticleScreen} />
+      <Stack.Screen name="ThreadBrowse" component={ThreadBrowseScreen} />
+      <Stack.Screen name="ThreadDetail" component={ThreadDetailScreen} />
+      <Stack.Screen name="SubmissionFlow" component={SubmissionFlowScreen} />
+      <Stack.Screen name="SubmissionDetail" component={SubmissionDetailScreen} />
+      <Stack.Screen name="SubmissionFeed" component={SubmissionFeedScreen} />
+      <Stack.Screen name="Chapter" component={ChapterScreen} />
+    </Stack.Navigator>
   );
 }

--- a/app/src/navigation/HomeStack.tsx
+++ b/app/src/navigation/HomeStack.tsx
@@ -1,60 +1,46 @@
-import React, { Suspense } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import HomeScreen from '../screens/HomeScreen';
 import { useTheme } from '../theme';
 import type { HomeStackParamList } from './types';
+import { lazySuspense } from './lazySuspense';
 
-// Lazy-loaded screens
-const ChapterScreen = React.lazy(() => import('../screens/ChapterScreen'));
-const ChapterListScreen = React.lazy(() => import('../screens/ChapterListScreen'));
-const BookListScreen = React.lazy(() => import('../screens/BookListScreen'));
-const BookIntroScreen = React.lazy(() => import('../screens/BookIntroScreen'));
-const ParallelPassageScreen = React.lazy(() => import('../screens/ParallelPassageScreen'));
-const ParallelDetailScreen = React.lazy(() => import('../screens/ParallelDetailScreen'));
-const HarmonyBrowseScreen = React.lazy(() => import('../screens/HarmonyBrowseScreen'));
-const HarmonyDetailScreen = React.lazy(() => import('../screens/HarmonyDetailScreen'));
-const TopicBrowseScreen = React.lazy(() => import('../screens/TopicBrowseScreen'));
-const TopicDetailScreen = React.lazy(() => import('../screens/TopicDetailScreen'));
-const DictionaryBrowseScreen = React.lazy(() => import('../screens/DictionaryBrowseScreen'));
-const DictionaryDetailScreen = React.lazy(() => import('../screens/DictionaryDetailScreen'));
-const PlanDetailScreen = React.lazy(() => import('../screens/PlanDetailScreen'));
+// Lazy-loaded screens — each wrapped in its own Suspense boundary
+const ChapterScreen = lazySuspense(() => import('../screens/ChapterScreen'));
+const ChapterListScreen = lazySuspense(() => import('../screens/ChapterListScreen'));
+const BookListScreen = lazySuspense(() => import('../screens/BookListScreen'));
+const BookIntroScreen = lazySuspense(() => import('../screens/BookIntroScreen'));
+const ParallelPassageScreen = lazySuspense(() => import('../screens/ParallelPassageScreen'));
+const ParallelDetailScreen = lazySuspense(() => import('../screens/ParallelDetailScreen'));
+const HarmonyBrowseScreen = lazySuspense(() => import('../screens/HarmonyBrowseScreen'));
+const HarmonyDetailScreen = lazySuspense(() => import('../screens/HarmonyDetailScreen'));
+const TopicBrowseScreen = lazySuspense(() => import('../screens/TopicBrowseScreen'));
+const TopicDetailScreen = lazySuspense(() => import('../screens/TopicDetailScreen'));
+const DictionaryBrowseScreen = lazySuspense(() => import('../screens/DictionaryBrowseScreen'));
+const DictionaryDetailScreen = lazySuspense(() => import('../screens/DictionaryDetailScreen'));
+const PlanDetailScreen = lazySuspense(() => import('../screens/PlanDetailScreen'));
 
 const Stack = createStackNavigator<HomeStackParamList>();
-
-function SuspenseFallback() {
-  return (
-    <View style={fallbackStyles.container}>
-      <ActivityIndicator color="#bfa050" size="large" />
-    </View>
-  );
-}
-
-const fallbackStyles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-});
 
 export function HomeStack() {
   const { base } = useTheme();
 
   return (
-    <Suspense fallback={<SuspenseFallback />}>
-      <Stack.Navigator screenOptions={{ headerShown: false, cardStyle: { backgroundColor: base.bg } }}>
-        <Stack.Screen name="HomeMain" component={HomeScreen} />
-        <Stack.Screen name="Chapter" component={ChapterScreen} />
-        <Stack.Screen name="ChapterList" component={ChapterListScreen} />
-        <Stack.Screen name="BookList" component={BookListScreen} />
-        <Stack.Screen name="BookIntro" component={BookIntroScreen} />
-        <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
-        <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
-        <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
-        <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
-        <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
-        <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
-        <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
-        <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
-        <Stack.Screen name="PlanDetail" component={PlanDetailScreen} />
-      </Stack.Navigator>
-    </Suspense>
+    <Stack.Navigator screenOptions={{ headerShown: false, cardStyle: { backgroundColor: base.bg } }}>
+      <Stack.Screen name="HomeMain" component={HomeScreen} />
+      <Stack.Screen name="Chapter" component={ChapterScreen} />
+      <Stack.Screen name="ChapterList" component={ChapterListScreen} />
+      <Stack.Screen name="BookList" component={BookListScreen} />
+      <Stack.Screen name="BookIntro" component={BookIntroScreen} />
+      <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
+      <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
+      <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
+      <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
+      <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
+      <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
+      <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
+      <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
+      <Stack.Screen name="PlanDetail" component={PlanDetailScreen} />
+    </Stack.Navigator>
   );
 }

--- a/app/src/navigation/MoreStack.tsx
+++ b/app/src/navigation/MoreStack.tsx
@@ -1,66 +1,52 @@
-import React, { Suspense } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import MoreMenuScreen from '../screens/MoreMenuScreen';
 import { useTheme } from '../theme';
 import type { MoreStackParamList } from './types';
+import { lazySuspense } from './lazySuspense';
 
-// Lazy-loaded screens
-const SettingsScreen = React.lazy(() => import('../screens/SettingsScreen'));
-const BookmarkListScreen = React.lazy(() => import('../screens/BookmarkListScreen'));
-const ReadingHistoryScreen = React.lazy(() => import('../screens/ReadingHistoryScreen'));
-const AllNotesScreen = React.lazy(() => import('../screens/AllNotesScreen'));
-const CollectionDetailScreen = React.lazy(() => import('../screens/CollectionDetailScreen'));
-const PlanListScreen = React.lazy(() => import('../screens/PlanListScreen'));
-const PlanDetailScreen = React.lazy(() => import('../screens/PlanDetailScreen'));
-const ChapterScreen = React.lazy(() => import('../screens/ChapterScreen'));
-const BookIntroScreen = React.lazy(() => import('../screens/BookIntroScreen'));
-const SubscriptionScreen = React.lazy(() => import('../screens/SubscriptionScreen'));
-const LoginScreen = React.lazy(() => import('../screens/LoginScreen'));
-const SignUpScreen = React.lazy(() => import('../screens/SignUpScreen'));
-const ForgotPasswordScreen = React.lazy(() => import('../screens/ForgotPasswordScreen'));
-const UserProfileScreen = React.lazy(() => import('../screens/UserProfileScreen'));
-const NotificationPrefsScreen = React.lazy(() => import('../screens/NotificationPrefsScreen'));
-const NotificationFeedScreen = React.lazy(() => import('../screens/NotificationFeedScreen'));
+// Lazy-loaded screens — each wrapped in its own Suspense boundary
+const SettingsScreen = lazySuspense(() => import('../screens/SettingsScreen'));
+const BookmarkListScreen = lazySuspense(() => import('../screens/BookmarkListScreen'));
+const ReadingHistoryScreen = lazySuspense(() => import('../screens/ReadingHistoryScreen'));
+const AllNotesScreen = lazySuspense(() => import('../screens/AllNotesScreen'));
+const CollectionDetailScreen = lazySuspense(() => import('../screens/CollectionDetailScreen'));
+const PlanListScreen = lazySuspense(() => import('../screens/PlanListScreen'));
+const PlanDetailScreen = lazySuspense(() => import('../screens/PlanDetailScreen'));
+const ChapterScreen = lazySuspense(() => import('../screens/ChapterScreen'));
+const BookIntroScreen = lazySuspense(() => import('../screens/BookIntroScreen'));
+const SubscriptionScreen = lazySuspense(() => import('../screens/SubscriptionScreen'));
+const LoginScreen = lazySuspense(() => import('../screens/LoginScreen'));
+const SignUpScreen = lazySuspense(() => import('../screens/SignUpScreen'));
+const ForgotPasswordScreen = lazySuspense(() => import('../screens/ForgotPasswordScreen'));
+const UserProfileScreen = lazySuspense(() => import('../screens/UserProfileScreen'));
+const NotificationPrefsScreen = lazySuspense(() => import('../screens/NotificationPrefsScreen'));
+const NotificationFeedScreen = lazySuspense(() => import('../screens/NotificationFeedScreen'));
 
 const Stack = createStackNavigator<MoreStackParamList>();
-
-function SuspenseFallback() {
-  return (
-    <View style={fallbackStyles.container}>
-      <ActivityIndicator color="#bfa050" size="large" />
-    </View>
-  );
-}
-
-const fallbackStyles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-});
 
 export function MoreStack() {
   const { base } = useTheme();
 
   return (
-    <Suspense fallback={<SuspenseFallback />}>
-      <Stack.Navigator screenOptions={{ headerShown: false, cardStyle: { backgroundColor: base.bg } }}>
-        <Stack.Screen name="MoreMenu" component={MoreMenuScreen} />
-        <Stack.Screen name="Settings" component={SettingsScreen} />
-        <Stack.Screen name="Bookmarks" component={BookmarkListScreen} />
-        <Stack.Screen name="ReadingHistory" component={ReadingHistoryScreen} />
-        <Stack.Screen name="AllNotes" component={AllNotesScreen} />
-        <Stack.Screen name="CollectionDetail" component={CollectionDetailScreen} />
-        <Stack.Screen name="PlanList" component={PlanListScreen} />
-        <Stack.Screen name="PlanDetail" component={PlanDetailScreen} />
-        <Stack.Screen name="Chapter" component={ChapterScreen} />
-        <Stack.Screen name="BookIntro" component={BookIntroScreen} />
-        <Stack.Screen name="Subscription" component={SubscriptionScreen} />
-        <Stack.Screen name="Login" component={LoginScreen} />
-        <Stack.Screen name="SignUp" component={SignUpScreen} />
-        <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
-        <Stack.Screen name="UserProfile" component={UserProfileScreen} />
-        <Stack.Screen name="NotificationPrefs" component={NotificationPrefsScreen} />
-        <Stack.Screen name="NotificationFeed" component={NotificationFeedScreen} />
-      </Stack.Navigator>
-    </Suspense>
+    <Stack.Navigator screenOptions={{ headerShown: false, cardStyle: { backgroundColor: base.bg } }}>
+      <Stack.Screen name="MoreMenu" component={MoreMenuScreen} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+      <Stack.Screen name="Bookmarks" component={BookmarkListScreen} />
+      <Stack.Screen name="ReadingHistory" component={ReadingHistoryScreen} />
+      <Stack.Screen name="AllNotes" component={AllNotesScreen} />
+      <Stack.Screen name="CollectionDetail" component={CollectionDetailScreen} />
+      <Stack.Screen name="PlanList" component={PlanListScreen} />
+      <Stack.Screen name="PlanDetail" component={PlanDetailScreen} />
+      <Stack.Screen name="Chapter" component={ChapterScreen} />
+      <Stack.Screen name="BookIntro" component={BookIntroScreen} />
+      <Stack.Screen name="Subscription" component={SubscriptionScreen} />
+      <Stack.Screen name="Login" component={LoginScreen} />
+      <Stack.Screen name="SignUp" component={SignUpScreen} />
+      <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+      <Stack.Screen name="UserProfile" component={UserProfileScreen} />
+      <Stack.Screen name="NotificationPrefs" component={NotificationPrefsScreen} />
+      <Stack.Screen name="NotificationFeed" component={NotificationFeedScreen} />
+    </Stack.Navigator>
   );
 }

--- a/app/src/navigation/ReadStack.tsx
+++ b/app/src/navigation/ReadStack.tsx
@@ -1,62 +1,48 @@
-import React, { Suspense } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import BookListScreen from '../screens/BookListScreen';
 import { useTheme } from '../theme';
 import type { ReadStackParamList } from './types';
+import { lazySuspense } from './lazySuspense';
 
-// Lazy-loaded screens
-const ChapterListScreen = React.lazy(() => import('../screens/ChapterListScreen'));
-const BookIntroScreen = React.lazy(() => import('../screens/BookIntroScreen'));
-const ChapterScreen = React.lazy(() => import('../screens/ChapterScreen'));
-const ParallelPassageScreen = React.lazy(() => import('../screens/ParallelPassageScreen'));
-const ParallelDetailScreen = React.lazy(() => import('../screens/ParallelDetailScreen'));
-const HarmonyBrowseScreen = React.lazy(() => import('../screens/HarmonyBrowseScreen'));
-const HarmonyDetailScreen = React.lazy(() => import('../screens/HarmonyDetailScreen'));
-const TopicBrowseScreen = React.lazy(() => import('../screens/TopicBrowseScreen'));
-const TopicDetailScreen = React.lazy(() => import('../screens/TopicDetailScreen'));
-const DictionaryBrowseScreen = React.lazy(() => import('../screens/DictionaryBrowseScreen'));
-const DictionaryDetailScreen = React.lazy(() => import('../screens/DictionaryDetailScreen'));
+// Lazy-loaded screens — each wrapped in its own Suspense boundary
+const ChapterListScreen = lazySuspense(() => import('../screens/ChapterListScreen'));
+const BookIntroScreen = lazySuspense(() => import('../screens/BookIntroScreen'));
+const ChapterScreen = lazySuspense(() => import('../screens/ChapterScreen'));
+const ParallelPassageScreen = lazySuspense(() => import('../screens/ParallelPassageScreen'));
+const ParallelDetailScreen = lazySuspense(() => import('../screens/ParallelDetailScreen'));
+const HarmonyBrowseScreen = lazySuspense(() => import('../screens/HarmonyBrowseScreen'));
+const HarmonyDetailScreen = lazySuspense(() => import('../screens/HarmonyDetailScreen'));
+const TopicBrowseScreen = lazySuspense(() => import('../screens/TopicBrowseScreen'));
+const TopicDetailScreen = lazySuspense(() => import('../screens/TopicDetailScreen'));
+const DictionaryBrowseScreen = lazySuspense(() => import('../screens/DictionaryBrowseScreen'));
+const DictionaryDetailScreen = lazySuspense(() => import('../screens/DictionaryDetailScreen'));
 
 const Stack = createStackNavigator<ReadStackParamList>();
-
-function SuspenseFallback() {
-  return (
-    <View style={fallbackStyles.container}>
-      <ActivityIndicator color="#bfa050" size="large" />
-    </View>
-  );
-}
-
-const fallbackStyles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-});
 
 export function ReadStack() {
   const { base } = useTheme();
 
   return (
-    <Suspense fallback={<SuspenseFallback />}>
-      <Stack.Navigator
-        screenOptions={{
-          headerShown: false,
-          cardStyle: { backgroundColor: base.bg },
-          gestureEnabled: true,
-        }}
-      >
-        <Stack.Screen name="BookList" component={BookListScreen} />
-        <Stack.Screen name="ChapterList" component={ChapterListScreen} />
-        <Stack.Screen name="BookIntro" component={BookIntroScreen} />
-        <Stack.Screen name="Chapter" component={ChapterScreen} />
-        <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
-        <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
-        <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
-        <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
-        <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
-        <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
-        <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
-        <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
-      </Stack.Navigator>
-    </Suspense>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        cardStyle: { backgroundColor: base.bg },
+        gestureEnabled: true,
+      }}
+    >
+      <Stack.Screen name="BookList" component={BookListScreen} />
+      <Stack.Screen name="ChapterList" component={ChapterListScreen} />
+      <Stack.Screen name="BookIntro" component={BookIntroScreen} />
+      <Stack.Screen name="Chapter" component={ChapterScreen} />
+      <Stack.Screen name="ParallelPassage" component={ParallelPassageScreen} />
+      <Stack.Screen name="ParallelDetail" component={ParallelDetailScreen} />
+      <Stack.Screen name="HarmonyBrowse" component={HarmonyBrowseScreen} />
+      <Stack.Screen name="HarmonyDetail" component={HarmonyDetailScreen} />
+      <Stack.Screen name="TopicBrowse" component={TopicBrowseScreen} />
+      <Stack.Screen name="TopicDetail" component={TopicDetailScreen} />
+      <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />
+      <Stack.Screen name="DictionaryDetail" component={DictionaryDetailScreen} />
+    </Stack.Navigator>
   );
 }

--- a/app/src/navigation/lazySuspense.tsx
+++ b/app/src/navigation/lazySuspense.tsx
@@ -1,0 +1,49 @@
+/**
+ * navigation/lazySuspense.tsx — Per-screen Suspense wrapper for React.lazy.
+ *
+ * Wraps each lazy-loaded screen in its own Suspense boundary so that
+ * when a screen suspends during import, only that screen shows the
+ * fallback — not the entire navigator. This prevents React Navigation
+ * from losing its stack state during lazy loads.
+ *
+ * Usage:
+ *   const MyScreen = lazySuspense(() => import('../screens/MyScreen'));
+ *   <Stack.Screen name="My" component={MyScreen} />
+ */
+
+import React, { Suspense, type ComponentType } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+
+function SuspenseFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator color="#bfa050" size="large" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});
+
+/**
+ * Create a lazy-loaded component wrapped in its own Suspense boundary.
+ * Drop-in replacement for React.lazy() in navigation stacks.
+ */
+export function lazySuspense<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+): React.FC<React.ComponentProps<T>> {
+  const LazyComponent = React.lazy(factory);
+
+  const Wrapped: React.FC<React.ComponentProps<T>> = (props) => (
+    <Suspense fallback={<SuspenseFallback />}>
+      <LazyComponent {...props} />
+    </Suspense>
+  );
+
+  // Preserve display name for debugging
+  const name = factory.toString().match(/\/(\w+?)['"`]/)?.[1] ?? 'Lazy';
+  Wrapped.displayName = `LazySuspense(${name})`;
+
+  return Wrapped;
+}

--- a/app/src/screens/PersonJourneyScreen.tsx
+++ b/app/src/screens/PersonJourneyScreen.tsx
@@ -87,9 +87,14 @@ function PersonJourneyScreen() {
                 onPress={() => {
                   if (stage.book_dir) {
                     const ch = stage.chapters ? JSON.parse(stage.chapters)[0] : 1;
-                    (navigation as any).navigate('ReadTab', {
-                      screen: 'Chapter',
-                      params: { bookId: stage.book_dir, chapterNum: ch },
+                    // Parse starting verse from verse_ref (e.g., "Gen 12:1-9" → 1)
+                    const verseMatch = stage.verse_ref?.match(/:(\d+)/);
+                    const verseNum = verseMatch ? parseInt(verseMatch[1], 10) : undefined;
+                    // Navigate within ExploreStack so Back returns here
+                    navigation.navigate('Chapter', {
+                      bookId: stage.book_dir,
+                      chapterNum: ch,
+                      ...(verseNum ? { verseNum } : {}),
                     });
                   }
                 }}


### PR DESCRIPTION
1. Suspense architecture fix (all 4 stacks):
   - Created lazySuspense() helper that wraps each lazy screen in its own Suspense boundary instead of wrapping the entire navigator
   - Prevents React Navigation stack corruption when a lazy screen is still loading — the source screen stays mounted, only the target screen shows the spinner
   - Applied to ExploreStack (45 screens), HomeStack (13), ReadStack (11), MoreStack (16)

2. PersonJourneyScreen navigation fixes:
   - Back button: navigate within ExploreStack ('Chapter') instead of cross-tab ('ReadTab' → 'Chapter'). Back now returns to the journey detail instead of the Read tab's BookList
   - Verse scroll: parse starting verse from verse_ref (e.g., 'Gen 12:1-9' → verseNum: 1) and pass to Chapter screen. ChapterScreen already supports auto-scroll via initialVerseNum