### PR TITLE
style: Gold monochrome cards — remove per-tool rainbow colors

### DIFF
--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -89,7 +89,7 @@ export function FeatureCard({
   return (
     <View style={[styles.card, {
       backgroundColor: base.bgElevated,
-      borderColor: feature.color + '20',
+      borderColor: base.gold + '12',
     }]}>
       {/* ── Image header ─── */}
       {currentImage ? (
@@ -134,7 +134,7 @@ export function FeatureCard({
         </TouchableOpacity>
       ) : (
         /* Fallback: accent-colored strip */
-        <View style={[styles.fallbackStrip, { backgroundColor: feature.color + '30' }]} />
+        <View style={[styles.fallbackStrip, { backgroundColor: base.gold + '20' }]} />
       )}
 
       {/* ── Text area (tappable → feature browse) ─── */}
@@ -146,7 +146,7 @@ export function FeatureCard({
         style={styles.textArea}
       >
         <View style={styles.header}>
-          <Text style={[styles.title, { color: feature.color }]} numberOfLines={1}>
+          <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
             {feature.title}
           </Text>
           {isLocked && <Text style={[styles.lockIcon, { color: base.gold }]}>✦</Text>}

--- a/app/src/components/RecommendedCard.tsx
+++ b/app/src/components/RecommendedCard.tsx
@@ -150,7 +150,7 @@ export function RecommendedCard({
           </View>
         </TouchableOpacity>
       ) : (
-        <View style={[styles.fallbackStrip, { backgroundColor: recommendation.color + '30' }]} />
+        <View style={[styles.fallbackStrip, { backgroundColor: base.gold + '20' }]} />
       )}
 
       {/* ── Text area with chevron ─── */}
@@ -164,7 +164,7 @@ export function RecommendedCard({
         <View style={styles.textContent}>
           <View style={styles.textLeft}>
             <View style={styles.header}>
-              <Text style={[styles.title, { color: recommendation.color }]} numberOfLines={1}>
+              <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
                 {recommendation.title}
               </Text>
               {isLocked && <Text style={[styles.lockIcon, { color: base.gold }]}>✦</Text>}


### PR DESCRIPTION
## What

Replaces the 22 unique per-tool colors on Explore/Home cards with a unified gold monochrome palette. Images provide visual differentiation; section headers provide category context.

## Changes (2 files, 5 lines)

**FeatureCard.tsx**
- Border: `feature.color + '20'` → `base.gold + '12'`
- Title: `feature.color` → `base.text`
- Fallback strip: `feature.color + '30'` → `base.gold + '20'`

**RecommendedCard.tsx**
- Title: `recommendation.color` → `base.text`
- Fallback strip: `recommendation.color + '30'` → `base.gold + '20'`

## Not changed
- `FeatureCardData.color` field remains in the interface (no breaking change)
- Panel accent colors (17 types in chapter reading)
- Scholar colors (54 entries for tradition badges)
- Era colors (timeline)
- Category/severity colors (browse screens)

## Why
The per-tool rainbow (pink for Word Studies, blue for Timeline, orange for People, etc.) clashed visually and competed with the artwork on image cards. Gold monochrome lets the classical art (Doré, Rembrandt, Raphael) provide visual identity while keeping the whole screen cohesive and premium.