### PR TITLE
style: gold monochrome cards — remove per-tool rainbow colors

### DIFF
--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -89,7 +89,7 @@ export function FeatureCard({
   return (
     <View style={[styles.card, {
       backgroundColor: base.bgElevated,
-      borderColor: feature.color + '20',
+      borderColor: base.gold + '12',
     }]}>
       {/* ── Image header ─── */}
       {currentImage ? (
@@ -134,7 +134,7 @@ export function FeatureCard({
         </TouchableOpacity>
       ) : (
         /* Fallback: accent-colored strip */
-        <View style={[styles.fallbackStrip, { backgroundColor: feature.color + '30' }]} />
+        <View style={[styles.fallbackStrip, { backgroundColor: base.gold + '20' }]} />
       )}
 
       {/* ── Text area (tappable → feature browse) ─── */}
@@ -146,7 +146,7 @@ export function FeatureCard({
         style={styles.textArea}
       >
         <View style={styles.header}>
-          <Text style={[styles.title, { color: feature.color }]} numberOfLines={1}>
+          <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
             {feature.title}
           </Text>
           {isLocked && <Text style={[styles.lockIcon, { color: base.gold }]}>✦</Text>}

--- a/app/src/components/RecommendedCard.tsx
+++ b/app/src/components/RecommendedCard.tsx
@@ -150,7 +150,7 @@ export function RecommendedCard({
           </View>
         </TouchableOpacity>
       ) : (
-        <View style={[styles.fallbackStrip, { backgroundColor: recommendation.color + '30' }]} />
+        <View style={[styles.fallbackStrip, { backgroundColor: base.gold + '20' }]} />
       )}
 
       {/* ── Text area with chevron ─── */}
@@ -164,7 +164,7 @@ export function RecommendedCard({
         <View style={styles.textContent}>
           <View style={styles.textLeft}>
             <View style={styles.header}>
-              <Text style={[styles.title, { color: recommendation.color }]} numberOfLines={1}>
+              <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
                 {recommendation.title}
               </Text>
               {isLocked && <Text style={[styles.lockIcon, { color: base.gold }]}>✦</Text>}


### PR DESCRIPTION
FeatureCard and RecommendedCard now use theme tokens instead of per-tool color props:
- Card border: feature.color + '20' → base.gold + '12'
- Card title: feature.color → base.text (neutral)
- Fallback strip: feature.color + '30' → base.gold + '20'

The color field remains in FeatureCardData interface (no breaking change) but is no longer rendered. Images provide visual differentiation; section headers provide category context.

Panel colors, scholar colors, era colors, and all other functional color systems in the chapter reading experience are untouched.