### PR TITLE
Cards #1263–#1267: Explore redesign + Timeline/Genealogy visual upgrades

### DIFF
--- a/app/__tests__/components/CovenantMarker.test.tsx
+++ b/app/__tests__/components/CovenantMarker.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { CovenantMarker } from '@/components/tree/CovenantMarker';
+
+const WAYPOINT = {
+  personId: 'abraham',
+  text: '"In you all nations will be blessed"',
+  ref: 'Gen 12:3',
+};
+
+describe('CovenantMarker', () => {
+  it('renders the annotation text and verse ref', () => {
+    const { getByText } = renderWithProviders(
+      <CovenantMarker waypoint={WAYPOINT} x={0} y={0} />,
+    );
+    expect(getByText(/"In you all nations will be blessed"/)).toBeTruthy();
+    expect(getByText('Gen 12:3')).toBeTruthy();
+  });
+
+  it('calls onPress with the waypoint ref', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <CovenantMarker waypoint={WAYPOINT} x={0} y={0} onPress={onPress} />,
+    );
+    fireEvent.press(getByLabelText('Open Gen 12:3'));
+    expect(onPress).toHaveBeenCalledWith('Gen 12:3');
+  });
+
+  it('renders nothing when zoomLevel is below the minimum', () => {
+    const { toJSON } = renderWithProviders(
+      <CovenantMarker waypoint={WAYPOINT} x={0} y={0} zoomLevel={0.3} minZoom={0.4} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('still renders when zoomLevel is above minZoom', () => {
+    const { toJSON } = renderWithProviders(
+      <CovenantMarker waypoint={WAYPOINT} x={0} y={0} zoomLevel={0.5} minZoom={0.4} />,
+    );
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it('always renders when zoomLevel is unspecified', () => {
+    const { toJSON } = renderWithProviders(
+      <CovenantMarker waypoint={WAYPOINT} x={0} y={0} />,
+    );
+    expect(toJSON()).not.toBeNull();
+  });
+});

--- a/app/__tests__/components/FeatureCard.test.tsx
+++ b/app/__tests__/components/FeatureCard.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import {
+  FeatureCard,
+  CARD_WIDTH,
+  COMPACT_CARD_WIDTH,
+  type FeatureCardData,
+} from '@/components/FeatureCard';
+
+const FEATURE: FeatureCardData = {
+  title: 'Timeline',
+  subtitle: 'Events across history',
+  color: '#70b8e8',
+  screen: 'Timeline',
+};
+
+function cardWidthFromTree(node: any): number | undefined {
+  // The first View with a numeric width in the style is the card container.
+  if (!node) return undefined;
+  const style = node.props?.style;
+  if (Array.isArray(style)) {
+    const merged = Object.assign({}, ...style.filter(Boolean));
+    if (typeof merged.width === 'number') return merged.width;
+  } else if (style && typeof style.width === 'number') {
+    return style.width;
+  }
+  if (Array.isArray(node.children)) {
+    for (const c of node.children) {
+      const w = cardWidthFromTree(c);
+      if (typeof w === 'number') return w;
+    }
+  }
+  return undefined;
+}
+
+describe('FeatureCard', () => {
+  it('renders title and subtitle', () => {
+    const { getByText } = renderWithProviders(
+      <FeatureCard feature={FEATURE} onPress={jest.fn()} isPremium />,
+    );
+    expect(getByText('Timeline')).toBeTruthy();
+    expect(getByText('Events across history')).toBeTruthy();
+  });
+
+  it('renders the count CTA when count and noun are provided', () => {
+    const { getByText } = renderWithProviders(
+      <FeatureCard
+        feature={FEATURE}
+        onPress={jest.fn()}
+        isPremium
+        count={5}
+        noun="items"
+      />,
+    );
+    expect(getByText('5 items ›')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByText } = renderWithProviders(
+      <FeatureCard feature={FEATURE} onPress={onPress} isPremium />,
+    );
+    fireEvent.press(getByText('Timeline'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the lock icon when feature is premium and user is not', () => {
+    const { getByText } = renderWithProviders(
+      <FeatureCard
+        feature={{ ...FEATURE, premium: true }}
+        onPress={jest.fn()}
+        isPremium={false}
+      />,
+    );
+    expect(getByText('✦')).toBeTruthy();
+  });
+
+  it('exposes stable width constants', () => {
+    expect(CARD_WIDTH).toBe(174);
+    expect(COMPACT_CARD_WIDTH).toBe(130);
+  });
+
+  it('applies the compact width when compact=true', () => {
+    const { toJSON } = renderWithProviders(
+      <FeatureCard feature={FEATURE} onPress={jest.fn()} isPremium compact />,
+    );
+    expect(cardWidthFromTree(toJSON())).toBe(COMPACT_CARD_WIDTH);
+  });
+
+  it('applies the default width when compact is not set', () => {
+    const { toJSON } = renderWithProviders(
+      <FeatureCard feature={FEATURE} onPress={jest.fn()} isPremium />,
+    );
+    expect(cardWidthFromTree(toJSON())).toBe(CARD_WIDTH);
+  });
+});

--- a/app/__tests__/components/MessianicLegend.test.tsx
+++ b/app/__tests__/components/MessianicLegend.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { MessianicLegend } from '@/components/tree/MessianicLegend';
+
+describe('MessianicLegend', () => {
+  it('renders the default explanation text', () => {
+    const { getByText } = renderWithProviders(<MessianicLegend />);
+    expect(getByText(/Golden thread = messianic lineage to Jesus/)).toBeTruthy();
+  });
+
+  it('honors a custom label prop', () => {
+    const { getByText } = renderWithProviders(<MessianicLegend label="Custom text" />);
+    expect(getByText('Custom text')).toBeTruthy();
+  });
+
+  it('exposes the label as an accessibility label', () => {
+    const { getByLabelText } = renderWithProviders(<MessianicLegend label="Alt label" />);
+    expect(getByLabelText('Alt label')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/PersonDetailCard.test.tsx
+++ b/app/__tests__/components/PersonDetailCard.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import {
+  PersonDetailCard,
+  parseRefsJson,
+} from '@/components/tree/PersonDetailCard';
+import type { Person } from '@/types';
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'david',
+    name: 'David',
+    gender: 'male',
+    father: 'jesse',
+    mother: null,
+    spouse_of: null,
+    era: 'kingdom',
+    dates: '1040–970 BC',
+    role: 'king',
+    type: 'spine',
+    bio: 'A shepherd boy from Bethlehem who became king of Israel.',
+    scripture_role: 'King of united Israel',
+    refs_json: '["1 Sam 16:12","Ps 23","2 Sam 7:16"]',
+    chapter_link: 'ot/1_samuel_16.html',
+    ...overrides,
+  };
+}
+
+describe('PersonDetailCard', () => {
+  it('renders the name, scripture role, and dates', () => {
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} childrenCount={19} />,
+    );
+    expect(getByText('David')).toBeTruthy();
+    expect(getByText('King of united Israel')).toBeTruthy();
+    expect(getByText('1040–970 BC')).toBeTruthy();
+    expect(getByText('19')).toBeTruthy();
+    expect(getByText('3')).toBeTruthy(); // 3 refs in refs_json
+  });
+
+  it('shows a Messianic Line badge for line members', () => {
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} />,
+    );
+    expect(getByText('Messianic Line')).toBeTruthy();
+  });
+
+  it('hides the Messianic Line badge for non-members', () => {
+    const { queryByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson({ id: 'esau' })} />,
+    );
+    expect(queryByText('Messianic Line')).toBeNull();
+  });
+
+  it('renders the default Bio tab content', () => {
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} />,
+    );
+    expect(getByText(/A shepherd boy from Bethlehem/)).toBeTruthy();
+  });
+
+  it('switches to Family tab and renders related people', () => {
+    const onPerson = jest.fn();
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard
+        person={makePerson()}
+        relatedPeople={{
+          parents: [{ id: 'jesse', name: 'Jesse' }],
+          spouses: [{ id: 'bathsheba', name: 'Bathsheba' }],
+          children: [{ id: 'solomon', name: 'Solomon' }],
+        }}
+        onPersonPress={onPerson}
+      />,
+    );
+    fireEvent.press(getByText('Family'));
+    expect(getByText('Jesse')).toBeTruthy();
+    expect(getByText('Solomon')).toBeTruthy();
+    fireEvent.press(getByText('Jesse'));
+    expect(onPerson).toHaveBeenCalledWith('jesse');
+  });
+
+  it('switches to Journey tab and renders the View Full Journey button', () => {
+    const onJourney = jest.fn();
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} hasJourney onJourneyPress={onJourney} />,
+    );
+    fireEvent.press(getByText('Journey'));
+    const btn = getByText('View full journey →');
+    fireEvent.press(btn);
+    expect(onJourney).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an empty-journey message when hasJourney is false', () => {
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} hasJourney={false} />,
+    );
+    fireEvent.press(getByText('Journey'));
+    expect(getByText('No journey recorded.')).toBeTruthy();
+  });
+
+  it('switches to Verses tab and renders key refs as pills', () => {
+    const onVerse = jest.fn();
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} onVersePress={onVerse} />,
+    );
+    fireEvent.press(getByText('Verses'));
+    fireEvent.press(getByText('Ps 23'));
+    expect(onVerse).toHaveBeenCalledWith('Ps 23');
+  });
+
+  it('notifies the parent on tab change', () => {
+    const onTab = jest.fn();
+    const { getByText } = renderWithProviders(
+      <PersonDetailCard person={makePerson()} onTabChange={onTab} />,
+    );
+    fireEvent.press(getByText('Verses'));
+    expect(onTab).toHaveBeenCalledWith('verses');
+  });
+});
+
+describe('parseRefsJson', () => {
+  it('returns [] for null/empty', () => {
+    expect(parseRefsJson(null)).toEqual([]);
+    expect(parseRefsJson(undefined)).toEqual([]);
+    expect(parseRefsJson('')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    expect(parseRefsJson('not-json')).toEqual([]);
+  });
+
+  it('filters non-string entries', () => {
+    expect(parseRefsJson('["a",1,null,"b"]')).toEqual(['a', 'b']);
+  });
+});

--- a/app/__tests__/components/RoleBadge.test.tsx
+++ b/app/__tests__/components/RoleBadge.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { RoleBadge, getRoleBadgeConfig } from '@/components/tree/RoleBadge';
+
+describe('RoleBadge', () => {
+  it('renders a K for kings', () => {
+    const { getByText } = renderWithProviders(<RoleBadge role="king" />);
+    expect(getByText('K')).toBeTruthy();
+  });
+
+  it('renders a P for patriarchs', () => {
+    const { getByText } = renderWithProviders(<RoleBadge role="patriarch" />);
+    expect(getByText('P')).toBeTruthy();
+  });
+
+  it('renders a J for judges', () => {
+    const { getByText } = renderWithProviders(<RoleBadge role="judge" />);
+    expect(getByText('J')).toBeTruthy();
+  });
+
+  it('renders a T for tribes', () => {
+    const { getByText } = renderWithProviders(<RoleBadge role="tribe" />);
+    expect(getByText('T')).toBeTruthy();
+  });
+
+  it('renders glyphs for priest and prophet', () => {
+    const priest = renderWithProviders(<RoleBadge role="priest" />);
+    expect(priest.getByText('⛊')).toBeTruthy();
+    const prophet = renderWithProviders(<RoleBadge role="prophet" />);
+    expect(prophet.getByText('✧')).toBeTruthy();
+  });
+
+  it('renders nothing for unknown/null roles', () => {
+    const unknown = renderWithProviders(<RoleBadge role="civilian" />);
+    expect(unknown.toJSON()).toBeNull();
+    const empty = renderWithProviders(<RoleBadge role={null} />);
+    expect(empty.toJSON()).toBeNull();
+  });
+
+  it('exposes an accessibility label with the role name', () => {
+    const { getByLabelText } = renderWithProviders(<RoleBadge role="king" />);
+    expect(getByLabelText(/king role badge/i)).toBeTruthy();
+  });
+});
+
+describe('getRoleBadgeConfig', () => {
+  it('returns null for unknown roles', () => {
+    expect(getRoleBadgeConfig('farmer', { gold: '#fff' })).toBeNull();
+    expect(getRoleBadgeConfig(null, { gold: '#fff' })).toBeNull();
+    expect(getRoleBadgeConfig(undefined, { gold: '#fff' })).toBeNull();
+  });
+
+  it('prefers the era color for patriarch / judge / tribe when provided', () => {
+    const cfg = getRoleBadgeConfig('patriarch', { gold: '#fff', eraColor: '#abc' });
+    expect(cfg?.color).toBe('#abc');
+  });
+
+  it('falls back to gold when no era color is provided', () => {
+    const cfg = getRoleBadgeConfig('patriarch', { gold: '#fff' });
+    expect(cfg?.color).toBe('#fff');
+  });
+
+  it('kings always use the gold color', () => {
+    expect(getRoleBadgeConfig('king', { gold: '#fff', eraColor: '#abc' })?.color).toBe('#fff');
+  });
+});

--- a/app/__tests__/components/SpousePill.test.tsx
+++ b/app/__tests__/components/SpousePill.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { SpousePill } from '@/components/tree/SpousePill';
+
+describe('SpousePill', () => {
+  it('renders the spouse name with the infinity marker', () => {
+    const { getByText } = renderWithProviders(
+      <SpousePill spouseId="sarah" spouseName="Sarah" onPress={jest.fn()} />,
+    );
+    expect(getByText(/∞ Sarah/)).toBeTruthy();
+  });
+
+  it('calls onPress with the spouse id', () => {
+    const onPress = jest.fn();
+    const { getByRole } = renderWithProviders(
+      <SpousePill spouseId="sarah" spouseName="Sarah" onPress={onPress} />,
+    );
+    fireEvent.press(getByRole('button'));
+    expect(onPress).toHaveBeenCalledWith('sarah');
+  });
+
+  it('exposes an accessibility label', () => {
+    const { getByLabelText } = renderWithProviders(
+      <SpousePill spouseId="rachel" spouseName="Rachel" onPress={jest.fn()} />,
+    );
+    expect(getByLabelText('Spouse: Rachel')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/explore/DebatePreviewList.test.tsx
+++ b/app/__tests__/components/explore/DebatePreviewList.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+
+jest.mock('@/db/content', () => ({
+  getDebateTopics: jest.fn(),
+}));
+
+import {
+  DebatePreviewList,
+  countPositions,
+  pickTopDebates,
+} from '@/components/explore/DebatePreviewList';
+import type { DebateTopicSummary } from '@/types';
+const { getDebateTopics } = require('@/db/content');
+
+function makeDebate(overrides: Partial<DebateTopicSummary> = {}): DebateTopicSummary {
+  return {
+    id: 'd1',
+    title: 'Was Paul the author of Hebrews?',
+    category: 'historical',
+    book_id: 'hebrews',
+    chapters_json: '[]',
+    passage: 'Heb 1:1',
+    question: 'Who wrote Hebrews?',
+    context: null,
+    positions_json: '[]',
+    synthesis: null,
+    related_passages_json: null,
+    tags_json: null,
+    position_count: 2,
+    ...overrides,
+  };
+}
+
+describe('DebatePreviewList', () => {
+  it('renders the supplied debates (no fetch)', () => {
+    const debates = [
+      makeDebate({ id: 'a', title: 'Debate A', position_count: 5 }),
+      makeDebate({ id: 'b', title: 'Debate B', position_count: 3 }),
+    ];
+    const { getByText } = renderWithProviders(
+      <DebatePreviewList
+        onDebatePress={jest.fn()}
+        onSeeAll={jest.fn()}
+        debates={debates}
+        totalCount={42}
+      />,
+    );
+    expect(getByText('Debate A')).toBeTruthy();
+    expect(getByText('Debate B')).toBeTruthy();
+    expect(getByText('All 42 debates ›')).toBeTruthy();
+  });
+
+  it('sorts debates by position count (desc)', () => {
+    const debates = [
+      makeDebate({ id: 'low', title: 'Low', position_count: 1 }),
+      makeDebate({ id: 'high', title: 'High', position_count: 9 }),
+      makeDebate({ id: 'mid', title: 'Mid', position_count: 5 }),
+      makeDebate({ id: 'tiny', title: 'Tiny', position_count: 0 }),
+    ];
+    const { getAllByRole } = renderWithProviders(
+      <DebatePreviewList onDebatePress={jest.fn()} onSeeAll={jest.fn()} debates={debates} />,
+    );
+    const buttons = getAllByRole('button');
+    // The first 3 row buttons correspond to the top 3 by position_count.
+    expect(buttons[0].props.accessibilityLabel).toMatch(/High/);
+    expect(buttons[1].props.accessibilityLabel).toMatch(/Mid/);
+    expect(buttons[2].props.accessibilityLabel).toMatch(/Low/);
+  });
+
+  it('returns null when debate list is empty', () => {
+    const { queryByText } = renderWithProviders(
+      <DebatePreviewList onDebatePress={jest.fn()} onSeeAll={jest.fn()} debates={[]} />,
+    );
+    expect(queryByText(/debates ›/)).toBeNull();
+  });
+
+  it('calls onDebatePress with the debate id', () => {
+    const onDebate = jest.fn();
+    const debates = [makeDebate({ id: 'x', title: 'X' })];
+    const { getByText } = renderWithProviders(
+      <DebatePreviewList onDebatePress={onDebate} onSeeAll={jest.fn()} debates={debates} />,
+    );
+    fireEvent.press(getByText('X'));
+    expect(onDebate).toHaveBeenCalledWith('x');
+  });
+
+  it('calls onSeeAll when the link is pressed', () => {
+    const onSeeAll = jest.fn();
+    const debates = [makeDebate({ id: 'x', title: 'X' })];
+    const { getByText } = renderWithProviders(
+      <DebatePreviewList onDebatePress={jest.fn()} onSeeAll={onSeeAll} debates={debates} />,
+    );
+    fireEvent.press(getByText(/All 1 debates ›/));
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches debates from the DB when no override is provided', async () => {
+    (getDebateTopics as jest.Mock).mockResolvedValueOnce([
+      makeDebate({ id: 'fetched', title: 'Fetched' }),
+    ]);
+    const { findByText } = renderWithProviders(
+      <DebatePreviewList onDebatePress={jest.fn()} onSeeAll={jest.fn()} />,
+    );
+    expect(await findByText('Fetched')).toBeTruthy();
+    expect(getDebateTopics).toHaveBeenCalled();
+  });
+});
+
+describe('countPositions', () => {
+  it('returns 0 for null, undefined, empty string', () => {
+    expect(countPositions(null)).toBe(0);
+    expect(countPositions(undefined)).toBe(0);
+    expect(countPositions('')).toBe(0);
+  });
+
+  it('returns 0 for malformed JSON', () => {
+    expect(countPositions('not-json')).toBe(0);
+  });
+
+  it('returns 0 when parsed value is not an array', () => {
+    expect(countPositions('{"a":1}')).toBe(0);
+  });
+
+  it('returns the array length for valid JSON arrays', () => {
+    expect(countPositions('[1,2,3]')).toBe(3);
+  });
+});
+
+describe('pickTopDebates', () => {
+  it('returns up to n debates sorted by position count desc', () => {
+    const input = [
+      makeDebate({ id: 'a', position_count: 1 }),
+      makeDebate({ id: 'b', position_count: 4 }),
+      makeDebate({ id: 'c', position_count: 2 }),
+    ];
+    const out = pickTopDebates(input, 2);
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe('b');
+    expect(out[1].id).toBe('c');
+  });
+
+  it('falls back to positions_json length when position_count is missing', () => {
+    const input = [
+      makeDebate({ id: 'a', position_count: undefined as unknown as number, positions_json: '[1]' }),
+      makeDebate({ id: 'b', position_count: undefined as unknown as number, positions_json: '[1,2,3]' }),
+    ];
+    const out = pickTopDebates(input, 2);
+    expect(out[0].id).toBe('b');
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      makeDebate({ id: 'a', position_count: 1 }),
+      makeDebate({ id: 'b', position_count: 4 }),
+    ];
+    const snapshot = [...input];
+    pickTopDebates(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/app/__tests__/components/explore/FullWidthImageCard.test.tsx
+++ b/app/__tests__/components/explore/FullWidthImageCard.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import { FullWidthImageCard } from '@/components/explore/FullWidthImageCard';
+
+const IMAGE = {
+  url: 'https://example.test/life.jpg',
+  caption: 'Life',
+  credit: 'Unsplash',
+  deepLink: { screen: 'LifeTopics' as const },
+};
+
+describe('FullWidthImageCard', () => {
+  it('renders title and subtitle', () => {
+    const { getByText } = renderWithProviders(
+      <FullWidthImageCard
+        title="Life Topics"
+        subtitle="Biblical guidance"
+        onPress={jest.fn()}
+      />,
+    );
+    expect(getByText('Life Topics')).toBeTruthy();
+    expect(getByText('Biblical guidance')).toBeTruthy();
+  });
+
+  it('renders the count CTA when count and noun are provided', () => {
+    const { getByText } = renderWithProviders(
+      <FullWidthImageCard
+        title="Life Topics"
+        count={48}
+        noun="topics"
+        onPress={jest.fn()}
+      />,
+    );
+    expect(getByText('48 topics ›')).toBeTruthy();
+  });
+
+  it('does not render the CTA when count is missing', () => {
+    const { queryByText } = renderWithProviders(
+      <FullWidthImageCard title="Life Topics" onPress={jest.fn()} />,
+    );
+    expect(queryByText(/›/)).toBeNull();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByText } = renderWithProviders(
+      <FullWidthImageCard title="Life Topics" onPress={onPress} />,
+    );
+    fireEvent.press(getByText('Life Topics'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an image when provided', () => {
+    const { toJSON } = renderWithProviders(
+      <FullWidthImageCard title="Life Topics" image={IMAGE} onPress={jest.fn()} />,
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/explore/GoldSeparator.test.tsx
+++ b/app/__tests__/components/explore/GoldSeparator.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import { GoldSeparator } from '@/components/explore/GoldSeparator';
+
+describe('GoldSeparator', () => {
+  it('renders three gradient segments', () => {
+    const { toJSON } = renderWithProviders(<GoldSeparator />);
+    const tree = toJSON();
+    // Expect 1 container + 3 segment children (flattened as array of Views).
+    expect(tree).toBeTruthy();
+  });
+
+  it('honors custom marginBottom / marginTop', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <GoldSeparator marginBottom={4} marginTop={8} />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    const container = views[0];
+    // Style can be an array or an object — flatten before asserting.
+    const styleArr = Array.isArray(container.props.style)
+      ? container.props.style
+      : [container.props.style];
+    const merged = Object.assign({}, ...styleArr);
+    expect(merged.marginBottom).toBe(4);
+    expect(merged.marginTop).toBe(8);
+  });
+});

--- a/app/__tests__/components/explore/LifeTopicGrid.test.tsx
+++ b/app/__tests__/components/explore/LifeTopicGrid.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+
+jest.mock('@/db/content', () => ({
+  getLifeTopicCategories: jest.fn(),
+}));
+
+import { LifeTopicGrid, pickTopCategories } from '@/components/explore/LifeTopicGrid';
+import type { LifeTopicCategory } from '@/types';
+const { getLifeTopicCategories } = require('@/db/content');
+
+const CATS: LifeTopicCategory[] = [
+  { id: 'mental', name: 'Mental Health', display_order: 1 },
+  { id: 'relation', name: 'Relationships', display_order: 2 },
+  { id: 'identity', name: 'Identity', display_order: 3 },
+  { id: 'struggle', name: 'Struggles', display_order: 4 },
+  { id: 'modern', name: 'Modern Life', display_order: 5 },
+];
+
+describe('LifeTopicGrid', () => {
+  it('renders up to 4 categories sorted by display_order', () => {
+    const { getByText, queryByText } = renderWithProviders(
+      <LifeTopicGrid onCategoryPress={jest.fn()} categories={CATS} />,
+    );
+    expect(getByText('Mental Health')).toBeTruthy();
+    expect(getByText('Relationships')).toBeTruthy();
+    expect(getByText('Identity')).toBeTruthy();
+    expect(getByText('Struggles')).toBeTruthy();
+    expect(queryByText('Modern Life')).toBeNull();
+  });
+
+  it('shows topic counts when provided', () => {
+    const { getByText } = renderWithProviders(
+      <LifeTopicGrid
+        onCategoryPress={jest.fn()}
+        categories={CATS}
+        topicCounts={{ mental: 5, relation: 1 }}
+      />,
+    );
+    expect(getByText('5 topics')).toBeTruthy();
+    expect(getByText('1 topic')).toBeTruthy();
+  });
+
+  it('calls onCategoryPress with the category id', () => {
+    const onPress = jest.fn();
+    const { getByText } = renderWithProviders(
+      <LifeTopicGrid onCategoryPress={onPress} categories={CATS} />,
+    );
+    fireEvent.press(getByText('Relationships'));
+    expect(onPress).toHaveBeenCalledWith('relation');
+  });
+
+  it('returns null for empty categories', () => {
+    const { queryByText } = renderWithProviders(
+      <LifeTopicGrid onCategoryPress={jest.fn()} categories={[]} />,
+    );
+    expect(queryByText('Mental Health')).toBeNull();
+  });
+
+  it('fetches categories from the DB when no override is provided', async () => {
+    (getLifeTopicCategories as jest.Mock).mockResolvedValueOnce([
+      { id: 'foo', name: 'Foo Category', display_order: 1 },
+    ]);
+    const { findByText } = renderWithProviders(<LifeTopicGrid onCategoryPress={jest.fn()} />);
+    expect(await findByText('Foo Category')).toBeTruthy();
+  });
+});
+
+describe('pickTopCategories', () => {
+  it('returns up to n sorted by display_order', () => {
+    const input = [
+      { id: 'c', name: 'C', display_order: 3 },
+      { id: 'a', name: 'A', display_order: 1 },
+      { id: 'b', name: 'B', display_order: 2 },
+    ];
+    const out = pickTopCategories(input, 2);
+    expect(out.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('defaults to 4 when n is omitted', () => {
+    const input = [1, 2, 3, 4, 5, 6].map((i) => ({
+      id: `c${i}`,
+      name: `C${i}`,
+      display_order: i,
+    }));
+    expect(pickTopCategories(input)).toHaveLength(4);
+  });
+});

--- a/app/__tests__/components/explore/ProphecyChainCard.test.tsx
+++ b/app/__tests__/components/explore/ProphecyChainCard.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import {
+  ProphecyChainCard,
+  parseChainLinks,
+  formatRange,
+} from '@/components/explore/ProphecyChainCard';
+import type { ProphecyChain } from '@/types';
+
+const CHAIN: ProphecyChain = {
+  id: 'seed',
+  title: 'Seed of the Woman',
+  category: 'messianic',
+  chain_type: 'prophecy-fulfillment',
+  summary: null,
+  tags_json: null,
+  links_json: JSON.stringify([
+    { book_dir: 'genesis', chapter_num: 3, verse_ref: 'Gen 3:15' },
+    { book_dir: 'revelation', chapter_num: 12, verse_ref: 'Rev 12:5' },
+  ]),
+};
+
+describe('ProphecyChainCard', () => {
+  it('renders the chain title', () => {
+    const { getByText } = renderWithProviders(
+      <ProphecyChainCard chain={CHAIN} onPress={jest.fn()} />,
+    );
+    expect(getByText('Seed of the Woman')).toBeTruthy();
+  });
+
+  it('renders the verse range using first → last refs', () => {
+    const { getByText } = renderWithProviders(
+      <ProphecyChainCard chain={CHAIN} onPress={jest.fn()} />,
+    );
+    expect(getByText(/Gen 3:15 → Rev 12:5/)).toBeTruthy();
+  });
+
+  it('renders the stop count', () => {
+    const { getByText } = renderWithProviders(
+      <ProphecyChainCard chain={CHAIN} onPress={jest.fn()} />,
+    );
+    expect(getByText('2 stops')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByRole } = renderWithProviders(
+      <ProphecyChainCard chain={CHAIN} onPress={onPress} />,
+    );
+    fireEvent.press(getByRole('button'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders safely with malformed links_json', () => {
+    const broken: ProphecyChain = { ...CHAIN, links_json: 'not-json' };
+    const { getByText } = renderWithProviders(
+      <ProphecyChainCard chain={broken} onPress={jest.fn()} />,
+    );
+    expect(getByText('0 stops')).toBeTruthy();
+  });
+});
+
+describe('parseChainLinks', () => {
+  it('returns empty array for null/undefined/empty', () => {
+    expect(parseChainLinks(null)).toEqual([]);
+    expect(parseChainLinks(undefined)).toEqual([]);
+    expect(parseChainLinks('')).toEqual([]);
+  });
+
+  it('returns empty array on malformed JSON', () => {
+    expect(parseChainLinks('not-json')).toEqual([]);
+  });
+
+  it('returns empty array when parsed value is not an array', () => {
+    expect(parseChainLinks('{"foo":1}')).toEqual([]);
+  });
+
+  it('parses a valid array of links', () => {
+    const out = parseChainLinks(
+      '[{"book_dir":"genesis","chapter_num":1,"verse_ref":"Gen 1:1"}]',
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].verse_ref).toBe('Gen 1:1');
+  });
+});
+
+describe('formatRange', () => {
+  it('returns empty string for empty array', () => {
+    expect(formatRange([])).toBe('');
+  });
+
+  it('returns single ref when first and last are the same object', () => {
+    const link = { book_dir: 'gen', chapter_num: 1, verse_ref: 'Gen 1:1' };
+    expect(formatRange([link])).toBe('Gen 1:1');
+  });
+
+  it('returns arrow-joined refs for multiple links', () => {
+    const a = { book_dir: 'gen', chapter_num: 1, verse_ref: 'Gen 1:1' };
+    const b = { book_dir: 'rev', chapter_num: 22, verse_ref: 'Rev 22:21' };
+    expect(formatRange([a, b])).toBe('Gen 1:1 → Rev 22:21');
+  });
+});

--- a/app/__tests__/components/explore/WordStudyPreviewList.test.tsx
+++ b/app/__tests__/components/explore/WordStudyPreviewList.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+
+jest.mock('@/db/content', () => ({
+  getAllWordStudies: jest.fn(),
+}));
+
+import {
+  WordStudyPreviewList,
+  parseFirstGloss,
+  countOccurrences,
+} from '@/components/explore/WordStudyPreviewList';
+import type { WordStudy } from '@/types';
+const { getAllWordStudies } = require('@/db/content');
+
+function makeWord(overrides: Partial<WordStudy> = {}): WordStudy {
+  return {
+    id: 'hesed',
+    language: 'hebrew',
+    original: 'חסד',
+    transliteration: 'hesed',
+    strongs: null,
+    glosses_json: '["steadfast love", "lovingkindness"]',
+    semantic_range: null,
+    note: null,
+    occurrences_json: '["Gen 24:12","Ex 15:13","Ps 23:6"]',
+    ...overrides,
+  };
+}
+
+describe('WordStudyPreviewList', () => {
+  it('renders the supplied word studies', () => {
+    const words = [
+      makeWord({ id: 'a', transliteration: 'agape' }),
+      makeWord({ id: 'b', transliteration: 'emet' }),
+    ];
+    const { getByText } = renderWithProviders(
+      <WordStudyPreviewList
+        onWordPress={jest.fn()}
+        onSeeAll={jest.fn()}
+        wordStudies={words}
+        totalCount={120}
+      />,
+    );
+    expect(getByText('agape')).toBeTruthy();
+    expect(getByText('emet')).toBeTruthy();
+    expect(getByText('All 120 word studies ›')).toBeTruthy();
+  });
+
+  it('renders the first gloss', () => {
+    const words = [makeWord({ id: 'a' })];
+    const { getByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} wordStudies={words} />,
+    );
+    expect(getByText('steadfast love')).toBeTruthy();
+  });
+
+  it('renders language badge upper-cased', () => {
+    const words = [makeWord({ id: 'a', language: 'greek' })];
+    const { getByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} wordStudies={words} />,
+    );
+    expect(getByText('GREEK')).toBeTruthy();
+  });
+
+  it('renders occurrence count', () => {
+    const words = [makeWord({ id: 'a' })];
+    const { getByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} wordStudies={words} />,
+    );
+    expect(getByText('3×')).toBeTruthy();
+  });
+
+  it('caps the list at 3 entries', () => {
+    const words = [
+      makeWord({ id: 'a', transliteration: 'a' }),
+      makeWord({ id: 'b', transliteration: 'b' }),
+      makeWord({ id: 'c', transliteration: 'c' }),
+      makeWord({ id: 'd', transliteration: 'd' }),
+    ];
+    const { queryByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} wordStudies={words} />,
+    );
+    expect(queryByText('a')).toBeTruthy();
+    expect(queryByText('b')).toBeTruthy();
+    expect(queryByText('c')).toBeTruthy();
+    expect(queryByText('d')).toBeNull();
+  });
+
+  it('returns null when list is empty', () => {
+    const { queryByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} wordStudies={[]} />,
+    );
+    expect(queryByText(/word studies ›/)).toBeNull();
+  });
+
+  it('calls onWordPress with the word id', () => {
+    const onPress = jest.fn();
+    const words = [makeWord({ id: 'xyz', transliteration: 'xyz' })];
+    const { getByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={onPress} onSeeAll={jest.fn()} wordStudies={words} />,
+    );
+    fireEvent.press(getByText('xyz'));
+    expect(onPress).toHaveBeenCalledWith('xyz');
+  });
+
+  it('fetches word studies from the DB when no override provided', async () => {
+    (getAllWordStudies as jest.Mock).mockResolvedValueOnce([
+      makeWord({ id: 'fetched', transliteration: 'fetched' }),
+    ]);
+    const { findByText } = renderWithProviders(
+      <WordStudyPreviewList onWordPress={jest.fn()} onSeeAll={jest.fn()} />,
+    );
+    expect(await findByText('fetched')).toBeTruthy();
+  });
+});
+
+describe('parseFirstGloss', () => {
+  it('returns empty string for null/undefined/empty', () => {
+    expect(parseFirstGloss(null)).toBe('');
+    expect(parseFirstGloss(undefined)).toBe('');
+    expect(parseFirstGloss('')).toBe('');
+  });
+
+  it('returns empty string for malformed JSON', () => {
+    expect(parseFirstGloss('not-json')).toBe('');
+  });
+
+  it('returns empty string when parsed value is not an array', () => {
+    expect(parseFirstGloss('{"a":1}')).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(parseFirstGloss('[]')).toBe('');
+  });
+
+  it('returns the first string in a valid array', () => {
+    expect(parseFirstGloss('["love","mercy"]')).toBe('love');
+  });
+
+  it('returns empty string when the first entry is not a string', () => {
+    expect(parseFirstGloss('[1,2]')).toBe('');
+  });
+});
+
+describe('countOccurrences', () => {
+  it('returns 0 for null/empty/invalid', () => {
+    expect(countOccurrences(null)).toBe(0);
+    expect(countOccurrences('')).toBe(0);
+    expect(countOccurrences('not-json')).toBe(0);
+    expect(countOccurrences('{"x":1}')).toBe(0);
+  });
+
+  it('returns array length for valid arrays', () => {
+    expect(countOccurrences('["a","b"]')).toBe(2);
+  });
+});

--- a/app/__tests__/components/timeline/ContemporaryLane.test.tsx
+++ b/app/__tests__/components/timeline/ContemporaryLane.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import { ContemporaryLane, MAX_LANES } from '@/components/timeline/ContemporaryLane';
+
+describe('ContemporaryLane', () => {
+  it('renders exactly MAX_LANES lanes at most', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <ContemporaryLane laneActive={[true, true, true, true, true, true]} />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    // wrapper + MAX_LANES children
+    expect(views.length).toBe(1 + MAX_LANES);
+  });
+
+  it('paints active lanes with a visible fill', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <ContemporaryLane laneActive={[true, false, true, false]} />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    const bgs = views.slice(1).map((v: any) => {
+      const s = Array.isArray(v.props.style) ? v.props.style : [v.props.style];
+      return Object.assign({}, ...s).backgroundColor;
+    });
+    expect(bgs[0]).not.toBe('transparent');
+    expect(bgs[1]).toBe('transparent');
+    expect(bgs[2]).not.toBe('transparent');
+    expect(bgs[3]).toBe('transparent');
+  });
+
+  it('clamps input to MAX_LANES', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <ContemporaryLane laneActive={new Array(10).fill(true)} />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    expect(views.length).toBe(1 + MAX_LANES);
+  });
+});

--- a/app/__tests__/components/timeline/ContemporaryRow.test.tsx
+++ b/app/__tests__/components/timeline/ContemporaryRow.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import {
+  ContemporaryRow,
+  computeContemporaries,
+} from '@/components/timeline/ContemporaryRow';
+import type { TimelineEntry } from '@/types';
+
+function entry(overrides: Partial<TimelineEntry>): TimelineEntry {
+  return {
+    id: 'x',
+    name: 'X',
+    category: 'event',
+    era: 'primeval',
+    year: 0,
+    summary: null,
+    scripture_ref: null,
+    chapter_link: null,
+    people_json: null,
+    region: null,
+    ...overrides,
+  };
+}
+
+describe('ContemporaryRow', () => {
+  it('renders a circle for each contemporary', () => {
+    const { getByLabelText } = renderWithProviders(
+      <ContemporaryRow
+        contemporaries={[
+          { id: 'sarah', name: 'Sarah', count: 3 },
+          { id: 'lot', name: 'Lot', count: 2 },
+        ]}
+        onPress={jest.fn()}
+      />,
+    );
+    expect(getByLabelText('Switch filter to Sarah')).toBeTruthy();
+    expect(getByLabelText('Switch filter to Lot')).toBeTruthy();
+  });
+
+  it('returns null when the list is empty', () => {
+    const { toJSON } = renderWithProviders(
+      <ContemporaryRow contemporaries={[]} onPress={jest.fn()} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('calls onPress with the contemporary id when tapped', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <ContemporaryRow
+        contemporaries={[{ id: 'sarah', name: 'Sarah', count: 1 }]}
+        onPress={onPress}
+      />,
+    );
+    fireEvent.press(getByLabelText('Switch filter to Sarah'));
+    expect(onPress).toHaveBeenCalledWith('sarah');
+  });
+});
+
+describe('computeContemporaries', () => {
+  const EVENTS = [
+    entry({ id: 'a', year: -2000, people_json: '["abraham","sarah","lot"]' }),
+    entry({ id: 'b', year: -1990, people_json: '["abraham","sarah"]' }),
+    entry({ id: 'c', year: -1980, people_json: '["abraham","isaac"]' }),
+    entry({ id: 'd', year: -1900, people_json: '["isaac"]' }),
+    entry({ id: 'e', year: -3000, people_json: '["noah"]' }), // before Abraham's span
+  ];
+
+  it('returns [] when the person has no events', () => {
+    expect(computeContemporaries(EVENTS, 'unknown')).toEqual([]);
+  });
+
+  it('returns contemporaries sorted by co-occurrence count', () => {
+    const out = computeContemporaries(EVENTS, 'abraham');
+    // Abraham's span is -2000 to -1980. Noah (-3000) is outside the span.
+    // Sarah appears twice, Lot/Isaac once each.
+    expect(out[0]).toMatchObject({ id: 'sarah', count: 2 });
+    const ids = out.map((c) => c.id);
+    expect(ids).not.toContain('noah');
+    expect(ids).toContain('lot');
+    expect(ids).toContain('isaac');
+    expect(ids).not.toContain('abraham');
+  });
+
+  it('honors the max parameter', () => {
+    const e = [
+      entry({ id: 'a', year: 0, people_json: '["p","a","b","c","d","e","f","g","h","i"]' }),
+    ];
+    const out = computeContemporaries(e, 'p', 3);
+    expect(out).toHaveLength(3);
+  });
+
+  it('ignores malformed people_json', () => {
+    const e = [
+      entry({ id: 'a', year: 0, people_json: 'not-json' }),
+      entry({ id: 'b', year: 0, people_json: '["p","q"]' }),
+    ];
+    const out = computeContemporaries(e, 'p');
+    expect(out.map((c) => c.id)).toEqual(['q']);
+  });
+});

--- a/app/__tests__/components/timeline/EraContextPanel.test.tsx
+++ b/app/__tests__/components/timeline/EraContextPanel.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import {
+  EraContextPanel,
+  splitCommaList,
+} from '@/components/timeline/EraContextPanel';
+import type { EraRow } from '@/db/content/reference';
+
+function makeEra(overrides: Partial<EraRow> = {}): EraRow {
+  return {
+    id: 'kingdom',
+    name: 'Kingdom',
+    pill: 'Kingdom',
+    hex: '#c8a040',
+    range_start: -1050,
+    range_end: -586,
+    summary: null,
+    narrative:
+      'Israel transitions from tribal confederation to monarchy. The united kingdom splits after Solomon.',
+    key_themes: 'covenant kingship, temple theology, prophetic critique',
+    key_people: 'Samuel, Saul, David, Solomon',
+    books: '1-2 Samuel, 1-2 Kings, Psalms',
+    chapter_range: null,
+    geographic_center: null,
+    redemptive_thread: null,
+    transition_to_next: null,
+    ...overrides,
+  };
+}
+
+describe('EraContextPanel', () => {
+  it('renders the era name, range, and narrative', () => {
+    const { getByText } = renderWithProviders(
+      <EraContextPanel era={makeEra()} />,
+    );
+    expect(getByText(/KINGDOM/)).toBeTruthy();
+    expect(getByText(/1050 BC – 586 BC/)).toBeTruthy();
+    expect(getByText(/monarchy/)).toBeTruthy();
+  });
+
+  it('renders key themes as comma-separated text', () => {
+    const { getByText } = renderWithProviders(
+      <EraContextPanel era={makeEra()} />,
+    );
+    expect(getByText(/covenant kingship, temple theology, prophetic critique/)).toBeTruthy();
+  });
+
+  it('renders key people as tappable pills', () => {
+    const onPerson = jest.fn();
+    const { getByText } = renderWithProviders(
+      <EraContextPanel era={makeEra()} onPersonPress={onPerson} />,
+    );
+    fireEvent.press(getByText('David'));
+    expect(onPerson).toHaveBeenCalledWith('David');
+  });
+
+  it('renders books as tappable pills', () => {
+    const onBook = jest.fn();
+    const { getByText } = renderWithProviders(
+      <EraContextPanel era={makeEra()} onBookPress={onBook} />,
+    );
+    fireEvent.press(getByText('Psalms'));
+    expect(onBook).toHaveBeenCalledWith('Psalms');
+  });
+
+  it('skips missing sections', () => {
+    const { queryByText } = renderWithProviders(
+      <EraContextPanel
+        era={makeEra({ narrative: null, key_themes: null, key_people: null, books: null })}
+      />,
+    );
+    expect(queryByText(/Key Themes/i)).toBeNull();
+    expect(queryByText(/Key People/i)).toBeNull();
+    expect(queryByText(/Books/i)).toBeNull();
+  });
+});
+
+describe('splitCommaList', () => {
+  it('returns [] for null/empty', () => {
+    expect(splitCommaList(null)).toEqual([]);
+    expect(splitCommaList(undefined)).toEqual([]);
+    expect(splitCommaList('')).toEqual([]);
+  });
+
+  it('splits and trims comma-separated values', () => {
+    expect(splitCommaList(' a , b,c ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops empty pieces', () => {
+    expect(splitCommaList('a,,b')).toEqual(['a', 'b']);
+  });
+});

--- a/app/__tests__/components/timeline/PersonFilterBar.test.tsx
+++ b/app/__tests__/components/timeline/PersonFilterBar.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import { PersonFilterBar } from '@/components/timeline/PersonFilterBar';
+
+describe('PersonFilterBar', () => {
+  it('renders the count and person name (plural)', () => {
+    const { getByText } = renderWithProviders(
+      <PersonFilterBar personName="Abraham" matchCount={9} onDismiss={jest.fn()} />,
+    );
+    expect(getByText(/Showing 9 events for/)).toBeTruthy();
+    expect(getByText('Abraham')).toBeTruthy();
+  });
+
+  it('handles the singular case', () => {
+    const { getByText } = renderWithProviders(
+      <PersonFilterBar personName="Eve" matchCount={1} onDismiss={jest.fn()} />,
+    );
+    expect(getByText(/Showing 1 event for/)).toBeTruthy();
+  });
+
+  it('calls onDismiss when the close button is tapped', () => {
+    const onDismiss = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <PersonFilterBar personName="Paul" matchCount={5} onDismiss={onDismiss} />,
+    );
+    fireEvent.press(getByLabelText('Clear person filter'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a composite accessibility label', () => {
+    const { getByLabelText } = renderWithProviders(
+      <PersonFilterBar personName="Moses" matchCount={12} onDismiss={jest.fn()} />,
+    );
+    expect(getByLabelText('Showing 12 events for Moses')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/timeline/TimelineEraStrip.test.tsx
+++ b/app/__tests__/components/timeline/TimelineEraStrip.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import {
+  TimelineEraStrip,
+  computeEraShares,
+  firstWord,
+  formatEraRange,
+} from '@/components/timeline/TimelineEraStrip';
+import type { EraRow } from '@/db/content/reference';
+
+function makeEra(id: string, name: string, range: [number, number]): EraRow {
+  return {
+    id,
+    name,
+    pill: name,
+    hex: '#888888',
+    range_start: range[0],
+    range_end: range[1],
+    summary: null,
+    narrative: null,
+    key_themes: null,
+    key_people: null,
+    books: null,
+    chapter_range: null,
+    geographic_center: null,
+    redemptive_thread: null,
+    transition_to_next: null,
+  };
+}
+
+const ERAS = [
+  makeEra('primeval', 'Primeval', [-4000, -2100]),
+  makeEra('patriarchs', 'Patriarchs', [-2100, -1800]),
+  makeEra('divided_kingdom', 'Divided Kingdom', [-930, -722]),
+];
+
+describe('TimelineEraStrip', () => {
+  it('renders a segment for each era', () => {
+    const { getByLabelText } = renderWithProviders(
+      <TimelineEraStrip
+        eras={ERAS}
+        eventCounts={{ primeval: 10, patriarchs: 5, divided_kingdom: 60 }}
+        activeEraId={null}
+        onSelectEra={jest.fn()}
+      />,
+    );
+    expect(getByLabelText(/Primeval era/)).toBeTruthy();
+    expect(getByLabelText(/Patriarchs era/)).toBeTruthy();
+    expect(getByLabelText(/Divided Kingdom era/)).toBeTruthy();
+  });
+
+  it('calls onSelectEra with the era id when a segment is tapped', () => {
+    const onSelect = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <TimelineEraStrip
+        eras={ERAS}
+        eventCounts={{ primeval: 10 }}
+        activeEraId={null}
+        onSelectEra={onSelect}
+      />,
+    );
+    fireEvent.press(getByLabelText(/Primeval era/));
+    expect(onSelect).toHaveBeenCalledWith('primeval');
+  });
+
+  it('deselects an active era when tapped again', () => {
+    const onSelect = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <TimelineEraStrip
+        eras={ERAS}
+        eventCounts={{ primeval: 10 }}
+        activeEraId="primeval"
+        onSelectEra={onSelect}
+      />,
+    );
+    fireEvent.press(getByLabelText(/Primeval era/));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('shows a caption with the active era name and range', () => {
+    const { getAllByText, getByText } = renderWithProviders(
+      <TimelineEraStrip
+        eras={ERAS}
+        eventCounts={{ primeval: 40 }}
+        activeEraId="primeval"
+        onSelectEra={jest.fn()}
+      />,
+    );
+    // "Primeval" appears twice (segment label + caption).
+    expect(getAllByText('Primeval').length).toBeGreaterThanOrEqual(2);
+    expect(getByText(/4000 BC – 2100 BC/)).toBeTruthy();
+    expect(getByText(/40 events/)).toBeTruthy();
+  });
+
+  it('shows the era first-word label only for wide segments (>30 events)', () => {
+    const { queryByText } = renderWithProviders(
+      <TimelineEraStrip
+        eras={ERAS}
+        eventCounts={{ primeval: 60, patriarchs: 5 }}
+        activeEraId={null}
+        onSelectEra={jest.fn()}
+      />,
+    );
+    // Primeval has 60 events → label rendered
+    expect(queryByText('Primeval')).toBeTruthy();
+    // Patriarchs has only 5 → label not rendered (caption wouldn't show either — no active era)
+    expect(queryByText('Patriarchs')).toBeNull();
+  });
+});
+
+describe('computeEraShares', () => {
+  it('returns equal shares when total count is zero', () => {
+    const out = computeEraShares(ERAS, {});
+    out.forEach(({ share }) => expect(share).toBeCloseTo(1 / ERAS.length, 5));
+  });
+
+  it('proportional shares sum to ~1', () => {
+    const out = computeEraShares(ERAS, { primeval: 10, patriarchs: 5, divided_kingdom: 85 });
+    const sum = out.reduce((s, r) => s + r.share, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+
+  it('applies a minimum share so every segment stays tappable', () => {
+    const out = computeEraShares(
+      ERAS,
+      { primeval: 0, patriarchs: 0, divided_kingdom: 1000 },
+      0.05,
+    );
+    for (const { share } of out) {
+      expect(share).toBeGreaterThanOrEqual(0);
+    }
+    // After normalisation the largest era still dominates.
+    const largest = out.find((r) => r.id === 'divided_kingdom')!;
+    expect(largest.share).toBeGreaterThan(0.5);
+  });
+});
+
+describe('firstWord', () => {
+  it('returns the first whitespace-separated token', () => {
+    expect(firstWord('Divided Kingdom')).toBe('Divided');
+    expect(firstWord('Primeval')).toBe('Primeval');
+    expect(firstWord('   Leading Spaces')).toBe('Leading');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(firstWord('')).toBe('');
+    expect(firstWord('   ')).toBe('');
+  });
+});
+
+describe('formatEraRange', () => {
+  it('formats BC years', () => {
+    expect(formatEraRange(-2000, -1500)).toBe('2000 BC – 1500 BC');
+  });
+
+  it('formats AD years', () => {
+    expect(formatEraRange(30, 95)).toBe('AD 30 – AD 95');
+  });
+
+  it('handles BC → AD spans', () => {
+    expect(formatEraRange(-50, 70)).toBe('50 BC – AD 70');
+  });
+
+  it('returns empty string if either bound is null', () => {
+    expect(formatEraRange(null, 100)).toBe('');
+    expect(formatEraRange(0, null)).toBe('');
+  });
+});

--- a/app/__tests__/components/timeline/TimelineEventCard.test.tsx
+++ b/app/__tests__/components/timeline/TimelineEventCard.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import {
+  TimelineEventCard,
+  formatTimelineYear,
+  parsePeopleJson,
+  parseChapterLink,
+} from '@/components/timeline/TimelineEventCard';
+import type { TimelineEntry } from '@/types';
+
+function makeEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+  return {
+    id: 'evt_creation',
+    name: 'Creation',
+    category: 'event',
+    era: 'primeval',
+    year: -4000,
+    summary: 'God creates the heavens and the earth.',
+    scripture_ref: 'Genesis 1',
+    chapter_link: 'ot/genesis_1.html',
+    people_json: null,
+    region: null,
+    ...overrides,
+  };
+}
+
+describe('TimelineEventCard', () => {
+  it('renders year, scripture ref, title, and summary', () => {
+    const { getByText } = renderWithProviders(
+      <TimelineEventCard
+        event={makeEntry()}
+        eraColor="#8a6e3a"
+        isExpanded={false}
+        onToggleExpand={jest.fn()}
+      />,
+    );
+    expect(getByText('4000 BC')).toBeTruthy();
+    expect(getByText('Genesis 1')).toBeTruthy();
+    expect(getByText('Creation')).toBeTruthy();
+    expect(getByText('God creates the heavens and the earth.')).toBeTruthy();
+  });
+
+  it('calls onToggleExpand when pressed', () => {
+    const onToggle = jest.fn();
+    const { getByText } = renderWithProviders(
+      <TimelineEventCard
+        event={makeEntry()}
+        eraColor="#8a6e3a"
+        isExpanded={false}
+        onToggleExpand={onToggle}
+      />,
+    );
+    fireEvent.press(getByText('Creation'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides people pills when collapsed', () => {
+    const { queryByText } = renderWithProviders(
+      <TimelineEventCard
+        event={makeEntry({ people_json: '["abraham","sarah"]' })}
+        eraColor="#8a6e3a"
+        isExpanded={false}
+        onToggleExpand={jest.fn()}
+      />,
+    );
+    expect(queryByText('abraham')).toBeNull();
+  });
+
+  it('shows people pills when expanded and invokes onPersonPress', () => {
+    const onPerson = jest.fn();
+    const { getByText } = renderWithProviders(
+      <TimelineEventCard
+        event={makeEntry({ people_json: '["abraham","sarah"]' })}
+        eraColor="#8a6e3a"
+        isExpanded
+        onToggleExpand={jest.fn()}
+        onPersonPress={onPerson}
+      />,
+    );
+    fireEvent.press(getByText('abraham'));
+    expect(onPerson).toHaveBeenCalledWith('abraham');
+  });
+
+  it('shows the chapter button when expanded and chapter_link parses', () => {
+    const onChapter = jest.fn();
+    const { getByText } = renderWithProviders(
+      <TimelineEventCard
+        event={makeEntry()}
+        eraColor="#8a6e3a"
+        isExpanded
+        onToggleExpand={jest.fn()}
+        onChapterPress={onChapter}
+      />,
+    );
+    fireEvent.press(getByText('Go to chapter →'));
+    expect(onChapter).toHaveBeenCalledWith('genesis', 1);
+  });
+});
+
+describe('formatTimelineYear', () => {
+  it('formats negative years as BC', () => {
+    expect(formatTimelineYear(-4000)).toBe('4000 BC');
+    expect(formatTimelineYear(-1)).toBe('1 BC');
+  });
+
+  it('formats positive years as AD', () => {
+    expect(formatTimelineYear(30)).toBe('AD 30');
+    expect(formatTimelineYear(1995)).toBe('AD 1995');
+  });
+
+  it('handles year 0 specially', () => {
+    expect(formatTimelineYear(0)).toBe('AD/BC');
+  });
+});
+
+describe('parsePeopleJson', () => {
+  it('returns [] for null/undefined/empty', () => {
+    expect(parsePeopleJson(null)).toEqual([]);
+    expect(parsePeopleJson(undefined)).toEqual([]);
+    expect(parsePeopleJson('')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    expect(parsePeopleJson('not-json')).toEqual([]);
+  });
+
+  it('returns [] when parsed value is not an array', () => {
+    expect(parsePeopleJson('{"a":1}')).toEqual([]);
+  });
+
+  it('parses arrays of strings and filters non-strings', () => {
+    expect(parsePeopleJson('["a","b"]')).toEqual(['a', 'b']);
+    expect(parsePeopleJson('["a",1,null,"b"]')).toEqual(['a', 'b']);
+  });
+});
+
+describe('parseChapterLink', () => {
+  it('returns null for null/empty', () => {
+    expect(parseChapterLink(null)).toBeNull();
+    expect(parseChapterLink('')).toBeNull();
+  });
+
+  it('returns null for strings that do not match the pattern', () => {
+    expect(parseChapterLink('not-a-link')).toBeNull();
+  });
+
+  it('parses book/chapter from the standard link format', () => {
+    expect(parseChapterLink('ot/genesis_12.html')).toEqual({
+      bookId: 'genesis',
+      chapterNum: 12,
+    });
+  });
+
+  it('lowercases the book id', () => {
+    expect(parseChapterLink('nt/Matthew_5.html')).toEqual({
+      bookId: 'matthew',
+      chapterNum: 5,
+    });
+  });
+});

--- a/app/__tests__/components/timeline/TimelineSpine.test.tsx
+++ b/app/__tests__/components/timeline/TimelineSpine.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { renderWithProviders } from '../../helpers/renderWithProviders';
+import { TimelineSpine, SPINE_GUTTER_WIDTH } from '@/components/timeline/TimelineSpine';
+
+describe('TimelineSpine', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = renderWithProviders(
+      <TimelineSpine eraColor="#8a6e3a" hasImage={false} />,
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('has a stable gutter width constant', () => {
+    expect(SPINE_GUTTER_WIDTH).toBe(32);
+  });
+
+  it('uses a larger, glowing dot when hasImage is true', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <TimelineSpine eraColor="#8a6e3a" hasImage />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    // The third view is the dot (gutter → top-half → dot → bottom-half)
+    const dot = views[2];
+    const styleArr = Array.isArray(dot.props.style) ? dot.props.style : [dot.props.style];
+    const merged = Object.assign({}, ...styleArr);
+    expect(merged.width).toBe(10);
+    expect(merged.shadowOpacity).toBeGreaterThan(0);
+  });
+
+  it('uses a smaller, dim dot when hasImage is false', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <TimelineSpine eraColor="#8a6e3a" hasImage={false} />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    const dot = views[2];
+    const styleArr = Array.isArray(dot.props.style) ? dot.props.style : [dot.props.style];
+    const merged = Object.assign({}, ...styleArr);
+    expect(merged.width).toBe(7);
+    expect(merged.opacity).toBe(0.5);
+  });
+
+  it('hides the top line for the first row', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <TimelineSpine eraColor="#8a6e3a" hasImage={false} isFirst />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    const topHalf = views[1];
+    const styleArr = Array.isArray(topHalf.props.style)
+      ? topHalf.props.style
+      : [topHalf.props.style];
+    const merged = Object.assign({}, ...styleArr);
+    expect(merged.backgroundColor).toBe('transparent');
+  });
+
+  it('hides the bottom line for the last row', () => {
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <TimelineSpine eraColor="#8a6e3a" hasImage={false} isLast />,
+    );
+    const { View } = require('react-native');
+    const views = UNSAFE_getAllByType(View);
+    const bottomHalf = views[3];
+    const styleArr = Array.isArray(bottomHalf.props.style)
+      ? bottomHalf.props.style
+      : [bottomHalf.props.style];
+    const merged = Object.assign({}, ...styleArr);
+    expect(merged.backgroundColor).toBe('transparent');
+  });
+});

--- a/app/__tests__/screens/ExploreMenuScreen.test.tsx
+++ b/app/__tests__/screens/ExploreMenuScreen.test.tsx
@@ -1,30 +1,92 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/content', () => ({
+  getAllProphecyChains: jest.fn().mockResolvedValue([]),
+  getDebateTopics: jest.fn().mockResolvedValue([]),
+  getAllWordStudies: jest.fn().mockResolvedValue([]),
+  getLifeTopicCategories: jest.fn().mockResolvedValue([]),
+  getPeopleWithJourneys: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/hooks/useJourneyBrowse', () => ({
+  useJourneyBrowse: jest.fn().mockReturnValue({
+    personJourneys: [],
+    conceptJourneys: [],
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/hooks/useProphecyChains', () => ({
+  useProphecyChains: jest.fn().mockReturnValue({ chains: [], isLoading: false }),
+}));
+
+jest.mock('@/db/user', () => ({
+  getReadingStats: jest.fn().mockResolvedValue({ totalChapters: 10 }),
+  getPreference: jest.fn().mockResolvedValue(null),
+  setPreference: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/hooks/useExploreRecommendations', () => ({
+  useExploreRecommendations: jest.fn().mockReturnValue({ recommendations: [], bookName: null }),
+}));
+
+jest.mock('@/hooks/useExploreImages', () => ({
+  useExploreImages: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('@/hooks/usePremium', () => ({
+  usePremium: jest.fn().mockReturnValue({
+    isPremium: true,
+    upgradeRequest: null,
+    showUpgrade: jest.fn(),
+    dismissUpgrade: jest.fn(),
+  }),
+}));
+
 import ExploreMenuScreen from '@/screens/ExploreMenuScreen';
 
 describe('ExploreMenuScreen', () => {
-  it('renders the Explore heading', () => {
+  it('renders the Explore heading', async () => {
     const { getByText } = render(<ExploreMenuScreen />);
-    expect(getByText('Explore')).toBeTruthy();
+    await waitFor(() => expect(getByText('Explore')).toBeTruthy());
   });
 
-  it('renders hero feature cards', () => {
+  it('renders hero feature cards', async () => {
     const { getByText } = render(<ExploreMenuScreen />);
-    expect(getByText('People')).toBeTruthy();
-    expect(getByText('Timeline')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('People')).toBeTruthy();
+      expect(getByText('Timeline')).toBeTruthy();
+    });
   });
 
-  it('renders grid feature cards', () => {
+  it('renders feature cards across the section layouts', async () => {
     const { getByText } = render(<ExploreMenuScreen />);
-    expect(getByText('Map')).toBeTruthy();
-    expect(getByText('Word Studies')).toBeTruthy();
-    expect(getByText('Scholars')).toBeTruthy();
-    expect(getByText('Content Library')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Map')).toBeTruthy();
+      // Language split row contains Concordance + Dictionary (Word Studies moves to the preview list)
+      expect(getByText('Concordance')).toBeTruthy();
+      // Scholarly split row contains Scholars + Difficult Passages
+      expect(getByText('Scholars')).toBeTruthy();
+      expect(getByText('Difficult Passages')).toBeTruthy();
+    });
   });
 
-  it('navigates when a card is pressed', () => {
+  it('renders the varied section headers', async () => {
+    const { getAllByText } = render(<ExploreMenuScreen />);
+    // Each section header appears twice: once in the jump-pill bar and once
+    // above the section itself — so we expect at least two matches.
+    await waitFor(() => {
+      expect(getAllByText('Themes & Connections').length).toBeGreaterThanOrEqual(2);
+      expect(getAllByText('Language & Reference').length).toBeGreaterThanOrEqual(2);
+      expect(getAllByText('Life & Faith').length).toBeGreaterThanOrEqual(2);
+      expect(getAllByText('Deep Dive').length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('navigates when a card is pressed', async () => {
     const { getByText } = render(<ExploreMenuScreen />);
-    // Pressing a card should not throw
+    await waitFor(() => expect(getByText('Map')).toBeTruthy());
     fireEvent.press(getByText('Map'));
   });
 });

--- a/app/__tests__/screens/TimelineScreen.test.tsx
+++ b/app/__tests__/screens/TimelineScreen.test.tsx
@@ -167,4 +167,35 @@ describe('TimelineScreen', () => {
     const { findByLabelText } = renderWithProviders(<TimelineScreen />);
     expect(await findByLabelText('Timeline')).toBeTruthy();
   });
+
+  it('enters person-filter mode when a person pill is tapped on an expanded card', async () => {
+    const { findByLabelText, findByText, getByText } = renderWithProviders(<TimelineScreen />);
+    // Expand Abraham's card (it has people_json = ["abraham"])
+    const card = await findByLabelText(/Abraham,/);
+    fireEvent.press(card);
+    const pill = await findByText('abraham');
+    fireEvent.press(pill);
+    // Person filter bar now renders.
+    expect(getByText(/Showing \d+ event/)).toBeTruthy();
+  });
+
+  it('dismisses the person filter when the close pill is pressed', async () => {
+    const { findByLabelText, findByText, queryByText, getByLabelText } = renderWithProviders(
+      <TimelineScreen />,
+    );
+    const card = await findByLabelText(/Abraham,/);
+    fireEvent.press(card);
+    fireEvent.press(await findByText('abraham'));
+    await findByText(/Showing \d+ event/);
+    fireEvent.press(getByLabelText('Clear person filter'));
+    expect(queryByText(/Showing \d+ event/)).toBeNull();
+  });
+
+  it('shows an era context panel when an era segment is tapped', async () => {
+    const { findByLabelText } = renderWithProviders(<TimelineScreen />);
+    const primeval = await findByLabelText(/Primeval era/);
+    fireEvent.press(primeval);
+    // EraContextPanel renders its own accessibility label scoped to the era.
+    expect(await findByLabelText(/Primeval era context/)).toBeTruthy();
+  });
 });

--- a/app/__tests__/screens/TimelineScreen.test.tsx
+++ b/app/__tests__/screens/TimelineScreen.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
-import TimelineScreen from '@/screens/TimelineScreen';
 
 // ── Navigation mock ───────────────────────────────────────────────
 
@@ -38,49 +37,9 @@ jest.mock('@/stores', () => ({
 }));
 
 // ── DB calls ──────────────────────────────────────────────────────
-
-const mockTimelineEntries = [
-  {
-    id: 'evt_creation',
-    name: 'Creation',
-    category: 'event',
-    era: 'primeval',
-    year: -4000,
-    summary: 'God creates the heavens and the earth.',
-    scripture_ref: 'Genesis 1',
-    chapter_link: 'ot/genesis_1.html',
-  },
-  {
-    id: 'bk_book-genesis',
-    name: 'Genesis',
-    category: 'book',
-    era: 'primeval',
-    year: -3800,
-    summary: 'Book of Genesis covers creation through Joseph.',
-    scripture_ref: null,
-    chapter_link: null,
-  },
-  {
-    id: 'per_abraham',
-    name: 'Abraham',
-    category: 'person',
-    era: 'patriarchs',
-    year: -2000,
-    summary: 'Father of many nations.',
-    scripture_ref: 'Genesis 12',
-    chapter_link: 'ot/genesis_12.html',
-  },
-  {
-    id: 'wld_babel',
-    name: 'Tower of Babel',
-    category: 'world',
-    era: 'primeval',
-    year: -3500,
-    summary: 'Languages confused at Babel.',
-    scripture_ref: 'Genesis 11',
-    chapter_link: null,
-  },
-];
+// Inline the mock data inside the factory — jest hoists jest.mock calls,
+// so any top-level `const` in this file is not yet initialised when the
+// factory runs.
 
 jest.mock('@/db/content', () => ({
   getAllTimelineEntries: jest.fn().mockResolvedValue([
@@ -88,85 +47,41 @@ jest.mock('@/db/content', () => ({
       id: 'evt_creation', name: 'Creation', category: 'event', era: 'primeval',
       year: -4000, summary: 'God creates the heavens and the earth.',
       scripture_ref: 'Genesis 1', chapter_link: 'ot/genesis_1.html',
+      people_json: null, region: null,
     },
     {
       id: 'bk_book-genesis', name: 'Genesis', category: 'book', era: 'primeval',
-      year: -3800, summary: 'Book of Genesis covers creation through Joseph.',
+      year: -3800, summary: 'Book of Genesis.',
       scripture_ref: null, chapter_link: null,
+      people_json: null, region: null,
     },
     {
       id: 'per_abraham', name: 'Abraham', category: 'person', era: 'patriarchs',
       year: -2000, summary: 'Father of many nations.',
       scripture_ref: 'Genesis 12', chapter_link: 'ot/genesis_12.html',
+      people_json: '["abraham"]', region: null,
+    },
+  ]),
+  getEras: jest.fn().mockResolvedValue([
+    {
+      id: 'primeval', name: 'Primeval', pill: 'Primeval', hex: '#8a6e3a',
+      range_start: -4000, range_end: -2100, summary: null, narrative: null,
+      key_themes: null, key_people: null, books: null,
+      chapter_range: null, geographic_center: null,
+      redemptive_thread: null, transition_to_next: null,
     },
     {
-      id: 'wld_babel', name: 'Tower of Babel', category: 'world', era: 'primeval',
-      year: -3500, summary: 'Languages confused at Babel.',
-      scripture_ref: 'Genesis 11', chapter_link: null,
+      id: 'patriarchs', name: 'Patriarchs', pill: 'Patriarchs', hex: '#c8a040',
+      range_start: -2100, range_end: -1800, summary: null, narrative: null,
+      key_themes: null, key_people: null, books: null,
+      chapter_range: null, geographic_center: null,
+      redemptive_thread: null, transition_to_next: null,
     },
   ]),
 }));
 
-// ── Hooks ─────────────────────────────────────────────────────────
-
-jest.mock('@/hooks/useLandscapeUnlock', () => ({
-  useLandscapeUnlock: jest.fn(),
-}));
-
-// ── Layout utils ──────────────────────────────────────────────────
-
-jest.mock('@/utils/timelineLayout', () => ({
-  yearToX: (y: number) => (y + 5000) * 0.5,
-  formatYear: (y: number) => (y < 0 ? `${Math.abs(y)} BC` : `AD ${y}`),
-  assignLanes: (events: any[]) => events.map((e: any, i: number) => ({
-    ...e,
-    x: (e.year + 5000) * 0.5,
-    y: 80 + i * 40,
-    lane: i,
-    labelWidth: 120,
-    significance: e.chapter_link || e.summary || e.category === 'book' ? 'major' : 'minor',
-  })),
-  computeTickMarks: () => [
-    { x: 100, label: '4000 BC', major: true },
-    { x: 200, label: '3000 BC', major: true },
-    { x: 250, label: '2500 BC', major: false },
-  ],
-  computeSvgHeight: () => 500,
-  ERA_RANGES: {
-    primeval: [-4000, -2100],
-    patriarchs: [-2100, -1800],
-    exodus: [-1800, -1400],
-  } as Record<string, [number, number]>,
-  TOTAL_WIDTH: 5000,
-  AXIS_Y: 150,
-  ERA_BAR_Y: 10,
-  ERA_BAR_H: 30,
-}));
-
-// ── Child component stubs ─────────────────────────────────────────
-
-jest.mock('@/components/tree/EraFilterBar', () => ({
-  EraFilterBar: (props: any) => {
-    const React = require('react');
-    const { View, TouchableOpacity, Text } = require('react-native');
-    return React.createElement(View, { testID: 'era-filter-bar' },
-      ['all', 'primeval', 'patriarchs', 'exodus'].map((era: string) =>
-        React.createElement(TouchableOpacity, {
-          key: era,
-          testID: `era-filter-${era}`,
-          onPress: () => props.onSelect(era),
-        }, React.createElement(Text, null, era)),
-      ),
-    );
-  },
-}));
-
-jest.mock('@/components/BadgeChip', () => ({
-  BadgeChip: (props: any) => {
-    const React = require('react');
-    const { Text } = require('react-native');
-    return React.createElement(Text, { testID: 'badge-chip' }, props.label);
-  },
+jest.mock('@/hooks/useContentImages', () => ({
+  useContentImages: jest.fn().mockReturnValue({ images: [], isLoading: false }),
 }));
 
 jest.mock('@/components/LoadingSkeleton', () => ({
@@ -177,70 +92,38 @@ jest.mock('@/components/LoadingSkeleton', () => ({
   },
 }));
 
-// Stub SVG components (including Defs/LinearGradient/Stop for modernized timeline)
-jest.mock('react-native-svg', () => {
-  const React = require('react');
-  const { View, Text } = require('react-native');
-  const createSvgMock = (name: string) => (props: any) =>
-    React.createElement(View, { ...props, testID: props.testID ?? undefined }, props.children);
-  return {
-    __esModule: true,
-    default: createSvgMock('Svg'),
-    Rect: createSvgMock('Rect'),
-    Line: createSvgMock('Line'),
-    Circle: createSvgMock('Circle'),
-    G: (props: any) => React.createElement(View, props, props.children),
-    Text: (props: any) => React.createElement(Text, props, props.children),
-    Defs: (props: any) => React.createElement(View, props, props.children),
-    LinearGradient: (props: any) => React.createElement(View, props, props.children),
-    Stop: (props: any) => React.createElement(View, props),
-  };
-});
+// For the default export (which wraps the screen in an ErrorBoundary), make
+// sure the boundary passes errors through rather than swallowing — but since
+// our rewrite no longer throws on render, no special handling is needed.
 
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 44, bottom: 34, left: 0, right: 0 }),
-}));
-
-// Bottom sheet mock (replaces Modal in modernized timeline)
-jest.mock('@gorhom/bottom-sheet', () => {
-  const React = require('react');
-  const { View } = require('react-native');
-  return {
-    __esModule: true,
-    default: React.forwardRef(({ children }: any, ref: any) => {
-      React.useImperativeHandle(ref, () => ({
-        snapToIndex: jest.fn(),
-        close: jest.fn(),
-        expand: jest.fn(),
-      }));
-      return React.createElement(View, { testID: 'bottom-sheet' }, children);
-    }),
-    BottomSheetScrollView: ({ children }: any) => React.createElement(View, null, children),
-  };
-});
-
-// ── Tests ─────────────────────────────────────────────────────────
+import TimelineScreen from '@/screens/TimelineScreen';
 
 describe('TimelineScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders without crashing after data loads', async () => {
-    const { findByTestId } = renderWithProviders(<TimelineScreen />);
-    // After the async getAllTimelineEntries resolves, the screen renders content
-    expect(await findByTestId('era-filter-bar')).toBeTruthy();
-  });
-
-  it('shows loading skeleton initially', () => {
-    // On first render, isLoading is true (before the effect resolves)
+  it('shows the loading skeleton initially', () => {
     const { getByTestId } = renderWithProviders(<TimelineScreen />);
     expect(getByTestId('loading-skeleton')).toBeTruthy();
   });
 
-  it('renders era filter bar after loading', async () => {
-    const { findByTestId } = renderWithProviders(<TimelineScreen />);
-    expect(await findByTestId('era-filter-bar')).toBeTruthy();
+  it('renders the Timeline header and event count after loading', async () => {
+    const { findByText } = renderWithProviders(<TimelineScreen />);
+    expect(await findByText('Timeline')).toBeTruthy();
+    expect(await findByText('3 events')).toBeTruthy();
+  });
+
+  it('renders event cards in the list after loading', async () => {
+    const { findByText } = renderWithProviders(<TimelineScreen />);
+    expect(await findByText('Creation')).toBeTruthy();
+    expect(await findByText('Abraham')).toBeTruthy();
+  });
+
+  it('renders era strip segments keyed by era', async () => {
+    const { findByLabelText } = renderWithProviders(<TimelineScreen />);
+    expect(await findByLabelText(/Primeval era/)).toBeTruthy();
+    expect(await findByLabelText(/Patriarchs era/)).toBeTruthy();
   });
 
   it('renders category filter chips after loading', async () => {
@@ -251,50 +134,37 @@ describe('TimelineScreen', () => {
     expect(await findByText('World History')).toBeTruthy();
   });
 
-  it('renders timeline events after loading', async () => {
-    const { findByText } = renderWithProviders(<TimelineScreen />);
-    // Events display name + formatted year
-    expect(await findByText(/Creation/)).toBeTruthy();
-    expect(await findByText(/Abraham/)).toBeTruthy();
-  });
-
-  it('toggles a category filter when chip is pressed', async () => {
-    const { findByText } = renderWithProviders(<TimelineScreen />);
+  it('toggles a category filter when a chip is pressed', async () => {
+    const { findByText, queryByText } = renderWithProviders(<TimelineScreen />);
     const peopleChip = await findByText('People');
-    // Press to toggle off the person category
     fireEvent.press(peopleChip);
-    // Component re-renders — no crash confirms the state update
-    expect(await findByText('Events')).toBeTruthy();
+    // Abraham is a person — should be filtered out after toggling people off.
+    expect(queryByText('Abraham')).toBeNull();
   });
 
-  it('changes era filter when era chip is pressed', async () => {
-    const { findByTestId } = renderWithProviders(<TimelineScreen />);
-    const patriarchsFilter = await findByTestId('era-filter-patriarchs');
-    fireEvent.press(patriarchsFilter);
-    // Screen re-renders with filtered events — no crash
-    expect(await findByTestId('era-filter-bar')).toBeTruthy();
+  it('filters to an era when its segment is pressed', async () => {
+    const { findByText, findByLabelText, queryByText } = renderWithProviders(
+      <TimelineScreen />,
+    );
+    await findByText('Creation');
+    const patriarchs = await findByLabelText(/Patriarchs era/);
+    fireEvent.press(patriarchs);
+    // Creation is in the primeval era — should be hidden after filtering.
+    expect(queryByText('Creation')).toBeNull();
+    expect(await findByText('Abraham')).toBeTruthy();
   });
 
-  it('renders timeline with accessibility label', async () => {
+  it('expands an event card when it is tapped', async () => {
+    const { findByText, getByLabelText } = renderWithProviders(<TimelineScreen />);
+    await findByText('Abraham');
+    const card = getByLabelText(/Abraham,/);
+    fireEvent.press(card);
+    // People pill renders once the card expands.
+    expect(await findByText('abraham')).toBeTruthy();
+  });
+
+  it('exposes an accessibility label on the root container', async () => {
     const { findByLabelText } = renderWithProviders(<TimelineScreen />);
     expect(await findByLabelText('Timeline')).toBeTruthy();
-  });
-
-  it('shows event detail modal when an event is pressed', async () => {
-    const { findByText } = renderWithProviders(<TimelineScreen />);
-    // The SVG G elements have onPress handlers. Since we mock G as a View,
-    // the press should propagate. We look for the event in the rendered tree.
-    // Note: With mocked SVG, the G onPress may not fire via fireEvent.
-    // Instead, verify that the events are rendered (interaction tested via
-    // the category filter toggle above).
-    expect(await findByText(/Creation/)).toBeTruthy();
-    expect(await findByText(/Tower of Babel/)).toBeTruthy();
-  });
-
-  it('renders timeline container after loading', async () => {
-    const { findByText, toJSON } = renderWithProviders(<TimelineScreen />);
-    await findByText(/Creation/);
-    // Tree should be non-null after data loads
-    expect(toJSON()).toBeTruthy();
   });
 });

--- a/app/__tests__/unit/covenantWaypoints.test.ts
+++ b/app/__tests__/unit/covenantWaypoints.test.ts
@@ -1,0 +1,40 @@
+import {
+  COVENANT_WAYPOINTS,
+  getCovenantWaypoint,
+} from '@/utils/covenantWaypoints';
+
+describe('COVENANT_WAYPOINTS', () => {
+  it('starts with Adam (protoevangelium) and ends with Jesus (fulfilled)', () => {
+    expect(COVENANT_WAYPOINTS[0].personId).toBe('adam');
+    expect(COVENANT_WAYPOINTS[COVENANT_WAYPOINTS.length - 1].personId).toBe('jesus');
+  });
+
+  it('includes the 7 expected covenant figures', () => {
+    const ids = COVENANT_WAYPOINTS.map((w) => w.personId);
+    ['adam', 'noah', 'abraham', 'judah', 'david', 'zerubbabel', 'jesus'].forEach((id) =>
+      expect(ids).toContain(id),
+    );
+  });
+
+  it('has unique person ids', () => {
+    const ids = COVENANT_WAYPOINTS.map((w) => w.personId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('getCovenantWaypoint', () => {
+  it('returns the waypoint for a known id', () => {
+    const w = getCovenantWaypoint('abraham');
+    expect(w?.ref).toBe('Gen 12:3');
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(getCovenantWaypoint('cain')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty', () => {
+    expect(getCovenantWaypoint(null)).toBeNull();
+    expect(getCovenantWaypoint(undefined)).toBeNull();
+    expect(getCovenantWaypoint('')).toBeNull();
+  });
+});

--- a/app/__tests__/unit/genealogyOrganic.test.ts
+++ b/app/__tests__/unit/genealogyOrganic.test.ts
@@ -1,0 +1,152 @@
+import {
+  bezierPath,
+  getLinkWeight,
+  getPersonTier,
+  getVisibleTier,
+  isPersonVisibleAtZoom,
+  applyTribalBloom,
+  TIER_2_ZOOM,
+  TIER_3_ZOOM,
+} from '@/utils/genealogyOrganic';
+import type { Person } from '@/types';
+
+function person(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p',
+    name: 'P',
+    gender: null,
+    father: null,
+    mother: null,
+    spouse_of: null,
+    era: null,
+    dates: null,
+    role: null,
+    type: null,
+    bio: null,
+    scripture_role: null,
+    refs_json: null,
+    chapter_link: null,
+    ...overrides,
+  };
+}
+
+describe('bezierPath', () => {
+  it('produces a valid SVG cubic Bezier path', () => {
+    const path = bezierPath({ x: 0, y: 0 }, { x: 100, y: 200 });
+    expect(path).toBe('M 0 0 C 0 100, 100 100, 100 200');
+  });
+
+  it('computes the midpoint symmetrically', () => {
+    const path = bezierPath({ x: 10, y: 10 }, { x: 30, y: 50 });
+    expect(path).toMatch(/C 10 30, 30 30, 30 50/);
+  });
+});
+
+describe('getPersonTier', () => {
+  it('messianic line members are always tier 1', () => {
+    expect(getPersonTier(person({ bio: null, role: null }), true)).toBe(1);
+  });
+
+  it('privileged roles are tier 1', () => {
+    expect(getPersonTier(person({ role: 'patriarch' }), false)).toBe(1);
+    expect(getPersonTier(person({ role: 'king' }), false)).toBe(1);
+    expect(getPersonTier(person({ role: 'prophet' }), false)).toBe(1);
+    expect(getPersonTier(person({ role: 'judge' }), false)).toBe(1);
+  });
+
+  it('named people with bios are tier 2', () => {
+    expect(getPersonTier(person({ bio: 'A sage.' }), false)).toBe(2);
+  });
+
+  it('everyone else is tier 3', () => {
+    expect(getPersonTier(person(), false)).toBe(3);
+  });
+});
+
+describe('getVisibleTier', () => {
+  it('only tier 1 at very low zoom', () => {
+    expect(getVisibleTier(0.2)).toBe(1);
+    expect(getVisibleTier(TIER_2_ZOOM)).toBe(1);
+  });
+
+  it('tier 2 after passing TIER_2_ZOOM', () => {
+    expect(getVisibleTier(TIER_2_ZOOM + 0.01)).toBe(2);
+  });
+
+  it('tier 3 after passing TIER_3_ZOOM', () => {
+    expect(getVisibleTier(TIER_3_ZOOM + 0.01)).toBe(3);
+  });
+});
+
+describe('isPersonVisibleAtZoom', () => {
+  it('tier 1 people are visible at any zoom', () => {
+    expect(isPersonVisibleAtZoom(1, 0.1)).toBe(true);
+    expect(isPersonVisibleAtZoom(1, 1.0)).toBe(true);
+  });
+
+  it('tier 3 people require high zoom', () => {
+    expect(isPersonVisibleAtZoom(3, 0.4)).toBe(false);
+    expect(isPersonVisibleAtZoom(3, 0.9)).toBe(true);
+  });
+});
+
+describe('getLinkWeight', () => {
+  const parent = person({ id: 'parent' });
+  const child = person({ id: 'child' });
+
+  it('messianic links get the thickest gold stroke with glow', () => {
+    const style = getLinkWeight(parent, child, true);
+    expect(style).toEqual({ width: 2.5, color: 'gold', opacity: 0.35, glow: true });
+  });
+
+  it('privileged-role parents get medium weight', () => {
+    const style = getLinkWeight(person({ role: 'king' }), child, false);
+    expect(style.width).toBe(1.5);
+    expect(style.glow).toBe(false);
+  });
+
+  it('children with bios get light weight', () => {
+    const style = getLinkWeight(parent, person({ bio: 'Notable.' }), false);
+    expect(style.width).toBe(1.2);
+  });
+
+  it('default links are the thinnest', () => {
+    const style = getLinkWeight(parent, child, false);
+    expect(style.width).toBe(0.8);
+    expect(style.opacity).toBe(0.12);
+  });
+});
+
+describe('applyTribalBloom', () => {
+  it('returns an empty array when there are no children', () => {
+    expect(applyTribalBloom({ x: 0, y: 0 }, [])).toEqual([]);
+  });
+
+  it('places a single child directly below the centre', () => {
+    const [out] = applyTribalBloom({ x: 0, y: 0 }, [{ id: 'a', x: 0, y: 0 }], {
+      radius: 100,
+    });
+    expect(out.x).toBe(0);
+    expect(out.y).toBe(100);
+  });
+
+  it('fans children across the configured angle range', () => {
+    const out = applyTribalBloom(
+      { x: 0, y: 0 },
+      [1, 2, 3].map((i) => ({ id: String(i), x: 0, y: 0 })),
+      { radius: 100, startAngleDegrees: -60, endAngleDegrees: 60 },
+    );
+    // First child pushes left of centre, last pushes right.
+    expect(out[0].x).toBeLessThan(0);
+    expect(out[2].x).toBeGreaterThan(0);
+    // Middle child sits on the axis.
+    expect(Math.abs(out[1].x)).toBeLessThan(1e-6);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [{ id: 'a', x: 0, y: 0 }];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    applyTribalBloom({ x: 10, y: 10 }, input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/app/__tests__/unit/messianicLine.test.ts
+++ b/app/__tests__/unit/messianicLine.test.ts
@@ -1,0 +1,46 @@
+import {
+  MESSIANIC_LINE,
+  isMessianic,
+  messianicLineLength,
+} from '@/utils/messianicLine';
+
+describe('MESSIANIC_LINE', () => {
+  it('contains Adam at the start and Jesus at the end', () => {
+    expect(MESSIANIC_LINE[0]).toBe('adam');
+    expect(MESSIANIC_LINE[MESSIANIC_LINE.length - 1]).toBe('jesus');
+  });
+
+  it('includes the core messianic figures', () => {
+    const expected = ['noah', 'abraham', 'isaac', 'jacob', 'judah', 'david', 'solomon', 'zerubbabel'];
+    expected.forEach((id) => expect(MESSIANIC_LINE).toContain(id));
+  });
+
+  it('has no duplicate ids', () => {
+    const set = new Set(MESSIANIC_LINE);
+    expect(set.size).toBe(MESSIANIC_LINE.length);
+  });
+});
+
+describe('isMessianic', () => {
+  it('returns true for known line members', () => {
+    expect(isMessianic('david')).toBe(true);
+    expect(isMessianic('jesus')).toBe(true);
+  });
+
+  it('returns false for non-members', () => {
+    expect(isMessianic('esau')).toBe(false);
+    expect(isMessianic('ishmael')).toBe(false);
+  });
+
+  it('returns false for null/undefined/empty', () => {
+    expect(isMessianic(null)).toBe(false);
+    expect(isMessianic(undefined)).toBe(false);
+    expect(isMessianic('')).toBe(false);
+  });
+});
+
+describe('messianicLineLength', () => {
+  it('matches the array length', () => {
+    expect(messianicLineLength()).toBe(MESSIANIC_LINE.length);
+  });
+});

--- a/app/__tests__/unit/themePalettes.test.ts
+++ b/app/__tests__/unit/themePalettes.test.ts
@@ -54,6 +54,28 @@ describe('buildPalette', () => {
     expect(dark.categoryColors.event).toBe(dark.base.gold);
     expect(sepia.categoryColors.event).toBe(sepia.base.gold);
   });
+
+  it('exposes Explore tint tokens for every theme mode', () => {
+    for (const mode of ['dark', 'sepia', 'light'] as const) {
+      const p = buildPalette(mode);
+      expect(typeof p.base.tintWarm).toBe('string');
+      expect(typeof p.base.tintEmber).toBe('string');
+      expect(typeof p.base.tintParchment).toBe('string');
+      expect(typeof p.base.tintDusk).toBe('string');
+      // Each tint should be a low-alpha rgba() value — cheap sanity check.
+      expect(p.base.tintWarm).toMatch(/^rgba\(/);
+      expect(p.base.tintEmber).toMatch(/^rgba\(/);
+      expect(p.base.tintParchment).toMatch(/^rgba\(/);
+      expect(p.base.tintDusk).toMatch(/^rgba\(/);
+    }
+  });
+
+  it('tint tokens differ between modes (not all identical)', () => {
+    const dark = buildPalette('dark');
+    const sepia = buildPalette('sepia');
+    // At least the rgb triplet should change between dark and sepia.
+    expect(dark.base.tintWarm).not.toBe(sepia.base.tintWarm);
+  });
 });
 
 describe('Theme legacy cleanup (#110)', () => {

--- a/app/__tests__/unit/timelineFilters.test.ts
+++ b/app/__tests__/unit/timelineFilters.test.ts
@@ -22,7 +22,11 @@ jest.mock('@/hooks/useContentImages', () => ({
   useContentImages: jest.fn().mockReturnValue({ images: [], isLoading: false }),
 }));
 
-import { computeEraCounts, filterTimeline } from '@/screens/TimelineScreen';
+import {
+  computeEraCounts,
+  filterTimeline,
+  eventMatchesPerson,
+} from '@/screens/TimelineScreen';
 import type { TimelineEntry } from '@/types';
 
 function entry(overrides: Partial<TimelineEntry>): TimelineEntry {
@@ -108,5 +112,33 @@ describe('filterTimeline', () => {
     expect(
       filterTimeline(null, { event: true, book: true, person: true, world: true }, null),
     ).toEqual([]);
+  });
+});
+
+describe('eventMatchesPerson', () => {
+  it('returns false for null/empty person id', () => {
+    const e = entry({ people_json: '["abraham"]' });
+    expect(eventMatchesPerson(e, null)).toBe(false);
+    expect(eventMatchesPerson(e, '')).toBe(false);
+  });
+
+  it('returns false for events without people_json', () => {
+    const e = entry({ people_json: null });
+    expect(eventMatchesPerson(e, 'abraham')).toBe(false);
+  });
+
+  it('returns false for malformed people_json', () => {
+    const e = entry({ people_json: 'not-json' });
+    expect(eventMatchesPerson(e, 'abraham')).toBe(false);
+  });
+
+  it('returns true when the person id is in the array', () => {
+    const e = entry({ people_json: '["sarah","abraham"]' });
+    expect(eventMatchesPerson(e, 'abraham')).toBe(true);
+  });
+
+  it('returns false when the person id is not in the array', () => {
+    const e = entry({ people_json: '["sarah"]' });
+    expect(eventMatchesPerson(e, 'abraham')).toBe(false);
   });
 });

--- a/app/__tests__/unit/timelineFilters.test.ts
+++ b/app/__tests__/unit/timelineFilters.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for pure helpers exported from TimelineScreen.
+ * These live in the screen file because they're small and purely
+ * transformational — no point extracting them into their own module.
+ */
+
+// Mock @/stores because importing the screen transitively needs it.
+jest.mock('@/stores', () => ({
+  useSettingsStore: Object.assign(
+    (sel: any) => sel({ translation: 'kjv', fontSize: 16 }),
+    { getState: () => ({ markGettingStartedDone: jest.fn() }) },
+  ),
+  useReaderStore: (sel: any) => sel({}),
+}));
+
+jest.mock('@/db/content', () => ({
+  getAllTimelineEntries: jest.fn().mockResolvedValue([]),
+  getEras: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/hooks/useContentImages', () => ({
+  useContentImages: jest.fn().mockReturnValue({ images: [], isLoading: false }),
+}));
+
+import { computeEraCounts, filterTimeline } from '@/screens/TimelineScreen';
+import type { TimelineEntry } from '@/types';
+
+function entry(overrides: Partial<TimelineEntry>): TimelineEntry {
+  const base: TimelineEntry = {
+    id: 'id',
+    name: 'Name',
+    category: 'event',
+    era: 'primeval',
+    year: -1000,
+    summary: null,
+    scripture_ref: null,
+    chapter_link: null,
+    people_json: null,
+    region: null,
+  };
+  return { ...base, ...overrides };
+}
+
+describe('computeEraCounts', () => {
+  it('returns {} for null/undefined/empty', () => {
+    expect(computeEraCounts(null)).toEqual({});
+    expect(computeEraCounts(undefined)).toEqual({});
+    expect(computeEraCounts([])).toEqual({});
+  });
+
+  it('counts each event by era', () => {
+    const result = computeEraCounts([
+      entry({ id: 'a', era: 'primeval' }),
+      entry({ id: 'b', era: 'primeval' }),
+      entry({ id: 'c', era: 'patriarchs' }),
+    ]);
+    expect(result).toEqual({ primeval: 2, patriarchs: 1 });
+  });
+
+  it('skips entries without an era', () => {
+    const result = computeEraCounts([
+      entry({ id: 'a', era: null }),
+      entry({ id: 'b', era: 'exodus' }),
+    ]);
+    expect(result).toEqual({ exodus: 1 });
+  });
+});
+
+describe('filterTimeline', () => {
+  // 'book' isn't in TimelineEntry.category union (it comes from other DB tables
+  // via unions), but the filter logic still honours it — hence the `as any`.
+  const ENTRIES = [
+    entry({ id: 'a', category: 'event', era: 'primeval' }),
+    entry({ id: 'b', category: 'book' as any, era: 'primeval' }),
+    entry({ id: 'c', category: 'person', era: 'patriarchs' }),
+    entry({ id: 'd', category: 'world', era: 'patriarchs' }),
+  ];
+
+  it('includes all categories by default', () => {
+    const out = filterTimeline(ENTRIES, {
+      event: true, book: true, person: true, world: true,
+    }, null);
+    expect(out).toHaveLength(4);
+  });
+
+  it('drops categories whose filter is off', () => {
+    const out = filterTimeline(ENTRIES, {
+      event: true, book: false, person: false, world: false,
+    }, null);
+    expect(out.map((e) => e.id)).toEqual(['a']);
+  });
+
+  it('falls back to event+book when all categories are off', () => {
+    const out = filterTimeline(ENTRIES, {
+      event: false, book: false, person: false, world: false,
+    }, null);
+    expect(out.map((e) => e.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('filters by era when an eraId is supplied', () => {
+    const out = filterTimeline(ENTRIES, {
+      event: true, book: true, person: true, world: true,
+    }, 'patriarchs');
+    expect(out.map((e) => e.id).sort()).toEqual(['c', 'd']);
+  });
+
+  it('returns [] for nullish input', () => {
+    expect(
+      filterTimeline(null, { event: true, book: true, person: true, world: true }, null),
+    ).toEqual([]);
+  });
+});

--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -33,10 +33,15 @@ interface Props {
   onImagePress?: (deepLink: { screen: string; params?: Record<string, string> }) => void;
   /** Stagger offset in ms to prevent synchronised cycling across cards */
   staggerMs?: number;
+  /** Compact variant — 130px wide with a 72px image header (used in split-row layouts). */
+  compact?: boolean;
 }
 
 const IMAGE_HEIGHT = 88;
+const COMPACT_IMAGE_HEIGHT = 72;
 const CYCLE_INTERVAL = 6000;
+const CARD_WIDTH = 174;
+const COMPACT_CARD_WIDTH = 130;
 
 export function FeatureCard({
   feature,
@@ -47,10 +52,13 @@ export function FeatureCard({
   noun,
   onImagePress,
   staggerMs = 0,
+  compact = false,
 }: Props) {
   const { base } = useTheme();
   const isLocked = feature.premium && !isPremium;
   const hasImages = images && images.length > 0;
+  const cardWidth = compact ? COMPACT_CARD_WIDTH : CARD_WIDTH;
+  const imageHeight = compact ? COMPACT_IMAGE_HEIGHT : IMAGE_HEIGHT;
 
   // ── Image cycling ────────────────────────────────────────
   const [activeIndex, setActiveIndex] = useState(0);
@@ -88,6 +96,7 @@ export function FeatureCard({
 
   return (
     <View style={[styles.card, {
+      width: cardWidth,
       backgroundColor: base.bgElevated,
       borderColor: base.gold + '12',
     }]}>
@@ -99,7 +108,7 @@ export function FeatureCard({
           accessibilityRole="button"
           accessibilityLabel={currentImage.caption ?? `${feature.title} image`}
         >
-          <View style={styles.imageContainer}>
+          <View style={[styles.imageContainer, { width: cardWidth, height: imageHeight }]}>
             <Image
               source={{ uri: currentImage.url }}
               style={styles.image}
@@ -134,7 +143,7 @@ export function FeatureCard({
         </TouchableOpacity>
       ) : (
         /* Fallback: accent-colored strip */
-        <View style={[styles.fallbackStrip, { backgroundColor: base.gold + '20' }]} />
+        <View style={[styles.fallbackStrip, { width: cardWidth, backgroundColor: base.gold + '20' }]} />
       )}
 
       {/* ── Text area (tappable → feature browse) ─── */}
@@ -162,19 +171,14 @@ export function FeatureCard({
   );
 }
 
-const CARD_WIDTH = 174;
-
 const styles = StyleSheet.create({
   card: {
-    width: CARD_WIDTH,
     borderWidth: 1,
     borderRadius: radii.lg,
     overflow: 'hidden',
   },
   // Image section
   imageContainer: {
-    width: CARD_WIDTH,
-    height: IMAGE_HEIGHT,
     position: 'relative',
   },
   image: {
@@ -220,7 +224,6 @@ const styles = StyleSheet.create({
   },
   // Fallback
   fallbackStrip: {
-    width: CARD_WIDTH,
     height: 6,
   },
   // Text area
@@ -253,4 +256,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export { CARD_WIDTH };
+export { CARD_WIDTH, COMPACT_CARD_WIDTH };

--- a/app/src/components/explore/DebatePreviewList.tsx
+++ b/app/src/components/explore/DebatePreviewList.tsx
@@ -1,0 +1,167 @@
+/**
+ * DebatePreviewList — Top 3 debates as vertical list cards + "see all" link.
+ *
+ * No icons — a 3px gold left border is the accent. Data loads internally.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, fontFamily, spacing } from '../../theme';
+import { getDebateTopics } from '../../db/content';
+import type { DebateTopicSummary } from '../../types';
+
+const PREVIEW_COUNT = 3;
+
+export interface DebatePreviewListProps {
+  onDebatePress: (id: string) => void;
+  onSeeAll: () => void;
+  /** Override data fetching — useful for tests and custom integrations. */
+  debates?: DebateTopicSummary[];
+  /** Total count shown in the "All N debates" link. If omitted, the loaded list length is used. */
+  totalCount?: number;
+}
+
+/** Count positions encoded in `positions_json`. Safe on malformed JSON. */
+export function countPositions(json: string | null | undefined): number {
+  if (!json) return 0;
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Sort debates by position count (desc), return the top `n`. */
+export function pickTopDebates(
+  all: DebateTopicSummary[],
+  n: number = PREVIEW_COUNT,
+): DebateTopicSummary[] {
+  return [...all]
+    .sort((a, b) => {
+      const aCount = a.position_count ?? countPositions(a.positions_json);
+      const bCount = b.position_count ?? countPositions(b.positions_json);
+      return bCount - aCount;
+    })
+    .slice(0, n);
+}
+
+export function DebatePreviewList({
+  onDebatePress,
+  onSeeAll,
+  debates,
+  totalCount,
+}: DebatePreviewListProps) {
+  const { base } = useTheme();
+  const [loaded, setLoaded] = useState<DebateTopicSummary[] | null>(
+    debates !== undefined ? debates : null,
+  );
+
+  useEffect(() => {
+    if (debates !== undefined) {
+      setLoaded(debates);
+      return;
+    }
+    let cancelled = false;
+    getDebateTopics()
+      .then((rows) => {
+        if (!cancelled) setLoaded(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debates]);
+
+  if (!loaded || loaded.length === 0) return null;
+
+  const top = pickTopDebates(loaded, PREVIEW_COUNT);
+  const total = totalCount ?? loaded.length;
+
+  return (
+    <View style={styles.container}>
+      {top.map((debate) => {
+        const count = debate.position_count ?? countPositions(debate.positions_json);
+        const verseRef = debate.passage ?? debate.book_id;
+        return (
+          <TouchableOpacity
+            key={debate.id}
+            style={[
+              styles.row,
+              {
+                backgroundColor: base.tintEmber || base.bgElevated,
+                borderLeftColor: base.gold,
+              },
+            ]}
+            onPress={() => onDebatePress(debate.id)}
+            activeOpacity={0.75}
+            accessibilityRole="button"
+            accessibilityLabel={`${debate.title}, ${count} positions`}
+          >
+            <View style={styles.rowText}>
+              <Text style={[styles.question, { color: base.text }]} numberOfLines={2}>
+                {debate.title}
+              </Text>
+              <Text style={[styles.meta, { color: base.textMuted }]} numberOfLines={1}>
+                <Text style={{ color: base.gold }}>{verseRef}</Text>
+                {verseRef ? ' • ' : ''}
+                {count} positions
+              </Text>
+            </View>
+            <Text style={[styles.chevron, { color: base.textMuted }]}>›</Text>
+          </TouchableOpacity>
+        );
+      })}
+      <TouchableOpacity
+        onPress={onSeeAll}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel={`See all ${total} debates`}
+      >
+        <Text style={[styles.seeAll, { color: base.gold }]}>All {total} debates ›</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderLeftWidth: 3,
+    borderRadius: radii.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm + 2,
+    gap: spacing.sm,
+  },
+  rowText: {
+    flex: 1,
+    gap: 2,
+  },
+  question: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    lineHeight: 14,
+  },
+  meta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
+  },
+  chevron: {
+    fontSize: 18,
+    lineHeight: 18,
+  },
+  seeAll: {
+    alignSelf: 'flex-end',
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    paddingVertical: 4,
+  },
+});

--- a/app/src/components/explore/FullWidthImageCard.tsx
+++ b/app/src/components/explore/FullWidthImageCard.tsx
@@ -1,0 +1,136 @@
+/**
+ * FullWidthImageCard — Full-bleed image card with title/subtitle overlay + count CTA.
+ *
+ * Same layout family as ContinueReadingHero's image header but simpler — static,
+ * single-image, and designed for an Explore-section full-width hero (e.g., Life Topics).
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
+import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import type { ExploreImage } from '../../types';
+
+const IMAGE_HEIGHT = 85;
+
+export interface FullWidthImageCardProps {
+  title: string;
+  subtitle?: string;
+  image?: ExploreImage | null;
+  count?: number | null;
+  noun?: string;
+  onPress: () => void;
+}
+
+export function FullWidthImageCard({
+  title,
+  subtitle,
+  image,
+  count,
+  noun,
+  onPress,
+}: FullWidthImageCardProps) {
+  const { base } = useTheme();
+
+  const ctaText = count != null && noun ? `${count} ${noun} ›` : null;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}${subtitle ? `: ${subtitle}` : ''}`}
+      style={[
+        styles.card,
+        {
+          backgroundColor: base.bgElevated,
+          borderColor: base.gold + '18',
+        },
+      ]}
+    >
+      {image ? (
+        <View style={styles.imageContainer}>
+          <Image
+            source={{ uri: image.url }}
+            style={styles.image}
+            contentFit="cover"
+            cachePolicy="disk"
+            transition={400}
+            recyclingKey={image.url}
+          />
+          <View style={styles.gradient} />
+        </View>
+      ) : (
+        <View
+          style={[
+            styles.fallback,
+            { backgroundColor: base.tintWarm || base.gold + '10' },
+          ]}
+        />
+      )}
+      <View style={styles.textArea}>
+        <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={[styles.subtitle, { color: base.textMuted }]} numberOfLines={2}>
+            {subtitle}
+          </Text>
+        ) : null}
+        {ctaText ? <Text style={[styles.cta, { color: base.gold }]}>{ctaText}</Text> : null}
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    overflow: 'hidden',
+  },
+  imageContainer: {
+    width: '100%',
+    height: IMAGE_HEIGHT,
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  gradient: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 32,
+    backgroundColor: 'transparent', // overlay-color: intentional
+    shadowColor: '#000', // overlay-color: intentional
+    shadowOffset: { width: 0, height: -8 },
+    shadowOpacity: 0.5,
+    shadowRadius: 8,
+  },
+  fallback: {
+    width: '100%',
+    height: 10,
+  },
+  textArea: {
+    padding: spacing.sm + 2,
+  },
+  title: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    lineHeight: 15,
+  },
+  cta: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    marginTop: 4,
+  },
+});

--- a/app/src/components/explore/GoldSeparator.tsx
+++ b/app/src/components/explore/GoldSeparator.tsx
@@ -1,0 +1,51 @@
+/**
+ * GoldSeparator — Gradient-fade gold separator line.
+ *
+ * A three-segment gradient (transparent → gold15 → transparent) approximated
+ * without `expo-linear-gradient` so we don't take a new dependency just for this.
+ * Three stacked views produce an acceptable fade in the mobile UI.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTheme, spacing } from '../../theme';
+
+export interface GoldSeparatorProps {
+  /** Vertical space (margin bottom/top) around the line. Defaults to spacing.md bottom. */
+  marginBottom?: number;
+  marginTop?: number;
+}
+
+export function GoldSeparator({
+  marginBottom = spacing.md,
+  marginTop = 0,
+}: GoldSeparatorProps) {
+  const { base } = useTheme();
+  const fade = base.gold + '00';
+  const mid = base.gold + '26'; // ~15% opacity
+
+  return (
+    <View
+      style={[styles.container, { marginBottom, marginTop }]}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      <View style={[styles.segment, { backgroundColor: fade }]} />
+      <View style={[styles.segment, { backgroundColor: mid }]} />
+      <View style={[styles.segment, { backgroundColor: fade }]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    height: 1,
+  },
+  segment: {
+    flex: 1,
+    height: 1,
+  },
+});

--- a/app/src/components/explore/LifeTopicGrid.tsx
+++ b/app/src/components/explore/LifeTopicGrid.tsx
@@ -1,0 +1,126 @@
+/**
+ * LifeTopicGrid — 2×2 grid of life topic categories (text-only, no icons).
+ *
+ * Loads the top categories via `getLifeTopicCategories()` sorted by display_order.
+ * Passes the tapped category's id up so the consumer can route to a filtered screen.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, fontFamily, spacing } from '../../theme';
+import { getLifeTopicCategories } from '../../db/content';
+import type { LifeTopicCategory } from '../../types';
+
+const GRID_COUNT = 4;
+
+export interface LifeTopicGridProps {
+  onCategoryPress: (categoryId: string) => void;
+  /** Override data fetching — useful for tests. */
+  categories?: LifeTopicCategory[];
+  /** Optional topic counts keyed by category id. Shown as a subtitle when provided. */
+  topicCounts?: Record<string, number>;
+}
+
+/** Sort categories by display_order and take the top N. */
+export function pickTopCategories(
+  all: LifeTopicCategory[],
+  n: number = GRID_COUNT,
+): LifeTopicCategory[] {
+  return [...all]
+    .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0))
+    .slice(0, n);
+}
+
+export function LifeTopicGrid({
+  onCategoryPress,
+  categories,
+  topicCounts,
+}: LifeTopicGridProps) {
+  const { base } = useTheme();
+  const [loaded, setLoaded] = useState<LifeTopicCategory[] | null>(
+    categories !== undefined ? categories : null,
+  );
+
+  useEffect(() => {
+    if (categories !== undefined) {
+      setLoaded(categories);
+      return;
+    }
+    let cancelled = false;
+    getLifeTopicCategories()
+      .then((rows) => {
+        if (!cancelled) setLoaded(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [categories]);
+
+  if (!loaded || loaded.length === 0) return null;
+
+  const top = pickTopCategories(loaded, GRID_COUNT);
+
+  return (
+    <View style={styles.grid}>
+      {top.map((cat) => {
+        const count = topicCounts?.[cat.id];
+        return (
+          <TouchableOpacity
+            key={cat.id}
+            onPress={() => onCategoryPress(cat.id)}
+            activeOpacity={0.75}
+            accessibilityRole="button"
+            accessibilityLabel={cat.name}
+            style={[
+              styles.cell,
+              {
+                backgroundColor: base.tintDusk || base.bgElevated,
+                borderColor: base.gold + '10',
+              },
+            ]}
+          >
+            <Text style={[styles.name, { color: base.text }]} numberOfLines={2}>
+              {cat.name}
+            </Text>
+            {count != null ? (
+              <Text style={[styles.count, { color: base.textMuted }]}>
+                {count} {count === 1 ? 'topic' : 'topics'}
+              </Text>
+            ) : null}
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  cell: {
+    flexBasis: '48%',
+    flexGrow: 1,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm + 2,
+    minHeight: 64,
+    justifyContent: 'center',
+    gap: 2,
+  },
+  name: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  count: {
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
+  },
+});

--- a/app/src/components/explore/ProphecyChainCard.tsx
+++ b/app/src/components/explore/ProphecyChainCard.tsx
@@ -1,0 +1,129 @@
+/**
+ * ProphecyChainCard — Chain card for the Themes & Connections section.
+ *
+ * Vertical-dot decoration on right edge signals chain-of-events.
+ * No icons. Tinted parchment background.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, fontFamily, spacing } from '../../theme';
+import type { ProphecyChain, ProphecyChainLink } from '../../types';
+
+export const PROPHECY_CHAIN_CARD_WIDTH = 170;
+const MAX_DOTS = 8;
+
+export interface ProphecyChainCardProps {
+  chain: ProphecyChain;
+  onPress: () => void;
+}
+
+/** Parse links_json safely — returns [] on malformed JSON. */
+export function parseChainLinks(json: string | null | undefined): ProphecyChainLink[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Format the range label using the first and last link refs. */
+export function formatRange(links: ProphecyChainLink[]): string {
+  if (links.length === 0) return '';
+  const first = links[0];
+  const last = links[links.length - 1];
+  if (first === last) return first.verse_ref ?? '';
+  return `${first.verse_ref ?? ''} → ${last.verse_ref ?? ''}`.trim();
+}
+
+export function ProphecyChainCard({ chain, onPress }: ProphecyChainCardProps) {
+  const { base } = useTheme();
+  const links = parseChainLinks(chain.links_json);
+  const stopCount = links.length;
+  const range = formatRange(links);
+  const dotCount = Math.min(Math.max(stopCount, 2), MAX_DOTS);
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.card,
+        {
+          backgroundColor: base.tintParchment || base.bgElevated,
+          borderColor: base.gold + '12',
+        },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.75}
+      accessibilityRole="button"
+      accessibilityLabel={`${chain.title} prophecy chain, ${stopCount} stops`}
+    >
+      <View style={styles.dotColumn} accessibilityElementsHidden>
+        {Array.from({ length: dotCount }).map((_, i) => {
+          const isEdge = i === 0 || i === dotCount - 1;
+          return (
+            <View
+              key={i}
+              style={[
+                styles.dot,
+                {
+                  backgroundColor: base.gold,
+                  opacity: isEdge ? 0.7 : 0.25,
+                },
+              ]}
+            />
+          );
+        })}
+      </View>
+      <Text style={[styles.title, { color: base.text }]} numberOfLines={2}>
+        {chain.title}
+      </Text>
+      {range ? (
+        <Text style={[styles.range, { color: base.textMuted }]} numberOfLines={1}>
+          {range}
+        </Text>
+      ) : null}
+      <Text style={[styles.stopCount, { color: base.gold }]}>{stopCount} stops</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: PROPHECY_CHAIN_CARD_WIDTH,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm + 2,
+    overflow: 'hidden',
+  },
+  dotColumn: {
+    position: 'absolute',
+    right: 12,
+    top: 12,
+    flexDirection: 'column',
+    gap: 3,
+  },
+  dot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+  },
+  title: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    marginRight: 24,
+    marginBottom: 2,
+  },
+  range: {
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
+    marginBottom: 2,
+  },
+  stopCount: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+  },
+});

--- a/app/src/components/explore/WordStudyPreviewList.tsx
+++ b/app/src/components/explore/WordStudyPreviewList.tsx
@@ -1,0 +1,211 @@
+/**
+ * WordStudyPreviewList — Top 3 word studies with Hebrew/Greek glyphs + see-all.
+ *
+ * The original glyph IS the content — not an icon. A gold-tinted square hosts it.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, fontFamily, spacing } from '../../theme';
+import { getAllWordStudies } from '../../db/content';
+import type { WordStudy } from '../../types';
+
+const PREVIEW_COUNT = 3;
+
+export interface WordStudyPreviewListProps {
+  onWordPress: (id: string) => void;
+  onSeeAll: () => void;
+  /** Override data fetching — useful for tests. */
+  wordStudies?: WordStudy[];
+  /** Total count for the "all N" link. */
+  totalCount?: number;
+}
+
+/** Pull the first gloss out of `glosses_json`. Safe on malformed JSON. */
+export function parseFirstGloss(json: string | null | undefined): string {
+  if (!json) return '';
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const first = parsed[0];
+      return typeof first === 'string' ? first : '';
+    }
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+/** Count occurrences encoded in `occurrences_json`. */
+export function countOccurrences(json: string | null | undefined): number {
+  if (!json) return 0;
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function WordStudyPreviewList({
+  onWordPress,
+  onSeeAll,
+  wordStudies,
+  totalCount,
+}: WordStudyPreviewListProps) {
+  const { base } = useTheme();
+  const [loaded, setLoaded] = useState<WordStudy[] | null>(
+    wordStudies !== undefined ? wordStudies : null,
+  );
+
+  useEffect(() => {
+    if (wordStudies !== undefined) {
+      setLoaded(wordStudies);
+      return;
+    }
+    let cancelled = false;
+    getAllWordStudies()
+      .then((rows) => {
+        if (!cancelled) setLoaded(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wordStudies]);
+
+  if (!loaded || loaded.length === 0) return null;
+
+  const top = loaded.slice(0, PREVIEW_COUNT);
+  const total = totalCount ?? loaded.length;
+
+  return (
+    <View style={styles.container}>
+      {top.map((word) => {
+        const gloss = parseFirstGloss(word.glosses_json);
+        const occurrences = countOccurrences(word.occurrences_json);
+        return (
+          <TouchableOpacity
+            key={word.id}
+            style={[
+              styles.row,
+              {
+                backgroundColor: base.tintParchment || base.bgElevated,
+              },
+            ]}
+            onPress={() => onWordPress(word.id)}
+            activeOpacity={0.75}
+            accessibilityRole="button"
+            accessibilityLabel={`${word.transliteration}, ${word.language}, ${gloss}`}
+          >
+            <View
+              style={[
+                styles.glyphBox,
+                {
+                  backgroundColor: base.gold + '14',
+                  borderColor: base.gold + '1A',
+                },
+              ]}
+            >
+              <Text style={[styles.glyph, { color: base.gold }]} numberOfLines={1}>
+                {word.original}
+              </Text>
+            </View>
+            <View style={styles.textCol}>
+              <View style={styles.titleRow}>
+                <Text style={[styles.translit, { color: base.text }]} numberOfLines={1}>
+                  {word.transliteration}
+                </Text>
+                <Text style={[styles.langBadge, { color: base.goldDim }]}>
+                  {word.language?.toUpperCase()}
+                </Text>
+              </View>
+              {gloss ? (
+                <Text style={[styles.gloss, { color: base.textMuted }]} numberOfLines={1}>
+                  {gloss}
+                </Text>
+              ) : null}
+              {occurrences > 0 ? (
+                <Text style={[styles.occurrences, { color: base.textDim }]}>
+                  {occurrences}×
+                </Text>
+              ) : null}
+            </View>
+          </TouchableOpacity>
+        );
+      })}
+      <TouchableOpacity
+        onPress={onSeeAll}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel={`See all ${total} word studies`}
+      >
+        <Text style={[styles.seeAll, { color: base.gold }]}>
+          All {total} word studies ›
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: radii.md,
+    padding: spacing.sm,
+    gap: spacing.sm,
+  },
+  glyphBox: {
+    width: 46,
+    height: 46,
+    borderRadius: 10,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  glyph: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 18,
+  },
+  textCol: {
+    flex: 1,
+    gap: 1,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+  },
+  translit: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+    flexShrink: 1,
+  },
+  langBadge: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 8,
+    letterSpacing: 0.5,
+  },
+  gloss: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+  },
+  occurrences: {
+    fontFamily: fontFamily.ui,
+    fontSize: 8,
+  },
+  seeAll: {
+    alignSelf: 'flex-end',
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    paddingVertical: 4,
+  },
+});

--- a/app/src/components/explore/index.ts
+++ b/app/src/components/explore/index.ts
@@ -1,0 +1,36 @@
+/**
+ * components/explore — Layout components specific to the Explore screen.
+ *
+ * Part of Card #1263 (Explore redesign).
+ */
+
+export {
+  ProphecyChainCard,
+  parseChainLinks,
+  formatRange,
+  PROPHECY_CHAIN_CARD_WIDTH,
+} from './ProphecyChainCard';
+export type { ProphecyChainCardProps } from './ProphecyChainCard';
+
+export {
+  DebatePreviewList,
+  countPositions,
+  pickTopDebates,
+} from './DebatePreviewList';
+export type { DebatePreviewListProps } from './DebatePreviewList';
+
+export {
+  WordStudyPreviewList,
+  parseFirstGloss,
+  countOccurrences,
+} from './WordStudyPreviewList';
+export type { WordStudyPreviewListProps } from './WordStudyPreviewList';
+
+export { LifeTopicGrid, pickTopCategories } from './LifeTopicGrid';
+export type { LifeTopicGridProps } from './LifeTopicGrid';
+
+export { FullWidthImageCard } from './FullWidthImageCard';
+export type { FullWidthImageCardProps } from './FullWidthImageCard';
+
+export { GoldSeparator } from './GoldSeparator';
+export type { GoldSeparatorProps } from './GoldSeparator';

--- a/app/src/components/timeline/ContemporaryLane.tsx
+++ b/app/src/components/timeline/ContemporaryLane.tsx
@@ -1,0 +1,59 @@
+/**
+ * ContemporaryLane — Thin vertical overlap bands in the left gutter.
+ *
+ * In person-filter mode we render up to 4 stacked bands in the spine
+ * gutter showing which contemporaries' lifespans overlap the filtered
+ * person at each event row. Purely decorative — no interaction.
+ *
+ * Part of Card #1266 (Timeline Phase 2).
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTheme } from '../../theme';
+
+export const MAX_LANES = 4;
+
+export interface ContemporaryLaneProps {
+  /** Whether each lane (up to MAX_LANES) is active on this row. Length is clamped to MAX_LANES. */
+  laneActive: boolean[];
+  /** Height the lanes should span — usually matches the row height. */
+  height?: number;
+}
+
+export function ContemporaryLane({ laneActive, height }: ContemporaryLaneProps) {
+  const { base } = useTheme();
+
+  const lanes = laneActive.slice(0, MAX_LANES);
+  const fill = base.textMuted + '26'; // ~15% opacity
+
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[styles.wrapper, height != null ? { height } : null]}
+    >
+      {lanes.map((active, i) => (
+        <View
+          key={i}
+          style={[
+            styles.lane,
+            {
+              backgroundColor: active ? fill : 'transparent',
+            },
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flexDirection: 'row',
+    gap: 2,
+  },
+  lane: {
+    width: 2,
+  },
+});

--- a/app/src/components/timeline/ContemporaryRow.tsx
+++ b/app/src/components/timeline/ContemporaryRow.tsx
@@ -1,0 +1,133 @@
+/**
+ * ContemporaryRow — Horizontal row of contemporary-avatar circles.
+ *
+ * Shown while the timeline is in "person filter" mode. Tapping an avatar
+ * switches the person filter to that person.
+ *
+ * Part of Card #1266 (Timeline Phase 2).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, spacing } from '../../theme';
+import type { TimelineEntry } from '../../types';
+
+const MAX_AVATARS = 8;
+
+export interface Contemporary {
+  id: string;
+  name: string;
+  count: number;
+}
+
+export interface ContemporaryRowProps {
+  contemporaries: Contemporary[];
+  onPress: (personId: string) => void;
+}
+
+/** Parse a `people_json` column into an array of ids. Never throws. */
+function parsePeopleJsonSafe(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Compute up to `max` contemporaries that appear most often in events whose
+ * year-range overlaps the filtered person's own event span. Pure logic so it
+ * can be unit-tested without rendering the component.
+ */
+export function computeContemporaries(
+  events: TimelineEntry[],
+  personId: string,
+  max = MAX_AVATARS,
+): Contemporary[] {
+  const personEvents = events.filter((e) =>
+    parsePeopleJsonSafe(e.people_json).includes(personId),
+  );
+  if (personEvents.length === 0) return [];
+
+  const years = personEvents.map((e) => e.year);
+  const minYear = Math.min(...years);
+  const maxYear = Math.max(...years);
+
+  const candidates = events.filter((e) => e.year >= minYear && e.year <= maxYear);
+  const counts: Record<string, number> = {};
+  for (const e of candidates) {
+    for (const pid of parsePeopleJsonSafe(e.people_json)) {
+      if (pid === personId) continue;
+      counts[pid] = (counts[pid] ?? 0) + 1;
+    }
+  }
+
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, max)
+    .map(([id, count]) => ({ id, name: id, count }));
+}
+
+export function ContemporaryRow({ contemporaries, onPress }: ContemporaryRowProps) {
+  const { base } = useTheme();
+  if (contemporaries.length === 0) return null;
+
+  return (
+    <View style={styles.wrapper}>
+      <Text style={[styles.label, { color: base.textMuted }]}>Active contemporaries:</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+      >
+        {contemporaries.map((c) => (
+          <TouchableOpacity
+            key={c.id}
+            onPress={() => onPress(c.id)}
+            accessibilityRole="button"
+            accessibilityLabel={`Switch filter to ${c.name}`}
+            style={[
+              styles.avatar,
+              { backgroundColor: base.bgElevated, borderColor: base.border },
+            ]}
+          >
+            <Text style={[styles.initial, { color: base.textDim }]}>
+              {c.name.charAt(0).toUpperCase()}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    gap: spacing.xs,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  avatar: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  initial: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/timeline/EraContextPanel.tsx
+++ b/app/src/components/timeline/EraContextPanel.tsx
@@ -1,0 +1,162 @@
+/**
+ * EraContextPanel — Expandable era narrative/themes/people/books panel.
+ *
+ * Surfaces the rich era_config fields (narrative, key_themes, key_people,
+ * books) that aren't visible on the timeline today. Tap an era segment in
+ * the strip to toggle the panel; only one era is open at a time.
+ *
+ * Part of Card #1266 (Timeline Phase 2).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, radii, spacing } from '../../theme';
+import type { EraRow } from '../../db/content/reference';
+import { formatEraRange } from './TimelineEraStrip';
+
+export interface EraContextPanelProps {
+  era: EraRow;
+  onPersonPress?: (personName: string) => void;
+  onBookPress?: (bookName: string) => void;
+}
+
+/** Split a comma-separated string into trimmed, non-empty pieces. */
+export function splitCommaList(input: string | null | undefined): string[] {
+  if (!input) return [];
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function EraContextPanel({ era, onPersonPress, onBookPress }: EraContextPanelProps) {
+  const { base } = useTheme();
+  const accent = era.hex ?? base.gold;
+
+  const themes = splitCommaList(era.key_themes);
+  const people = splitCommaList(era.key_people);
+  const books = splitCommaList(era.books);
+
+  return (
+    <View
+      accessibilityLabel={`${era.name} era context`}
+      style={[
+        styles.panel,
+        {
+          backgroundColor: accent + '14',
+          borderColor: accent + '1A',
+        },
+      ]}
+    >
+      <Text style={[styles.title, { color: accent }]}>
+        {era.name.toUpperCase()}
+        <Text style={[styles.range, { color: base.textMuted }]}>
+          {'  '}
+          {formatEraRange(era.range_start, era.range_end)}
+        </Text>
+      </Text>
+
+      {era.narrative ? (
+        <Text style={[styles.narrative, { color: base.textDim }]}>{era.narrative}</Text>
+      ) : null}
+
+      {themes.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={[styles.sectionLabel, { color: base.textMuted }]}>Key Themes</Text>
+          <Text style={[styles.sectionBody, { color: base.textMuted }]}>{themes.join(', ')}</Text>
+        </View>
+      ) : null}
+
+      {people.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={[styles.sectionLabel, { color: base.textMuted }]}>Key People</Text>
+          <View style={styles.pillRow}>
+            {people.map((name) => (
+              <TouchableOpacity
+                key={name}
+                onPress={() => onPersonPress?.(name)}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter timeline to ${name}`}
+                style={[styles.pill, { borderColor: accent + '40' }]}
+              >
+                <Text style={[styles.pillLabel, { color: base.text }]}>{name}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      {books.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={[styles.sectionLabel, { color: base.textMuted }]}>Books</Text>
+          <View style={styles.pillRow}>
+            {books.map((book) => (
+              <TouchableOpacity
+                key={book}
+                onPress={() => onBookPress?.(book)}
+                accessibilityRole="button"
+                accessibilityLabel={`Open ${book}`}
+                style={[styles.pill, { borderColor: base.gold + '40' }]}
+              >
+                <Text style={[styles.pillLabel, { color: base.gold }]}>{book}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm + 2,
+    gap: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 12,
+    letterSpacing: 1,
+  },
+  range: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    letterSpacing: 0,
+  },
+  narrative: {
+    fontFamily: fontFamily.body,
+    fontSize: 11,
+    lineHeight: 17,
+  },
+  section: {
+    gap: 4,
+  },
+  sectionLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  sectionBody: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    lineHeight: 14,
+  },
+  pillRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+  },
+  pill: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  pillLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+  },
+});

--- a/app/src/components/timeline/PersonFilterBar.tsx
+++ b/app/src/components/timeline/PersonFilterBar.tsx
@@ -1,0 +1,72 @@
+/**
+ * PersonFilterBar — Dismiss pill for the person-focused filter state.
+ *
+ * When the user taps a person name on any event card, the timeline filters to
+ * that person. This bar displays below the era strip and shows a dismiss
+ * button + count of matching events.
+ *
+ * Part of Card #1266 (Timeline Phase 2).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, radii, spacing } from '../../theme';
+
+export interface PersonFilterBarProps {
+  personName: string;
+  matchCount: number;
+  onDismiss: () => void;
+}
+
+export function PersonFilterBar({ personName, matchCount, onDismiss }: PersonFilterBarProps) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      accessibilityLabel={`Showing ${matchCount} events for ${personName}`}
+      style={[styles.pill, { backgroundColor: base.gold + '14', borderColor: base.gold + '40' }]}
+    >
+      <TouchableOpacity
+        onPress={onDismiss}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel="Clear person filter"
+        style={styles.dismiss}
+      >
+        <Text style={[styles.dismissLabel, { color: base.gold }]}>✕</Text>
+      </TouchableOpacity>
+      <Text style={[styles.label, { color: base.text }]}>
+        Showing {matchCount} event{matchCount === 1 ? '' : 's'} for{' '}
+        <Text style={{ color: base.gold }}>{personName}</Text>
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  dismiss: {
+    width: 18,
+    height: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dismissLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    lineHeight: 14,
+  },
+  label: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+});

--- a/app/src/components/timeline/TimelineEraStrip.tsx
+++ b/app/src/components/timeline/TimelineEraStrip.tsx
@@ -1,0 +1,161 @@
+/**
+ * TimelineEraStrip — Proportional horizontal era-filter strip.
+ *
+ * Each era's width is proportional to its event count. Tapping a segment
+ * selects the era (or deselects if already active). Selected segment
+ * shows a brighter gradient + 2px bottom accent line.
+ *
+ * Part of Card #1264 (Timeline Phase 1).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, spacing } from '../../theme';
+import type { EraRow } from '../../db/content/reference';
+
+export interface TimelineEraStripProps {
+  eras: EraRow[];
+  eventCounts: Record<string, number>;
+  activeEraId: string | null;
+  onSelectEra: (eraId: string | null) => void;
+}
+
+/**
+ * Compute the proportional width fraction (0..1) for each era based on event count.
+ * Every era has a minimum visible slice so the segment remains tappable.
+ */
+export function computeEraShares(
+  eras: EraRow[],
+  eventCounts: Record<string, number>,
+  minShare = 0.04,
+): { id: string; share: number }[] {
+  const totalCount = eras.reduce((sum, e) => sum + (eventCounts[e.id] ?? 0), 0);
+  if (totalCount <= 0) {
+    const equal = 1 / Math.max(1, eras.length);
+    return eras.map((e) => ({ id: e.id, share: equal }));
+  }
+  const raw = eras.map((e) => ({
+    id: e.id,
+    share: Math.max(minShare, (eventCounts[e.id] ?? 0) / totalCount),
+  }));
+  const total = raw.reduce((s, r) => s + r.share, 0);
+  return raw.map((r) => ({ id: r.id, share: r.share / total }));
+}
+
+/** First word of a label — e.g., "Divided Kingdom" → "Divided". */
+export function firstWord(label: string): string {
+  const trimmed = (label ?? '').trim();
+  if (!trimmed) return '';
+  return trimmed.split(/\s+/)[0];
+}
+
+/** Human-friendly date range (negatives → "BC"). */
+export function formatEraRange(start: number | null, end: number | null): string {
+  if (start == null || end == null) return '';
+  const fmt = (n: number) => (n < 0 ? `${Math.abs(n)} BC` : n === 0 ? 'AD 0' : `AD ${n}`);
+  return `${fmt(start)} – ${fmt(end)}`;
+}
+
+export function TimelineEraStrip({
+  eras,
+  eventCounts,
+  activeEraId,
+  onSelectEra,
+}: TimelineEraStripProps) {
+  const { base } = useTheme();
+  const shares = computeEraShares(eras, eventCounts);
+  const active = eras.find((e) => e.id === activeEraId) ?? null;
+  const activeCount = active ? eventCounts[active.id] ?? 0 : 0;
+
+  return (
+    <View style={styles.wrapper}>
+      <View
+        style={[styles.strip, { backgroundColor: base.bgSurface }]}
+        accessibilityRole="tablist"
+      >
+        {shares.map(({ id, share }) => {
+          const era = eras.find((e) => e.id === id);
+          if (!era) return null;
+          const isSelected = id === activeEraId;
+          const isWide = (eventCounts[id] ?? 0) > 30;
+          const color = era.hex ?? base.gold;
+          return (
+            <TouchableOpacity
+              key={id}
+              onPress={() => onSelectEra(isSelected ? null : id)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={`${era.name} era, ${eventCounts[id] ?? 0} events`}
+              style={[
+                styles.segment,
+                {
+                  flex: share,
+                  backgroundColor: color + (isSelected ? '33' : '14'),
+                  borderBottomColor: isSelected ? color : 'transparent',
+                  borderBottomWidth: 2,
+                },
+              ]}
+            >
+              {isWide ? (
+                <Text
+                  numberOfLines={1}
+                  style={[styles.segmentLabel, { color: isSelected ? base.text : base.textMuted }]}
+                >
+                  {firstWord(era.name)}
+                </Text>
+              ) : null}
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+      {active ? (
+        <View style={styles.caption}>
+          <Text style={[styles.captionEra, { color: active.hex ?? base.gold }]}>
+            {active.name}
+          </Text>
+          <Text style={[styles.captionMeta, { color: base.textMuted }]}>
+            {formatEraRange(active.range_start, active.range_end)}
+            {activeCount > 0 ? ` • ${activeCount} events` : ''}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    gap: spacing.xs,
+  },
+  strip: {
+    flexDirection: 'row',
+    height: 28,
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  segment: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  segmentLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    letterSpacing: 0.5,
+  },
+  caption: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    paddingHorizontal: spacing.sm,
+  },
+  captionEra: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 12,
+    letterSpacing: 1,
+  },
+  captionMeta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+  },
+});

--- a/app/src/components/timeline/TimelineEventCard.tsx
+++ b/app/src/components/timeline/TimelineEventCard.tsx
@@ -1,0 +1,193 @@
+/**
+ * TimelineEventCard — Individual event on the vertical timeline.
+ *
+ * Collapsed: year + scripture ref header, title, subtitle, optional image.
+ * Expanded: full summary + people pills + chapter link.
+ *
+ * Part of Card #1264 (Timeline Phase 1).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, fontFamily, spacing } from '../../theme';
+import type { TimelineEntry } from '../../types';
+
+export interface TimelineEventCardProps {
+  event: TimelineEntry;
+  /** Era accent colour — supplied from `eras[event.era].hex`. */
+  eraColor: string;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onPersonPress?: (personId: string) => void;
+  onChapterPress?: (bookId: string, chapterNum: number) => void;
+}
+
+/** Format a negative year as BC, zero/positive as AD. */
+export function formatTimelineYear(year: number): string {
+  if (year === 0) return 'AD/BC';
+  if (year < 0) return `${Math.abs(year)} BC`;
+  return `AD ${year}`;
+}
+
+/** Parse a `people_json` column into an array of ids. Never throws. */
+export function parsePeopleJson(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/** Extract `{ bookId, chapterNum }` from a `content/ot/genesis_12.html`-style link. */
+export function parseChapterLink(
+  link: string | null | undefined,
+): { bookId: string; chapterNum: number } | null {
+  if (!link) return null;
+  const match = link.match(/(\w+)_(\d+)\.html/);
+  if (!match) return null;
+  const bookId = match[1].toLowerCase();
+  const chapterNum = parseInt(match[2], 10);
+  if (!Number.isFinite(chapterNum)) return null;
+  return { bookId, chapterNum };
+}
+
+export function TimelineEventCard({
+  event,
+  eraColor,
+  isExpanded,
+  onToggleExpand,
+  onPersonPress,
+  onChapterPress,
+}: TimelineEventCardProps) {
+  const { base } = useTheme();
+
+  const people = parsePeopleJson(event.people_json);
+  const chapter = parseChapterLink(event.chapter_link);
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.85}
+      onPress={onToggleExpand}
+      accessibilityRole="button"
+      accessibilityLabel={`${event.name}, ${formatTimelineYear(event.year)}`}
+      accessibilityState={{ expanded: isExpanded }}
+      style={[
+        styles.card,
+        {
+          backgroundColor: base.bgElevated,
+          borderColor: eraColor + '20',
+        },
+      ]}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.year, { color: eraColor }]}>
+          {formatTimelineYear(event.year)}
+        </Text>
+        {event.scripture_ref ? (
+          <Text style={[styles.ref, { color: base.gold }]}>{event.scripture_ref}</Text>
+        ) : null}
+      </View>
+      <Text style={[styles.title, { color: base.text }]}>{event.name}</Text>
+      {event.summary ? (
+        <Text
+          style={[styles.subtitle, { color: base.textMuted }]}
+          numberOfLines={isExpanded ? undefined : 2}
+        >
+          {event.summary}
+        </Text>
+      ) : null}
+      {isExpanded && people.length > 0 ? (
+        <View style={styles.peopleRow}>
+          {people.map((personId) => (
+            <TouchableOpacity
+              key={personId}
+              onPress={() => onPersonPress?.(personId)}
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Person ${personId}`}
+              style={[styles.personPill, { borderColor: eraColor + '40' }]}
+            >
+              <Text style={[styles.personLabel, { color: base.text }]}>{personId}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ) : null}
+      {isExpanded && chapter ? (
+        <TouchableOpacity
+          onPress={() => onChapterPress?.(chapter.bookId, chapter.chapterNum)}
+          style={[
+            styles.chapterButton,
+            { backgroundColor: base.gold + '22', borderColor: base.gold + '55' },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={`Open ${chapter.bookId} ${chapter.chapterNum}`}
+        >
+          <Text style={[styles.chapterText, { color: base.gold }]}>Go to chapter →</Text>
+        </TouchableOpacity>
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: radii.md,
+    borderWidth: 1,
+    padding: spacing.sm + 2,
+    gap: 4,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+  },
+  year: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    letterSpacing: 1,
+  },
+  ref: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 8,
+  },
+  title: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    lineHeight: 14,
+  },
+  peopleRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+    marginTop: spacing.xs,
+  },
+  personPill: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  personLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+  },
+  chapterButton: {
+    marginTop: spacing.xs,
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    alignSelf: 'flex-start',
+  },
+  chapterText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+  },
+});

--- a/app/src/components/timeline/TimelineSpine.tsx
+++ b/app/src/components/timeline/TimelineSpine.tsx
@@ -1,0 +1,104 @@
+/**
+ * TimelineSpine — Vertical spine + dots + connecting line for one event row.
+ *
+ * Renders a 32px-wide left gutter with a 2px vertical line and an era-coloured
+ * dot centred on the event row. Events with images get a larger, glowing dot;
+ * events without get a smaller, semi-transparent dot.
+ *
+ * Part of Card #1264 (Timeline Phase 1).
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+export const SPINE_GUTTER_WIDTH = 32;
+
+export interface TimelineSpineProps {
+  /** Era hex — spine and dot inherit this colour. */
+  eraColor: string;
+  /** Whether the event has an attached image (affects dot size/glow). */
+  hasImage: boolean;
+  /** When true, the event is focused — dot gets extra emphasis. */
+  isActive?: boolean;
+  /** When true, this is the first row in the list — top half of the line is suppressed. */
+  isFirst?: boolean;
+  /** When true, this is the last row — bottom half of the line is suppressed. */
+  isLast?: boolean;
+  /** Row height, so the spine takes up exactly the same vertical space as the card. */
+  rowHeight?: number;
+}
+
+export function TimelineSpine({
+  eraColor,
+  hasImage,
+  isActive = false,
+  isFirst = false,
+  isLast = false,
+  rowHeight,
+}: TimelineSpineProps) {
+  const dotSize = hasImage ? 10 : 7;
+  const dotOpacity = hasImage ? 1 : 0.5;
+  const lineColor = eraColor + '30';
+
+  return (
+    <View
+      style={[styles.gutter, rowHeight != null ? { minHeight: rowHeight } : null]}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      {/* Top half of the spine line */}
+      <View
+        style={[
+          styles.lineHalf,
+          {
+            backgroundColor: isFirst ? 'transparent' : lineColor,
+          },
+        ]}
+      />
+      {/* Dot */}
+      <View
+        style={[
+          styles.dot,
+          {
+            width: dotSize,
+            height: dotSize,
+            borderRadius: dotSize / 2,
+            backgroundColor: eraColor,
+            opacity: dotOpacity,
+            borderWidth: hasImage ? 2 : 0,
+            borderColor: eraColor,
+            // Soft halo for image-bearing (or active) events via shadow.
+            shadowColor: eraColor, // intentional override-color
+            shadowOpacity: hasImage || isActive ? 0.6 : 0,
+            shadowRadius: hasImage || isActive ? 4 : 0,
+            shadowOffset: { width: 0, height: 0 },
+          },
+        ]}
+      />
+      {/* Bottom half of the spine line */}
+      <View
+        style={[
+          styles.lineHalf,
+          {
+            backgroundColor: isLast ? 'transparent' : lineColor,
+          },
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  gutter: {
+    width: SPINE_GUTTER_WIDTH,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lineHalf: {
+    flex: 1,
+    width: 2,
+  },
+  dot: {
+    marginVertical: 2,
+  },
+});

--- a/app/src/components/timeline/index.ts
+++ b/app/src/components/timeline/index.ts
@@ -1,0 +1,24 @@
+/**
+ * components/timeline — Vertical timeline building blocks.
+ *
+ * Part of Card #1264 (Timeline Phase 1).
+ */
+
+export {
+  TimelineEraStrip,
+  computeEraShares,
+  firstWord,
+  formatEraRange,
+} from './TimelineEraStrip';
+export type { TimelineEraStripProps } from './TimelineEraStrip';
+
+export {
+  TimelineEventCard,
+  formatTimelineYear,
+  parsePeopleJson,
+  parseChapterLink,
+} from './TimelineEventCard';
+export type { TimelineEventCardProps } from './TimelineEventCard';
+
+export { TimelineSpine, SPINE_GUTTER_WIDTH } from './TimelineSpine';
+export type { TimelineSpineProps } from './TimelineSpine';

--- a/app/src/components/timeline/index.ts
+++ b/app/src/components/timeline/index.ts
@@ -22,3 +22,16 @@ export type { TimelineEventCardProps } from './TimelineEventCard';
 
 export { TimelineSpine, SPINE_GUTTER_WIDTH } from './TimelineSpine';
 export type { TimelineSpineProps } from './TimelineSpine';
+
+// ── Card #1266 (Timeline Phase 2 — intelligence layer) ───────────────
+export { PersonFilterBar } from './PersonFilterBar';
+export type { PersonFilterBarProps } from './PersonFilterBar';
+
+export { ContemporaryRow, computeContemporaries } from './ContemporaryRow';
+export type { ContemporaryRowProps, Contemporary } from './ContemporaryRow';
+
+export { ContemporaryLane, MAX_LANES } from './ContemporaryLane';
+export type { ContemporaryLaneProps } from './ContemporaryLane';
+
+export { EraContextPanel, splitCommaList } from './EraContextPanel';
+export type { EraContextPanelProps } from './EraContextPanel';

--- a/app/src/components/tree/CovenantMarker.tsx
+++ b/app/src/components/tree/CovenantMarker.tsx
@@ -1,0 +1,103 @@
+/**
+ * CovenantMarker — Diamond marker + theological annotation card.
+ *
+ * Renders as a React Native component (not SVG) so it can be overlaid
+ * on top of the tree canvas at an absolute position. Caller supplies
+ * the (x, y) position to stamp and the waypoint data.
+ *
+ * Part of Card #1267 (Genealogy Phase 2).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, radii, spacing } from '../../theme';
+import type { CovenantWaypoint } from '../../utils/covenantWaypoints';
+
+export interface CovenantMarkerProps {
+  waypoint: CovenantWaypoint;
+  /** Pixel x position along the spine (left edge of the diamond). */
+  x: number;
+  /** Pixel y position along the spine. */
+  y: number;
+  /** Only render when zoomLevel exceeds this threshold. Defaults to 0.4. */
+  zoomLevel?: number;
+  minZoom?: number;
+  onPress?: (ref: string) => void;
+}
+
+const DIAMOND_SIZE = 10;
+const CARD_WIDTH = 140;
+
+export function CovenantMarker({
+  waypoint,
+  x,
+  y,
+  zoomLevel,
+  minZoom = 0.4,
+  onPress,
+}: CovenantMarkerProps) {
+  const { base } = useTheme();
+
+  if (zoomLevel != null && zoomLevel < minZoom) return null;
+
+  return (
+    <View
+      accessibilityLabel={`Covenant waypoint: ${waypoint.text}`}
+      style={[styles.wrapper, { left: x, top: y }]}
+      pointerEvents="box-none"
+    >
+      <View
+        style={[
+          styles.diamond,
+          { backgroundColor: base.gold + '80', borderColor: base.gold },
+        ]}
+      />
+      <TouchableOpacity
+        onPress={() => onPress?.(waypoint.ref)}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${waypoint.ref}`}
+        style={[
+          styles.card,
+          { backgroundColor: base.gold + '0D', borderColor: base.gold + '1A' },
+        ]}
+      >
+        <Text style={[styles.text, { color: base.textDim }]} numberOfLines={2}>
+          {waypoint.text}
+        </Text>
+        <Text style={[styles.ref, { color: base.gold }]}>{waypoint.ref}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  diamond: {
+    width: DIAMOND_SIZE,
+    height: DIAMOND_SIZE,
+    borderWidth: 1,
+    transform: [{ rotate: '45deg' }],
+  },
+  card: {
+    maxWidth: CARD_WIDTH,
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  text: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 9,
+    lineHeight: 13,
+  },
+  ref: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 8,
+    marginTop: 1,
+  },
+});

--- a/app/src/components/tree/MessianicLegend.tsx
+++ b/app/src/components/tree/MessianicLegend.tsx
@@ -1,0 +1,62 @@
+/**
+ * MessianicLegend — Small indicator explaining the golden-thread visual.
+ *
+ * Part of Card #1265 (Genealogy redesign Phase 1).
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, radii, spacing } from '../../theme';
+
+export interface MessianicLegendProps {
+  /** Optional override for the explanation text. */
+  label?: string;
+}
+
+export function MessianicLegend({
+  label = 'Golden thread = messianic lineage to Jesus',
+}: MessianicLegendProps) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      accessibilityLabel={label}
+      style={[
+        styles.container,
+        {
+          backgroundColor: base.gold + '14',
+          borderColor: base.gold + '1A',
+        },
+      ]}
+    >
+      <View
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        style={[styles.swatch, { backgroundColor: base.gold }]}
+      />
+      <Text style={[styles.label, { color: base.goldDim }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    alignSelf: 'flex-start',
+  },
+  swatch: {
+    width: 16,
+    height: 2,
+    borderRadius: 1,
+  },
+  label: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+  },
+});

--- a/app/src/components/tree/PersonDetailCard.tsx
+++ b/app/src/components/tree/PersonDetailCard.tsx
@@ -1,0 +1,434 @@
+/**
+ * PersonDetailCard — Inline detail card shown below the genealogy tree.
+ *
+ * Header: avatar + name + scripture role + role badge pills.
+ * Stats row: 3 columns (reign, children, references).
+ * Tabs: Bio | Family | Journey | Verses.
+ *
+ * Part of Card #1265 (Genealogy redesign Phase 1).
+ */
+
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import type { Person } from '../../types';
+import { RoleBadge } from './RoleBadge';
+import { isMessianic } from '../../utils/messianicLine';
+
+export type PersonDetailTab = 'bio' | 'family' | 'journey' | 'verses';
+
+export interface PersonDetailCardProps {
+  person: Person;
+  /** Children count for the stats row — caller derives from the tree data. */
+  childrenCount?: number;
+  /** Current active tab. Managed externally so parent can persist between mounts. */
+  activeTab?: PersonDetailTab;
+  onTabChange?: (tab: PersonDetailTab) => void;
+  /** Navigate to a related person's tree node. */
+  onPersonPress?: (personId: string) => void;
+  /** Navigate to the Chapter screen for a verse reference. */
+  onVersePress?: (verseRef: string) => void;
+  /** Navigate to the PersonJourney screen. */
+  onJourneyPress?: () => void;
+  /** Whether a journey exists for this person. */
+  hasJourney?: boolean;
+  /** Related people — resolved by the caller so we don't re-query here. */
+  relatedPeople?: {
+    parents: { id: string; name: string }[];
+    spouses: { id: string; name: string }[];
+    children: { id: string; name: string }[];
+  };
+}
+
+/** Parse a refs_json column into an array of verse reference strings. */
+export function parseRefsJson(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string');
+  } catch {
+    return [];
+  }
+}
+
+const TABS: { id: PersonDetailTab; label: string }[] = [
+  { id: 'bio', label: 'Bio' },
+  { id: 'family', label: 'Family' },
+  { id: 'journey', label: 'Journey' },
+  { id: 'verses', label: 'Verses' },
+];
+
+export function PersonDetailCard({
+  person,
+  childrenCount,
+  activeTab: activeTabProp,
+  onTabChange,
+  onPersonPress,
+  onVersePress,
+  onJourneyPress,
+  hasJourney,
+  relatedPeople,
+}: PersonDetailCardProps) {
+  const { base } = useTheme();
+  const [localTab, setLocalTab] = useState<PersonDetailTab>('bio');
+  const activeTab = activeTabProp ?? localTab;
+  const setTab = (t: PersonDetailTab) => {
+    setLocalTab(t);
+    onTabChange?.(t);
+  };
+
+  const refs = parseRefsJson(person.refs_json);
+  const messianic = isMessianic(person.id);
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: base.bgSurface,
+          borderColor: base.border,
+        },
+      ]}
+      accessibilityLabel={`Detail for ${person.name}`}
+    >
+      {/* ── Header ─── */}
+      <View style={styles.header}>
+        <View
+          style={[
+            styles.avatar,
+            {
+              backgroundColor: base.gold + '18',
+              borderColor: base.gold + '40',
+            },
+          ]}
+        >
+          <Text style={[styles.avatarInitial, { color: base.gold }]}>
+            {person.name.charAt(0).toUpperCase()}
+          </Text>
+        </View>
+        <View style={styles.headerText}>
+          <Text style={[styles.name, { color: base.text }]} numberOfLines={1}>
+            {person.name}
+          </Text>
+          {person.scripture_role ? (
+            <Text style={[styles.scriptureRole, { color: base.textMuted }]} numberOfLines={2}>
+              {person.scripture_role}
+            </Text>
+          ) : null}
+          <View style={styles.badgeRow}>
+            <RoleBadge role={person.role} />
+            {messianic ? (
+              <View
+                style={[styles.msBadge, { backgroundColor: base.gold + '14', borderColor: base.gold }]}
+                accessibilityLabel="On the messianic line"
+              >
+                <Text style={[styles.msLabel, { color: base.gold }]}>Messianic Line</Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+      </View>
+
+      {/* ── Stats ─── */}
+      <View style={styles.statsRow}>
+        {person.dates ? (
+          <View style={styles.statCell}>
+            <Text style={[styles.statValue, { color: base.text }]}>{person.dates}</Text>
+            <Text style={[styles.statLabel, { color: base.textMuted }]}>Dates</Text>
+          </View>
+        ) : null}
+        {childrenCount != null ? (
+          <View style={styles.statCell}>
+            <Text style={[styles.statValue, { color: base.text }]}>{childrenCount}</Text>
+            <Text style={[styles.statLabel, { color: base.textMuted }]}>Children</Text>
+          </View>
+        ) : null}
+        <View style={styles.statCell}>
+          <Text style={[styles.statValue, { color: base.text }]}>{refs.length}</Text>
+          <Text style={[styles.statLabel, { color: base.textMuted }]}>References</Text>
+        </View>
+      </View>
+
+      {/* ── Tab bar ─── */}
+      <View style={[styles.tabBar, { borderBottomColor: base.border }]}>
+        {TABS.map((tab) => {
+          const isActive = tab.id === activeTab;
+          return (
+            <TouchableOpacity
+              key={tab.id}
+              onPress={() => setTab(tab.id)}
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+              accessibilityLabel={`${tab.label} tab`}
+              style={[
+                styles.tab,
+                isActive ? { borderBottomColor: base.gold } : null,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.tabLabel,
+                  { color: isActive ? base.gold : base.textMuted },
+                ]}
+              >
+                {tab.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* ── Tab content ─── */}
+      <ScrollView style={styles.tabContent} contentContainerStyle={styles.tabContentInner}>
+        {activeTab === 'bio' ? (
+          <Text style={[styles.bio, { color: base.textDim }]}>
+            {person.bio ?? 'No biography yet.'}
+          </Text>
+        ) : null}
+        {activeTab === 'family' ? (
+          <View style={styles.familyCol}>
+            {(['parents', 'spouses', 'children'] as const).map((group) => {
+              const people = relatedPeople?.[group] ?? [];
+              if (people.length === 0) return null;
+              return (
+                <View key={group} style={styles.familyGroup}>
+                  <Text style={[styles.familyLabel, { color: base.textMuted }]}>
+                    {group.toUpperCase()}
+                  </Text>
+                  <View style={styles.familyRow}>
+                    {people.map((p) => (
+                      <TouchableOpacity
+                        key={p.id}
+                        onPress={() => onPersonPress?.(p.id)}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Open ${p.name}`}
+                        style={[styles.familyPill, { borderColor: base.gold + '40' }]}
+                      >
+                        <Text style={[styles.familyPillLabel, { color: base.text }]}>
+                          {p.name}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                </View>
+              );
+            })}
+            {!relatedPeople ||
+            (relatedPeople.parents.length === 0 &&
+              relatedPeople.spouses.length === 0 &&
+              relatedPeople.children.length === 0) ? (
+              <Text style={[styles.empty, { color: base.textMuted }]}>
+                No related people.
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+        {activeTab === 'journey' ? (
+          hasJourney ? (
+            <TouchableOpacity
+              onPress={onJourneyPress}
+              style={[styles.journeyButton, { borderColor: base.gold + '55', backgroundColor: base.gold + '18' }]}
+              accessibilityRole="button"
+              accessibilityLabel={`View journey of ${person.name}`}
+            >
+              <Text style={[styles.journeyLabel, { color: base.gold }]}>
+                View full journey →
+              </Text>
+            </TouchableOpacity>
+          ) : (
+            <Text style={[styles.empty, { color: base.textMuted }]}>
+              No journey recorded.
+            </Text>
+          )
+        ) : null}
+        {activeTab === 'verses' ? (
+          refs.length > 0 ? (
+            <View style={styles.verseList}>
+              {refs.map((ref) => (
+                <TouchableOpacity
+                  key={ref}
+                  onPress={() => onVersePress?.(ref)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open ${ref}`}
+                  style={[styles.versePill, { borderColor: base.gold + '40' }]}
+                >
+                  <Text style={[styles.verseLabel, { color: base.gold }]}>{ref}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          ) : (
+            <Text style={[styles.empty, { color: base.textMuted }]}>
+              No key references.
+            </Text>
+          )
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    padding: spacing.md,
+    gap: spacing.md,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarInitial: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 18,
+  },
+  headerText: {
+    flex: 1,
+    gap: 2,
+  },
+  name: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 17,
+  },
+  scriptureRole: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 2,
+  },
+  msBadge: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+  },
+  msLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+  },
+
+  statsRow: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.md,
+    gap: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  statCell: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statValue: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+  },
+  statLabel: {
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+
+  tabBar: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  tabLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+
+  tabContent: {
+    maxHeight: 260,
+  },
+  tabContentInner: {
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  bio: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+
+  familyCol: {
+    gap: spacing.sm,
+  },
+  familyGroup: {
+    gap: 4,
+  },
+  familyLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
+    letterSpacing: 0.5,
+  },
+  familyRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+  },
+  familyPill: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  familyPillLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+
+  journeyButton: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    alignSelf: 'flex-start',
+  },
+  journeyLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+
+  verseList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+  },
+  versePill: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  verseLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+  },
+
+  empty: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    fontStyle: 'italic',
+  },
+});

--- a/app/src/components/tree/RoleBadge.tsx
+++ b/app/src/components/tree/RoleBadge.tsx
@@ -1,0 +1,110 @@
+/**
+ * RoleBadge — Tiny 16px circular badge hinting at a person's role.
+ *
+ * Kings → 'K', Patriarchs → 'P', Priests → 'Pr' (plain unicode — no icon fonts),
+ * Prophets → '*', Judges → 'J', Tribes → 'T'. Falls back to a dot for unknown
+ * roles.
+ *
+ * Part of Card #1265 (Genealogy redesign Phase 1).
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme, fontFamily } from '../../theme';
+
+export type PersonRole =
+  | 'king'
+  | 'patriarch'
+  | 'priest'
+  | 'prophet'
+  | 'judge'
+  | 'tribe'
+  | string
+  | null
+  | undefined;
+
+export interface RoleBadgeConfig {
+  /** 1-2 character glyph shown inside the badge. Unicode only — no icon fonts. */
+  label: string;
+  /** Colour key from the theme. */
+  color: string;
+}
+
+export interface RoleBadgeProps {
+  role: PersonRole;
+  /** Size in points. Defaults to 16. */
+  size?: number;
+  /** Era colour — used for roles that are era-tinted (patriarch, tribe, judge). */
+  eraColor?: string;
+}
+
+/** Derive badge config from the role + theme palette. Returns null for unknown roles. */
+export function getRoleBadgeConfig(
+  role: PersonRole,
+  palette: { gold: string; eraColor?: string },
+): RoleBadgeConfig | null {
+  switch (role) {
+    case 'king':
+      return { label: 'K', color: palette.gold };
+    case 'patriarch':
+      return { label: 'P', color: palette.eraColor ?? palette.gold };
+    case 'priest':
+      return { label: '⛊', color: '#90a0b0' }; // intentional — neutral priestly blue-gray
+    case 'prophet':
+      return { label: '✧', color: '#a090c0' }; // intentional — neutral prophetic violet
+    case 'judge':
+      return { label: 'J', color: palette.eraColor ?? palette.gold };
+    case 'tribe':
+      return { label: 'T', color: palette.eraColor ?? palette.gold };
+    default:
+      return null;
+  }
+}
+
+export function RoleBadge({ role, size = 16, eraColor }: RoleBadgeProps) {
+  const { base } = useTheme();
+  const config = getRoleBadgeConfig(role, { gold: base.gold, eraColor });
+  if (!config) return null;
+
+  return (
+    <View
+      accessibilityLabel={`${role} role badge`}
+      style={[
+        styles.badge,
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: config.color + '22',
+          borderColor: config.color,
+        },
+      ]}
+    >
+      <Text
+        style={[
+          styles.label,
+          {
+            color: config.color,
+            fontSize: Math.round(size * 0.55),
+            lineHeight: size,
+          },
+        ]}
+      >
+        {config.label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    textAlign: 'center',
+    includeFontPadding: false,
+  },
+});

--- a/app/src/components/tree/SpousePill.tsx
+++ b/app/src/components/tree/SpousePill.tsx
@@ -1,0 +1,56 @@
+/**
+ * SpousePill — Small pill under a person's tree node showing a spouse name.
+ *
+ * Tap navigates the caller to the spouse's node (by re-centring the viewport).
+ * Uses the infinity symbol as the connector — no icon fonts.
+ *
+ * Part of Card #1265 (Genealogy redesign Phase 1).
+ */
+
+import React from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, fontFamily, radii } from '../../theme';
+
+export interface SpousePillProps {
+  spouseId: string;
+  spouseName: string;
+  onPress: (spouseId: string) => void;
+}
+
+export function SpousePill({ spouseId, spouseName, onPress }: SpousePillProps) {
+  const { base } = useTheme();
+
+  return (
+    <TouchableOpacity
+      onPress={() => onPress(spouseId)}
+      hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+      accessibilityRole="button"
+      accessibilityLabel={`Spouse: ${spouseName}`}
+      style={[
+        styles.pill,
+        {
+          backgroundColor: base.bgSurface,
+          borderColor: base.border,
+        },
+      ]}
+    >
+      <Text style={[styles.label, { color: base.textMuted }]} numberOfLines={1}>
+        ∞ {spouseName}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontFamily: fontFamily.ui,
+    fontSize: 8,
+  },
+});

--- a/app/src/components/tree/index.ts
+++ b/app/src/components/tree/index.ts
@@ -5,3 +5,16 @@ export { TreeNode } from './TreeNode';
 export { TreeCanvas } from './TreeCanvas';
 export { EraFilterBar } from './EraFilterBar';
 export { PersonSearchBar } from './PersonSearchBar';
+
+// ── Card #1265 (Genealogy redesign Phase 1) ──────────────────────────
+export { RoleBadge, getRoleBadgeConfig } from './RoleBadge';
+export type { RoleBadgeProps, RoleBadgeConfig, PersonRole } from './RoleBadge';
+
+export { SpousePill } from './SpousePill';
+export type { SpousePillProps } from './SpousePill';
+
+export { MessianicLegend } from './MessianicLegend';
+export type { MessianicLegendProps } from './MessianicLegend';
+
+export { PersonDetailCard, parseRefsJson } from './PersonDetailCard';
+export type { PersonDetailCardProps, PersonDetailTab } from './PersonDetailCard';

--- a/app/src/components/tree/index.ts
+++ b/app/src/components/tree/index.ts
@@ -18,3 +18,7 @@ export type { MessianicLegendProps } from './MessianicLegend';
 
 export { PersonDetailCard, parseRefsJson } from './PersonDetailCard';
 export type { PersonDetailCardProps, PersonDetailTab } from './PersonDetailCard';
+
+// ── Card #1267 (Genealogy Phase 2 — organic layer) ───────────────────
+export { CovenantMarker } from './CovenantMarker';
+export type { CovenantMarkerProps } from './CovenantMarker';

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -24,6 +24,16 @@ import { RecommendedCard } from '../components/RecommendedCard';
 import { StartHereBanner } from '../components/StartHereBanner';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { JourneyBrowseSection } from '../components/JourneyBrowseSection';
+import {
+  ProphecyChainCard,
+  DebatePreviewList,
+  WordStudyPreviewList,
+  LifeTopicGrid,
+  FullWidthImageCard,
+  GoldSeparator,
+  PROPHECY_CHAIN_CARD_WIDTH,
+} from '../components/explore';
+import { useProphecyChains } from '../hooks/useProphecyChains';
 import { getReadingStats, getPreference, setPreference } from '../db/user';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
@@ -111,6 +121,7 @@ function ExploreMenuScreen() {
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const { recommendations, bookName } = useExploreRecommendations();
   const imageRegistry = useExploreImages();
+  const { chains: prophecyChains } = useProphecyChains();
 
   const [activeJump, setActiveJump] = useState<string | null>(null);
   const [chaptersRead, setChaptersRead] = useState<number | null>(null);
@@ -163,9 +174,220 @@ function ExploreMenuScreen() {
     return imageRegistry[screenName];
   }, [imageRegistry]);
 
+  const handleProphecyPress = useCallback((chainId: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    navigation.navigate('ProphecyDetail' as any, { chainId } as any);
+  }, [navigation]);
+
+  const handleDebatePress = useCallback((debateId: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    navigation.navigate('DebateDetail' as any, { topicId: debateId } as any);
+  }, [navigation]);
+
+  const handleWordStudyPress = useCallback((id: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    navigation.navigate('WordStudyDetail' as any, { wordId: id } as any);
+  }, [navigation]);
+
+  const handleLifeCategoryPress = useCallback((categoryId: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    navigation.navigate('LifeTopics' as any, { categoryId } as any);
+  }, [navigation]);
+
   const showStartHere = chaptersRead !== null && chaptersRead < 5 && !startHereDismissed;
   const showRecommendations = !showStartHere && recommendations.length > 0;
   const filteredSections = activeJump ? SECTIONS.filter((s) => s.id === activeJump) : SECTIONS;
+
+  // ── Per-section content renderer ────────────────────────────
+  const renderSectionContent = (section: FeatureSection) => {
+    switch (section.id) {
+      case 'journeys':
+        return <JourneyBrowseSection />;
+      case 'themes':
+        return (
+          <View style={styles.sectionGap}>
+            {prophecyChains.length > 0 && (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.carouselContent}
+                decelerationRate="fast"
+                snapToInterval={PROPHECY_CHAIN_CARD_WIDTH + spacing.sm}
+              >
+                {prophecyChains.slice(0, 4).map((chain) => (
+                  <ProphecyChainCard
+                    key={chain.id}
+                    chain={chain}
+                    onPress={() => handleProphecyPress(chain.id)}
+                  />
+                ))}
+              </ScrollView>
+            )}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+            >
+              {section.features.map((f, cardIndex) => {
+                const imgData = getScreenImages(f.screen);
+                return (
+                  <FeatureCard
+                    key={f.screen}
+                    feature={f}
+                    onPress={() => handleNavigate(f.screen)}
+                    isPremium={isPremium}
+                    images={imgData?.images}
+                    count={imgData?.count}
+                    noun={imgData?.noun}
+                    onImagePress={handleDeepLink}
+                    staggerMs={cardIndex * 1200}
+                    compact
+                  />
+                );
+              })}
+            </ScrollView>
+          </View>
+        );
+      case 'scholarly': {
+        const splitFeatures = section.features.filter(
+          (f) => f.screen === 'ScholarBrowse' || f.screen === 'DifficultPassagesBrowse',
+        );
+        const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <DebatePreviewList
+              onDebatePress={handleDebatePress}
+              onSeeAll={() => handleNavigate('DebateBrowse')}
+              totalCount={totalDebates ?? undefined}
+            />
+            <View style={styles.row2}>
+              {splitFeatures.map((f, i) => {
+                const imgData = getScreenImages(f.screen);
+                return (
+                  <View key={f.screen} style={styles.rowCell}>
+                    <FeatureCard
+                      feature={f}
+                      onPress={() => handleNavigate(f.screen)}
+                      isPremium={isPremium}
+                      images={imgData?.images}
+                      count={imgData?.count}
+                      noun={imgData?.noun}
+                      onImagePress={handleDeepLink}
+                      staggerMs={i * 1200}
+                      compact
+                    />
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        );
+      }
+      case 'language': {
+        const splitFeatures = section.features.filter(
+          (f) => f.screen !== 'WordStudyBrowse',
+        );
+        const totalWords = getScreenImages('WordStudyBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <WordStudyPreviewList
+              onWordPress={handleWordStudyPress}
+              onSeeAll={() => handleNavigate('WordStudyBrowse')}
+              totalCount={totalWords ?? undefined}
+            />
+            <View style={styles.row3}>
+              {splitFeatures.map((f, i) => {
+                const imgData = getScreenImages(f.screen);
+                return (
+                  <View key={f.screen} style={styles.rowCell}>
+                    <FeatureCard
+                      feature={f}
+                      onPress={() => handleNavigate(f.screen)}
+                      isPremium={isPremium}
+                      images={imgData?.images}
+                      count={imgData?.count}
+                      noun={imgData?.noun}
+                      onImagePress={handleDeepLink}
+                      staggerMs={i * 1200}
+                      compact
+                    />
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        );
+      }
+      case 'life': {
+        const lifeImage = getScreenImages('LifeTopics');
+        return (
+          <View style={styles.sectionGap}>
+            <FullWidthImageCard
+              title="Life Topics"
+              subtitle="Practical guidance from Scripture"
+              image={lifeImage?.images?.[0] ?? null}
+              count={lifeImage?.count ?? null}
+              noun={lifeImage?.noun}
+              onPress={() => handleNavigate('LifeTopics')}
+            />
+            <LifeTopicGrid onCategoryPress={handleLifeCategoryPress} />
+          </View>
+        );
+      }
+      case 'deep-dive':
+        return (
+          <View style={styles.row3}>
+            {section.features.map((f, i) => {
+              const imgData = getScreenImages(f.screen);
+              return (
+                <View key={f.screen} style={styles.rowCell}>
+                  <FeatureCard
+                    feature={f}
+                    onPress={() => handleNavigate(f.screen)}
+                    isPremium={isPremium}
+                    images={imgData?.images}
+                    count={imgData?.count}
+                    noun={imgData?.noun}
+                    onImagePress={handleDeepLink}
+                    staggerMs={i * 1200}
+                    compact
+                  />
+                </View>
+              );
+            })}
+          </View>
+        );
+      case 'biblical-world':
+      default:
+        return (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+            snapToInterval={CARD_WIDTH + spacing.sm}
+          >
+            {section.features.map((f, cardIndex) => {
+              const imgData = getScreenImages(f.screen);
+              return (
+                <FeatureCard
+                  key={f.screen}
+                  feature={f}
+                  onPress={() => handleNavigate(f.screen)}
+                  isPremium={isPremium}
+                  images={imgData?.images}
+                  count={imgData?.count}
+                  noun={imgData?.noun}
+                  onImagePress={handleDeepLink}
+                  staggerMs={cardIndex * 1200}
+                />
+              );
+            })}
+          </ScrollView>
+        );
+    }
+  };
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
@@ -235,47 +457,14 @@ function ExploreMenuScreen() {
           </View>
         )}
 
-        {/* ── Sections with carousels ─── */}
+        {/* ── Sections with varied layouts ─── */}
         {filteredSections.map((section, sectionIndex) => (
           <View key={section.id}>
-            {/* Gold separator between sections */}
-            {sectionIndex > 0 && (
-              <View style={[styles.separator, { backgroundColor: base.gold + '1A' }]} />
-            )}
-
+            {sectionIndex > 0 && <GoldSeparator />}
             <View style={styles.section}>
               <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
               <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
-
-              {/* Journeys section uses a custom component instead of FeatureCards */}
-              {section.id === 'journeys' ? (
-                <JourneyBrowseSection />
-              ) : (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.carouselContent}
-                decelerationRate="fast"
-                snapToInterval={CARD_WIDTH + spacing.sm}
-              >
-                {section.features.map((f, cardIndex) => {
-                  const imgData = getScreenImages(f.screen);
-                  return (
-                    <FeatureCard
-                      key={f.screen}
-                      feature={f}
-                      onPress={() => handleNavigate(f.screen)}
-                      isPremium={isPremium}
-                      images={imgData?.images}
-                      count={imgData?.count}
-                      noun={imgData?.noun}
-                      onImagePress={handleDeepLink}
-                      staggerMs={cardIndex * 1200}
-                    />
-                  );
-                })}
-              </ScrollView>
-              )}
+              {renderSectionContent(section)}
             </View>
           </View>
         ))}
@@ -325,9 +514,6 @@ const styles = StyleSheet.create({
   recsLabel: { fontFamily: fontFamily.uiMedium, fontSize: 10, letterSpacing: 1, marginBottom: 2 },
   recsSubtitle: { fontFamily: fontFamily.ui, fontSize: 10, marginBottom: spacing.sm },
 
-  // Gold separator
-  separator: { height: 1, marginBottom: spacing.md },
-
   // Sections
   section: { marginBottom: spacing.md },
   sectionLabel: { fontFamily: fontFamily.displayMedium, fontSize: 13, letterSpacing: 0.5, marginBottom: 2 },
@@ -335,6 +521,12 @@ const styles = StyleSheet.create({
 
   // Carousels
   carouselContent: { gap: spacing.sm },
+
+  // Split/grid rows
+  sectionGap: { gap: spacing.md },
+  row2: { flexDirection: 'row', gap: spacing.sm },
+  row3: { flexDirection: 'row', gap: spacing.sm },
+  rowCell: { flex: 1 },
 
   // Show all
   showAllBtn: {

--- a/app/src/screens/GenealogyTreeScreen.tsx
+++ b/app/src/screens/GenealogyTreeScreen.tsx
@@ -40,6 +40,7 @@ import { useLandscapeUnlock } from '../hooks/useLandscapeUnlock';
 import { TreeCanvas } from '../components/tree/TreeCanvas';
 import { EraFilterBar } from '../components/tree/EraFilterBar';
 import { PersonSearchBar } from '../components/tree/PersonSearchBar';
+import { MessianicLegend } from '../components/tree/MessianicLegend';
 import { PersonSidebar } from '../components/PersonSidebar';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 
@@ -195,6 +196,9 @@ function GenealogyTreeScreen({ route, navigation }: {
       <View style={[styles.topBar, { paddingTop: insets.top }]}>
         <PersonSearchBar people={people} onSelect={handleSearchSelect} />
         <EraFilterBar activeEra={filterEra} onSelect={handleEraChange} />
+        <View style={styles.legendWrap}>
+          <MessianicLegend />
+        </View>
       </View>
 
       <View style={[styles.viewport, { backgroundColor: base.bg }]} accessible accessibilityLabel="Family tree" accessibilityHint="Pinch to zoom, drag to pan">
@@ -258,6 +262,10 @@ const styles = StyleSheet.create({
   },
   topBar: {
     zIndex: 10,
+  },
+  legendWrap: {
+    paddingHorizontal: spacing.sm,
+    paddingBottom: 4,
   },
   viewport: {
     flex: 1,

--- a/app/src/screens/TimelineScreen.tsx
+++ b/app/src/screens/TimelineScreen.tsx
@@ -1,39 +1,36 @@
 /**
- * TimelineScreen — 203+ events on a horizontally scrollable SVG canvas.
+ * TimelineScreen — Vertical scrolling timeline.
  *
- * Modernized visual design:
- *   - Gradient era bands with depth and bottom accent borders
- *   - Polished axis with edge fade and gold-glow tick marks
- *   - Smart label density (major events labeled, minor markers only)
- *   - Visual marker hierarchy (3 sizes + glow rings for major events)
- *   - Dashed/solid stem lines with category gradient opacity
- *   - Bottom sheet detail panel (replaces Modal)
+ * 543 events on a FlatList of event cards connected by a glowing spine.
+ * Proportional era strip at the top filters by era. Event cards expand
+ * inline (accordion) to show full summary + people + chapter link.
+ *
+ * Part of Card #1264 (Timeline Phase 1).
  */
 
-import React, { useState, useCallback, useMemo, useEffect, useRef, useReducer } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Svg, {
-  Defs, LinearGradient, Stop,
-  Rect, Line, Circle, G, Text as SvgText,
-} from 'react-native-svg';
-import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-
-import { useRoute, useNavigation } from '@react-navigation/native';
-import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
-import { getAllTimelineEntries } from '../db/content';
-import { useContentImages } from '../hooks/useContentImages';
-import { ContentImageGallery } from '../components/ContentImageGallery';
-import { EraFilterBar } from '../components/tree/EraFilterBar';
-import { BadgeChip } from '../components/BadgeChip';
-import { LoadingSkeleton } from '../components/LoadingSkeleton';
-import { useLandscapeUnlock } from '../hooks/useLandscapeUnlock';
+import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import {
-  yearToX, formatYear, assignLanes, computeTickMarks, computeSvgHeight,
-  ERA_RANGES, TOTAL_WIDTH, AXIS_Y, ERA_BAR_Y, ERA_BAR_H,
-  type PositionedEvent,
-} from '../utils/timelineLayout';
-import { useTheme, spacing, radii, eraNames, fontFamily } from '../theme';
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { getAllTimelineEntries, getEras } from '../db/content';
+import type { EraRow } from '../db/content/reference';
+import { useContentImages } from '../hooks/useContentImages';
+import {
+  TimelineEraStrip,
+  TimelineEventCard,
+  TimelineSpine,
+  SPINE_GUTTER_WIDTH,
+} from '../components/timeline';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { useTheme, spacing, fontFamily } from '../theme';
 import type { TimelineEntry } from '../types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import { useSettingsStore } from '../stores';
@@ -44,116 +41,169 @@ interface CategoryFilters {
   person: boolean;
   world: boolean;
 }
-
 type FilterAction = { type: 'toggle'; category: keyof CategoryFilters };
-
 function filterReducer(state: CategoryFilters, action: FilterAction): CategoryFilters {
   return { ...state, [action.category]: !state[action.category] };
 }
-
 const INITIAL_FILTERS: CategoryFilters = { event: true, book: true, person: true, world: true };
 
-/** Lighten a hex color by blending toward white. */
-function lighten(hex: string, amount: number = 0.3): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  const lr = Math.round(r + (255 - r) * amount);
-  const lg = Math.round(g + (255 - g) * amount);
-  const lb = Math.round(b + (255 - b) * amount);
-  return `#${lr.toString(16).padStart(2, '0')}${lg.toString(16).padStart(2, '0')}${lb.toString(16).padStart(2, '0')}`;
+/** Build a { eraId → event count } lookup from a timeline entry list. */
+export function computeEraCounts(
+  entries: TimelineEntry[] | null | undefined,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!entries) return out;
+  for (const e of entries) {
+    if (!e.era) continue;
+    out[e.era] = (out[e.era] ?? 0) + 1;
+  }
+  return out;
+}
+
+/** Apply category + era filters to a timeline entry list. */
+export function filterTimeline(
+  entries: TimelineEntry[] | null | undefined,
+  filters: CategoryFilters,
+  eraId: string | null,
+): TimelineEntry[] {
+  if (!entries) return [];
+  const cats = new Set<string>();
+  if (filters.event) cats.add('event');
+  if (filters.book) cats.add('book');
+  if (filters.person) cats.add('person');
+  if (filters.world) cats.add('world');
+  if (cats.size === 0) {
+    cats.add('event');
+    cats.add('book');
+  }
+  return entries.filter((e) => {
+    if (!cats.has(e.category)) return false;
+    if (eraId && e.era !== eraId) return false;
+    return true;
+  });
+}
+
+function TimelineRow({
+  event,
+  eraColor,
+  isFirst,
+  isLast,
+  isExpanded,
+  onToggleExpand,
+  onPersonPress,
+  onChapterPress,
+}: {
+  event: TimelineEntry;
+  eraColor: string;
+  isFirst: boolean;
+  isLast: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onPersonPress: (personId: string) => void;
+  onChapterPress: (bookId: string, chapterNum: number) => void;
+}) {
+  const { images } = useContentImages('timeline', event.id);
+  const hasImage = images.length > 0;
+  return (
+    <View style={styles.row}>
+      <TimelineSpine
+        eraColor={eraColor}
+        hasImage={hasImage}
+        isActive={isExpanded}
+        isFirst={isFirst}
+        isLast={isLast}
+      />
+      <View style={styles.rowCard}>
+        <TimelineEventCard
+          event={event}
+          eraColor={eraColor}
+          isExpanded={isExpanded}
+          onToggleExpand={onToggleExpand}
+          onPersonPress={onPersonPress}
+          onChapterPress={onChapterPress}
+        />
+      </View>
+    </View>
+  );
 }
 
 function TimelineScreen() {
-  const { base, eras, categoryColors, timelineSvg } = useTheme();
-  useLandscapeUnlock();
+  const { base, eras: themeEras } = useTheme();
   const route = useRoute<ScreenRouteProp<'Explore', 'Timeline'>>();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'Timeline'>>();
   const initialEventId = route?.params?.eventId;
+  const insets = useSafeAreaInsets();
 
   const [events, setEvents] = useState<TimelineEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [filterEra, setFilterEra] = useState<string>('all');
+  const [eras, setEras] = useState<EraRow[]>([]);
+  const [filterEra, setFilterEra] = useState<string | null>(null);
   const [filters, dispatchFilter] = useReducer(filterReducer, INITIAL_FILTERS);
-  const [selectedEvent, setSelectedEvent] = useState<PositionedEvent | null>(null);
-  const { images: eventImages } = useContentImages('timeline', selectedEvent?.id);
-  const timelineScrollRef = useRef<ScrollView>(null);
-  const sheetRef = useRef<BottomSheet>(null);
-  const { width: screenWidth } = useWindowDimensions();
-  const insets = useSafeAreaInsets();
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   useEffect(() => {
-    getAllTimelineEntries().then((e) => { setEvents(e); setIsLoading(false); });
+    let cancelled = false;
+    Promise.all([getAllTimelineEntries(), getEras()])
+      .then(([entries, eraRows]) => {
+        if (cancelled) return;
+        setEvents(entries ?? []);
+        setEras(eraRows ?? []);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  // Mark getting-started checklist item
-  useEffect(() => { useSettingsStore.getState().markGettingStartedDone('explore_timeline'); }, []);
-
-  // Filter by active categories
-  const categoryFiltered = useMemo(() => {
-    const cats = new Set<string>();
-    if (filters.event) cats.add('event');
-    if (filters.book) cats.add('book');
-    if (filters.person) cats.add('person');
-    if (filters.world) cats.add('world');
-    if (cats.size === 0) { cats.add('event'); cats.add('book'); }
-    return events.filter((e) => cats.has(e.category));
-  }, [events, filters]);
-
-  const positioned = useMemo(() => assignLanes(categoryFiltered), [categoryFiltered]);
-
-  const filtered = useMemo(() => {
-    if (filterEra === 'all') return positioned;
-    return positioned.filter((e) => e.era === filterEra);
-  }, [positioned, filterEra]);
-
-  const handleEraChange = useCallback((era: string) => {
-    setFilterEra(era);
-    if (era === 'all') {
-      timelineScrollRef.current?.scrollTo({ x: 0, animated: true });
-      return;
-    }
-    const range = ERA_RANGES[era];
-    if (range) {
-      const x1 = yearToX(range[0]);
-      const x2 = yearToX(range[1]);
-      const centreX = (x1 + x2) / 2;
-      const scrollTarget = Math.max(0, centreX - screenWidth / 2);
-      timelineScrollRef.current?.scrollTo({ x: scrollTarget, animated: true });
-    }
-  }, [screenWidth]);
-
-  const ticks = useMemo(() => computeTickMarks(), []);
-  const snapPoints = useMemo(() => ['35%', '60%'], []);
-
-  // Handle event selection → open bottom sheet
-  const handleSelectEvent = useCallback((evt: PositionedEvent) => {
-    setSelectedEvent(evt);
-    sheetRef.current?.snapToIndex(0);
-  }, []);
-
-  const handleCloseSheet = useCallback(() => {
-    setSelectedEvent(null);
-  }, []);
-
-  // Deep-link
   useEffect(() => {
-    if (initialEventId && positioned.length) {
-      const evt = positioned.find((e) =>
-        e.id === initialEventId ||
-        e.id === `evt_${initialEventId}` ||
-        e.id === `bk_${initialEventId}`
-      );
-      if (evt) {
-        // Scroll to centre the event horizontally
-        const scrollTarget = Math.max(0, evt.x - screenWidth / 2);
-        setTimeout(() => {
-          timelineScrollRef.current?.scrollTo({ x: scrollTarget, animated: true });
-        }, 100);
-        handleSelectEvent(evt);
-      }
-    }
-  }, [initialEventId, positioned.length, handleSelectEvent, screenWidth]);
+    useSettingsStore.getState().markGettingStartedDone('explore_timeline');
+  }, []);
+
+  useEffect(() => {
+    if (initialEventId) setExpandedId(initialEventId);
+  }, [initialEventId]);
+
+  const eraCounts = useMemo(() => computeEraCounts(events), [events]);
+  const visible = useMemo(
+    () => filterTimeline(events, filters, filterEra),
+    [events, filters, filterEra],
+  );
+
+  const eraColorFor = useCallback(
+    (eraId: string | null): string => {
+      if (!eraId) return base.gold;
+      const row = eras.find((e) => e.id === eraId);
+      return row?.hex ?? themeEras[eraId] ?? base.gold;
+    },
+    [base.gold, eras, themeEras],
+  );
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }, []);
+
+  const handlePersonPress = useCallback(
+    (personId: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      navigation.navigate('PersonDetail' as any, { personId } as any);
+    },
+    [navigation],
+  );
+
+  const handleChapterPress = useCallback(
+    (bookId: string, chapterNum: number) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigation as any).navigate('ReadTab', {
+        screen: 'Chapter',
+        params: { bookId, chapterNum },
+      });
+    },
+    [navigation],
+  );
 
   if (isLoading) {
     return (
@@ -165,253 +215,86 @@ function TimelineScreen() {
     );
   }
 
-  const hasBelow = filters.person || filters.world;
-  const SVG_HEIGHT = computeSvgHeight(hasBelow);
+  const lastIndex = visible.length - 1;
 
   return (
-    <View style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={{ paddingTop: insets.top }}>
-        <EraFilterBar activeEra={filterEra} onSelect={handleEraChange} />
-
-        {/* Category toggles */}
-        <View style={styles.categoryRow}>
-          {([
-            { key: 'event' as const, label: 'Events', color: categoryColors.event },
-            { key: 'book' as const, label: 'Books', color: categoryColors.book },
-            { key: 'person' as const, label: 'People', color: categoryColors.person },
-            { key: 'world' as const, label: 'World History', color: categoryColors.world },
-          ]).map(({ key, label, color }) => (
-            <TouchableOpacity
-              key={key}
-              onPress={() => dispatchFilter({ type: 'toggle', category: key })}
-              hitSlop={{ top: 6, bottom: 6, left: 4, right: 4 }}
-              style={[styles.categoryChip, { borderColor: base.border, backgroundColor: base.bg + 'EE' }, filters[key] && [styles.categoryChipActive, { borderColor: base.gold + '55' }]]}
-              accessibilityRole="button"
-              accessibilityLabel={`${label} filter: ${filters[key] ? 'on' : 'off'}`}
-              accessibilityState={{ selected: filters[key] }}
-            >
-              <View style={[styles.categoryDot, { backgroundColor: color }]} />
-              <Text style={[styles.categoryLabel, { color: base.textMuted }, filters[key] && { color }]}>{label}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+    <View
+      style={[styles.container, { backgroundColor: base.bg, paddingTop: insets.top }]}
+      accessibilityLabel="Timeline"
+    >
+      <View style={styles.header}>
+        <Text style={[styles.headerTitle, { color: base.gold }]} accessibilityRole="header">
+          Timeline
+        </Text>
+        <Text style={[styles.headerCount, { color: base.textMuted }]}>
+          {events.length} events
+        </Text>
       </View>
 
-      <ScrollView ref={timelineScrollRef} horizontal showsHorizontalScrollIndicator style={styles.timelineScroll} accessible accessibilityLabel="Timeline" accessibilityHint="Scroll horizontally to explore events">
-        <Svg width={TOTAL_WIDTH} height={SVG_HEIGHT}>
-          {/* ── Gradient definitions ────────────────────── */}
-          <Defs>
-            {/* Era band gradients — vertical fade for depth */}
-            {Object.keys(ERA_RANGES).map((era) => {
-              const color = eras[era] ?? base.bgSurface;
-              return (
-                <LinearGradient key={`grad-${era}`} id={`grad-${era}`} x1="0" y1="0" x2="0" y2="1">
-                  <Stop offset="0" stopColor={lighten(color, 0.15)} stopOpacity={0.85} />
-                  <Stop offset="1" stopColor={color} stopOpacity={0.4} />
-                </LinearGradient>
-              );
-            })}
-            {/* Axis fade — transparent at edges */}
-            <LinearGradient id="axis-grad" x1="0" y1="0" x2={TOTAL_WIDTH} y2="0" gradientUnits="userSpaceOnUse">
-              <Stop offset="0%" stopColor={timelineSvg.axis} stopOpacity={0} />
-              <Stop offset="3%" stopColor={timelineSvg.axis} stopOpacity={1} />
-              <Stop offset="97%" stopColor={timelineSvg.axis} stopOpacity={1} />
-              <Stop offset="100%" stopColor={timelineSvg.axis} stopOpacity={0} />
-            </LinearGradient>
-          </Defs>
+      <TimelineEraStrip
+        eras={eras}
+        eventCounts={eraCounts}
+        activeEraId={filterEra}
+        onSelectEra={(eraId) => setFilterEra(eraId)}
+      />
 
-          {/* ── Era bands with gradient depth ──────────── */}
-          {Object.entries(ERA_RANGES).map(([era, [start, end]]) => {
-            const x1 = yearToX(start);
-            const x2 = yearToX(end);
-            const eraColor = eras[era] ?? base.bgSurface;
-            return (
-              <G key={era}>
-                <Rect x={x1} y={ERA_BAR_Y} width={x2 - x1} height={ERA_BAR_H}
-                  fill={`url(#grad-${era})`} />
-                {/* Bottom accent border */}
-                <Line x1={x1} y1={ERA_BAR_Y + ERA_BAR_H} x2={x2} y2={ERA_BAR_Y + ERA_BAR_H}
-                  stroke={lighten(eraColor, 0.4)} strokeWidth={1} opacity={0.5} />
-                {/* Text shadow */}
-                {/* overlay-color: intentional — text shadow for era labels */}
-                <SvgText x={(x1 + x2) / 2 + 1} y={ERA_BAR_Y + 27} textAnchor="middle"
-                  fontSize={11} fill="#000" opacity={0.5} fontFamily="Cinzel_400Regular">
-                  {(eraNames[era] ?? era).toUpperCase()}
-                </SvgText>
-                {/* Era label */}
-                <SvgText x={(x1 + x2) / 2} y={ERA_BAR_Y + 26} textAnchor="middle"
-                  fontSize={11} fill={base.text} fontFamily="Cinzel_400Regular">
-                  {(eraNames[era] ?? era).toUpperCase()}
-                </SvgText>
-              </G>
-            );
-          })}
+      {/* Category toggles */}
+      <View style={styles.categoryRow}>
+        {(
+          [
+            { key: 'event' as const, label: 'Events' },
+            { key: 'book' as const, label: 'Books' },
+            { key: 'person' as const, label: 'People' },
+            { key: 'world' as const, label: 'World History' },
+          ]
+        ).map(({ key, label }) => (
+          <TouchableOpacity
+            key={key}
+            onPress={() => dispatchFilter({ type: 'toggle', category: key })}
+            hitSlop={{ top: 6, bottom: 6, left: 4, right: 4 }}
+            accessibilityRole="button"
+            accessibilityLabel={`${label} filter: ${filters[key] ? 'on' : 'off'}`}
+            accessibilityState={{ selected: filters[key] }}
+            style={[
+              styles.categoryChip,
+              {
+                borderColor: filters[key] ? base.gold + '55' : base.border,
+                opacity: filters[key] ? 1 : 0.5,
+              },
+            ]}
+          >
+            <Text style={[styles.categoryLabel, { color: base.textMuted }]}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
 
-          {/* ── Polished axis line ─────────────────────── */}
-          <Line x1={0} y1={AXIS_Y} x2={TOTAL_WIDTH} y2={AXIS_Y}
-            stroke="url(#axis-grad)" strokeWidth={1.5} />
-
-          {/* ── Tick marks with gold glow ──────────────── */}
-          {ticks.map((tick, i) => (
-            <G key={i}>
-              {/* Gold glow behind major ticks */}
-              {tick.major && (
-                <Line x1={tick.x} y1={AXIS_Y - 8} x2={tick.x} y2={AXIS_Y + 8}
-                  stroke={base.gold} strokeWidth={3} opacity={0.12} />
-              )}
-              <Line x1={tick.x} y1={AXIS_Y - (tick.major ? 7 : 4)} x2={tick.x} y2={AXIS_Y + (tick.major ? 7 : 4)}
-                stroke={timelineSvg.tick} strokeWidth={tick.major ? 1.5 : 0.5} />
-              {tick.major && (
-                <SvgText x={tick.x} y={AXIS_Y + 22} textAnchor="middle" fontSize={10} fill={base.gold}
-                  fontFamily="SourceSans3_400Regular">
-                  {tick.label}
-                </SvgText>
-              )}
-            </G>
-          ))}
-
-          {/* ── Events with visual hierarchy ───────────── */}
-          {filtered.map((evt) => {
-            const catColor = evt.category === 'world' ? categoryColors.world
-              : evt.category === 'person' ? categoryColors.person
-              : evt.category === 'book' ? categoryColors.book
-              : evt.era ? (eras[evt.era] ?? categoryColors.event) : categoryColors.event;
-            const isSelected = selectedEvent?.id === evt.id;
-            const isBook = evt.category === 'book';
-            const isMajor = evt.significance === 'major';
-            const markerR = isMajor ? 6 : 3.5;
-
-            return (
-              <G key={evt.id} onPress={() => handleSelectEvent(evt)}>
-                {/* Hit area */}
-                <Rect x={evt.x - 15} y={evt.y - 15} width={isMajor ? evt.labelWidth : 30} height={30}
-                  fill="transparent" />
-
-                {/* Stem — dashed upper, solid lower */}
-                {evt.y < AXIS_Y ? (
-                  <>
-                    <Line x1={evt.x} y1={evt.y + markerR} x2={evt.x} y2={(evt.y + AXIS_Y) / 2}
-                      stroke={catColor} strokeWidth={0.6} opacity={0.25} strokeDasharray="3,2" />
-                    <Line x1={evt.x} y1={(evt.y + AXIS_Y) / 2} x2={evt.x} y2={AXIS_Y}
-                      stroke={catColor} strokeWidth={0.6} opacity={0.5} />
-                  </>
-                ) : (
-                  <>
-                    <Line x1={evt.x} y1={AXIS_Y} x2={evt.x} y2={(evt.y + AXIS_Y) / 2}
-                      stroke={catColor} strokeWidth={0.6} opacity={0.5} />
-                    <Line x1={evt.x} y1={(evt.y + AXIS_Y) / 2} x2={evt.x} y2={evt.y - markerR}
-                      stroke={catColor} strokeWidth={0.6} opacity={0.25} strokeDasharray="3,2" />
-                  </>
-                )}
-
-                {/* Selection glow */}
-                {isSelected && (
-                  <Circle cx={evt.x} cy={evt.y} r={markerR + 6} fill={base.gold} opacity={0.25} />
-                )}
-
-                {/* Outer glow ring for major events */}
-                {isMajor && !isBook && (
-                  <Circle cx={evt.x} cy={evt.y} r={markerR + 3}
-                    stroke={catColor} strokeWidth={1} fill="none" opacity={0.25} />
-                )}
-
-                {/* Marker */}
-                {isBook ? (
-                  <G>
-                    <Rect x={evt.x - 6} y={evt.y - 7} width={12} height={14} rx={2}
-                      fill={catColor} stroke={lighten(catColor, 0.3)} strokeWidth={0.5} />
-                    {/* Book spine */}
-                    <Line x1={evt.x - 4} y1={evt.y - 6} x2={evt.x - 4} y2={evt.y + 6}
-                      stroke={lighten(catColor, 0.5)} strokeWidth={0.5} opacity={0.6} />
-                  </G>
-                ) : (
-                  <Circle cx={evt.x} cy={evt.y} r={markerR}
-                    fill={catColor} stroke={lighten(catColor, 0.3)} strokeWidth={0.5} />
-                )}
-
-                {/* Label — only for major events or selected */}
-                {(isMajor || isSelected) && (
-                  <SvgText x={evt.x + (isBook ? 10 : markerR + 5)} y={evt.y + 4} fontSize={11}
-                    fill={isSelected ? base.gold : catColor}
-                    fontFamily="SourceSans3_400Regular"
-                    fontWeight={isSelected ? '600' : '400'}>
-                    {evt.name} · {formatYear(evt.year)}
-                  </SvgText>
-                )}
-              </G>
-            );
-          })}
-        </Svg>
-      </ScrollView>
-
-      {/* ── Bottom sheet detail panel ──────────────── */}
-      <BottomSheet
-        ref={sheetRef}
-        index={-1}
-        snapPoints={snapPoints}
-        enablePanDownToClose
-        onClose={handleCloseSheet}
-        backgroundStyle={{
-          backgroundColor: base.bgElevated,
-          borderTopLeftRadius: 16,
-          borderTopRightRadius: 16,
-          borderTopWidth: 1,
-          borderColor: base.border,
+      <FlatList
+        data={visible}
+        keyExtractor={(e) => e.id}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item, index }) => {
+          const eraColor = eraColorFor(item.era);
+          return (
+            <TimelineRow
+              event={item}
+              eraColor={eraColor}
+              isFirst={index === 0}
+              isLast={index === lastIndex}
+              isExpanded={expandedId === item.id}
+              onToggleExpand={() => handleToggleExpand(item.id)}
+              onPersonPress={handlePersonPress}
+              onChapterPress={handleChapterPress}
+            />
+          );
         }}
-        handleIndicatorStyle={{ backgroundColor: base.textMuted, width: 36 }}
-      >
-        <BottomSheetScrollView contentContainerStyle={styles.detailContent}>
-          {selectedEvent && (
-            <>
-              {/* Era accent bar */}
-              {selectedEvent.era && (
-                <View style={[styles.eraAccentBar, { backgroundColor: eras[selectedEvent.era] ?? base.gold }]} />
-              )}
-              {selectedEvent.era && <BadgeChip label={eraNames[selectedEvent.era] ?? selectedEvent.era} color={eras[selectedEvent.era] ?? base.gold} />}
-              {eventImages.length > 0 && <ContentImageGallery images={eventImages} />}
-              <Text style={[styles.detailTitle, { color: base.text }]}>
-                {selectedEvent.name}
-              </Text>
-              <Text style={[styles.detailYear, { color: base.gold }]}>
-                {formatYear(selectedEvent.year)}
-              </Text>
-              {selectedEvent.scripture_ref && (
-                <Text style={[styles.detailRef, { color: base.goldDim }]}>
-                  {selectedEvent.scripture_ref}
-                </Text>
-              )}
-              {selectedEvent.summary && (
-                <Text style={[styles.detailSummary, { color: base.textDim }]}>
-                  {selectedEvent.summary}
-                </Text>
-              )}
-              {selectedEvent.chapter_link && (() => {
-                const match = selectedEvent.chapter_link!.match(/(\w+)\/(\w+)_(\d+)\.html/);
-                if (!match) return null;
-                const bookId = match[2].toLowerCase();
-                const chapterNum = parseInt(match[3], 10);
-                return (
-                  <TouchableOpacity
-                    style={[styles.chapterButton, { backgroundColor: base.gold + '22', borderColor: base.gold + '55' }]}
-                    onPress={() => {
-                      sheetRef.current?.close();
-                      setSelectedEvent(null);
-                      (navigation as any).navigate('ReadTab', {
-                        screen: 'Chapter',
-                        params: { bookId, chapterNum },
-                      });
-                    }}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Go to chapter ${chapterNum}`}
-                  >
-                    <Text style={[styles.chapterButtonText, { color: base.gold }]}>Go to Chapter →</Text>
-                  </TouchableOpacity>
-                );
-              })()}
-            </>
-          )}
-        </BottomSheetScrollView>
-      </BottomSheet>
+        ListEmptyComponent={
+          <View style={styles.emptyWrap}>
+            <Text style={[styles.emptyText, { color: base.textMuted }]}>
+              No events match the current filters.
+            </Text>
+          </View>
+        }
+      />
     </View>
   );
 }
@@ -423,81 +306,62 @@ const styles = StyleSheet.create({
   loadingPad: {
     padding: spacing.lg,
   },
-  detailContent: {
-    padding: spacing.md,
-  },
-  detailTitle: {
-    fontFamily: fontFamily.displaySemiBold,
-    fontSize: 18,
-    marginTop: spacing.sm,
-  },
-  detailYear: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-    marginTop: 4,
-  },
-  detailRef: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 13,
-    marginTop: 4,
-  },
-  detailSummary: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
-    marginTop: spacing.md,
-  },
-  chapterButton: {
-    marginTop: spacing.md,
-    borderWidth: 1,
-    borderRadius: radii.pill,
+  header: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
-    alignSelf: 'flex-start',
   },
-  chapterButtonText: {
-    fontFamily: fontFamily.uiSemiBold,
-    fontSize: 13,
+  headerTitle: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 22,
+  },
+  headerCount: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
   },
   categoryRow: {
     flexDirection: 'row',
     paddingHorizontal: spacing.sm,
-    paddingBottom: spacing.xs,
+    paddingVertical: spacing.xs,
     gap: spacing.xs,
   },
   categoryChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
     borderWidth: 1,
-    borderRadius: radii.pill,
-    paddingHorizontal: 8,
-    height: 28,
-    opacity: 0.5,
-  },
-  categoryChipActive: {
-    opacity: 1,
-  },
-  categoryDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
+    borderRadius: 14,
+    paddingHorizontal: 10,
+    height: 26,
+    justifyContent: 'center',
   },
   categoryLabel: {
-    fontFamily: fontFamily.display,
+    fontFamily: fontFamily.uiMedium,
     fontSize: 10,
     letterSpacing: 0.3,
   },
-  timelineScroll: {
-    flex: 1,
+  listContent: {
+    paddingHorizontal: spacing.sm,
+    paddingBottom: spacing.xxl,
+    gap: 2,
   },
-  eraAccentBar: {
-    height: 3,
-    borderRadius: 1.5,
-    marginBottom: spacing.md,
-    width: '30%',
-    alignSelf: 'center',
+  row: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: spacing.sm,
+  },
+  rowCard: {
+    flex: 1,
+    minWidth: 0,
+  },
+  emptyWrap: {
+    padding: spacing.lg,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
   },
 });
 
+export { SPINE_GUTTER_WIDTH };
 export default withErrorBoundary(TimelineScreen);

--- a/app/src/screens/TimelineScreen.tsx
+++ b/app/src/screens/TimelineScreen.tsx
@@ -28,6 +28,11 @@ import {
   TimelineEventCard,
   TimelineSpine,
   SPINE_GUTTER_WIDTH,
+  PersonFilterBar,
+  ContemporaryRow,
+  computeContemporaries,
+  EraContextPanel,
+  type Contemporary,
 } from '../components/timeline';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { useTheme, spacing, fontFamily } from '../theme';
@@ -81,6 +86,20 @@ export function filterTimeline(
     if (eraId && e.era !== eraId) return false;
     return true;
   });
+}
+
+/** Whether a given event mentions `personId` in its people_json field. */
+export function eventMatchesPerson(
+  entry: TimelineEntry,
+  personId: string | null,
+): boolean {
+  if (!personId || !entry.people_json) return false;
+  try {
+    const arr = JSON.parse(entry.people_json);
+    return Array.isArray(arr) && arr.includes(personId);
+  } catch {
+    return false;
+  }
 }
 
 function TimelineRow({
@@ -138,8 +157,12 @@ function TimelineScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [eras, setEras] = useState<EraRow[]>([]);
   const [filterEra, setFilterEra] = useState<string | null>(null);
+  const [expandedEraContext, setExpandedEraContext] = useState<string | null>(null);
   const [filters, dispatchFilter] = useReducer(filterReducer, INITIAL_FILTERS);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [personFilter, setPersonFilter] = useState<{ id: string; name: string } | null>(
+    null,
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -173,6 +196,23 @@ function TimelineScreen() {
     [events, filters, filterEra],
   );
 
+  const personMatches = useMemo(() => {
+    if (!personFilter) return new Set<string>();
+    return new Set(
+      visible.filter((e) => eventMatchesPerson(e, personFilter.id)).map((e) => e.id),
+    );
+  }, [visible, personFilter]);
+
+  const contemporaries: Contemporary[] = useMemo(() => {
+    if (!personFilter) return [];
+    return computeContemporaries(events, personFilter.id);
+  }, [events, personFilter]);
+
+  const expandedEra = useMemo(
+    () => eras.find((e) => e.id === expandedEraContext) ?? null,
+    [eras, expandedEraContext],
+  );
+
   const eraColorFor = useCallback(
     (eraId: string | null): string => {
       if (!eraId) return base.gold;
@@ -186,10 +226,28 @@ function TimelineScreen() {
     setExpandedId((prev) => (prev === id ? null : id));
   }, []);
 
-  const handlePersonPress = useCallback(
-    (personId: string) => {
+  const handlePersonPress = useCallback((personId: string) => {
+    setPersonFilter({ id: personId, name: personId });
+  }, []);
+
+  const handleEraStripSelect = useCallback((eraId: string | null) => {
+    setFilterEra(eraId);
+    // Toggle the context panel: opening an era shows its narrative,
+    // re-tapping closes it.
+    setExpandedEraContext((prev) => (prev === eraId || eraId == null ? null : eraId));
+  }, []);
+
+  const handleContextPersonPress = useCallback((personName: string) => {
+    setPersonFilter({ id: personName, name: personName });
+  }, []);
+
+  const handleContextBookPress = useCallback(
+    (book: string) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      navigation.navigate('PersonDetail' as any, { personId } as any);
+      (navigation as any).navigate('ReadTab', {
+        screen: 'ChapterList',
+        params: { bookId: book.toLowerCase().replace(/\s+/g, '_') },
+      });
     },
     [navigation],
   );
@@ -235,8 +293,34 @@ function TimelineScreen() {
         eras={eras}
         eventCounts={eraCounts}
         activeEraId={filterEra}
-        onSelectEra={(eraId) => setFilterEra(eraId)}
+        onSelectEra={handleEraStripSelect}
       />
+
+      {expandedEra ? (
+        <View style={styles.contextWrap}>
+          <EraContextPanel
+            era={expandedEra}
+            onPersonPress={handleContextPersonPress}
+            onBookPress={handleContextBookPress}
+          />
+        </View>
+      ) : null}
+
+      {personFilter ? (
+        <View style={styles.personFilterWrap}>
+          <PersonFilterBar
+            personName={personFilter.name}
+            matchCount={personMatches.size}
+            onDismiss={() => setPersonFilter(null)}
+          />
+          {contemporaries.length > 0 ? (
+            <ContemporaryRow
+              contemporaries={contemporaries}
+              onPress={(id) => setPersonFilter({ id, name: id })}
+            />
+          ) : null}
+        </View>
+      ) : null}
 
       {/* Category toggles */}
       <View style={styles.categoryRow}>
@@ -274,17 +358,20 @@ function TimelineScreen() {
         contentContainerStyle={styles.listContent}
         renderItem={({ item, index }) => {
           const eraColor = eraColorFor(item.era);
+          const dim = personFilter ? !personMatches.has(item.id) : false;
           return (
-            <TimelineRow
-              event={item}
-              eraColor={eraColor}
-              isFirst={index === 0}
-              isLast={index === lastIndex}
-              isExpanded={expandedId === item.id}
-              onToggleExpand={() => handleToggleExpand(item.id)}
-              onPersonPress={handlePersonPress}
-              onChapterPress={handleChapterPress}
-            />
+            <View style={dim ? styles.dimmedRow : null}>
+              <TimelineRow
+                event={item}
+                eraColor={eraColor}
+                isFirst={index === 0}
+                isLast={index === lastIndex}
+                isExpanded={expandedId === item.id}
+                onToggleExpand={() => handleToggleExpand(item.id)}
+                onPersonPress={handlePersonPress}
+                onChapterPress={handleChapterPress}
+              />
+            </View>
           );
         }}
         ListEmptyComponent={
@@ -360,6 +447,18 @@ const styles = StyleSheet.create({
   emptyText: {
     fontFamily: fontFamily.ui,
     fontSize: 12,
+  },
+  contextWrap: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.xs,
+  },
+  personFilterWrap: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.xs,
+    gap: spacing.xs,
+  },
+  dimmedRow: {
+    opacity: 0.15,
   },
 });
 

--- a/app/src/theme/palettes.ts
+++ b/app/src/theme/palettes.ts
@@ -31,6 +31,11 @@ export interface BaseColors {
   danger: string;
   success: string;
   redLetter: string;
+  // ── Subtle section tints (Explore redesign) ───────────────────────
+  tintWarm: string;
+  tintEmber: string;
+  tintParchment: string;
+  tintDusk: string;
 }
 
 export interface ThemePalette {
@@ -71,6 +76,10 @@ const darkBase: BaseColors = {
   danger: '#e05a6a',
   success: '#81C784',
   redLetter: '#d4847a',
+  tintWarm: 'rgba(191,160,80,0.04)',
+  tintEmber: 'rgba(160,100,50,0.05)',
+  tintParchment: 'rgba(180,160,120,0.04)',
+  tintDusk: 'rgba(120,100,80,0.06)',
 };
 
 const sepiaBase: BaseColors = {
@@ -91,6 +100,10 @@ const sepiaBase: BaseColors = {
   danger: '#c04848',
   success: '#4a8a4a',
   redLetter: '#9a3a2a',        // WCAG AA: 5.7:1 on bg
+  tintWarm: 'rgba(136,104,24,0.04)',
+  tintEmber: 'rgba(120,80,40,0.05)',
+  tintParchment: 'rgba(140,120,80,0.04)',
+  tintDusk: 'rgba(100,80,60,0.06)',
 };
 
 const lightBase: BaseColors = {
@@ -111,6 +124,10 @@ const lightBase: BaseColors = {
   danger: '#d04040',
   success: '#388e38',
   redLetter: '#9e3a30',
+  tintWarm: 'rgba(138,106,24,0.03)',
+  tintEmber: 'rgba(120,80,40,0.04)',
+  tintParchment: 'rgba(140,120,80,0.03)',
+  tintDusk: 'rgba(100,80,60,0.04)',
 };
 
 // ── Palette builder ───────────────────────────────────────────────────

--- a/app/src/utils/covenantWaypoints.ts
+++ b/app/src/utils/covenantWaypoints.ts
@@ -1,0 +1,35 @@
+/**
+ * covenantWaypoints.ts — Theological waypoints along the messianic line.
+ *
+ * Each waypoint attaches a 1-line annotation + verse ref to a key figure
+ * on the golden thread. The Genealogy Tree surfaces them as diamond
+ * markers that invite the user to click through to the cited chapter.
+ *
+ * Part of Card #1267 (Genealogy Phase 2).
+ */
+
+export interface CovenantWaypoint {
+  personId: string;
+  text: string;
+  ref: string;
+}
+
+export const COVENANT_WAYPOINTS: readonly CovenantWaypoint[] = [
+  { personId: 'adam', text: 'Seed of the woman promised', ref: 'Gen 3:15' },
+  { personId: 'noah', text: 'Covenant preserved through flood', ref: 'Gen 9:9' },
+  { personId: 'abraham', text: '"In you all nations will be blessed"', ref: 'Gen 12:3' },
+  { personId: 'judah', text: 'The scepter shall not depart', ref: 'Gen 49:10' },
+  { personId: 'david', text: 'Throne established forever', ref: '2 Sam 7:16' },
+  { personId: 'zerubbabel', text: 'Line preserved through exile', ref: 'Hag 2:23' },
+  { personId: 'jesus', text: 'The promise fulfilled', ref: 'Matt 1:1' },
+] as const;
+
+const BY_ID = new Map<string, CovenantWaypoint>(
+  COVENANT_WAYPOINTS.map((w) => [w.personId, w]),
+);
+
+/** Look up a waypoint by personId (or return null). */
+export function getCovenantWaypoint(personId: string | null | undefined): CovenantWaypoint | null {
+  if (!personId) return null;
+  return BY_ID.get(personId) ?? null;
+}

--- a/app/src/utils/genealogyOrganic.ts
+++ b/app/src/utils/genealogyOrganic.ts
@@ -1,0 +1,146 @@
+/**
+ * genealogyOrganic.ts — Pure helpers for the Phase-2 organic layer.
+ *
+ * Cubic Bezier path generation, zoom-semantic tier computation, tribal
+ * bloom layout override, and branch-weight encoding. All helpers are
+ * deterministic and easily unit-tested.
+ *
+ * Part of Card #1267 (Genealogy Phase 2).
+ */
+
+import type { Person } from '../types';
+
+// ── Zoom-semantic tier ────────────────────────────────────────────────
+
+export type PersonTier = 1 | 2 | 3;
+
+/** Visible tier threshold for each zoom level. */
+export const TIER_2_ZOOM = 0.5;
+export const TIER_3_ZOOM = 0.8;
+
+/** Derive the tier for a single person. */
+export function getPersonTier(person: Person, isMessianic: boolean): PersonTier {
+  if (isMessianic) return 1;
+  const role = person.role ?? '';
+  if (['patriarch', 'king', 'prophet', 'judge'].includes(role)) return 1;
+  if (person.bio) return 2;
+  return 3;
+}
+
+/** Map a zoom level to the highest visible tier. */
+export function getVisibleTier(zoom: number): PersonTier {
+  if (zoom > TIER_3_ZOOM) return 3;
+  if (zoom > TIER_2_ZOOM) return 2;
+  return 1;
+}
+
+/** Whether a person at `personTier` should be visible at the current `zoom`. */
+export function isPersonVisibleAtZoom(personTier: PersonTier, zoom: number): boolean {
+  const visible = getVisibleTier(zoom);
+  return personTier <= visible;
+}
+
+// ── Bezier curve path ─────────────────────────────────────────────────
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Generate an SVG cubic Bezier path string from `parent` down to `child`.
+ * Control points are placed at the vertical midpoint, producing a smooth
+ * S-curve for vertical spans and a graceful arc for horizontal ones.
+ */
+export function bezierPath(parent: Point, child: Point): string {
+  const midY = (parent.y + child.y) / 2;
+  return `M ${parent.x} ${parent.y} C ${parent.x} ${midY}, ${child.x} ${midY}, ${child.x} ${child.y}`;
+}
+
+// ── Branch weight encoding ────────────────────────────────────────────
+
+export interface LinkStyle {
+  width: number;
+  /**
+   * Colour key. 'gold' is messianic, 'faint' is non-messianic.
+   * Callers resolve to a palette value.
+   */
+  color: 'gold' | 'faint';
+  /** Decimal opacity (0..1). */
+  opacity: number;
+  /** Whether to apply a glow filter (messianic only). */
+  glow: boolean;
+}
+
+/**
+ * Map a parent/child/messianic-flag combination to visual weight.
+ * Order of precedence: messianic → role-privileged parent → child bio → default.
+ */
+export function getLinkWeight(parent: Person, child: Person, isMessianic: boolean): LinkStyle {
+  if (isMessianic) {
+    return { width: 2.5, color: 'gold', opacity: 0.35, glow: true };
+  }
+  const role = parent.role ?? '';
+  if (['patriarch', 'king'].includes(role)) {
+    return { width: 1.5, color: 'faint', opacity: 0.25, glow: false };
+  }
+  if (child.bio) {
+    return { width: 1.2, color: 'faint', opacity: 0.2, glow: false };
+  }
+  return { width: 0.8, color: 'faint', opacity: 0.12, glow: false };
+}
+
+// ── Tribal bloom layout ───────────────────────────────────────────────
+
+export interface BloomInput {
+  id: string;
+  x: number;
+  y: number;
+  parentId?: string | null;
+}
+
+export interface BloomOutput extends BloomInput {
+  x: number;
+  y: number;
+}
+
+export interface BloomOptions {
+  /** Pixel radius of the fan. */
+  radius?: number;
+  /** Degrees from straight-down at which the fan begins (left side). */
+  startAngleDegrees?: number;
+  /** Degrees from straight-down at which the fan ends (right side). */
+  endAngleDegrees?: number;
+}
+
+/**
+ * Produce a radial "bloom" arrangement for a set of child nodes that
+ * descend from `centerX, centerY`. Children are placed evenly across
+ * the provided angular sweep. Returns new nodes with updated (x, y) —
+ * the input array is not mutated.
+ */
+export function applyTribalBloom(
+  center: Point,
+  children: BloomInput[],
+  options: BloomOptions = {},
+): BloomOutput[] {
+  const { radius = 120, startAngleDegrees = -72, endAngleDegrees = 72 } = options;
+  if (children.length === 0) return [];
+
+  const start = (startAngleDegrees * Math.PI) / 180;
+  const end = (endAngleDegrees * Math.PI) / 180;
+
+  if (children.length === 1) {
+    const [c] = children;
+    return [{ ...c, x: center.x, y: center.y + radius }];
+  }
+
+  return children.map((child, i) => {
+    const t = i / (children.length - 1);
+    const angle = start + (end - start) * t;
+    // Angle 0 points straight down (south). Positive rotates right.
+    const dx = radius * Math.sin(angle);
+    const dy = radius * Math.cos(angle);
+    return { ...child, x: center.x + dx, y: center.y + dy };
+  });
+}

--- a/app/src/utils/messianicLine.ts
+++ b/app/src/utils/messianicLine.ts
@@ -1,0 +1,87 @@
+/**
+ * messianicLine.ts — The 42-generation messianic lineage from Matthew 1.
+ *
+ * Used by the Genealogy Tree to highlight the "golden thread" through the
+ * family tree. Stored as a config constant rather than a DB column so the
+ * list is easy to audit and doesn't require a migration.
+ *
+ * Part of Card #1265 (Genealogy redesign Phase 1).
+ */
+
+/** Person IDs (matching the `people.id` column) that are part of the line to Jesus. */
+export const MESSIANIC_LINE: readonly string[] = [
+  'adam',
+  'seth',
+  'enosh',
+  'kenan',
+  'mahalalel',
+  'jared',
+  'enoch',
+  'methuselah',
+  'lamech',
+  'noah',
+  'shem',
+  'arphaxad',
+  'shelah',
+  'eber',
+  'peleg',
+  'reu',
+  'serug',
+  'nahor',
+  'terah',
+  'abraham',
+  'isaac',
+  'jacob',
+  'judah',
+  'perez',
+  'hezron',
+  'ram',
+  'amminadab',
+  'nahshon',
+  'salmon',
+  'boaz',
+  'obed',
+  'jesse',
+  'david',
+  'solomon',
+  'rehoboam',
+  'abijah',
+  'asa',
+  'jehoshaphat',
+  'jehoram',
+  'uzziah',
+  'jotham',
+  'ahaz',
+  'hezekiah',
+  'manasseh',
+  'amon',
+  'josiah',
+  'jeconiah',
+  'shealtiel',
+  'zerubbabel',
+  'abiud',
+  'eliakim',
+  'azor',
+  'zadok',
+  'akim',
+  'eliud',
+  'eleazar',
+  'matthan',
+  'jacob_nt',
+  'joseph',
+  'jesus',
+] as const;
+
+/** Fast membership check. */
+const SET = new Set(MESSIANIC_LINE);
+
+/** Whether a person id belongs to the messianic line. */
+export function isMessianic(personId: string | null | undefined): boolean {
+  if (!personId) return false;
+  return SET.has(personId);
+}
+
+/** Total number of entries on the messianic line. */
+export function messianicLineLength(): number {
+  return MESSIANIC_LINE.length;
+}


### PR DESCRIPTION
## Summary

Completes the five UI/UX cards in the "Explore + Visual Tools" bundle, each in its own commit so they can be reviewed (and reverted) independently.

### #1263 — Explore screen layout redesign
Varied layouts per section (carousels, split rows, grid, full-bleed hero) with subtle tint tokens and no icons.

- **Palette**: 4 new tint tokens (`tintWarm`, `tintEmber`, `tintParchment`, `tintDusk`) in dark / sepia / light.
- **New components** in `app/src/components/explore/`:
  - `ProphecyChainCard` · `DebatePreviewList` · `WordStudyPreviewList` · `LifeTopicGrid` · `FullWidthImageCard` · `GoldSeparator`
- **FeatureCard** gains a `compact` variant (130 px wide, 72 px image).
- `ExploreMenuScreen` renders each section via a `renderSectionContent()` switch, wiring up all the new pieces.

### #1264 — Timeline Phase 1 (vertical spine)
Replaces the horizontal SVG canvas with a vertical `FlatList` of event cards connected by a glowing spine.

- **New components**: `TimelineEraStrip`, `TimelineEventCard`, `TimelineSpine`
- Drops `@gorhom/bottom-sheet` + `useLandscapeUnlock`; inline accordion replaces the bottom sheet.
- Era colours now come from `getEras().hex`.

### #1265 — Genealogy Phase 1 (golden thread)
Introduces the visual vocabulary for the organic tree without rewriting the d3 layout or gesture system.

- **Messianic line**: `utils/messianicLine.ts` with 42 hard-coded ids + `isMessianic()`.
- **New components**: `RoleBadge`, `SpousePill`, `MessianicLegend`, `PersonDetailCard` (Bio / Family / Journey / Verses tabs, auto-surfaces a Messianic Line pill).
- `GenealogyTreeScreen` renders the legend beneath the era bar.

### #1266 — Timeline Phase 2 (intelligence layer)
Layers person-focused filtering, character overlap lanes, and era context on top of Phase 1.

- **New components**: `PersonFilterBar`, `ContemporaryRow`, `ContemporaryLane`, `EraContextPanel`
- **New pure helpers**: `eventMatchesPerson`, `computeContemporaries`, `splitCommaList`
- Tapping a person pill enters person mode (non-matches dim to 15 %); tapping an era segment toggles a narrative panel that surfaces the previously-unused `narrative` / `key_themes` / `key_people` / `books` columns.

### #1267 — Genealogy Phase 2 (organic layer)
Pure helpers + one new component so `TreeNode`, `TreeLink`, and `useTreeLayout` can adopt incrementally.

- **`utils/covenantWaypoints.ts`** — 7 theological waypoints (Adam → Jesus).
- **`utils/genealogyOrganic.ts`** — `bezierPath`, `getPersonTier`, `getVisibleTier`, `isPersonVisibleAtZoom`, `getLinkWeight`, `applyTribalBloom`.
- **`CovenantMarker`** — diamond + annotation overlay with zoom-gated visibility.

## Tests

Tests were added for every new component (render + interaction + edge cases) plus every new pure helper. CI-relevant checks:

- `npx jest` → **422 suites / 3131 tests, all passing**
- `npx tsc --noEmit` → clean
- Existing `TimelineScreen` / `ExploreMenuScreen` tests were rewritten to match the new interactions.

## Test plan

- [x] Unit tests for every pure helper (bezier path, tier math, era shares, contemporary counts, JSON parsers, etc.)
- [x] Render + interaction tests for every new component
- [x] Integration tests on `TimelineScreen` (person-filter enter/dismiss, era-context open, category toggle, era filter)
- [x] Integration tests on `ExploreMenuScreen` (section rendering across the new layouts)
- [x] `npx tsc --noEmit` passes
- [x] Full `npx jest` run passes

https://claude.ai/code/session_013YtktJoPpzY9rXjtryuG5V