### PR TITLE
Card #1272: Map UX overhaul — place card, search, distance labels, story grid, Google Maps

### DIFF
--- a/app/__tests__/components/PlaceDetailCard.test.tsx
+++ b/app/__tests__/components/PlaceDetailCard.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { PlaceDetailCard, formatCoord } from '@/components/map/PlaceDetailCard';
+import type { Place, MapStory } from '@/types';
+
+function makePlace(overrides: Partial<Place> = {}): Place {
+  return {
+    id: 'jerusalem',
+    ancient_name: 'Jerusalem',
+    modern_name: 'Yerushalayim',
+    latitude: 31.77,
+    longitude: 35.23,
+    type: 'city',
+    priority: 1,
+    label_dir: 'n',
+    ...overrides,
+  };
+}
+
+function makeStory(overrides: Partial<MapStory> = {}): MapStory {
+  return {
+    id: 'davidic-kingdom',
+    era: 'kingdom',
+    name: 'Davidic Kingdom',
+    scripture_ref: '2 Samuel 5',
+    chapter_link: null,
+    summary: 'David takes Jerusalem.',
+    places_json: '["jerusalem"]',
+    regions_json: null,
+    paths_json: null,
+    ...overrides,
+  };
+}
+
+describe('PlaceDetailCard', () => {
+  it('renders ancient and modern names', () => {
+    const { getByText } = renderWithProviders(
+      <PlaceDetailCard place={makePlace()} onClose={jest.fn()} />,
+    );
+    expect(getByText('Jerusalem')).toBeTruthy();
+    expect(getByText('Yerushalayim')).toBeTruthy();
+  });
+
+  it('hides the modern name row when none is provided', () => {
+    const { queryByText } = renderWithProviders(
+      <PlaceDetailCard
+        place={makePlace({ modern_name: null })}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(queryByText('Yerushalayim')).toBeNull();
+  });
+
+  it('renders the type badge label for each known type', () => {
+    const cases: Array<[Place['type'], string]> = [
+      ['city', 'City'],
+      ['mountain', 'Mountain'],
+      ['water', 'Water'],
+      ['region', 'Region'],
+      ['site', 'Site'],
+    ];
+    for (const [type, label] of cases) {
+      const { getByText, unmount } = renderWithProviders(
+        <PlaceDetailCard place={makePlace({ type })} onClose={jest.fn()} />,
+      );
+      expect(getByText(label)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('renders related story chips and invokes onStoryPress', () => {
+    const onStory = jest.fn();
+    const stories = [
+      makeStory({ id: 's1', name: 'Story One' }),
+      makeStory({ id: 's2', name: 'Story Two' }),
+    ];
+    const { getByText } = renderWithProviders(
+      <PlaceDetailCard
+        place={makePlace()}
+        stories={stories}
+        onClose={jest.fn()}
+        onStoryPress={onStory}
+      />,
+    );
+    expect(getByText('Story One')).toBeTruthy();
+    expect(getByText('Story Two')).toBeTruthy();
+    fireEvent.press(getByText('Story Two'));
+    expect(onStory).toHaveBeenCalledWith(stories[1]);
+  });
+
+  it('shows the empty-state message when no stories are linked', () => {
+    const { getByText } = renderWithProviders(
+      <PlaceDetailCard place={makePlace()} stories={[]} onClose={jest.fn()} />,
+    );
+    expect(getByText(/No stories link to this place yet/)).toBeTruthy();
+  });
+
+  it('renders the coordinates footer with N/S/E/W markers', () => {
+    const { getByText } = renderWithProviders(
+      <PlaceDetailCard place={makePlace()} onClose={jest.fn()} />,
+    );
+    expect(getByText(/31\.77° N · 35\.23° E/)).toBeTruthy();
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const onClose = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <PlaceDetailCard place={makePlace()} onClose={onClose} />,
+    );
+    fireEvent.press(getByLabelText('Close place details'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('formatCoord', () => {
+  it('formats positive latitudes as N', () => {
+    expect(formatCoord(31.77, 'lat')).toBe('31.77° N');
+  });
+
+  it('formats negative latitudes as S', () => {
+    expect(formatCoord(-15.5, 'lat')).toBe('15.50° S');
+  });
+
+  it('formats positive longitudes as E', () => {
+    expect(formatCoord(35.23, 'lon')).toBe('35.23° E');
+  });
+
+  it('formats negative longitudes as W', () => {
+    expect(formatCoord(-100.1, 'lon')).toBe('100.10° W');
+  });
+
+  it('always uses 2 decimals', () => {
+    expect(formatCoord(0, 'lat')).toBe('0.00° N');
+  });
+});

--- a/app/__tests__/components/PlaceMarkerList.test.tsx
+++ b/app/__tests__/components/PlaceMarkerList.test.tsx
@@ -78,4 +78,36 @@ describe('PlaceMarkerList', () => {
     // At least the high-priority place should be visible at zoom 5
     expect(getAllByText(/Place \d+/).length).toBeGreaterThanOrEqual(1);
   });
+
+  it('forwards taps to onPlacePress with the matching place', () => {
+    const onPlacePress = jest.fn();
+    const ReactNativeMaps = require('react-native-maps');
+    const Marker = ReactNativeMaps.Marker;
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <PlaceMarkerList
+        places={places}
+        showModern={false}
+        zoomLevel={7}
+        onPlacePress={onPlacePress}
+      />,
+    );
+    const markers = UNSAFE_getAllByType(Marker);
+    expect(markers.length).toBe(3);
+    // Fire the first marker's onPress directly — react-native-maps mocks Marker
+    // as a string element so fireEvent.press doesn't recognise it.
+    markers[0].props.onPress();
+    expect(onPlacePress).toHaveBeenCalledWith(places[0]);
+  });
+
+  it('omits onPress on the marker when no handler is provided', () => {
+    const ReactNativeMaps = require('react-native-maps');
+    const Marker = ReactNativeMaps.Marker;
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <PlaceMarkerList places={places} showModern={false} zoomLevel={7} />,
+    );
+    const markers = UNSAFE_getAllByType(Marker);
+    for (const m of markers) {
+      expect(m.props.onPress).toBeUndefined();
+    }
+  });
 });

--- a/app/__tests__/components/PlaceSearchBar.test.tsx
+++ b/app/__tests__/components/PlaceSearchBar.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { PlaceSearchBar, filterPlaces } from '@/components/map/PlaceSearchBar';
+import type { Place } from '@/types';
+
+function makePlace(overrides: Partial<Place>): Place {
+  return {
+    id: overrides.id ?? 'jerusalem',
+    ancient_name: 'Jerusalem',
+    modern_name: 'Yerushalayim',
+    latitude: 31.77,
+    longitude: 35.23,
+    type: 'city',
+    priority: 1,
+    label_dir: 'n',
+    ...overrides,
+  };
+}
+
+const PLACES: Place[] = [
+  makePlace({ id: 'jerusalem', ancient_name: 'Jerusalem', modern_name: 'Yerushalayim' }),
+  makePlace({ id: 'jericho', ancient_name: 'Jericho', modern_name: 'Ariha' }),
+  makePlace({ id: 'bethlehem', ancient_name: 'Bethlehem', modern_name: 'Beit Lehem' }),
+  makePlace({ id: 'galilee', ancient_name: 'Sea of Galilee', modern_name: null, type: 'water' }),
+];
+
+describe('PlaceSearchBar', () => {
+  it('renders the input and shows no dropdown initially', () => {
+    const { queryByLabelText } = renderWithProviders(
+      <PlaceSearchBar places={PLACES} onSelect={jest.fn()} />,
+    );
+    // No result rows yet — verifies the dropdown stays hidden under the 2-char threshold.
+    expect(queryByLabelText(/Select Jerusalem/)).toBeNull();
+  });
+
+  it('reveals matching places once the query has 2+ characters', async () => {
+    const { getByPlaceholderText, findByLabelText } = renderWithProviders(
+      <PlaceSearchBar places={PLACES} onSelect={jest.fn()} />,
+    );
+    fireEvent.changeText(getByPlaceholderText('Search places...'), 'jer');
+    expect(await findByLabelText('Select Jerusalem')).toBeTruthy();
+    expect(await findByLabelText('Select Jericho')).toBeTruthy();
+  });
+
+  it('calls onSelect with the matching place and clears the query', () => {
+    const onSelect = jest.fn();
+    const { getByPlaceholderText, getByLabelText, queryByLabelText } = renderWithProviders(
+      <PlaceSearchBar places={PLACES} onSelect={onSelect} />,
+    );
+    fireEvent.changeText(getByPlaceholderText('Search places...'), 'beth');
+    fireEvent.press(getByLabelText('Select Bethlehem'));
+    expect(onSelect).toHaveBeenCalledWith(PLACES[2]);
+    // Dropdown closes after selection
+    expect(queryByLabelText(/Select Bethlehem/)).toBeNull();
+  });
+
+  it('matches the modern name as well as the ancient name', async () => {
+    const { getByPlaceholderText, findByLabelText } = renderWithProviders(
+      <PlaceSearchBar places={PLACES} onSelect={jest.fn()} />,
+    );
+    fireEvent.changeText(getByPlaceholderText('Search places...'), 'ari');
+    // "Ariha" is the modern name of Jericho — the row should still surface.
+    expect(await findByLabelText('Select Jericho')).toBeTruthy();
+  });
+});
+
+describe('filterPlaces', () => {
+  it('returns [] for a query under 2 characters', () => {
+    expect(filterPlaces(PLACES, '')).toEqual([]);
+    expect(filterPlaces(PLACES, ' ')).toEqual([]);
+    expect(filterPlaces(PLACES, 'j')).toEqual([]);
+  });
+
+  it('matches the start of an ancient name (case-insensitive)', () => {
+    const out = filterPlaces(PLACES, 'JER');
+    expect(out.map((p) => p.id)).toEqual(['jerusalem', 'jericho']);
+  });
+
+  it('matches the start of a modern name when ancient name does not match', () => {
+    const out = filterPlaces(PLACES, 'beit');
+    expect(out.map((p) => p.id)).toEqual(['bethlehem']);
+  });
+
+  it('caps results at the supplied max', () => {
+    expect(filterPlaces(PLACES, 'j', 8)).toHaveLength(0); // < 2 chars
+    const all = filterPlaces(PLACES, 'je', 1);
+    expect(all).toHaveLength(1);
+  });
+
+  it('skips places where neither name starts with the query', () => {
+    const out = filterPlaces(PLACES, 'galilee');
+    // 'Sea of Galilee' does NOT start with 'galilee' — only "Sea ..." does.
+    expect(out).toHaveLength(0);
+  });
+
+  it('finds water-type places by their ancient_name prefix', () => {
+    const out = filterPlaces(PLACES, 'sea');
+    expect(out.map((p) => p.id)).toEqual(['galilee']);
+  });
+});

--- a/app/__tests__/components/StoryOverlays.test.tsx
+++ b/app/__tests__/components/StoryOverlays.test.tsx
@@ -6,6 +6,16 @@ import type { MapStory } from '@/types';
 jest.mock('@/utils/geoMath', () => ({
   toLatLng: ([lon, lat]: number[]) => ({ latitude: lat, longitude: lon }),
   computeBearing: () => 45,
+  midpoint: (
+    a: { latitude: number; longitude: number },
+    b: { latitude: number; longitude: number },
+  ) => ({
+    latitude: (a.latitude + b.latitude) / 2,
+    longitude: (a.longitude + b.longitude) / 2,
+  }),
+  pathDistance: (coords: { latitude: number; longitude: number }[]) =>
+    // Simple stub: 100 miles per leg so the label renders deterministically.
+    Math.max(0, coords.length - 1) * 100,
 }));
 
 beforeEach(() => jest.clearAllMocks());
@@ -86,5 +96,32 @@ describe('StoryOverlays', () => {
       <StoryOverlays story={story} zoomLevel={7} />,
     );
     expect(toJSON()).toBeNull();
+  });
+
+  it('renders a distance label at zoom >= 5 for paths with >= 2 points', () => {
+    const story: MapStory = {
+      ...baseStory,
+      paths_json: JSON.stringify([
+        { coords: [[35, 31], [36, 32]], dashed: false },
+      ]),
+    };
+    const { getByLabelText } = renderWithProviders(
+      <StoryOverlays story={story} zoomLevel={6} />,
+    );
+    // Stub returns 100 miles per leg (1 leg → 100 mi).
+    expect(getByLabelText('Distance: about 100 miles')).toBeTruthy();
+  });
+
+  it('does not render a distance label below the min zoom', () => {
+    const story: MapStory = {
+      ...baseStory,
+      paths_json: JSON.stringify([
+        { coords: [[35, 31], [36, 32]], dashed: false },
+      ]),
+    };
+    const { queryByLabelText } = renderWithProviders(
+      <StoryOverlays story={story} zoomLevel={4} />,
+    );
+    expect(queryByLabelText(/Distance: about/)).toBeNull();
   });
 });

--- a/app/__tests__/components/StoryPicker.test.tsx
+++ b/app/__tests__/components/StoryPicker.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
-import { StoryPicker } from '@/components/map/StoryPicker';
+import { StoryPicker, placeCount } from '@/components/map/StoryPicker';
 import { renderWithProviders } from '../helpers/renderWithProviders';
-import type { MapStory } from '@/types';
+import type { MapStory, Place } from '@/types';
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -72,5 +72,88 @@ describe('StoryPicker', () => {
     const activeChip = getByText('Abraham Journey');
     expect(activeChip).toBeTruthy();
     expect(getByText('The Exodus')).toBeTruthy();
+  });
+
+  it('exposes a "Browse all stories" toggle', () => {
+    const { getByLabelText } = renderWithProviders(
+      <StoryPicker stories={stories} activeStoryId={null} onSelect={jest.fn()} />,
+    );
+    expect(getByLabelText('Browse all stories')).toBeTruthy();
+  });
+
+  it('expands into the grid when the browse toggle is pressed', () => {
+    const { getByLabelText } = renderWithProviders(
+      <StoryPicker stories={stories} activeStoryId={null} onSelect={jest.fn()} />,
+    );
+    fireEvent.press(getByLabelText('Browse all stories'));
+    // Grid renders an "Open story ..." labelled card for each story.
+    expect(getByLabelText(/Open story Abraham Journey/)).toBeTruthy();
+    expect(getByLabelText(/Open story The Exodus/)).toBeTruthy();
+  });
+
+  it('collapses back to the strip when the close toggle is pressed', () => {
+    const { getByLabelText, queryByLabelText } = renderWithProviders(
+      <StoryPicker stories={stories} activeStoryId={null} onSelect={jest.fn()} />,
+    );
+    fireEvent.press(getByLabelText('Browse all stories'));
+    expect(getByLabelText(/Open story Abraham Journey/)).toBeTruthy();
+    fireEvent.press(getByLabelText('Collapse story browser'));
+    expect(queryByLabelText(/Open story Abraham Journey/)).toBeNull();
+  });
+
+  it('selecting a story from the grid bubbles the id and collapses', () => {
+    const onSelect = jest.fn();
+    const { getByLabelText, queryByLabelText } = renderWithProviders(
+      <StoryPicker stories={stories} activeStoryId={null} onSelect={onSelect} />,
+    );
+    fireEvent.press(getByLabelText('Browse all stories'));
+    fireEvent.press(getByLabelText(/Open story The Exodus/));
+    expect(onSelect).toHaveBeenCalledWith('s2');
+    // Grid closed → no more "Open story" label.
+    expect(queryByLabelText(/Open story Abraham Journey/)).toBeNull();
+  });
+
+  it('shows place counts in the grid when places are provided', () => {
+    const places: Place[] = [
+      {
+        id: 'jerusalem', ancient_name: 'Jerusalem', modern_name: null,
+        latitude: 0, longitude: 0, type: 'city', priority: 1, label_dir: 'n',
+      },
+    ];
+    const enriched: MapStory[] = [
+      { ...stories[0], places_json: '["jerusalem","bethlehem"]' },
+      { ...stories[1], places_json: '["jerusalem"]' },
+    ];
+    const { getByLabelText, getByText } = renderWithProviders(
+      <StoryPicker
+        stories={enriched}
+        activeStoryId={null}
+        onSelect={jest.fn()}
+        places={places}
+      />,
+    );
+    fireEvent.press(getByLabelText('Browse all stories'));
+    expect(getByText('2 places')).toBeTruthy();
+    expect(getByText('1 place')).toBeTruthy();
+  });
+});
+
+describe('placeCount', () => {
+  function story(places_json: string | null): MapStory {
+    return {
+      id: 'x', era: 'patriarchs', name: 'X', scripture_ref: null,
+      chapter_link: null, summary: '', places_json,
+      regions_json: null, paths_json: null,
+    };
+  }
+
+  it('returns 0 for null/empty/malformed JSON', () => {
+    expect(placeCount(story(null))).toBe(0);
+    expect(placeCount(story('not-json'))).toBe(0);
+    expect(placeCount(story(''))).toBe(0);
+  });
+
+  it('returns the array length', () => {
+    expect(placeCount(story('["a","b","c"]'))).toBe(3);
   });
 });

--- a/app/__tests__/screens/MapScreen.test.tsx
+++ b/app/__tests__/screens/MapScreen.test.tsx
@@ -25,9 +25,18 @@ jest.mock('@/stores', () => ({
 
 const mockPlacesData = {
   places: [
-    { id: 'jerusalem', name: 'Jerusalem', modern_name: 'Jerusalem', latitude: 31.77, longitude: 35.23, era: 'monarchy' },
-    { id: 'bethlehem', name: 'Bethlehem', modern_name: 'Bethlehem', latitude: 31.70, longitude: 35.20, era: 'monarchy' },
-    { id: 'nazareth', name: 'Nazareth', modern_name: 'Nazareth', latitude: 32.70, longitude: 35.30, era: 'gospels' },
+    {
+      id: 'jerusalem', ancient_name: 'Jerusalem', modern_name: 'Yerushalayim',
+      latitude: 31.77, longitude: 35.23, type: 'city', priority: 1, label_dir: 'n',
+    },
+    {
+      id: 'bethlehem', ancient_name: 'Bethlehem', modern_name: 'Beit Lehem',
+      latitude: 31.70, longitude: 35.20, type: 'city', priority: 1, label_dir: 'n',
+    },
+    {
+      id: 'nazareth', ancient_name: 'Nazareth', modern_name: 'Nazaret',
+      latitude: 32.70, longitude: 35.30, type: 'city', priority: 1, label_dir: 'n',
+    },
   ],
   isLoading: false,
 };
@@ -119,10 +128,18 @@ jest.mock('@/components/tree/EraFilterBar', () => ({
 jest.mock('@/components/map/PlaceMarkerList', () => ({
   PlaceMarkerList: (props: any) => {
     const React = require('react');
-    const { View, Text } = require('react-native');
+    const { View, TouchableOpacity, Text } = require('react-native');
     return React.createElement(View, { testID: 'place-marker-list' },
       (props.places ?? []).map((p: any) =>
-        React.createElement(Text, { key: p.id, testID: `marker-${p.id}` }, p.name),
+        React.createElement(
+          TouchableOpacity,
+          {
+            key: p.id,
+            testID: `marker-${p.id}`,
+            onPress: () => props.onPlacePress?.(p),
+          },
+          React.createElement(Text, null, p.ancient_name ?? p.name),
+        ),
       ),
     );
   },
@@ -189,6 +206,14 @@ jest.mock('react-native-safe-area-context', () => ({
 
 jest.mock('@/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  safeParse: <T,>(json: string | null | undefined, fallback: T): T => {
+    if (!json) return fallback;
+    try {
+      return JSON.parse(json) as T;
+    } catch {
+      return fallback;
+    }
+  },
 }));
 
 // ── Tests ─────────────────────────────────────────────────────────
@@ -367,5 +392,60 @@ describe('MapScreen', () => {
     );
     fireEvent.press(getByTestId('story-chip-exodus-journey'));
     expect(getByTestId('story-overlays')).toBeTruthy();
+  });
+
+  it('opens the place detail card when a marker is tapped', () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    fireEvent.press(getByTestId('marker-jerusalem'));
+    // Modern name only appears in the PlaceDetailCard, so it's a unique signal.
+    expect(getByText('Yerushalayim')).toBeTruthy();
+    // Coordinate footer is also unique to the card.
+    expect(getByText(/31\.77° N · 35\.23° E/)).toBeTruthy();
+  });
+
+  it('lists related stories on the place detail card', () => {
+    const { getByTestId, getByLabelText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    fireEvent.press(getByTestId('marker-bethlehem'));
+    // Bethlehem appears in the 'nativity' story per mockStoriesData. The
+    // PlaceDetailCard's chip uses an "Open story ..." accessibility label
+    // which is unique versus the chip in the StoryPicker.
+    expect(getByLabelText(/Open story Birth of Jesus/)).toBeTruthy();
+  });
+
+  it('switches from the place card to a story when a related story chip is tapped', () => {
+    const { getByTestId, getByLabelText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    fireEvent.press(getByTestId('marker-bethlehem'));
+    fireEvent.press(getByLabelText(/Open story Birth of Jesus/));
+    // Story panel opens; the place card unmounts (so its labelled chip vanishes).
+    expect(getByTestId('story-panel')).toBeTruthy();
+  });
+
+  it('closes the place detail card when its close button is pressed', () => {
+    const { getByTestId, getByLabelText, queryByText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    fireEvent.press(getByTestId('marker-jerusalem'));
+    expect(queryByText('Yerushalayim')).toBeTruthy();
+    fireEvent.press(getByLabelText('Close place details'));
+    expect(queryByText('Yerushalayim')).toBeNull();
+  });
+
+  it('closes the story panel when a marker is tapped', () => {
+    const { getByTestId, queryByTestId, queryByText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    // Open story panel first
+    fireEvent.press(getByTestId('story-chip-nativity'));
+    expect(getByTestId('story-panel')).toBeTruthy();
+    // Tap a marker — story panel closes, place card opens
+    fireEvent.press(getByTestId('marker-jerusalem'));
+    expect(queryByTestId('story-panel')).toBeNull();
+    expect(queryByText('Yerushalayim')).toBeTruthy();
   });
 });

--- a/app/__tests__/screens/MapScreen.test.tsx
+++ b/app/__tests__/screens/MapScreen.test.tsx
@@ -181,6 +181,26 @@ jest.mock('@/components/map/StoryPanel', () => ({
   },
 }));
 
+jest.mock('@/components/map/PlaceSearchBar', () => ({
+  PlaceSearchBar: (props: any) => {
+    const React = require('react');
+    const { View, TouchableOpacity, Text } = require('react-native');
+    return React.createElement(View, { testID: 'place-search-bar' },
+      (props.places ?? []).map((p: any) =>
+        React.createElement(
+          TouchableOpacity,
+          {
+            key: p.id,
+            testID: `search-result-${p.id}`,
+            onPress: () => props.onSelect?.(p),
+          },
+          React.createElement(Text, null, p.ancient_name),
+        ),
+      ),
+    );
+  },
+}));
+
 jest.mock('@/components/map/FloatingControls', () => ({
   FloatingControls: (props: any) => {
     const React = require('react');
@@ -434,6 +454,21 @@ describe('MapScreen', () => {
     expect(queryByText('Yerushalayim')).toBeTruthy();
     fireEvent.press(getByLabelText('Close place details'));
     expect(queryByText('Yerushalayim')).toBeNull();
+  });
+
+  it('renders the place search bar in the top controls', () => {
+    const { getByTestId } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    expect(getByTestId('place-search-bar')).toBeTruthy();
+  });
+
+  it('opens the place detail card when a search result is selected', () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      <MapScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    fireEvent.press(getByTestId('search-result-jerusalem'));
+    expect(getByText('Yerushalayim')).toBeTruthy();
   });
 
   it('closes the story panel when a marker is tapped', () => {

--- a/app/__tests__/unit/geoMath.test.ts
+++ b/app/__tests__/unit/geoMath.test.ts
@@ -1,4 +1,15 @@
-import { toLatLng, computeBearing, computeBounds, midpoint, zoomFromDelta, maxPriorityForZoom, labelScale, labelOffset } from '../../src/utils/geoMath';
+import {
+  toLatLng,
+  computeBearing,
+  computeBounds,
+  midpoint,
+  zoomFromDelta,
+  maxPriorityForZoom,
+  labelScale,
+  labelOffset,
+  haversineDistance,
+  pathDistance,
+} from '../../src/utils/geoMath';
 
 describe('toLatLng', () => {
   it('flips lon,lat to latitude,longitude', () => {
@@ -108,6 +119,61 @@ describe('zoomFromDelta', () => {
   });
   it('larger delta yields lower zoom', () => {
     expect(zoomFromDelta(10)).toBeLessThan(zoomFromDelta(1));
+  });
+});
+
+describe('haversineDistance', () => {
+  it('returns 0 for identical coordinates', () => {
+    const d = haversineDistance(
+      { latitude: 31.77, longitude: 35.23 },
+      { latitude: 31.77, longitude: 35.23 },
+    );
+    expect(d).toBeCloseTo(0, 5);
+  });
+
+  it('matches the known Jerusalem → Babylon distance (~530–560 mi)', () => {
+    // Jerusalem (31.77, 35.23) → Babylon ruins (32.54, 44.42)
+    const d = haversineDistance(
+      { latitude: 31.77, longitude: 35.23 },
+      { latitude: 32.54, longitude: 44.42 },
+    );
+    expect(d).toBeGreaterThan(530);
+    expect(d).toBeLessThan(580);
+  });
+
+  it('matches the known Jerusalem → Bethlehem distance (~5 mi)', () => {
+    const d = haversineDistance(
+      { latitude: 31.77, longitude: 35.23 },
+      { latitude: 31.70, longitude: 35.20 },
+    );
+    expect(d).toBeGreaterThan(4);
+    expect(d).toBeLessThan(7);
+  });
+
+  it('is symmetric', () => {
+    const a = { latitude: 0, longitude: 0 };
+    const b = { latitude: 5, longitude: 5 };
+    expect(haversineDistance(a, b)).toBeCloseTo(haversineDistance(b, a), 5);
+  });
+});
+
+describe('pathDistance', () => {
+  it('returns 0 for an empty or single-point path', () => {
+    expect(pathDistance([])).toBe(0);
+    expect(pathDistance([{ latitude: 31, longitude: 35 }])).toBe(0);
+  });
+
+  it('sums leg distances along a polyline', () => {
+    const single = haversineDistance(
+      { latitude: 31.77, longitude: 35.23 },
+      { latitude: 31.70, longitude: 35.20 },
+    );
+    const looped = pathDistance([
+      { latitude: 31.77, longitude: 35.23 },
+      { latitude: 31.70, longitude: 35.20 },
+      { latitude: 31.77, longitude: 35.23 },
+    ]);
+    expect(looped).toBeCloseTo(single * 2, 5);
   });
 });
 

--- a/app/__tests__/unit/mapScreenHelpers.test.ts
+++ b/app/__tests__/unit/mapScreenHelpers.test.ts
@@ -30,7 +30,7 @@ jest.mock('react-native-maps', () => {
   };
 });
 
-import { buildPlaceToStoriesMap } from '@/screens/MapScreen';
+import { buildPlaceToStoriesMap, detectGoogleMapsKey } from '@/screens/MapScreen';
 import type { MapStory } from '@/types';
 
 function story(id: string, places: string[]): MapStory {
@@ -74,5 +74,40 @@ describe('buildPlaceToStoriesMap', () => {
     const s3 = story('s3', ['p']);
     const out = buildPlaceToStoriesMap([s1, s2, s3]);
     expect(out.get('p')).toEqual([s1, s2, s3]);
+  });
+});
+
+describe('detectGoogleMapsKey', () => {
+  it('returns null when no key is configured (e.g. Expo Go)', () => {
+    expect(detectGoogleMapsKey({ expoConfig: { version: '1.0.0' } } as any)).toBeNull();
+  });
+
+  it('returns the iOS key when present', () => {
+    const out = detectGoogleMapsKey({
+      expoConfig: { ios: { config: { googleMapsApiKey: 'ios-key' } } },
+    } as any);
+    expect(out).toBe('ios-key');
+  });
+
+  it('falls back to the Android key when iOS key is absent', () => {
+    const out = detectGoogleMapsKey({
+      expoConfig: { android: { config: { googleMaps: { apiKey: 'android-key' } } } },
+    } as any);
+    expect(out).toBe('android-key');
+  });
+
+  it('prefers the iOS key when both are set', () => {
+    const out = detectGoogleMapsKey({
+      expoConfig: {
+        ios: { config: { googleMapsApiKey: 'ios-key' } },
+        android: { config: { googleMaps: { apiKey: 'android-key' } } },
+      },
+    } as any);
+    expect(out).toBe('ios-key');
+  });
+
+  it('returns null when expoConfig is missing entirely', () => {
+    expect(detectGoogleMapsKey({} as any)).toBeNull();
+    expect(detectGoogleMapsKey(null as any)).toBeNull();
   });
 });

--- a/app/__tests__/unit/mapScreenHelpers.test.ts
+++ b/app/__tests__/unit/mapScreenHelpers.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for pure helpers exported from MapScreen.
+ */
+
+// MapScreen transitively imports a few platform modules; mock them out so
+// requiring the screen module is cheap.
+jest.mock('@/stores', () => ({
+  useSettingsStore: Object.assign(
+    (sel: any) => sel({ translation: 'kjv', fontSize: 16 }),
+    { getState: () => ({ markGettingStartedDone: jest.fn() }) },
+  ),
+  useReaderStore: (sel: any) => sel({}),
+}));
+
+jest.mock('@/hooks/usePlaces', () => ({ usePlaces: () => ({ places: [], isLoading: false }) }));
+jest.mock('@/hooks/useMapStories', () => ({ useMapStories: () => ({ stories: [], isLoading: false }) }));
+jest.mock('@/hooks/useMapZoom', () => ({ useMapZoom: () => ({ zoomLevel: 5, onRegionChange: jest.fn() }) }));
+jest.mock('@/hooks/useLandscapeUnlock', () => ({ useLandscapeUnlock: jest.fn() }));
+jest.mock('@/utils/mapStyles', () => ({ ancientMapStyle: [], modernMapStyle: [] }));
+jest.mock('react-native-maps', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: React.forwardRef((props: any, _ref: any) =>
+      React.createElement(View, props, props.children),
+    ),
+    PROVIDER_GOOGLE: 'google',
+    PROVIDER_DEFAULT: undefined,
+  };
+});
+
+import { buildPlaceToStoriesMap } from '@/screens/MapScreen';
+import type { MapStory } from '@/types';
+
+function story(id: string, places: string[]): MapStory {
+  return {
+    id,
+    era: 'patriarchs',
+    name: id,
+    scripture_ref: null,
+    chapter_link: null,
+    summary: '',
+    places_json: JSON.stringify(places),
+    regions_json: null,
+    paths_json: null,
+  };
+}
+
+describe('buildPlaceToStoriesMap', () => {
+  it('returns an empty map for no stories', () => {
+    const out = buildPlaceToStoriesMap([]);
+    expect(out.size).toBe(0);
+  });
+
+  it('indexes stories by every place id they reference', () => {
+    const a = story('a', ['jerusalem', 'bethlehem']);
+    const b = story('b', ['jerusalem']);
+    const out = buildPlaceToStoriesMap([a, b]);
+    expect(out.get('jerusalem')).toEqual([a, b]);
+    expect(out.get('bethlehem')).toEqual([a]);
+  });
+
+  it('skips stories whose places_json is malformed', () => {
+    const ok = story('ok', ['jerusalem']);
+    const bad: MapStory = { ...ok, id: 'bad', places_json: 'not-json' };
+    const out = buildPlaceToStoriesMap([bad, ok]);
+    expect(out.get('jerusalem')).toEqual([ok]);
+  });
+
+  it('preserves story insertion order for each place', () => {
+    const s1 = story('s1', ['p']);
+    const s2 = story('s2', ['p']);
+    const s3 = story('s3', ['p']);
+    const out = buildPlaceToStoriesMap([s1, s2, s3]);
+    expect(out.get('p')).toEqual([s1, s2, s3]);
+  });
+});

--- a/app/src/components/map/PlaceDetailCard.tsx
+++ b/app/src/components/map/PlaceDetailCard.tsx
@@ -1,0 +1,208 @@
+/**
+ * PlaceDetailCard — Bottom-overlay detail card for a tapped place.
+ *
+ * Surfaces the ancient + modern names, type badge, related stories,
+ * and coordinates. Mirrors StoryPanel's card pattern (bgElevated +
+ * top border) but caps at ~30% screen height since there's less to
+ * show.
+ *
+ * Part of Card #1272 Fix 1 (Map UX overhaul).
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { X } from 'lucide-react-native';
+import { BadgeChip } from '../BadgeChip';
+import {
+  useTheme,
+  spacing,
+  radii,
+  eras,
+  eraNames,
+  fontFamily,
+  MIN_TOUCH_TARGET,
+} from '../../theme';
+import { lightImpact } from '../../utils/haptics';
+import type { MapStory, Place } from '../../types';
+
+export interface PlaceDetailCardProps {
+  place: Place;
+  /** Stories whose places_json includes this place. Caller derives once. */
+  stories?: MapStory[];
+  onClose: () => void;
+  onStoryPress?: (story: MapStory) => void;
+}
+
+const TYPE_LABELS: Record<Place['type'], string> = {
+  city: 'City',
+  mountain: 'Mountain',
+  water: 'Water',
+  region: 'Region',
+  site: 'Site',
+};
+
+const TYPE_COLORS: Record<Place['type'], string> = {
+  city: '#d4b483',
+  mountain: '#d4b483',
+  site: '#d4b483',
+  water: '#90c8d8',
+  region: '#b8a070',
+};
+
+/** Format a coordinate to 2 decimals with N/S, E/W suffix. */
+export function formatCoord(value: number, axis: 'lat' | 'lon'): string {
+  const positive = axis === 'lat' ? 'N' : 'E';
+  const negative = axis === 'lat' ? 'S' : 'W';
+  const suffix = value >= 0 ? positive : negative;
+  return `${Math.abs(value).toFixed(2)}° ${suffix}`;
+}
+
+export function PlaceDetailCard({
+  place,
+  stories,
+  onClose,
+  onStoryPress,
+}: PlaceDetailCardProps) {
+  const { base } = useTheme();
+  const typeColor = TYPE_COLORS[place.type] ?? base.gold;
+  const typeLabel = TYPE_LABELS[place.type] ?? place.type;
+  const list = stories ?? [];
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      {/* Top row — type badge + close */}
+      <View style={styles.topRow}>
+        <BadgeChip label={typeLabel} color={typeColor} />
+        <TouchableOpacity
+          onPress={() => {
+            lightImpact();
+            onClose();
+          }}
+          style={styles.closeBtn}
+          accessibilityLabel="Close place details"
+          accessibilityRole="button"
+        >
+          <X size={18} color={base.textMuted} />
+        </TouchableOpacity>
+      </View>
+
+      {/* Ancient name */}
+      <Text style={[styles.name, { color: base.text }]}>{place.ancient_name}</Text>
+
+      {/* Modern name */}
+      {place.modern_name ? (
+        <Text style={[styles.modernName, { color: base.textDim }]}>{place.modern_name}</Text>
+      ) : null}
+
+      <View style={[styles.divider, { backgroundColor: base.border }]} />
+
+      {/* Related stories */}
+      {list.length > 0 ? (
+        <View style={styles.storiesSection}>
+          <Text style={[styles.storiesLabel, { color: base.textMuted }]}>
+            APPEARS IN
+          </Text>
+          <View style={styles.storiesRow}>
+            {list.map((s) => {
+              const eraColor = eras[s.era] ?? base.gold;
+              const eraLabel = eraNames[s.era] ?? s.era;
+              return (
+                <TouchableOpacity
+                  key={s.id}
+                  onPress={() => {
+                    lightImpact();
+                    onStoryPress?.(s);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open story ${s.name}, ${eraLabel} era`}
+                  style={[
+                    styles.storyChip,
+                    { backgroundColor: eraColor + '1A', borderColor: eraColor + '40' },
+                  ]}
+                >
+                  <Text style={[styles.storyChipText, { color: eraColor }]} numberOfLines={1}>
+                    {s.name}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      ) : (
+        <Text style={[styles.empty, { color: base.textMuted }]}>
+          No stories link to this place yet.
+        </Text>
+      )}
+
+      {/* Coordinates footer */}
+      <Text style={[styles.coords, { color: base.textMuted }]}>
+        {formatCoord(place.latitude, 'lat')} · {formatCoord(place.longitude, 'lon')}
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    padding: spacing.md,
+  },
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  closeBtn: {
+    minWidth: MIN_TOUCH_TARGET,
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  name: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 18,
+    marginTop: spacing.sm,
+  },
+  modernName: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    marginTop: 2,
+  },
+  divider: {
+    height: 1,
+    marginVertical: spacing.md,
+  },
+  storiesSection: {
+    gap: spacing.xs,
+  },
+  storiesLabel: {
+    fontFamily: fontFamily.display,
+    fontSize: 10,
+    letterSpacing: 0.5,
+  },
+  storiesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  storyChip: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    maxWidth: '100%',
+  },
+  storyChipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+  empty: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    fontStyle: 'italic',
+  },
+  coords: {
+    marginTop: spacing.md,
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+});

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -16,10 +16,11 @@ interface Props {
   showModern: boolean;
   zoomLevel: number;
   activeStory?: MapStory | null;
+  onPlacePress?: (place: Place) => void;
 }
 
 export const PlaceMarkerList = memo(function PlaceMarkerList({
-  places, showModern, zoomLevel, activeStory,
+  places, showModern, zoomLevel, activeStory, onPlacePress,
 }: Props) {
   const visiblePlaces = useMemo(() => {
     const maxPriority = maxPriorityForZoom(zoomLevel);
@@ -45,6 +46,7 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           coordinate={{ latitude: place.latitude, longitude: place.longitude }}
           tracksViewChanges={false}
           anchor={{ x: 0.5, y: 0.5 }}
+          onPress={onPlacePress ? () => onPlacePress(place) : undefined}
         >
           <PlaceLabel place={place} showModern={showModern} zoomLevel={zoomLevel} />
         </Marker>

--- a/app/src/components/map/PlaceSearchBar.tsx
+++ b/app/src/components/map/PlaceSearchBar.tsx
@@ -1,0 +1,173 @@
+/**
+ * PlaceSearchBar — Search input for finding places on the map.
+ *
+ * Mirrors PersonSearchBar from the genealogy tree. Filters by ancient
+ * AND modern names with a starts-with match (case-insensitive). The
+ * coloured dot in each row encodes the place type, matching the
+ * marker label colour scheme.
+ *
+ * Part of Card #1272 Fix 2 (Map UX overhaul).
+ */
+
+import React, { useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { SearchInput } from '../SearchInput';
+import {
+  useTheme,
+  spacing,
+  radii,
+  fontFamily,
+  MIN_TOUCH_TARGET,
+} from '../../theme';
+import type { Place } from '../../types';
+
+const MAX_RESULTS = 8;
+
+/** Colour of the leading dot in each result row. Mirrors PlaceLabel. */
+const TYPE_COLORS: Record<Place['type'], string> = {
+  city: '#d4b483',
+  mountain: '#d4b483',
+  site: '#d4b483',
+  water: '#90c8d8',
+  region: '#b8a070',
+};
+
+export interface PlaceSearchBarProps {
+  places: Place[];
+  onSelect: (place: Place) => void;
+  /** Override the default 8-result cap (useful for tests). */
+  maxResults?: number;
+}
+
+/** Pure filter so it can be unit-tested without mounting the component. */
+export function filterPlaces(
+  places: Place[],
+  query: string,
+  max = MAX_RESULTS,
+): Place[] {
+  const q = query.trim().toLowerCase();
+  if (q.length < 2) return [];
+  const matches: Place[] = [];
+  for (const p of places) {
+    if (p.ancient_name.toLowerCase().startsWith(q)) {
+      matches.push(p);
+    } else if (p.modern_name && p.modern_name.toLowerCase().startsWith(q)) {
+      matches.push(p);
+    }
+    if (matches.length >= max) break;
+  }
+  return matches;
+}
+
+export function PlaceSearchBar({
+  places,
+  onSelect,
+  maxResults = MAX_RESULTS,
+}: PlaceSearchBarProps) {
+  const { base } = useTheme();
+  const [query, setQuery] = useState('');
+
+  const results = useMemo(
+    () => filterPlaces(places, query, maxResults),
+    [places, query, maxResults],
+  );
+
+  const handleSelect = (place: Place) => {
+    setQuery('');
+    onSelect(place);
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <SearchInput
+        value={query}
+        onChangeText={setQuery}
+        placeholder="Search places..."
+        compact
+      />
+      {results.length > 0 && (
+        <View
+          style={[
+            styles.dropdown,
+            { backgroundColor: base.bgElevated, borderColor: base.border },
+          ]}
+        >
+          {results.map((p) => {
+            const dotColor = TYPE_COLORS[p.type] ?? base.textMuted;
+            return (
+              <TouchableOpacity
+                key={p.id}
+                onPress={() => handleSelect(p)}
+                accessibilityRole="button"
+                accessibilityLabel={`Select ${p.ancient_name}`}
+                style={[
+                  styles.resultRow,
+                  { borderBottomColor: base.border + '40' },
+                ]}
+              >
+                <View style={[styles.typeDot, { backgroundColor: dotColor }]} />
+                <View style={styles.resultInfo}>
+                  <Text
+                    style={[styles.resultName, { color: base.text }]}
+                    numberOfLines={1}
+                  >
+                    {p.ancient_name}
+                  </Text>
+                  {p.modern_name ? (
+                    <Text
+                      style={[styles.resultModern, { color: base.textMuted }]}
+                      numberOfLines={1}
+                    >
+                      {p.modern_name}
+                    </Text>
+                  ) : null}
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    paddingHorizontal: spacing.md,
+    zIndex: 20,
+  },
+  dropdown: {
+    position: 'absolute',
+    top: 36,
+    left: spacing.md,
+    right: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    maxHeight: 300,
+    zIndex: 20,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    minHeight: MIN_TOUCH_TARGET,
+    borderBottomWidth: 1,
+  },
+  typeDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  resultInfo: {
+    flex: 1,
+  },
+  resultName: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  resultModern: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+});

--- a/app/src/components/map/StoryOverlays.tsx
+++ b/app/src/components/map/StoryOverlays.tsx
@@ -6,12 +6,20 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { Polygon, Polyline, Marker } from 'react-native-maps';
-import { toLatLng, computeBearing } from '../../utils/geoMath';
-import { eras } from '../../theme';
+import {
+  toLatLng,
+  computeBearing,
+  midpoint,
+  pathDistance,
+} from '../../utils/geoMath';
+import { useTheme, eras, fontFamily, radii } from '../../theme';
 import type { MapStory } from '../../types';
 import { safeParse } from '../../utils/logger';
+
+/** Min zoom at which path-distance labels render to avoid clutter. */
+export const DISTANCE_LABEL_MIN_ZOOM = 5;
 
 interface Props {
   story: MapStory;
@@ -19,6 +27,7 @@ interface Props {
 }
 
 export const StoryOverlays = memo(function StoryOverlays({ story, zoomLevel }: Props) {
+  const { base } = useTheme();
   const eraColor = eras[story.era] ?? '#bfa050'; // data-color: intentional (fallback)
 
   // Parse regions
@@ -54,6 +63,12 @@ export const StoryOverlays = memo(function StoryOverlays({ story, zoomLevel }: P
       {paths.map((path, i) => {
         const coords = path.coords.map(toLatLng);
         const dashLen = Math.max(3, Math.min(12, zoomLevel));
+        const showDistance =
+          coords.length >= 2 && zoomLevel >= DISTANCE_LABEL_MIN_ZOOM;
+        const distanceMiles = showDistance ? Math.round(pathDistance(coords)) : 0;
+        const labelCoord = showDistance
+          ? midpoint(coords[0], coords[coords.length - 1])
+          : null;
 
         return (
           <React.Fragment key={`p-${i}`}>
@@ -79,6 +94,26 @@ export const StoryOverlays = memo(function StoryOverlays({ story, zoomLevel }: P
                     coords[coords.length - 1]
                   )}
                 />
+              </Marker>
+            )}
+            {/* Distance label at the path midpoint — only shown above min zoom */}
+            {labelCoord && distanceMiles > 0 && (
+              <Marker
+                coordinate={labelCoord}
+                anchor={{ x: 0.5, y: 0.5 }}
+                tracksViewChanges={false}
+              >
+                <View
+                  style={[
+                    styles.distanceBadge,
+                    { backgroundColor: base.bg + 'CC', borderColor: base.border },
+                  ]}
+                  accessibilityLabel={`Distance: about ${distanceMiles} miles`}
+                >
+                  <Text style={[styles.distanceLabel, { color: base.textDim }]}>
+                    ~{distanceMiles} mi
+                  </Text>
+                </View>
               </Marker>
             )}
           </React.Fragment>
@@ -110,5 +145,15 @@ const styles = StyleSheet.create({
     borderBottomWidth: 10,
     borderLeftColor: 'transparent',
     borderRightColor: 'transparent',
+  },
+  distanceBadge: {
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  distanceLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 9,
   },
 });

--- a/app/src/components/map/StoryPicker.tsx
+++ b/app/src/components/map/StoryPicker.tsx
@@ -1,23 +1,67 @@
 /**
- * StoryPicker — Horizontal scrollable strip of story buttons.
+ * StoryPicker — Horizontal scroll strip OR expandable 2-column grid.
+ *
+ * Default state: a single-row scroll of story chips (the original UX).
+ * Tapping the toggle on the right swaps in a vertical 2-column overlay
+ * grid that shows every story with era + place-count metadata. Selecting
+ * a story closes the grid and bubbles the id up.
+ *
+ * Part of Card #1272 Fix 4 (Map UX overhaul).
  */
 
-import React from 'react';
-import { ScrollView, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, eras, fontFamily } from '../../theme';
+import React, { useMemo, useState } from 'react';
+import {
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  View,
+  Dimensions,
+} from 'react-native';
+import { BadgeChip } from '../BadgeChip';
+import {
+  useTheme,
+  spacing,
+  radii,
+  eras,
+  eraNames,
+  fontFamily,
+} from '../../theme';
 import { lightImpact } from '../../utils/haptics';
-import type { MapStory } from '../../types';
+import type { MapStory, Place } from '../../types';
+import { safeParse } from '../../utils/logger';
 
 interface Props {
   stories: MapStory[];
   activeStoryId: string | null;
   onSelect: (storyId: string) => void;
+  /** Optional — when provided, each grid card shows "N places" derived from
+   *  the story's places_json. Strip view ignores it. */
+  places?: Place[];
 }
 
 const CHIP_HEIGHT = 32;
 
-export function StoryPicker({ stories, activeStoryId, onSelect }: Props) {
+/** Count places referenced by a story's `places_json` field. */
+export function placeCount(story: MapStory): number {
+  return safeParse<string[]>(story.places_json, []).length;
+}
+
+export function StoryPicker({ stories, activeStoryId, onSelect, places }: Props) {
   const { base } = useTheme();
+  const [expanded, setExpanded] = useState(false);
+
+  // Reset to the strip whenever the era filter empties the story list.
+  React.useEffect(() => {
+    if (stories.length === 0 && expanded) setExpanded(false);
+  }, [stories.length, expanded]);
+
+  const selectAndCollapse = (id: string) => {
+    lightImpact();
+    setExpanded(false);
+    onSelect(id);
+  };
+
   if (stories.length === 0) {
     return (
       <Text style={[styles.emptyText, { color: base.textMuted }]}>
@@ -26,34 +70,157 @@ export function StoryPicker({ stories, activeStoryId, onSelect }: Props) {
     );
   }
 
+  if (expanded) {
+    return (
+      <StoryGrid
+        stories={stories}
+        activeStoryId={activeStoryId}
+        onSelect={selectAndCollapse}
+        onCollapse={() => setExpanded(false)}
+        places={places}
+      />
+    );
+  }
+
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ paddingHorizontal: spacing.sm, gap: spacing.xs, paddingVertical: spacing.xs }}
+    <View style={styles.stripRow}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.stripContent}
+      >
+        {stories.map((story) => {
+          const isActive = activeStoryId === story.id;
+          const color = eras[story.era] ?? base.gold;
+          return (
+            <TouchableOpacity
+              key={story.id}
+              onPress={() => {
+                lightImpact();
+                onSelect(story.id);
+              }}
+              hitSlop={{ top: 6, bottom: 6, left: 2, right: 2 }}
+              accessibilityRole="button"
+              accessibilityLabel={`${isActive ? 'Selected story: ' : 'Select story: '}${story.name}`}
+              style={[
+                styles.storyChip,
+                {
+                  backgroundColor: isActive ? color + '33' : base.bg + 'EE',
+                  borderColor: isActive ? color : base.gold + '55',
+                },
+              ]}
+            >
+              <Text
+                style={[styles.storyChipText, { color: isActive ? color : base.gold }]}
+              >
+                {story.name}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+      <TouchableOpacity
+        onPress={() => setExpanded(true)}
+        accessibilityRole="button"
+        accessibilityLabel="Browse all stories"
+        style={[
+          styles.expandToggle,
+          { backgroundColor: base.bg + 'EE', borderColor: base.gold + '55' },
+        ]}
+      >
+        <Text style={[styles.expandIcon, { color: base.gold }]}>▴</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+// ── Grid view ──────────────────────────────────────────────────────────
+
+interface GridProps {
+  stories: MapStory[];
+  activeStoryId: string | null;
+  onSelect: (storyId: string) => void;
+  onCollapse: () => void;
+  places?: Place[];
+}
+
+function StoryGrid({ stories, activeStoryId, onSelect, onCollapse, places }: GridProps) {
+  const { base } = useTheme();
+  const screenHeight = Dimensions.get('window').height;
+  const maxHeight = Math.round(screenHeight * 0.6);
+  const placesAvailable = (places?.length ?? 0) > 0;
+
+  return (
+    <View
+      accessibilityLabel="Story browser"
+      style={[
+        styles.gridOverlay,
+        {
+          backgroundColor: base.bgElevated + 'F5',
+          borderColor: base.gold + '40',
+          maxHeight,
+        },
+      ]}
     >
-      {stories.map((story) => {
-        const isActive = activeStoryId === story.id;
-        const color = eras[story.era] ?? base.gold;
-        return (
-          <TouchableOpacity
-            key={story.id}
-            onPress={() => { lightImpact(); onSelect(story.id); }}
-            hitSlop={{ top: 6, bottom: 6, left: 2, right: 2 }}
-            accessibilityRole="button"
-            accessibilityLabel={`${isActive ? 'Selected story: ' : 'Select story: '}${story.name}`}
-            style={[styles.storyChip, {
-              backgroundColor: isActive ? color + '33' : base.bg + 'EE',
-              borderColor: isActive ? color : base.gold + '55',
-            }]}
-          >
-            <Text style={[styles.storyChipText, { color: isActive ? color : base.gold }]}>
-              {story.name}
-            </Text>
-          </TouchableOpacity>
-        );
-      })}
-    </ScrollView>
+      <View style={styles.gridHeader}>
+        <Text style={[styles.gridTitle, { color: base.gold }]}>
+          {stories.length} stor{stories.length === 1 ? 'y' : 'ies'}
+        </Text>
+        <TouchableOpacity
+          onPress={() => {
+            lightImpact();
+            onCollapse();
+          }}
+          hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+          accessibilityRole="button"
+          accessibilityLabel="Collapse story browser"
+          style={[styles.expandToggle, { backgroundColor: 'transparent', borderColor: base.gold + '55' }]}
+        >
+          <Text style={[styles.expandIcon, { color: base.gold }]}>▾</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.gridScroll}>
+        <View style={styles.gridWrap}>
+          {stories.map((story) => {
+            const isActive = activeStoryId === story.id;
+            const color = eras[story.era] ?? base.gold;
+            const eraLabel = eraNames[story.era] ?? story.era;
+            const count = placesAvailable ? placeCount(story) : null;
+            return (
+              <TouchableOpacity
+                key={story.id}
+                onPress={() => onSelect(story.id)}
+                accessibilityRole="button"
+                accessibilityLabel={`Open story ${story.name}, ${eraLabel} era`}
+                style={[
+                  styles.gridCard,
+                  {
+                    backgroundColor: isActive ? color + '20' : base.bg + 'CC',
+                    borderColor: isActive ? color : base.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[styles.gridName, { color: isActive ? color : base.text }]}
+                  numberOfLines={2}
+                >
+                  {story.name}
+                </Text>
+                <View style={styles.gridMetaRow}>
+                  <BadgeChip label={eraLabel} color={color} />
+                  {count != null ? (
+                    <Text style={[styles.gridCount, { color: base.textMuted }]}>
+                      {count} place{count === 1 ? '' : 's'}
+                    </Text>
+                  ) : null}
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
   );
 }
 
@@ -63,6 +230,19 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.ui,
     textAlign: 'center',
     paddingVertical: spacing.xs,
+  },
+  // ── Strip mode ──
+  stripRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.xs,
+    gap: spacing.xs,
+  },
+  stripContent: {
+    gap: spacing.xs,
+    paddingHorizontal: spacing.xs,
+    flexGrow: 1,
   },
   storyChip: {
     borderWidth: 1,
@@ -75,5 +255,71 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.uiMedium,
     fontSize: 10,
     letterSpacing: 0.3,
+  },
+  expandToggle: {
+    height: CHIP_HEIGHT,
+    minWidth: CHIP_HEIGHT,
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 6,
+  },
+  expandIcon: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+  },
+  // ── Grid mode ──
+  gridOverlay: {
+    borderTopLeftRadius: radii.lg,
+    borderTopRightRadius: radii.lg,
+    borderTopWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+  },
+  gridHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  gridTitle: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  gridScroll: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+  },
+  gridWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  gridCard: {
+    flexBasis: '48%',
+    flexGrow: 1,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: spacing.sm,
+    gap: spacing.xs,
+    minHeight: 64,
+  },
+  gridName: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+  gridMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  gridCount: {
+    fontFamily: fontFamily.ui,
+    fontSize: 9,
   },
 });

--- a/app/src/components/map/index.ts
+++ b/app/src/components/map/index.ts
@@ -2,7 +2,7 @@ export { PlaceLabel } from './PlaceLabel';
 export { PlaceMarkerList } from './PlaceMarkerList';
 export { StoryOverlays } from './StoryOverlays';
 export { StoryPanel } from './StoryPanel';
-export { StoryPicker } from './StoryPicker';
+export { StoryPicker, placeCount } from './StoryPicker';
 export { FloatingControls } from './FloatingControls';
 export { PlaceDetailCard, formatCoord } from './PlaceDetailCard';
 export type { PlaceDetailCardProps } from './PlaceDetailCard';

--- a/app/src/components/map/index.ts
+++ b/app/src/components/map/index.ts
@@ -6,3 +6,5 @@ export { StoryPicker } from './StoryPicker';
 export { FloatingControls } from './FloatingControls';
 export { PlaceDetailCard, formatCoord } from './PlaceDetailCard';
 export type { PlaceDetailCardProps } from './PlaceDetailCard';
+export { PlaceSearchBar, filterPlaces } from './PlaceSearchBar';
+export type { PlaceSearchBarProps } from './PlaceSearchBar';

--- a/app/src/components/map/index.ts
+++ b/app/src/components/map/index.ts
@@ -4,3 +4,5 @@ export { StoryOverlays } from './StoryOverlays';
 export { StoryPanel } from './StoryPanel';
 export { StoryPicker } from './StoryPicker';
 export { FloatingControls } from './FloatingControls';
+export { PlaceDetailCard, formatCoord } from './PlaceDetailCard';
+export type { PlaceDetailCardProps } from './PlaceDetailCard';

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -256,6 +256,7 @@ function MapScreen({ route, navigation }: {
         <StoryPicker
           stories={filteredStories}
           activeStoryId={activeStory?.id ?? null}
+          places={places}
           onSelect={(id) => {
             const story = stories.find((s) => s.id === id);
             if (story) {

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -30,14 +30,30 @@ import { PlaceMarkerList } from '../components/map/PlaceMarkerList';
 import { StoryOverlays } from '../components/map/StoryOverlays';
 import { StoryPicker } from '../components/map/StoryPicker';
 import { StoryPanel } from '../components/map/StoryPanel';
+import { PlaceDetailCard } from '../components/map/PlaceDetailCard';
 import { FloatingControls } from '../components/map/FloatingControls';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 
 import { useTheme, spacing } from '../theme';
 import type { MapStory, Place } from '../types';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
-import { logger } from '../utils/logger';
+import { logger, safeParse } from '../utils/logger';
+import { lightImpact } from '../utils/haptics';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+
+/** Build a place-id → stories[] index. Pure helper so it's unit-testable. */
+export function buildPlaceToStoriesMap(stories: MapStory[]): Map<string, MapStory[]> {
+  const map = new Map<string, MapStory[]>();
+  for (const story of stories) {
+    const ids = safeParse<string[]>(story.places_json, []);
+    for (const id of ids) {
+      const list = map.get(id);
+      if (list) list.push(story);
+      else map.set(id, [story]);
+    }
+  }
+  return map;
+}
 
 const INITIAL_REGION = {
   latitude: 30,
@@ -66,6 +82,7 @@ function MapScreen({ route, navigation }: {
   const [activeStory, setActiveStory] = useState<MapStory | null>(null);
   const [showModern, setShowModern] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
+  const [selectedPlace, setSelectedPlace] = useState<Place | null>(null);
 
   // Filter stories by era
   const filteredStories = useMemo(() =>
@@ -73,10 +90,14 @@ function MapScreen({ route, navigation }: {
     [stories, activeEra]
   );
 
+  // Map of placeId → stories that include it (computed once per stories change)
+  const placeToStories = useMemo(() => buildPlaceToStoriesMap(stories), [stories]);
+
   // Select a story → show overlays, fit map bounds, open panel
   const selectStory = useCallback((story: MapStory) => {
     setActiveStory(story);
     setShowPanel(true);
+    setSelectedPlace(null); // story panel and place card share the bottom slot
 
     try {
       const placeIds: string[] = JSON.parse(story.places_json ?? '[]');
@@ -105,6 +126,15 @@ function MapScreen({ route, navigation }: {
       longitudeDelta: 2,
     }, 500);
   }, []);
+
+  // Tap a marker → open detail card + recentre
+  const handlePlacePress = useCallback((place: Place) => {
+    lightImpact();
+    setActiveStory(null);
+    setShowPanel(false);
+    setSelectedPlace(place);
+    panToPlace(place);
+  }, [panToPlace]);
 
   // Deep-link handling — auto-select story/place from route params
   const lastProcessedStory = useRef<string | null>(null);
@@ -143,6 +173,7 @@ function MapScreen({ route, navigation }: {
   // Era filter change — auto-select the first matching story to jump the map
   const handleEraChange = useCallback((era: string) => {
     setActiveEra(era);
+    setSelectedPlace(null); // close any open place detail card
     if (era === 'all') {
       setActiveStory(null);
       setShowPanel(false);
@@ -194,6 +225,7 @@ function MapScreen({ route, navigation }: {
           showModern={showModern}
           zoomLevel={zoomLevel}
           activeStory={activeStory}
+          onPlacePress={handlePlacePress}
         />
         {activeStory && (
           <StoryOverlays story={activeStory} zoomLevel={zoomLevel} />
@@ -252,6 +284,18 @@ function MapScreen({ route, navigation }: {
           />
         </View>
       )}
+
+      {/* Place detail card — shares the bottom slot with the story panel */}
+      {selectedPlace && !showPanel && (
+        <View style={[styles.placeDetailWrap, { backgroundColor: base.bgElevated, borderTopColor: base.border }]}>
+          <PlaceDetailCard
+            place={selectedPlace}
+            stories={placeToStories.get(selectedPlace.id)}
+            onClose={() => setSelectedPlace(null)}
+            onStoryPress={(s) => selectStory(s)}
+          />
+        </View>
+      )}
     </View>
   );
 }
@@ -289,6 +333,15 @@ const styles = StyleSheet.create({
     right: 0,
     borderTopWidth: 1,
     maxHeight: '40%',
+    zIndex: 20,
+  },
+  placeDetailWrap: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    borderTopWidth: 1,
+    maxHeight: '30%',
     zIndex: 20,
   },
 });

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -31,6 +31,7 @@ import { StoryOverlays } from '../components/map/StoryOverlays';
 import { StoryPicker } from '../components/map/StoryPicker';
 import { StoryPanel } from '../components/map/StoryPanel';
 import { PlaceDetailCard } from '../components/map/PlaceDetailCard';
+import { PlaceSearchBar } from '../components/map/PlaceSearchBar';
 import { FloatingControls } from '../components/map/FloatingControls';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 
@@ -232,13 +233,14 @@ function MapScreen({ route, navigation }: {
         )}
       </MapView>
 
-      {/* Era filter — overlaid at top below status bar */}
+      {/* Search bar + era filter — overlaid at top below status bar */}
       <View style={[styles.topControls, { paddingTop: insets.top }]} pointerEvents="box-none">
+        <PlaceSearchBar places={places} onSelect={handlePlacePress} />
         <EraFilterBar activeEra={activeEra} onSelect={handleEraChange} />
       </View>
 
-      {/* Floating controls — offset below era filter */}
-      <View style={[styles.floatingWrap, { top: insets.top + 44 }]} pointerEvents="box-none">
+      {/* Floating controls — offset below the search bar + era filter */}
+      <View style={[styles.floatingWrap, { top: insets.top + 84 }]} pointerEvents="box-none">
         <FloatingControls
           showModern={showModern}
           onToggleNames={() => setShowModern((v) => !v)}

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -11,6 +11,7 @@ import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MapView, { PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
+import Constants from 'expo-constants';
 
 import { usePlaces } from '../hooks/usePlaces';
 import { useMapStories } from '../hooks/useMapStories';
@@ -19,11 +20,25 @@ import { useLandscapeUnlock } from '../hooks/useLandscapeUnlock';
 import { ancientMapStyle, modernMapStyle } from '../utils/mapStyles';
 
 /**
- * Google Maps is only available in custom dev builds, never in Expo Go.
- * Set this to true once you have a working dev build with react-native-maps
- * linked to the Google Maps SDK. Until then, Apple Maps + POI suppression.
+ * Google Maps key auto-detection. The iOS / Android keys are injected by
+ * `app.config.js` when GOOGLE_MAPS_API_KEY is present in the build env.
+ * We use the presence of either platform key as the signal that this build
+ * has the Google Maps SDK linked. In Expo Go (no key), we fall back to the
+ * default provider (Apple Maps on iOS, OSM-backed terrain elsewhere).
+ *
+ * Exported so unit tests can verify the detection logic.
  */
-const USE_GOOGLE_MAPS = false;
+export function detectGoogleMapsKey(constants: typeof Constants): string | null {
+  const cfg: any = constants?.expoConfig ?? {};
+  return (
+    cfg?.ios?.config?.googleMapsApiKey ??
+    cfg?.android?.config?.googleMaps?.apiKey ??
+    null
+  );
+}
+
+const GOOGLE_MAPS_KEY = detectGoogleMapsKey(Constants);
+const USE_GOOGLE_MAPS = !!GOOGLE_MAPS_KEY;
 
 import { EraFilterBar } from '../components/tree/EraFilterBar';
 import { PlaceMarkerList } from '../components/map/PlaceMarkerList';

--- a/app/src/utils/geoMath.ts
+++ b/app/src/utils/geoMath.ts
@@ -41,6 +41,33 @@ export function midpoint(
   return { latitude: (a.latitude + b.latitude) / 2, longitude: (a.longitude + b.longitude) / 2 };
 }
 
+/** Haversine distance in miles between two coordinates. */
+export function haversineDistance(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number }
+): number {
+  const R = 3959; // Earth radius in miles
+  const dLat = ((b.latitude - a.latitude) * Math.PI) / 180;
+  const dLon = ((b.longitude - a.longitude) * Math.PI) / 180;
+  const lat1 = (a.latitude * Math.PI) / 180;
+  const lat2 = (b.latitude * Math.PI) / 180;
+  const aVal =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(aVal), Math.sqrt(1 - aVal));
+}
+
+/** Sum of haversine distances along a polyline. */
+export function pathDistance(
+  coords: { latitude: number; longitude: number }[]
+): number {
+  let total = 0;
+  for (let i = 1; i < coords.length; i++) {
+    total += haversineDistance(coords[i - 1], coords[i]);
+  }
+  return total;
+}
+
 /** Compute zoom level from latitudeDelta */
 export function zoomFromDelta(latDelta: number): number {
   return Math.max(3, Math.min(16, Math.round(Math.log2(360 / latDelta))));


### PR DESCRIPTION
## Summary

Closes the five biggest interaction gaps on the Biblical World Map vs. Logos / Bible Map / The Map Bible. Each fix is a separate commit so they can be reviewed (and reverted) independently.

### Fix 1 — Place detail card on tap (commit 1)
Tapping a place marker now opens an inline detail card at the bottom of the map (badge type label, ancient name, modern name, related-stories chips, coordinates). The story panel and place card share the bottom slot — opening one closes the other.

- New `PlaceDetailCard` + `formatCoord` helper.
- `PlaceMarkerList` gains an optional `onPlacePress` callback.
- `buildPlaceToStoriesMap()` exported pure helper for the place → stories index.

### Fix 2 — Place search bar (commit 2)
New `PlaceSearchBar` mirrors `PersonSearchBar` from the genealogy tree. Case-insensitive prefix match against ancient AND modern names, 8-result cap. Selecting a result pans the map and opens the detail card from Fix 1.

- New `PlaceSearchBar` + `filterPlaces` pure helper.
- Floating-controls offset bumped to clear the new top bar.

### Fix 3 — Distance labels on journey paths (commit 3)
Adds haversine path-distance computation. Each story polyline now gets a small `~N mi` pill at its midpoint, hidden below zoom 5 to avoid clutter at world view.

- New `haversineDistance` and `pathDistance` in `geoMath.ts`.
- `StoryOverlays` renders the distance marker; exports `DISTANCE_LABEL_MIN_ZOOM`.

### Fix 4 — Story picker grid browse mode (commit 4)
The horizontal strip hides ~25 of the 28 stories under invisible overflow. New toggle swaps the strip for a 2-column grid with era badge + place count per card.

- `StoryPicker` is now stateful; selecting a story collapses the grid.
- Exports `placeCount(story)` helper.

### Fix 5 — Auto-detect Google Maps provider (commit 5)
`USE_GOOGLE_MAPS` was hardcoded to `false`, so the existing parchment-world `ancientMapStyle` never ran. New `detectGoogleMapsKey(Constants)` reads the iOS / Android key injected by `app.config.js` at build time and flips the provider accordingly. Expo Go (no key) falls back gracefully.

## Tests

Every fix ships with new tests. Pure helpers (`buildPlaceToStoriesMap`, `formatCoord`, `filterPlaces`, `haversineDistance`, `pathDistance`, `placeCount`, `detectGoogleMapsKey`) are unit-tested. New components have render + interaction tests. Existing `MapScreen.test.tsx` was extended with marker-tap → detail-card and search-result-tap → detail-card flows.

- `npx jest` → **425 suites / 3186 tests, all passing**
- `npx tsc --noEmit` → clean

## Test plan

- [x] Place tap → card with name, type, modern name, related stories
- [x] Place search → autocomplete filters; selecting pans + opens detail
- [x] Distance labels appear at zoom ≥ 5 with reasonable values (Jerusalem→Babylon ~530-580 mi covered by unit test)
- [x] Story grid expand/collapse + grid-tap selects story
- [x] Google Maps key auto-detected; missing key falls back to default provider
- [x] No regressions in existing flows (story selection, era filter, deep links)
- [x] All new components use `StyleSheet.create`, `useTheme`, `fontFamily` conventions

https://claude.ai/code/session_013YtktJoPpzY9rXjtryuG5V