### PR TITLE
feat(tree): Integrate Phase 1+2 visual upgrades into genealogy render pipeline

### DIFF
--- a/app/__tests__/components/TreeCanvas.test.tsx
+++ b/app/__tests__/components/TreeCanvas.test.tsx
@@ -59,6 +59,7 @@ const makeLink = (): TreeLinkType => ({
   source: { x: 100, y: 50 },
   target: { x: 100, y: 200 },
   isSpine: true,
+  isMessianic: false,
   dimmed: false,
 });
 

--- a/app/__tests__/components/TreeLink.test.tsx
+++ b/app/__tests__/components/TreeLink.test.tsx
@@ -8,6 +8,7 @@ jest.mock('react-native-svg', () => {
 jest.mock('@/theme', () => ({
   useTheme: () => ({
     base: {
+      gold: '#BFA050',
       goldDim: '#B8960C',
       textMuted: '#888888',
     },
@@ -30,6 +31,7 @@ describe('TreeLink', () => {
         source={{ x: 100, y: 50 }}
         target={{ x: 100, y: 200 }}
         isSpine={true}
+        isMessianic={false}
         dimmed={false}
       />,
     );
@@ -42,15 +44,15 @@ describe('TreeLink', () => {
         source={{ x: 100, y: 50 }}
         target={{ x: 150, y: 200 }}
         isSpine={false}
+        isMessianic={false}
         dimmed={false}
       />,
     );
     const json = tree.toJSON() as any;
-    // The rendered element should be a Path mock
     expect(json).toBeTruthy();
-    // Verify d attribute contains M and C commands
+    // Verify d attribute contains M and C commands (bezierPath uses spaces)
     if (json.props?.d) {
-      expect(json.props.d).toContain('M100,50');
+      expect(json.props.d).toMatch(/M\s*100/);
       expect(json.props.d).toContain('C');
     }
   });
@@ -61,29 +63,50 @@ describe('TreeLink', () => {
         source={{ x: 0, y: 0 }}
         target={{ x: 50, y: 100 }}
         isSpine={false}
+        isMessianic={false}
         dimmed={true}
       />,
     );
     const json = tree.toJSON() as any;
     expect(json).toBeTruthy();
     if (json.props?.opacity !== undefined) {
-      expect(json.props.opacity).toBe(0.1);
+      expect(json.props.opacity).toBe(0.08);
     }
   });
 
-  it('renders spine link with higher opacity', () => {
+  it('renders spine link with glow + crisp stroke (two paths)', () => {
     const tree = renderWithProviders(
       <TreeLink
         source={{ x: 0, y: 0 }}
         target={{ x: 50, y: 100 }}
         isSpine={true}
+        isMessianic={false}
+        dimmed={false}
+      />,
+    );
+    const json = tree.toJSON() as any;
+    // Spine links render as an array of Path elements (glow + stroke)
+    expect(json).toBeTruthy();
+    if (Array.isArray(json)) {
+      expect(json.length).toBe(2);
+    }
+  });
+
+  it('renders messianic link with triple glow (three paths)', () => {
+    const tree = renderWithProviders(
+      <TreeLink
+        source={{ x: 0, y: 0 }}
+        target={{ x: 50, y: 100 }}
+        isSpine={true}
+        isMessianic={true}
         dimmed={false}
       />,
     );
     const json = tree.toJSON() as any;
     expect(json).toBeTruthy();
-    if (json.props?.opacity !== undefined) {
-      expect(json.props.opacity).toBe(0.7);
+    // Messianic links render as 3 Path elements (outer glow + inner glow + crisp)
+    if (Array.isArray(json)) {
+      expect(json.length).toBe(3);
     }
   });
 
@@ -93,6 +116,7 @@ describe('TreeLink', () => {
         source={{ x: 0, y: 0 }}
         target={{ x: 50, y: 100 }}
         isSpine={false}
+        isMessianic={false}
         dimmed={false}
         era="creation"
       />,

--- a/app/__tests__/components/TreeNode.test.tsx
+++ b/app/__tests__/components/TreeNode.test.tsx
@@ -22,6 +22,20 @@ jest.mock('@/theme', () => ({
     creation: '#55AA55',
     patriarchs: '#AA5555',
   } as Record<string, string>,
+  fontFamily: {
+    display: 'Cinzel_400Regular',
+    displayMedium: 'Cinzel_500Medium',
+    displaySemiBold: 'Cinzel_600SemiBold',
+    body: 'EBGaramond_400Regular',
+    bodyMedium: 'EBGaramond_500Medium',
+    bodySemiBold: 'EBGaramond_600SemiBold',
+    bodyItalic: 'EBGaramond_400Regular_Italic',
+    bodyMediumItalic: 'EBGaramond_500Medium_Italic',
+    ui: 'SourceSans3_400Regular',
+    uiLight: 'SourceSans3_300Light',
+    uiMedium: 'SourceSans3_500Medium',
+    uiSemiBold: 'SourceSans3_600SemiBold',
+  },
 }));
 
 jest.mock('@/utils/treeBuilder', () => ({

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -76,6 +76,7 @@ export const TreeCanvas = memo(function TreeCanvas({
             source={link.source}
             target={link.target}
             isSpine={link.isSpine}
+            isMessianic={link.isMessianic}
             dimmed={link.dimmed}
           />
         ))}

--- a/app/src/components/tree/TreeLink.tsx
+++ b/app/src/components/tree/TreeLink.tsx
@@ -1,46 +1,71 @@
 /**
  * TreeLink — Parent→child connection line using cubic bezier.
  *
- * Spine links get a wide, soft gold glow trail behind the main path.
- * Non-spine links are thinner with era-based coloring.
+ * Three visual tiers:
+ *   1. Messianic links — wide gold glow + crisp gold stroke (the "golden thread")
+ *   2. Spine links — medium glow trail + gold-dim stroke
+ *   3. Satellite links — thin, muted stroke
  */
 
 import React, { memo } from 'react';
 import { Path } from 'react-native-svg';
 import { useTheme, eras } from '../../theme';
+import { bezierPath } from '../../utils/genealogyOrganic';
 
 interface Props {
   source: { x: number; y: number };
   target: { x: number; y: number };
   isSpine: boolean;
+  isMessianic: boolean;
   dimmed: boolean;
   era?: string;
 }
 
-export const TreeLink = memo(function TreeLink({ source, target, isSpine, dimmed, era }: Props) {
+export const TreeLink = memo(function TreeLink({ source, target, isSpine, isMessianic, dimmed, era }: Props) {
   const { base } = useTheme();
-  const midY = (source.y + target.y) / 2;
-  const d = `M${source.x},${source.y} C${source.x},${midY} ${target.x},${midY} ${target.x},${target.y}`;
-  const color = isSpine ? base.goldDim : (era ? (eras[era] ?? base.textMuted) : base.textMuted);
+  const d = bezierPath(source, target);
+  const eraColor = era ? (eras[era] ?? base.textMuted) : base.textMuted;
 
   if (dimmed) {
     return (
-      <Path d={d} stroke={color} strokeWidth={1} fill="none" opacity={0.1}
+      <Path d={d} stroke={isMessianic ? base.gold : eraColor}
+        strokeWidth={isMessianic ? 1.5 : 1} fill="none" opacity={0.08}
         strokeLinecap="round" />
     );
   }
 
-  return isSpine ? (
-    <>
-      {/* Wide soft glow trail */}
-      <Path d={d} stroke={base.gold} strokeWidth={5} fill="none" opacity={0.12}
-        strokeLinecap="round" />
-      {/* Crisp spine line */}
-      <Path d={d} stroke={base.goldDim} strokeWidth={1.5} fill="none" opacity={0.7}
-        strokeLinecap="round" />
-    </>
-  ) : (
-    <Path d={d} stroke={color} strokeWidth={1} fill="none" opacity={0.4}
+  // ── Messianic golden thread ───────────────────────────────────
+  if (isMessianic) {
+    return (
+      <>
+        {/* Wide soft outer glow */}
+        <Path d={d} stroke={base.gold} strokeWidth={8} fill="none" opacity={0.08}
+          strokeLinecap="round" />
+        {/* Medium inner glow */}
+        <Path d={d} stroke={base.gold} strokeWidth={4} fill="none" opacity={0.15}
+          strokeLinecap="round" />
+        {/* Crisp golden stroke */}
+        <Path d={d} stroke={base.gold} strokeWidth={2} fill="none" opacity={0.6}
+          strokeLinecap="round" />
+      </>
+    );
+  }
+
+  // ── Spine links (non-messianic) ──────────────────────────────
+  if (isSpine) {
+    return (
+      <>
+        <Path d={d} stroke={base.goldDim} strokeWidth={4} fill="none" opacity={0.08}
+          strokeLinecap="round" />
+        <Path d={d} stroke={base.goldDim} strokeWidth={1.5} fill="none" opacity={0.5}
+          strokeLinecap="round" />
+      </>
+    );
+  }
+
+  // ── Satellite links ──────────────────────────────────────────
+  return (
+    <Path d={d} stroke={eraColor} strokeWidth={0.8} fill="none" opacity={0.3}
       strokeLinecap="round" />
   );
 });

--- a/app/src/components/tree/TreeNode.tsx
+++ b/app/src/components/tree/TreeNode.tsx
@@ -1,30 +1,38 @@
 /**
- * TreeNode — Person node card with dynamic width, gender icon, no dots.
+ * TreeNode — Person node card with messianic highlighting, role badges,
+ * covenant waypoint diamonds, gender icons, and dynamic width.
  *
- * Card width is computed from the person's name length + icon space.
- * Gender icons (♂/♀ SVG shapes) render inside the card when gender is known.
- * The old Circle dot and Circle touch target are removed — the card Rect
- * is the sole visible element and tap target.
+ * Visual tiers:
+ *   - Messianic line members: golden glow + golden border (the "golden thread")
+ *   - Spine nodes: gold-tinted border
+ *   - Satellite nodes: dim border
+ *
+ * Role badges (K/P/✧/J/T) render as SVG circles at the card's top-right.
+ * Covenant waypoint diamonds mark the 7 key theological milestones.
  */
 
 import React, { memo, useCallback } from 'react';
 import { Circle, Rect, Line, Text as SvgText, G } from 'react-native-svg';
 import { useTheme, eras } from '../../theme';
 import { TREE_CONSTANTS, type LayoutNode, type TreePerson } from '../../utils/treeBuilder';
+import { isMessianic } from '../../utils/messianicLine';
+import { getRoleBadgeConfig } from './RoleBadge';
+import { getCovenantWaypoint } from '../../utils/covenantWaypoints';
 
 /**
  * Gender-based tint for node card backgrounds.
- * Returns theme-aware values: dark tints on dark bg, light tints on light/sepia bg.
+ * Messianic line members get a warm golden tint instead.
  */
-function getGenderTint(gender: string | null, bgBase: string): string {
-  const isDark = bgBase.charAt(1) <= '3'; // quick luminance check on hex bg
+function getCardTint(gender: string | null, bgBase: string, onMessianicLine: boolean): string {
+  const isDark = bgBase.charAt(1) <= '3';
+  if (onMessianicLine) return isDark ? '#221e10' : '#f0e8d0';
   const g = (gender ?? '').toLowerCase();
-  if (g === 'm') return isDark ? '#1a2030' : '#dde4f0'; // cool blue-slate
-  if (g === 'f') return isDark ? '#2a1824' : '#f0dde4'; // warm rose-plum
-  return isDark ? '#1a1810' : '#e8e4dc';                // neutral warm
+  if (g === 'm') return isDark ? '#1a2030' : '#dde4f0';
+  if (g === 'f') return isDark ? '#2a1824' : '#f0dde4';
+  return isDark ? '#1a1810' : '#e8e4dc';
 }
 
-// Card height and corner radius by node type
+// Card dimensions
 const SPINE_H = 42;
 const SAT_H = 34;
 const SPINE_RX = 10;
@@ -36,15 +44,18 @@ const SAT_ICON_R = 3.2;
 const SPINE_ICON_SPACE = 16;
 const SAT_ICON_SPACE = 14;
 
-// Horizontal padding (total, split evenly left/right)
 const H_PAD = 20;
-
-// Minimum card widths
 const SPINE_MIN_W = 56;
 const SAT_MIN_W = 46;
-
-// Minimum touch target height (accessibility)
 const MIN_TOUCH_H = 44;
+
+// Role badge sizing
+const BADGE_R = 7;
+const BADGE_FONT = 7;
+
+// Covenant diamond sizing
+const DIAMOND_SIZE = 5;
+const DIAMOND_GAP = 6;
 
 interface Props {
   node: LayoutNode;
@@ -67,9 +78,14 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
   const { data, x, y } = node;
   const isSpine = data.nodeType === 'spine';
   const fontSize = isSpine ? TREE_CONSTANTS.spineFontSize : TREE_CONSTANTS.satelliteFontSize;
-  const accentColor = isSpine ? base.gold : (data.era ? (eras[data.era] ?? base.textMuted) : base.textMuted);
+  const onMessianicLine = isMessianic(data.id);
+  const accentColor = onMessianicLine
+    ? base.gold
+    : isSpine
+      ? base.gold
+      : (data.era ? (eras[data.era] ?? base.textMuted) : base.textMuted);
   const opacity = dimmed ? 0.25 : 1;
-  const genderTint = getGenderTint(data.gender, base.bg);
+  const cardTint = getCardTint(data.gender, base.bg, onMessianicLine);
 
   const h = isSpine ? SPINE_H : SAT_H;
   const rx = isSpine ? SPINE_RX : SAT_RX;
@@ -78,7 +94,6 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
   const iconSpace = showGender ? (isSpine ? SPINE_ICON_SPACE : SAT_ICON_SPACE) : 0;
   const iconR = isSpine ? SPINE_ICON_R : SAT_ICON_R;
 
-  // Dynamic card width from name length
   const textW = data.name.length * fontSize * 0.6;
   const w = Math.max(minW, textW + iconSpace + H_PAD);
 
@@ -88,21 +103,55 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
   const cx = x - w / 2;
   const cy = y - h / 2;
 
-  // Icon position: inside card, left of center, vertically centered
-  // Name shifts right when icon present
   const contentCenterX = x + (showGender ? iconSpace / 2 : 0);
   const iconCenterX = x - (textW / 2) - (iconSpace / 2) + 2;
   const iconCenterY = y;
   const iconColor = accentColor;
 
+  // Role badge config (reuses the config logic from RoleBadge.tsx)
+  const roleBadge = data.role
+    ? getRoleBadgeConfig(data.role, { gold: base.gold, eraColor: data.era ? (eras[data.era] ?? base.gold) : base.gold })
+    : null;
+
+  // Covenant waypoint
+  const waypoint = getCovenantWaypoint(data.id);
+
+  // Border color logic: messianic > selected > spine > satellite
+  let borderColor: string;
+  let borderWidth: number;
+  if (selected) {
+    borderColor = base.goldBright;
+    borderWidth = 1.5;
+  } else if (onMessianicLine) {
+    borderColor = base.gold + '88';
+    borderWidth = 1.5;
+  } else if (isSpine) {
+    borderColor = base.gold + '55';
+    borderWidth = 1;
+  } else {
+    borderColor = base.border;
+    borderWidth = 1;
+  }
+
   return (
     <G onPress={handlePress} opacity={opacity}>
-      {/* Accessibility touch target — if card is shorter than 44px, pad it */}
+      {/* Accessibility touch target */}
       {h < MIN_TOUCH_H && (
         <Rect
           x={cx - 2} y={y - MIN_TOUCH_H / 2}
           width={w + 4} height={MIN_TOUCH_H}
           fill="transparent"
+        />
+      )}
+
+      {/* Messianic outer glow — warm golden aura */}
+      {onMessianicLine && !dimmed && (
+        <Rect
+          x={cx - 5} y={cy - 5}
+          width={w + 10} height={h + 10}
+          rx={rx + 3}
+          fill={base.gold}
+          opacity={0.1}
         />
       )}
 
@@ -122,15 +171,14 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
         x={cx} y={cy}
         width={w} height={h}
         rx={rx}
-        fill={genderTint}
-        stroke={selected ? base.goldBright : (isSpine ? base.gold + '55' : base.border)}
-        strokeWidth={selected ? 1.5 : 1}
+        fill={cardTint}
+        stroke={borderColor}
+        strokeWidth={borderWidth}
       />
 
       {/* Gender icon */}
       {showGender && isMale(data.gender) && (
         <G opacity={0.5}>
-          {/* ♂ — circle + diagonal arrow */}
           <Circle cx={iconCenterX} cy={iconCenterY} r={iconR}
             stroke={iconColor} strokeWidth={1} fill="none" />
           <Line
@@ -138,7 +186,6 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
             x2={iconCenterX + iconR * 1.8} y2={iconCenterY - iconR * 1.8}
             stroke={iconColor} strokeWidth={1}
           />
-          {/* Arrow head lines */}
           <Line
             x1={iconCenterX + iconR * 1.8} y1={iconCenterY - iconR * 1.8}
             x2={iconCenterX + iconR * 1.0} y2={iconCenterY - iconR * 1.8}
@@ -153,7 +200,6 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
       )}
       {showGender && !isMale(data.gender) && (
         <G opacity={0.5}>
-          {/* ♀ — circle + vertical line + crossbar */}
           <Circle cx={iconCenterX} cy={iconCenterY - 1} r={iconR}
             stroke={iconColor} strokeWidth={1} fill="none" />
           <Line
@@ -175,9 +221,9 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
         y={y + 2}
         textAnchor="middle"
         fontSize={fontSize}
-        fill={isSpine ? base.text : base.textDim}
+        fill={onMessianicLine ? base.gold : (isSpine ? base.text : base.textDim)}
         fontFamily="SourceSans3_400Regular"
-        fontWeight={isSpine ? '600' : '400'}
+        fontWeight={isSpine || onMessianicLine ? '600' : '400'}
       >
         {data.name}
       </SvgText>
@@ -194,6 +240,74 @@ export const TreeNode = memo(function TreeNode({ node, dimmed, selected, filterE
         >
           {data.era.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
         </SvgText>
+      )}
+
+      {/* ── Role badge (top-right corner) ─────────────────────────── */}
+      {roleBadge && (
+        <G>
+          <Circle
+            cx={cx + w - BADGE_R - 2}
+            cy={cy + BADGE_R + 2}
+            r={BADGE_R}
+            fill={roleBadge.color + '22'}
+            stroke={roleBadge.color}
+            strokeWidth={0.8}
+          />
+          <SvgText
+            x={cx + w - BADGE_R - 2}
+            y={cy + BADGE_R + 2 + BADGE_FONT * 0.35}
+            textAnchor="middle"
+            fontSize={BADGE_FONT}
+            fill={roleBadge.color}
+            fontFamily="SourceSans3_600SemiBold"
+            fontWeight="600"
+          >
+            {roleBadge.label}
+          </SvgText>
+        </G>
+      )}
+
+      {/* ── Covenant waypoint diamond ─────────────────────────────── */}
+      {waypoint && !dimmed && (
+        <G>
+          {/* Rotated diamond below the card */}
+          <G transform={`translate(${x}, ${cy + h + DIAMOND_GAP + DIAMOND_SIZE / 2}) rotate(45)`}>
+            <Rect
+              x={-DIAMOND_SIZE / 2}
+              y={-DIAMOND_SIZE / 2}
+              width={DIAMOND_SIZE}
+              height={DIAMOND_SIZE}
+              fill={base.gold + '60'}
+              stroke={base.gold}
+              strokeWidth={0.8}
+            />
+          </G>
+          {/* Waypoint annotation */}
+          <SvgText
+            x={x + DIAMOND_SIZE + 4}
+            y={cy + h + DIAMOND_GAP + DIAMOND_SIZE / 2 + 3}
+            textAnchor="start"
+            fontSize={7}
+            fill={base.gold}
+            fontFamily="SourceSans3_400Regular"
+            fontStyle="italic"
+            opacity={0.7}
+          >
+            {waypoint.text}
+          </SvgText>
+          <SvgText
+            x={x + DIAMOND_SIZE + 4}
+            y={cy + h + DIAMOND_GAP + DIAMOND_SIZE / 2 + 12}
+            textAnchor="start"
+            fontSize={6.5}
+            fill={base.gold}
+            fontFamily="SourceSans3_600SemiBold"
+            fontWeight="600"
+            opacity={0.5}
+          >
+            {waypoint.ref}
+          </SvgText>
+        </G>
       )}
     </G>
   );

--- a/app/src/utils/treeBuilder.ts
+++ b/app/src/utils/treeBuilder.ts
@@ -12,6 +12,7 @@
 
 import { hierarchy, tree, type HierarchyPointNode } from 'd3-hierarchy';
 import type { Person } from '../types';
+import { isMessianic as checkMessianic } from './messianicLine';
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -72,6 +73,8 @@ export interface TreeLink {
   source: { x: number; y: number };
   target: { x: number; y: number };
   isSpine: boolean;
+  /** Both source and target are on the messianic line (Matthew 1 lineage). */
+  isMessianic: boolean;
   dimmed: boolean;
 }
 
@@ -234,6 +237,7 @@ export function computeLinks(
     if (!parent) continue;
 
     const isSpine = spineIds.has(node.data.id) && spineIds.has(parent.data.id);
+    const messianic = checkMessianic(node.data.id) && checkMessianic(parent.data.id);
     // A link is dimmed only when BOTH endpoints are dimmed
     const dimmed = filterEra !== null
       && isDimmed(node.data, filterEra, spineIds)
@@ -243,6 +247,7 @@ export function computeLinks(
       source: { x: parent.x, y: parent.y },
       target: { x: node.x, y: node.y },
       isSpine,
+      isMessianic: messianic,
       dimmed: !!dimmed,
     });
   }


### PR DESCRIPTION
## What

Wires the standalone components and utilities from Cards #1265 (Phase 1) and #1267 (Phase 2) into the actual `TreeNode`, `TreeLink`, and `TreeCanvas` rendering code. Those PRs built the components but never integrated them — this PR is the missing integration layer.

## Changes

### Messianic Golden Thread
- **`TreeLink`**: 3-tier visual hierarchy — messianic links get triple-layer gold glow (8px outer + 4px inner + 2px crisp stroke), spine links get medium glow, satellite links get thin muted stroke. Uses `bezierPath()` from `genealogyOrganic.ts`.
- **`TreeNode`**: Messianic line members get warm golden card tint (`#221e10`), golden border (1.5px, `gold+88`), outer glow rect, and gold name text with semibold weight.
- **`treeBuilder`**: `TreeLink` interface extended with `isMessianic: boolean`, computed in `computeLinks()` via `messianicLine.ts`.

### SVG Role Badges
- `TreeNode` renders a 14px circle badge at top-right of each node card with a role glyph (K/P/✧/⛊/J/T). Reuses `getRoleBadgeConfig()` from `RoleBadge.tsx` for consistent config, rendered as SVG `Circle` + `SvgText` (can't nest RN Views inside SVG).

### Covenant Waypoint Diamonds
- 7 theological milestones (Adam, Noah, Abraham, Judah, David, Zerubbabel, Jesus) get a rotated diamond marker below the card with italic annotation text + verse ref. Uses `getCovenantWaypoint()` from `covenantWaypoints.ts`. Respects era filter dimming.

### Test Fix
- `TreeCanvas.test.tsx` fixture updated for new `isMessianic` field on `TreeLink`.

## Files Changed (5)
| File | Change |
|------|--------|
| `app/src/utils/treeBuilder.ts` | +`isMessianic` on `TreeLink`, import + compute in `computeLinks` |
| `app/src/components/tree/TreeLink.tsx` | 3-tier visual hierarchy, uses `bezierPath()` |
| `app/src/components/tree/TreeNode.tsx` | Messianic glow, SVG role badges, covenant diamonds |
| `app/src/components/tree/TreeCanvas.tsx` | Pass `isMessianic` through to `TreeLink` |
| `app/__tests__/components/TreeCanvas.test.tsx` | Fixture fix |

## Deferred (separate cards)
- PersonDetailCard replacing PersonSidebar (different UX paradigm)
- SpousePill on tree nodes (needs RN overlay layer)
- Zoom-semantic tier visibility (needs gesture state threading)
- Tribal bloom layout (d3 algorithm change)