### PR TITLE
Card #1271: Place-import pipeline (OpenBible.info CC BY 4.0) — scripts + schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ _tools/audit/.cache/
 _tools/.env
 _tools/audit/ci_results.json
 .env
--e 
+-e
 # Image staging (downloaded but not committed)
 _tools/art_staging/
+
+# Local-only source data (Card #1271) — see _data/README.md
+_data/openbible/*.jsonl

--- a/_data/README.md
+++ b/_data/README.md
@@ -1,0 +1,27 @@
+# _data/ — Local-only source data
+
+This directory holds raw source data that is **downloaded locally** and
+**not committed to git**. The files are typically too large to track
+and/or belong to upstream datasets that we re-fetch on demand.
+
+## openbible/
+
+- `ancient.jsonl` — ancient-place geocoding data (~11 MB)
+- `modern.jsonl` — modern-place geocoding data (~3 MB)
+
+Source: [openbibleinfo/Bible-Geocoding-Data](https://github.com/openbibleinfo/Bible-Geocoding-Data)
+License: Creative Commons Attribution 4.0
+
+To fetch these files, run:
+
+```bash
+python3 _tools/download_openbible.py
+```
+
+Then import them into `content/meta/places.json`:
+
+```bash
+python3 _tools/import_openbible_places.py
+```
+
+See `_tools/import_openbible_places.py` for full import details.

--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -555,12 +555,19 @@ def populate_places(cur):
     places = _load_json(META / 'places.json')
     count = 0
     for p in places:
+        refs = p.get('refs')
+        refs_json = _json_str(refs) if isinstance(refs, list) else None
+        confidence = p.get('confidence')
+        if not isinstance(confidence, int):
+            confidence = None
         cur.execute(
             'INSERT INTO places (id, ancient_name, modern_name, latitude, longitude, '
-            'type, priority, label_dir) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            'type, priority, label_dir, refs_json, confidence) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             (p['id'], p.get('ancient', ''), p.get('modern'),
              p['lat'], p['lon'], p['type'],
-             p.get('priority', 2), p.get('labelDir', 'n'))
+             p.get('priority', 2), p.get('labelDir', 'n'),
+             refs_json, confidence)
         )
         count += 1
     return count

--- a/_tools/build_sqlite_schema.py
+++ b/_tools/build_sqlite_schema.py
@@ -147,7 +147,9 @@ CREATE TABLE places (
   longitude REAL NOT NULL,
   type TEXT NOT NULL,
   priority INTEGER DEFAULT 2,
-  label_dir TEXT DEFAULT 'n'
+  label_dir TEXT DEFAULT 'n',
+  refs_json TEXT,          -- JSON array of verse-ref strings (Card #1271)
+  confidence INTEGER       -- 1–1000 identification confidence (Card #1271)
 );
 
 CREATE TABLE map_stories (

--- a/_tools/download_openbible.py
+++ b/_tools/download_openbible.py
@@ -1,0 +1,71 @@
+"""download_openbible.py — Fetch OpenBible.info source data for the place import.
+
+Downloads the CC BY 4.0 geocoding JSONL files from
+https://github.com/openbibleinfo/Bible-Geocoding-Data into
+`_data/openbible/`. This script must be run locally — the Claude Code
+container has no egress to raw.githubusercontent.com.
+
+Usage
+-----
+    python3 _tools/download_openbible.py
+
+Outputs
+-------
+    _data/openbible/ancient.jsonl   (~11 MB)
+    _data/openbible/modern.jsonl    (~3 MB)
+
+The files are git-ignored by default (see _data/README.md). Re-run this
+script whenever you need to refresh the source data.
+
+Part of Card #1271 (expand places from 73 to 300+).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+
+
+SOURCE_REPO = 'openbibleinfo/Bible-Geocoding-Data'
+BASE_URL = f'https://raw.githubusercontent.com/{SOURCE_REPO}/main/data'
+FILES = ('ancient.jsonl', 'modern.jsonl')
+
+
+def main() -> int:
+    out_dir = os.path.join(os.path.dirname(__file__), '..', '_data', 'openbible')
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+
+    print(f'Target directory: {out_dir}')
+    downloaded = 0
+    skipped = 0
+
+    for fname in FILES:
+        dest = os.path.join(out_dir, fname)
+        if os.path.exists(dest):
+            size_kb = os.path.getsize(dest) / 1024
+            print(f'  SKIP {fname} (already exists, {size_kb:.0f} KB)')
+            skipped += 1
+            continue
+
+        url = f'{BASE_URL}/{fname}'
+        print(f'  GET {url}')
+        try:
+            urllib.request.urlretrieve(url, dest)
+        except Exception as exc:  # network, HTTP, IO — all fatal
+            print(f'  FAILED {fname}: {exc}', file=sys.stderr)
+            return 1
+        size_kb = os.path.getsize(dest) / 1024
+        print(f'  Saved → {dest} ({size_kb:.0f} KB)')
+        downloaded += 1
+
+    print(
+        f'Done. Downloaded {downloaded}, skipped {skipped}. '
+        'Run `python3 _tools/import_openbible_places.py` next.'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/_tools/import_openbible_places.py
+++ b/_tools/import_openbible_places.py
@@ -1,0 +1,415 @@
+"""import_openbible_places.py — Expand places.json with OpenBible.info data.
+
+Reads `_data/openbible/ancient.jsonl` and `_data/openbible/modern.jsonl`,
+joins them, classifies/scores/filters, and **appends** new rows to
+`content/meta/places.json`. The existing 73 places and their `stories`
+links are preserved exactly — this is an append-only operation.
+
+Usage
+-----
+    # 1. First download the source data locally:
+    python3 _tools/download_openbible.py
+    # 2. Then import:
+    python3 _tools/import_openbible_places.py
+
+Source data license: Creative Commons Attribution 4.0
+See `content/meta/map-stories.json` → `attribution` for user-facing credit.
+
+Part of Card #1271 (expand places from 73 to 300+).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+# ── Config ────────────────────────────────────────────────────────────
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SOURCE_DIR = os.path.join(REPO_ROOT, '_data', 'openbible')
+ANCIENT_JSONL = os.path.join(SOURCE_DIR, 'ancient.jsonl')
+MODERN_JSONL = os.path.join(SOURCE_DIR, 'modern.jsonl')
+PLACES_JSON = os.path.join(REPO_ROOT, 'content', 'meta', 'places.json')
+
+# How many new entries to keep (in addition to the existing 73).
+TARGET_NEW_MIN = 200
+TARGET_NEW_MAX = 300
+
+# Filter thresholds.
+MIN_CONFIDENCE = 100  # out of 1000
+MIN_REF_COUNT = 1
+
+# Duplicate proximity (degrees of lat/lon — ~0.1° ≈ 11 km).
+DUP_PROXIMITY_DEGREES = 0.1
+
+# ── OSIS book map ─────────────────────────────────────────────────────
+
+OSIS_BOOK_MAP: Dict[str, str] = {
+    'Gen': 'Genesis', 'Exod': 'Exodus', 'Lev': 'Leviticus', 'Num': 'Numbers',
+    'Deut': 'Deuteronomy', 'Josh': 'Joshua', 'Judg': 'Judges', 'Ruth': 'Ruth',
+    '1Sam': '1 Samuel', '2Sam': '2 Samuel', '1Kgs': '1 Kings', '2Kgs': '2 Kings',
+    '1Chr': '1 Chronicles', '2Chr': '2 Chronicles', 'Ezra': 'Ezra', 'Neh': 'Nehemiah',
+    'Esth': 'Esther', 'Job': 'Job', 'Ps': 'Psalms', 'Prov': 'Proverbs',
+    'Eccl': 'Ecclesiastes', 'Song': 'Song of Solomon', 'Isa': 'Isaiah',
+    'Jer': 'Jeremiah', 'Lam': 'Lamentations', 'Ezek': 'Ezekiel', 'Dan': 'Daniel',
+    'Hos': 'Hosea', 'Joel': 'Joel', 'Amos': 'Amos', 'Obad': 'Obadiah',
+    'Jonah': 'Jonah', 'Mic': 'Micah', 'Nah': 'Nahum', 'Hab': 'Habakkuk',
+    'Zeph': 'Zephaniah', 'Hag': 'Haggai', 'Zech': 'Zechariah', 'Mal': 'Malachi',
+    'Matt': 'Matthew', 'Mark': 'Mark', 'Luke': 'Luke', 'John': 'John',
+    'Acts': 'Acts', 'Rom': 'Romans', '1Cor': '1 Corinthians', '2Cor': '2 Corinthians',
+    'Gal': 'Galatians', 'Eph': 'Ephesians', 'Phil': 'Philippians', 'Col': 'Colossians',
+    '1Thess': '1 Thessalonians', '2Thess': '2 Thessalonians', '1Tim': '1 Timothy',
+    '2Tim': '2 Timothy', 'Titus': 'Titus', 'Phlm': 'Philemon', 'Heb': 'Hebrews',
+    'Jas': 'James', '1Pet': '1 Peter', '2Pet': '2 Peter', '1John': '1 John',
+    '2John': '2 John', '3John': '3 John', 'Jude': 'Jude', 'Rev': 'Revelation',
+}
+
+DIRS = ('e', 'n', 'w', 's', 'ne', 'nw', 'se', 'sw')
+
+
+# ── Pure helpers (all unit-tested) ────────────────────────────────────
+
+def osis_to_ref(osis: str) -> str:
+    """Convert an OSIS reference to a human-readable form.
+
+    Examples:
+        Gen.12.1     → "Genesis 12:1"
+        2Kgs.5.12    → "2 Kings 5:12"
+        Ps.23        → "Psalms 23"
+        Unknown.1.1  → "Unknown 1:1"   (book kept verbatim)
+    """
+    if not osis:
+        return ''
+    parts = osis.split('.')
+    book = OSIS_BOOK_MAP.get(parts[0], parts[0])
+    if len(parts) >= 3:
+        return f'{book} {parts[1]}:{parts[2]}'
+    if len(parts) == 2:
+        return f'{book} {parts[1]}'
+    return book
+
+
+def classify_type(cls: str, land_or_water: str, ancient_name: str) -> str:
+    """Map OpenBible's class/land-or-water to our `type` enum.
+
+    Returns one of: 'city', 'water', 'mountain', 'region', 'site'.
+    """
+    if land_or_water == 'water':
+        return 'water'
+    if cls == 'natural':
+        name_lower = (ancient_name or '').lower()
+        if any(w in name_lower for w in ('mount', 'hill', 'peak')):
+            return 'mountain'
+        if any(
+            w in name_lower
+            for w in ('valley', 'plain', 'desert', 'wilderness', 'land of', 'region')
+        ):
+            return 'region'
+        return 'site'
+    return 'city'
+
+
+def assign_priority(ref_count: int) -> int:
+    """Map a Bible-reference count to a zoom-priority tier (1 = most important)."""
+    if ref_count >= 50:
+        return 1
+    if ref_count >= 10:
+        return 2
+    if ref_count >= 5:
+        return 3
+    return 4
+
+
+def assign_label_dir(index: int) -> str:
+    """Deterministically rotate label offsets across new places."""
+    return DIRS[index % len(DIRS)]
+
+
+def parse_lonlat(raw: str) -> Optional[Tuple[float, float]]:
+    """Parse the "lon,lat" string used by modern.jsonl.
+
+    Returns (lon, lat) as floats, or None if parsing fails.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    parts = raw.split(',')
+    if len(parts) != 2:
+        return None
+    try:
+        return (float(parts[0].strip()), float(parts[1].strip()))
+    except ValueError:
+        return None
+
+
+def parse_ancient_extra(extra: Any) -> Dict[str, Any]:
+    """Parse the `extra` field — it's a JSON-string INSIDE a JSON object.
+
+    Returns the parsed dict, or {} on any failure. Tolerates when `extra`
+    is already a dict (defensive — some JSONL variants may change format).
+    """
+    if isinstance(extra, dict):
+        return extra
+    if not isinstance(extra, str):
+        return {}
+    try:
+        value = json.loads(extra)
+        return value if isinstance(value, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def make_id(ancient_name: str, existing_ids: Set[str]) -> str:
+    """Slug `ancient_name` into a short, url-friendly id unique to `existing_ids`."""
+    slug = re.sub(r'[^a-z0-9]+', '_', (ancient_name or '').lower()).strip('_')
+    if not slug:
+        slug = 'place'
+    candidate = slug
+    suffix = 2
+    while candidate in existing_ids:
+        candidate = f'{slug}_{suffix}'
+        suffix += 1
+    return candidate
+
+
+def is_duplicate(
+    new_place: Dict[str, Any],
+    existing: Iterable[Dict[str, Any]],
+    threshold_deg: float = DUP_PROXIMITY_DEGREES,
+) -> bool:
+    """Whether `new_place` already exists in `existing` (by name or proximity)."""
+    name_lower = new_place['ancient'].lower()
+    lat = new_place['lat']
+    lon = new_place['lon']
+    for ex in existing:
+        ex_name = (ex.get('ancient') or '').lower()
+        if not ex_name:
+            continue
+        if ex_name == name_lower:
+            return True
+        ex_lat = ex.get('lat')
+        ex_lon = ex.get('lon')
+        if ex_lat is None or ex_lon is None:
+            continue
+        if (
+            abs(ex_lat - lat) < threshold_deg
+            and abs(ex_lon - lon) < threshold_deg
+            and (name_lower in ex_name or ex_name in name_lower)
+        ):
+            return True
+    return False
+
+
+def osises_to_refs(osises: List[str], limit: int = 5) -> List[str]:
+    """Convert up to `limit` OSIS refs to display-form strings, preserving order."""
+    if not osises:
+        return []
+    out: List[str] = []
+    for osis in osises:
+        if not isinstance(osis, str) or not osis:
+            continue
+        out.append(osis_to_ref(osis))
+        if len(out) >= limit:
+            break
+    return out
+
+
+def build_place_entry(
+    ancient: Dict[str, Any],
+    modern: Dict[str, Any],
+    osises: List[str],
+    label_index: int,
+    existing_ids: Set[str],
+) -> Optional[Dict[str, Any]]:
+    """Assemble the final places.json entry from a joined ancient/modern pair.
+
+    Returns None if the pair can't produce a valid entry (missing
+    coordinates, etc.). Mutates `existing_ids` to reserve the newly
+    allocated id.
+    """
+    ancient_name = ancient.get('friendly_id') or ''
+    if not ancient_name:
+        return None
+
+    coords = parse_lonlat(modern.get('lonlat'))
+    if coords is None:
+        return None
+    lon, lat = coords
+
+    refs = osises_to_refs(osises)
+    ref_count = len(osises)
+
+    associations = modern.get('ancient_associations') or {}
+    score_obj = associations.get(ancient.get('id'), {})
+    confidence = score_obj.get('score') if isinstance(score_obj, dict) else None
+    if not isinstance(confidence, (int, float)):
+        confidence = None
+    else:
+        confidence = int(confidence)
+
+    cls = modern.get('class') or ancient.get('identifications', [{}])[0].get('class', '')
+    land_or_water = modern.get('land_or_water') or ''
+    place_type = classify_type(cls, land_or_water, ancient_name)
+
+    new_id = make_id(ancient_name, existing_ids)
+    existing_ids.add(new_id)
+
+    return {
+        'id': new_id,
+        'ancient': ancient_name,
+        'modern': modern.get('friendly_id') or None,
+        'lon': round(lon, 4),
+        'lat': round(lat, 4),
+        'type': place_type,
+        'priority': assign_priority(ref_count),
+        'labelDir': assign_label_dir(label_index),
+        'stories': [],
+        'refs': refs,
+        'confidence': confidence,
+    }
+
+
+# ── IO + join ─────────────────────────────────────────────────────────
+
+def load_jsonl(path: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with open(path, 'r', encoding='utf-8') as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rows.append(json.loads(raw))
+            except ValueError as exc:
+                print(f'WARN {path}:{lineno} — bad JSON ({exc})', file=sys.stderr)
+    return rows
+
+
+def index_modern_by_id(modern_rows: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {row['id']: row for row in modern_rows if 'id' in row}
+
+
+def join_and_filter(
+    ancient_rows: List[Dict[str, Any]],
+    modern_rows: List[Dict[str, Any]],
+    existing_places: List[Dict[str, Any]],
+    *,
+    min_confidence: int = MIN_CONFIDENCE,
+    min_ref_count: int = MIN_REF_COUNT,
+    target_max: int = TARGET_NEW_MAX,
+) -> List[Dict[str, Any]]:
+    """Join ancient ↔ modern, filter, dedup against existing, return new entries.
+
+    Entries are sorted by reference count desc; we take up to `target_max`.
+    The pure logic lives here so it can be exercised from unit tests with
+    small in-memory fixtures.
+    """
+    modern_by_id = index_modern_by_id(modern_rows)
+    existing_ids: Set[str] = {p['id'] for p in existing_places if 'id' in p}
+
+    # (ref_count, entry)
+    candidates: List[Tuple[int, Dict[str, Any]]] = []
+
+    for idx, ancient in enumerate(ancient_rows):
+        identifications = ancient.get('identifications') or []
+        if not identifications:
+            continue
+
+        modern_id = identifications[0].get('id')
+        if not modern_id:
+            continue
+        modern = modern_by_id.get(modern_id)
+        if modern is None:
+            continue
+
+        extra = parse_ancient_extra(ancient.get('extra'))
+        osises = extra.get('osises') or []
+        if not isinstance(osises, list):
+            osises = []
+        if len(osises) < min_ref_count:
+            continue
+
+        entry = build_place_entry(ancient, modern, osises, idx, existing_ids)
+        if entry is None:
+            continue
+
+        if entry['confidence'] is not None and entry['confidence'] < min_confidence:
+            # Claim the id for nothing — release it so we don't block others.
+            existing_ids.discard(entry['id'])
+            continue
+
+        if is_duplicate(entry, existing_places):
+            existing_ids.discard(entry['id'])
+            continue
+
+        candidates.append((len(osises), entry))
+
+    # Sort by reference count desc, stable by insertion order.
+    candidates.sort(key=lambda pair: pair[0], reverse=True)
+
+    # Re-assign `labelDir` after the final sort so rotation feels even on the map.
+    selected: List[Dict[str, Any]] = []
+    for i, (_, entry) in enumerate(candidates[:target_max]):
+        entry['labelDir'] = assign_label_dir(i)
+        selected.append(entry)
+    return selected
+
+
+# ── CLI driver ────────────────────────────────────────────────────────
+
+def _ensure_source_files() -> None:
+    missing = [p for p in (ANCIENT_JSONL, MODERN_JSONL) if not os.path.exists(p)]
+    if not missing:
+        return
+    rel = [os.path.relpath(p, REPO_ROOT) for p in missing]
+    print(
+        'Source JSONL files not found:\n  ' + '\n  '.join(rel) + '\n'
+        'Run `python3 _tools/download_openbible.py` first.',
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    _ensure_source_files()
+
+    print(f'Loading {os.path.relpath(ANCIENT_JSONL, REPO_ROOT)}...')
+    ancient_rows = load_jsonl(ANCIENT_JSONL)
+    print(f'  {len(ancient_rows)} ancient rows')
+
+    print(f'Loading {os.path.relpath(MODERN_JSONL, REPO_ROOT)}...')
+    modern_rows = load_jsonl(MODERN_JSONL)
+    print(f'  {len(modern_rows)} modern rows')
+
+    print(f'Loading {os.path.relpath(PLACES_JSON, REPO_ROOT)}...')
+    with open(PLACES_JSON, 'r', encoding='utf-8') as fh:
+        existing = json.load(fh)
+    print(f'  {len(existing)} existing places')
+
+    new_entries = join_and_filter(ancient_rows, modern_rows, existing)
+    if len(new_entries) < TARGET_NEW_MIN:
+        print(
+            f'WARN: only {len(new_entries)} new entries survived filtering '
+            f'(target {TARGET_NEW_MIN}+). Check thresholds.',
+            file=sys.stderr,
+        )
+
+    combined = existing + new_entries
+
+    # Write back with the same formatting as existing content files.
+    with open(PLACES_JSON, 'w', encoding='utf-8') as fh:
+        json.dump(combined, fh, indent=2, ensure_ascii=False)
+        fh.write('\n')
+
+    print(
+        f'Wrote {len(combined)} total places '
+        f'({len(existing)} existing + {len(new_entries)} new) '
+        f'to {os.path.relpath(PLACES_JSON, REPO_ROOT)}.'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/_tools/test_import_openbible_places.py
+++ b/_tools/test_import_openbible_places.py
@@ -1,0 +1,343 @@
+"""Unit tests for _tools/import_openbible_places.py helpers.
+
+Run locally with either:
+    python3 _tools/test_import_openbible_places.py
+    python3 -m unittest _tools.test_import_openbible_places   # if _tools/__init__.py exists
+
+All tests work on small in-memory fixtures — no source JSONL required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# Allow running as a plain script from the repo root or from _tools/.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from import_openbible_places import (  # type: ignore  # noqa: E402
+    OSIS_BOOK_MAP,
+    assign_label_dir,
+    assign_priority,
+    build_place_entry,
+    classify_type,
+    index_modern_by_id,
+    is_duplicate,
+    join_and_filter,
+    make_id,
+    osis_to_ref,
+    osises_to_refs,
+    parse_ancient_extra,
+    parse_lonlat,
+)
+
+
+# ── osis_to_ref ────────────────────────────────────────────────────────
+
+class OsisToRefTest(unittest.TestCase):
+    def test_three_segment_osis(self):
+        self.assertEqual(osis_to_ref('Gen.12.1'), 'Genesis 12:1')
+        self.assertEqual(osis_to_ref('2Kgs.5.12'), '2 Kings 5:12')
+        self.assertEqual(osis_to_ref('Rev.16.16'), 'Revelation 16:16')
+
+    def test_two_segment_osis(self):
+        self.assertEqual(osis_to_ref('Ps.23'), 'Psalms 23')
+
+    def test_single_segment_osis(self):
+        self.assertEqual(osis_to_ref('Jude'), 'Jude')
+
+    def test_unknown_book_is_passed_through(self):
+        # Foreign keys should round-trip so we don't silently corrupt data.
+        self.assertEqual(osis_to_ref('Unknown.1.1'), 'Unknown 1:1')
+
+    def test_empty_string(self):
+        self.assertEqual(osis_to_ref(''), '')
+
+    def test_every_canonical_book_mapped(self):
+        # Sanity check: the map should cover at least 66 canonical books.
+        self.assertGreaterEqual(len(OSIS_BOOK_MAP), 66)
+
+
+# ── classify_type ──────────────────────────────────────────────────────
+
+class ClassifyTypeTest(unittest.TestCase):
+    def test_water_takes_priority(self):
+        self.assertEqual(classify_type('natural', 'water', 'Sea of Galilee'), 'water')
+        self.assertEqual(classify_type('human', 'water', 'Harbor'), 'water')
+
+    def test_natural_with_mountain_keyword(self):
+        self.assertEqual(classify_type('natural', 'land', 'Mount Sinai'), 'mountain')
+        self.assertEqual(classify_type('natural', 'land', 'Mizar Hill'), 'mountain')
+
+    def test_natural_with_region_keyword(self):
+        self.assertEqual(classify_type('natural', 'land', 'Valley of Hinnom'), 'region')
+        self.assertEqual(classify_type('natural', 'land', 'Land of Goshen'), 'region')
+        self.assertEqual(classify_type('natural', 'land', 'Wilderness of Sin'), 'region')
+
+    def test_natural_fallback_to_site(self):
+        self.assertEqual(classify_type('natural', 'land', 'Rock of Rimmon'), 'site')
+
+    def test_human_is_city(self):
+        self.assertEqual(classify_type('human', 'land', 'Jerusalem'), 'city')
+
+
+# ── assign_priority ────────────────────────────────────────────────────
+
+class AssignPriorityTest(unittest.TestCase):
+    def test_tier_1_for_50_plus(self):
+        self.assertEqual(assign_priority(500), 1)
+        self.assertEqual(assign_priority(50), 1)
+
+    def test_tier_2_for_10_to_49(self):
+        self.assertEqual(assign_priority(49), 2)
+        self.assertEqual(assign_priority(10), 2)
+
+    def test_tier_3_for_5_to_9(self):
+        self.assertEqual(assign_priority(9), 3)
+        self.assertEqual(assign_priority(5), 3)
+
+    def test_tier_4_default(self):
+        self.assertEqual(assign_priority(4), 4)
+        self.assertEqual(assign_priority(0), 4)
+
+
+# ── assign_label_dir ───────────────────────────────────────────────────
+
+class AssignLabelDirTest(unittest.TestCase):
+    def test_rotates_through_dirs(self):
+        seen = {assign_label_dir(i) for i in range(8)}
+        self.assertEqual(seen, {'e', 'n', 'w', 's', 'ne', 'nw', 'se', 'sw'})
+
+    def test_wraps_after_eight(self):
+        self.assertEqual(assign_label_dir(8), assign_label_dir(0))
+
+
+# ── parse_lonlat ───────────────────────────────────────────────────────
+
+class ParseLonLatTest(unittest.TestCase):
+    def test_valid_string(self):
+        self.assertEqual(parse_lonlat('35.2,31.7'), (35.2, 31.7))
+
+    def test_with_whitespace(self):
+        self.assertEqual(parse_lonlat(' 35.2 , 31.7 '), (35.2, 31.7))
+
+    def test_invalid_inputs(self):
+        self.assertIsNone(parse_lonlat(''))
+        self.assertIsNone(parse_lonlat('35.2'))
+        self.assertIsNone(parse_lonlat('a,b'))
+        self.assertIsNone(parse_lonlat(None))  # type: ignore[arg-type]
+
+
+# ── parse_ancient_extra ────────────────────────────────────────────────
+
+class ParseAncientExtraTest(unittest.TestCase):
+    def test_json_string_parsed(self):
+        raw = '{"osises":["Gen.1.1"]}'
+        self.assertEqual(parse_ancient_extra(raw), {'osises': ['Gen.1.1']})
+
+    def test_dict_returned_as_is(self):
+        d = {'osises': ['Gen.1.1']}
+        self.assertEqual(parse_ancient_extra(d), d)
+
+    def test_malformed_json_returns_empty(self):
+        self.assertEqual(parse_ancient_extra('not json'), {})
+
+    def test_non_object_json_returns_empty(self):
+        # A top-level list is valid JSON but not a dict.
+        self.assertEqual(parse_ancient_extra('[1,2,3]'), {})
+
+
+# ── osises_to_refs ─────────────────────────────────────────────────────
+
+class OsisesToRefsTest(unittest.TestCase):
+    def test_limits_output(self):
+        osises = [f'Gen.{i}.1' for i in range(1, 11)]
+        self.assertEqual(len(osises_to_refs(osises, limit=5)), 5)
+
+    def test_preserves_order(self):
+        self.assertEqual(
+            osises_to_refs(['Gen.12.1', 'Exod.3.1']),
+            ['Genesis 12:1', 'Exodus 3:1'],
+        )
+
+    def test_empty_and_none_inputs(self):
+        self.assertEqual(osises_to_refs([]), [])
+        self.assertEqual(osises_to_refs(None), [])  # type: ignore[arg-type]
+
+    def test_skips_non_strings(self):
+        # Defensive: bad data in the source shouldn't crash the import.
+        self.assertEqual(osises_to_refs(['Gen.1.1', None, 42, 'Exod.3.1']), ['Genesis 1:1', 'Exodus 3:1'])  # type: ignore[list-item]
+
+
+# ── make_id ────────────────────────────────────────────────────────────
+
+class MakeIdTest(unittest.TestCase):
+    def test_slugifies_name(self):
+        self.assertEqual(make_id('Jerusalem', set()), 'jerusalem')
+        self.assertEqual(make_id('Abel-beth-maacah', set()), 'abel_beth_maacah')
+        self.assertEqual(make_id("Sea of Galilee", set()), 'sea_of_galilee')
+
+    def test_avoids_collisions(self):
+        existing = {'jerusalem'}
+        self.assertEqual(make_id('Jerusalem', existing), 'jerusalem_2')
+        existing.add('jerusalem_2')
+        self.assertEqual(make_id('Jerusalem', existing), 'jerusalem_3')
+
+    def test_empty_name_falls_back(self):
+        self.assertEqual(make_id('', set()), 'place')
+
+
+# ── is_duplicate ───────────────────────────────────────────────────────
+
+class IsDuplicateTest(unittest.TestCase):
+    def setUp(self):
+        self.existing = [
+            {'id': 'jerusalem', 'ancient': 'Jerusalem', 'lat': 31.77, 'lon': 35.23},
+            {'id': 'bethlehem', 'ancient': 'Bethlehem', 'lat': 31.70, 'lon': 35.20},
+        ]
+
+    def test_exact_name_match(self):
+        new = {'ancient': 'jerusalem', 'lat': 0.0, 'lon': 0.0}
+        self.assertTrue(is_duplicate(new, self.existing))
+
+    def test_close_coords_and_substring_name(self):
+        new = {'ancient': 'Jerusalem (old)', 'lat': 31.78, 'lon': 35.24}
+        self.assertTrue(is_duplicate(new, self.existing))
+
+    def test_different_far_place(self):
+        new = {'ancient': 'Rome', 'lat': 41.9, 'lon': 12.5}
+        self.assertFalse(is_duplicate(new, self.existing))
+
+    def test_same_coords_but_unrelated_name(self):
+        # Same location, but names don't share a substring → not a dup.
+        new = {'ancient': 'Foobar', 'lat': 31.77, 'lon': 35.23}
+        self.assertFalse(is_duplicate(new, self.existing))
+
+
+# ── build_place_entry + join_and_filter (end-to-end on fixtures) ───────
+
+def _ancient(id_: str, name: str, modern_id: str, osises: list[str], cls: str = 'human') -> dict:
+    return {
+        'id': id_,
+        'friendly_id': name,
+        'identifications': [{'id': modern_id, 'id_source': 'modern', 'class': cls}],
+        'extra': '{"osises":%s}' % ('[' + ','.join(f'"{o}"' for o in osises) + ']'),
+    }
+
+
+def _modern(id_: str, name: str, lonlat: str, ancient_id: str, score: int,
+            cls: str = 'human', land_or_water: str = 'land') -> dict:
+    return {
+        'id': id_,
+        'friendly_id': name,
+        'lonlat': lonlat,
+        'class': cls,
+        'type': 'node',
+        'land_or_water': land_or_water,
+        'ancient_associations': {
+            ancient_id: {'name': name, 'score': score, 'url_slug': name.lower()},
+        },
+    }
+
+
+class BuildPlaceEntryTest(unittest.TestCase):
+    def test_builds_full_entry(self):
+        ancient = _ancient('a1', 'Megiddo', 'm1', ['Judg.5.19', '2Kgs.23.29'])
+        modern = _modern('m1', 'Tel Megiddo', '35.184,32.585', 'a1', 1000)
+        existing_ids: set[str] = set()
+        entry = build_place_entry(
+            ancient, modern,
+            osises=['Judg.5.19', '2Kgs.23.29'],
+            label_index=0, existing_ids=existing_ids,
+        )
+        self.assertIsNotNone(entry)
+        assert entry is not None  # mypy / narrowing
+        self.assertEqual(entry['id'], 'megiddo')
+        self.assertEqual(entry['ancient'], 'Megiddo')
+        self.assertEqual(entry['modern'], 'Tel Megiddo')
+        self.assertAlmostEqual(entry['lat'], 32.585, places=3)
+        self.assertAlmostEqual(entry['lon'], 35.184, places=3)
+        self.assertEqual(entry['type'], 'city')
+        self.assertEqual(entry['priority'], 4)  # 2 refs
+        self.assertIn(entry['labelDir'], {'e', 'n', 'w', 's', 'ne', 'nw', 'se', 'sw'})
+        self.assertEqual(entry['stories'], [])
+        self.assertEqual(entry['refs'], ['Judges 5:19', '2 Kings 23:29'])
+        self.assertEqual(entry['confidence'], 1000)
+        self.assertIn('megiddo', existing_ids)
+
+    def test_missing_coords_returns_none(self):
+        ancient = _ancient('a1', 'NoCoords', 'm1', ['Gen.1.1'])
+        modern = _modern('m1', 'Whatever', '', 'a1', 500)  # bad lonlat
+        self.assertIsNone(build_place_entry(ancient, modern, ['Gen.1.1'], 0, set()))
+
+
+class JoinAndFilterTest(unittest.TestCase):
+    def _build_rows(self):
+        a1 = _ancient('a1', 'Megiddo', 'm1', ['Judg.5.19', '2Kgs.23.29', 'Rev.16.16'])
+        a2 = _ancient('a2', 'LowScore', 'm2', ['Gen.1.1'])
+        a3 = _ancient('a3', 'NoOsises', 'm3', [])
+        # Exact-name collision with an existing place → filtered via is_duplicate.
+        a4 = _ancient('a4', 'Jerusalem', 'm4', ['Gen.1.1'])
+        a5 = _ancient('a5', 'NoModern', 'mMissing', ['Gen.1.1'])
+
+        m1 = _modern('m1', 'Tel Megiddo', '35.184,32.585', 'a1', 1000)
+        # Below threshold confidence → filtered out.
+        m2 = _modern('m2', 'Tel Lowscore', '35.5,32.5', 'a2', 50)
+        m3 = _modern('m3', 'Tel NoRef', '35.6,32.6', 'a3', 800)
+        m4 = _modern('m4', 'Jerusalem Modern', '35.23,31.77', 'a4', 900)
+        # Note: m5 missing, so a5 join fails silently.
+        return [a1, a2, a3, a4, a5], [m1, m2, m3, m4]
+
+    def test_join_filter_dedup(self):
+        ancients, moderns = self._build_rows()
+        existing = [
+            {'id': 'jerusalem', 'ancient': 'Jerusalem', 'lat': 31.77, 'lon': 35.23},
+        ]
+        out = join_and_filter(ancients, moderns, existing)
+        # Expect only Megiddo — lowscore filtered, no-ref filtered, dup filtered, no-modern filtered.
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]['ancient'], 'Megiddo')
+        # labelDir rotates per final order — first entry is always 'e'.
+        self.assertEqual(out[0]['labelDir'], 'e')
+
+    def test_sorted_by_ref_count_desc(self):
+        # 3 ancient entries → 3, 2, 1 refs respectively. All should survive.
+        a_big = _ancient('b', 'Big', 'mb', ['Gen.1.1', 'Gen.1.2', 'Gen.1.3'])
+        a_mid = _ancient('m', 'Mid', 'mm', ['Gen.1.1', 'Gen.1.2'])
+        a_sml = _ancient('s', 'Sml', 'ms', ['Gen.1.1'])
+        moderns = [
+            _modern('mb', 'Mod Big', '10.0,10.0', 'b', 900),
+            _modern('mm', 'Mod Mid', '20.0,20.0', 'm', 900),
+            _modern('ms', 'Mod Sml', '30.0,30.0', 's', 900),
+        ]
+        out = join_and_filter([a_sml, a_mid, a_big], moderns, [])
+        self.assertEqual([e['ancient'] for e in out], ['Big', 'Mid', 'Sml'])
+
+    def test_target_max_enforced(self):
+        rows = []
+        moderns = []
+        for i in range(30):
+            a_id = f'a{i}'
+            m_id = f'm{i}'
+            rows.append(_ancient(a_id, f'City{i}', m_id, ['Gen.1.1']))
+            moderns.append(_modern(m_id, f'Mod{i}', f'{i}.0,{i}.0', a_id, 900))
+        out = join_and_filter(rows, moderns, [], target_max=10)
+        self.assertEqual(len(out), 10)
+
+
+# ── index_modern_by_id ─────────────────────────────────────────────────
+
+class IndexModernByIdTest(unittest.TestCase):
+    def test_indexes_by_id(self):
+        rows = [{'id': 'a'}, {'id': 'b'}, {'no_id': True}]
+        idx = index_modern_by_id(rows)  # type: ignore[arg-type]
+        self.assertIn('a', idx)
+        self.assertIn('b', idx)
+        self.assertEqual(len(idx), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -176,6 +176,10 @@ export interface Place {
   type: 'city' | 'water' | 'region' | 'mountain' | 'site';
   priority: number;
   label_dir: string;
+  /** JSON-encoded array of verse-ref strings — added by Card #1271. */
+  refs_json?: string | null;
+  /** 1–1000 identification confidence from OpenBible.info (Card #1271). */
+  confidence?: number | null;
 }
 
 export interface MapStory {

--- a/content/meta/map-stories.json
+++ b/content/meta/map-stories.json
@@ -1,4 +1,5 @@
 {
+  "attribution": "Map location data includes material from OpenBible.info (openbible.info/geo), licensed under Creative Commons Attribution 4.0. Some coordinate data derived from OpenStreetMap contributors (ODbL).",
   "era_hex": {
     "primeval": "#8b6914",
     "patriarch": "#7a5c9a",


### PR DESCRIPTION
## Summary

Lands the pipeline needed to expand `content/meta/places.json` from 73 entries to 250–300+ using CC BY 4.0 data from [OpenBible.info](https://github.com/openbibleinfo/Bible-Geocoding-Data). The JSONL download itself must happen locally (container egress is blocked from raw.githubusercontent.com, per the same pattern as #1205–#1207), so this PR lands the **scripts + schema + tests**. Craig runs the download + import locally when ready — the append-only import has no impact on the existing 73 places.

## What's in the PR

### New tools (`_tools/`)
- **`download_openbible.py`** — fetches `ancient.jsonl` + `modern.jsonl` into `_data/openbible/`.
- **`import_openbible_places.py`** — the main import script:
  - Pure helpers: `osis_to_ref`, `classify_type`, `assign_priority`, `assign_label_dir`, `parse_lonlat`, `parse_ancient_extra`, `make_id`, `is_duplicate`, `osises_to_refs`, `build_place_entry`
  - `join_and_filter(ancients, moderns, existing)` → returns new entries, sorted by ref-count desc, filtered by confidence (≥100/1000), ref count (≥1), and duplicates (name match OR close-coord + substring-name). Caps at 300.
  - Append-only: the existing 73 places + their `stories` links are preserved exactly.
- **`test_import_openbible_places.py`** — 41 unit tests covering every helper plus an end-to-end `join_and_filter` test over in-memory fixtures. Runs with `python3 _tools/test_import_openbible_places.py` (no pytest dependency).

### Schema + loader
- `_tools/build_sqlite_schema.py`: `places` table gains `refs_json TEXT` + `confidence INTEGER`.
- `_tools/build_sqlite_loaders.py`: `populate_places()` writes the two new columns (existing 73 rows load with `NULL`).

### TypeScript
- `app/src/types/content.ts`: `Place` gains optional `refs_json` + `confidence`.
- `usePlaces` uses `SELECT *` so no query change needed.

### Content
- `content/meta/map-stories.json`: adds top-level `attribution` string crediting OpenBible.info + OpenStreetMap per CC BY 4.0.

### Local-only data
- `_data/README.md` breadcrumb.
- `.gitignore` ignores `_data/openbible/*.jsonl` so the 14 MB of source data never ends up in the repo.

## Verification

- **41/41** Python unit tests pass (`python3 _tools/test_import_openbible_places.py`)
- **3186/3186** JS tests pass (`npx jest`)
- `npx tsc --noEmit` clean
- `python3 _tools/build_sqlite.py` rebuilds cleanly, new columns present
- `python3 _tools/validate_sqlite.py` → **83/83** checks pass
- Pre-existing `schema_validator.py` failures (76, all unrelated — life_topics cross-refs + `era_config.geographic_center`) are identical before and after this change

## How to run the import (local only)

```bash
python3 _tools/download_openbible.py       # fetches the JSONL files
python3 _tools/import_openbible_places.py  # appends new entries to places.json
python3 _tools/build_sqlite.py             # rebuilds scripture.db
python3 _tools/validate_sqlite.py          # sanity-checks row counts
```

## Acceptance criteria (card #1271)

- [x] `_tools/download_openbible.py` provided
- [x] `_tools/import_openbible_places.py` script reads JSONL, joins, filters, outputs
- [ ] `content/meta/places.json` expanded from 73 to 250–350 entries — _deferred; script ready, Craig runs it locally_
- [x] Schema gains `refs_json` and `confidence` columns
- [x] `populate_places()` writes new columns
- [x] `Place` TS type updated
- [x] `schema_validator.py` passes (no new failures introduced)
- [x] `validate_sqlite.py` passes
- [x] Attribution added to map-stories.json
- [x] Existing 73 places and story links preserved exactly

## Test plan

- [x] Python unit tests (41) for every helper
- [x] `build_sqlite.py` rebuild + `validate_sqlite.py` on the un-imported DB
- [x] Rebuilt DB schema inspection: new columns exist with correct types + defaults
- [x] Existing 73 places load with `NULL` refs_json/confidence (backwards-compatible)
- [x] Full JS test suite + `tsc --noEmit` still clean

https://claude.ai/code/session_013YtktJoPpzY9rXjtryuG5V