### PR TITLE
fix: Color stripping round 2 — Start Here, Deep Dive, Scholars

### DIFF
--- a/app/src/components/StartHereBanner.tsx
+++ b/app/src/components/StartHereBanner.tsx
@@ -16,16 +16,14 @@ import { useTheme, spacing, radii, fontFamily } from '../theme';
 interface StartHereTool {
   title: string;
   subtitle: string;
-  icon: string;
   screen: string;
-  color: string;
 }
 
 const START_HERE_TOOLS: StartHereTool[] = [
-  { title: 'People',        subtitle: "See who's in the story",              icon: '', screen: 'GenealogyTree',  color: '#e86040' }, // data-color: intentional
-  { title: 'Timeline',      subtitle: 'When did this happen?',               icon: '', screen: 'Timeline',       color: '#70b8e8' }, // data-color: intentional
-  { title: 'Word Studies',  subtitle: 'What does this word mean?',           icon: '', screen: 'WordStudyBrowse',color: '#e890b8' }, // data-color: intentional
-  { title: 'Topical Index', subtitle: 'What does the Bible say about...?',   icon: '', screen: 'TopicBrowse',    color: '#c8a040' }, // data-color: intentional
+  { title: 'People',        subtitle: "See who's in the story",              screen: 'GenealogyTree' },
+  { title: 'Timeline',      subtitle: 'When did this happen?',               screen: 'Timeline' },
+  { title: 'Word Studies',  subtitle: 'What does this word mean?',           screen: 'WordStudyBrowse' },
+  { title: 'Topical Index', subtitle: 'What does the Bible say about...?',   screen: 'TopicBrowse' },
 ];
 
 interface Props {
@@ -64,9 +62,9 @@ export function StartHereBanner({ onDismiss, onNavigate }: Props) {
             activeOpacity={0.7}
             accessibilityRole="button"
             accessibilityLabel={`${tool.title}: ${tool.subtitle}`}
-            style={[styles.toolCard, { backgroundColor: base.bgElevated, borderColor: tool.color + '25' }]}
+            style={[styles.toolCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '25' }]}
           >
-            <Text style={[styles.toolTitle, { color: tool.color }]}>{tool.title}</Text>
+            <Text style={[styles.toolTitle, { color: base.gold }]}>{tool.title}</Text>
             <Text style={[styles.toolSubtitle, { color: base.textMuted }]}>{tool.subtitle}</Text>
           </TouchableOpacity>
         ))}

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -337,26 +337,30 @@ function ExploreMenuScreen() {
       }
       case 'deep-dive':
         return (
-          <View style={styles.row3}>
-            {section.features.map((f, i) => {
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+            snapToInterval={CARD_WIDTH + spacing.sm}
+          >
+            {section.features.map((f, cardIndex) => {
               const imgData = getScreenImages(f.screen);
               return (
-                <View key={f.screen} style={styles.rowCell}>
-                  <FeatureCard
-                    feature={f}
-                    onPress={() => handleNavigate(f.screen)}
-                    isPremium={isPremium}
-                    images={imgData?.images}
-                    count={imgData?.count}
-                    noun={imgData?.noun}
-                    onImagePress={handleDeepLink}
-                    staggerMs={i * 1200}
-                    compact
-                  />
-                </View>
+                <FeatureCard
+                  key={f.screen}
+                  feature={f}
+                  onPress={() => handleNavigate(f.screen)}
+                  isPremium={isPremium}
+                  images={imgData?.images}
+                  count={imgData?.count}
+                  noun={imgData?.noun}
+                  onImagePress={handleDeepLink}
+                  staggerMs={cardIndex * 1200}
+                />
               );
             })}
-          </View>
+          </ScrollView>
         );
       case 'biblical-world':
       default:

--- a/app/src/screens/ScholarBrowseScreen.tsx
+++ b/app/src/screens/ScholarBrowseScreen.tsx
@@ -1,5 +1,7 @@
 /**
- * ScholarBrowseScreen — Grid of 43 scholar cards, filterable by tradition.
+ * ScholarBrowseScreen — Grid of 54 scholar cards, filterable by tradition.
+ *
+ * Glorify polish: neutral cards with gold accents, no tradition-based colors.
  */
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
@@ -14,7 +16,7 @@ import { logger } from '../utils/logger';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function ScholarBrowseScreen() {
-  const { base, getScholarColor } = useTheme();
+  const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'ScholarBrowse'>>();
   const { scholars, isLoading } = useScholars();
   const [search, setSearch] = useState('');
@@ -50,7 +52,6 @@ function ScholarBrowseScreen() {
 
   const renderItem = useCallback(
     ({ item: s }: { item: any }) => {
-      const color = getScholarColor(s.id);
       let scope = 'All books';
       try {
         const parsed = JSON.parse(s.scope_json);
@@ -60,29 +61,37 @@ function ScholarBrowseScreen() {
       return (
         <TouchableOpacity
           onPress={() => navigation.navigate('ScholarBio', { scholarId: s.id })}
-          style={[styles.card, { backgroundColor: color + '14', borderLeftColor: color }]}
+          style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '15' }]}
           accessibilityLabel={`${s.name}${s.tradition ? ", " + s.tradition : ""}`}
           accessibilityRole="button"
+          activeOpacity={0.7}
         >
-          <Text style={[styles.cardName, { color }]}>{s.name}</Text>
-          {s.tradition && <Text style={[styles.cardTradition, { color: base.textMuted }]}>{s.tradition}</Text>}
-          <Text style={[styles.cardScope, { color: base.textDim }]}>{scope}</Text>
+          <Text style={[styles.cardName, { color: base.text }]}>{s.name}</Text>
+          {s.tradition && <Text style={[styles.cardTradition, { color: base.gold }]}>{s.tradition}</Text>}
+          <Text style={[styles.cardScope, { color: base.textMuted }]}>{scope}</Text>
         </TouchableOpacity>
       );
     },
-    [base, getScholarColor, navigation]
+    [base, navigation]
   );
 
   const filterBar = (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.filterRow}>
       {traditions.map((t) => (
-        <TouchableOpacity key={t} onPress={() => setTradition(t)}>
+        <TouchableOpacity
+          key={t}
+          onPress={() => setTradition(t)}
+          style={[
+            styles.filterPill,
+            { borderColor: tradition === t ? base.gold : base.border },
+            tradition === t && { backgroundColor: base.gold + '12' },
+          ]}
+          activeOpacity={0.7}
+        >
           <Text style={[
             styles.filterLabel,
-            { color: base.textMuted },
-            tradition === t && { color: base.gold, borderBottomColor: base.gold },
-            tradition === t && styles.filterLabelActive,
+            { color: tradition === t ? base.gold : base.textMuted },
           ]}>
             {t === 'all' ? 'All' : t}
           </Text>
@@ -111,17 +120,18 @@ function ScholarBrowseScreen() {
 
 const styles = StyleSheet.create({
   filterRow: {
-    gap: spacing.xs,
+    gap: 6,
     marginBottom: spacing.md,
+  },
+  filterPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 14,
+    borderWidth: 1,
   },
   filterLabel: {
     fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-    paddingBottom: 4,
-    paddingHorizontal: 4,
-  },
-  filterLabelActive: {
-    borderBottomWidth: 2,
+    fontSize: 10,
   },
   gridContent: {
     paddingHorizontal: spacing.md,
@@ -132,7 +142,7 @@ const styles = StyleSheet.create({
   },
   card: {
     flex: 1,
-    borderLeftWidth: 3,
+    borderWidth: 1,
     borderRadius: radii.md,
     padding: spacing.sm,
   },


### PR DESCRIPTION
## Summary
Three remaining areas with legacy colors that weren't updated during the Explore redesign:

### 1. Start Here Banner
- Removed hardcoded red (`#e86040`), blue (`#70b8e8`), pink (`#e890b8`), gold (`#c8a040`) per-tool colors
- Now uses uniform `base.gold` accent for all tool cards

### 2. Deep Dive Carousel
- **Bug fix**: 4 features were being crammed into a `row3` layout designed for 3 items
- Converted to horizontal `<ScrollView>` carousel matching other sections
- Now scrolls properly with snap-to-card behavior

### 3. Scholar Browse Screen
- **Glorify polish treatment** to match redesigned Explore
- Removed `getScholarColor(s.id)` per-scholar tradition colors
- Neutral card backgrounds with gold accent for titles/borders
- Pills-style filter bar (matching Explore jump-to UX)

## Testing
- [ ] Start Here banner shows uniform gold-themed cards
- [ ] Deep Dive section scrolls horizontally with all 4 cards visible
- [ ] Scholars screen shows neutral cards with gold tradition labels
- [ ] Filter pills work correctly with gold highlight state