### PR TITLE
fix: Hot-swap DB connection after OTA content update (no navigation bounce)

### DIFF
--- a/app/__tests__/unit/contentUpdateProvider.test.tsx
+++ b/app/__tests__/unit/contentUpdateProvider.test.tsx
@@ -20,6 +20,11 @@ jest.mock('@/components/ContentUpdateBanner', () => ({
   ContentUpdateBanner: () => null,
 }));
 
+// Mock reloadDatabase
+jest.mock('@/db/database', () => ({
+  reloadDatabase: jest.fn().mockResolvedValue({}),
+}));
+
 // Mock ContentUpdateContext
 jest.mock('@/contexts/ContentUpdateContext', () => {
   const React = require('react');
@@ -28,10 +33,12 @@ jest.mock('@/contexts/ContentUpdateContext', () => {
     progress: 0,
     status: 'downloading',
     error: null,
+    dbVersion: 0,
     showUpdate: jest.fn(),
     updateProgress: jest.fn(),
     setStatus: jest.fn(),
     hideUpdate: jest.fn(),
+    bumpDbVersion: jest.fn(),
   };
   return {
     ContentUpdateProvider: ({ children }: any) => children,
@@ -93,7 +100,13 @@ describe('ContentUpdateProvider', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(showUpdate).toHaveBeenCalled();
     expect(updateProgress).toHaveBeenCalledWith(10);
-    expect(setStatus).toHaveBeenCalledWith('success');
+    // New flow: setStatus('applying') → reloadDatabase() → bumpDbVersion() → setStatus('success')
+    expect(setStatus).toHaveBeenCalledWith('applying');
+    const { reloadDatabase } = require('@/db/database');
+    expect(reloadDatabase).toHaveBeenCalled();
+    const { bumpDbVersion } = contextMock.useContentUpdate();
+    expect(bumpDbVersion).toHaveBeenCalled();
+    expect(setStatus).toHaveBeenLastCalledWith('success');
   });
 
   it('skips update banner when versions match', async () => {

--- a/app/src/contexts/ContentUpdateContext.tsx
+++ b/app/src/contexts/ContentUpdateContext.tsx
@@ -1,8 +1,10 @@
 /**
  * ContentUpdateContext — Shared state for content update UI.
  *
- * Tracks banner visibility, progress percentage, and update status
- * so any component in the tree can react to ongoing OTA updates.
+ * Tracks banner visibility, progress percentage, update status,
+ * and a dbVersion counter that bumps after each successful OTA
+ * update. Data hooks subscribe to dbVersion via useDbVersion()
+ * to auto-refetch when the underlying database changes.
  * Part of epic #758 (CloudFlare R2 Delta DB Delivery).
  */
 
@@ -14,6 +16,8 @@ interface ContentUpdateState {
   progress: number;
   status: UpdateStatus;
   error: string | null;
+  /** Monotonically increasing counter. Bumps after each successful DB swap. */
+  dbVersion: number;
 }
 
 interface ContentUpdateActions {
@@ -21,6 +25,8 @@ interface ContentUpdateActions {
   updateProgress: (pct: number) => void;
   setStatus: (status: UpdateStatus, error?: string) => void;
   hideUpdate: () => void;
+  /** Increment dbVersion to trigger data hook re-fetches. */
+  bumpDbVersion: () => void;
 }
 
 type ContentUpdateContextType = ContentUpdateState & ContentUpdateActions;
@@ -35,6 +41,16 @@ export function useContentUpdate(): ContentUpdateContextType {
   return ctx;
 }
 
+/**
+ * Safe accessor for dbVersion only. Returns 0 if called outside the
+ * provider (e.g., in tests or isolated renders). Data hooks use this
+ * so they work in any context but auto-reload when the DB changes.
+ */
+export function useDbVersion(): number {
+  const ctx = useContext(ContentUpdateCtx);
+  return ctx?.dbVersion ?? 0;
+}
+
 interface ProviderProps {
   children: ReactNode;
 }
@@ -45,10 +61,11 @@ export function ContentUpdateProvider({ children }: ProviderProps) {
     progress: 0,
     status: 'downloading',
     error: null,
+    dbVersion: 0,
   });
 
   const showUpdate = useCallback(() => {
-    setState({ visible: true, progress: 0, status: 'downloading', error: null });
+    setState((prev) => ({ ...prev, visible: true, progress: 0, status: 'downloading', error: null }));
   }, []);
 
   const updateProgress = useCallback((pct: number) => {
@@ -63,9 +80,13 @@ export function ContentUpdateProvider({ children }: ProviderProps) {
     setState((prev) => ({ ...prev, visible: false }));
   }, []);
 
+  const bumpDbVersion = useCallback(() => {
+    setState((prev) => ({ ...prev, dbVersion: prev.dbVersion + 1 }));
+  }, []);
+
   return (
     <ContentUpdateCtx.Provider
-      value={{ ...state, showUpdate, updateProgress, setStatus, hideUpdate }}
+      value={{ ...state, showUpdate, updateProgress, setStatus, hideUpdate, bumpDbVersion }}
     >
       {children}
     </ContentUpdateCtx.Provider>

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -142,6 +142,28 @@ export function getDb(): SQLite.SQLiteDatabase {
 }
 
 /**
+ * Close the current DB connection and reopen from the (updated) file.
+ * Called after ContentUpdater swaps the DB file on disk so all
+ * subsequent getDb() calls return a connection to the new content.
+ */
+export async function reloadDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (db) {
+    try {
+      await db.closeAsync();
+    } catch {
+      // Connection may already be invalid if the file was swapped — safe to ignore
+    }
+    db = null;
+  }
+  db = await SQLite.openDatabaseAsync('scripture.db');
+  if (Platform.OS !== 'web') {
+    await db.execAsync('PRAGMA journal_mode=WAL');
+  }
+  logger.info('DB', 'Database connection reloaded after content update');
+  return db;
+}
+
+/**
  * Get the database that contains verses for the given translation.
  * - Bundled translations (NIV, KJV) → core scripture.db
  * - Downloaded translations (ESV, ASV, etc.) → separate translation_*.db

--- a/app/src/hooks/useAsyncData.ts
+++ b/app/src/hooks/useAsyncData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, DependencyList } from 'react';
+import { useDbVersion } from '../contexts/ContentUpdateContext';
 
 export function useAsyncData<T>(
   fetchFn: () => Promise<T>,
@@ -9,6 +10,7 @@ export function useAsyncData<T>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const mountedRef = useRef(true);
+  const dbVersion = useDbVersion();
 
   useEffect(() => {
     mountedRef.current = true;
@@ -32,7 +34,7 @@ export function useAsyncData<T>(
         }
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, [...deps, dbVersion]);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,7 +49,7 @@ export function useAsyncData<T>(
       });
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, [...deps, dbVersion]);
 
   return { data, loading, error, reload: load };
 }

--- a/app/src/providers/ContentUpdateProvider.tsx
+++ b/app/src/providers/ContentUpdateProvider.tsx
@@ -15,6 +15,7 @@ import {
   useContentUpdate,
 } from '../contexts/ContentUpdateContext';
 import { ContentUpdateBanner } from '../components/ContentUpdateBanner';
+import { reloadDatabase } from '../db/database';
 import { logger } from '../utils/logger';
 
 const TAG = 'ContentUpdateProvider';
@@ -24,7 +25,7 @@ const TAG = 'ContentUpdateProvider';
  * Separated so it can call useContentUpdate() inside the provider.
  */
 function ContentUpdateListener({ children }: { children: ReactNode }) {
-  const { visible, progress, status, showUpdate, updateProgress, setStatus, hideUpdate } =
+  const { visible, progress, status, showUpdate, updateProgress, setStatus, hideUpdate, bumpDbVersion } =
     useContentUpdate();
   const checking = useRef(false);
 
@@ -51,8 +52,14 @@ function ContentUpdateListener({ children }: { children: ReactNode }) {
         const result = await ContentUpdater.checkForUpdates();
 
         if (result.status === 'updated') {
+          // DB file has been swapped on disk — reload the live connection
+          // and bump version so all data hooks re-fetch automatically.
+          setStatus('applying');
+          await reloadDatabase();
+          bumpDbVersion();
           updateProgress(100);
           setStatus('success');
+          logger.info(TAG, `Content hot-swapped: ${result.fromVersion} → ${result.toVersion}`);
         } else if (result.status === 'failed') {
           setStatus('error', result.error);
         }
@@ -80,7 +87,7 @@ function ContentUpdateListener({ children }: { children: ReactNode }) {
     // Check when app comes to foreground
     const sub = AppState.addEventListener('change', handleAppState);
     return () => sub.remove();
-  }, [showUpdate, updateProgress, setStatus, hideUpdate]);
+  }, [showUpdate, updateProgress, setStatus, hideUpdate, bumpDbVersion]);
 
   return (
     <>


### PR DESCRIPTION
## Problem

When `ContentUpdater.downloadFullDb()` swaps the DB file on disk, the `db` singleton in `database.ts` still holds an open connection to the deleted file. Screens querying after the swap hit a dead connection, error out, and the error boundary bounces the user to the home screen.

## Fix (5 files, +74 lines)

### `database.ts` — `reloadDatabase()`
Closes the stale connection, reopens from the swapped file, re-enables WAL mode. All subsequent `getDb()` calls return the fresh connection.

### `ContentUpdateContext.tsx` — `dbVersion` counter + `useDbVersion()`
Monotonically increasing integer that bumps after each successful DB swap. `useDbVersion()` returns 0 outside the provider (safe for tests).

### `useAsyncData.ts` — inject `dbVersion` into deps
All 15+ hooks that use `useAsyncData` (usePeople, usePlaces, useScholars, useMapStories, etc.) automatically re-fetch when `dbVersion` bumps. **Zero changes to any consumer hook.**

### `ContentUpdateProvider.tsx` — wire reload into success path
After `checkForUpdates()` returns `'updated'`:
1. `setStatus('applying')`
2. `await reloadDatabase()` — swap the live connection
3. `bumpDbVersion()` — trigger React re-renders
4. `setStatus('success')`

### Test fix
`contentUpdateProvider.test.tsx` — added `bumpDbVersion` + `reloadDatabase` mocks, updated assertion for new 2-step status flow (`'applying'` → `'success'`).

## What this gives users

- App launches instantly with whatever DB is on disk
- Background download starts immediately on mount — no user action needed
- **No navigation bounce** — screens keep showing current data until the swap
- Hot-swap is invisible — screens re-render in-place with fresh data
- Offline-first preserved — bundled DB always works

## Not in scope (follow-up)

25 hooks that query DB directly (useBooks, useChapterData, etc.) get fresh data naturally on next navigation. Adding `dbVersion` to their deps is a nice-to-have for a follow-up card.

## Tests

96 pass across 13 suites (all content update + data hook tests).