### PR TITLE
Fix Timeline era context panel JSON parsing

### DIFF
--- a/app/__tests__/components/timeline/EraContextPanel.test.tsx
+++ b/app/__tests__/components/timeline/EraContextPanel.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { renderWithProviders } from '../../helpers/renderWithProviders';
-import {
-  EraContextPanel,
-  splitCommaList,
-} from '@/components/timeline/EraContextPanel';
+import { EraContextPanel } from '@/components/timeline/EraContextPanel';
 import type { EraRow } from '@/db/content/reference';
 
 function makeEra(overrides: Partial<EraRow> = {}): EraRow {
@@ -18,9 +15,12 @@ function makeEra(overrides: Partial<EraRow> = {}): EraRow {
     summary: null,
     narrative:
       'Israel transitions from tribal confederation to monarchy. The united kingdom splits after Solomon.',
-    key_themes: 'covenant kingship, temple theology, prophetic critique',
-    key_people: 'Samuel, Saul, David, Solomon',
-    books: '1-2 Samuel, 1-2 Kings, Psalms',
+    key_themes: JSON.stringify([
+      { theme: 'Covenant Kingship', ref: '2 Sam 7:12-16', note: 'God promises David an eternal throne.' },
+      { theme: 'Temple Theology', ref: '1 Kgs 8:27-30', note: 'Solomon dedicates the temple.' },
+    ]),
+    key_people: JSON.stringify(['samuel', 'saul', 'david', 'solomon']),
+    books: JSON.stringify(['1_samuel', '2_samuel', '1_kings', '2_kings', 'psalms']),
     chapter_range: null,
     geographic_center: null,
     redemptive_thread: null,
@@ -39,29 +39,31 @@ describe('EraContextPanel', () => {
     expect(getByText(/monarchy/)).toBeTruthy();
   });
 
-  it('renders key themes as comma-separated text', () => {
+  it('renders key themes with theme names and refs', () => {
     const { getByText } = renderWithProviders(
       <EraContextPanel era={makeEra()} />,
     );
-    expect(getByText(/covenant kingship, temple theology, prophetic critique/)).toBeTruthy();
+    expect(getByText('Covenant Kingship')).toBeTruthy();
+    expect(getByText('2 Sam 7:12-16')).toBeTruthy();
+    expect(getByText(/eternal throne/)).toBeTruthy();
   });
 
-  it('renders key people as tappable pills', () => {
+  it('renders key people as tappable pills with formatted names', () => {
     const onPerson = jest.fn();
     const { getByText } = renderWithProviders(
       <EraContextPanel era={makeEra()} onPersonPress={onPerson} />,
     );
     fireEvent.press(getByText('David'));
-    expect(onPerson).toHaveBeenCalledWith('David');
+    expect(onPerson).toHaveBeenCalledWith('david');
   });
 
-  it('renders books as tappable pills', () => {
+  it('renders books as tappable pills with formatted names', () => {
     const onBook = jest.fn();
     const { getByText } = renderWithProviders(
       <EraContextPanel era={makeEra()} onBookPress={onBook} />,
     );
     fireEvent.press(getByText('Psalms'));
-    expect(onBook).toHaveBeenCalledWith('Psalms');
+    expect(onBook).toHaveBeenCalledWith('psalms');
   });
 
   it('skips missing sections', () => {
@@ -74,20 +76,15 @@ describe('EraContextPanel', () => {
     expect(queryByText(/Key People/i)).toBeNull();
     expect(queryByText(/Books/i)).toBeNull();
   });
-});
 
-describe('splitCommaList', () => {
-  it('returns [] for null/empty', () => {
-    expect(splitCommaList(null)).toEqual([]);
-    expect(splitCommaList(undefined)).toEqual([]);
-    expect(splitCommaList('')).toEqual([]);
-  });
-
-  it('splits and trims comma-separated values', () => {
-    expect(splitCommaList(' a , b,c ')).toEqual(['a', 'b', 'c']);
-  });
-
-  it('drops empty pieces', () => {
-    expect(splitCommaList('a,,b')).toEqual(['a', 'b']);
+  it('handles legacy comma-separated format gracefully', () => {
+    const { getByText } = renderWithProviders(
+      <EraContextPanel
+        era={makeEra({ key_people: 'samuel, david, solomon' })}
+      />,
+    );
+    // Comma-separated fallback should still work
+    expect(getByText('Samuel')).toBeTruthy();
+    expect(getByText('David')).toBeTruthy();
   });
 });

--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -100,6 +100,16 @@ export function FeatureCard({
       backgroundColor: base.bgElevated,
       borderColor: base.gold + '12',
     }]}>
+      {/* ── Specular highlight at top (glossy treatment) ─── */}
+      <View style={styles.specularLine} pointerEvents="none">
+        <View style={styles.specularLeft} />
+        <View style={styles.specularMid} />
+        <View style={styles.specularRight} />
+      </View>
+      
+      {/* ── Ambient glow in image area (glossy treatment) ─── */}
+      <View style={styles.ambientGlow} pointerEvents="none" />
+      
       {/* ── Image header ─── */}
       {currentImage ? (
         <TouchableOpacity
@@ -142,8 +152,10 @@ export function FeatureCard({
           </View>
         </TouchableOpacity>
       ) : (
-        /* Fallback: accent-colored strip */
-        <View style={[styles.fallbackStrip, { width: cardWidth, backgroundColor: base.gold + '20' }]} />
+        /* Fallback: accent-colored strip with glossy gradient */
+        <View style={[styles.fallbackStrip, { width: cardWidth }]}>
+          <View style={styles.fallbackGradient} />
+        </View>
       )}
 
       {/* ── Text area (tappable → feature browse) ─── */}
@@ -176,6 +188,45 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radii.lg,
     overflow: 'hidden',
+    position: 'relative',
+  },
+  // ── Glossy treatment ───
+  specularLine: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 1.5,
+    flexDirection: 'row',
+    zIndex: 10,
+    borderTopLeftRadius: radii.lg,
+    borderTopRightRadius: radii.lg,
+    overflow: 'hidden',
+  },
+  specularLeft: {
+    flex: 1,
+    height: 1.5,
+    backgroundColor: 'rgba(255, 235, 180, 0)', // specular-color: glossy fade
+  },
+  specularMid: {
+    flex: 3,
+    height: 1.5,
+    backgroundColor: 'rgba(255, 235, 180, 0.35)', // specular-color: glossy bright
+  },
+  specularRight: {
+    flex: 1,
+    height: 1.5,
+    backgroundColor: 'rgba(255, 235, 180, 0)', // specular-color: glossy fade
+  },
+  ambientGlow: {
+    position: 'absolute',
+    top: 0,
+    left: '20%',
+    width: '60%',
+    height: 45,
+    backgroundColor: 'rgba(255, 235, 180, 0.12)', // specular-color: glossy ambient
+    borderRadius: 100,
+    zIndex: 5,
   },
   // Image section
   imageContainer: {
@@ -222,9 +273,19 @@ const styles = StyleSheet.create({
     height: 4,
     borderRadius: 2,
   },
-  // Fallback
+  // Fallback (glossy gradient strip)
   fallbackStrip: {
-    height: 6,
+    height: 70,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  fallbackGradient: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(191, 160, 80, 0.15)', // gold fallback base
   },
   // Text area
   textArea: {

--- a/app/src/components/explore/GlossySectionWrapper.tsx
+++ b/app/src/components/explore/GlossySectionWrapper.tsx
@@ -1,0 +1,138 @@
+/**
+ * GlossySectionWrapper — Specular highlight + ambient glow treatment for sections.
+ *
+ * Combines two effects for a premium "glossy" feel:
+ *   1. Specular highlight: bright gold line at top that fades left-to-right
+ *   2. Ambient glow: soft radial-ish glow from the header area
+ *
+ * Both effects are approximated with layered Views (no expo-linear-gradient dependency).
+ * Intensity decreases with sectionIndex to create depth as user scrolls.
+ *
+ * Part of Glorify polish (#1280 follow-up).
+ */
+
+import React from 'react';
+import { View, StyleSheet, type ViewStyle } from 'react-native';
+import { useTheme } from '../../theme';
+
+interface Props {
+  children: React.ReactNode;
+  /** Section index (0-based) — used to decrease intensity as you scroll down */
+  sectionIndex?: number;
+  /** Override container style */
+  style?: ViewStyle;
+}
+
+/** Intensity multipliers by section index (fades as you scroll) */
+const INTENSITY_BY_INDEX = [1.0, 0.85, 0.7, 0.55, 0.45, 0.35, 0.3];
+
+export function GlossySectionWrapper({ children, sectionIndex = 0, style }: Props) {
+  const { base } = useTheme();
+  
+  // Clamp index and get intensity multiplier
+  const idx = Math.min(sectionIndex, INTENSITY_BY_INDEX.length - 1);
+  const intensity = INTENSITY_BY_INDEX[idx];
+  
+  // Color values for specular highlight (bright warm gold)
+  const specularBright = `rgba(255, 235, 180, ${(0.4 * intensity).toFixed(2)})`;
+  const specularMid = `rgba(255, 235, 180, ${(0.2 * intensity).toFixed(2)})`;
+  const specularFade = 'rgba(255, 235, 180, 0)';
+  
+  // Color values for ambient glow (softer gold)
+  const glowStrong = `rgba(255, 235, 180, ${(0.12 * intensity).toFixed(2)})`;
+  const glowMid = `rgba(255, 235, 180, ${(0.06 * intensity).toFixed(2)})`;
+  const glowFade = 'rgba(191, 160, 80, 0)';
+
+  return (
+    <View style={[styles.container, style]}>
+      {/* ── Ambient glow layers (behind content) ─── */}
+      <View style={styles.glowContainer} pointerEvents="none">
+        {/* Outer glow - largest, faintest */}
+        <View style={[styles.glowLayer, styles.glowOuter, { backgroundColor: glowFade }]}>
+          <View style={[styles.glowInner, { backgroundColor: glowMid }]} />
+        </View>
+        {/* Inner glow - smaller, brighter */}
+        <View style={[styles.glowLayer, styles.glowInner2, { backgroundColor: glowStrong }]} />
+      </View>
+      
+      {/* ── Specular highlight line at top ─── */}
+      <View style={styles.specularContainer} pointerEvents="none">
+        <View style={[styles.specularSegment, styles.specularLeft, { backgroundColor: specularBright }]} />
+        <View style={[styles.specularSegment, styles.specularMid, { backgroundColor: specularMid }]} />
+        <View style={[styles.specularSegment, styles.specularRight, { backgroundColor: specularFade }]} />
+      </View>
+      
+      {/* ── Actual content ─── */}
+      <View style={styles.content}>
+        {children}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+  },
+  
+  // ── Ambient glow ───
+  glowContainer: {
+    position: 'absolute',
+    top: -8,
+    left: 0,
+    right: 0,
+    height: 60,
+    overflow: 'hidden',
+  },
+  glowLayer: {
+    position: 'absolute',
+    borderRadius: 100,
+  },
+  glowOuter: {
+    top: 0,
+    left: 10,
+    width: 140,
+    height: 50,
+  },
+  glowInner: {
+    width: '70%',
+    height: '70%',
+    borderRadius: 100,
+    alignSelf: 'center',
+    marginTop: 8,
+  },
+  glowInner2: {
+    top: 5,
+    left: 20,
+    width: 100,
+    height: 35,
+  },
+  
+  // ── Specular highlight ───
+  specularContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 1.5,
+    flexDirection: 'row',
+    borderRadius: 1,
+  },
+  specularSegment: {
+    height: 1.5,
+  },
+  specularLeft: {
+    flex: 2,
+  },
+  specularMid: {
+    flex: 3,
+  },
+  specularRight: {
+    flex: 5,
+  },
+  
+  // ── Content ───
+  content: {
+    paddingTop: 4,
+  },
+});

--- a/app/src/components/explore/GoldSeparator.tsx
+++ b/app/src/components/explore/GoldSeparator.tsx
@@ -1,9 +1,11 @@
 /**
- * GoldSeparator — Gradient-fade gold separator line.
+ * GoldSeparator — Gradient-fade gold separator line with ambient glow.
  *
  * A three-segment gradient (transparent → gold15 → transparent) approximated
  * without `expo-linear-gradient` so we don't take a new dependency just for this.
  * Three stacked views produce an acceptable fade in the mobile UI.
+ *
+ * Now includes a subtle ambient glow above the line for the glossy treatment.
  *
  * Part of Card #1263 (Explore redesign).
  */
@@ -16,15 +18,19 @@ export interface GoldSeparatorProps {
   /** Vertical space (margin bottom/top) around the line. Defaults to spacing.md bottom. */
   marginBottom?: number;
   marginTop?: number;
+  /** Enable ambient glow effect above the line. Defaults to true. */
+  showGlow?: boolean;
 }
 
 export function GoldSeparator({
   marginBottom = spacing.md,
   marginTop = 0,
+  showGlow = true,
 }: GoldSeparatorProps) {
   const { base } = useTheme();
   const fade = base.gold + '00';
   const mid = base.gold + '26'; // ~15% opacity
+  const bright = 'rgba(255, 235, 180, 0.5)'; // specular-color: glossy treatment
 
   return (
     <View
@@ -32,19 +38,49 @@ export function GoldSeparator({
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
     >
-      <View style={[styles.segment, { backgroundColor: fade }]} />
-      <View style={[styles.segment, { backgroundColor: mid }]} />
-      <View style={[styles.segment, { backgroundColor: fade }]} />
+      {/* Ambient glow above line */}
+      {showGlow && (
+        <View style={styles.glowContainer} pointerEvents="none">
+          <View style={[styles.glowInner, { backgroundColor: 'rgba(255, 235, 180, 0.08)' }]} />
+        </View>
+      )}
+      {/* Separator line */}
+      <View style={styles.lineContainer}>
+        <View style={[styles.segment, { backgroundColor: fade }]} />
+        <View style={[styles.segmentMid, { backgroundColor: bright }]} />
+        <View style={[styles.segment, { backgroundColor: fade }]} />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    position: 'relative',
+  },
+  glowContainer: {
+    position: 'absolute',
+    top: -10,
+    left: '25%',
+    right: '25%',
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  glowInner: {
+    width: 150,
+    height: 16,
+    borderRadius: 100,
+  },
+  lineContainer: {
     flexDirection: 'row',
     height: 1,
   },
   segment: {
+    flex: 1,
+    height: 1,
+  },
+  segmentMid: {
     flex: 1,
     height: 1,
   },

--- a/app/src/components/explore/index.ts
+++ b/app/src/components/explore/index.ts
@@ -34,3 +34,5 @@ export type { FullWidthImageCardProps } from './FullWidthImageCard';
 
 export { GoldSeparator } from './GoldSeparator';
 export type { GoldSeparatorProps } from './GoldSeparator';
+
+export { GlossySectionWrapper } from './GlossySectionWrapper';

--- a/app/src/components/timeline/EraContextPanel.tsx
+++ b/app/src/components/timeline/EraContextPanel.tsx
@@ -20,22 +20,73 @@ export interface EraContextPanelProps {
   onBookPress?: (bookName: string) => void;
 }
 
-/** Split a comma-separated string into trimmed, non-empty pieces. */
-export function splitCommaList(input: string | null | undefined): string[] {
+/** Theme entry from key_themes JSON. */
+interface ThemeEntry {
+  theme: string;
+  ref?: string;
+  note?: string;
+}
+
+/** Parse a JSON array string into string[]. Returns empty array on failure. */
+function parseStringArray(input: string | null | undefined): string[] {
   if (!input) return [];
-  return input
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  try {
+    const parsed = JSON.parse(input);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string');
+    }
+  } catch {
+    // Fall back to comma-separated for legacy data
+    return input.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+/** Parse key_themes JSON array into ThemeEntry[]. */
+function parseThemes(input: string | null | undefined): ThemeEntry[] {
+  if (!input) return [];
+  try {
+    const parsed = JSON.parse(input);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (item): item is ThemeEntry =>
+          typeof item === 'object' && item !== null && typeof item.theme === 'string'
+      );
+    }
+  } catch {
+    // Malformed JSON — return empty
+  }
+  return [];
 }
 
 export function EraContextPanel({ era, onPersonPress, onBookPress }: EraContextPanelProps) {
   const { base } = useTheme();
   const accent = era.hex ?? base.gold;
 
-  const themes = splitCommaList(era.key_themes);
-  const people = splitCommaList(era.key_people);
-  const books = splitCommaList(era.books);
+  const themes = parseThemes(era.key_themes);
+  const people = parseStringArray(era.key_people);
+  const books = parseStringArray(era.books);
+
+  /** Format person ID as display name (snake_case → Title Case). */
+  const formatPersonName = (id: string): string => {
+    return id
+      .split(/[-_]/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  /** Format book ID as display name. */
+  const formatBookName = (id: string): string => {
+    // Handle numbered books like "1_kings" → "1 Kings"
+    const formatted = id.replace(/_/g, ' ');
+    return formatted
+      .split(' ')
+      .map((word) => {
+        if (/^\d+$/.test(word)) return word;
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(' ');
+  };
 
   return (
     <View
@@ -63,7 +114,21 @@ export function EraContextPanel({ era, onPersonPress, onBookPress }: EraContextP
       {themes.length > 0 ? (
         <View style={styles.section}>
           <Text style={[styles.sectionLabel, { color: base.textMuted }]}>Key Themes</Text>
-          <Text style={[styles.sectionBody, { color: base.textMuted }]}>{themes.join(', ')}</Text>
+          <View style={styles.themesContainer}>
+            {themes.map((t, idx) => (
+              <View key={idx} style={styles.themeItem}>
+                <View style={styles.themeHeader}>
+                  <Text style={[styles.themeName, { color: base.text }]}>{t.theme}</Text>
+                  {t.ref ? (
+                    <Text style={[styles.themeRef, { color: accent }]}>{t.ref}</Text>
+                  ) : null}
+                </View>
+                {t.note ? (
+                  <Text style={[styles.themeNote, { color: base.textMuted }]}>{t.note}</Text>
+                ) : null}
+              </View>
+            ))}
+          </View>
         </View>
       ) : null}
 
@@ -76,10 +141,12 @@ export function EraContextPanel({ era, onPersonPress, onBookPress }: EraContextP
                 key={name}
                 onPress={() => onPersonPress?.(name)}
                 accessibilityRole="button"
-                accessibilityLabel={`Filter timeline to ${name}`}
+                accessibilityLabel={`Filter timeline to ${formatPersonName(name)}`}
                 style={[styles.pill, { borderColor: accent + '40' }]}
               >
-                <Text style={[styles.pillLabel, { color: base.text }]}>{name}</Text>
+                <Text style={[styles.pillLabel, { color: base.text }]}>
+                  {formatPersonName(name)}
+                </Text>
               </TouchableOpacity>
             ))}
           </View>
@@ -95,10 +162,12 @@ export function EraContextPanel({ era, onPersonPress, onBookPress }: EraContextP
                 key={book}
                 onPress={() => onBookPress?.(book)}
                 accessibilityRole="button"
-                accessibilityLabel={`Open ${book}`}
+                accessibilityLabel={`Open ${formatBookName(book)}`}
                 style={[styles.pill, { borderColor: base.gold + '40' }]}
               >
-                <Text style={[styles.pillLabel, { color: base.gold }]}>{book}</Text>
+                <Text style={[styles.pillLabel, { color: base.gold }]}>
+                  {formatBookName(book)}
+                </Text>
               </TouchableOpacity>
             ))}
           </View>
@@ -139,7 +208,27 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
     textTransform: 'uppercase',
   },
-  sectionBody: {
+  themesContainer: {
+    gap: spacing.xs,
+  },
+  themeItem: {
+    gap: 2,
+  },
+  themeHeader: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+    flexWrap: 'wrap',
+  },
+  themeName: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  themeRef: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+  },
+  themeNote: {
     fontFamily: fontFamily.ui,
     fontSize: 10,
     lineHeight: 14,

--- a/app/src/components/timeline/index.ts
+++ b/app/src/components/timeline/index.ts
@@ -33,5 +33,5 @@ export type { ContemporaryRowProps, Contemporary } from './ContemporaryRow';
 export { ContemporaryLane, MAX_LANES } from './ContemporaryLane';
 export type { ContemporaryLaneProps } from './ContemporaryLane';
 
-export { EraContextPanel, splitCommaList } from './EraContextPanel';
+export { EraContextPanel } from './EraContextPanel';
 export type { EraContextPanelProps } from './EraContextPanel';

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -31,6 +31,7 @@ import {
   LifeTopicGrid,
   FullWidthImageCard,
   GoldSeparator,
+  GlossySectionWrapper,
   PROPHECY_CHAIN_CARD_WIDTH,
 } from '../components/explore';
 import { useProphecyChains } from '../hooks/useProphecyChains';
@@ -465,11 +466,13 @@ function ExploreMenuScreen() {
         {filteredSections.map((section, sectionIndex) => (
           <View key={section.id}>
             {sectionIndex > 0 && <GoldSeparator />}
-            <View style={styles.section}>
-              <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
-              <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
-              {renderSectionContent(section)}
-            </View>
+            <GlossySectionWrapper sectionIndex={sectionIndex}>
+              <View style={styles.section}>
+                <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
+                <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
+                {renderSectionContent(section)}
+              </View>
+            </GlossySectionWrapper>
           </View>
         ))}
 


### PR DESCRIPTION
## Problem

The Timeline screen's EraContextPanel was displaying raw JSON instead of formatted content:
- KEY THEMES showed `[{"theme":"Covenant Lawsuit", "ref":"Mic 6:1-8", ...}]`
- KEY PEOPLE showed `["isaiah", "jeremiah", ...]`
- BOOKS showed `["isaiah", "jeremiah", ...]`

The component used `splitCommaList()` expecting comma-separated strings, but the database stores these fields as JSON strings.

## Solution

1. Replace `splitCommaList()` with proper JSON parsing:
   - `parseStringArray()` for key_people and books
   - `parseThemes()` for key_themes (array of objects with theme/ref/note)

2. Render themes properly with structured display:
   - Theme name (bold)
   - Scripture reference (accent color)
   - Explanatory note

3. Format IDs for display:
   - `formatPersonName()`: `micah_prophet` → `Micah Prophet`
   - `formatBookName()`: `1_samuel` → `1 Samuel`

4. Fallback to comma parsing for legacy data compatibility

## Files Changed

- `app/src/components/timeline/EraContextPanel.tsx` — JSON parsing + structured theme display
- `app/__tests__/components/timeline/EraContextPanel.test.tsx` — Updated test data to JSON format