### PR TITLE
fix: Replace ambient glow with center-bright specular (Option F)

### DIFF
--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -100,15 +100,17 @@ export function FeatureCard({
       backgroundColor: base.bgElevated,
       borderColor: base.gold + '12',
     }]}>
-      {/* ── Specular highlight at top (glossy treatment) ─── */}
-      <View style={styles.specularLine} pointerEvents="none">
-        <View style={styles.specularLeft} />
-        <View style={styles.specularMid} />
-        <View style={styles.specularRight} />
-      </View>
+      {/* ── Subtle underglow halo (glossy treatment) ─── */}
+      <View style={styles.specularHalo} pointerEvents="none" />
       
-      {/* ── Ambient glow in image area (glossy treatment) ─── */}
-      <View style={styles.ambientGlow} pointerEvents="none" />
+      {/* ── Specular highlight at top (center-bright, glossy treatment) ─── */}
+      <View style={styles.specularLine} pointerEvents="none">
+        <View style={styles.specularEdge} />
+        <View style={styles.specularMid} />
+        <View style={styles.specularCenter} />
+        <View style={styles.specularMid} />
+        <View style={styles.specularEdge} />
+      </View>
       
       {/* ── Image header ─── */}
       {currentImage ? (
@@ -196,36 +198,36 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    height: 1.5,
+    height: 2,
     flexDirection: 'row',
     zIndex: 10,
     borderTopLeftRadius: radii.lg,
     borderTopRightRadius: radii.lg,
     overflow: 'hidden',
   },
-  specularLeft: {
+  specularEdge: {
     flex: 1,
-    height: 1.5,
-    backgroundColor: 'rgba(255, 235, 180, 0)', // specular-color: glossy fade
+    height: 2,
+    backgroundColor: 'rgba(255, 235, 180, 0.1)',
   },
   specularMid: {
-    flex: 3,
-    height: 1.5,
-    backgroundColor: 'rgba(255, 235, 180, 0.35)', // specular-color: glossy bright
+    flex: 1.5,
+    height: 2,
+    backgroundColor: 'rgba(255, 235, 180, 0.3)',
   },
-  specularRight: {
-    flex: 1,
-    height: 1.5,
-    backgroundColor: 'rgba(255, 235, 180, 0)', // specular-color: glossy fade
+  specularCenter: {
+    flex: 2,
+    height: 2,
+    backgroundColor: 'rgba(255, 235, 180, 0.65)',
   },
-  ambientGlow: {
+  specularHalo: {
     position: 'absolute',
-    top: 0,
+    top: 2,
     left: '20%',
     width: '60%',
-    height: 45,
-    backgroundColor: 'rgba(255, 235, 180, 0.12)', // specular-color: glossy ambient
-    borderRadius: 100,
+    height: 6,
+    backgroundColor: 'rgba(255, 235, 180, 0.04)',
+    borderRadius: 3,
     zIndex: 5,
   },
   // Image section

--- a/app/src/components/explore/GlossySectionWrapper.tsx
+++ b/app/src/components/explore/GlossySectionWrapper.tsx
@@ -1,11 +1,10 @@
 /**
- * GlossySectionWrapper — Specular highlight + ambient glow treatment for sections.
+ * GlossySectionWrapper — Specular highlight treatment for sections.
  *
- * Combines two effects for a premium "glossy" feel:
- *   1. Specular highlight: bright gold line at top that fades left-to-right
- *   2. Ambient glow: soft radial-ish glow from the header area
+ * Adds a center-bright gold line at the top with subtle underglow,
+ * simulating light hitting the edge of a shelf or panel.
  *
- * Both effects are approximated with layered Views (no expo-linear-gradient dependency).
+ * Approximated with layered Views (no expo-linear-gradient dependency).
  * Intensity decreases with sectionIndex to create depth as user scrolls.
  *
  * Part of Glorify polish (#1280 follow-up).
@@ -13,7 +12,6 @@
 
 import React from 'react';
 import { View, StyleSheet, type ViewStyle } from 'react-native';
-import { useTheme } from '../../theme';
 
 interface Props {
   children: React.ReactNode;
@@ -27,39 +25,28 @@ interface Props {
 const INTENSITY_BY_INDEX = [1.0, 0.85, 0.7, 0.55, 0.45, 0.35, 0.3];
 
 export function GlossySectionWrapper({ children, sectionIndex = 0, style }: Props) {
-  const { base } = useTheme();
-  
   // Clamp index and get intensity multiplier
   const idx = Math.min(sectionIndex, INTENSITY_BY_INDEX.length - 1);
   const intensity = INTENSITY_BY_INDEX[idx];
   
-  // Color values for specular highlight (bright warm gold)
-  const specularBright = `rgba(255, 235, 180, ${(0.4 * intensity).toFixed(2)})`;
-  const specularMid = `rgba(255, 235, 180, ${(0.2 * intensity).toFixed(2)})`;
-  const specularFade = 'rgba(255, 235, 180, 0)';
-  
-  // Color values for ambient glow (softer gold)
-  const glowStrong = `rgba(255, 235, 180, ${(0.12 * intensity).toFixed(2)})`;
-  const glowMid = `rgba(255, 235, 180, ${(0.06 * intensity).toFixed(2)})`;
-  const glowFade = 'rgba(191, 160, 80, 0)';
+  // Center-bright specular: edges fade → mid brighter → center brightest
+  const specularEdge = `rgba(255, 235, 180, ${(0.1 * intensity).toFixed(2)})`;
+  const specularMid = `rgba(255, 235, 180, ${(0.3 * intensity).toFixed(2)})`;
+  const specularCenter = `rgba(255, 235, 180, ${(0.65 * intensity).toFixed(2)})`;
+  const haloColor = `rgba(255, 235, 180, ${(0.04 * intensity).toFixed(2)})`;
 
   return (
     <View style={[styles.container, style]}>
-      {/* ── Ambient glow layers (behind content) ─── */}
-      <View style={styles.glowContainer} pointerEvents="none">
-        {/* Outer glow - largest, faintest */}
-        <View style={[styles.glowLayer, styles.glowOuter, { backgroundColor: glowFade }]}>
-          <View style={[styles.glowInner, { backgroundColor: glowMid }]} />
-        </View>
-        {/* Inner glow - smaller, brighter */}
-        <View style={[styles.glowLayer, styles.glowInner2, { backgroundColor: glowStrong }]} />
-      </View>
+      {/* ── Subtle underglow halo ─── */}
+      <View style={[styles.halo, { backgroundColor: haloColor }]} pointerEvents="none" />
       
-      {/* ── Specular highlight line at top ─── */}
+      {/* ── Specular highlight line (center-bright) ─── */}
       <View style={styles.specularContainer} pointerEvents="none">
-        <View style={[styles.specularSegment, styles.specularLeft, { backgroundColor: specularBright }]} />
-        <View style={[styles.specularSegment, styles.specularMid, { backgroundColor: specularMid }]} />
-        <View style={[styles.specularSegment, styles.specularRight, { backgroundColor: specularFade }]} />
+        <View style={[styles.segment, styles.segmentEdge, { backgroundColor: specularEdge }]} />
+        <View style={[styles.segment, styles.segmentMid, { backgroundColor: specularMid }]} />
+        <View style={[styles.segment, styles.segmentCenter, { backgroundColor: specularCenter }]} />
+        <View style={[styles.segment, styles.segmentMid, { backgroundColor: specularMid }]} />
+        <View style={[styles.segment, styles.segmentEdge, { backgroundColor: specularEdge }]} />
       </View>
       
       {/* ── Actual content ─── */}
@@ -75,60 +62,36 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   
-  // ── Ambient glow ───
-  glowContainer: {
+  // ── Underglow halo ───
+  halo: {
     position: 'absolute',
-    top: -8,
-    left: 0,
-    right: 0,
-    height: 60,
-    overflow: 'hidden',
-  },
-  glowLayer: {
-    position: 'absolute',
-    borderRadius: 100,
-  },
-  glowOuter: {
-    top: 0,
-    left: 10,
-    width: 140,
-    height: 50,
-  },
-  glowInner: {
-    width: '70%',
-    height: '70%',
-    borderRadius: 100,
-    alignSelf: 'center',
-    marginTop: 8,
-  },
-  glowInner2: {
-    top: 5,
-    left: 20,
-    width: 100,
-    height: 35,
+    top: 2,
+    left: '15%',
+    right: '15%',
+    height: 6,
+    borderRadius: 3,
   },
   
-  // ── Specular highlight ───
+  // ── Specular highlight (center-bright) ───
   specularContainer: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    height: 1.5,
+    height: 2,
     flexDirection: 'row',
-    borderRadius: 1,
   },
-  specularSegment: {
-    height: 1.5,
+  segment: {
+    height: 2,
   },
-  specularLeft: {
+  segmentEdge: {
+    flex: 1,
+  },
+  segmentMid: {
+    flex: 1.5,
+  },
+  segmentCenter: {
     flex: 2,
-  },
-  specularMid: {
-    flex: 3,
-  },
-  specularRight: {
-    flex: 5,
   },
   
   // ── Content ───

--- a/app/src/components/explore/GoldSeparator.tsx
+++ b/app/src/components/explore/GoldSeparator.tsx
@@ -1,87 +1,78 @@
 /**
- * GoldSeparator — Gradient-fade gold separator line with ambient glow.
+ * GoldSeparator — Center-bright gold separator line with subtle underglow.
  *
- * A three-segment gradient (transparent → gold15 → transparent) approximated
+ * A five-segment gradient (edge → mid → center → mid → edge) approximated
  * without `expo-linear-gradient` so we don't take a new dependency just for this.
- * Three stacked views produce an acceptable fade in the mobile UI.
- *
- * Now includes a subtle ambient glow above the line for the glossy treatment.
  *
  * Part of Card #1263 (Explore redesign).
  */
 
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { useTheme, spacing } from '../../theme';
+import { spacing } from '../../theme';
 
 export interface GoldSeparatorProps {
   /** Vertical space (margin bottom/top) around the line. Defaults to spacing.md bottom. */
   marginBottom?: number;
   marginTop?: number;
-  /** Enable ambient glow effect above the line. Defaults to true. */
-  showGlow?: boolean;
 }
 
 export function GoldSeparator({
   marginBottom = spacing.md,
   marginTop = 0,
-  showGlow = true,
 }: GoldSeparatorProps) {
-  const { base } = useTheme();
-  const fade = base.gold + '00';
-  const mid = base.gold + '26'; // ~15% opacity
-  const bright = 'rgba(255, 235, 180, 0.5)'; // specular-color: glossy treatment
-
   return (
     <View
       style={[styles.container, { marginBottom, marginTop }]}
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
     >
-      {/* Ambient glow above line */}
-      {showGlow && (
-        <View style={styles.glowContainer} pointerEvents="none">
-          <View style={[styles.glowInner, { backgroundColor: 'rgba(255, 235, 180, 0.08)' }]} />
-        </View>
-      )}
-      {/* Separator line */}
+      {/* Subtle underglow halo */}
+      <View style={styles.halo} pointerEvents="none" />
+      {/* Center-bright separator line */}
       <View style={styles.lineContainer}>
-        <View style={[styles.segment, { backgroundColor: fade }]} />
-        <View style={[styles.segmentMid, { backgroundColor: bright }]} />
-        <View style={[styles.segment, { backgroundColor: fade }]} />
+        <View style={[styles.segment, styles.segmentEdge]} />
+        <View style={[styles.segment, styles.segmentMid]} />
+        <View style={[styles.segment, styles.segmentCenter]} />
+        <View style={[styles.segment, styles.segmentMid]} />
+        <View style={[styles.segment, styles.segmentEdge]} />
       </View>
     </View>
   );
 }
 
+const SPECULAR_WARM = 'rgba(255, 235, 180,';
+
 const styles = StyleSheet.create({
   container: {
     position: 'relative',
   },
-  glowContainer: {
+  halo: {
     position: 'absolute',
-    top: -10,
-    left: '25%',
-    right: '25%',
-    height: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  glowInner: {
-    width: 150,
-    height: 16,
-    borderRadius: 100,
+    top: 2,
+    left: '20%',
+    right: '20%',
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: SPECULAR_WARM + ' 0.04)',
   },
   lineContainer: {
     flexDirection: 'row',
-    height: 1,
+    height: 2,
   },
   segment: {
+    height: 2,
+  },
+  segmentEdge: {
     flex: 1,
-    height: 1,
+    backgroundColor: SPECULAR_WARM + ' 0.1)',
   },
   segmentMid: {
-    flex: 1,
-    height: 1,
+    flex: 1.5,
+    backgroundColor: SPECULAR_WARM + ' 0.3)',
+  },
+  segmentCenter: {
+    flex: 2,
+    backgroundColor: SPECULAR_WARM + ' 0.65)',
   },
 });


### PR DESCRIPTION
## Summary
Removes the oval ambient glow that appeared as visible oval shapes rather than soft light on device. Replaces with **Option F** specular treatment — center-bright with subtle underglow.

## What changed

### Removed
- Ambient glow ovals (looked like visible shapes, not soft light)
- `showGlow` prop from `GoldSeparator`
- Unused `useTheme` import from `GlossySectionWrapper`

### Added/Updated
- **Center-bright specular line**: 2px height with 5-segment gradient
  - Edge (10%) → Mid (30%) → Center (65%) → Mid (30%) → Edge (10%)
- **Subtle underglow halo**: 6px height at 4% opacity beneath the line
- All components use consistent `rgba(255, 235, 180, ...)` warm gold

### Files
- `GlossySectionWrapper.tsx` — center-bright + halo, intensity still fades by section index
- `GoldSeparator.tsx` — center-bright + halo, removed `showGlow` prop
- `FeatureCard.tsx` — center-bright + halo, removed ambient glow

## Net impact
- **-44 lines** (simpler implementation)
- More visible specular effect
- No more oval artifacts

## Testing
- [ ] Explore screen shows center-bright specular at top of sections
- [ ] Effect is more visible than before
- [ ] No oval shapes visible
- [ ] Intensity still fades as you scroll down sections