### PR TITLE
fix: Remove duplicate separator line between Explore sections

### DIFF
--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -30,7 +30,6 @@ import {
   WordStudyPreviewList,
   LifeTopicGrid,
   FullWidthImageCard,
-  GoldSeparator,
   GlossySectionWrapper,
   PROPHECY_CHAIN_CARD_WIDTH,
 } from '../components/explore';
@@ -465,7 +464,6 @@ function ExploreMenuScreen() {
         {/* ── Sections with varied layouts ─── */}
         {filteredSections.map((section, sectionIndex) => (
           <View key={section.id}>
-            {sectionIndex > 0 && <GoldSeparator />}
             <GlossySectionWrapper sectionIndex={sectionIndex}>
               <View style={styles.section}>
                 <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>


### PR DESCRIPTION
## Problem
Double gold lines appearing between Explore sections:
1. `GoldSeparator` renders between sections
2. `GlossySectionWrapper` adds a specular line at the top of each section

## Fix
Removed `GoldSeparator` from between sections since `GlossySectionWrapper`s specular line already serves as the visual divider.

## Changes
- `ExploreMenuScreen.tsx`: Removed `{sectionIndex > 0 && <GoldSeparator />}`
- Removed unused `GoldSeparator` import