### PR TITLE
tree: gap-driven bloom radii + focal-point pinch zoom

### DIFF
--- a/app/__tests__/utils/treeBuilder.organic.test.ts
+++ b/app/__tests__/utils/treeBuilder.organic.test.ts
@@ -72,6 +72,36 @@ describe('treeBuilder — #1290 associate tribal bloom', () => {
       expect(n.y).toBeGreaterThan(jesusNode.y);
     }
   });
+
+  it('spaces associates with enough gap for their name labels (≥ 70 px)', () => {
+    // Guard against the "tight cluster" regression — large clusters must
+    // scale radius so adjacent names don't overlap.
+    const people: Person[] = [
+      makePerson({ id: 'adam', name: 'Adam' }),
+      makePerson({ id: 'jacob_nt', name: 'Jacob', father: 'adam' }),
+      makePerson({ id: 'joseph-nt', name: 'Joseph', father: 'jacob_nt' }),
+      makePerson({ id: 'jesus', name: 'Jesus', father: 'joseph-nt' }),
+      makePerson({ id: 'peter', name: 'Peter', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'andrew', name: 'Andrew', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'james', name: 'James', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'john', name: 'John', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'thomas', name: 'Thomas', associated_with: 'jesus', association_type: 'disciple' }),
+    ];
+    const { nodes } = computeFullLayout(people, null);
+    const ids = ['peter', 'andrew', 'james', 'john', 'thomas'];
+    const placed = ids
+      .map((id) => nodes.find((n) => n.data.id === id)!)
+      .sort((a, b) => a.x - b.x);
+    // Minimum distance between any two adjacent associate centres on the arc.
+    let minGap = Infinity;
+    for (let i = 1; i < placed.length; i++) {
+      const dx = placed[i].x - placed[i - 1].x;
+      const dy = placed[i].y - placed[i - 1].y;
+      const gap = Math.hypot(dx, dy);
+      if (gap < minGap) minGap = gap;
+    }
+    expect(minGap).toBeGreaterThanOrEqual(70);
+  });
 });
 
 describe("treeBuilder — #1291 Jacob's tribal bloom", () => {
@@ -106,5 +136,30 @@ describe("treeBuilder — #1291 Jacob's tribal bloom", () => {
     for (const s of sons) {
       expect(s.y).toBeGreaterThan(jacob.y);
     }
+  });
+
+  it('gives 12 sons a wide-enough X span for readable names (≥ 600 px)', () => {
+    // 12 spine circles with patriarch names ("Issachar", "Zebulun",
+    // "Benjamin" …) need a lot of horizontal room to avoid overlapping.
+    const sonIds = [
+      'reuben', 'simeon', 'levi', 'judah-s', 'dan', 'naphtali',
+      'gad', 'asher', 'issachar', 'zebulun', 'joseph-s', 'benjamin',
+    ];
+    const people: Person[] = [
+      makePerson({ id: 'adam', name: 'Adam' }),
+      makePerson({ id: 'jacob', name: 'Jacob', father: 'adam' }),
+      ...sonIds.map((id) => makePerson({ id, name: id, father: 'jacob' })),
+      // minimal spine path so the tree has a Jesus
+      makePerson({ id: 'perez', name: 'Perez', father: 'judah-s' }),
+      makePerson({ id: 'jesus', name: 'Jesus', father: 'perez' }),
+    ];
+    const { nodes } = computeFullLayout(people, null);
+    const placed = sonIds
+      .map((id) => nodes.find((n) => n.data.id === id))
+      .filter((n): n is NonNullable<typeof n> => Boolean(n));
+    expect(placed).toHaveLength(12);
+    const xs = placed.map((n) => n.x);
+    const span = Math.max(...xs) - Math.min(...xs);
+    expect(span).toBeGreaterThanOrEqual(600);
   });
 });

--- a/app/src/hooks/useTreeGestures.ts
+++ b/app/src/hooks/useTreeGestures.ts
@@ -131,6 +131,15 @@ export function useTreeGestures(): TreeGestureResult {
   const savedTy = useSharedValue(0);
   const savedScale = useSharedValue(1);
 
+  // Focal-point pinch state. Captured at pinch onBegin; used by onUpdate
+  // to keep the world point under the finger centroid stationary on
+  // screen (iOS-Maps-style zoom rather than corner-anchored zoom).
+  const pinchActive = useSharedValue(false);
+  const startFocalX = useSharedValue(0);
+  const startFocalY = useSharedValue(0);
+  const pinchStartTx = useSharedValue(0);
+  const pinchStartTy = useSharedValue(0);
+
   /**
    * Merge current gesture transform into base state, reset gesture to identity.
    * Combined transform: screen = (x * baseS + baseTx) * gestScale + gestTx
@@ -156,14 +165,29 @@ export function useTreeGestures(): TreeGestureResult {
   }, []);
 
   const pinchGesture = Gesture.Pinch()
-    .onBegin(() => {
+    .onBegin((e) => {
+      pinchActive.value = true;
       savedScale.value = gestScale.value;
+      startFocalX.value = e.focalX;
+      startFocalY.value = e.focalY;
+      pinchStartTx.value = gestTx.value;
+      pinchStartTy.value = gestTy.value;
     })
     .onUpdate((e) => {
+      // Focal-point zoom: keep the world point under the finger centroid
+      // stationary on screen. Derivation in useTreeGestures.ts plan file.
+      //   screen = world * savedScale + startTx   (at pinch begin)
+      //   screen = world * gestScale + gestTx     (during pinch)
+      //   gestScale = savedScale * e.scale
+      //   ⇒ gestTx = focalX − (startFocalX − startTx) * e.scale
+      // Using the live e.focalX lets the view follow centroid drift too.
       gestScale.value = savedScale.value * e.scale;
+      gestTx.value = e.focalX - (startFocalX.value - pinchStartTx.value) * e.scale;
+      gestTy.value = e.focalY - (startFocalY.value - pinchStartTy.value) * e.scale;
     })
     .onEnd(() => {
       // Commit scale to base so SVG re-rasterizes at the new zoom level
+      pinchActive.value = false;
       runOnJS(commitGesture)();
     });
 
@@ -176,6 +200,14 @@ export function useTreeGestures(): TreeGestureResult {
       savedTy.value = gestTy.value;
     })
     .onUpdate((e) => {
+      if (pinchActive.value) {
+        // Pinch owns the transform while active. Keep pan's baseline in
+        // sync so that when pinch ends the next pan tick picks up from
+        // the current gesture position without a visible jump.
+        savedTx.value = gestTx.value - e.translationX;
+        savedTy.value = gestTy.value - e.translationY;
+        return;
+      }
       gestTx.value = savedTx.value + e.translationX;
       gestTy.value = savedTy.value + e.translationY;
     })

--- a/app/src/utils/treeBuilder.ts
+++ b/app/src/utils/treeBuilder.ts
@@ -411,10 +411,21 @@ function applyJacobBloom(nodes: LayoutNode[]): void {
   if (!jacobNode) return;
   const sons = nodes.filter((n) => n.data.father === 'jacob' && !n.isSpouse);
   if (sons.length < 3) return;
+  // Gap-driven radius: solve for the radius that gives each son at least
+  // JACOB_GAP px of breathing room on the arc. Spine circles are 48 px
+  // wide and patriarch names run 60–110 px, so 130 px gap keeps them legible.
+  const JACOB_GAP = 130;
+  const MIN_RADIUS_JACOB = 220;
+  const sweepDeg = Math.min(170, 80 + sons.length * 8);
+  const sweepRad = (sweepDeg * Math.PI) / 180;
+  const radius = Math.max(
+    MIN_RADIUS_JACOB,
+    (JACOB_GAP * Math.max(sons.length - 1, 1)) / sweepRad,
+  );
   const placed = applyTribalBloom(
     { x: jacobNode.x, y: jacobNode.y },
     sons.map((s) => ({ id: s.data.id, x: s.x, y: s.y })),
-    { radius: 180, startAngleDegrees: -75, endAngleDegrees: 75 },
+    { radius, startAngleDegrees: -sweepDeg / 2, endAngleDegrees: sweepDeg / 2 },
   );
   for (let i = 0; i < sons.length; i++) {
     const dx = placed[i].x - sons[i].x;
@@ -586,15 +597,24 @@ export function computeFullLayout(
     const anchorPos = positionById.get(anchorId);
     if (!anchorPos) continue; // anchor wasn't placed (orphaned anchor) — drop silently
 
-    const radius = 90 + Math.min(members.length, 8) * 8; // 98 → 154 px
-    const sweep = Math.min(160, 60 + members.length * 14); // degrees
+    // Gap-driven radius: ensure ≥ BLOOM_GAP px centre-to-centre even for
+    // large clusters (e.g. Jesus's 16 disciples). Satellite circles are
+    // 30 px wide so 80 px keeps a comfortable name zone between them.
+    const BLOOM_GAP = 80;
+    const MIN_RADIUS_ASSOCIATE = 120;
+    const sweepDeg = Math.min(180, 80 + members.length * 10);
+    const sweepRad = (sweepDeg * Math.PI) / 180;
+    const radius = Math.max(
+      MIN_RADIUS_ASSOCIATE,
+      (BLOOM_GAP * Math.max(members.length - 1, 1)) / sweepRad,
+    );
     const placed = applyTribalBloom(
       { x: anchorPos.x, y: anchorPos.y },
       members.map((m) => ({ id: m.id, x: 0, y: 0 })),
       {
         radius,
-        startAngleDegrees: -sweep / 2, // fan below the anchor, centred straight down
-        endAngleDegrees: sweep / 2,
+        startAngleDegrees: -sweepDeg / 2, // fan below the anchor, centred straight down
+        endAngleDegrees: sweepDeg / 2,
       },
     );
 


### PR DESCRIPTION
Two follow-up fixes from device testing of #1290/#1291:

1. Bloom radii now solve for a target centre-to-centre gap so large clusters don't squish. The old fixed formulas gave Jesus's 16 disciples only ~29 px between centres (overlapping circles + names).

   Associate bloom: BLOOM_GAP=80, MIN_RADIUS=120, sweep up to 180° N=5  → r≈131 (was 130) N=8  → r≈201 (was 154) N=16 → r≈382 (was 154, badly overlapping)

   Jacob bloom: JACOB_GAP=130, MIN_RADIUS=220, sweep up to 170° N=12 sons → r≈482 (was 180)

2. Pinch gesture now keeps the world point under the finger centroid stationary on screen. Before, Gesture.Pinch only wrote gestScale, so the outer Animated.View scaled from its top-left — content under your fingers zoomed away from them. The fix tracks e.focalX/focalY and compensates gestTx/gestTy each frame:

     gestTx = focalX − (startFocalX − pinchStartTx) * e.scale

   Centroid drift during the pinch is followed naturally because e.focalX updates live.

   Pan compatibility: new pinchActive flag; pan skips writes while pinch is active and resyncs savedTx/savedTy each frame so pan continues seamlessly after pinch ends.

Tests
  * 2 new gap-assertion tests in treeBuilder.organic.test.ts
  * Full suite: 426 suites / 3205 tests passing (+2)
  * tsc --noEmit clean

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3