### PR TITLE
tree: type-sector associate blooms + collision avoidance

### DIFF
--- a/app/__tests__/utils/treeBuilder.organic.test.ts
+++ b/app/__tests__/utils/treeBuilder.organic.test.ts
@@ -73,6 +73,29 @@ describe('treeBuilder — #1290 associate tribal bloom', () => {
     }
   });
 
+  it('groups associates by type and emits one label per type present', () => {
+    const people: Person[] = [
+      makePerson({ id: 'adam', name: 'Adam' }),
+      makePerson({ id: 'jacob_nt', name: 'Jacob', father: 'adam' }),
+      makePerson({ id: 'joseph-nt', name: 'Joseph', father: 'jacob_nt' }),
+      makePerson({ id: 'jesus', name: 'Jesus', father: 'joseph-nt' }),
+      makePerson({ id: 'peter', name: 'Peter', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'andrew', name: 'Andrew', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'john-ap', name: 'John', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'pilate', name: 'Pilate', associated_with: 'jesus', association_type: 'contemporary' }),
+      makePerson({ id: 'caiaphas', name: 'Caiaphas', associated_with: 'jesus', association_type: 'contemporary' }),
+      makePerson({ id: 'barabbas', name: 'Barabbas', associated_with: 'jesus', association_type: 'adversary' }),
+    ];
+    const { associateBloomLabels } = computeFullLayout(people, null);
+    const jesusLabels = associateBloomLabels.filter((l) => l.anchorId === 'jesus');
+    const types = jesusLabels.map((l) => l.type).sort();
+    expect(types).toEqual(['adversary', 'contemporary', 'disciple']);
+    const byType = new Map(jesusLabels.map((l) => [l.type, l.text]));
+    expect(byType.get('disciple')).toBe('disciples');
+    expect(byType.get('contemporary')).toBe('contemporaries');
+    expect(byType.get('adversary')).toBe('adversaries');
+  });
+
   it('spaces associates with enough gap for their name labels (≥ 70 px)', () => {
     // Guard against the "tight cluster" regression — large clusters must
     // scale radius so adjacent names don't overlap.

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -16,8 +16,8 @@ import { MarriageBarSvg } from './MarriageBarSvg';
 import { SpouseConnectorSvg } from './SpouseConnectorSvg';
 import { TreeNode } from './TreeNode';
 import { AssociationLinkSvg } from './AssociationLinkSvg';
-import { TIER_2_ZOOM } from '../../utils/genealogyOrganic';
-import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink } from '../../utils/treeBuilder';
+import { TIER_2_ZOOM, TIER_3_ZOOM } from '../../utils/genealogyOrganic';
+import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
 
 interface Props {
   nodes: LayoutNode[];
@@ -26,6 +26,11 @@ interface Props {
   spouseConnectors: SpouseConnector[];
   /** Dotted connectors from anchors to associated_with satellites (#1288). */
   associationLinks?: AssociationLink[];
+  /** Type-sector labels ("disciples", "contemporaries"…) emitted by
+   *  the associate bloom layout. Shown at mid-zoom+. */
+  associateBloomLabels?: AssociateBloomLabel[];
+  /** Thick trail connectors from anchors to offset associate blooms. */
+  associateTrails?: AssociateTrail[];
   filterEra: string | null;
   spineIds: Set<string>;
   selectedPersonId: string | null;
@@ -44,6 +49,8 @@ interface Props {
 export const TreeCanvas = memo(function TreeCanvas({
   nodes, links, marriageBars, spouseConnectors,
   associationLinks = [],
+  associateBloomLabels = [],
+  associateTrails = [],
   filterEra, spineIds, selectedPersonId, onNodePress,
   offsetX = 0, offsetY = 0,
   canvasWidth = 4000, canvasHeight = 4000,
@@ -150,6 +157,40 @@ export const TreeCanvas = memo(function TreeCanvas({
               +{b.count}
             </SvgText>
           </G>
+        ))}
+
+        {/* 1d. Associate-bloom trails — thick gold line from anchor to the
+               apex of a bloom that had to be shifted sideways. */}
+        {!clustersCollapsed && associateTrails.map((t) => (
+          <Line
+            key={`at-${t.anchorId}`}
+            x1={t.source.x}
+            y1={t.source.y}
+            x2={t.target.x}
+            y2={t.target.y}
+            stroke={base.gold}
+            strokeWidth={1.5}
+            opacity={0.35}
+            strokeLinecap="round"
+          />
+        ))}
+
+        {/* 1e. Type-sector labels ("disciples", "contemporaries"…) at the
+               apex of each sub-bloom. Visible at mid-zoom+ so the overview
+               stays clean. */}
+        {!clustersCollapsed && zoom >= TIER_3_ZOOM && associateBloomLabels.map((lbl) => (
+          <SvgText
+            key={`abl-${lbl.anchorId}-${lbl.type}`}
+            x={lbl.x}
+            y={lbl.y}
+            fill={base.gold}
+            fontSize={11}
+            fontFamily="Cinzel_500Medium"
+            textAnchor="middle"
+            opacity={0.65}
+          >
+            {lbl.text}
+          </SvgText>
         ))}
 
         {/* 2. Marriage bars */}

--- a/app/src/hooks/useTreeLayout.ts
+++ b/app/src/hooks/useTreeLayout.ts
@@ -21,6 +21,8 @@ export function useTreeLayout(
         marriageBars: [],
         spouseConnectors: [],
         associationLinks: [],
+        associateBloomLabels: [],
+        associateTrails: [],
         spineIds: new Set<string>(),
         bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100, width: 100, height: 100 },
       };

--- a/app/src/screens/GenealogyTreeScreen.tsx
+++ b/app/src/screens/GenealogyTreeScreen.tsx
@@ -63,7 +63,8 @@ function GenealogyTreeScreen({ route, navigation }: {
   const [filterEra, setFilterEra] = useState<string>('all');
   const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
 
-  const { nodes, links, marriageBars, spouseConnectors, associationLinks, spineIds, bounds } =
+  const { nodes, links, marriageBars, spouseConnectors, associationLinks,
+    associateBloomLabels, associateTrails, spineIds, bounds } =
     useTreeLayout(people, filterEra);
 
   useEffect(() => {
@@ -220,6 +221,8 @@ function GenealogyTreeScreen({ route, navigation }: {
                   marriageBars={marriageBars}
                   spouseConnectors={spouseConnectors}
                   associationLinks={associationLinks}
+                  associateBloomLabels={associateBloomLabels}
+                  associateTrails={associateTrails}
                   filterEra={filterEra === 'all' ? null : filterEra}
                   spineIds={spineIds}
                   selectedPersonId={selectedPerson?.id ?? null}

--- a/app/src/utils/treeBuilder.ts
+++ b/app/src/utils/treeBuilder.ts
@@ -91,6 +91,24 @@ export interface AssociationLink {
   type: AssociationType | null;
 }
 
+/** Text label placed at the apex of a type sub-bloom — "disciples",
+ *  "contemporaries", etc. Rendered at mid-zoom+ so overview stays clean. */
+export interface AssociateBloomLabel {
+  anchorId: string;
+  type: AssociationType;
+  text: string;
+  x: number;
+  y: number;
+}
+
+/** Thick trail line from the anchor to an offset bloom's apex. Only
+ *  emitted when the bloom had to be shifted sideways to avoid overlap. */
+export interface AssociateTrail {
+  anchorId: string;
+  source: { x: number; y: number };
+  target: { x: number; y: number };
+}
+
 // ── Spine computation ───────────────────────────────────────────────
 
 export function computeSpineIds(people: Person[]): Set<string> {
@@ -370,6 +388,11 @@ export interface TreeLayoutResult {
   spouseConnectors: SpouseConnector[];
   /** Dotted connectors from anchors to associated_with satellites (#1288). */
   associationLinks: AssociationLink[];
+  /** Type labels placed at each sub-bloom's apex ("disciples", "contemporaries"…). */
+  associateBloomLabels: AssociateBloomLabel[];
+  /** Thick trail from the anchor to an offset bloom's apex — only when
+   *  the bloom had to be shifted to avoid overlapping other nodes. */
+  associateTrails: AssociateTrail[];
   spineIds: Set<string>;
   bounds: TreeBounds;
 }
@@ -468,6 +491,88 @@ function applyImportantFigureSpread(nodes: LayoutNode[]): void {
   }
 }
 
+// ── Associate clustering (#1290, type-sector redesign) ────────────────
+
+/** One of the four biblical association categories, rendered in its
+ *  own angular sector around the anchor. */
+interface AssociateSectorSpec {
+  /** Centre angle in degrees — 0 = straight down. */
+  center: number;
+  /** Max half-sweep in degrees; actual sweep may be narrower. */
+  halfSweepMax: number;
+  /** Label text placed at the sub-bloom's apex. */
+  labelText: string;
+}
+
+const ASSOCIATE_TYPE_ORDER = ['disciple', 'servant', 'contemporary', 'adversary'] as const;
+
+const ASSOCIATE_SECTORS: Record<string, AssociateSectorSpec> = {
+  // Main group fans straight down in a wide arc.
+  disciple:     { center:   0, halfSweepMax: 80, labelText: 'disciples' },
+  // Servants share the disciple sector but sit inside, closer to the anchor.
+  servant:      { center:   0, halfSweepMax: 35, labelText: 'servants' },
+  // Neutral and opposition fan to the right and left respectively.
+  contemporary: { center:  70, halfSweepMax: 25, labelText: 'contemporaries' },
+  adversary:    { center: -70, halfSweepMax: 25, labelText: 'adversaries' },
+};
+
+const ASSOCIATE_BLOOM_GAP = 80;         // target centre-to-centre between circles
+const ASSOCIATE_MIN_RADIUS = 120;
+const ASSOCIATE_MAX_PER_RING = 12;      // above this, split into concentric rings
+const ASSOCIATE_LABEL_GAP = 28;
+const ASSOCIATE_COLLISION_PAD = 60;     // halo around other nodes to treat as occupied
+const ASSOCIATE_SHIFT_STEP_X = 180;     // px to offset the bloom when a placement collides
+
+/** Lay out one type group, returning member positions RELATIVE to the
+ *  bloom centre (0,0) plus a label position and outermost radius. */
+function layOutAssociateType(
+  members: Person[],
+  sector: AssociateSectorSpec,
+  innerRadius: number,
+): { placed: Array<{ id: string; x: number; y: number }>; labelX: number; labelY: number; outerRadius: number } {
+  // Split very large groups into 2 concentric half-rings so the radius
+  // doesn't have to blow past 800 px.
+  const rings = members.length > ASSOCIATE_MAX_PER_RING
+    ? [
+        members.slice(0, Math.ceil(members.length / 2)),
+        members.slice(Math.ceil(members.length / 2)),
+      ]
+    : [members];
+
+  const all: Array<{ id: string; x: number; y: number }> = [];
+  let outer = innerRadius;
+  rings.forEach((ring, ringIdx) => {
+    const desiredSweep = Math.min(sector.halfSweepMax * 2, 60 + ring.length * 10);
+    const sweepRad = (desiredSweep * Math.PI) / 180;
+    const radius = Math.max(
+      innerRadius + ringIdx * 110,
+      (ASSOCIATE_BLOOM_GAP * Math.max(ring.length - 1, 1)) / sweepRad,
+    );
+    outer = Math.max(outer, radius);
+    const half = desiredSweep / 2;
+    const placed = applyTribalBloom(
+      { x: 0, y: 0 },
+      ring.map((m) => ({ id: m.id, x: 0, y: 0 })),
+      {
+        radius,
+        startAngleDegrees: sector.center - half,
+        endAngleDegrees: sector.center + half,
+      },
+    );
+    all.push(...placed);
+  });
+
+  // Label sits just beyond the outermost ring at the sector's centre angle.
+  const labelRadius = outer + ASSOCIATE_LABEL_GAP;
+  const labelAngle = (sector.center * Math.PI) / 180;
+  return {
+    placed: all,
+    labelX: labelRadius * Math.sin(labelAngle),
+    labelY: labelRadius * Math.cos(labelAngle),
+    outerRadius: outer,
+  };
+}
+
 export function computeFullLayout(
   people: Person[],
   filterEra: string | null
@@ -478,7 +583,8 @@ export function computeFullLayout(
   if (!root) {
     return {
       nodes: [], links: [], marriageBars: [], spouseConnectors: [],
-      associationLinks: [], spineIds,
+      associationLinks: [], associateBloomLabels: [], associateTrails: [],
+      spineIds,
       bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100, width: 100, height: 100 },
     };
   }
@@ -586,57 +692,141 @@ export function computeFullLayout(
     clusterY += rows * ROW_SPACING_Y + 80; // gap before next era group
   }
 
-  // Layout association clusters radially around their anchor via tribal
-  // bloom (#1290). Sweep widens with cluster size so large groups fan more.
+  // Lay out association clusters by type with collision avoidance (#1290).
+  // Members are grouped by association_type; each type gets its own angular
+  // sector around the anchor. Very large groups split into concentric rings.
+  // If the resulting bloom would overlap existing nodes, the whole bloom
+  // shifts sideways and a thick trail connects the anchor to its apex.
   const positionById = new Map<string, { x: number; y: number }>();
   for (const n of allTreeNodes) positionById.set(n.data.id, { x: n.x, y: n.y });
   for (const n of disconnectedNodes) positionById.set(n.data.id, { x: n.x, y: n.y });
 
   const associationLinks: AssociationLink[] = [];
+  const associateBloomLabels: AssociateBloomLabel[] = [];
+  const associateTrails: AssociateTrail[] = [];
+
   for (const [anchorId, members] of clusterByAnchor) {
     const anchorPos = positionById.get(anchorId);
-    if (!anchorPos) continue; // anchor wasn't placed (orphaned anchor) — drop silently
+    if (!anchorPos) continue; // anchor wasn't placed — drop silently
 
-    // Gap-driven radius: ensure ≥ BLOOM_GAP px centre-to-centre even for
-    // large clusters (e.g. Jesus's 16 disciples). Satellite circles are
-    // 30 px wide so 80 px keeps a comfortable name zone between them.
-    const BLOOM_GAP = 80;
-    const MIN_RADIUS_ASSOCIATE = 120;
-    const sweepDeg = Math.min(180, 80 + members.length * 10);
-    const sweepRad = (sweepDeg * Math.PI) / 180;
-    const radius = Math.max(
-      MIN_RADIUS_ASSOCIATE,
-      (BLOOM_GAP * Math.max(members.length - 1, 1)) / sweepRad,
-    );
-    const placed = applyTribalBloom(
-      { x: anchorPos.x, y: anchorPos.y },
-      members.map((m) => ({ id: m.id, x: 0, y: 0 })),
-      {
-        radius,
-        startAngleDegrees: -sweepDeg / 2, // fan below the anchor, centred straight down
-        endAngleDegrees: sweepDeg / 2,
-      },
-    );
+    // Group this anchor's members by association_type (null → 'disciple')
+    const byType = new Map<string, Person[]>();
+    for (const m of members) {
+      const t = (m.association_type ?? 'disciple') as string;
+      const list = byType.get(t) ?? [];
+      list.push(m);
+      byType.set(t, list);
+    }
 
-    members.forEach((p, i) => {
-      const { x, y } = placed[i];
-      disconnectedNodes.push({
-        data: { ...p, nodeType: 'satellite', isAssociate: true },
-        x,
-        y,
-        parent: null,
-        children: [],
-        depth: 0,
-        isSpouse: false,
-      });
-      associationLinks.push({
+    // Servants (if present) sit inside the disciple sector, closer to the
+    // anchor. Disciples then start at a larger inner radius.
+    const servantCount = byType.get('servant')?.length ?? 0;
+    const discipleStart = servantCount > 0 ? 230 : ASSOCIATE_MIN_RADIUS;
+
+    // Lay out each type (positions relative to 0,0)
+    const sub: Record<string, ReturnType<typeof layOutAssociateType> | null> = {
+      disciple: null, servant: null, contemporary: null, adversary: null,
+    };
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const list = byType.get(type);
+      if (!list || list.length === 0) continue;
+      const sector = ASSOCIATE_SECTORS[type];
+      const start = type === 'disciple' ? discipleStart : ASSOCIATE_MIN_RADIUS;
+      sub[type] = layOutAssociateType(list, sector, start);
+    }
+
+    // Aggregate bbox across all sub-blooms (relative to bloom centre 0,0)
+    let bbMinX = 0, bbMaxX = 0, bbMinY = 0, bbMaxY = 0;
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const s = sub[type];
+      if (!s) continue;
+      for (const p of s.placed) {
+        if (p.x < bbMinX) bbMinX = p.x;
+        if (p.x > bbMaxX) bbMaxX = p.x;
+        if (p.y < bbMinY) bbMinY = p.y;
+        if (p.y > bbMaxY) bbMaxY = p.y;
+      }
+    }
+
+    // Collision check: does placing the bloom at anchor + (offsetX, 0)
+    // overlap any non-member existing node?
+    const memberIdSet = new Set(members.map((m) => m.id));
+    const checkCollision = (offsetX: number): boolean => {
+      const minX = anchorPos.x + offsetX + bbMinX - ASSOCIATE_COLLISION_PAD;
+      const maxX = anchorPos.x + offsetX + bbMaxX + ASSOCIATE_COLLISION_PAD;
+      const minY = anchorPos.y + bbMinY - ASSOCIATE_COLLISION_PAD;
+      const maxY = anchorPos.y + bbMaxY + ASSOCIATE_COLLISION_PAD;
+      for (const [id, pos] of positionById) {
+        if (id === anchorId || memberIdSet.has(id)) continue;
+        if (pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    let offsetX = 0;
+    if (checkCollision(0)) {
+      let found = false;
+      for (let step = 1; step <= 8 && !found; step++) {
+        for (const sign of [1, -1]) {
+          const dx = sign * step * ASSOCIATE_SHIFT_STEP_X;
+          if (!checkCollision(dx)) {
+            offsetX = dx;
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) offsetX = 9 * ASSOCIATE_SHIFT_STEP_X; // forced far-right
+    }
+
+    // Emit member nodes + anchor→member links + type labels
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const s = sub[type];
+      if (!s) continue;
+      const memberIndex = new Map(members.map((m) => [m.id, m]));
+      for (const placed of s.placed) {
+        const person = memberIndex.get(placed.id);
+        if (!person) continue;
+        const absX = anchorPos.x + offsetX + placed.x;
+        const absY = anchorPos.y + placed.y;
+        disconnectedNodes.push({
+          data: { ...person, nodeType: 'satellite', isAssociate: true },
+          x: absX,
+          y: absY,
+          parent: null,
+          children: [],
+          depth: 0,
+          isSpouse: false,
+        });
+        positionById.set(person.id, { x: absX, y: absY });
+        associationLinks.push({
+          anchorId,
+          memberId: person.id,
+          source: { x: anchorPos.x, y: anchorPos.y },
+          target: { x: absX, y: absY },
+          type: person.association_type,
+        });
+      }
+      associateBloomLabels.push({
         anchorId,
-        memberId: p.id,
-        source: { x: anchorPos.x, y: anchorPos.y },
-        target: { x, y },
-        type: p.association_type,
+        type: type as AssociationType,
+        text: ASSOCIATE_SECTORS[type].labelText,
+        x: anchorPos.x + offsetX + s.labelX,
+        y: anchorPos.y + s.labelY,
       });
-    });
+    }
+
+    // If we had to shift, draw a thick trail from the anchor to the
+    // bloom's apex (top of its bbox).
+    if (offsetX !== 0) {
+      associateTrails.push({
+        anchorId,
+        source: { x: anchorPos.x, y: anchorPos.y },
+        target: { x: anchorPos.x + offsetX, y: anchorPos.y + bbMinY },
+      });
+    }
   }
 
   const allNodes = [...allTreeNodes, ...disconnectedNodes];
@@ -667,6 +857,7 @@ export function computeFullLayout(
 
   return {
     nodes: allNodes, links, marriageBars, spouseConnectors,
-    associationLinks, spineIds, bounds,
+    associationLinks, associateBloomLabels, associateTrails,
+    spineIds, bounds,
   };
 }


### PR DESCRIPTION
Follow-up to the organic layout PR. With Jesus (34 associates) and Paul (39 associates) fanned in a single bloom, names overlapped each other and the cluster collided with the era-grid below the main tree.

## Changes

- Each anchor's members are now **grouped by `association_type`**; each type gets its own angular sector around the anchor:

  | Type | Sector | Position |
  |------|--------|----------|
  | `disciple` | -80° to +80° | main group, straight below |
  | `servant` | -35° to +35° | inside the disciple ring, closer to anchor |
  | `contemporary` | +45° to +95° | below-right |
  | `adversary` | -95° to -45° | below-left |

- **Concentric rings for very large types** — groups > 12 members split into two concentric half-rings so the radius doesn't have to grow past ~800 px.

- **Collision avoidance** — after laying out an anchor's sub-blooms, the aggregate bbox is checked against every existing non-member node (main tree, spouses, era-grid, previously-placed blooms) with a 60 px halo. If there's overlap, the whole bloom shifts sideways in 180 px steps (right-first, spiraling outward) until clear. Two new fields on `TreeLayoutResult`:
  - `associateBloomLabels` — "disciples" / "contemporaries" / "adversaries" labels at each sub-bloom's apex, rendered only at `zoom ≥ TIER_3_ZOOM` so the overview stays clean.
  - `associateTrails` — a thick gold line from the anchor to a shifted bloom's apex so the association stays visually traceable.

## Test plan

- [ ] `./node_modules/.bin/jest` — 426 suites / 3206 tests passing (+1 new type-grouping test)
- [ ] `npx tsc --noEmit` — clean
- [ ] **Device check**: Jesus's 34 associates render in three distinct labelled sub-arcs (disciples below, contemporaries right, adversaries left); Paul's 39 likewise. No names overlap other names or unrelated era-grid entries; if a bloom had to shift, a gold trail is visible from the anchor to its apex.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3