### PR TITLE
tree: diagnostic logging + label font swap (crash investigation)

### DIFF
--- a/app/__tests__/utils/treeBuilder.organic.test.ts
+++ b/app/__tests__/utils/treeBuilder.organic.test.ts
@@ -72,6 +72,59 @@ describe('treeBuilder — #1290 associate tribal bloom', () => {
       expect(n.y).toBeGreaterThan(jesusNode.y);
     }
   });
+
+  it('groups associates by type and emits one label per type present', () => {
+    const people: Person[] = [
+      makePerson({ id: 'adam', name: 'Adam' }),
+      makePerson({ id: 'jacob_nt', name: 'Jacob', father: 'adam' }),
+      makePerson({ id: 'joseph-nt', name: 'Joseph', father: 'jacob_nt' }),
+      makePerson({ id: 'jesus', name: 'Jesus', father: 'joseph-nt' }),
+      makePerson({ id: 'peter', name: 'Peter', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'andrew', name: 'Andrew', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'john-ap', name: 'John', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'pilate', name: 'Pilate', associated_with: 'jesus', association_type: 'contemporary' }),
+      makePerson({ id: 'caiaphas', name: 'Caiaphas', associated_with: 'jesus', association_type: 'contemporary' }),
+      makePerson({ id: 'barabbas', name: 'Barabbas', associated_with: 'jesus', association_type: 'adversary' }),
+    ];
+    const { associateBloomLabels } = computeFullLayout(people, null);
+    const jesusLabels = associateBloomLabels.filter((l) => l.anchorId === 'jesus');
+    const types = jesusLabels.map((l) => l.type).sort();
+    expect(types).toEqual(['adversary', 'contemporary', 'disciple']);
+    const byType = new Map(jesusLabels.map((l) => [l.type, l.text]));
+    expect(byType.get('disciple')).toBe('disciples');
+    expect(byType.get('contemporary')).toBe('contemporaries');
+    expect(byType.get('adversary')).toBe('adversaries');
+  });
+
+  it('spaces associates with enough gap for their name labels (≥ 70 px)', () => {
+    // Guard against the "tight cluster" regression — large clusters must
+    // scale radius so adjacent names don't overlap.
+    const people: Person[] = [
+      makePerson({ id: 'adam', name: 'Adam' }),
+      makePerson({ id: 'jacob_nt', name: 'Jacob', father: 'adam' }),
+      makePerson({ id: 'joseph-nt', name: 'Joseph', father: 'jacob_nt' }),
+      makePerson({ id: 'jesus', name: 'Jesus', father: 'joseph-nt' }),
+      makePerson({ id: 'peter', name: 'Peter', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'andrew', name: 'Andrew', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'james', name: 'James', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'john', name: 'John', associated_with: 'jesus', association_type: 'disciple' }),
+      makePerson({ id: 'thomas', name: 'Thomas', associated_with: 'jesus', association_type: 'disciple' }),
+    ];
+    const { nodes } = computeFullLayout(people, null);
+    const ids = ['peter', 'andrew', 'james', 'john', 'thomas'];
+    const placed = ids
+      .map((id) => nodes.find((n) => n.data.id === id)!)
+      .sort((a, b) => a.x - b.x);
+    // Minimum distance between any two adjacent associate centres on the arc.
+    let minGap = Infinity;
+    for (let i = 1; i < placed.length; i++) {
+      const dx = placed[i].x - placed[i - 1].x;
+      const dy = placed[i].y - placed[i - 1].y;
+      const gap = Math.hypot(dx, dy);
+      if (gap < minGap) minGap = gap;
+    }
+    expect(minGap).toBeGreaterThanOrEqual(70);
+  });
 });
 
 describe("treeBuilder — #1291 Jacob's tribal bloom", () => {

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -16,8 +16,9 @@ import { MarriageBarSvg } from './MarriageBarSvg';
 import { SpouseConnectorSvg } from './SpouseConnectorSvg';
 import { TreeNode } from './TreeNode';
 import { AssociationLinkSvg } from './AssociationLinkSvg';
-import { TIER_2_ZOOM } from '../../utils/genealogyOrganic';
-import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink } from '../../utils/treeBuilder';
+import { TIER_2_ZOOM, TIER_3_ZOOM } from '../../utils/genealogyOrganic';
+import { logger } from '../../utils/logger';
+import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
 
 interface Props {
   nodes: LayoutNode[];
@@ -26,6 +27,11 @@ interface Props {
   spouseConnectors: SpouseConnector[];
   /** Dotted connectors from anchors to associated_with satellites (#1288). */
   associationLinks?: AssociationLink[];
+  /** Type-sector labels ("disciples", "contemporaries"…) emitted by
+   *  the associate bloom layout. Shown at mid-zoom+. */
+  associateBloomLabels?: AssociateBloomLabel[];
+  /** Thick trail connectors from anchors to offset associate blooms. */
+  associateTrails?: AssociateTrail[];
   filterEra: string | null;
   spineIds: Set<string>;
   selectedPersonId: string | null;
@@ -44,6 +50,8 @@ interface Props {
 export const TreeCanvas = memo(function TreeCanvas({
   nodes, links, marriageBars, spouseConnectors,
   associationLinks = [],
+  associateBloomLabels = [],
+  associateTrails = [],
   filterEra, spineIds, selectedPersonId, onNodePress,
   offsetX = 0, offsetY = 0,
   canvasWidth = 4000, canvasHeight = 4000,
@@ -54,6 +62,20 @@ export const TreeCanvas = memo(function TreeCanvas({
   // Below TIER_2_ZOOM, collapse each associate cluster into a single "+N"
   // badge at the anchor and hide the individual associate nodes + links.
   const clustersCollapsed = zoom < TIER_2_ZOOM;
+
+  // Render-entry diagnostic — the LAST line before the SVG tree commits.
+  // If the crash happens after this log but before the post-commit effect
+  // log, the failure is inside the SVG render tree.
+  logger.info(
+    'Canvas',
+    `render z=${zoom.toFixed(2)} collapsed=${clustersCollapsed} `
+    + `nodes=${nodes.length} links=${links.length} al=${associationLinks.length} `
+    + `labels=${associateBloomLabels.length} trails=${associateTrails.length} `
+    + `canvas=${canvasWidth}x${canvasHeight}`,
+  );
+  React.useEffect(() => {
+    logger.info('Canvas', `render COMMITTED z=${zoom.toFixed(2)}`);
+  });
   const associateIds = useMemo(
     () => new Set(associationLinks.map((al) => al.memberId)),
     [associationLinks],
@@ -150,6 +172,40 @@ export const TreeCanvas = memo(function TreeCanvas({
               +{b.count}
             </SvgText>
           </G>
+        ))}
+
+        {/* 1d. Associate-bloom trails — thick gold line from anchor to the
+               apex of a bloom that had to be shifted sideways. */}
+        {!clustersCollapsed && associateTrails.map((t) => (
+          <Line
+            key={`at-${t.anchorId}`}
+            x1={t.source.x}
+            y1={t.source.y}
+            x2={t.target.x}
+            y2={t.target.y}
+            stroke={base.gold}
+            strokeWidth={1.5}
+            opacity={0.35}
+            strokeLinecap="round"
+          />
+        ))}
+
+        {/* 1e. Type-sector labels ("disciples", "contemporaries"…) at the
+               apex of each sub-bloom. Visible at mid-zoom+ so the overview
+               stays clean. */}
+        {!clustersCollapsed && zoom >= TIER_3_ZOOM && associateBloomLabels.map((lbl) => (
+          <SvgText
+            key={`abl-${lbl.anchorId}-${lbl.type}`}
+            x={lbl.x}
+            y={lbl.y}
+            fill={base.gold}
+            fontSize={11}
+            fontFamily="Cinzel_600SemiBold"
+            textAnchor="middle"
+            opacity={0.65}
+          >
+            {lbl.text}
+          </SvgText>
         ))}
 
         {/* 2. Marriage bars */}

--- a/app/src/hooks/useTreeLayout.ts
+++ b/app/src/hooks/useTreeLayout.ts
@@ -21,6 +21,8 @@ export function useTreeLayout(
         marriageBars: [],
         spouseConnectors: [],
         associationLinks: [],
+        associateBloomLabels: [],
+        associateTrails: [],
         spineIds: new Set<string>(),
         bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100, width: 100, height: 100 },
       };

--- a/app/src/screens/GenealogyTreeScreen.tsx
+++ b/app/src/screens/GenealogyTreeScreen.tsx
@@ -63,7 +63,8 @@ function GenealogyTreeScreen({ route, navigation }: {
   const [filterEra, setFilterEra] = useState<string>('all');
   const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
 
-  const { nodes, links, marriageBars, spouseConnectors, associationLinks, spineIds, bounds } =
+  const { nodes, links, marriageBars, spouseConnectors, associationLinks,
+    associateBloomLabels, associateTrails, spineIds, bounds } =
     useTreeLayout(people, filterEra);
 
   useEffect(() => {
@@ -220,6 +221,8 @@ function GenealogyTreeScreen({ route, navigation }: {
                   marriageBars={marriageBars}
                   spouseConnectors={spouseConnectors}
                   associationLinks={associationLinks}
+                  associateBloomLabels={associateBloomLabels}
+                  associateTrails={associateTrails}
                   filterEra={filterEra === 'all' ? null : filterEra}
                   spineIds={spineIds}
                   selectedPersonId={selectedPerson?.id ?? null}

--- a/app/src/utils/treeBuilder.ts
+++ b/app/src/utils/treeBuilder.ts
@@ -14,6 +14,7 @@ import { hierarchy, tree, type HierarchyPointNode } from 'd3-hierarchy';
 import type { AssociationType, Person } from '../types';
 import { isMessianic as checkMessianic } from './messianicLine';
 import { applyTribalBloom } from './genealogyOrganic';
+import { logger } from './logger';
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -89,6 +90,24 @@ export interface AssociationLink {
   source: { x: number; y: number };
   target: { x: number; y: number };
   type: AssociationType | null;
+}
+
+/** Text label placed at the apex of a type sub-bloom — "disciples",
+ *  "contemporaries", etc. Rendered at mid-zoom+ so overview stays clean. */
+export interface AssociateBloomLabel {
+  anchorId: string;
+  type: AssociationType;
+  text: string;
+  x: number;
+  y: number;
+}
+
+/** Thick trail line from the anchor to an offset bloom's apex. Only
+ *  emitted when the bloom had to be shifted sideways to avoid overlap. */
+export interface AssociateTrail {
+  anchorId: string;
+  source: { x: number; y: number };
+  target: { x: number; y: number };
 }
 
 // ── Spine computation ───────────────────────────────────────────────
@@ -370,6 +389,11 @@ export interface TreeLayoutResult {
   spouseConnectors: SpouseConnector[];
   /** Dotted connectors from anchors to associated_with satellites (#1288). */
   associationLinks: AssociationLink[];
+  /** Type labels placed at each sub-bloom's apex ("disciples", "contemporaries"…). */
+  associateBloomLabels: AssociateBloomLabel[];
+  /** Thick trail from the anchor to an offset bloom's apex — only when
+   *  the bloom had to be shifted to avoid overlapping other nodes. */
+  associateTrails: AssociateTrail[];
   spineIds: Set<string>;
   bounds: TreeBounds;
 }
@@ -457,6 +481,88 @@ function applyImportantFigureSpread(nodes: LayoutNode[]): void {
   }
 }
 
+// ── Associate clustering (#1290, type-sector redesign) ────────────────
+
+/** One of the four biblical association categories, rendered in its
+ *  own angular sector around the anchor. */
+interface AssociateSectorSpec {
+  /** Centre angle in degrees — 0 = straight down. */
+  center: number;
+  /** Max half-sweep in degrees; actual sweep may be narrower. */
+  halfSweepMax: number;
+  /** Label text placed at the sub-bloom's apex. */
+  labelText: string;
+}
+
+const ASSOCIATE_TYPE_ORDER = ['disciple', 'servant', 'contemporary', 'adversary'] as const;
+
+const ASSOCIATE_SECTORS: Record<string, AssociateSectorSpec> = {
+  // Main group fans straight down in a wide arc.
+  disciple:     { center:   0, halfSweepMax: 80, labelText: 'disciples' },
+  // Servants share the disciple sector but sit inside, closer to the anchor.
+  servant:      { center:   0, halfSweepMax: 35, labelText: 'servants' },
+  // Neutral and opposition fan to the right and left respectively.
+  contemporary: { center:  70, halfSweepMax: 25, labelText: 'contemporaries' },
+  adversary:    { center: -70, halfSweepMax: 25, labelText: 'adversaries' },
+};
+
+const ASSOCIATE_BLOOM_GAP = 80;         // target centre-to-centre between circles
+const ASSOCIATE_MIN_RADIUS = 120;
+const ASSOCIATE_MAX_PER_RING = 12;      // above this, split into concentric rings
+const ASSOCIATE_LABEL_GAP = 28;
+const ASSOCIATE_COLLISION_PAD = 60;     // halo around other nodes to treat as occupied
+const ASSOCIATE_SHIFT_STEP_X = 180;     // px to offset the bloom when a placement collides
+
+/** Lay out one type group, returning member positions RELATIVE to the
+ *  bloom centre (0,0) plus a label position and outermost radius. */
+function layOutAssociateType(
+  members: Person[],
+  sector: AssociateSectorSpec,
+  innerRadius: number,
+): { placed: Array<{ id: string; x: number; y: number }>; labelX: number; labelY: number; outerRadius: number } {
+  // Split very large groups into 2 concentric half-rings so the radius
+  // doesn't have to blow past 800 px.
+  const rings = members.length > ASSOCIATE_MAX_PER_RING
+    ? [
+        members.slice(0, Math.ceil(members.length / 2)),
+        members.slice(Math.ceil(members.length / 2)),
+      ]
+    : [members];
+
+  const all: Array<{ id: string; x: number; y: number }> = [];
+  let outer = innerRadius;
+  rings.forEach((ring, ringIdx) => {
+    const desiredSweep = Math.min(sector.halfSweepMax * 2, 60 + ring.length * 10);
+    const sweepRad = (desiredSweep * Math.PI) / 180;
+    const radius = Math.max(
+      innerRadius + ringIdx * 110,
+      (ASSOCIATE_BLOOM_GAP * Math.max(ring.length - 1, 1)) / sweepRad,
+    );
+    outer = Math.max(outer, radius);
+    const half = desiredSweep / 2;
+    const placed = applyTribalBloom(
+      { x: 0, y: 0 },
+      ring.map((m) => ({ id: m.id, x: 0, y: 0 })),
+      {
+        radius,
+        startAngleDegrees: sector.center - half,
+        endAngleDegrees: sector.center + half,
+      },
+    );
+    all.push(...placed);
+  });
+
+  // Label sits just beyond the outermost ring at the sector's centre angle.
+  const labelRadius = outer + ASSOCIATE_LABEL_GAP;
+  const labelAngle = (sector.center * Math.PI) / 180;
+  return {
+    placed: all,
+    labelX: labelRadius * Math.sin(labelAngle),
+    labelY: labelRadius * Math.cos(labelAngle),
+    outerRadius: outer,
+  };
+}
+
 export function computeFullLayout(
   people: Person[],
   filterEra: string | null
@@ -467,7 +573,8 @@ export function computeFullLayout(
   if (!root) {
     return {
       nodes: [], links: [], marriageBars: [], spouseConnectors: [],
-      associationLinks: [], spineIds,
+      associationLinks: [], associateBloomLabels: [], associateTrails: [],
+      spineIds,
       bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100, width: 100, height: 100 },
     };
   }
@@ -575,48 +682,154 @@ export function computeFullLayout(
     clusterY += rows * ROW_SPACING_Y + 80; // gap before next era group
   }
 
-  // Layout association clusters radially around their anchor via tribal
-  // bloom (#1290). Sweep widens with cluster size so large groups fan more.
+  // Lay out association clusters by type with collision avoidance (#1290).
+  // Members are grouped by association_type; each type gets its own angular
+  // sector around the anchor. Very large groups split into concentric rings.
+  // If the resulting bloom would overlap existing nodes, the whole bloom
+  // shifts sideways and a thick trail connects the anchor to its apex.
   const positionById = new Map<string, { x: number; y: number }>();
   for (const n of allTreeNodes) positionById.set(n.data.id, { x: n.x, y: n.y });
   for (const n of disconnectedNodes) positionById.set(n.data.id, { x: n.x, y: n.y });
 
   const associationLinks: AssociationLink[] = [];
+  const associateBloomLabels: AssociateBloomLabel[] = [];
+  const associateTrails: AssociateTrail[] = [];
+
+  logger.info('Assoc', `${clusterByAnchor.size} anchors to lay out`);
   for (const [anchorId, members] of clusterByAnchor) {
     const anchorPos = positionById.get(anchorId);
-    if (!anchorPos) continue; // anchor wasn't placed (orphaned anchor) — drop silently
+    if (!anchorPos) {
+      logger.info('Assoc', `anchor=${anchorId} SKIPPED — no position`);
+      continue; // anchor wasn't placed — drop silently
+    }
 
-    const radius = 90 + Math.min(members.length, 8) * 8; // 98 → 154 px
-    const sweep = Math.min(160, 60 + members.length * 14); // degrees
-    const placed = applyTribalBloom(
-      { x: anchorPos.x, y: anchorPos.y },
-      members.map((m) => ({ id: m.id, x: 0, y: 0 })),
-      {
-        radius,
-        startAngleDegrees: -sweep / 2, // fan below the anchor, centred straight down
-        endAngleDegrees: sweep / 2,
-      },
-    );
+    // Group this anchor's members by association_type (null → 'disciple')
+    const byType = new Map<string, Person[]>();
+    for (const m of members) {
+      const t = (m.association_type ?? 'disciple') as string;
+      const list = byType.get(t) ?? [];
+      list.push(m);
+      byType.set(t, list);
+    }
 
-    members.forEach((p, i) => {
-      const { x, y } = placed[i];
-      disconnectedNodes.push({
-        data: { ...p, nodeType: 'satellite', isAssociate: true },
-        x,
-        y,
-        parent: null,
-        children: [],
-        depth: 0,
-        isSpouse: false,
-      });
-      associationLinks.push({
+    // Servants (if present) sit inside the disciple sector, closer to the
+    // anchor. Disciples then start at a larger inner radius.
+    const servantCount = byType.get('servant')?.length ?? 0;
+    const discipleStart = servantCount > 0 ? 230 : ASSOCIATE_MIN_RADIUS;
+
+    // Lay out each type (positions relative to 0,0)
+    const sub: Record<string, ReturnType<typeof layOutAssociateType> | null> = {
+      disciple: null, servant: null, contemporary: null, adversary: null,
+    };
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const list = byType.get(type);
+      if (!list || list.length === 0) continue;
+      const sector = ASSOCIATE_SECTORS[type];
+      const start = type === 'disciple' ? discipleStart : ASSOCIATE_MIN_RADIUS;
+      sub[type] = layOutAssociateType(list, sector, start);
+    }
+
+    // Aggregate bbox across all sub-blooms (relative to bloom centre 0,0)
+    let bbMinX = 0, bbMaxX = 0, bbMinY = 0, bbMaxY = 0;
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const s = sub[type];
+      if (!s) continue;
+      for (const p of s.placed) {
+        if (p.x < bbMinX) bbMinX = p.x;
+        if (p.x > bbMaxX) bbMaxX = p.x;
+        if (p.y < bbMinY) bbMinY = p.y;
+        if (p.y > bbMaxY) bbMaxY = p.y;
+      }
+    }
+
+    // Collision check: does placing the bloom at anchor + (offsetX, 0)
+    // overlap any non-member existing node?
+    const memberIdSet = new Set(members.map((m) => m.id));
+    const checkCollision = (offsetX: number): boolean => {
+      const minX = anchorPos.x + offsetX + bbMinX - ASSOCIATE_COLLISION_PAD;
+      const maxX = anchorPos.x + offsetX + bbMaxX + ASSOCIATE_COLLISION_PAD;
+      const minY = anchorPos.y + bbMinY - ASSOCIATE_COLLISION_PAD;
+      const maxY = anchorPos.y + bbMaxY + ASSOCIATE_COLLISION_PAD;
+      for (const [id, pos] of positionById) {
+        if (id === anchorId || memberIdSet.has(id)) continue;
+        if (pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    let offsetX = 0;
+    if (checkCollision(0)) {
+      let found = false;
+      for (let step = 1; step <= 8 && !found; step++) {
+        for (const sign of [1, -1]) {
+          const dx = sign * step * ASSOCIATE_SHIFT_STEP_X;
+          if (!checkCollision(dx)) {
+            offsetX = dx;
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) offsetX = 9 * ASSOCIATE_SHIFT_STEP_X; // forced far-right
+    }
+
+    // Emit member nodes + anchor→member links + type labels
+    for (const type of ASSOCIATE_TYPE_ORDER) {
+      const s = sub[type];
+      if (!s) continue;
+      const memberIndex = new Map(members.map((m) => [m.id, m]));
+      for (const placed of s.placed) {
+        const person = memberIndex.get(placed.id);
+        if (!person) continue;
+        const absX = anchorPos.x + offsetX + placed.x;
+        const absY = anchorPos.y + placed.y;
+        disconnectedNodes.push({
+          data: { ...person, nodeType: 'satellite', isAssociate: true },
+          x: absX,
+          y: absY,
+          parent: null,
+          children: [],
+          depth: 0,
+          isSpouse: false,
+        });
+        positionById.set(person.id, { x: absX, y: absY });
+        associationLinks.push({
+          anchorId,
+          memberId: person.id,
+          source: { x: anchorPos.x, y: anchorPos.y },
+          target: { x: absX, y: absY },
+          type: person.association_type,
+        });
+      }
+      associateBloomLabels.push({
         anchorId,
-        memberId: p.id,
-        source: { x: anchorPos.x, y: anchorPos.y },
-        target: { x, y },
-        type: p.association_type,
+        type: type as AssociationType,
+        text: ASSOCIATE_SECTORS[type].labelText,
+        x: anchorPos.x + offsetX + s.labelX,
+        y: anchorPos.y + s.labelY,
       });
-    });
+    }
+
+    // If we had to shift, draw a thick trail from the anchor to the
+    // bloom's apex (top of its bbox).
+    if (offsetX !== 0) {
+      associateTrails.push({
+        anchorId,
+        source: { x: anchorPos.x, y: anchorPos.y },
+        target: { x: anchorPos.x + offsetX, y: anchorPos.y + bbMinY },
+      });
+    }
+
+    const typeBreakdown = Array.from(byType.entries())
+      .map(([t, list]) => `${t}=${list.length}`).join(',');
+    logger.info(
+      'Assoc',
+      `anchor=${anchorId} N=${members.length} types=${typeBreakdown} `
+      + `bbox=${Math.round(bbMaxX - bbMinX)}x${Math.round(bbMaxY - bbMinY)} `
+      + `offsetX=${offsetX} trail=${offsetX !== 0}`,
+    );
   }
 
   const allNodes = [...allTreeNodes, ...disconnectedNodes];
@@ -645,8 +858,18 @@ export function computeFullLayout(
     height: maxY - minY,
   };
 
+  logger.info(
+    'Layout',
+    `nodes=${allNodes.length} links=${links.length} mb=${marriageBars.length} `
+    + `sc=${spouseConnectors.length} al=${associationLinks.length} `
+    + `labels=${associateBloomLabels.length} trails=${associateTrails.length} `
+    + `bounds=${Math.round(bounds.width)}x${Math.round(bounds.height)} `
+    + `minX=${Math.round(bounds.minX)} minY=${Math.round(bounds.minY)}`,
+  );
+
   return {
     nodes: allNodes, links, marriageBars, spouseConnectors,
-    associationLinks, spineIds, bounds,
+    associationLinks, associateBloomLabels, associateTrails,
+    spineIds, bounds,
   };
 }


### PR DESCRIPTION
Diagnostic PR — built on top of current master (which has the crashing type-sector work from #1300). Adds breadcrumb logging so the next crash tells us exactly where it dies.

## What's added

1. **`treeBuilder.ts`** — per-cluster and post-layout summaries:
   ```
   [Assoc] 10 anchors to lay out
   [Assoc] anchor=jesus N=34 types=disciple=23,contemporary=9,adversary=2 bbox=900x700 offsetX=0 trail=false
   [Assoc] anchor=paul  N=39 types=disciple=33,contemporary=3,adversary=3 bbox=900x900 offsetX=180 trail=true
   ...
   [Layout] nodes=337 links=298 mb=12 sc=4 al=95 labels=18 trails=2 bounds=3200x10017 minX=-1600 minY=-100
   ```

2. **`TreeCanvas.tsx`** — render-entry log + post-commit effect:
   ```
   [Canvas] render z=0.65 collapsed=false nodes=337 links=298 al=95 labels=18 trails=2 canvas=3200x10017
   [Canvas] render COMMITTED z=0.65   ← only fires if the SVG commit succeeded
   ```

3. **Defensive font swap**: the new type-sector apex labels were using `Cinzel_500Medium`; switched to `Cinzel_600SemiBold` (already used by `TreeNode`, proven loaded). RN SVG on Android can hard-crash on unknown `fontFamily` even when the element is inside a conditional that shouldn't render.

## What we'll learn

From the current report — *loading spinner → background renders for ~2 s → crash, last log is `jumpTo … s=0.65`* — merging this gives us one of three outcomes:

| Last log line seen | Diagnosis |
|---|---|
| `[Canvas] render z=0.65 …` (no COMMITTED) | Crash is inside the SVG render tree. Next step: bisect by disabling associationLinks / trails / nodes map. |
| `[Canvas] render COMMITTED z=0.65` then nothing | Crash is during native paint, not render — probably a GPU surface limit (`bounds=3200x10017` is at the edge). Next step: clamp bounds. |
| No `[Canvas] render` at all at z=0.65 | Something in `GenealogyTreeScreen` between `jumpTo` and the TreeCanvas render is dying. |
| **No crash** | Either the font swap was the culprit, or the new logging somehow perturbs timing in our favour. |

## Relationship to revert PR #1301

#1301 still reverts this work entirely (safest path for staying shippable). This PR is *instead of* that revert if you want to keep the type-sector work and get diagnostic data. If #1301 merges first, this PR will need re-basing (the diagnostic code assumes the type-sector code is present).

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open the genealogy tree, capture full log output up to the crash and paste it back.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3