### PR TITLE
tree: raise collapse threshold + drop per-link text (iOS paint fix)

### DIFF
--- a/app/src/components/tree/AssociationLinkSvg.tsx
+++ b/app/src/components/tree/AssociationLinkSvg.tsx
@@ -3,10 +3,15 @@
  * satellites (#1290). A visual counterpart to TreeLink, distinguished by
  * the dashed stroke so users can tell a contemporary association (e.g.
  * Peter → Jesus) apart from a genealogical link.
+ *
+ * No per-link type text — the apex labels rendered by TreeCanvas on each
+ * sub-bloom ("disciples", "contemporaries", …) convey type already, and
+ * rendering 89 extra <SvgText> elements here contributed to an iOS
+ * native-paint crash on a tall (10k px) canvas.
  */
 
 import React, { memo } from 'react';
-import { Path, Text as SvgText } from 'react-native-svg';
+import { Path } from 'react-native-svg';
 import { useTheme } from '../../theme';
 import { bezierPath } from '../../utils/genealogyOrganic';
 import type { AssociationType } from '../../types';
@@ -14,41 +19,25 @@ import type { AssociationType } from '../../types';
 interface Props {
   source: { x: number; y: number };
   target: { x: number; y: number };
+  /** Retained on the prop for future per-type styling; unused at render. */
   type: AssociationType | null;
   dimmed: boolean;
 }
 
 export const AssociationLinkSvg = memo(function AssociationLinkSvg({
-  source, target, type, dimmed,
+  source, target, dimmed,
 }: Props) {
   const { base } = useTheme();
   const d = bezierPath(source, target);
-  const midX = (source.x + target.x) / 2;
-  const midY = (source.y + target.y) / 2;
-
   return (
-    <>
-      <Path
-        d={d}
-        stroke={base.border}
-        strokeWidth={0.9}
-        strokeDasharray="4,4"
-        fill="none"
-        opacity={dimmed ? 0.15 : 0.55}
-        strokeLinecap="round"
-      />
-      {type && !dimmed && (
-        <SvgText
-          x={midX}
-          y={midY - 2}
-          fill={base.textMuted}
-          fontSize={9}
-          textAnchor="middle"
-          opacity={0.7}
-        >
-          {type}
-        </SvgText>
-      )}
-    </>
+    <Path
+      d={d}
+      stroke={base.border}
+      strokeWidth={0.9}
+      strokeDasharray="4,4"
+      fill="none"
+      opacity={dimmed ? 0.15 : 0.55}
+      strokeLinecap="round"
+    />
   );
 });

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -59,9 +59,17 @@ export const TreeCanvas = memo(function TreeCanvas({
 }: Props) {
   const { base } = useTheme();
 
-  // Below TIER_2_ZOOM, collapse each associate cluster into a single "+N"
+  // Below TIER_3_ZOOM, collapse each associate cluster into a single "+N"
   // badge at the anchor and hide the individual associate nodes + links.
-  const clustersCollapsed = zoom < TIER_2_ZOOM;
+  //
+  // WHY TIER_3_ZOOM and not TIER_2_ZOOM? Associates are tier-3 figures
+  // (no role, no bio) — TreeNode already returns null for them below 0.8.
+  // If we un-collapse at 0.5, the 89 association-link bezier paths render
+  // but point to invisible targets, AND the combined render load crashes
+  // iOS's native paint on a 2748×10017 canvas. Collapsing until 0.8 keeps
+  // cluster links and nodes in sync and dramatically reduces the render
+  // footprint at the initial centre-on-Adam zoom of 0.65.
+  const clustersCollapsed = zoom < TIER_3_ZOOM;
 
   // Render-entry diagnostic — the LAST line before the SVG tree commits.
   // If the crash happens after this log but before the post-commit effect


### PR DESCRIPTION
Follow-up to PR #1302 (now merged). The device logs from that build nailed the crash point:

```
[Canvas] render z=0.45 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.65 collapsed=false → COMMITTED ✓
(crash — no further log)
```

React committed both renders cleanly — the crash is iOS's native paint after the second commit. At z=0.45 only 10 "+N" cluster badges rendered; at z=0.65 the clusters expanded and **89 long dashed bezier paths + 89 per-link `<SvgText>` labels + 7 trails + 298 tree nodes** all landed on a 2748×10017 canvas simultaneously. iOS's layer compositor didn't survive.

## Fixes

**1. `clustersCollapsed = zoom < TIER_3_ZOOM`** (0.8), was `< TIER_2_ZOOM` (0.5).

Associates are tier-3 figures — `TreeNode` already hides them individually below 0.8. Previously the connector bezier paths still rendered below 0.8, pointing to invisible targets. Now clusters stay as "+N" badges until the user zooms to the tier at which their member nodes would actually be visible. At your `z=0.65` this removes all 89 association links, 7 trails, and 18 apex labels from the frame.

**2. Dropped per-link `<SvgText>` in `AssociationLinkSvg`.**

The apex labels on each sub-bloom ("disciples", "contemporaries", "adversaries") already convey type. 89 extra font-rendered SvgText layers inside each bezier link were the other half of the paint overload. The `type` prop is retained for future per-type styling hooks but is unused at render.

## What the next device test will show

| Log trace | Meaning |
|---|---|
| `[Canvas] render z=0.65 collapsed=true → COMMITTED` then the app sits (no crash) | Fix works. App ready to ship. Clusters appear as "+N" badges; user zooms to 0.8 to expand. |
| Crash still at `z=0.65` | Problem is elsewhere; logs will narrow it down. |
| Crash when user pinches in to 0.8 | Expanded rendering itself is too heavy on iOS. Next step: vertical-tile the SVG or set `shouldRasterizeIOS={false}`. |

## Test plan

- [x] `./node_modules/.bin/jest` — 426 suites / 3205 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open genealogy tree, confirm it loads. Then pinch in past 0.8 to see clusters expand.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3