### PR TITLE
tree: lean tier-2 render below TIER_3_ZOOM (iOS paint fix)

### DIFF
--- a/app/src/components/tree/TreeNode.tsx
+++ b/app/src/components/tree/TreeNode.tsx
@@ -19,7 +19,7 @@ import type { LayoutNode, TreePerson } from '../../utils/treeBuilder';
 import { isMessianic } from '../../utils/messianicLine';
 import { getRoleBadgeConfig } from './RoleBadge';
 import { getCovenantWaypoint } from '../../utils/covenantWaypoints';
-import { getPersonTier, isPersonVisibleAtZoom } from '../../utils/genealogyOrganic';
+import { getPersonTier, isPersonVisibleAtZoom, TIER_3_ZOOM } from '../../utils/genealogyOrganic';
 
 // ── Circle dimensions ─────────────────────────────────────────────────
 const SPINE_R = 24;            // 48 px diameter
@@ -123,6 +123,39 @@ export const TreeNode = memo(function TreeNode({
   const nameFill = onMessianicLine
     ? base.gold
     : (isSpine ? base.text : base.textDim);
+
+  // Lean render for tier-2 at mid zoom (0.7 ≤ zoom < 0.8): just a circle
+  // + name. Avoids adding ~80 multi-layer TreeNode instances when the
+  // user pinches past TIER_2_ZOOM. iOS's compositor crashes on the full
+  // variant at that node count on a ~10 000-px tall canvas. Full variant
+  // (initial letter, role badge, waypoint, glow, touch rect) kicks back
+  // in at TIER_3_ZOOM where the user has pinched far enough to care about
+  // the extra detail.
+  if (tier === 2 && zoom < TIER_3_ZOOM) {
+    return (
+      <G onPress={handlePress} opacity={opacity}>
+        <Circle
+          cx={x}
+          cy={y}
+          r={r}
+          fill={nodeFill}
+          stroke={borderColor}
+          strokeWidth={borderWidth}
+          strokeDasharray={isAssociate ? '2,2' : undefined}
+        />
+        <SvgText
+          x={x}
+          y={y + r + NAME_GAP}
+          textAnchor="middle"
+          fontSize={nameFont}
+          fill={nameFill}
+          fontFamily="SourceSans3_400Regular"
+        >
+          {data.name}
+        </SvgText>
+      </G>
+    );
+  }
 
   // Initial colour — gold inside messianic, light text inside spine, dim text inside satellite
   const initialFill = onMessianicLine


### PR DESCRIPTION
Fourth layer of the iOS paint crash fix. #1304 moved the first crash to a higher zoom; this drops the per-node render cost at that zoom band so the app survives it.

## What the logs showed

```
[Canvas] render z=0.45 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.65 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.46 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.15 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.37 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.68 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.79 visibleTier=2 collapsed=true  ← no COMMITTED
```

The transition from tier 1 (~100 TreeNodes) to tier 2 (~180 TreeNodes) is the breaking point.

## Why it's expensive

A full-variant `TreeNode` emits 5–10 native SVG layers:

- Main `Circle`
- Initial-letter `SvgText`
- Name `SvgText`
- Optional touch-target `Rect` (small satellites only)
- Optional messianic-glow `Circle`
- Optional selection-ring `Circle`
- Optional role-badge `G` + `Circle` + `SvgText`
- Optional covenant-waypoint `G` + rotated `G` + `Rect` + 2× `SvgText`

Tier-1 (~100 nodes × full variant) ≈ 500 layers and renders fine. Tier-1 + tier-2 at full variant (~180 × full) is ~1,000 layers; iOS's compositor gives up on the 2748 × 10017 canvas.

## Fix

When `tier === 2 && zoom < TIER_3_ZOOM`, `TreeNode` renders a lean variant:

```tsx
<G opacity={opacity}>
  <Circle cx={x} cy={y} r={r} fill=… stroke=… strokeWidth=… />
  <SvgText x={x} y={y + r + NAME_GAP}>{data.name}</SvgText>
</G>
```

Two layers per tier-2 node. Total at mid-zoom: ~500 (tier-1 full) + ~160 (tier-2 lean) ≈ 660 layers — safely under the previous working budget. Tier 1 keeps its full treatment so the spine still reads as the spine.

At `zoom ≥ TIER_3_ZOOM` (0.8) the full variant comes back for tier-2 and tier-3 becomes visible, and clusters un-collapse. That's still ~1,200+ layers and may require the next optimisation (SVG vertical tiling or disabling iOS offscreen rasterization) — but it's a deliberate pinch past 0.8 rather than a routine zoom-in.

## UX at each zoom band

| Zoom | Spine + roles | Bio-holders | Minor figures | Associate clusters |
|---|---|---|---|---|
| `< 0.7` | full | hidden | hidden | "+N" badges |
| `0.7 – 0.8` | full | **lean** (circle + name) | hidden | "+N" badges |
| `≥ 0.8` | full | full | full | expanded sub-blooms |

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, tree loads, then pinch past 0.7 and confirm `COMMITTED z=0.79` (or similar) now appears. Then pinch past 0.8 to test the full-variant expansion.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3