### PR TITLE
tree: constant-structure TreeNode (opacity-based tier gating)

### DIFF
--- a/app/__tests__/components/TreeNode.test.tsx
+++ b/app/__tests__/components/TreeNode.test.tsx
@@ -207,8 +207,10 @@ describe('TreeNode', () => {
 
   // ── Card #1291: zoom-semantic tier visibility ──────────────────────
 
-  it('renders null for a tier-3 person when zoomed out', () => {
-    // Tier 3 = no role, no bio, not messianic.
+  it('hides a tier-3 person at low zoom via opacity=0', () => {
+    // Tier 3 = no role, no bio, not messianic. Post-constant-tree-render
+    // refactor: the node still mounts (so we don't churn the native view
+    // tree during pinch) but is drawn with opacity 0.
     const minor = makeNode({
       id: 'some-minor-figure',
       name: 'Minor',
@@ -216,11 +218,13 @@ describe('TreeNode', () => {
       role: null,
       bio: null,
     });
-    const { queryByText } = renderWithProviders(
+    const { toJSON } = renderWithProviders(
       <TreeNode node={minor} dimmed={false} filterEra={null} selected={false}
         zoom={0.3} onPress={jest.fn()} />,
     );
-    expect(queryByText('Minor')).toBeNull();
+    // Root G should have opacity 0 when the tier is hidden.
+    const json = toJSON() as any;
+    expect(json?.props?.opacity).toBe(0);
   });
 
   it('renders a tier-3 person at full zoom', () => {

--- a/app/src/components/tree/TreeNode.tsx
+++ b/app/src/components/tree/TreeNode.tsx
@@ -1,25 +1,38 @@
 /**
  * TreeNode — Circular avatar node with initial letter inside, full name below.
  *
- * Visual tiers:
- *   - Messianic line: warm radial-gradient fill + bright gold border + outer aura
- *   - Spine: flat dark fill + gold-tinted border
- *   - Satellite: flat dark fill + dim border (smaller circle)
+ * Visual tiers (expressed via opacity; native layer count is constant):
+ *   - Messianic line: warm radial-gradient fill + gold stroke
+ *   - Spine:          flat dark fill + gold-tinted stroke
+ *   - Satellite:      flat dark fill + dim stroke (smaller circle)
  *
- * Role badges (K/P/✧/J/T) sit on the circle's top-right quadrant.
- * Covenant waypoint diamonds + theological annotations stack below the name.
+ * Constant render tree: every node emits the same 3 SVG layers regardless
+ * of tier (Circle + initial SvgText + name SvgText) plus an optional
+ * invisible touch-target Rect for satellites. Visibility by tier is
+ * controlled via opacity, never via null returns or JSX-structure swaps.
+ *
+ * WHY constant structure? Previous iterations conditionally mounted role
+ * badges, waypoint diamonds, messianic glows, and selection rings —
+ * each an extra native view. When a zoom gesture crossed a tier
+ * threshold, React would mount ~80 new views (tier 1 → tier 2) or
+ * ~200 (tier 2 → tier 3) in a single commit. iOS's compositor crashed
+ * on those batch mounts on the tall (~10 000 px) Svg canvas. With a
+ * constant structure, a zoom change only toggles opacity on existing
+ * layers — no mid-session allocations — and iOS handles it cleanly.
+ *
+ * Role badges and covenant waypoints aren't rendered here anymore; if
+ * we want to surface them per node, we'll wire them to a tap-selection
+ * state or a side panel so they can appear without a batch-mount.
  *
  * Card #1281: replaces the previous rectangular-card design.
  */
 
 import React, { memo, useCallback } from 'react';
 import { Circle, Rect, Text as SvgText, G } from 'react-native-svg';
-import { useTheme, eras } from '../../theme';
+import { useTheme } from '../../theme';
 import type { LayoutNode, TreePerson } from '../../utils/treeBuilder';
 import { isMessianic } from '../../utils/messianicLine';
-import { getRoleBadgeConfig } from './RoleBadge';
-import { getCovenantWaypoint } from '../../utils/covenantWaypoints';
-import { getPersonTier, isPersonVisibleAtZoom, TIER_3_ZOOM } from '../../utils/genealogyOrganic';
+import { getPersonTier, isPersonVisibleAtZoom } from '../../utils/genealogyOrganic';
 
 // ── Circle dimensions ─────────────────────────────────────────────────
 const SPINE_R = 24;            // 48 px diameter
@@ -33,14 +46,6 @@ const SAT_INITIAL_FONT = 14;
 const NAME_FONT_SPINE = 10;
 const NAME_FONT_SAT = 9;
 const NAME_GAP = 8;            // circle bottom edge → name baseline
-
-// Role badge sizing (kept from previous design)
-const BADGE_R = 7;
-const BADGE_FONT = 7;
-
-// Covenant diamond sizing (kept from previous design)
-const DIAMOND_SIZE = 5;
-const DIAMOND_GAP = 6;
 
 // Accessibility — every interactive node should have a 44 pt touch target
 const MIN_TOUCH_H = 44;
@@ -68,13 +73,15 @@ export const TreeNode = memo(function TreeNode({
   const onMessianicLine = isMessianic(data.id);
   const handlePress = useCallback(() => onPress(data), [data, onPress]);
 
-  // Zoom-semantic tier filtering (#1291): hide tier-3 nodes when zoomed out.
-  // Must come AFTER all hook calls to respect the rules-of-hooks contract.
+  // Tier / opacity model — visibility via opacity, not null returns.
+  // The React tree is always the same size; only opacity varies with zoom.
   const tier = getPersonTier(data, onMessianicLine);
-  if (!isPersonVisibleAtZoom(tier, zoom)) return null;
-
+  const visible = isPersonVisibleAtZoom(tier, zoom);
   const isAssociate = data.isAssociate === true;
-  const opacity = (dimmed ? 0.25 : 1) * (isAssociate ? 0.75 : 1);
+  const opacity =
+    (visible ? 1 : 0)
+    * (dimmed ? 0.25 : 1)
+    * (isAssociate ? 0.75 : 1);
 
   // Geometry — associate satellites render slightly smaller to read as
   // "off-tree" contemporaries rather than genealogical descendants (#1290).
@@ -105,17 +112,6 @@ export const TreeNode = memo(function TreeNode({
     ? 'url(#messianic-node-fill)'
     : (isSpine ? SPINE_FILL : SAT_FILL);
 
-  // Role badge config (reuses RoleBadge's mapping)
-  const roleBadge = data.role
-    ? getRoleBadgeConfig(data.role, {
-        gold: base.gold,
-        eraColor: data.era ? (eras[data.era] ?? base.gold) : base.gold,
-      })
-    : null;
-
-  // Covenant waypoint
-  const waypoint = getCovenantWaypoint(data.id);
-
   // Initial letter — first character of the person's name, uppercased
   const initial = (data.name?.[0] ?? '').toUpperCase();
 
@@ -124,52 +120,17 @@ export const TreeNode = memo(function TreeNode({
     ? base.gold
     : (isSpine ? base.text : base.textDim);
 
-  // Lean render for tier-2 at mid zoom (0.7 ≤ zoom < 0.8): just a circle
-  // + name. Avoids adding ~80 multi-layer TreeNode instances when the
-  // user pinches past TIER_2_ZOOM. iOS's compositor crashes on the full
-  // variant at that node count on a ~10 000-px tall canvas. Full variant
-  // (initial letter, role badge, waypoint, glow, touch rect) kicks back
-  // in at TIER_3_ZOOM where the user has pinched far enough to care about
-  // the extra detail.
-  if (tier === 2 && zoom < TIER_3_ZOOM) {
-    return (
-      <G onPress={handlePress} opacity={opacity}>
-        <Circle
-          cx={x}
-          cy={y}
-          r={r}
-          fill={nodeFill}
-          stroke={borderColor}
-          strokeWidth={borderWidth}
-          strokeDasharray={isAssociate ? '2,2' : undefined}
-        />
-        <SvgText
-          x={x}
-          y={y + r + NAME_GAP}
-          textAnchor="middle"
-          fontSize={nameFont}
-          fill={nameFill}
-          fontFamily="SourceSans3_400Regular"
-        >
-          {data.name}
-        </SvgText>
-      </G>
-    );
-  }
-
   // Initial colour — gold inside messianic, light text inside spine, dim text inside satellite
   const initialFill = onMessianicLine
     ? base.gold
     : (isSpine ? base.text : base.textDim);
 
-  // Layout for the role badge: top-right quadrant of the circle
-  // (cos(-45°), sin(-45°)) = (~0.707, -0.707) → scaled by r
-  const badgeOffset = r * 0.707;
+  const needsTouchTarget = r * 2 < MIN_TOUCH_H;
 
   return (
     <G onPress={handlePress} opacity={opacity}>
-      {/* ── Touch target ─── */}
-      {r * 2 < MIN_TOUCH_H && (
+      {/* Invisible touch target so small satellite circles still hit 44 pt. */}
+      {needsTouchTarget && (
         <Rect
           x={x - MIN_TOUCH_H / 2}
           y={y - MIN_TOUCH_H / 2}
@@ -179,29 +140,7 @@ export const TreeNode = memo(function TreeNode({
         />
       )}
 
-      {/* ── Messianic outer glow — warm golden aura ─── */}
-      {onMessianicLine && !dimmed && (
-        <Circle
-          cx={x}
-          cy={y}
-          r={r + 6}
-          fill={base.gold}
-          opacity={0.12}
-        />
-      )}
-
-      {/* ── Selected glow ring ─── */}
-      {selected && (
-        <Circle
-          cx={x}
-          cy={y}
-          r={r + 4}
-          fill={base.gold}
-          opacity={0.2}
-        />
-      )}
-
-      {/* ── Main circle ─── */}
+      {/* Main circle */}
       <Circle
         cx={x}
         cy={y}
@@ -212,7 +151,7 @@ export const TreeNode = memo(function TreeNode({
         strokeDasharray={isAssociate ? '2,2' : undefined}
       />
 
-      {/* ── Initial letter (Cinzel SemiBold, visually centred) ─── */}
+      {/* Initial letter, visually centred in the circle */}
       <SvgText
         x={x}
         y={y + initialFont * 0.35}
@@ -225,7 +164,7 @@ export const TreeNode = memo(function TreeNode({
         {initial}
       </SvgText>
 
-      {/* ── Full name below the circle ─── */}
+      {/* Full name below the circle */}
       <SvgText
         x={x}
         y={y + r + NAME_GAP}
@@ -237,76 +176,6 @@ export const TreeNode = memo(function TreeNode({
       >
         {data.name}
       </SvgText>
-
-      {/* ── Role badge — top-right quadrant ─── */}
-      {roleBadge && (
-        <G>
-          <Circle
-            cx={x + badgeOffset}
-            cy={y - badgeOffset}
-            r={BADGE_R}
-            fill={roleBadge.color + '22'}
-            stroke={roleBadge.color}
-            strokeWidth={0.8}
-          />
-          <SvgText
-            x={x + badgeOffset}
-            y={y - badgeOffset + BADGE_FONT * 0.35}
-            textAnchor="middle"
-            fontSize={BADGE_FONT}
-            fill={roleBadge.color}
-            fontFamily="SourceSans3_600SemiBold"
-            fontWeight="600"
-          >
-            {roleBadge.label}
-          </SvgText>
-        </G>
-      )}
-
-      {/* ── Covenant waypoint diamond + annotation ─── */}
-      {waypoint && !dimmed && (
-        <G>
-          {/* Diamond sits below the name text */}
-          <G
-            transform={`translate(${x}, ${y + r + NAME_GAP + nameFont + DIAMOND_GAP + DIAMOND_SIZE / 2}) rotate(45)`}
-          >
-            <Rect
-              x={-DIAMOND_SIZE / 2}
-              y={-DIAMOND_SIZE / 2}
-              width={DIAMOND_SIZE}
-              height={DIAMOND_SIZE}
-              fill={base.gold + '60'}
-              stroke={base.gold}
-              strokeWidth={0.8}
-            />
-          </G>
-          {/* Waypoint annotation */}
-          <SvgText
-            x={x + DIAMOND_SIZE + 4}
-            y={y + r + NAME_GAP + nameFont + DIAMOND_GAP + DIAMOND_SIZE / 2 + 3}
-            textAnchor="start"
-            fontSize={7}
-            fill={base.gold}
-            fontFamily="SourceSans3_400Regular"
-            fontStyle="italic"
-            opacity={0.7}
-          >
-            {waypoint.text}
-          </SvgText>
-          <SvgText
-            x={x + DIAMOND_SIZE + 4}
-            y={y + r + NAME_GAP + nameFont + DIAMOND_GAP + DIAMOND_SIZE / 2 + 12}
-            textAnchor="start"
-            fontSize={6.5}
-            fill={base.gold}
-            fontFamily="SourceSans3_600SemiBold"
-            fontWeight="600"
-            opacity={0.5}
-          >
-            {waypoint.ref}
-          </SvgText>
-        </G>
-      )}
     </G>
   );
 });


### PR DESCRIPTION
Fifth round on the iOS paint crash. Two fresh device tests after #1305 both crashed right after a zoom crossed a tier threshold:

```
[Canvas] render z=0.72 visibleTier=2 collapsed=true ...  (no COMMITTED)
[Canvas] render z=0.88 visibleTier=3 collapsed=false ... (no COMMITTED)
```

## Diagnosis

The crash happens on the **first render that mounts a batch of new SVG subviews**:

| Transition | Batch mount |
|---|---|
| `tier 1 → tier 2` at 0.72 | ~80 new TreeNodes |
| `tier 2 → tier 3` at 0.88 | tier-3 TreeNodes + 89 AssociationLinkSvg + 18 labels + 7 trails |

Previous round's lean tier-2 variant brought per-node layer count down to 2 — still not enough, because the issue wasn't per-node cost, it was **batch-mounting ~80 native subviews onto a 10 000-px tall `<Svg>` in a single commit**.

## Fix

Stop conditionally mounting / unmounting TreeNodes. Every node now emits the same 3–4 SVG layers regardless of tier:

- Main `Circle`
- Initial-letter `SvgText`
- Name `SvgText`
- Optional 44-pt touch `Rect` for small satellites

Tier visibility moves to the root `G`'s opacity:

```ts
opacity = (visible ? 1 : 0) * (dimmed ? 0.25 : 1) * (isAssociate ? 0.75 : 1)
```

Zoom gestures now only flip opacity on already-mounted layers. No mid-session allocations, no batch mounts. The React tree size stays constant across every zoom transition.

## What's removed

- **Role badges** (the K / P / ✧ / J / T chips on each spine node). Visual tier distinction survives via the gold stroke on the main Circle + the radial-gradient fill on messianic circles.
- **Covenant waypoint diamonds** (the gold diamonds + ref text beneath certain nodes).
- **Messianic outer-glow Circle**.
- **Selection outer ring** (the selected-node halo).

All four were expensive optional sub-components that grew per-node layer count from 3 → 10. They should return in a later pass **tied to tap/selection state** — they'll render only for the one selected node, guaranteeing no batch mount can ever happen.

## Trade-off summary

| | Before | After |
|---|---|---|
| Tier 1 per-node layers | 5–10 | 3–4 |
| Tier 2 per-node layers | 5–10 (or 2 lean) | 3–4 |
| Mount on zoom transition | ~80 new views | 0 (opacity toggle) |
| Role badges visible | yes, on every spine node | no (future: on selection) |
| Waypoint diamonds visible | yes, on every covenant person | no (future: on selection) |
| Messianic visual distinction | gold glow + gold stroke + gradient fill | gold stroke + gradient fill |

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 passing (one test adapted: `null when hidden` → `opacity 0 when hidden`)
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open genealogy tree, zoom from 0.45 all the way to 1.0+ and confirm every zoom step emits a `[Canvas] render COMMITTED z=...` log without crashing.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3