### PR TITLE
ci: auto DB rebuild + EAS deploy on content changes

### DIFF
--- a/.github/workflows/content-deploy.yml
+++ b/.github/workflows/content-deploy.yml
@@ -1,0 +1,83 @@
+name: Content Deploy
+
+# Fires on every push to master, but the job only runs if content
+# or build tooling changed — skips pure app/infra commits.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'content/**'
+      - '_tools/build_sqlite*.py'
+      - '_tools/validate_sqlite.py'
+      - '_tools/schema_validator.py'
+      - '_tools/config.py'
+      - '_tools/content_writer.py'
+
+jobs:
+  build-and-deploy:
+    name: Rebuild DB + EAS Update
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── 1. Checkout ──────────────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need full history so we can commit the rebuilt DB back
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── 2. Python setup ──────────────────────────────────────
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # ── 3. Rebuild scripture.db ──────────────────────────────
+      - name: Build SQLite database
+        run: python _tools/build_sqlite.py
+
+      # ── 4. Validate ──────────────────────────────────────────
+      - name: Validate SQLite database
+        run: python _tools/validate_sqlite.py
+
+      # ── 5. Commit rebuilt DB back to master ──────────────────
+      - name: Commit rebuilt scripture.db
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add scripture.db
+          # Only commit if the DB actually changed
+          if git diff --cached --quiet; then
+            echo "scripture.db unchanged, skipping commit"
+          else
+            git commit -m "chore: rebuild scripture.db from content changes [skip ci]"
+            git push
+          fi
+
+      # ── 6. Node + EAS CLI setup ──────────────────────────────
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install app dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@latest
+
+      # ── 7. EAS Update ────────────────────────────────────────
+      - name: Deploy OTA update
+        working-directory: app
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          eas update \
+            --branch production \
+            --message "Content update from ${{ github.sha }}" \
+            --non-interactive


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that fires automatically whenever content is merged to master.

## Workflow steps
1. Triggers on push to `master` — only when `content/**`, `_tools/build_sqlite*.py`, or related tooling changes (skips app-only commits)
2. Sets up Python 3.11, runs `build_sqlite.py`
3. Runs `validate_sqlite.py` — workflow fails and deploy is blocked if validation fails
4. Commits rebuilt `scripture.db` back to master with `[skip ci]` to avoid loop
5. Sets up Node 20, installs app deps, installs `eas-cli`
6. Runs `eas update --branch production --non-interactive`

## Required setup (one-time)
Add `EXPO_TOKEN` to GitHub repo secrets:
- expo.dev → Account Settings → Access Tokens → Create token
- GitHub repo → Settings → Secrets and variables → Actions → New secret → `EXPO_TOKEN`

## Result
Merge a content PR → DB rebuilds → validates → deploys to users automatically. No local steps required.