### PR TITLE
tree: BISECT hide all associate rendering (diagnostic)

### DIFF
--- a/app/__tests__/components/TreeCanvas.test.tsx
+++ b/app/__tests__/components/TreeCanvas.test.tsx
@@ -152,7 +152,9 @@ describe('TreeCanvas', () => {
     type: 'disciple',
   });
 
-  it('consolidates association links into a single Path at normal zoom', () => {
+  // BISECT: skipped while TreeCanvas has all associate rendering hidden
+  // behind BISECT_HIDE_ASSOCIATES. Re-enable when the flag flips back.
+  it.skip('consolidates association links into a single Path at normal zoom', () => {
     // Post-constant-canvas-render refactor: all 89+ dashed connectors
     // share a single <Path> with a multi-M `d` attribute, so zoom
     // transitions never mount new native views.
@@ -175,7 +177,8 @@ describe('TreeCanvas', () => {
     expect(mCount).toBe(3);
   });
 
-  it('fades the consolidated association-link Path to opacity 0 when clusters collapsed', () => {
+  // BISECT: skipped while TreeCanvas has all associate rendering hidden.
+  it.skip('fades the consolidated association-link Path to opacity 0 when clusters collapsed', () => {
     const links = [
       makeAssocLink('jesus', 'peter', 0),
       makeAssocLink('jesus', 'andrew', 1),
@@ -196,7 +199,8 @@ describe('TreeCanvas', () => {
     expect(badgeText).toBeTruthy();
   });
 
-  it('always renders associate TreeNodes and forwards clustersCollapsed', () => {
+  // BISECT: skipped while associate TreeNodes are filtered out in the canvas.
+  it.skip('always renders associate TreeNodes and forwards clustersCollapsed', () => {
     // Associate nodes are no longer null-skipped when clusters collapse;
     // they mount at initial render and use opacity inside TreeNode to hide.
     const peter = makeNode('peter');

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -1,24 +1,20 @@
 /**
  * TreeCanvas — SVG container rendering all tree elements.
  *
- * Constant render structure: every zoom level mounts the same set of
- * native views. Visibility transitions are driven by opacity changes
- * (and a single combined path `d` attribute for association links /
- * trails). iOS's compositor crashes on batch mid-session mounts of
- * many native subviews on a tall (~10 000 px) Svg canvas; keeping
- * the structure constant eliminates that failure mode.
- *
- * Render order (back to front):
- *   background defs → bg rect → links → marriage bars →
- *   spouse connectors → association links (consolidated) →
- *   associate trails (consolidated) → collapse badges → nodes →
- *   bloom apex labels.
+ * *** CRASH BISECT BUILD ***
+ * All associate-related rendering (paths, trails, labels, badges,
+ * associate nodes) is temporarily hidden to test whether the iOS
+ * paint crash at z=0.93 is caused by the associate content. If the
+ * tree loads and zooms freely without crashing, the associate
+ * rendering is the culprit and we'll add it back as simpler
+ * per-anchor straight-line paths. If it still crashes, the cause is
+ * elsewhere (e.g., TreeLink messianic glow paths at high zoom).
  */
 
 import React, { memo, useMemo } from 'react';
 import {
   Defs, RadialGradient, Stop, Pattern,
-  Rect, Line, G, Circle, Text as SvgText, Path,
+  Rect, Line, G,
 } from 'react-native-svg';
 import { useTheme } from '../../theme';
 import { TreeLink } from './TreeLink';
@@ -26,9 +22,11 @@ import { MarriageBarSvg } from './MarriageBarSvg';
 import { SpouseConnectorSvg } from './SpouseConnectorSvg';
 import { TreeNode } from './TreeNode';
 import { TIER_3_ZOOM, getVisibleTier } from '../../utils/genealogyOrganic';
-import { bezierPath } from '../../utils/genealogyOrganic';
 import { logger } from '../../utils/logger';
 import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
+
+// *** BISECT FLAG — set to false to restore full associate rendering. ***
+const BISECT_HIDE_ASSOCIATES = true;
 
 interface Props {
   nodes: LayoutNode[];
@@ -80,44 +78,18 @@ export const TreeCanvas = memo(function TreeCanvas({
     + `collapsed=${clustersCollapsed} `
     + `nodes=${nodes.length} links=${links.length} al=${associationLinks.length} `
     + `labels=${associateBloomLabels.length} trails=${associateTrails.length} `
-    + `canvas=${canvasWidth}x${canvasHeight}`,
+    + `canvas=${canvasWidth}x${canvasHeight} `
+    + `BISECT=hide-associates:${BISECT_HIDE_ASSOCIATES}`,
   );
   React.useEffect(() => {
     logger.info('Canvas', `render COMMITTED z=${zoom.toFixed(2)}`);
   });
 
-  // Consolidate all dashed-bezier association connectors into ONE Path
-  // string so a cluster-uncollapse transition changes one `d` attribute
-  // instead of mounting 89 new CAShapeLayers. Styling is uniform across
-  // connectors so single-path rendering is safe.
-  const associationPathD = useMemo(
-    () => associationLinks.map((al) => bezierPath(al.source, al.target)).join(' '),
+  // Associate id set so the nodes.map can skip them when bisect flag is on.
+  const associateIdSet = useMemo(
+    () => new Set(associationLinks.map((al) => al.memberId)),
     [associationLinks],
   );
-
-  // Same consolidation for trail lines. Straight segments concatenated
-  // as `M x1 y1 L x2 y2` with a space between each pair.
-  const trailsPathD = useMemo(
-    () => associateTrails
-      .map((t) => `M ${t.source.x} ${t.source.y} L ${t.target.x} ${t.target.y}`)
-      .join(' '),
-    [associateTrails],
-  );
-
-  // Badge positions are derived from association links by anchor — constant
-  // for a given tree layout, so compute them once.
-  const anchorBadges = useMemo(() => {
-    const byAnchor = new Map<string, { x: number; y: number; count: number }>();
-    for (const al of associationLinks) {
-      const existing = byAnchor.get(al.anchorId);
-      if (existing) {
-        existing.count += 1;
-      } else {
-        byAnchor.set(al.anchorId, { x: al.source.x, y: al.source.y, count: 1 });
-      }
-    }
-    return Array.from(byAnchor, ([anchorId, v]) => ({ anchorId, ...v }));
-  }, [associationLinks]);
 
   return (
     <>
@@ -164,46 +136,8 @@ export const TreeCanvas = memo(function TreeCanvas({
           />
         ))}
 
-        {/* 1b. Association links — ALL dashed bezier connectors consolidated
-               into a single Path. Opacity toggles with cluster collapse state;
-               no native views mount or unmount across zoom transitions. */}
-        {associationPathD.length > 0 && (
-          <Path
-            d={associationPathD}
-            stroke={base.border}
-            strokeWidth={0.9}
-            strokeDasharray="4,4"
-            fill="none"
-            opacity={clustersCollapsed ? 0 : 0.55}
-            strokeLinecap="round"
-          />
-        )}
-
-        {/* 1c. Associate-bloom trails — all consolidated into one Path. */}
-        {trailsPathD.length > 0 && (
-          <Path
-            d={trailsPathD}
-            stroke={base.gold}
-            strokeWidth={1.5}
-            fill="none"
-            opacity={clustersCollapsed ? 0 : 0.35}
-            strokeLinecap="round"
-          />
-        )}
-
-        {/* 1d. Collapsed-cluster "+N" badges. Always rendered; opacity gated
-               so a cluster-expand transition just flips a number, never
-               mounts or unmounts a view. */}
-        {anchorBadges.map((b) => (
-          <G key={`ab-${b.anchorId}`} opacity={clustersCollapsed ? 0.85 : 0}>
-            <Circle cx={b.x + 30} cy={b.y + 30} r={14}
-              fill={base.bgSurface} stroke={base.gold} strokeWidth={1} />
-            <SvgText x={b.x + 30} y={b.y + 33}
-              fill={base.gold} fontSize={11} textAnchor="middle" fontWeight="600">
-              +{b.count}
-            </SvgText>
-          </G>
-        ))}
+        {/* 1b–1d. Association paths / trails / badges — hidden by the
+               BISECT flag. See top of file. */}
 
         {/* 2. Marriage bars */}
         {marriageBars.map((bar) => (
@@ -215,10 +149,14 @@ export const TreeCanvas = memo(function TreeCanvas({
           <SpouseConnectorSvg key={`sc-${i}`} connector={conn} />
         ))}
 
-        {/* 4. Nodes (front). Every node — including associates — is always
-               rendered. TreeNode itself handles visibility via opacity so
-               there's no mount / unmount churn at tier transitions. */}
+        {/* 4. Nodes (front). Associate nodes filtered out by the BISECT
+               flag. Everyone else always renders; TreeNode handles
+               tier visibility via opacity so there's no mount / unmount
+               churn at tier transitions. */}
         {nodes.map((node) => {
+          if (BISECT_HIDE_ASSOCIATES && associateIdSet.has(node.data.id)) {
+            return null;
+          }
           const dimmed = filterEra !== null
             && node.data.era !== filterEra
             && !spineIds.has(node.data.id);
@@ -236,22 +174,7 @@ export const TreeCanvas = memo(function TreeCanvas({
           );
         })}
 
-        {/* 5. Bloom-apex labels ("disciples", "contemporaries"…). Always
-               rendered; opacity gated. */}
-        {associateBloomLabels.map((lbl) => (
-          <SvgText
-            key={`abl-${lbl.anchorId}-${lbl.type}`}
-            x={lbl.x}
-            y={lbl.y}
-            fill={base.gold}
-            fontSize={11}
-            fontFamily="Cinzel_600SemiBold"
-            textAnchor="middle"
-            opacity={labelsVisible ? 0.65 : 0}
-          >
-            {lbl.text}
-          </SvgText>
-        ))}
+        {/* 5. Bloom-apex labels — hidden by the BISECT flag. */}
       </G>
     </>
   );


### PR DESCRIPTION
**Diagnostic bisect PR, not a final fix.** Post-#1309 device logs:

```
[Canvas] render z=0.45 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.65 visibleTier=1 collapsed=true  → COMMITTED ✓
[Canvas] render z=0.93 visibleTier=3 collapsed=false → (no COMMITTED)
```

Crash moved down from 1.31+ to 0.93, but exactly coincides with `visibleTier=3 AND collapsed=false` — same moment when 89 associates become visible + 89 association bezier paths + 7 trails + 18 labels all fade in. Layer count is constant (from #1307 + #1308), rasterization is off (#1309), so the crash trigger must be the **content of the associate rendering itself** rather than layer allocation.

## Bisect

A `BISECT_HIDE_ASSOCIATES = true` flag at the top of TreeCanvas skips everything related to associates:

- Association `<Path>` (89 consolidated dashed-bezier subpaths)
- Trail `<Path>` (7 consolidated segments)
- "+N" collapse badges
- Bloom apex labels
- Associate TreeNodes themselves (filtered out of `nodes.map`)

The render log gains a `BISECT=hide-associates:true` suffix so we can confirm the variant ran.

## What we'll learn

| Device result | Conclusion |
|---|---|
| Tree loads, zooms through full range to 1.5, no crash | Associate content is the trigger. Next step: re-introduce as simpler per-anchor straight-line paths (no dashed bezier) and/or always-visible at low opacity so the 0→0.55 step doesn't happen. |
| Still crashes at the same `visibleTier=3` transition | Cause is elsewhere — most likely TreeLink's messianic 3-paths-per-link rendering hitting a complexity limit at high zoom. Next bisect: hide the messianic glow paths. |
| Crashes at a different point than before | Tells us something about composition — we'll iterate from there. |

## UX during bisect

Tree shows main genealogy only. No Peter, Paul's companions, etc. This isn't shippable long-term; it's a two-person test to narrow the cause. Revert / merge behavior either way once we know.

## Test plan

- [x] `./node_modules/.bin/jest` — 426 suites / 3202 passing / 3 skipped (the three TreeCanvas tests that specifically check for associate content; each marked `it.skip` with a pointer back to the bisect flag)
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree, pinch freely through the full zoom range. Report whether any commit crashes and at what zoom / visibleTier.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3