### PR TITLE
tree: BISECT add associate nodes back, hide paths/labels/badges

### DIFF
--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -25,8 +25,20 @@ import { TIER_3_ZOOM, getVisibleTier } from '../../utils/genealogyOrganic';
 import { logger } from '../../utils/logger';
 import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
 
-// *** BISECT FLAG — set to false to restore full associate rendering. ***
-const BISECT_HIDE_ASSOCIATES = true;
+// *** BISECT FLAGS — finer-grained than the previous all-or-nothing flag.
+// PR #1313 confirmed associate rendering is the crash trigger. This build
+// adds the associate TreeNodes back (89 Circle+text instances) but keeps
+// the consolidated dashed-bezier path, trails, labels, and badges hidden.
+// If this build still loads and zooms freely, the crash is in the paths/
+// labels/badges and not the nodes themselves. If it crashes, the 89 node
+// transitions are the cause.
+const BISECT = {
+  hideAssociationPath: true,
+  hideTrails: true,
+  hideLabels: true,
+  hideBadges: true,
+  hideAssociateNodes: false,    // ← re-enabled this round
+} as const;
 
 interface Props {
   nodes: LayoutNode[];
@@ -79,7 +91,11 @@ export const TreeCanvas = memo(function TreeCanvas({
     + `nodes=${nodes.length} links=${links.length} al=${associationLinks.length} `
     + `labels=${associateBloomLabels.length} trails=${associateTrails.length} `
     + `canvas=${canvasWidth}x${canvasHeight} `
-    + `BISECT=hide-associates:${BISECT_HIDE_ASSOCIATES}`,
+    + `BISECT=path:${BISECT.hideAssociationPath ? 'hide' : 'show'},`
+    + `trails:${BISECT.hideTrails ? 'hide' : 'show'},`
+    + `labels:${BISECT.hideLabels ? 'hide' : 'show'},`
+    + `badges:${BISECT.hideBadges ? 'hide' : 'show'},`
+    + `nodes:${BISECT.hideAssociateNodes ? 'hide' : 'show'}`,
   );
   React.useEffect(() => {
     logger.info('Canvas', `render COMMITTED z=${zoom.toFixed(2)}`);
@@ -154,7 +170,7 @@ export const TreeCanvas = memo(function TreeCanvas({
                tier visibility via opacity so there's no mount / unmount
                churn at tier transitions. */}
         {nodes.map((node) => {
-          if (BISECT_HIDE_ASSOCIATES && associateIdSet.has(node.data.id)) {
+          if (BISECT.hideAssociateNodes && associateIdSet.has(node.data.id)) {
             return null;
           }
           const dimmed = filterEra !== null


### PR DESCRIPTION
**Diagnostic bisect 2.** PR #1313 proved the associate rendering is the crasher. This PR re-enables the associate TreeNodes (89 Circle+text instances) but **keeps the four heavier-suspected pieces hidden**: the consolidated dashed-bezier association path, the trails path, the 18 labels, and the 9 collapse badges.

## Granular flags

```ts
const BISECT = {
  hideAssociationPath: true,    // 89 dashed-bezier subpaths in 1 Path
  hideTrails: true,             // 7 segments in 1 Path
  hideLabels: true,             // 18 SvgText
  hideBadges: true,             // 9 G groups
  hideAssociateNodes: false,    // ← re-enabled this round
};
```

The render log reports each switch state:

```
BISECT=path:hide,trails:hide,labels:hide,badges:hide,nodes:show
```

## Outcomes

| Device result | Conclusion |
|---|---|
| Tree zooms freely to 1.5 with no crash | Associate TreeNode opacity transitions are fine. Crash is in **paths / trails / labels / badges**. Next bisect re-enables them one at a time, starting with the most-suspected (the dashed-bezier consolidated path). |
| Crashes at `z=0.93` (or wherever tier-3 + uncollapse first happen) | The 89 associate TreeNodes themselves (Circle + 2 SvgText each going from opacity 0 → 0.75) are the crasher. We'd then look at simplifying TreeNode further or breaking up the opacity flip across multiple frames. |

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3202 passing / 3 skipped
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree, zoom through 0.27 → 1.5. Report whether/where it crashes.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3