### PR TITLE
tree: stagger associate mount across frames (no feature loss)

### DIFF
--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -25,20 +25,23 @@ import { TIER_3_ZOOM, getVisibleTier } from '../../utils/genealogyOrganic';
 import { logger } from '../../utils/logger';
 import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
 
-// *** BISECT FLAGS — finer-grained than the previous all-or-nothing flag.
-// PR #1313 confirmed associate rendering is the crash trigger. This build
-// adds the associate TreeNodes back (89 Circle+text instances) but keeps
-// the consolidated dashed-bezier path, trails, labels, and badges hidden.
-// If this build still loads and zooms freely, the crash is in the paths/
-// labels/badges and not the nodes themselves. If it crashes, the 89 node
-// transitions are the cause.
+// *** BISECT FLAGS — paths/labels/badges still hidden so this PR isolates
+// the staggered-mount fix to associate TreeNodes only. Once that proves
+// stable, follow-up PRs re-enable the rest with similar staggering if
+// needed.
 const BISECT = {
   hideAssociationPath: true,
   hideTrails: true,
   hideLabels: true,
   hideBadges: true,
-  hideAssociateNodes: false,    // ← re-enabled this round
+  hideAssociateNodes: false,
 } as const;
+
+/** How many associate TreeNodes to mount per animation frame. Smaller =
+ *  smoother fade-in but slower full reveal; larger = faster reveal but
+ *  bigger per-frame native-view allocation cost. 5/frame ≈ 18 frames
+ *  ≈ 0.3 s for 89 associates. */
+const ASSOCIATE_REVEAL_BATCH = 5;
 
 interface Props {
   nodes: LayoutNode[];
@@ -107,6 +110,46 @@ export const TreeCanvas = memo(function TreeCanvas({
     [associationLinks],
   );
 
+  // Stable index per associate so the staggered reveal can mount them in
+  // a deterministic order (associationLinks order = data order). Switching
+  // anchors mid-cluster would interleave; that's fine, it just means the
+  // reveal sweeps through anchors left-to-right.
+  const associateIndexById = useMemo(() => {
+    const m = new Map<string, number>();
+    associationLinks.forEach((al, i) => m.set(al.memberId, i));
+    return m;
+  }, [associationLinks]);
+
+  // Staggered reveal counter — animates from 0 → associationLinks.length
+  // when clusters un-collapse, and back to 0 when they re-collapse.
+  // Mounting / unmounting in batches of ASSOCIATE_REVEAL_BATCH per frame
+  // keeps each iOS commit's native-view delta small enough that the
+  // compositor doesn't choke.
+  const [revealedAssociates, setRevealedAssociates] = React.useState(0);
+  React.useEffect(() => {
+    const target = clustersCollapsed ? 0 : associationLinks.length;
+    let current = revealedAssociates;
+    if (current === target) return;
+    let cancelled = false;
+    const tick = () => {
+      if (cancelled) return;
+      const direction = target > current ? 1 : -1;
+      current += direction * ASSOCIATE_REVEAL_BATCH;
+      if ((direction > 0 && current >= target)
+          || (direction < 0 && current <= target)) {
+        current = target;
+      }
+      setRevealedAssociates(current);
+      if (current !== target) requestAnimationFrame(tick);
+    };
+    const handle = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(handle);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clustersCollapsed, associationLinks.length]);
+
   return (
     <>
       {/* ── Background definitions ─────────────────── */}
@@ -172,6 +215,16 @@ export const TreeCanvas = memo(function TreeCanvas({
         {nodes.map((node) => {
           if (BISECT.hideAssociateNodes && associateIdSet.has(node.data.id)) {
             return null;
+          }
+          // Staggered reveal: associates only mount once their index has
+          // been reached by the reveal counter. At z<TIER_3 this is 0
+          // (none), so initial mount stays light. Crossing the
+          // threshold animates the counter up over ~0.3 s in batches
+          // of ASSOCIATE_REVEAL_BATCH per frame so iOS's compositor
+          // never has to add too many native subviews in a single commit.
+          if (associateIdSet.has(node.data.id)) {
+            const idx = associateIndexById.get(node.data.id) ?? 0;
+            if (idx >= revealedAssociates) return null;
           }
           const dimmed = filterEra !== null
             && node.data.era !== filterEra

--- a/app/src/components/tree/TreeNode.tsx
+++ b/app/src/components/tree/TreeNode.tsx
@@ -80,6 +80,9 @@ export const TreeNode = memo(function TreeNode({
 
   // Tier / opacity model — visibility via opacity, not null returns.
   // The React tree is always the same size; only opacity varies with zoom.
+  // Associate mount/unmount is staggered by TreeCanvas across frames to
+  // avoid iOS compositor crashes from a batch native-view delta in a
+  // single commit; once mounted, this opacity calc takes over.
   const tier = getPersonTier(data, onMessianicLine);
   const visible = isPersonVisibleAtZoom(tier, zoom);
   const isAssociate = data.isAssociate === true;


### PR DESCRIPTION
**The user's instinct nailed the right approach.** Rather than dropping per-node features (initial letter, name) to make the crash-triggering batch smaller, **stagger the batch across multiple animation frames** so iOS only ever has to add a few native subviews per commit.

## Diagnosis recap

PR #1326 confirmed: re-enabling 89 associate `<TreeNode>` instances brought the crash back at `z=0.90 visibleTier=3 collapsed=false` (no `COMMITTED` log). The trigger is iOS's compositor refusing a single commit that introduces 89 × 3 = 267 new native layers.

## Fix — staggered reveal

In `TreeCanvas`:

```ts
const [revealedAssociates, setRevealedAssociates] = useState(0);

useEffect(() => {
  const target = clustersCollapsed ? 0 : associationLinks.length;
  // requestAnimationFrame loop, ± ASSOCIATE_REVEAL_BATCH (=5) per frame
  // until current === target.
}, [clustersCollapsed, associationLinks.length]);
```

Each associate has a stable index. The `nodes.map` renders an associate only when `idx < revealedAssociates`. As the counter increments by 5 each frame, 5 new TreeNodes mount per commit — well within iOS's tolerance. 89 associates / 5 = ~18 frames ≈ **0.3 s** for the full reveal.

Reverse on cluster re-collapse: counter ticks back down, associates unmount in batches of 5.

## What's preserved

| Per-associate feature | Status |
|---|---|
| Circle (with dashed border for associates) | ✅ |
| Initial letter glyph inside circle | ✅ |
| Full name SvgText below circle | ✅ |
| Smaller radius / lower opacity styling | ✅ |
| Tap-to-detail | ✅ |

Everything visual is back. The only behavioral change is the ~0.3 s waterfall fade-in/out at the tier-3 boundary, which should read as intentional polish rather than a glitch.

## What's still hidden

The BISECT flags from #1326 stay as-is for this PR — paths / trails / labels / "+N" badges still hidden — so the effect of the staggered fix is isolated to the associate node render path. If staggered mount works on device, the next PR re-enables the rest:

- Trails (7 segments in 1 Path) — single layer, opacity tween, probably fine without staggering
- Labels (18 SvgText) — small batch, also probably fine
- Badges (9 G groups) — 9 layers, unmount when uncollapse, probably fine
- Association `<Path>` (89 dashed-bezier subpaths in 1 Path) — single layer but heavy first-rasterization; might need a brief opacity stagger of its own

## Test plan

- [x] `./node_modules/.bin/jest` — 426 suites / 3202 passing / 3 skipped
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree, pinch from 0.45 → 1.5. Watch for the waterfall fade-in around `z=0.8` boundary. Every render should emit `COMMITTED`. Pinch back out to confirm reverse stagger.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3