### PR TITLE
tree: re-enable full associate rendering on top of the stagger fix

### DIFF
--- a/app/__tests__/components/TreeCanvas.test.tsx
+++ b/app/__tests__/components/TreeCanvas.test.tsx
@@ -152,9 +152,7 @@ describe('TreeCanvas', () => {
     type: 'disciple',
   });
 
-  // BISECT: skipped while TreeCanvas has all associate rendering hidden
-  // behind BISECT_HIDE_ASSOCIATES. Re-enable when the flag flips back.
-  it.skip('consolidates association links into a single Path at normal zoom', () => {
+  it('consolidates association links into a single Path at normal zoom', () => {
     // Post-constant-canvas-render refactor: all 89+ dashed connectors
     // share a single <Path> with a multi-M `d` attribute, so zoom
     // transitions never mount new native views.
@@ -177,8 +175,7 @@ describe('TreeCanvas', () => {
     expect(mCount).toBe(3);
   });
 
-  // BISECT: skipped while TreeCanvas has all associate rendering hidden.
-  it.skip('fades the consolidated association-link Path to opacity 0 when clusters collapsed', () => {
+  it('fades the consolidated association-link Path to opacity 0 when clusters collapsed', () => {
     const links = [
       makeAssocLink('jesus', 'peter', 0),
       makeAssocLink('jesus', 'andrew', 1),
@@ -199,10 +196,12 @@ describe('TreeCanvas', () => {
     expect(badgeText).toBeTruthy();
   });
 
-  // BISECT: skipped while associate TreeNodes are filtered out in the canvas.
-  it.skip('always renders associate TreeNodes and forwards clustersCollapsed', () => {
-    // Associate nodes are no longer null-skipped when clusters collapse;
-    // they mount at initial render and use opacity inside TreeNode to hide.
+  it('renders associate TreeNodes once zoom crosses the reveal threshold and forwards clustersCollapsed', () => {
+    // Associate nodes are now mount-staggered: below TIER_2_ZOOM the
+    // reveal counter is 0 so associates are null-skipped to keep the
+    // native-view delta small during tier transitions. Above TIER_3_ZOOM
+    // the counter reaches the full extra count so they mount; they
+    // still receive clustersCollapsed=false at that zoom.
     const peter = makeNode('peter');
     peter.data.isAssociate = true;
     const jesus = makeNode('jesus');
@@ -211,7 +210,7 @@ describe('TreeCanvas', () => {
         {...defaultProps}
         nodes={[jesus, peter]}
         associationLinks={[makeAssocLink('jesus', 'peter', 0)]}
-        zoom={0.3}
+        zoom={1.0}
       />,
     );
     const json = tree.toJSON() as any;
@@ -219,10 +218,10 @@ describe('TreeCanvas', () => {
     const ids = treeNodes.map((n: any) => n.props?.node?.data?.id);
     expect(ids).toContain('jesus');
     expect(ids).toContain('peter');
-    // Both receive clustersCollapsed=true; TreeNode applies opacity=0
-    // to the associate while leaving jesus visible.
+    // At zoom 1.0 clusters are expanded (clustersCollapsed=false); the
+    // prop still flows through to each TreeNode.
     for (const n of treeNodes) {
-      expect(n.props?.clustersCollapsed).toBe(true);
+      expect(n.props?.clustersCollapsed).toBe(false);
     }
   });
 

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -1,40 +1,38 @@
 /**
  * TreeCanvas — SVG container rendering all tree elements.
  *
- * *** CRASH BISECT BUILD ***
- * All associate-related rendering (paths, trails, labels, badges,
- * associate nodes) is temporarily hidden to test whether the iOS
- * paint crash at z=0.93 is caused by the associate content. If the
- * tree loads and zooms freely without crashing, the associate
- * rendering is the culprit and we'll add it back as simpler
- * per-anchor straight-line paths. If it still crashes, the cause is
- * elsewhere (e.g., TreeLink messianic glow paths at high zoom).
+ * Associate rendering is fully enabled as of #1329 (staggered TreeNode
+ * reveal) + this PR. The BISECT constants at the top of the file stay
+ * in place as emergency hide-switches: flip one to `true` to disable
+ * that specific component if it regresses on a future iOS version.
  */
 
 import React, { memo, useMemo } from 'react';
 import {
   Defs, RadialGradient, Stop, Pattern,
-  Rect, Line, G,
+  Rect, Line, G, Circle, Text as SvgText, Path,
 } from 'react-native-svg';
 import { useTheme } from '../../theme';
 import { TreeLink } from './TreeLink';
 import { MarriageBarSvg } from './MarriageBarSvg';
 import { SpouseConnectorSvg } from './SpouseConnectorSvg';
 import { TreeNode } from './TreeNode';
-import { TIER_2_ZOOM, TIER_3_ZOOM, getVisibleTier, getPersonTier } from '../../utils/genealogyOrganic';
+import { TIER_2_ZOOM, TIER_3_ZOOM, getVisibleTier, getPersonTier, bezierPath } from '../../utils/genealogyOrganic';
 import { isMessianic } from '../../utils/messianicLine';
 import { logger } from '../../utils/logger';
 import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
 
-// *** BISECT FLAGS — paths/labels/badges still hidden so this PR isolates
-// the staggered-mount fix to associate TreeNodes only. Once that proves
-// stable, follow-up PRs re-enable the rest with similar staggering if
-// needed.
+// BISECT flags now that #1329 proved the staggered TreeNode reveal works
+// across the full zoom range. All four remaining flags flip to `false`
+// so the full associate rendering (paths, trails, labels, badges) comes
+// back online. Kept in place as a pair of emergency switches in case a
+// specific component regresses — flipping one back to `true` hides just
+// that component without touching the others.
 const BISECT = {
-  hideAssociationPath: true,
-  hideTrails: true,
-  hideLabels: true,
-  hideBadges: true,
+  hideAssociationPath: false,
+  hideTrails: false,
+  hideLabels: false,
+  hideBadges: false,
   hideAssociateNodes: false,
 } as const;
 
@@ -110,6 +108,38 @@ export const TreeCanvas = memo(function TreeCanvas({
     () => new Set(associationLinks.map((al) => al.memberId)),
     [associationLinks],
   );
+
+  // All dashed-bezier associate connectors consolidated into ONE Path
+  // string. 89 individual `<AssociationLinkSvg>` components → 1 native
+  // CAShapeLayer. Tier-3 zoom transitions flip one opacity value instead
+  // of mounting 89 layers (see #1308, #1329).
+  const associationPathD = useMemo(
+    () => associationLinks.map((al) => bezierPath(al.source, al.target)).join(' '),
+    [associationLinks],
+  );
+
+  // Same consolidation for trail lines.
+  const trailsPathD = useMemo(
+    () => associateTrails
+      .map((t) => `M ${t.source.x} ${t.source.y} L ${t.target.x} ${t.target.y}`)
+      .join(' '),
+    [associateTrails],
+  );
+
+  // Badge positions derived from association links (stable for a given
+  // tree layout). Always rendered, opacity-gated by clustersCollapsed.
+  const anchorBadges = useMemo(() => {
+    const byAnchor = new Map<string, { x: number; y: number; count: number }>();
+    for (const al of associationLinks) {
+      const existing = byAnchor.get(al.anchorId);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        byAnchor.set(al.anchorId, { x: al.source.x, y: al.source.y, count: 1 });
+      }
+    }
+    return Array.from(byAnchor, ([anchorId, v]) => ({ anchorId, ...v }));
+  }, [associationLinks]);
 
   // Universal staggered-reveal index for every tier-2 and tier-3 node
   // (including associates). Tier 1 is always visible and never counted.
@@ -222,8 +252,44 @@ export const TreeCanvas = memo(function TreeCanvas({
           />
         ))}
 
-        {/* 1b–1d. Association paths / trails / badges — hidden by the
-               BISECT flag. See top of file. */}
+        {/* 1b. Association links — ALL dashed bezier connectors consolidated
+               into a single Path. Opacity toggles with cluster collapse state;
+               no native views mount or unmount across zoom transitions. */}
+        {!BISECT.hideAssociationPath && associationPathD.length > 0 && (
+          <Path
+            d={associationPathD}
+            stroke={base.border}
+            strokeWidth={0.9}
+            strokeDasharray="4,4"
+            fill="none"
+            opacity={clustersCollapsed ? 0 : 0.55}
+            strokeLinecap="round"
+          />
+        )}
+
+        {/* 1c. Associate-bloom trails — all consolidated into one Path. */}
+        {!BISECT.hideTrails && trailsPathD.length > 0 && (
+          <Path
+            d={trailsPathD}
+            stroke={base.gold}
+            strokeWidth={1.5}
+            fill="none"
+            opacity={clustersCollapsed ? 0 : 0.35}
+            strokeLinecap="round"
+          />
+        )}
+
+        {/* 1d. Collapsed-cluster "+N" badges. Always rendered; opacity gated. */}
+        {!BISECT.hideBadges && anchorBadges.map((b) => (
+          <G key={`ab-${b.anchorId}`} opacity={clustersCollapsed ? 0.85 : 0}>
+            <Circle cx={b.x + 30} cy={b.y + 30} r={14}
+              fill={base.bgSurface} stroke={base.gold} strokeWidth={1} />
+            <SvgText x={b.x + 30} y={b.y + 33}
+              fill={base.gold} fontSize={11} textAnchor="middle" fontWeight="600">
+              +{b.count}
+            </SvgText>
+          </G>
+        ))}
 
         {/* 2. Marriage bars */}
         {marriageBars.map((bar) => (
@@ -269,7 +335,22 @@ export const TreeCanvas = memo(function TreeCanvas({
           );
         })}
 
-        {/* 5. Bloom-apex labels — hidden by the BISECT flag. */}
+        {/* 5. Bloom-apex labels ("disciples", "contemporaries"…). Always
+               rendered; opacity gated by TIER_3_ZOOM. */}
+        {!BISECT.hideLabels && associateBloomLabels.map((lbl) => (
+          <SvgText
+            key={`abl-${lbl.anchorId}-${lbl.type}`}
+            x={lbl.x}
+            y={lbl.y}
+            fill={base.gold}
+            fontSize={11}
+            fontFamily="Cinzel_600SemiBold"
+            textAnchor="middle"
+            opacity={zoom >= TIER_3_ZOOM ? 0.65 : 0}
+          >
+            {lbl.text}
+          </SvgText>
+        ))}
       </G>
     </>
   );


### PR DESCRIPTION
Follow-up to #1329. Device test of the universal stagger was a huge win — the tree loaded and zoomed freely through the full `z=0.15 → z=1.50` range with every single render emitting `COMMITTED`, including many re-renders at tier-3 uncollapsed zooms (0.88, 0.91, 0.99, 1.11, 1.50). The staggered mount eliminated the batch-mount crash.

With that proven stable, flip the remaining BISECT switches back to `false` and **restore the full associate rendering**:

| Component | Restored |
|---|---|
| Consolidated association-links `<Path>` (89 dashed-bezier subpaths, 1 native layer) | ✅ |
| Consolidated associate-trails `<Path>` (7 segments, 1 native layer) | ✅ |
| "+N" collapse badges (9 G groups, opacity-gated) | ✅ |
| Bloom apex labels ("disciples" / "contemporaries" / "adversaries", 18 SvgText, opacity-gated at `TIER_3_ZOOM`) | ✅ |

## The BISECT flags stay

The `BISECT` constant at the top of `TreeCanvas` stays in place as **emergency hide-switches per component**:

```ts
const BISECT = {
  hideAssociationPath: false,
  hideTrails: false,
  hideLabels: false,
  hideBadges: false,
  hideAssociateNodes: false,
} as const;
```

Flipping one to `true` disables that specific rendering without touching the others — useful if a future iOS version regresses on one specific element. The comments above the constant document the crash-investigation history.

## Tests

The three `it.skip`s in `TreeCanvas.test.tsx` from the BISECT era are re-enabled. One of them ("always renders associate TreeNodes…") was renamed and reworked to match the **new** stagger behavior — at low zoom associates are intentionally null-skipped by the reveal counter, so the test now exercises `zoom=1.0` where the reveal has mounted everything.

Full suite: **426 suites / 3205 tests passing / 0 skipped**. `tsc --noEmit` clean.

## Expected device behavior after merge

- Initial load at z=0.45: main tree + collapsed "+N" badges
- Pinch to 0.7+: tier-2 bio-holders fade in over ~0.27s (stagger)
- Pinch to 0.8+: tier-3 figures fade in, clusters expand, connector paths & trails appear, apex labels appear
- Full zoom range (0.15 – 1.5) stable with no crashes

## Crash-hunt summary

| PR | Moved crash from | … to |
|---|---|---|
| #1302 | instrumented | identified boundary at z=0.65 |
| #1303 | z=0.65 | z=0.79 |
| #1304 | z=0.79 | z=0.72 / z=0.88 |
| #1305 | z=0.72 | z=0.72 still |
| #1307 | z=0.72 | z=0.82 (cluster uncollapse) |
| #1308 | z=0.82 | z=1.31 (Metal texture limit) |
| #1309 | z=1.31 | z=0.93 |
| #1313 BISECT | z=0.93 | no crash (associates hidden) |
| #1326 | confirmed nodes are the trigger | still crashed at z=0.90 with nodes shown |
| #1328 | staggered associates only | still crashed at z=0.84 (tier-2 batch) |
| #1329 | universal stagger (all tiers) | **no crash through full zoom range** |
| **#1330** (this) | — | full associate rendering restored on top |

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3