### PR TITLE
tree: lower tier thresholds so blooms show at default zoom

### DIFF
--- a/app/src/utils/genealogyOrganic.ts
+++ b/app/src/utils/genealogyOrganic.ts
@@ -16,17 +16,24 @@ export type PersonTier = 1 | 2 | 3;
 
 /** Visible tier threshold for each zoom level.
  *
- * TIER_2_ZOOM is set ABOVE the default mobile centre-on-Adam scale (0.65,
- * from useTreeGestures.centreOnNode). On-device testing showed the jump
- * from tier-1-only (~100 spine + role-holder nodes) to tier-1+tier-2
- * (~180 nodes including every bio-holder) across that 0.45→0.65 transition
- * roughly doubles the rendered SVG element count and causes iOS's
- * compositor to crash on the re-paint of a tall (~10 000 px) canvas.
- * Keeping tier 2 behind 0.7 means the initial centred view stays lean
- * (spine + role-holders only); the user pinches in to reveal bio-holders.
+ * Thresholds are set LOW (both at 0.4) so the default mobile centre-on-Adam
+ * scale (0.45 initial, 0.65 post-centring) shows the FULL tree including
+ * bio-holders, tier-3 figures, and expanded associate clusters. Higher
+ * thresholds hid too much content by default.
+ *
+ * At zoom ≤ 0.4 (extreme zoom-out) the tree falls back to tier-1 only
+ * (messianic spine + role-holders) and associate clusters collapse to
+ * "+N" badges, giving a readable overview at the bird's-eye scale.
+ *
+ * The original crash that justified higher thresholds (a single commit
+ * that mounted ~240 SVG layers when tier 2 first became visible) is
+ * now prevented by the staggered reveal in TreeCanvas (#1329) — mount
+ * batches of REVEAL_BATCH_PER_FRAME per animation frame instead of a
+ * single commit. So we no longer need the thresholds themselves to
+ * defend against the batch-mount crash.
  */
-export const TIER_2_ZOOM = 0.7;
-export const TIER_3_ZOOM = 0.8;
+export const TIER_2_ZOOM = 0.3;
+export const TIER_3_ZOOM = 0.4;
 
 /** Derive the tier for a single person. */
 export function getPersonTier(person: Person, isMessianic: boolean): PersonTier {


### PR DESCRIPTION
Follow-up to #1330. Tree no longer crashes at any zoom, but the user reports "missing a lot of people" and "no bloom" at the default mobile zoom.

## Diagnosis

The tier-visibility thresholds I set during the crash hunt (`TIER_2_ZOOM=0.7`, `TIER_3_ZOOM=0.8`) were chosen to force a lean initial render — the tier-2 transition was a batch-mount crash trigger, so hiding tier 2/3 until a deliberate pinch past 0.7 was a workaround.

That workaround is no longer needed because:
- #1329 added a **staggered reveal** that spreads the tier-transition mount across ~40 animation frames, preventing the batch-mount crash.
- #1330 restored full associate rendering on top of the stagger.

So the thresholds can now be much lower, and blooms can show at the default zoom where users actually start.

## Fix

```diff
-export const TIER_2_ZOOM = 0.7;
-export const TIER_3_ZOOM = 0.8;
+export const TIER_2_ZOOM = 0.3;
+export const TIER_3_ZOOM = 0.4;
```

## What the user sees at z=0.45 (default mobile)

| | Before (this PR) | After |
|---|---|---|
| Tier 1 (spine + role-holders) | ✅ visible | ✅ visible |
| Tier 2 (bio-holders) | ❌ hidden | ✅ visible |
| Tier 3 (minor figures) | ❌ hidden | ✅ visible |
| Associate clusters | "+N" badges only | ✅ expanded bloom |
| Association paths / trails | ❌ hidden | ✅ visible |
| Bloom apex labels ("disciples", "contemporaries"…) | ❌ hidden | ✅ visible |

## What still works

- **Extreme zoom-out** (z ≤ 0.4): falls back to tier-1 only with collapsed "+N" badges — useful for bird's-eye overview.
- **Progressive disclosure**: z in (0.3, 0.4] shows tier 2 but keeps clusters collapsed; z > 0.4 shows everything.
- **Staggered reveal**: every tier transition still fires the ~0.3s waterfall from #1329, so zoom-outs smoothly collapse the cluster population rather than a jarring pop.

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree — bio-holders and expanded blooms should be visible from the first commit. Pinch out below 0.4 to verify collapsed-badge fallback still works.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3