### PR TITLE
tree: stagger the initial mount too (fix post-#1331 crash on load)

### DIFF
--- a/app/__tests__/components/TreeCanvas.test.tsx
+++ b/app/__tests__/components/TreeCanvas.test.tsx
@@ -81,6 +81,10 @@ describe('TreeCanvas', () => {
     spineIds: new Set<string>(),
     selectedPersonId: null,
     onNodePress: jest.fn(),
+    // Tests render synchronously; skipStagger bypasses the
+    // requestAnimationFrame-based reveal so assertions can see the
+    // fully revealed node set immediately.
+    skipStagger: true,
   };
 
   it('renders without crashing with empty data', () => {

--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -67,10 +67,16 @@ interface Props {
   /** Current committed zoom scale (#1291). Controls per-tier visibility
    *  and associate-cluster collapse-to-badge below {@link TIER_3_ZOOM}. */
   zoom?: number;
+  /** Testing hook: skip the requestAnimationFrame-based staggered reveal
+   *  and render the entire target set immediately. Useful for test
+   *  snapshots / synchronous render assertions. Production renders leave
+   *  this undefined so the crash-preventing stagger runs as designed. */
+  skipStagger?: boolean;
 }
 
 export const TreeCanvas = memo(function TreeCanvas({
   nodes, links, marriageBars, spouseConnectors,
+  skipStagger = false,
   associationLinks = [],
   associateBloomLabels = [],
   associateTrails = [],
@@ -174,13 +180,20 @@ export const TreeCanvas = memo(function TreeCanvas({
     return totalExtraCount;
   }, [zoom, tier2Count, totalExtraCount]);
 
-  // Initial state matches the target for the FIRST render's zoom — so
-  // initial mount instantly shows everything the user should see. iOS
-  // handles a single all-at-once mount fine; it's transitions that
-  // crash. Only zoom CHANGES (after first render) animate via the
-  // staggered reveal below.
-  const [revealedExtra, setRevealedExtra] = React.useState(() => targetRevealed);
-  const lastTargetRef = React.useRef(targetRevealed);
+  // Initial state is 0 — the reveal animation fires on the very first
+  // commit and mounts extras in batches of REVEAL_BATCH_PER_FRAME per
+  // animation frame. The earlier shortcut of seeding with `targetRevealed`
+  // to avoid a startup waterfall crashed iOS when the initial zoom put
+  // targetRevealed near its maximum (e.g. z=0.45 with low TIER_3_ZOOM,
+  // post-#1331): that becomes a single-commit mount of ~198 TreeNodes
+  // plus paths/trails/labels/badges — the exact batch the stagger was
+  // meant to prevent. Starting at 0 guarantees the first frame only
+  // mounts tier-1 nodes; the rest animate in over ~0.7 s. Brief startup
+  // waterfall is acceptable; a crash is not.
+  const [revealedExtra, setRevealedExtra] = React.useState(
+    skipStagger ? targetRevealed : 0,
+  );
+  const lastTargetRef = React.useRef(skipStagger ? targetRevealed : 0);
   React.useEffect(() => {
     // Skip the no-op case where target hasn't actually changed.
     if (lastTargetRef.current === targetRevealed) return;


### PR DESCRIPTION
Follow-up to #1331. Crash returned on tree load:

```
[Canvas] render z=0.45 visibleTier=3 collapsed=false ...  COMMITTED
(DB hot-swaps, re-render)
[Canvas] render z=0.45 visibleTier=3 collapsed=false ...  (no COMMITTED)
```

## Root cause

The lower thresholds from #1331 (`TIER_2_ZOOM=0.3`, `TIER_3_ZOOM=0.4`) mean the default mobile zoom (0.45) now starts at `visibleTier=3 collapsed=false` — `targetRevealed` = `totalExtraCount` (198) on the very first render.

My earlier `useState(() => targetRevealed)` pattern was written when the initial target was near 0 (high thresholds hid tier 2/3 at default zoom). It seeded the counter at its full target on first render to avoid a startup waterfall. With the new low thresholds, that seeding **mounts 198 extra TreeNodes + consolidated association Path + trails + 18 labels + 9 badges in a single commit** — the exact batch-mount crash the stagger was supposed to prevent.

iOS committed the first render on cold launch (weird but OK). The DB hot-swap triggered a re-render with the same props, and this time the compositor gave up.

## Fix

Initial state is now `0`. The reveal effect fires on the very first commit and animates up over ~0.7s in `REVEAL_BATCH_PER_FRAME` batches, same mechanism that let #1329 zoom the full range without crashing.

```diff
-const [revealedExtra, setRevealedExtra] = React.useState(() => targetRevealed);
-const lastTargetRef = React.useRef(targetRevealed);
+const [revealedExtra, setRevealedExtra] = React.useState(
+  skipStagger ? targetRevealed : 0,
+);
+const lastTargetRef = React.useRef(skipStagger ? targetRevealed : 0);
```

## UX consequence

A ~0.7s **waterfall reveal on the first tree render**. Spine and role-holders appear immediately; bio-holders, minor figures, and associate clusters fade in over the next second. The eye is typically on Adam/title at top-of-tree at that moment, not on the associates at the bottom, so it should read as intentional polish.

Vastly preferable to a crash.

## Test escape hatch

Added a `skipStagger?: boolean` prop (default `false`). Synchronous render tests pass `skipStagger: true` via the shared `defaultProps` fixture so they can observe the full node set immediately without driving rAF. Production never sets it.

## Test plan

- [x] `./node_modules/.bin/jest` — 426 suites / 3205 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree. Expected: spine appears immediately, then bio-holders / minor figures / associate blooms fade in over ~0.7s. No crash.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3