### PR TITLE
tree: straight-line association path (fix post-#1332 re-render crash)

### DIFF
--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -17,7 +17,7 @@ import { TreeLink } from './TreeLink';
 import { MarriageBarSvg } from './MarriageBarSvg';
 import { SpouseConnectorSvg } from './SpouseConnectorSvg';
 import { TreeNode } from './TreeNode';
-import { TIER_2_ZOOM, TIER_3_ZOOM, getVisibleTier, getPersonTier, bezierPath } from '../../utils/genealogyOrganic';
+import { TIER_2_ZOOM, TIER_3_ZOOM, getVisibleTier, getPersonTier } from '../../utils/genealogyOrganic';
 import { isMessianic } from '../../utils/messianicLine';
 import { logger } from '../../utils/logger';
 import type { LayoutNode, TreeLink as TreeLinkType, MarriageBar, SpouseConnector, TreePerson, AssociationLink, AssociateBloomLabel, AssociateTrail } from '../../utils/treeBuilder';
@@ -115,12 +115,17 @@ export const TreeCanvas = memo(function TreeCanvas({
     [associationLinks],
   );
 
-  // All dashed-bezier associate connectors consolidated into ONE Path
-  // string. 89 individual `<AssociationLinkSvg>` components → 1 native
-  // CAShapeLayer. Tier-3 zoom transitions flip one opacity value instead
-  // of mounting 89 layers (see #1308, #1329).
+  // All associate connectors consolidated into ONE Path string using
+  // STRAIGHT lines (not bezier). 89 individual `<AssociationLinkSvg>`
+  // components → 1 native CAShapeLayer. Straight-line geometry keeps
+  // the consolidated Path cheap enough to first-rasterize at opacity
+  // 0.55 at the default zoom — the bezier version crashed iOS's
+  // compositor when it had to evaluate 89 cubic curves + dash positions
+  // in a single paint (device log, post-#1331 / #1332).
   const associationPathD = useMemo(
-    () => associationLinks.map((al) => bezierPath(al.source, al.target)).join(' '),
+    () => associationLinks
+      .map((al) => `M ${al.source.x} ${al.source.y} L ${al.target.x} ${al.target.y}`)
+      .join(' '),
     [associationLinks],
   );
 


### PR DESCRIPTION
Follow-up to #1332. Device log shows the stagger fixed the TreeNode mount issue, but a different first-rasterization path is still crashing iOS when the DB hot-swap triggers a re-render:

```
[Canvas] render z=0.45 visibleTier=3 collapsed=false ... COMMITTED
(DB hot-swaps to updated content, triggers re-render)
[Canvas] render z=0.45 ... (no COMMITTED — crash)
```

## Diagnosis

The consolidated association-links `<Path>` is one native CAShapeLayer — but with 89 cubic-bezier subpaths + dashed stroke, its first-time rasterization requires iOS to evaluate 89 curves and compute dash positions along each. Pre-#1331 the path rendered at `opacity=0` at the default zoom (clusters collapsed below TIER_3_ZOOM=0.8) so iOS skipped it entirely. Post-#1331 the thresholds dropped and the path now renders at `opacity=0.55` from the very first commit — iOS's compositor apparently handles it on the initial paint, but when the DB hot-swap forces a re-paint it gives up.

## Fix

Switch the consolidated path from cubic beziers to straight lines:

```diff
-const associationPathD = useMemo(
-  () => associationLinks.map((al) => bezierPath(al.source, al.target)).join(' '),
-  [associationLinks],
-);
+const associationPathD = useMemo(
+  () => associationLinks
+    .map((al) => `M ${al.source.x} ${al.source.y} L ${al.target.x} ${al.target.y}`)
+    .join(' '),
+  [associationLinks],
+);
```

`M x y L x y` per connector instead of `M x y C cx1 cy1, cx2 cy2, x2 y2`. 89 straight-line segments in one Path are trivially cheap for iOS to rasterize.

**Dashed stroke is kept** so association connectors stay visually distinct from the solid-stroked genealogical TreeLinks.

## UX trade-off

Association connectors lose their gentle S-curve — they're now straight diagonals between anchor and each member. The organic look from card #1290's original design is slightly diminished. Restorable later if we find a cheaper way to render the bezier version (e.g. split the 89 subpaths into 9 per-anchor `<Path>` elements so each one's rasterization is smaller, or opacity-stagger the path's first paint).

## What's still bezier

`bezierPath()` is still used by `TreeLink` for genealogical connections (parent→child lines on the main tree). Those are **per-link `<Path>` elements**, not a single consolidated mega-path, so each one's rasterization is trivial. No reason to touch them.

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree. Expected: first render commits, stagger runs, then a DB hot-swap re-render commits cleanly instead of crashing.

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3