### PR TITLE
tree: decouple cluster-collapse threshold from tier-3 zoom

### DIFF
--- a/app/src/components/tree/TreeCanvas.tsx
+++ b/app/src/components/tree/TreeCanvas.tsx
@@ -65,7 +65,8 @@ interface Props {
   /** Full SVG height — needed for background sizing. */
   canvasHeight?: number;
   /** Current committed zoom scale (#1291). Controls per-tier visibility
-   *  and associate-cluster collapse-to-badge below {@link TIER_3_ZOOM}. */
+   *  (below TIER_2_ZOOM / TIER_3_ZOOM) AND associate-cluster
+   *  collapse-to-badge (below the local CLUSTER_COLLAPSE_ZOOM). */
   zoom?: number;
   /** Testing hook: skip the requestAnimationFrame-based staggered reveal
    *  and render the entire target set immediately. Useful for test
@@ -87,8 +88,24 @@ export const TreeCanvas = memo(function TreeCanvas({
 }: Props) {
   const { base } = useTheme();
 
-  const clustersCollapsed = zoom < TIER_3_ZOOM;
-  const labelsVisible = zoom >= TIER_3_ZOOM;
+  // Cluster-collapse threshold is deliberately DECOUPLED from tier
+  // visibility thresholds. Rationale from post-#1331 device crashes:
+  // - Tier visibility controls which TreeNodes render (node mount stagger).
+  //   We want this permissive (TIER_3_ZOOM = 0.4) so the user sees most
+  //   people at the default mobile zoom.
+  // - Cluster collapse controls whether the consolidated association
+  //   <Path> (89 dashed-stroke segments in one native CAShapeLayer) is
+  //   rendered at visible opacity. iOS re-rasterizes this Path on every
+  //   scale change, and with 89 dashed segments + the ~10k-tall canvas
+  //   the re-rasterization crashes the compositor.
+  // Keeping CLUSTER_COLLAPSE_ZOOM high (0.8) means the expensive Path
+  // stays at opacity=0 (iOS skips it entirely) at default zooms. Users
+  // see "+N" badges at anchors instead — same information, cheap to paint.
+  // Pinching past 0.8 is a deliberate "I want to see the connectors"
+  // action; iOS is more tolerant when the user expects a slight delay.
+  const CLUSTER_COLLAPSE_ZOOM = 0.8;
+  const clustersCollapsed = zoom < CLUSTER_COLLAPSE_ZOOM;
+  const labelsVisible = zoom >= CLUSTER_COLLAPSE_ZOOM;
 
   // Render-entry diagnostic.
   const visibleTier = getVisibleTier(zoom);
@@ -354,7 +371,8 @@ export const TreeCanvas = memo(function TreeCanvas({
         })}
 
         {/* 5. Bloom-apex labels ("disciples", "contemporaries"…). Always
-               rendered; opacity gated by TIER_3_ZOOM. */}
+               rendered; opacity gated by CLUSTER_COLLAPSE_ZOOM (same
+               threshold as the path + trails + badges). */}
         {!BISECT.hideLabels && associateBloomLabels.map((lbl) => (
           <SvgText
             key={`abl-${lbl.anchorId}-${lbl.type}`}
@@ -364,7 +382,7 @@ export const TreeCanvas = memo(function TreeCanvas({
             fontSize={11}
             fontFamily="Cinzel_600SemiBold"
             textAnchor="middle"
-            opacity={zoom >= TIER_3_ZOOM ? 0.65 : 0}
+            opacity={labelsVisible ? 0.65 : 0}
           >
             {lbl.text}
           </SvgText>


### PR DESCRIPTION
Post-#1333 device log: straight-line path didn't prevent the scale-change crash. Initial render at `z=0.45` commits cleanly; when `centreOnNode` fires `jumpTo(s=0.65)`, the re-render at z=0.65 never commits.

## Root cause

iOS re-rasterizes the consolidated association `<Path>` on **every scale change**. Even a 89-segment **straight-line** dashed-stroke path is heavy enough to crash the compositor during that re-paint on a 2 748 × 10 017 canvas. #1333's bezier→straight switch reduced rasterization cost but not enough.

What every prior stable build had in common: the association Path was at `opacity=0` at the default zoom (because `clustersCollapsed = zoom < TIER_3_ZOOM = 0.8`), so iOS **skipped** it from rasterization entirely. PR #1331 broke that by lowering `TIER_3_ZOOM` to 0.4 in an effort to show blooms at default zoom.

## Fix

Stop coupling two separate concerns to the same threshold:

| Concern | Threshold | Value | What it drives |
|---|---|---|---|
| Tier visibility | `TIER_2_ZOOM` / `TIER_3_ZOOM` | 0.3 / 0.4 | Which TreeNodes render — driven by the stagger. Permissive so users see most people at default zoom. |
| **Cluster collapse** | `CLUSTER_COLLAPSE_ZOOM` (new, local to TreeCanvas) | **0.8** | Whether the expensive consolidated Path + trails + labels + badges render at visible opacity. Restrictive because iOS can't re-rasterize the Path on scale changes. |

```ts
const CLUSTER_COLLAPSE_ZOOM = 0.8;
const clustersCollapsed = zoom < CLUSTER_COLLAPSE_ZOOM;
const labelsVisible = zoom >= CLUSTER_COLLAPSE_ZOOM;
```

## What the user sees at each zoom band now

| Zoom | TreeNodes visible | Associate-cluster visual |
|---|---|---|
| `z < 0.3` | Tier 1 only (spine + roles) | "+N" badges at anchors |
| `0.3 ≤ z < 0.4` | + Tier 2 (bio-holders) | Still badges |
| `0.4 ≤ z < 0.8` | + Tier 3 (minor figures + associates) | Still badges |
| `z ≥ 0.8` | All tiers | **Full bloom**: dashed connectors + trails + apex labels |

**At the default mobile zoom (0.45), the user now sees EVERY person.** Just the expensive connector paths stay at opacity 0 until they deliberately pinch past 0.8 for the full-detail "bloom" view. That's the information content #1331 was trying to expose, without the re-rasterization crash from #1333.

## Test plan

- [x] `./node_modules/.bin/jest` — 426 / 3205 passing
- [x] `npx tsc --noEmit` — clean
- [ ] **Device**: merge, open tree. Expected:
  - Every person visible at initial load (spine, role-holders, bio-holders, associates)
  - "+N" badges at anchors with lots of associates (Paul, Jesus, David, Moses)
  - Centre-on-Adam `jumpTo 0.65` commits cleanly — no crash
  - Pinch past 0.8 to see the full bloom with connector lines

https://claude.ai/code/session_01UJsyeC4bGncy2GoPjgNLj3