### PR TITLE
fix: era filter jump fallbacks + gesture throttle

### DIFF
--- a/app/__tests__/hooks/useTreeCamera.test.ts
+++ b/app/__tests__/hooks/useTreeCamera.test.ts
@@ -84,4 +84,100 @@ describe('useTreeCamera', () => {
     });
     expect(result.current.camera.y).toBeCloseTo(600 - vH * 0.25, 3);
   });
+
+  // ── Gesture throttling ───────────────────────────────────────────
+
+  /** Grab the pan gesture's captured onUpdate handler from the mock.
+   *  The Simultaneous() mock wraps [pinch, pan] in that order. */
+  function getPanHandlers(result: any) {
+    const pan = result.current.gesture._simultaneous[1];
+    return pan.__handlers;
+  }
+
+  function getPinchHandlers(result: any) {
+    const pinch = result.current.gesture._simultaneous[0];
+    return pinch.__handlers;
+  }
+
+  it('throttles rapid pan updates to ~35fps', () => {
+    const { result } = renderHook(() => useTreeCamera());
+    const pan = getPanHandlers(result);
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    try {
+      // Simulate gesture begin — resets throttle so the first update fires.
+      nowSpy.mockReturnValue(1000);
+      act(() => { pan.onBegin(); });
+
+      // First update at t=1000 — throttle sees 1000 - 0 = 1000 ≥ 28 → fires.
+      nowSpy.mockReturnValue(1000);
+      act(() => { pan.onUpdate({ translationX: 10, translationY: 0 }); });
+      const afterFirst = result.current.camera.x;
+
+      // Second update 10ms later — throttle sees 10 < 28 → DROPPED.
+      nowSpy.mockReturnValue(1010);
+      act(() => { pan.onUpdate({ translationX: 50, translationY: 0 }); });
+      expect(result.current.camera.x).toBe(afterFirst);
+
+      // Third update 35ms after the first — throttle sees 35 ≥ 28 → fires.
+      nowSpy.mockReturnValue(1035);
+      act(() => { pan.onUpdate({ translationX: 100, translationY: 0 }); });
+      expect(result.current.camera.x).not.toBe(afterFirst);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('throttles rapid pinch updates to ~35fps', () => {
+    const { result } = renderHook(() => useTreeCamera());
+    const pinch = getPinchHandlers(result);
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    try {
+      nowSpy.mockReturnValue(1000);
+      act(() => { pinch.onBegin({ focalX: 100, focalY: 100 }); });
+
+      nowSpy.mockReturnValue(1000);
+      act(() => { pinch.onUpdate({ scale: 1.1, focalX: 100, focalY: 100 }); });
+      const afterFirstZoom = result.current.camera.zoom;
+
+      // Within the throttle window → camera zoom unchanged.
+      nowSpy.mockReturnValue(1010);
+      act(() => { pinch.onUpdate({ scale: 1.5, focalX: 100, focalY: 100 }); });
+      expect(result.current.camera.zoom).toBe(afterFirstZoom);
+
+      // Past the throttle window → camera zoom updates.
+      nowSpy.mockReturnValue(1040);
+      act(() => { pinch.onUpdate({ scale: 2.0, focalX: 100, focalY: 100 }); });
+      expect(result.current.camera.zoom).not.toBe(afterFirstZoom);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('always fires the first frame of a new pan gesture (throttle reset)', () => {
+    const { result } = renderHook(() => useTreeCamera());
+    const pan = getPanHandlers(result);
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    try {
+      // First gesture: an update fills lastPanTime = 5000.
+      nowSpy.mockReturnValue(5000);
+      act(() => { pan.onBegin(); });
+      nowSpy.mockReturnValue(5000);
+      act(() => { pan.onUpdate({ translationX: 10, translationY: 0 }); });
+
+      // New gesture 10ms later — without the reset, this first update
+      // would be throttled. onBegin resets lastPanTime to 0 so now - 0
+      // is always large enough to pass.
+      nowSpy.mockReturnValue(5010);
+      act(() => { pan.onBegin(); });
+      const beforeFirstUpdate = result.current.camera.x;
+      nowSpy.mockReturnValue(5010);
+      act(() => { pan.onUpdate({ translationX: 100, translationY: 0 }); });
+      expect(result.current.camera.x).not.toBe(beforeFirstUpdate);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/app/__tests__/screens/GenealogyTreeScreen.test.tsx
+++ b/app/__tests__/screens/GenealogyTreeScreen.test.tsx
@@ -41,6 +41,9 @@ const mockTreeLayout = {
     { data: { id: 'adam', name: 'Adam', era: 'primeval' }, x: 100, y: 50, tier: 1 },
     { data: { id: 'eve', name: 'Eve', era: 'primeval' }, x: 200, y: 50, tier: 1 },
     { data: { id: 'seth', name: 'Seth', era: 'primeval' }, x: 150, y: 150, tier: 1 },
+    // A prophets-era person so the divided_kingdom → prophets fallback
+    // has somewhere to land in the fixture.
+    { data: { id: 'isaiah', name: 'Isaiah', era: 'prophets' }, x: 500, y: 800, tier: 2 },
   ],
   links: [],
   marriageBars: [],
@@ -100,7 +103,7 @@ jest.mock('@/components/tree/EraFilterBar', () => ({
     const React = require('react');
     const { View, TouchableOpacity, Text } = require('react-native');
     return React.createElement(View, { testID: 'era-filter-bar' },
-      ['all', 'primeval', 'patriarchs', 'exodus'].map((era: string) =>
+      ['all', 'primeval', 'patriarchs', 'exodus', 'divided_kingdom', 'prophets'].map((era: string) =>
         React.createElement(TouchableOpacity, {
           key: era,
           testID: `era-filter-${era}`,
@@ -241,6 +244,28 @@ describe('GenealogyTreeScreen', () => {
     // The component calls setFilterEra('patriarchs') — verified by the tree re-rendering
     // (no crash proves the state update worked)
     expect(getByTestId('era-filter-bar')).toBeTruthy();
+  });
+
+  it('jumps to prophets region when divided_kingdom filter is selected', () => {
+    // The fixture has zero people tagged with `era: 'divided_kingdom'`, so
+    // the fallback chain should land on the first 'prophets' person
+    // (Isaiah in the fixture at x=500, y=800).
+    const { getByTestId } = renderWithProviders(
+      <GenealogyTreeScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    mockCentreOnNode.mockClear();
+    fireEvent.press(getByTestId('era-filter-divided_kingdom'));
+    expect(mockCentreOnNode).toHaveBeenCalledWith(500, 800);
+  });
+
+  it('jumps to matching era directly when at least one person tagged with that era exists', () => {
+    const { getByTestId } = renderWithProviders(
+      <GenealogyTreeScreen route={mockRoute as any} navigation={{ navigate: mockNavigate, goBack: mockGoBack } as any} />,
+    );
+    mockCentreOnNode.mockClear();
+    fireEvent.press(getByTestId('era-filter-prophets'));
+    // Direct match on prophets → Isaiah at (500, 800) — no fallback needed.
+    expect(mockCentreOnNode).toHaveBeenCalledWith(500, 800);
   });
 
   it('opens person sidebar when search result is selected', () => {

--- a/app/src/hooks/useTreeCamera.ts
+++ b/app/src/hooks/useTreeCamera.ts
@@ -99,6 +99,15 @@ export function useTreeCamera(): TreeCameraResult {
     focalScreenY: number;
   } | null>(null);
 
+  /** Timestamp of the last camera update during active pan.
+   *  Skipping intermediate frames reduces React re-renders from ~60/s to
+   *  ~35/s during active gestures. One-shot updates (centering, search,
+   *  era jump) are not throttled. */
+  const lastPanTime = useRef(0);
+
+  /** Same throttle for pinch gestures. */
+  const lastPinchTime = useRef(0);
+
   // RAF handle for pan-decay loop (nullable so we can cancel on new gestures).
   const decayHandleRef = useRef<number | null>(null);
   const cancelDecay = useCallback(() => {
@@ -113,10 +122,16 @@ export function useTreeCamera(): TreeCameraResult {
   // ── Pan gesture ────────────────────────────────────────────────────
   const onPanBegin = useCallback(() => {
     cancelDecay();
+    // Reset throttle so the first frame of a new gesture fires immediately.
+    lastPanTime.current = 0;
     panStartRef.current = { x: cameraRef.current.x, y: cameraRef.current.y };
   }, [cancelDecay]);
 
   const onPanUpdate = useCallback((translationX: number, translationY: number) => {
+    const now = Date.now();
+    if (now - lastPanTime.current < 28) return; // ~35fps during active pan
+    lastPanTime.current = now;
+
     const start = panStartRef.current;
     if (!start) return;
     const zoom = cameraRef.current.zoom;
@@ -150,6 +165,8 @@ export function useTreeCamera(): TreeCameraResult {
   // ── Pinch gesture ──────────────────────────────────────────────────
   const onPinchBegin = useCallback((focalScreenX: number, focalScreenY: number) => {
     cancelDecay();
+    // Reset throttle so the first frame of a new gesture fires immediately.
+    lastPinchTime.current = 0;
     const { x, y, zoom } = cameraRef.current;
     pinchStartRef.current = {
       zoom,
@@ -161,6 +178,10 @@ export function useTreeCamera(): TreeCameraResult {
   }, [cancelDecay]);
 
   const onPinchUpdate = useCallback((scale: number, focalScreenX: number, focalScreenY: number) => {
+    const now = Date.now();
+    if (now - lastPinchTime.current < 28) return; // ~35fps during active pinch
+    lastPinchTime.current = now;
+
     const start = pinchStartRef.current;
     if (!start) return;
     const newZoom = clampZoom(start.zoom * scale);

--- a/app/src/screens/GenealogyTreeScreen.tsx
+++ b/app/src/screens/GenealogyTreeScreen.tsx
@@ -39,6 +39,15 @@ import { logger } from '../utils/logger';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
+/** Era-filter fallbacks for keys that have no matching people in the
+ *  data. When the user taps "Divided Kingdom" the camera jumps to the
+ *  prophets region, etc. — so the filter never silently no-ops. */
+const ERA_FALLBACKS: Record<string, string[]> = {
+  divided_kingdom: ['prophets', 'kingdom'],
+  intertestamental: ['post-exilic', 'exile'],
+  apostolic: ['nt'],
+};
+
 function GenealogyTreeScreen({ route, navigation }: {
   route: ScreenRouteProp<'Explore', 'GenealogyTree'>;
   navigation: ScreenNavProp<'Explore', 'GenealogyTree'>;
@@ -111,6 +120,9 @@ function GenealogyTreeScreen({ route, navigation }: {
   }, [initialPersonId, nodes, people, centreOnNodeAbovePanel]);
 
   // Era filter change: jump to the first matching person.
+  // Some theme era keys have zero people in the data — the content uses
+  // adjacent era values instead. The fallback chain finds the closest
+  // populated era so the camera always jumps somewhere meaningful.
   useEffect(() => {
     if (!hasCentred.current || nodes.length === 0) return;
     if (filterEra === prevEra.current) return;
@@ -123,10 +135,18 @@ function GenealogyTreeScreen({ route, navigation }: {
         centreOnNodeTop(adam.x, adam.y);
       }
     } else {
-      const firstMatch = nodes.find((n) => n.data.era === filterEra);
+      // Try exact era first, then fallbacks for eras with no people.
+      const erasToTry = [filterEra, ...(ERA_FALLBACKS[filterEra] ?? [])];
+      let firstMatch = null;
+      for (const era of erasToTry) {
+        firstMatch = nodes.find((n) => n.data.era === era);
+        if (firstMatch) break;
+      }
       if (firstMatch) {
         logger.info('Tree', `Era→${filterEra}: centering on ${firstMatch.data.name}`);
         centreOnNode(firstMatch.x, firstMatch.y);
+      } else {
+        logger.info('Tree', `Era→${filterEra}: no matching nodes found`);
       }
     }
   }, [filterEra, nodes, centreOnNode, centreOnNodeTop]);


### PR DESCRIPTION
Two tree-screen follow-ups to the viewBox refactor:

1. Era filter jump silently no-oped for `divided_kingdom`, `intertestamental`, and `apostolic` because the data has zero people tagged with those era values. Added an ERA_FALLBACKS map so each orphan era falls back to an adjacent populated era (prophets, post-exilic, nt respectively). The dimming behaviour is unchanged — only the camera jump target is affected.

2. Pan/pinch updates now skip frames to cap camera setState at ~35fps during active gestures (half the prior rate). A per-gesture-type timestamp ref guards each onUpdate; onBegin resets it so the first frame of a new gesture is never throttled. Centering functions, gesture end handlers, and pan-decay loops are all left untouched — the only throttled path is the high-frequency update callback.

Added tests: era_fallback + direct-era-match cases for the screen, three throttle scenarios for the hook (drop within window, pass after window, reset on new gesture). All 3,193 tests pass.

https://claude.ai/code/session_013sZspGb2WihfxCJuSagk7D