### PR TITLE
fix: reorder Biblical World carousel — People, Timeline, Map, Periods, Story

### DIFF
--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -58,9 +58,9 @@ const SECTIONS: FeatureSection[] = [
     features: [
       { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
       { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
+      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
       { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
       { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
-      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
     ],
   },
   {


### PR DESCRIPTION
Moves Map from position 5 to position 3 in the Biblical World carousel on ExploreMenuScreen.

New order: People → Timeline → Map → Periods → Story