### PR TITLE
content: wire Explore screen images — tool panels, periods, story acts

### DIFF
--- a/_tools/download_explore_images.py
+++ b/_tools/download_explore_images.py
@@ -36,9 +36,22 @@ DOWNLOADS = [
         "https://upload.wikimedia.org/wikipedia/commons/2/2a/Babylonian_cuneiform_tablet_with_a_map_from_Nippur_1550-1450_BCE.jpg",
         "Map tool panel — Babylonian cuneiform map tablet from Nippur",
     ),
-    # Dictionary (Gutenberg Bible) — already referenced, verify on R2
-    # Concordance (Aleppo Codex) — already referenced, verify on R2
-    # Topical Index (Botticelli St Augustine) — already referenced, verify on R2
+    # === TOOL PANEL IMAGES (Wikimedia) ===
+    (
+        "aleppo-codex-joshua.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/4/4d/Aleppo_Codex_Joshua_1_1.jpg",
+        "Concordance tool panel — Aleppo Codex, Joshua 1:1",
+    ),
+    (
+        "gutenberg-bible.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/b/b6/Gutenberg_Bible%2C_Lenox_Copy%2C_New_York_Public_Library%2C_2009._Pic_01.jpg",
+        "Dictionary tool panel — Gutenberg Bible, Lenox Copy",
+    ),
+    (
+        "botticelli-augustine.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/d/d4/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg",
+        "Topical Index tool panel — Botticelli St. Augustine in His Study",
+    ),
 
     # === DORÉ — Period cards (missing from R2) ===
     (

--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -32,6 +32,13 @@
       "exodus-plagues",
       "paul-journey3",
       "nativity"
+    ],
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/map-babylonian-tablet.jpg",
+        "caption": "Babylonian cuneiform map tablet from Nippur, 1550–1450 BCE",
+        "credit": "Penn Museum · Public domain"
+      }
     ]
   },
   "ConceptBrowse": {
@@ -49,7 +56,14 @@
     "count": 110,
     "noun": "topics",
     "contentType": "topic",
-    "featured": []
+    "featured": [],
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/botticelli-augustine.jpg",
+        "caption": "Botticelli's St. Augustine in His Study — a scholar among organized texts",
+        "credit": "Sandro Botticelli · Public domain"
+      }
+    ]
   },
   "ProphecyBrowse": {
     "count": 50,
@@ -109,8 +123,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Codex_Sinaiticus_open_full.jpg/400px-Codex_Sinaiticus_open_full.jpg",
-        "caption": "Codex Sinaiticus — one of the oldest complete New Testaments",
+        "url": "https://contentcompanionstudy.com/art/aleppo-codex-joshua.jpg",
+        "caption": "Aleppo Codex — oldest Hebrew Bible manuscript, Joshua 1:1",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -121,8 +135,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Aleppo_Codex_%28Deuteronomy%29.jpg/400px-Aleppo_Codex_%28Deuteronomy%29.jpg",
-        "caption": "The Aleppo Codex — the oldest near-complete Hebrew Bible manuscript",
+        "url": "https://contentcompanionstudy.com/art/gutenberg-bible.jpg",
+        "caption": "Gutenberg Bible — the first major book printed with movable type",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -240,6 +254,60 @@
         "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/P46.jpg/400px-P46.jpg",
         "caption": "Papyrus 46 — Greek verb forms preserved in ancient manuscripts",
         "credit": "Public domain, via Wikimedia Commons"
+      }
+    ]
+  },
+  "Periods": {
+    "count": 12,
+    "noun": "eras",
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-creation-light.jpg",
+        "caption": "The Creation of Light — Primeval History",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-red-sea.jpg",
+        "caption": "Crossing the Red Sea — Egypt & Exodus",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-solomon-judgment.jpg",
+        "caption": "Judgment of Solomon — United Kingdom",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-nativity.jpg",
+        "caption": "The Nativity — New Testament",
+        "credit": "Gustave Doré · Public domain"
+      }
+    ]
+  },
+  "RedemptiveArc": {
+    "count": 8,
+    "noun": "acts",
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-creation-light.jpg",
+        "caption": "The Creation of Light — Act 1: Creation",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-adam-eve.jpg",
+        "caption": "Driven Out of Eden — Act 2: Rebellion",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-david-goliath.jpg",
+        "caption": "David and Goliath — Act 4: Kingdom",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-new-jerusalem.jpg",
+        "caption": "The New Jerusalem — Act 8: Restoration",
+        "credit": "Gustave Doré · Public domain"
       }
     ]
   }


### PR DESCRIPTION
Wires images into the Explore screen manifest (`explore-images.json`) for 6 feature cards:

**Tool panels (updated/new):**
- Map → Babylonian cuneiform map tablet from Nippur (R2)
- Concordance → Aleppo Codex Joshua 1:1 (R2)
- Dictionary → Gutenberg Bible, Lenox Copy (R2)
- Topical Index → Botticelli St. Augustine in His Study (R2)

**New entries:**
- Periods → 4 representative Doré images (Creation of Light, Red Sea, Solomon, Nativity)
- Redemptive Arc → 4 representative Doré images (Creation, Eden, David & Goliath, New Jerusalem)

Also updates `download_explore_images.py` to include the 3 tool panel Wikimedia images.

**DEPENDENCY:** Run `python _tools/download_explore_images.py` then `python _tools/upload_images_to_r2.py --priority` before deploying — the R2 URLs in the manifest require the images to be uploaded first.