### PR TITLE
content: swap all Explore images to verified R2 URLs

### DIFF
--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -32,6 +32,13 @@
       "exodus-plagues",
       "paul-journey3",
       "nativity"
+    ],
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/map-babylonian-tablet.jpg",
+        "caption": "Babylonian cuneiform map tablet from Nippur, 1550–1450 BCE",
+        "credit": "Penn Museum · Public domain"
+      }
     ]
   },
   "ConceptBrowse": {
@@ -52,7 +59,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg/400px-Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg",
+        "url": "https://contentcompanionstudy.com/art/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg",
         "caption": "Botticelli's St. Augustine in His Study",
         "credit": "Sandro Botticelli · Public domain"
       }
@@ -116,8 +123,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Codex_Sinaiticus_open_full.jpg/400px-Codex_Sinaiticus_open_full.jpg",
-        "caption": "Codex Sinaiticus — one of the oldest complete New Testaments",
+        "url": "https://contentcompanionstudy.com/art/Aleppo_Codex_Joshua_1_1.jpg",
+        "caption": "Aleppo Codex — oldest Hebrew Bible manuscript, Joshua 1:1",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -128,8 +135,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Aleppo_Codex_%28Deuteronomy%29.jpg/400px-Aleppo_Codex_%28Deuteronomy%29.jpg",
-        "caption": "The Aleppo Codex — the oldest near-complete Hebrew Bible manuscript",
+        "url": "https://contentcompanionstudy.com/art/gutenberg-bible.jpg",
+        "caption": "Gutenberg Bible — the first major book printed with movable type",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -256,7 +263,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Gustave_Dor%C3%A9_-_The_Holy_Bible_-_Plate_I%2C_The_Deluge.jpg/400px-Gustave_Dor%C3%A9_-_The_Holy_Bible_-_Plate_I%2C_The_Deluge.jpg",
+        "url": "https://contentcompanionstudy.com/art/dore-flood.jpg",
         "caption": "The Deluge — Primeval History",
         "credit": "Gustave Doré · Public domain"
       },
@@ -293,13 +300,13 @@
         "credit": "Gustave Doré · Public domain"
       },
       {
-        "url": "https://contentcompanionstudy.com/art/dore-jeremiah.jpg",
-        "caption": "Jeremiah — Act 5: Exile",
+        "url": "https://contentcompanionstudy.com/art/dore-david-goliath.jpg",
+        "caption": "David and Goliath — Act 4: Kingdom",
         "credit": "Gustave Doré · Public domain"
       },
       {
-        "url": "https://contentcompanionstudy.com/art/dore-nativity.jpg",
-        "caption": "The Nativity — Act 6: Incarnation",
+        "url": "https://contentcompanionstudy.com/art/dore-new-jerusalem.jpg",
+        "caption": "The New Jerusalem — Act 8: Restoration",
         "credit": "Gustave Doré · Public domain"
       }
     ]


### PR DESCRIPTION
All 27 images confirmed uploaded to R2. Swaps remaining Wikimedia thumb URLs to R2:
- Concordance: Aleppo Codex → R2
- Dictionary: Gutenberg Bible → R2
- TopicBrowse: Botticelli → R2
- Map: adds Babylonian tablet from R2
- Periods + RedemptiveArc: all Doré images on R2