### PR TITLE
fix: Map card image — use inline R2 image

### DIFF
--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -26,13 +26,7 @@
   "Map": {
     "count": 28,
     "noun": "journeys",
-    "contentType": "map_story",
-    "featured": [
-      "abram-call",
-      "exodus-plagues",
-      "paul-journey3",
-      "nativity"
-    ],
+    "contentType": null,
     "images": [
       {
         "url": "https://contentcompanionstudy.com/art/map-babylonian-tablet.jpg",


### PR DESCRIPTION
Map had both contentType='map_story' and an inline images[]. The useExploreImages hook ignores inline images when contentType is set (takes the SQLite resolution path). Since the map_story content_images table has no images for those featured IDs, the card showed nothing.

Fix: set contentType to null so the hook uses the inline Babylonian tablet image from R2.