### PR TITLE
fix: make TimelineEraStrip horizontally scrollable with labeled segments

### DIFF
--- a/app/src/components/timeline/TimelineEraStrip.tsx
+++ b/app/src/components/timeline/TimelineEraStrip.tsx
@@ -1,16 +1,19 @@
 /**
- * TimelineEraStrip — Proportional horizontal era-filter strip.
+ * TimelineEraStrip — Scrollable horizontal era-filter strip.
  *
- * Each era's width is proportional to its event count. Tapping a segment
- * selects the era (or deselects if already active). Selected segment
- * shows a brighter gradient + 2px bottom accent line.
+ * Each era is a labeled pill with a minimum tappable width. The strip
+ * scrolls horizontally so all eras are readable regardless of count.
+ * Tapping a segment selects the era (or deselects if already active).
+ * Selected segment shows a brighter fill + 2px bottom accent line.
+ * A caption row below shows the selected era's full name and date range.
  *
  * Part of Card #1264 (Timeline Phase 1).
  */
 
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useTheme, fontFamily, spacing } from '../../theme';
+import React, { useRef, useCallback } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet,
+  type LayoutChangeEvent } from 'react-native';
+import { useTheme, fontFamily, eraPillLabels, spacing } from '../../theme';
 import type { EraRow } from '../../db/content/reference';
 
 export interface TimelineEraStripProps {
@@ -42,11 +45,9 @@ export function computeEraShares(
   return raw.map((r) => ({ id: r.id, share: r.share / total }));
 }
 
-/** First word of a label — e.g., "Divided Kingdom" → "Divided". */
-export function firstWord(label: string): string {
-  const trimmed = (label ?? '').trim();
-  if (!trimmed) return '';
-  return trimmed.split(/\s+/)[0];
+/** Short label for a pill — uses eraPillLabels or first word as fallback. */
+export function pillLabel(era: EraRow): string {
+  return eraPillLabels[era.id] ?? (era.name ?? '').split(/\s+/)[0] ?? '';
 }
 
 /** Human-friendly date range (negatives → "BC"). */
@@ -55,6 +56,18 @@ export function formatEraRange(start: number | null, end: number | null): string
   const fmt = (n: number) => (n < 0 ? `${Math.abs(n)} BC` : n === 0 ? 'AD 0' : `AD ${n}`);
   return `${fmt(start)} – ${fmt(end)}`;
 }
+
+/** @deprecated Kept for test compatibility. Use pillLabel instead. */
+export function firstWord(label: string): string {
+  const trimmed = (label ?? '').trim();
+  if (!trimmed) return '';
+  return trimmed.split(/\s+/)[0];
+}
+
+/** Minimum segment width so every era is tappable and labeled. */
+const MIN_SEGMENT_WIDTH = 72;
+/** Extra width per proportional share unit, added on top of the minimum. */
+const PROPORTIONAL_EXTRA = 40;
 
 export function TimelineEraStrip({
   eras,
@@ -67,47 +80,80 @@ export function TimelineEraStrip({
   const active = eras.find((e) => e.id === activeEraId) ?? null;
   const activeCount = active ? eventCounts[active.id] ?? 0 : 0;
 
+  const scrollRef = useRef<ScrollView>(null);
+  const segmentLayouts = useRef<Record<string, { x: number; width: number }>>({});
+
+  const handleSegmentLayout = useCallback(
+    (eraId: string) => (e: LayoutChangeEvent) => {
+      segmentLayouts.current[eraId] = {
+        x: e.nativeEvent.layout.x,
+        width: e.nativeEvent.layout.width,
+      };
+    },
+    [],
+  );
+
+  const handleSelect = useCallback(
+    (eraId: string, isSelected: boolean) => {
+      onSelectEra(isSelected ? null : eraId);
+      if (!isSelected) {
+        requestAnimationFrame(() => {
+          const layout = segmentLayouts.current[eraId];
+          if (layout && scrollRef.current) {
+            scrollRef.current.scrollTo({
+              x: Math.max(0, layout.x - 40),
+              animated: true,
+            });
+          }
+        });
+      }
+    },
+    [onSelectEra],
+  );
+
   return (
     <View style={styles.wrapper}>
-      <View
-        style={[styles.strip, { backgroundColor: base.bgSurface }]}
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={[styles.strip, { backgroundColor: base.bgSurface }]}
         accessibilityRole="tablist"
       >
         {shares.map(({ id, share }) => {
           const era = eras.find((e) => e.id === id);
           if (!era) return null;
           const isSelected = id === activeEraId;
-          const isWide = (eventCounts[id] ?? 0) > 30;
           const color = era.hex ?? base.gold;
+          const width = MIN_SEGMENT_WIDTH + share * PROPORTIONAL_EXTRA * eras.length;
           return (
             <TouchableOpacity
               key={id}
-              onPress={() => onSelectEra(isSelected ? null : id)}
+              onPress={() => handleSelect(id, isSelected)}
+              onLayout={handleSegmentLayout(id)}
               accessibilityRole="tab"
               accessibilityState={{ selected: isSelected }}
               accessibilityLabel={`${era.name} era, ${eventCounts[id] ?? 0} events`}
               style={[
                 styles.segment,
                 {
-                  flex: share,
+                  width,
                   backgroundColor: color + (isSelected ? '33' : '14'),
                   borderBottomColor: isSelected ? color : 'transparent',
                   borderBottomWidth: 2,
                 },
               ]}
             >
-              {isWide ? (
-                <Text
-                  numberOfLines={1}
-                  style={[styles.segmentLabel, { color: isSelected ? base.text : base.textMuted }]}
-                >
-                  {firstWord(era.name)}
-                </Text>
-              ) : null}
+              <Text
+                numberOfLines={1}
+                style={[styles.segmentLabel, { color: isSelected ? base.text : base.textMuted }]}
+              >
+                {pillLabel(era)}
+              </Text>
             </TouchableOpacity>
           );
         })}
-      </View>
+      </ScrollView>
       {active ? (
         <View style={styles.caption}>
           <Text style={[styles.captionEra, { color: active.hex ?? base.gold }]}>
@@ -129,19 +175,22 @@ const styles = StyleSheet.create({
   },
   strip: {
     flexDirection: 'row',
-    height: 28,
+    height: 32,
     borderRadius: 6,
     overflow: 'hidden',
+    gap: 2,
+    paddingHorizontal: spacing.xs,
   },
   segment: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingHorizontal: 4,
+    borderRadius: 4,
+    paddingHorizontal: 6,
   },
   segmentLabel: {
     fontFamily: fontFamily.uiMedium,
-    fontSize: 9,
-    letterSpacing: 0.5,
+    fontSize: 10,
+    letterSpacing: 0.3,
   },
   caption: {
     flexDirection: 'row',


### PR DESCRIPTION
The era filter strip at the top of the Timeline screen crammed 12 eras into screen width using `flex: share`. Small eras were invisible slivers, labels only showed on eras with 30+ events, and the whole thing was untappable on narrow screens.

Changes:
- Wrap strip in a horizontal `ScrollView`
- Each segment gets a minimum 72px width + proportional extra based on event share
- Every segment shows its era pill label (using `eraPillLabels` from theme)
- Tapping a segment auto-scrolls to keep it visible
- Segments have 2px gap and individual border radius for visual separation
- Height bumped from 28 to 32px for better tap targets
- `firstWord()` kept as deprecated export for test compatibility