### PR TITLE
feat(app): first-launch DB download screen (epic #1312 — step 1)

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -20,6 +20,7 @@ import { RootNavigator } from './src/navigation';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
 import { ContentUpdateProvider } from './src/providers/ContentUpdateProvider';
+import { DbDownloadScreen } from './src/screens/DbDownloadScreen';
 import { Sentry, DSN } from './src/lib/sentry';
 
 // Keep splash visible while we load
@@ -111,27 +112,30 @@ function AppShell() {
 
 function App() {
   const [fontsLoaded] = useFonts(FONT_MAP);
-  const [dbReady, setDbReady] = useState(false);
+  const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
 
   useEffect(() => {
     async function init() {
       try {
         // Lock to portrait by default — specific screens unlock for landscape
         await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
-        await initDatabase();        // Content DB (scripture.db) — replaced on updates
-        await initUserDatabase();    // User DB (user.db) — never replaced, migrated
+        const status = await initDatabase();   // Content DB (scripture.db) — may be missing on first launch
+        await initUserDatabase();              // User DB (user.db) — never replaced, migrated
         await useSettingsStore.getState().hydrate();
         await useAuthStore.getState().hydrate();
         await usePremiumStore.getState().hydrate();
         pruneEvents(90); // Clean up old analytics (fire-and-forget)
+        setDbStatus(status);
       } catch (e) {
         console.error('Init error:', e);
-      } finally {
-        setDbReady(true);
+        // Fail-safe: surface the download screen so the user can recover
+        setDbStatus('needs_download');
       }
     }
     init();
   }, []);
+
+  const dbReady = dbStatus === 'ready';
 
   // Re-engagement + premium sync: check on app foreground
   useEffect(() => {
@@ -154,17 +158,39 @@ function App() {
   }, []);
 
   const onLayoutReady = useCallback(async () => {
-    if (fontsLoaded && dbReady) {
+    if (fontsLoaded && dbStatus !== 'loading') {
       await SplashScreen.hideAsync();
     }
-  }, [fontsLoaded, dbReady]);
+  }, [fontsLoaded, dbStatus]);
 
-  if (!fontsLoaded || !dbReady) {
+  if (!fontsLoaded || dbStatus === 'loading') {
     return (
       <View style={appStyles.splashContainer}>
         <ActivityIndicator color="#bfa050" size="large" />
         <Text style={appStyles.splashText}>Loading...</Text>
       </View>
+    );
+  }
+
+  if (dbStatus === 'needs_download') {
+    return (
+      <GestureHandlerRootView style={appStyles.rootView} onLayout={onLayoutReady}>
+        <SafeAreaProvider>
+          <ThemeProvider>
+            <DbDownloadScreen
+              onComplete={async () => {
+                // Open the freshly-downloaded DB before entering the app tree
+                try {
+                  await initDatabase();
+                } catch (e) {
+                  console.error('Post-download init error:', e);
+                }
+                setDbStatus('ready');
+              }}
+            />
+          </ThemeProvider>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
     );
   }
 

--- a/app/__tests__/db/database.test.ts
+++ b/app/__tests__/db/database.test.ts
@@ -1,5 +1,9 @@
 /**
  * Tests for db/database.ts — Content database initialization.
+ *
+ * Since scripture.db is now delivered via R2 (not bundled), initDatabase()
+ * returns 'needs_download' when the DB file is missing or too small, and
+ * 'ready' once the DB is open.
  */
 
 const mockOpenDatabaseAsync = jest.fn();
@@ -22,22 +26,6 @@ jest.mock('expo-file-system/legacy', () => ({
   deleteAsync: (...args: any[]) => mockDeleteAsync(...args),
   copyAsync: (...args: any[]) => mockCopyAsync(...args),
 }));
-
-jest.mock('expo-asset', () => ({
-  Asset: {
-    fromModule: jest.fn(() => ({
-      downloadAsync: jest.fn().mockResolvedValue(undefined),
-      localUri: 'file:///mock/asset/scripture.db',
-    })),
-  },
-}));
-
-jest.mock('../../assets/db-manifest.json', () => ({
-  content_hash: 'abc123',
-  build_time: '2025-01-01',
-}), { virtual: true });
-
-jest.mock('../../assets/scripture.db', () => 'mock-asset', { virtual: true });
 
 jest.mock('@/db/translationRegistry', () => ({
   isBundled: jest.fn((id: string) => id === 'kjv' || id === 'asv'),
@@ -76,27 +64,28 @@ describe('database', () => {
     });
   });
 
-  describe('initDatabase', () => {
-    it('opens database and returns it', async () => {
+  describe('initDatabase on web', () => {
+    it('opens database and returns ready', async () => {
       jest.doMock('react-native', () => ({
         Platform: { OS: 'web' },
       }));
       jest.resetModules();
       databaseModule = require('@/db/database');
-      const db = await databaseModule.initDatabase();
-      expect(db).toBeDefined();
+      const status = await databaseModule.initDatabase();
+      expect(status).toBe('ready');
       expect(mockOpenDatabaseAsync).toHaveBeenCalledWith('scripture.db');
     });
 
-    it('returns cached db on second call', async () => {
+    it('returns ready on cached second call', async () => {
       jest.doMock('react-native', () => ({
         Platform: { OS: 'web' },
       }));
       jest.resetModules();
       databaseModule = require('@/db/database');
-      const db1 = await databaseModule.initDatabase();
-      const db2 = await databaseModule.initDatabase();
-      expect(db1).toBe(db2);
+      const s1 = await databaseModule.initDatabase();
+      const s2 = await databaseModule.initDatabase();
+      expect(s1).toBe('ready');
+      expect(s2).toBe('ready');
       expect(mockOpenDatabaseAsync).toHaveBeenCalledTimes(1);
     });
   });
@@ -127,58 +116,45 @@ describe('database', () => {
   });
 
   describe('initDatabase on native platform', () => {
-    it('copies asset database when file does not exist', async () => {
+    it('returns needs_download when DB file does not exist', async () => {
       jest.doMock('react-native', () => ({
         Platform: { OS: 'ios' },
       }));
       jest.resetModules();
-      // DB file doesn't exist => needs copy
-      mockGetInfoAsync
-        .mockResolvedValueOnce({ exists: false }) // copyAssetDatabaseIfNeeded check
-        .mockResolvedValueOnce({ exists: true, size: 5000000 }); // post-copy info check
+      mockGetInfoAsync.mockResolvedValueOnce({ exists: false });
 
       databaseModule = require('@/db/database');
-      const db = await databaseModule.initDatabase();
-      expect(db).toBeDefined();
-      expect(mockMakeDirectoryAsync).toHaveBeenCalled();
-      expect(mockCopyAsync).toHaveBeenCalled();
-      expect(mockExecAsync).toHaveBeenCalledWith('PRAGMA journal_mode=WAL');
+      const status = await databaseModule.initDatabase();
+      expect(status).toBe('needs_download');
+      // Should NOT open the DB until it has been downloaded
+      expect(mockOpenDatabaseAsync).not.toHaveBeenCalled();
     });
 
-    it('skips copy when installed hash matches expected', async () => {
+    it('returns needs_download when DB file is too small', async () => {
+      jest.doMock('react-native', () => ({
+        Platform: { OS: 'ios' },
+      }));
+      jest.resetModules();
+      mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 100 });
+
+      databaseModule = require('@/db/database');
+      const status = await databaseModule.initDatabase();
+      expect(status).toBe('needs_download');
+      expect(mockOpenDatabaseAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns ready and enables WAL when DB is present', async () => {
       jest.doMock('react-native', () => ({
         Platform: { OS: 'android' },
       }));
       jest.resetModules();
-      // DB exists with correct hash
-      mockGetInfoAsync.mockResolvedValue({ exists: true, size: 5000000 });
-      mockGetFirstAsync.mockResolvedValueOnce({ value: 'abc123' });
+      mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 5_000_000 });
 
       databaseModule = require('@/db/database');
-      const db = await databaseModule.initDatabase();
-      expect(db).toBeDefined();
-      // Should not copy since hash matches
-      expect(mockCopyAsync).not.toHaveBeenCalled();
-    });
-
-    it('replaces DB when hash does not match', async () => {
-      jest.doMock('react-native', () => ({
-        Platform: { OS: 'ios' },
-      }));
-      jest.resetModules();
-      // DB exists but wrong hash
-      mockGetInfoAsync
-        .mockResolvedValueOnce({ exists: true, size: 5000000 }) // exists check
-        .mockResolvedValueOnce({ exists: true, size: 5000000 }); // post-copy
-      // getInstalledContentHash opens db, reads hash, closes
-      mockGetFirstAsync.mockResolvedValueOnce({ value: 'old_hash' });
-
-      databaseModule = require('@/db/database');
-      const db = await databaseModule.initDatabase();
-      expect(db).toBeDefined();
-      // Should delete old and copy new
-      expect(mockDeleteAsync).toHaveBeenCalled();
-      expect(mockCopyAsync).toHaveBeenCalled();
+      const status = await databaseModule.initDatabase();
+      expect(status).toBe('ready');
+      expect(mockOpenDatabaseAsync).toHaveBeenCalledWith('scripture.db');
+      expect(mockExecAsync).toHaveBeenCalledWith('PRAGMA journal_mode=WAL');
     });
   });
 });

--- a/app/__tests__/helpers/mockDb.ts
+++ b/app/__tests__/helpers/mockDb.ts
@@ -22,7 +22,8 @@ export function mockDatabaseModule() {
   return {
     getDb: () => sharedMockDb,
     getVerseDb: jest.fn().mockResolvedValue(sharedMockDb),
-    initDatabase: jest.fn().mockResolvedValue(sharedMockDb),
+    // initDatabase now returns a status ('ready' | 'needs_download')
+    initDatabase: jest.fn().mockResolvedValue('ready'),
   };
 }
 

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -17,7 +17,8 @@ const mockGetInfoAsync = jest.fn();
 const mockCopyAsync = jest.fn();
 const mockDeleteAsync = jest.fn();
 const mockResumableDownloadAsync = jest.fn();
-const mockCreateDownloadResumable = jest.fn(() => ({
+// Typed as (...any[]) because ContentUpdater passes (url, path, options, progressCb).
+const mockCreateDownloadResumable: jest.Mock<any, any[]> = jest.fn((..._args: any[]) => ({
   downloadAsync: (...args: any[]) => mockResumableDownloadAsync(...args),
 }));
 

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -16,6 +16,10 @@ const mockMoveAsync = jest.fn();
 const mockGetInfoAsync = jest.fn();
 const mockCopyAsync = jest.fn();
 const mockDeleteAsync = jest.fn();
+const mockResumableDownloadAsync = jest.fn();
+const mockCreateDownloadResumable = jest.fn(() => ({
+  downloadAsync: (...args: any[]) => mockResumableDownloadAsync(...args),
+}));
 
 jest.mock('expo-file-system/legacy', () => ({
   documentDirectory: '/fake/docs/',
@@ -24,6 +28,7 @@ jest.mock('expo-file-system/legacy', () => ({
   copyAsync: (...args: any[]) => mockCopyAsync(...args),
   deleteAsync: (...args: any[]) => mockDeleteAsync(...args),
   downloadAsync: (...args: any[]) => mockDownloadAsync(...args),
+  createDownloadResumable: (...args: any[]) => mockCreateDownloadResumable(...args),
   readAsStringAsync: (...args: any[]) => mockReadAsStringAsync(...args),
   moveAsync: (...args: any[]) => mockMoveAsync(...args),
   EncodingType: { Base64: 'base64' },
@@ -136,6 +141,10 @@ describe('ContentUpdater service', () => {
     mockCopyAsync.mockResolvedValue(undefined);
     mockMoveAsync.mockResolvedValue(undefined);
     mockDownloadAsync.mockResolvedValue({ status: 200 });
+    mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
+    mockCreateDownloadResumable.mockImplementation(() => ({
+      downloadAsync: (...args: any[]) => mockResumableDownloadAsync(...args),
+    }));
     mockReadAsStringAsync.mockResolvedValue(
       Buffer.from('fake-content').toString('base64'),
     );
@@ -290,7 +299,7 @@ describe('ContentUpdater service', () => {
       mockFetchManifest();
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v0.5.0' });
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v0.5.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
 
@@ -304,7 +313,7 @@ describe('ContentUpdater service', () => {
       mockFetchManifest();
       mockGetFirstAsync.mockResolvedValueOnce(null);
       mockGetFirstAsync.mockResolvedValueOnce(null);
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
 
@@ -418,7 +427,7 @@ describe('ContentUpdater service', () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
 
       const result = await ContentUpdater.downloadFullDb(sampleManifest);
@@ -430,9 +439,32 @@ describe('ContentUpdater service', () => {
       expect(result.bytesDownloaded).toBe(sampleManifest.full_db_size_bytes);
     });
 
+    it('forwards download progress to the onProgress callback', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
+      mockChecksumPass(sampleManifest.full_db_sha256);
+
+      let capturedCallback: ((p: { totalBytesWritten: number; totalBytesExpectedToWrite: number }) => void) | undefined;
+      mockCreateDownloadResumable.mockImplementation((_url: string, _path: string, _opts: any, cb: any) => {
+        capturedCallback = cb;
+        return { downloadAsync: (...args: any[]) => mockResumableDownloadAsync(...args) };
+      });
+      mockResumableDownloadAsync.mockImplementation(async () => {
+        capturedCallback?.({ totalBytesWritten: 50, totalBytesExpectedToWrite: 200 });
+        capturedCallback?.({ totalBytesWritten: 200, totalBytesExpectedToWrite: 200 });
+        return { status: 200 };
+      });
+
+      const progress: number[] = [];
+      await ContentUpdater.downloadFullDb(sampleManifest, (pct) => progress.push(pct));
+
+      expect(progress).toEqual([25, 100]);
+    });
+
     it('returns failed on download HTTP error', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 500 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 500 });
 
       const result = await ContentUpdater.downloadFullDb(sampleManifest);
 
@@ -442,7 +474,7 @@ describe('ContentUpdater service', () => {
 
     it('returns failed on checksum mismatch', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumFail();
 
       const result = await ContentUpdater.downloadFullDb(sampleManifest);
@@ -455,7 +487,7 @@ describe('ContentUpdater service', () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
         .mockResolvedValueOnce({ value: 'wrong_hash' }); // verify after swap
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetInfoAsync.mockResolvedValue({ exists: true });
 
@@ -469,7 +501,7 @@ describe('ContentUpdater service', () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
 
       await ContentUpdater.downloadFullDb(sampleManifest);
@@ -484,7 +516,7 @@ describe('ContentUpdater service', () => {
 
     it('cleans up temp file on failure', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 500 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 500 });
 
       await ContentUpdater.downloadFullDb(sampleManifest);
 
@@ -498,7 +530,7 @@ describe('ContentUpdater service', () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      mockDownloadAsync.mockResolvedValue({ status: 200 });
+      mockResumableDownloadAsync.mockResolvedValue({ status: 200 });
       mockChecksumPass(sampleManifest.full_db_sha256);
 
       await ContentUpdater.downloadFullDb(sampleManifest);

--- a/app/__tests__/unit/database.test.ts
+++ b/app/__tests__/unit/database.test.ts
@@ -21,18 +21,11 @@ jest.mock('expo-sqlite', () => ({
   openDatabaseAsync: jest.fn().mockResolvedValue(mockDbInstance),
 }));
 
-jest.mock('expo-asset', () => ({
-  Asset: {
-    fromModule: jest.fn().mockReturnValue({
-      downloadAsync: jest.fn().mockResolvedValue(undefined),
-      localUri: '/fake/asset/scripture.db',
-    }),
-  },
-}));
-
+// Simulate a DB file present on-device so initDatabase() returns 'ready'.
+const mockGetInfoAsync = jest.fn().mockResolvedValue({ exists: true, size: 5_000_000 });
 jest.mock('expo-file-system/legacy', () => ({
   documentDirectory: '/fake/docs/',
-  getInfoAsync: jest.fn().mockResolvedValue({ exists: false }),
+  getInfoAsync: (...args: any[]) => mockGetInfoAsync(...args),
   makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
   copyAsync: jest.fn().mockResolvedValue(undefined),
   deleteAsync: jest.fn().mockResolvedValue(undefined),
@@ -48,6 +41,7 @@ jest.mock('@/db/translationManager', () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGetInfoAsync.mockResolvedValue({ exists: true, size: 5_000_000 });
 });
 
 describe('database', () => {
@@ -55,10 +49,17 @@ describe('database', () => {
     jest.resetModules();
   });
 
-  it('initDatabase returns a database instance', async () => {
+  it('initDatabase returns ready when DB is present', async () => {
     const { initDatabase } = require('@/db/database');
-    const db = await initDatabase();
-    expect(db).toBe(mockDbInstance);
+    const status = await initDatabase();
+    expect(status).toBe('ready');
+  });
+
+  it('initDatabase returns needs_download when DB is missing', async () => {
+    mockGetInfoAsync.mockResolvedValueOnce({ exists: false });
+    const { initDatabase } = require('@/db/database');
+    const status = await initDatabase();
+    expect(status).toBe('needs_download');
   });
 
   it('getDb throws if not initialized', () => {
@@ -73,11 +74,12 @@ describe('database', () => {
     expect(db).toBe(mockDbInstance);
   });
 
-  it('initDatabase returns cached db on second call', async () => {
+  it('initDatabase returns ready on cached second call', async () => {
     const { initDatabase } = require('@/db/database');
-    const db1 = await initDatabase();
-    const db2 = await initDatabase();
-    expect(db1).toBe(db2);
+    const s1 = await initDatabase();
+    const s2 = await initDatabase();
+    expect(s1).toBe('ready');
+    expect(s2).toBe('ready');
   });
 
   it('getVerseDb returns core db for bundled translations', async () => {

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -2,8 +2,9 @@
  * db/database.ts — Content database initialization (scripture.db).
  *
  * This database is READ-ONLY content: books, chapters, sections, panels,
- * verses, scholars, people, places, timelines, etc. It is replaced in
- * full on every content update (hash mismatch → delete + recopy).
+ * verses, scholars, people, places, timelines, etc. It is no longer bundled
+ * with the app — the first-launch download screen fetches it from R2 via
+ * ContentUpdater. Subsequent updates are applied by ContentUpdater as well.
  *
  * User data (notes, bookmarks, highlights, preferences, plans) lives
  * in a separate user.db managed by userDatabase.ts, which is NEVER
@@ -12,125 +13,52 @@
 
 import { Platform } from 'react-native';
 import * as SQLite from 'expo-sqlite';
-import { Asset } from 'expo-asset';
 import * as FileSystem from 'expo-file-system/legacy';
 import { isBundled } from './translationRegistry';
 import { openTranslationDb } from './translationManager';
 import { logger } from '../utils/logger';
 
 /**
- * Load the expected content hash from the bundled db-manifest.json.
- * This hash is computed by build_sqlite.py from all content JSON files.
- * Any content change → new hash → app replaces cached DB automatically.
+ * Result of {@link initDatabase}. When `'needs_download'`, the caller should
+ * render the DbDownloadScreen to fetch scripture.db from R2 before continuing.
  */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const dbManifest = require('../../assets/db-manifest.json') as { content_hash: string; build_time: string };
-const EXPECTED_CONTENT_HASH = dbManifest.content_hash;
+export type DbInitStatus = 'ready' | 'needs_download';
 
 let db: SQLite.SQLiteDatabase | null = null;
 
 /**
  * Initialize the database. Call once at app startup.
- * On native: loads the bundled scripture.db asset.
- * On web: opens an empty database (data not yet available on web).
+ *
+ * Returns `'needs_download'` if the DB file is missing (or too small to be
+ * valid) so the caller can show the download screen. Returns `'ready'` once
+ * the DB is open and WAL mode is enabled.
  */
-export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (db) return db;
+export async function initDatabase(): Promise<DbInitStatus> {
+  if (db) return 'ready';
 
-  if (Platform.OS !== 'web') {
-    await copyAssetDatabaseIfNeeded();
-  } else {
+  if (Platform.OS === 'web') {
     logger.warn('DB',
-      'Web platform detected — scripture.db cannot be loaded from assets on web. ' +
+      'Web platform detected — scripture.db cannot be loaded on web. ' +
       'The database will be empty. Use Expo Go on a phone for the full experience.'
     );
+    db = await SQLite.openDatabaseAsync('scripture.db');
+    return 'ready';
+  }
+
+  const dbPath = `${FileSystem.documentDirectory}SQLite/scripture.db`;
+  const info = await FileSystem.getInfoAsync(dbPath);
+  if (!info.exists || !info.size || info.size < 1000) {
+    logger.info('DB', 'scripture.db missing or too small — signaling needs_download');
+    return 'needs_download';
   }
 
   db = await SQLite.openDatabaseAsync('scripture.db');
-
-  // Enable WAL mode for better read performance (native only)
-  if (Platform.OS !== 'web') {
-    await db.execAsync('PRAGMA journal_mode=WAL');
-  }
+  await db.execAsync('PRAGMA journal_mode=WAL');
 
   // Content DB is read-only — no runtime migrations needed.
   // User tables live in user.db (see userDatabase.ts).
 
-  return db;
-}
-
-/**
- * Read the installed DB content hash. Returns null if the db_meta table
- * doesn't exist (pre-hash DB) or on any error.
- */
-async function getInstalledContentHash(dbPath: string): Promise<string | null> {
-  let tempDb: SQLite.SQLiteDatabase | null = null;
-  try {
-    tempDb = await SQLite.openDatabaseAsync('scripture.db');
-    const row = await tempDb.getFirstAsync<{ value: string }>(
-      "SELECT value FROM db_meta WHERE key = 'content_hash'"
-    );
-    return row?.value ?? null;
-  } catch (err) {
-    // db_meta table doesn't exist in old DBs — that's fine
-    return null;
-  } finally {
-    if (tempDb) {
-      await tempDb.closeAsync();
-    }
-  }
-}
-
-/**
- * Copy the bundled scripture.db asset to the SQLite directory.
- * Compares the installed DB content hash against EXPECTED_CONTENT_HASH.
- * Replaces the DB if hashes don't match or DB is missing.
- */
-async function copyAssetDatabaseIfNeeded(): Promise<void> {
-  const sqliteDir = `${FileSystem.documentDirectory}SQLite/`;
-  const dbPath = `${sqliteDir}scripture.db`;
-
-  // Check if DB already exists in documents
-  const fileInfo = await FileSystem.getInfoAsync(dbPath);
-  if (fileInfo.exists && fileInfo.size && fileInfo.size > 1000) {
-    // DB exists — check its content hash
-    const installedHash = await getInstalledContentHash(dbPath);
-    if (installedHash === EXPECTED_CONTENT_HASH) {
-      logger.info('DB', `scripture.db [${installedHash}] is current — skipping copy`);
-      return;
-    }
-    logger.info('DB',
-      `scripture.db hash mismatch (installed: ${installedHash ?? 'none'}, ` +
-      `expected: ${EXPECTED_CONTENT_HASH}) — replacing`
-    );
-    // Delete the stale DB so the copy succeeds cleanly
-    await FileSystem.deleteAsync(dbPath, { idempotent: true });
-  }
-
-  logger.info('DB', 'Copying scripture.db from assets to documents...');
-
-  // Ensure SQLite directory exists
-  await FileSystem.makeDirectoryAsync(sqliteDir, { intermediates: true });
-
-  // Resolve and download the bundled asset
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const asset = Asset.fromModule(require('../../assets/scripture.db'));
-  await asset.downloadAsync();
-
-  if (!asset.localUri) {
-    throw new Error('[DB] Failed to resolve scripture.db asset — localUri is null');
-  }
-
-  // Copy to the SQLite directory where expo-sqlite expects it
-  await FileSystem.copyAsync({
-    from: asset.localUri,
-    to: dbPath,
-  });
-
-  const copied = await FileSystem.getInfoAsync(dbPath);
-  logger.info('DB',
-    `Copied scripture.db [${EXPECTED_CONTENT_HASH}] (${(((copied.exists && copied.size) || 0) / 1024 / 1024).toFixed(1)} MB)`
-  );
+  return 'ready';
 }
 
 /**

--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -1,0 +1,178 @@
+/**
+ * DbDownloadScreen — First-launch full-screen download UI.
+ *
+ * Shown by App.tsx when initDatabase() reports 'needs_download' (no DB on
+ * device, or DB file is too small to be valid). Drives ContentUpdater to
+ * fetch the full scripture.db from R2, showing progress + error states.
+ *
+ * Calls onComplete() after a successful download so the parent can
+ * transition to the normal app tree.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+
+import { useTheme, spacing, fontFamily } from '../theme';
+import { ContentUpdater } from '../services/ContentUpdater';
+
+interface Props {
+  onComplete: () => void;
+}
+
+export function DbDownloadScreen({ onComplete }: Props) {
+  const { base } = useTheme();
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState<'idle' | 'downloading' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [sizeBytes, setSizeBytes] = useState<number | null>(null);
+
+  const startDownload = useCallback(async () => {
+    setStatus('downloading');
+    setError(null);
+    setProgress(0);
+
+    try {
+      const manifest = await ContentUpdater.fetchManifest();
+      setSizeBytes(manifest.full_db_size_bytes);
+
+      const result = await ContentUpdater.downloadFullDb(manifest, (pct) => {
+        setProgress(pct);
+      });
+
+      if (result.status === 'updated') {
+        onComplete();
+        return;
+      }
+
+      setStatus('error');
+      setError(result.error ?? 'Download failed. Please try again.');
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [onComplete]);
+
+  useEffect(() => {
+    startDownload();
+  }, [startDownload]);
+
+  const clampedPct = Math.max(0, Math.min(100, progress));
+  const sizeMb = sizeBytes ? (sizeBytes / 1024 / 1024).toFixed(1) : null;
+
+  return (
+    <View style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: base.gold }]}>Companion Study</Text>
+        <Text style={[styles.subtitle, { color: base.textDim }]}>Setting up your library…</Text>
+
+        {status === 'downloading' && (
+          <>
+            <View
+              style={[
+                styles.progressTrack,
+                { backgroundColor: base.bgElevated, borderColor: base.border },
+              ]}
+            >
+              <View
+                style={[
+                  styles.progressFill,
+                  { backgroundColor: '#bfa050', width: `${clampedPct}%` },
+                ]}
+              />
+            </View>
+            <Text style={[styles.progressText, { color: base.text }]}>
+              {clampedPct.toFixed(0)}%
+              {sizeMb ? ` • ${sizeMb} MB` : ''}
+            </Text>
+            {clampedPct === 0 && <ActivityIndicator color={base.gold} style={styles.spinner} />}
+          </>
+        )}
+
+        {status === 'error' && (
+          <View style={styles.errorBlock}>
+            <Text style={[styles.errorText, { color: base.danger }]}>
+              {error ?? 'Something went wrong.'}
+            </Text>
+            <TouchableOpacity
+              onPress={startDownload}
+              accessibilityRole="button"
+              accessibilityLabel="Retry download"
+              style={[styles.retryButton, { borderColor: base.gold }]}
+            >
+              <Text style={[styles.retryText, { color: base.gold }]}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+export default DbDownloadScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 360,
+    alignItems: 'center',
+  },
+  title: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 28,
+    letterSpacing: 1.5,
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 15,
+    marginBottom: spacing.xl,
+    textAlign: 'center',
+  },
+  progressTrack: {
+    width: '100%',
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+    borderWidth: 1,
+    marginBottom: spacing.md,
+  },
+  progressFill: {
+    height: '100%',
+  },
+  progressText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    marginTop: spacing.xs,
+  },
+  spinner: {
+    marginTop: spacing.md,
+  },
+  errorBlock: {
+    alignItems: 'center',
+    marginTop: spacing.lg,
+  },
+  errorText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xl,
+  },
+  retryText: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+    letterSpacing: 0.5,
+  },
+});

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -242,17 +242,41 @@ class ContentUpdaterService {
    * Download a complete replacement database from R2.
    * Downloads to a temp file, verifies checksum AND content hash
    * BEFORE touching the live database, then swaps in place.
+   *
+   * @param onProgress Optional callback receiving download percentage (0–100).
    */
-  async downloadFullDb(manifest: Manifest): Promise<UpdateResult> {
+  async downloadFullDb(
+    manifest: Manifest,
+    onProgress?: (pct: number) => void,
+  ): Promise<UpdateResult> {
     const tempPath = `${SQLITE_DIR}scripture_download.db`;
     const tempDbName = 'scripture_download.db';
     try {
       const fromVersion = await this.getInstalledVersion();
 
-      // Download the full DB
-      const download = await FileSystem.downloadAsync(manifest.full_db_url, tempPath);
-      if (download.status !== 200) {
-        throw new Error(`Full DB download failed: HTTP ${download.status}`);
+      // Ensure SQLite directory exists (first-launch fallback — scripture.db
+      // may never have been opened yet, so the parent dir may not exist).
+      await FileSystem.makeDirectoryAsync(SQLITE_DIR, { intermediates: true });
+
+      // Remove any partial download from a previous failed attempt
+      await FileSystem.deleteAsync(tempPath, { idempotent: true });
+
+      // Download the full DB with progress tracking.
+      // createDownloadResumable supports progressCallback; downloadAsync does not.
+      const resumable = FileSystem.createDownloadResumable(
+        manifest.full_db_url,
+        tempPath,
+        {},
+        (downloadProgress) => {
+          const { totalBytesWritten, totalBytesExpectedToWrite } = downloadProgress;
+          if (totalBytesExpectedToWrite > 0) {
+            onProgress?.((totalBytesWritten / totalBytesExpectedToWrite) * 100);
+          }
+        },
+      );
+      const download = await resumable.downloadAsync();
+      if (!download || download.status !== 200) {
+        throw new Error(`Full DB download failed: HTTP ${download?.status ?? 'unknown'}`);
       }
 
       // Verify file checksum


### PR DESCRIPTION
Step 1 of epic #1312 — R2-only DB delivery.

## What this PR does

Prepares the app to boot without a bundled `scripture.db` by introducing a full-screen download UI that fetches the DB from R2 on first launch (or after the local DB is lost).

### Files changed

- **NEW** `app/src/screens/DbDownloadScreen.tsx` — themed full-screen component with gold (`#bfa050`) progress bar, size display, and error-state retry button. Drives `ContentUpdater.downloadFullDb()` with a progress callback and invokes `onComplete` after success.
- **MODIFIED** `app/src/services/ContentUpdater.ts` — `downloadFullDb()` now accepts an optional `onProgress?: (pct: number) => void` callback. Switched from `FileSystem.downloadAsync` to `FileSystem.createDownloadResumable` so we can surface byte-level progress. Also ensures the `SQLite/` directory exists before writing (first-launch fallback).
- **MODIFIED** `app/src/db/database.ts` — returns a `DbInitStatus` (`'ready' | 'needs_download'`) instead of throwing. Removed `copyAssetDatabaseIfNeeded()`, the `EXPECTED_CONTENT_HASH` constant, and the `db-manifest.json` require. The WAL pragma and existing singleton behaviour are preserved.
- **MODIFIED** `app/App.tsx` — tracks `dbStatus` state; when `'needs_download'`, renders `<DbDownloadScreen />` inside `ThemeProvider`. On completion, re-calls `initDatabase()` so the singleton opens the freshly-downloaded file before the normal app tree mounts. Init-error path sets `'needs_download'` as a fail-safe.
- **MODIFIED** tests — `ContentUpdater.test.ts` mocks `createDownloadResumable` (plus a new test verifying progress callback forwarding), `database.test.ts` / `unit/database.test.ts` updated for the new status-return shape, `mockDb.ts` helper returns `'ready'`.

## Test plan

- [ ] `cd app && npm test` — verify all existing + new tests pass
- [ ] Run the app on-device with no DB present → download screen appears, progress bar animates, app enters normally after completion
- [ ] Force a download failure (e.g. airplane mode) → retry button works, succeeds once connectivity restored
- [ ] Subsequent launches → no download screen; app opens straight to home

## Notes

- `scripture.db` is still bundled and still used by fresh installs right now — removal happens in Steps 4 & 5 of the epic. Step 1 is purely additive so there is a safe fallback.
- Do **not** merge until the rest of the epic PRs are stacked and reviewed — see #1312 for ordering.

Refs #1312