### PR TITLE
ci: content.yml workflow for R2 DB deployment (epic #1312 — step 2)

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -1,0 +1,72 @@
+name: Content Deploy (R2)
+
+# Step 2 of epic #1312 — post-merge deployment of scripture.db to CloudFlare R2.
+#
+# This is the deploy-to-production half of the content pipeline. PR-time
+# schema validation still lives in content-pipeline.yml and is unchanged.
+#
+# Flow on push to master:
+#   1. build_sqlite.py       — build scripture.db from content/**
+#   2. validate_sqlite.py    — integrity checks on the new DB
+#   3. generate_delta.py     — download previously-deployed DB from R2,
+#                              diff against new, upload delta under /db/deltas/
+#   4. upload_to_r2.py       — upload new full DB + refresh manifest.json
+#
+# NOTE: generate_delta.py runs BEFORE upload_to_r2.py on purpose. The delta
+# generator fetches the currently-deployed DB from R2 to diff against, so it
+# must run while the old version is still "current" in the manifest.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'content/**'
+      - '_tools/build_sqlite.py'
+      - '_tools/validate_sqlite.py'
+      - '_tools/config.py'
+      - '_tools/content_writer.py'
+      - '_tools/upload_to_r2.py'
+      - '_tools/generate_delta.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-content:
+    name: Build and deploy scripture.db to R2
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+      R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install boto3
+
+      - name: Build scripture.db
+        run: python _tools/build_sqlite.py
+
+      - name: Validate scripture.db
+        run: python _tools/validate_sqlite.py
+
+      - name: Generate and upload delta (old → new)
+        run: python _tools/generate_delta.py
+
+      - name: Upload full DB + manifest to R2
+        run: python _tools/upload_to_r2.py


### PR DESCRIPTION
Step 2 of epic #1312 — R2-only DB delivery.

## What this PR does

Adds `.github/workflows/content.yml` — the post-merge deploy-to-production half of the content pipeline. Runs on push to `master` when `content/**` or the relevant `_tools/*.py` files change.

### Pipeline steps

1. `actions/checkout@v4` with `fetch-depth: 0`
2. `actions/setup-python@v5` (Python 3.11)
3. `pip install boto3`
4. `python _tools/build_sqlite.py` — build DB from content JSON
5. `python _tools/validate_sqlite.py` — integrity checks
6. `python _tools/generate_delta.py` — diff previous R2 DB against new, upload delta
7. `python _tools/upload_to_r2.py` — upload new full DB + refresh manifest.json

### Ordering note (important)

`generate_delta.py` runs **before** `upload_to_r2.py` on purpose. The delta generator downloads the currently-deployed DB from R2 to diff against — it must run while the manifest still points at the *old* version. `upload_to_r2.py` then swaps the manifest to the new version.

### Secrets used

All already configured in repo settings:
- `R2_ACCOUNT_ID`
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_BUCKET_NAME` (`companionstudybucket`)
- `R2_PUBLIC_URL` (`https://contentcompanionstudy.com`)

### Coexistence with `content-pipeline.yml`

The existing `content-pipeline.yml` runs PR-time schema validation and is unchanged. The two workflows serve different purposes — keep both.

## Test plan

- [ ] Merge to master, then touch a file under `content/` to trigger the new workflow
- [ ] Verify in the Actions tab that the workflow runs all 4 Python steps green
- [ ] Confirm `https://contentcompanionstudy.com/db/manifest.json` reflects the new `current_version`
- [ ] Confirm the delta file was written to `/db/deltas/{old}-{new}.sql.gz`

## Notes

- No `eas update` in this workflow — app code deploys via the `app.yml` workflow added in Step 3
- Do **not** merge until the rest of the epic PRs are stacked and reviewed — see #1312 for ordering

Refs #1312