### PR TITLE
ci: app.yml workflow for EAS update on master (epic #1312 — step 3)

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,52 @@
+name: App Deploy (EAS)
+
+# Step 3 of epic #1312 — ship JS bundle updates via Expo EAS on push to master.
+#
+# Content (scripture.db) is deployed separately by content.yml. This workflow
+# handles app code only — lint, then `eas update --branch production`. No DB
+# rebuild, no R2 upload.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'app/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-app:
+    name: Lint and publish EAS update
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Lint
+        working-directory: app
+        run: npm run lint
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@latest
+
+      - name: Publish EAS update
+        working-directory: app
+        run: eas update --branch production --message "App update from ${{ github.sha }}" --non-interactive


### PR DESCRIPTION
Step 3 of epic #1312 — R2-only DB delivery.

## What this PR does

Adds `.github/workflows/app.yml` — publishes JS bundle updates via EAS on push to `master` when anything under `app/**` changes. Content deploys live in the separate `content.yml` workflow from Step 2.

### Pipeline steps

1. `actions/checkout@v4`
2. `actions/setup-node@v4` (Node 20, `cache: npm`, `cache-dependency-path: app/package-lock.json`)
3. `cd app && npm ci`
4. `npm run lint` (fails workflow on lint errors)
5. `npm install -g eas-cli@latest`
6. `eas update --branch production --message "App update from ${{ github.sha }}" --non-interactive`

### Secrets used

- `EXPO_TOKEN` (already configured in repo settings)

## Test plan

- [ ] After merge, touch any file under `app/` on master to trigger
- [ ] Actions tab shows green on all six steps
- [ ] Check `expo.dev` for a new production update tagged with the commit SHA
- [ ] Device running the app picks up the update on next foreground

## Notes

- No DB rebuild, no R2 upload — content deploys are handled by `content.yml` (Step 2)
- Do **not** merge until the rest of the epic PRs are stacked and reviewed — see #1312 for ordering

Refs #1312