### PR TITLE
fix: expand OnboardingDemo test mockBase to satisfy BaseColors type

### DIFF
--- a/app/__tests__/components/OnboardingDemo.test.tsx
+++ b/app/__tests__/components/OnboardingDemo.test.tsx
@@ -2,15 +2,30 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
 import { OnboardingDemo } from '@/components/OnboardingDemo';
+import type { ThemePalette } from '@/theme';
 
-const mockBase = {
+const mockBase: ThemePalette['base'] = {
   bg: '#000',
   bgElevated: '#111',
+  bgSurface: '#0a0a0a',
+  bg3: '#050505',
   text: '#fff',
   textDim: '#ccc',
   textMuted: '#888',
   gold: '#c9a227',
+  goldDim: '#8a6e1a',
+  goldBright: '#d4b868',
   border: '#333',
+  borderLight: '#222',
+  verseNum: '#9a8a6a',
+  navText: '#d8ccb0',
+  danger: '#e05a6a',
+  success: '#81C784',
+  redLetter: '#d4847a',
+  tintWarm: '#1a1508',
+  tintEmber: '#1f1410',
+  tintParchment: '#1e1a12',
+  tintDusk: '#141824',
 };
 
 describe('OnboardingDemo', () => {


### PR DESCRIPTION
## Hotfix for CI failures on master after #1366

PR #1366 tightened `OnboardingDemo`'s `base` prop from `any` to `ThemePalette['base']` (the full `BaseColors` interface), but `__tests__/components/OnboardingDemo.test.tsx` still used a partial mock with only 7 properties. This caused `tsc --noEmit` to fail in both `lint` and `test` CI jobs on master.

## Fix

Expand the test's `mockBase` to include all 21 `BaseColors` properties so it satisfies the type. No production code change.

## Local verification

```
cd app
npx tsc --noEmit           # exit 0
npx eslint src/ --max-warnings 0   # exit 0
npx jest                   # 3209/3209 passing
```

## Test plan

- [x] `tsc --noEmit` passes locally
- [x] `eslint src/ --max-warnings 0` passes locally
- [x] `jest` passes locally (3209 tests)
- [ ] **Wait for CI to go green before merging** (lesson learned from #1366)

Sorry about the premature merge on #1366 — I should have waited for CI before hitting merge.

https://claude.ai/code/session_015Yzc4wA8ypqVWdhwCVcS5x