### PR TITLE
feat(ui): phase 2 UI polish — browse screen template + 15 browse scre…

### DIFF
--- a/app/src/components/BrowseScreenTemplate.tsx
+++ b/app/src/components/BrowseScreenTemplate.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import {
   View,
   Text,
+  TouchableOpacity,
   FlatList,
   SectionList,
   StyleSheet,
@@ -28,7 +29,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import type { BaseColors } from '../theme/palettes';
 import { ScreenHeader } from './ScreenHeader';
 import { SearchInput } from './SearchInput';
 import { LoadingSkeleton } from './LoadingSkeleton';
@@ -234,6 +236,90 @@ const sectionHeaderStyles = StyleSheet.create({
     fontFamily: fontFamily.displayMedium,
     fontSize: 14,
     letterSpacing: 0.6,
+  },
+});
+
+// ─── Shared card style ────────────────────────────────────────────
+
+/**
+ * Returns the standard browse-card style object (parchment tint + 10% gold
+ * border). Screens opt in by spreading this into their card's style prop.
+ * Card #1359 (UI polish phase 2).
+ */
+export function browseCardStyle(base: BaseColors): ViewStyle {
+  return {
+    backgroundColor: base.tintParchment,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: base.gold + '1A', // ~10% opacity
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  };
+}
+
+// ─── Shared filter pill ───────────────────────────────────────────
+
+interface BrowseFilterPillProps {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  accessibilityLabel?: string;
+  /** Optional role — use 'tab' for language/view switchers, defaults to 'button'. */
+  role?: 'button' | 'tab';
+}
+
+/**
+ * Standard filter pill for browse-screen filter bars.
+ * Gold active state, transparent inactive, consistent sizing.
+ * Card #1359 (UI polish phase 2).
+ */
+export function BrowseFilterPill({
+  label,
+  active,
+  onPress,
+  accessibilityLabel,
+  role = 'button',
+}: BrowseFilterPillProps) {
+  const { base } = useTheme();
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole={role}
+      accessibilityState={role === 'tab' ? { selected: active } : undefined}
+      accessibilityLabel={accessibilityLabel ?? label}
+      style={[
+        filterPillStyles.pill,
+        {
+          borderColor: active ? base.gold : base.border,
+          backgroundColor: active ? base.gold + '20' : 'transparent',
+        },
+      ]}
+    >
+      <Text
+        style={[
+          filterPillStyles.label,
+          { color: active ? base.gold : base.textMuted },
+        ]}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const filterPillStyles = StyleSheet.create({
+  pill: {
+    height: 32,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    letterSpacing: 0.3,
   },
 });
 

--- a/app/src/screens/ArchaeologyBrowseScreen.tsx
+++ b/app/src/screens/ArchaeologyBrowseScreen.tsx
@@ -3,31 +3,26 @@
  *
  * Shows a list of discovery cards with category filter chips and search.
  * Free access — no premium gate on the browse screen.
+ *
+ * Card #1359 (UI polish phase 2): migrated to shared BrowseScreenTemplate
+ * and BrowseFilterPill. Search + filter/empty/loading are now template-owned.
  */
 
 import React, { useCallback, useState, useMemo } from 'react';
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  ScrollView,
-  StyleSheet,
-} from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
-import { ScreenHeader } from '../components/ScreenHeader';
-import { SearchInput } from '../components/SearchInput';
-import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+} from '../components/BrowseScreenTemplate';
 import { ArchaeologyCard } from '../components/ArchaeologyCard';
 import { useArchaeologyBrowse, useArchaeologySearch } from '../hooks/useArchaeology';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { spacing } from '../theme';
 import type { ArchaeologicalDiscovery } from '../types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function ArchaeologyBrowseScreen() {
-  const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'ArchaeologyBrowse'>>();
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
 
@@ -74,133 +69,55 @@ function ArchaeologyBrowseScreen() {
     [handleDiscoveryPress],
   );
 
-  if (loading && !isSearching) {
-    return (
-      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-        <View style={styles.headerPad}>
-          <ScreenHeader title="Archaeological Evidence" onBack={() => navigation.goBack()} />
-        </View>
-        <View style={styles.loadingPad}><LoadingSkeleton lines={6} /></View>
-      </SafeAreaView>
-    );
-  }
+  const filterBar = !isSearching && categories.length > 0 ? (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.pillRow}
+    >
+      <BrowseFilterPill
+        label="All"
+        active={!selectedCategory}
+        onPress={() => { setSelectedCategory(undefined); setSearch(''); }}
+      />
+      {categories.map((cat) => (
+        <BrowseFilterPill
+          key={cat}
+          label={cat}
+          active={selectedCategory === cat}
+          onPress={() => handleCategoryPress(cat)}
+        />
+      ))}
+    </ScrollView>
+  ) : null;
+
+  const showLoading = (loading && !isSearching) || searching;
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.headerPad}>
-        <ScreenHeader title="Archaeological Evidence" onBack={() => navigation.goBack()} />
-        <View style={styles.searchWrap}>
-          <SearchInput
-            value={search}
-            onChangeText={setSearch}
-            placeholder="Search discoveries..."
-          />
-        </View>
-
-        {/* Category filter pills */}
-        {!isSearching && categories.length > 0 && (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.pillRow}
-          >
-            <TouchableOpacity
-              onPress={() => { setSelectedCategory(undefined); setSearch(''); }}
-              style={[
-                styles.pill,
-                { borderColor: base.border },
-                !selectedCategory && {
-                  borderColor: base.gold + '55',
-                  backgroundColor: base.gold + '12',
-                },
-              ]}
-            >
-              <Text
-                style={[
-                  styles.pillText,
-                  { color: base.textMuted },
-                  !selectedCategory && { color: base.gold },
-                ]}
-              >
-                All
-              </Text>
-            </TouchableOpacity>
-            {categories.map((cat) => {
-              const active = selectedCategory === cat;
-              return (
-                <TouchableOpacity
-                  key={cat}
-                  onPress={() => handleCategoryPress(cat)}
-                  style={[
-                    styles.pill,
-                    { borderColor: base.border },
-                    active && {
-                      borderColor: base.gold + '55',
-                      backgroundColor: base.gold + '12',
-                    },
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.pillText,
-                      { color: base.textMuted },
-                      active && { color: base.gold },
-                    ]}
-                  >
-                    {cat}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </ScrollView>
-        )}
-      </View>
-
-      {searching ? (
-        <View style={styles.loadingPad}><LoadingSkeleton lines={4} /></View>
-      ) : (
-        <FlatList
-          data={displayData}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          contentContainerStyle={styles.listPad}
-          showsVerticalScrollIndicator={false}
-          ListEmptyComponent={
-            <View style={styles.emptyState}>
-              <Text style={[styles.emptyText, { color: base.textMuted }]}>
-                {isSearching
-                  ? `No discoveries found for "${search}"`
-                  : 'No archaeological discoveries available'}
-              </Text>
-            </View>
-          }
-        />
-      )}
-    </SafeAreaView>
+    <BrowseScreenTemplate
+      title="Archaeological Evidence"
+      loading={showLoading}
+      search={search}
+      onSearchChange={setSearch}
+      searchPlaceholder="Search discoveries..."
+      filterBar={filterBar}
+      data={displayData}
+      renderItem={renderItem}
+      keyExtractor={(item: ArchaeologicalDiscovery) => item.id}
+      emptyMessage={
+        isSearching
+          ? `No discoveries found for "${search}"`
+          : 'No archaeological discoveries available'
+      }
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.lg },
-  searchWrap: { marginBottom: spacing.sm },
-  pillRow: { gap: spacing.xs, marginBottom: spacing.md },
-  pill: {
-    borderWidth: 1,
-    borderRadius: radii.pill,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
+  pillRow: {
+    gap: spacing.xs,
+    paddingBottom: spacing.md,
   },
-  pillText: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 0.3,
-    textTransform: 'capitalize',
-  },
-  listPad: { paddingHorizontal: spacing.md, paddingBottom: spacing.xxl },
-  loadingPad: { padding: spacing.lg },
-  emptyState: { padding: spacing.xl, alignItems: 'center' },
-  emptyText: { fontFamily: fontFamily.ui, fontSize: 14 },
 });
 
 export default withErrorBoundary(ArchaeologyBrowseScreen);

--- a/app/src/screens/DebateBrowseScreen.tsx
+++ b/app/src/screens/DebateBrowseScreen.tsx
@@ -11,13 +11,21 @@ import { useNavigation } from '@react-navigation/native';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { families } from '../theme/colors';
 import { useDebateTopics, DEBATE_CATEGORY_LABELS } from '../hooks/useDebateTopics';
-import { BrowseScreenTemplate } from '../components/BrowseScreenTemplate';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+} from '../components/BrowseScreenTemplate';
 import type { DebateTopicSummary } from '../types';
 import type { ScreenNavProp } from '../navigation/types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 type Nav = ScreenNavProp<'Explore', 'DebateBrowse'>;
 
+/**
+ * Per-category accent colors kept as-is — they're used on the card's left
+ * border + tradition dots to preserve at-a-glance category differentiation.
+ * The filter bar itself uses the monochrome gold pills now (#1359).
+ */
 const CATEGORY_COLORS: Record<string, string> = {
   theological: '#64B5F6', // data-color: intentional
   ethical: '#81C784', // data-color: intentional
@@ -25,8 +33,6 @@ const CATEGORY_COLORS: Record<string, string> = {
   textual: '#BA68C8', // data-color: intentional
   interpretive: '#4FC3F7', // data-color: intentional
 };
-
-const CHIP_ACTIVE_TEXT = '#fff'; // overlay-color: intentional (white text on active colored category chip)
 
 function getPositionTraditions(topic: DebateTopicSummary): string[] {
   try {
@@ -112,42 +118,19 @@ function DebateBrowseScreen() {
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.chipRow}
     >
-      <TouchableOpacity
+      <BrowseFilterPill
+        label="All"
+        active={categoryFilter === 'all'}
         onPress={() => setCategoryFilter('all')}
-        style={[
-          styles.chip,
-          {
-            backgroundColor: categoryFilter === 'all' ? base.gold : base.gold + '15',
-            borderColor: base.gold + '40',
-          },
-        ]}
-      >
-        <Text style={[styles.chipText, { color: categoryFilter === 'all' ? base.bg : base.gold }]}>
-          All
-        </Text>
-      </TouchableOpacity>
-      {categories.map((cat) => {
-        const active = categoryFilter === cat;
-        const color = CATEGORY_COLORS[cat] || base.gold;
-        return (
-          <TouchableOpacity
-            key={cat}
-            onPress={() => setCategoryFilter(cat)}
-            style={[
-              styles.chip,
-              {
-                backgroundColor: active ? color : color + '15',
-                borderColor: color + '40',
-              },
-            ]}
-          >
-            {/* data-color: intentional — white text on active colored chip */}
-            <Text style={[styles.chipText, { color: active ? CHIP_ACTIVE_TEXT : color }]}>
-              {DEBATE_CATEGORY_LABELS[cat] || cat}
-            </Text>
-          </TouchableOpacity>
-        );
-      })}
+      />
+      {categories.map((cat) => (
+        <BrowseFilterPill
+          key={cat}
+          label={DEBATE_CATEGORY_LABELS[cat] || cat}
+          active={categoryFilter === cat}
+          onPress={() => setCategoryFilter(cat)}
+        />
+      ))}
     </ScrollView>
   );
 
@@ -173,16 +156,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 8,
     paddingBottom: spacing.xs,
-  },
-  chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: radii.md,
-    borderWidth: 1,
-  },
-  chipText: {
-    fontFamily: fontFamily.displayMedium,
-    fontSize: 12,
   },
   list: {
     padding: spacing.md,

--- a/app/src/screens/GrammarBrowseScreen.tsx
+++ b/app/src/screens/GrammarBrowseScreen.tsx
@@ -1,18 +1,23 @@
 /**
  * GrammarBrowseScreen — Browse grammar articles by language (Greek/Hebrew tabs)
  * and category, with search. Premium gated for full article access.
+ *
+ * Card #1359 (UI polish phase 2): migrated to BrowseScreenTemplate in
+ * SectionList mode with BrowseSectionHeader for category grouping, and
+ * BrowseFilterPill for the language tabs.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
-  View, Text, TouchableOpacity, FlatList, StyleSheet,
+  View, Text, TouchableOpacity, StyleSheet,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
-import { ScreenHeader } from '../components/ScreenHeader';
-import { SearchInput } from '../components/SearchInput';
-import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { useTheme, spacing, fontFamily } from '../theme';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+  BrowseSectionHeader,
+} from '../components/BrowseScreenTemplate';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import { getGrammarArticles, searchGrammarArticles } from '../db/content/grammar';
 import type { GrammarArticle } from '../types';
@@ -62,21 +67,20 @@ function GrammarBrowseScreen() {
   const isSearching = searchQuery.length >= 2;
   const displayData = isSearching ? searchResults : articles;
 
-  // Group articles by category
-  const categories = React.useMemo(() => {
+  // Group articles by category for SectionList.
+  const sections = useMemo(() => {
     const map = new Map<string, GrammarArticle[]>();
     for (const a of displayData) {
       const cat = a.category || 'General';
       if (!map.has(cat)) map.set(cat, []);
       map.get(cat)!.push(a);
     }
-    return Array.from(map.entries());
+    return Array.from(map.entries()).map(([title, data]) => ({ title, data }));
   }, [displayData]);
 
-  const renderArticle = useCallback(
-    (item: GrammarArticle) => (
+  const renderItem = useCallback(
+    ({ item }: { item: GrammarArticle }) => (
       <TouchableOpacity
-        key={item.id}
         onPress={() => handleArticlePress(item)}
         activeOpacity={0.6}
         style={[styles.articleRow, { borderBottomColor: base.border }]}
@@ -94,128 +98,54 @@ function GrammarBrowseScreen() {
     [base, handleArticlePress]
   );
 
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: { title: string; data: GrammarArticle[] } }) => (
+      <BrowseSectionHeader title={section.title.toUpperCase()} />
+    ),
+    [],
+  );
+
+  const filterBar = !isSearching ? (
+    <View style={styles.tabRow}>
+      {LANGUAGE_TABS.map((tab) => (
+        <BrowseFilterPill
+          key={tab.key}
+          label={tab.label}
+          active={language === tab.key}
+          onPress={() => setLanguage(tab.key)}
+          role="tab"
+        />
+      ))}
+    </View>
+  ) : null;
+
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.topSection}>
-        <ScreenHeader
-          title="Grammar Reference"
-          onBack={() => navigation.goBack()}
-          style={styles.headerSpacing}
-        />
-        <View style={styles.searchWrap}>
-          <SearchInput
-            value={searchQuery}
-            onChangeText={setSearchQuery}
-            placeholder="Search grammar articles..."
-          />
-        </View>
-
-        {/* Language tabs */}
-        {!isSearching && (
-          <View style={styles.tabRow}>
-            {LANGUAGE_TABS.map((tab) => {
-              const isActive = language === tab.key;
-              return (
-                <TouchableOpacity
-                  key={tab.key}
-                  onPress={() => setLanguage(tab.key)}
-                  style={[
-                    styles.tab,
-                    { borderColor: isActive ? base.gold : base.border },
-                    isActive && { backgroundColor: base.gold + '10' },
-                  ]}
-                  accessibilityRole="tab"
-                  accessibilityState={{ selected: isActive }}
-                >
-                  <Text
-                    style={[
-                      styles.tabText,
-                      { color: isActive ? base.gold : base.textMuted },
-                    ]}
-                  >
-                    {tab.label}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-        )}
-      </View>
-
-      {/* Content */}
-      {loading ? (
-        <View style={styles.loadingPad}>
-          <LoadingSkeleton lines={6} />
-        </View>
-      ) : displayData.length === 0 ? (
-        <View style={styles.center}>
-          <Text style={[styles.emptyText, { color: base.textDim }]}>
-            {isSearching
-              ? `No articles found for "${searchQuery}"`
-              : 'No grammar articles available yet.'}
-          </Text>
-        </View>
-      ) : (
-        <FlatList
-          data={categories}
-          keyExtractor={([cat]) => cat}
-          renderItem={({ item: [category, items] }) => (
-            <View>
-              <View style={[styles.categoryHeader, { backgroundColor: base.bgElevated }]}>
-                <Text style={[styles.categoryText, { color: base.gold }]}>
-                  {category.toUpperCase()}
-                </Text>
-              </View>
-              {items.map(renderArticle)}
-            </View>
-          )}
-        />
-      )}
-    </SafeAreaView>
+    <BrowseScreenTemplate
+      title="Grammar Reference"
+      loading={loading}
+      search={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search grammar articles..."
+      filterBar={filterBar}
+      mode="section"
+      sections={sections}
+      renderItem={renderItem}
+      renderSectionHeader={renderSectionHeader}
+      keyExtractor={(a: GrammarArticle) => a.id}
+      emptyMessage={
+        isSearching
+          ? `No articles found for "${searchQuery}"`
+          : 'No grammar articles available yet.'
+      }
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  topSection: {
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.lg,
-  },
-  headerSpacing: {
-    marginBottom: spacing.md,
-  },
-  searchWrap: {
-    marginBottom: spacing.sm,
-  },
   tabRow: {
     flexDirection: 'row',
     gap: spacing.sm,
-    marginBottom: spacing.sm,
-  },
-  tab: {
-    flex: 1,
-    paddingVertical: spacing.xs + 2,
-    borderWidth: 1,
-    borderRadius: radii.pill,
-    alignItems: 'center',
-  },
-  tabText: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-  },
-  loadingPad: {
-    padding: spacing.lg,
-  },
-  categoryHeader: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: 6,
-  },
-  categoryText: {
-    fontFamily: fontFamily.displaySemiBold,
-    fontSize: 11,
-    letterSpacing: 0.8,
+    paddingBottom: spacing.sm,
   },
   articleRow: {
     flexDirection: 'row',
@@ -237,17 +167,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginTop: 3,
     lineHeight: 16,
-  },
-  center: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.xl,
-  },
-  emptyText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 14,
-    textAlign: 'center',
   },
 });
 

--- a/app/src/screens/JourneyBrowseScreen.tsx
+++ b/app/src/screens/JourneyBrowseScreen.tsx
@@ -6,23 +6,29 @@
  * Taps navigate to PersonJourney or ConceptDetail (journey tab).
  *
  * Part of Journeys on Explore feature.
+ *
+ * Card #1359 (UI polish phase 2): migrated to shared BrowseScreenTemplate.
+ * The People/Concepts tab switcher now uses BrowseFilterPill for consistency
+ * with other browse screens; row-level layout is preserved.
  */
 
 import React, { useState, useCallback } from 'react';
 import {
-  View, Text, TouchableOpacity, FlatList, StyleSheet,
+  View, Text, TouchableOpacity, StyleSheet,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronRight } from 'lucide-react-native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { useJourneyBrowse, type PersonJourneyEntry, type ConceptJourneyEntry } from '../hooks/useJourneyBrowse';
-import { ScreenHeader } from '../components/ScreenHeader';
-import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+} from '../components/BrowseScreenTemplate';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 type Tab = 'people' | 'concepts';
+type AnyJourneyEntry = PersonJourneyEntry | ConceptJourneyEntry;
 
 function JourneyBrowseScreen() {
   const { base } = useTheme();
@@ -40,7 +46,7 @@ function JourneyBrowseScreen() {
     navigation.navigate('ConceptDetail', { conceptId, initialTab: 'journey' });
   }, [navigation]);
 
-  const renderPersonItem = useCallback(({ item }: { item: PersonJourneyEntry }) => (
+  const renderPersonItem = useCallback((item: PersonJourneyEntry) => (
     <TouchableOpacity
       style={[styles.row, { borderBottomColor: base.border }]}
       onPress={() => handlePersonPress(item.personId)}
@@ -68,7 +74,7 @@ function JourneyBrowseScreen() {
     </TouchableOpacity>
   ), [base, handlePersonPress]);
 
-  const renderConceptItem = useCallback(({ item }: { item: ConceptJourneyEntry }) => (
+  const renderConceptItem = useCallback((item: ConceptJourneyEntry) => (
     <TouchableOpacity
       style={[styles.row, { borderBottomColor: base.border }]}
       onPress={() => handleConceptPress(item.conceptId)}
@@ -96,98 +102,60 @@ function JourneyBrowseScreen() {
     </TouchableOpacity>
   ), [base, handleConceptPress]);
 
-  if (isLoading) {
-    return (
-      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-        <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
-        <View style={styles.loadingPad}>
-          <LoadingSkeleton lines={8} />
-        </View>
-      </SafeAreaView>
-    );
-  }
+  const data: AnyJourneyEntry[] = activeTab === 'people' ? personJourneys : conceptJourneys;
+
+  const renderItem = useCallback(({ item }: { item: AnyJourneyEntry }) => {
+    if (activeTab === 'people') {
+      return renderPersonItem(item as PersonJourneyEntry);
+    }
+    return renderConceptItem(item as ConceptJourneyEntry);
+  }, [activeTab, renderPersonItem, renderConceptItem]);
+
+  const keyExtractor = useCallback((item: AnyJourneyEntry) => {
+    return activeTab === 'people'
+      ? (item as PersonJourneyEntry).personId
+      : (item as ConceptJourneyEntry).conceptId;
+  }, [activeTab]);
+
+  const filterBar = (
+    <View style={styles.tabRow}>
+      <BrowseFilterPill
+        label={`People (${personJourneys.length})`}
+        active={activeTab === 'people'}
+        onPress={() => setActiveTab('people')}
+        role="tab"
+      />
+      <BrowseFilterPill
+        label={`Concepts (${conceptJourneys.length})`}
+        active={activeTab === 'concepts'}
+        onPress={() => setActiveTab('concepts')}
+        role="tab"
+      />
+    </View>
+  );
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
-
-      {/* Tab bar */}
-      <View style={[styles.tabBar, { borderBottomColor: base.border }]}>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'people' && [styles.tabActive, { backgroundColor: base.gold + '15' }]]}
-          onPress={() => setActiveTab('people')}
-          accessibilityRole="tab"
-          accessibilityState={{ selected: activeTab === 'people' }}
-        >
-          <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'people' && { color: base.gold }]}>
-            People ({personJourneys.length})
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'concepts' && [styles.tabActive, { backgroundColor: base.gold + '15' }]]}
-          onPress={() => setActiveTab('concepts')}
-          accessibilityRole="tab"
-          accessibilityState={{ selected: activeTab === 'concepts' }}
-        >
-          <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'concepts' && { color: base.gold }]}>
-            Concepts ({conceptJourneys.length})
-          </Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* List */}
-      {activeTab === 'people' ? (
-        <FlatList
-          data={personJourneys}
-          keyExtractor={(item) => item.personId}
-          renderItem={renderPersonItem}
-          contentContainerStyle={styles.listContent}
-          showsVerticalScrollIndicator={false}
-        />
-      ) : (
-        <FlatList
-          data={conceptJourneys}
-          keyExtractor={(item) => item.conceptId}
-          renderItem={renderConceptItem}
-          contentContainerStyle={styles.listContent}
-          showsVerticalScrollIndicator={false}
-        />
-      )}
-    </SafeAreaView>
+    <BrowseScreenTemplate
+      title="Journeys"
+      loading={isLoading}
+      filterBar={filterBar}
+      data={data}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      emptyMessage={activeTab === 'people' ? 'No journeys available.' : 'No concept journeys available.'}
+      contentContainerStyle={styles.listContent}
+    />
   );
 }
 
 export default withErrorBoundary(JourneyBrowseScreen);
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  loadingPad: {
-    padding: spacing.lg,
-  },
-
-  // Tab bar
-  tabBar: {
+  tabRow: {
     flexDirection: 'row',
-    borderBottomWidth: 1,
-    paddingHorizontal: spacing.lg,
+    gap: spacing.sm,
+    paddingBottom: spacing.md,
   },
-  tab: {
-    paddingVertical: spacing.sm + 2,
-    paddingHorizontal: spacing.md,
-    borderRadius: radii.sm,
-    marginBottom: -1,
-  },
-  tabActive: {
-    borderRadius: radii.sm,
-  },
-  tabText: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-  },
-
-  // List
   listContent: {
     paddingBottom: spacing.xxl,
   },

--- a/app/src/screens/LensBrowseScreen.tsx
+++ b/app/src/screens/LensBrowseScreen.tsx
@@ -2,14 +2,17 @@
  * LensBrowseScreen — Browse all hermeneutic lenses with descriptions.
  *
  * Explains each interpretive framework and links to try it on a sample chapter.
+ *
+ * Card #1359 (UI polish phase 2): migrated from a raw ScrollView to the
+ * BrowseScreenTemplate (FlatList). The intro paragraph is rendered via the
+ * template's flatListProps.ListHeaderComponent so it scrolls with the list.
  */
 
-import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import React, { useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
-import { ScreenHeader } from '../components/ScreenHeader';
+import { BrowseScreenTemplate, browseCardStyle } from '../components/BrowseScreenTemplate';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { useAsyncData } from '../hooks/useAsyncData';
 import { getAllLenses } from '../db/content/hermeneutics';
@@ -41,89 +44,67 @@ function LensBrowseScreen() {
     [],
   );
 
-  const handleTry = (_lensId: string) => {
+  const handleTry = useCallback((_lensId: string) => {
     navigation.navigate('Chapter', {
       bookId: SAMPLE_CHAPTER.bookId,
       chapterNum: SAMPLE_CHAPTER.chapterNum,
     });
-  };
+  }, [navigation]);
+
+  const cardStyle = browseCardStyle(base);
+
+  const renderItem = useCallback(({ item: lens }: { item: HermeneuticLens }) => (
+    <View style={cardStyle}>
+      <View style={styles.cardHeader}>
+        {lens.icon ? <Text style={styles.cardIcon}>{lens.icon}</Text> : null}
+        <Text style={[styles.cardTitle, { color: base.text }]}>{lens.name}</Text>
+      </View>
+      <Text style={[styles.cardDescription, { color: base.textDim }]}>
+        {lens.description}
+      </Text>
+      {LENS_DETAILS[lens.id] && (
+        <Text style={[styles.cardDetail, { color: base.textMuted }]}>
+          {LENS_DETAILS[lens.id]}
+        </Text>
+      )}
+      <TouchableOpacity
+        onPress={() => handleTry(lens.id)}
+        activeOpacity={0.7}
+        style={[styles.tryButton, { borderColor: base.gold }]}
+      >
+        <Text style={[styles.tryButtonText, { color: base.gold }]}>
+          Try on Genesis 1
+        </Text>
+      </TouchableOpacity>
+    </View>
+  ), [base, cardStyle, handleTry]);
+
+  const intro = (
+    <Text style={[styles.intro, { color: base.textDim }]}>
+      Read Scripture through different interpretive frameworks. Each lens highlights
+      different aspects of the text and reshapes the study tools shown alongside it.
+    </Text>
+  );
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.headerPad}>
-        <ScreenHeader title="Hermeneutic Lenses" onBack={() => navigation.goBack()} />
-      </View>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={[styles.intro, { color: base.textDim }]}>
-          Read Scripture through different interpretive frameworks. Each lens highlights
-          different aspects of the text and reshapes the study tools shown alongside it.
-        </Text>
-
-        {loading && (
-          <Text style={[styles.loadingText, { color: base.textMuted }]}>Loading lenses...</Text>
-        )}
-
-        {lenses.map((lens) => (
-          <View
-            key={lens.id}
-            style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '20' }]}
-          >
-            <View style={styles.cardHeader}>
-              {lens.icon ? <Text style={styles.cardIcon}>{lens.icon}</Text> : null}
-              <Text style={[styles.cardTitle, { color: base.text }]}>{lens.name}</Text>
-            </View>
-            <Text style={[styles.cardDescription, { color: base.textDim }]}>
-              {lens.description}
-            </Text>
-            {LENS_DETAILS[lens.id] && (
-              <Text style={[styles.cardDetail, { color: base.textMuted }]}>
-                {LENS_DETAILS[lens.id]}
-              </Text>
-            )}
-            <TouchableOpacity
-              onPress={() => handleTry(lens.id)}
-              activeOpacity={0.7}
-              style={[styles.tryButton, { borderColor: base.gold }]}
-            >
-              <Text style={[styles.tryButtonText, { color: base.gold }]}>
-                Try on Genesis 1
-              </Text>
-            </TouchableOpacity>
-          </View>
-        ))}
-      </ScrollView>
-    </SafeAreaView>
+    <BrowseScreenTemplate
+      title="Hermeneutic Lenses"
+      loading={loading}
+      data={lenses}
+      renderItem={renderItem}
+      keyExtractor={(lens: HermeneuticLens) => lens.id}
+      emptyMessage="No lenses available."
+      flatListProps={{ ListHeaderComponent: intro }}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  headerPad: {
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.md,
-  },
-  content: {
-    padding: spacing.md,
-    paddingBottom: spacing.xxl,
-  },
   intro: {
     fontFamily: fontFamily.ui,
     fontSize: 13,
     lineHeight: 20,
     marginBottom: spacing.lg,
-  },
-  loadingText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 13,
-    marginBottom: spacing.md,
-  },
-  card: {
-    borderWidth: 1,
-    borderRadius: radii.lg,
-    padding: spacing.md,
-    marginBottom: spacing.md,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/app/src/screens/ScholarBrowseScreen.tsx
+++ b/app/src/screens/ScholarBrowseScreen.tsx
@@ -10,7 +10,10 @@ import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
 import { useScholars } from '../hooks/useScholars';
 import type { Scholar } from '../types';
-import { BrowseScreenTemplate } from '../components/BrowseScreenTemplate';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+} from '../components/BrowseScreenTemplate';
 import { useSettingsStore } from '../stores';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { logger } from '../utils/logger';
@@ -80,23 +83,12 @@ function ScholarBrowseScreen() {
     <ScrollView horizontal showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.filterRow}>
       {traditions.map((t) => (
-        <TouchableOpacity
+        <BrowseFilterPill
           key={t}
+          label={t === 'all' ? 'All' : t}
+          active={tradition === t}
           onPress={() => setTradition(t)}
-          style={[
-            styles.filterPill,
-            { borderColor: tradition === t ? base.gold : base.border },
-            tradition === t && { backgroundColor: base.gold + '12' },
-          ]}
-          activeOpacity={0.7}
-        >
-          <Text style={[
-            styles.filterLabel,
-            { color: tradition === t ? base.gold : base.textMuted },
-          ]}>
-            {t === 'all' ? 'All' : t}
-          </Text>
-        </TouchableOpacity>
+        />
       ))}
     </ScrollView>
   );
@@ -121,18 +113,8 @@ function ScholarBrowseScreen() {
 
 const styles = StyleSheet.create({
   filterRow: {
-    gap: 6,
+    gap: spacing.xs,
     marginBottom: spacing.md,
-  },
-  filterPill: {
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 14,
-    borderWidth: 1,
-  },
-  filterLabel: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 10,
   },
   gridContent: {
     paddingHorizontal: spacing.md,

--- a/app/src/screens/ThreadBrowseScreen.tsx
+++ b/app/src/screens/ThreadBrowseScreen.tsx
@@ -3,17 +3,19 @@
  *
  * Each thread shows its theme, tag chips (max 4), and stop count.
  * Follows the ProphecyBrowseScreen pattern.
+ *
+ * Card #1359 (UI polish phase 2): migrated to shared BrowseScreenTemplate.
+ * The custom TextInput is replaced by the template's SearchInput; the plain
+ * empty Text now flows through EmptyState + tint.
  */
 
 import React, { useState, useMemo } from 'react';
-import { View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
 import { useThreads } from '../hooks/useThreads';
 import type { ParsedThread } from '../hooks/useThreads';
-import { ScreenHeader } from '../components/ScreenHeader';
-import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { BrowseScreenTemplate, browseCardStyle } from '../components/BrowseScreenTemplate';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 
 export default function ThreadBrowseScreen() {
@@ -32,20 +34,12 @@ export default function ThreadBrowseScreen() {
     );
   }, [threads, search]);
 
-  if (isLoading) {
-    return (
-      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-        <View style={styles.loadingPad}>
-          <LoadingSkeleton lines={6} />
-        </View>
-      </SafeAreaView>
-    );
-  }
+  const cardStyle = browseCardStyle(base);
 
   const renderItem = ({ item }: { item: ParsedThread }) => (
     <TouchableOpacity
       onPress={() => navigation.navigate('ThreadDetail', { threadId: item.id })}
-      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '25' }]}
+      style={cardStyle}
       accessibilityLabel={item.theme}
       accessibilityRole="button"
     >
@@ -70,73 +64,21 @@ export default function ThreadBrowseScreen() {
   );
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.topSection}>
-        <ScreenHeader
-          title="Threads"
-          onBack={() => navigation.goBack()}
-          style={styles.headerSpacing}
-        />
-
-        <TextInput
-          style={[styles.searchInput, { backgroundColor: base.bgElevated, color: base.text, borderColor: base.border }]}
-          placeholder="Search threads..."
-          placeholderTextColor={base.textMuted}
-          value={search}
-          onChangeText={setSearch}
-          autoCorrect={false}
-          accessibilityLabel="Search threads"
-        />
-      </View>
-
-      <FlatList
-        data={filtered}
-        keyExtractor={(t) => t.id}
-        renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
-        ListEmptyComponent={
-          <Text style={[styles.emptyText, { color: base.textMuted }]}>
-            {search ? 'No threads match your search.' : 'No threads available.'}
-          </Text>
-        }
-      />
-    </SafeAreaView>
+    <BrowseScreenTemplate
+      title="Threads"
+      loading={isLoading}
+      search={search}
+      onSearchChange={setSearch}
+      searchPlaceholder="Search threads..."
+      data={filtered}
+      renderItem={renderItem}
+      keyExtractor={(t: ParsedThread) => t.id}
+      emptyMessage={search ? 'No threads match your search.' : 'No threads available.'}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  loadingPad: {
-    padding: spacing.lg,
-  },
-  topSection: {
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.lg,
-  },
-  headerSpacing: {
-    marginBottom: spacing.md,
-  },
-  searchInput: {
-    fontFamily: fontFamily.ui,
-    fontSize: 14,
-    borderWidth: 1,
-    borderRadius: radii.md,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs + 2,
-    marginBottom: spacing.md,
-  },
-  listContent: {
-    paddingHorizontal: spacing.md,
-    paddingBottom: spacing.xxl,
-  },
-  card: {
-    borderWidth: 1,
-    borderRadius: radii.md,
-    padding: spacing.md,
-    marginBottom: spacing.sm,
-  },
   cardTitle: {
     fontFamily: fontFamily.displayMedium,
     fontSize: 15,
@@ -160,11 +102,5 @@ const styles = StyleSheet.create({
   stopCount: {
     fontFamily: fontFamily.ui,
     fontSize: 11,
-  },
-  emptyText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 14,
-    textAlign: 'center',
-    marginTop: spacing.xl,
   },
 });

--- a/app/src/screens/TopicBrowseScreen.tsx
+++ b/app/src/screens/TopicBrowseScreen.tsx
@@ -11,9 +11,13 @@ import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
-import { BrowseScreenTemplate } from '../components/BrowseScreenTemplate';
+import {
+  BrowseScreenTemplate,
+  BrowseFilterPill,
+  BrowseSectionHeader,
+} from '../components/BrowseScreenTemplate';
 import { useTopicData, CATEGORY_LABELS } from '../hooks/useTopicData';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, fontFamily } from '../theme';
 import type { Topic } from '../types/topic';
 import type { Subtopic } from '../types/topic';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
@@ -94,18 +98,14 @@ function TopicBrowseScreen() {
   const filterBar = !isSearching ? (
     <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pillRow}>
       {['all', ...categories].map((cat) => {
-        const active = categoryFilter === cat;
         const label = cat === 'all' ? 'All' : (CATEGORY_LABELS[cat] ?? cat);
         return (
-          <TouchableOpacity
+          <BrowseFilterPill
             key={cat}
+            label={label}
+            active={categoryFilter === cat}
             onPress={() => setCategoryFilter(cat)}
-            style={[styles.pill, { borderColor: base.border }, active && { borderColor: base.gold + '55', backgroundColor: base.gold + '12' }]}
-          >
-            <Text style={[styles.pillText, { color: base.textMuted }, active && { color: base.gold }]}>
-              {label}
-            </Text>
-          </TouchableOpacity>
+          />
         );
       })}
     </ScrollView>
@@ -156,11 +156,7 @@ function TopicBrowseScreen() {
       sections={sectionListData}
       keyExtractor={(item) => item.id}
       renderSectionHeader={({ section }) => (
-        <View style={[styles.sectionHeader, { borderBottomColor: base.gold + '25', backgroundColor: base.bg }]}>
-          <Text style={[styles.sectionHeaderText, { color: base.gold }]}>
-            {section.title}
-          </Text>
-        </View>
+        <BrowseSectionHeader title={section.title} />
       )}
       renderItem={renderTopicItem}
       emptyMessage="No topics found"
@@ -173,30 +169,7 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.lg },
   pillRow: { gap: spacing.xs, marginBottom: spacing.md },
-  pill: {
-    borderWidth: 1,
-    borderRadius: radii.pill,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  pillText: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 0.3,
-  },
   listPad: { paddingHorizontal: spacing.md },
-  sectionHeader: {
-    paddingTop: spacing.lg,
-    paddingBottom: spacing.xs,
-    borderBottomWidth: 1,
-    marginBottom: spacing.xs,
-  },
-  sectionHeaderText: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-  },
   entryRow: {
     paddingVertical: spacing.md,
     borderBottomWidth: 1,


### PR DESCRIPTION
…ens (#1359)

Second of 7 phases of the Glorify-level UI polish plan (parent #1269). Consolidates all 15 browse screens onto the shared BrowseScreenTemplate and introduces two new helpers so filter bars and cards stay consistent.

BrowseScreenTemplate additions:
- browseCardStyle(base) — reusable parchment-tinted card style (tintParchment bg, 10% gold border, radii.lg, spacing.md padding)
- BrowseFilterPill — standard 32px-high gold-active pill for filter bars. Gold@20 bg + gold border + gold text when active; transparent with muted text when inactive.

Migrated to the template (5 screens previously hand-rolling the shell):
- ArchaeologyBrowseScreen — filter chips → BrowseFilterPill, empty/ loading states flow through the template
- ThreadBrowseScreen — custom TextInput dropped in favor of the template's SearchInput; cards use browseCardStyle
- LensBrowseScreen — ScrollView replaced by template FlatList with intro paragraph via ListHeaderComponent; cards use browseCardStyle
- JourneyBrowseScreen — People/Concepts tabs now BrowseFilterPill (role="tab"); template drives loading + empty states
- GrammarBrowseScreen — SectionList mode with BrowseSectionHeader for category grouping; Greek/Hebrew tabs use BrowseFilterPill

Filter-bar polish on 3 already-template screens:
- ScholarBrowseScreen (tradition filter)
- DebateBrowseScreen (category filter) — category colors retained on the card left-border + tradition dots for at-a-glance differentiation; filter bar itself goes monochrome gold per design philosophy
- TopicBrowseScreen (category filter) — plus sticky section headers now use BrowseSectionHeader

Verification: npx tsc --noEmit clean, npm run lint clean (0 warnings), npx jest 429/429 suites 3209/3209 tests passing. Net −265 lines across 9 files.

https://claude.ai/code/session_01GZ9uZpqxF3yTMHp6L1rUx5