### PR TITLE
UI polish 3/7 — detail screen pattern foundation (#1360)

### DIFF
--- a/app/src/components/DetailHeroHeader.tsx
+++ b/app/src/components/DetailHeroHeader.tsx
@@ -1,0 +1,174 @@
+/**
+ * DetailHeroHeader — Shared hero header for detail screens with imagery.
+ *
+ * Two visual variants:
+ *   1. Image variant: full-width image at `height`px with dark gradient overlay
+ *      at the bottom. Title + subtitle overlaid in white text.
+ *   2. No-image variant: shorter (100px) tinted gradient background with title
+ *      in gold.
+ *
+ * Back button is overlaid at top-left in a semi-transparent circle so it works
+ * against both variants. Falls back gracefully when imageUrl fails to load.
+ *
+ * Card #1360 (UI polish phase 3). Used by Archaeology / Person / TimeTravel /
+ * Topic detail screens where imagery exists on R2.
+ */
+
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
+import { ArrowLeft } from 'lucide-react-native';
+import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  /** R2 URL for the hero image. If omitted or load fails, falls back to the tinted variant. */
+  imageUrl?: string;
+  /** Override the tinted background color for the no-image variant. Defaults to base.tintParchment. */
+  fallbackTint?: string;
+  /** Image variant height. Defaults to 140. */
+  height?: number;
+  onBack: () => void;
+  /** Accessibility label for the back button. */
+  backLabel?: string;
+}
+
+const NO_IMAGE_HEIGHT = 100;
+
+const OVERLAY_TITLE = '#ffffff'; // overlay-color: intentional (title over dark gradient)
+const OVERLAY_SUBTITLE = 'rgba(255,255,255,0.85)'; // overlay-color: intentional
+const BACK_BG = 'rgba(0,0,0,0.35)'; // overlay-color: intentional
+
+export function DetailHeroHeader({
+  title,
+  subtitle,
+  imageUrl,
+  fallbackTint,
+  height = 140,
+  onBack,
+  backLabel = 'Go back',
+}: Props) {
+  const { base } = useTheme();
+  const [imageFailed, setImageFailed] = useState(false);
+
+  const showImage = !!imageUrl && !imageFailed;
+  const containerHeight = showImage ? height : NO_IMAGE_HEIGHT;
+  const tint = fallbackTint ?? base.tintParchment;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          height: containerHeight,
+          backgroundColor: showImage ? base.bgElevated : tint,
+        },
+      ]}
+    >
+      {showImage ? (
+        <>
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.image}
+            contentFit="cover"
+            cachePolicy="disk"
+            transition={400}
+            onError={() => setImageFailed(true)}
+            recyclingKey={imageUrl}
+          />
+          <View style={styles.gradient} pointerEvents="none" />
+        </>
+      ) : null}
+
+      {/* Back button */}
+      <TouchableOpacity
+        onPress={onBack}
+        style={[styles.backButton, { backgroundColor: showImage ? BACK_BG : 'transparent' }]}
+        accessibilityRole="button"
+        accessibilityLabel={backLabel}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <ArrowLeft size={20} color={showImage ? OVERLAY_TITLE : base.gold} />
+      </TouchableOpacity>
+
+      {/* Title / subtitle */}
+      <View style={styles.textBlock} pointerEvents="none">
+        <Text
+          style={[
+            styles.title,
+            { color: showImage ? OVERLAY_TITLE : base.gold },
+          ]}
+          numberOfLines={2}
+          accessibilityRole="header"
+        >
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text
+            style={[
+              styles.subtitle,
+              { color: showImage ? OVERLAY_SUBTITLE : base.textMuted },
+            ]}
+            numberOfLines={1}
+          >
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  gradient: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: '60%',
+    // Approximate a bottom-to-top dark gradient using a shadow cast over
+    // a transparent view. Avoids pulling in expo-linear-gradient for this
+    // single use case (same approach as GoldSeparator).
+    backgroundColor: 'transparent',
+    shadowColor: '#000', // overlay-color: intentional
+    shadowOffset: { width: 0, height: -12 },
+    shadowOpacity: 0.6,
+    shadowRadius: 14,
+  },
+  backButton: {
+    position: 'absolute',
+    top: spacing.sm,
+    left: spacing.sm,
+    width: MIN_TOUCH_TARGET,
+    height: MIN_TOUCH_TARGET,
+    borderRadius: MIN_TOUCH_TARGET / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textBlock: {
+    position: 'absolute',
+    left: spacing.md,
+    right: spacing.md,
+    bottom: spacing.md,
+  },
+  title: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 22,
+    letterSpacing: 0.3,
+  },
+  subtitle: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 14,
+    marginTop: spacing['2xs'],
+  },
+});

--- a/app/src/components/DetailSectionTitle.tsx
+++ b/app/src/components/DetailSectionTitle.tsx
@@ -1,0 +1,84 @@
+/**
+ * DetailSectionTitle — Shared section heading for detail screens.
+ *
+ * Cinzel (displayMedium) in gold with a 3px gold bar to the left. Matches
+ * the treatment used by ScreenHeader / CollapsibleSection / BrowseSectionHeader
+ * so section labels read consistently across the app.
+ *
+ * Card #1360 (UI polish phase 3).
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, type TextStyle, type ViewStyle } from 'react-native';
+import { useTheme, spacing, fontFamily } from '../theme';
+
+interface Props {
+  title: string;
+  /** Optional leading icon rendered between the bar and the title. */
+  icon?: React.ReactNode;
+  /** Override text color. Defaults to base.gold. */
+  color?: string;
+  /** Additional container style (e.g. margin tweaks). */
+  style?: ViewStyle;
+  /** Additional title text style. */
+  titleStyle?: TextStyle;
+  /** Title transform: 'none' (default) keeps source casing; 'uppercase' for label-style headers. */
+  transform?: 'none' | 'uppercase';
+}
+
+export function DetailSectionTitle({
+  title,
+  icon,
+  color,
+  style,
+  titleStyle,
+  transform = 'none',
+}: Props) {
+  const { base } = useTheme();
+  const accent = color ?? base.gold;
+  return (
+    <View style={[styles.row, style]}>
+      <View style={[styles.bar, { backgroundColor: accent }]} />
+      {icon ? <View style={styles.iconSlot}>{icon}</View> : null}
+      <Text
+        style={[
+          styles.title,
+          transform === 'uppercase' && styles.uppercase,
+          { color: accent },
+          titleStyle,
+        ]}
+        accessibilityRole="header"
+      >
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  bar: {
+    width: 3,
+    alignSelf: 'stretch',
+    minHeight: 16,
+    marginRight: spacing.sm,
+    borderRadius: 1.5,
+  },
+  iconSlot: {
+    marginRight: spacing.xs,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 14,
+    letterSpacing: 0.6,
+  },
+  uppercase: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.9,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/DetailTabBar.tsx
+++ b/app/src/components/DetailTabBar.tsx
@@ -1,0 +1,87 @@
+/**
+ * DetailTabBar — Shared tab bar for detail screens with internal tabs.
+ *
+ * Active tab gets a gold text color and a 2px gold underline indicator.
+ * Inactive tabs show muted text on a transparent background. No full-width
+ * tab highlight — the underline is the only active affordance.
+ *
+ * Card #1360 (UI polish phase 3). Used by ConceptDetail (Overview/Journey),
+ * DebateDetail (if/when tabs are added), PersonDetail.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, spacing, fontFamily } from '../theme';
+
+export interface DetailTab<K extends string = string> {
+  key: K;
+  label: string;
+}
+
+interface Props<K extends string> {
+  tabs: DetailTab<K>[];
+  active: K;
+  onChange: (key: K) => void;
+}
+
+export function DetailTabBar<K extends string>({ tabs, active, onChange }: Props<K>) {
+  const { base } = useTheme();
+
+  return (
+    <View style={[styles.bar, { borderBottomColor: base.border }]}>
+      {tabs.map((tab) => {
+        const isActive = tab.key === active;
+        return (
+          <TouchableOpacity
+            key={tab.key}
+            onPress={() => onChange(tab.key)}
+            accessibilityRole="tab"
+            accessibilityLabel={`${tab.label} tab`}
+            accessibilityState={{ selected: isActive }}
+            style={styles.tab}
+            activeOpacity={0.7}
+          >
+            <Text
+              style={[
+                styles.tabText,
+                { color: isActive ? base.gold : base.textMuted },
+              ]}
+            >
+              {tab.label}
+            </Text>
+            <View
+              style={[
+                styles.underline,
+                { backgroundColor: isActive ? base.gold : 'transparent' },
+              ]}
+            />
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    paddingTop: spacing.sm + 2,
+    paddingBottom: 0,
+  },
+  tabText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+    marginBottom: spacing.xs,
+  },
+  underline: {
+    height: 2,
+    width: '50%',
+    borderTopLeftRadius: 1,
+    borderTopRightRadius: 1,
+  },
+});

--- a/app/src/components/MetadataPill.tsx
+++ b/app/src/components/MetadataPill.tsx
@@ -1,0 +1,70 @@
+/**
+ * MetadataPill — Small gold-bordered pill for detail-screen metadata.
+ *
+ * Used for verse refs, date ranges, category labels, era badges, etc. —
+ * anything small, labelled, and non-actionable (or lightly tappable). For
+ * strongly tappable filter chips, prefer BrowseFilterPill; for in-line
+ * enumerated tags, prefer BadgeChip.
+ *
+ * Styling per Card #1360: gold@30 border, pill radius, spacing.sm/xs padding.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, radii, spacing, fontFamily } from '../theme';
+
+interface Props {
+  label: string;
+  onPress?: () => void;
+  /** Override the accent color (used for border + text). Defaults to base.gold. */
+  color?: string;
+  /** Accessibility label override. */
+  accessibilityLabel?: string;
+}
+
+function MetadataPillImpl({ label, onPress, color, accessibilityLabel }: Props) {
+  const { base } = useTheme();
+  const accent = color ?? base.gold;
+
+  const content = (
+    <View
+      style={[
+        styles.pill,
+        { borderColor: accent + '30' },
+      ]}
+    >
+      <Text style={[styles.label, { color: accent }]}>{label}</Text>
+    </View>
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? label}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+  return content;
+}
+
+export const MetadataPill = React.memo(MetadataPillImpl);
+
+const styles = StyleSheet.create({
+  pill: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.2,
+  },
+});

--- a/app/src/components/interpretations/InterpretationCard.tsx
+++ b/app/src/components/interpretations/InterpretationCard.tsx
@@ -31,7 +31,12 @@ export const InterpretationCard = React.memo(function InterpretationCard({
       {...wrapperProps}
       style={[
         styles.card,
-        { backgroundColor: base.bgElevated, borderColor: eraColor + '30' },
+        {
+          backgroundColor: base.tintWarm,
+          // Scholar-quote accent: 3px gold left border per Card #1360.
+          // Era color still differentiates via the eraBadge and eraDot.
+          borderLeftColor: base.gold,
+        },
       ]}
     >
       {/* Era badge + verse ref row */}
@@ -94,7 +99,7 @@ export const InterpretationCard = React.memo(function InterpretationCard({
 
 const styles = StyleSheet.create({
   card: {
-    borderWidth: 1,
+    borderLeftWidth: 3,
     borderRadius: radii.md,
     padding: spacing.md,
     marginBottom: spacing.sm,

--- a/app/src/components/lifetopics/ScholarQuoteCard.tsx
+++ b/app/src/components/lifetopics/ScholarQuoteCard.tsx
@@ -1,5 +1,10 @@
 /**
  * ScholarQuoteCard — Scholar quote with name and tradition.
+ *
+ * Card #1360 (UI polish phase 3):
+ *   - 3px gold left border accent (rest of the card border is transparent)
+ *   - Parchment-tinted background (base.tintWarm) for a warmer look than
+ *     the previous bgElevated fill.
  */
 
 import React from 'react';
@@ -16,7 +21,15 @@ function ScholarQuoteCard({ quote, scholarName, tradition }: Props) {
   const { base } = useTheme();
 
   return (
-    <View style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.border + '40' }]}>
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: base.tintWarm,
+          borderLeftColor: base.gold,
+        },
+      ]}
+    >
       <Text style={[styles.quote, { color: base.text }]}>{`\u201C${quote}\u201D`}</Text>
       <View style={styles.attribution}>
         <Text style={[styles.name, { color: base.gold }]}>{scholarName}</Text>
@@ -32,15 +45,15 @@ export default React.memo(ScholarQuoteCard);
 
 const styles = StyleSheet.create({
   card: {
-    borderWidth: 1,
+    borderLeftWidth: 3,
     borderRadius: radii.md,
     padding: spacing.md,
     marginBottom: spacing.sm,
   },
   quote: {
     fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
+    fontSize: 14,
+    lineHeight: 22,
     fontStyle: 'italic',
   },
   attribution: {

--- a/app/src/screens/ArchaeologyDetailScreen.tsx
+++ b/app/src/screens/ArchaeologyDetailScreen.tsx
@@ -4,6 +4,12 @@
  * Shows name, date range, location, significance, description, and linked
  * verses (tappable to navigate to Chapter). Description is visible to free
  * users; full detail (linked verses, source) is premium-gated.
+ *
+ * Card #1360 (UI polish phase 3):
+ *   - Hero image via DetailHeroHeader when R2 images exist
+ *   - Section titles use DetailSectionTitle (Cinzel + gold bar)
+ *   - Verse-ref / date / location metadata use MetadataPill
+ *   - Hairline section separators replaced by GoldSeparator
  */
 
 import React, { useCallback } from 'react';
@@ -18,6 +24,10 @@ import { CollapsibleSection } from '../components/CollapsibleSection';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { DiscoveryImageGallery } from '../components/DiscoveryImageGallery';
 import { BadgeChip } from '../components/BadgeChip';
+import { DetailHeroHeader } from '../components/DetailHeroHeader';
+import { DetailSectionTitle } from '../components/DetailSectionTitle';
+import { MetadataPill } from '../components/MetadataPill';
+import { GoldSeparator } from '../components/GoldSeparator';
 import { useArchaeologyDetail } from '../hooks/useArchaeology';
 import { usePremium } from '../hooks/usePremium';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
@@ -60,99 +70,98 @@ function ArchaeologyDetailScreen() {
     );
   }
 
+  const heroImage = images.length > 0 ? images[0].url : undefined;
+
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.headerPad}>
-        <ScreenHeader title={discovery.name} onBack={() => navigation.goBack()} />
-        <View style={styles.badgeRow}>
-          <BadgeChip label={discovery.category} />
-        </View>
-        {discovery.location && (
-          <Text style={[styles.locationText, { color: base.textDim }]}>
-            {discovery.location}
-          </Text>
-        )}
-      </View>
-
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]} edges={['top']}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
-        {/* Icon + date range */}
-        <View style={styles.heroRow}>
-          <Text style={styles.heroEmoji}>🏛</Text>
-          {discovery.date_range && (
-            <Text style={[styles.dateRange, { color: base.textDim }]}>
-              {discovery.date_range}
-            </Text>
+        <DetailHeroHeader
+          title={discovery.name}
+          subtitle={discovery.location ?? undefined}
+          imageUrl={heroImage}
+          onBack={() => navigation.goBack()}
+        />
+
+        <View style={styles.body}>
+          {/* Metadata pill row */}
+          <View style={styles.pillRow}>
+            <MetadataPill label={discovery.category} />
+            {discovery.date_range && <MetadataPill label={discovery.date_range} />}
+          </View>
+
+          {/* Image gallery — only when we have more than one image (hero already shows the first) */}
+          {images.length > 1 && (
+            <View style={styles.galleryWrap}>
+              <DiscoveryImageGallery images={images} />
+            </View>
           )}
-        </View>
 
-        {/* Image gallery */}
-        {images.length > 0 && (
-          <DiscoveryImageGallery images={images} />
-        )}
+          {/* Significance — always visible */}
+          <View style={[styles.significanceCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '30' }]}>
+            <DetailSectionTitle title="Significance" transform="uppercase" />
+            <Text style={[styles.significanceText, { color: base.text }]}>
+              {discovery.significance}
+            </Text>
+          </View>
 
-        {/* Significance — always visible */}
-        <View style={[styles.significanceCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '30' }]}>
-          <Text style={[styles.significanceLabel, { color: base.gold }]}>Significance</Text>
-          <Text style={[styles.significanceText, { color: base.text }]}>
-            {discovery.significance}
-          </Text>
-        </View>
-
-        {/* Description — always visible */}
-        <View style={styles.bodySection}>
+          {/* Description */}
           <Text style={[styles.bodyText, { color: base.text }]}>
             {discovery.description}
           </Text>
+
+          {/* Linked Verses — premium gated */}
+          {isPremium && verseLinks.length > 0 && (
+            <>
+              <GoldSeparator marginTop={spacing.md} />
+              <CollapsibleSection title="Linked Verses" initiallyCollapsed={false}>
+                {verseLinks.map((vl: ArchaeologyVerseLink) => (
+                  <TouchableOpacity
+                    key={vl.id}
+                    onPress={() => handleVersePress(vl.verse_ref)}
+                    style={[styles.verseCard, { backgroundColor: base.tintParchment, borderColor: base.gold + '20' }]}
+                  >
+                    <Text style={[styles.verseRef, { color: base.gold }]}>
+                      {vl.verse_ref}
+                    </Text>
+                    {vl.relevance && (
+                      <Text style={[styles.verseRelevance, { color: base.textDim }]}>
+                        {vl.relevance}
+                      </Text>
+                    )}
+                  </TouchableOpacity>
+                ))}
+              </CollapsibleSection>
+            </>
+          )}
+
+          {/* Source — premium gated */}
+          {isPremium && discovery.source && (
+            <View style={styles.sourceSection}>
+              <GoldSeparator marginBottom={spacing.md} />
+              <DetailSectionTitle title="Source" transform="uppercase" />
+              <Text style={[styles.sourceText, { color: base.textDim }]}>
+                {discovery.source}
+              </Text>
+            </View>
+          )}
+
+          {/* Premium upsell for free users */}
+          {!isPremium && (
+            <View style={[styles.gateCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '30' }]}>
+              <Text style={[styles.gateIcon, { color: base.gold }]}>{'✦'}</Text>
+              <Text style={[styles.gateTitle, { color: base.text }]}>
+                Full discovery details available with Companion+
+              </Text>
+              <Text style={[styles.gateDesc, { color: base.textDim }]}>
+                Unlock linked verses, source references, and more.
+              </Text>
+              <BadgeChip
+                label="Learn More"
+                onPress={() => showUpgrade('explore', 'Archaeological Evidence')}
+              />
+            </View>
+          )}
         </View>
-
-        {/* Linked Verses — premium gated */}
-        {isPremium && verseLinks.length > 0 && (
-          <CollapsibleSection title="Linked Verses" initiallyCollapsed={false}>
-            {verseLinks.map((vl: ArchaeologyVerseLink) => (
-              <TouchableOpacity
-                key={vl.id}
-                onPress={() => handleVersePress(vl.verse_ref)}
-                style={[styles.verseCard, { backgroundColor: base.bgElevated, borderColor: base.border + '40' }]}
-              >
-                <Text style={[styles.verseRef, { color: base.gold }]}>
-                  {vl.verse_ref}
-                </Text>
-                {vl.relevance && (
-                  <Text style={[styles.verseRelevance, { color: base.textDim }]}>
-                    {vl.relevance}
-                  </Text>
-                )}
-              </TouchableOpacity>
-            ))}
-          </CollapsibleSection>
-        )}
-
-        {/* Source — premium gated */}
-        {isPremium && discovery.source && (
-          <View style={styles.sourceSection}>
-            <Text style={[styles.sourceLabel, { color: base.textMuted }]}>Source</Text>
-            <Text style={[styles.sourceText, { color: base.textDim }]}>
-              {discovery.source}
-            </Text>
-          </View>
-        )}
-
-        {/* Premium upsell for free users */}
-        {!isPremium && (
-          <View style={[styles.gateCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '30' }]}>
-            <Text style={[styles.gateIcon, { color: base.gold }]}>{'✦'}</Text>
-            <Text style={[styles.gateTitle, { color: base.text }]}>
-              Full discovery details available with Companion+
-            </Text>
-            <Text style={[styles.gateDesc, { color: base.textDim }]}>
-              Unlock linked verses, source references, and more.
-            </Text>
-            <BadgeChip
-              label="Learn More"
-              onPress={() => showUpgrade('explore', 'Archaeological Evidence')}
-            />
-          </View>
-        )}
       </ScrollView>
 
       {upgradeRequest && (
@@ -170,32 +179,19 @@ function ArchaeologyDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.md },
-  badgeRow: {
+  scroll: { flex: 1 },
+  scrollContent: { paddingBottom: spacing.xxl },
+  body: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  pillRow: {
     flexDirection: 'row',
     gap: spacing.xs,
-    marginTop: spacing.xs,
-  },
-  locationText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 12,
-    lineHeight: 18,
-    marginTop: spacing.xs,
-    marginBottom: spacing.sm,
-  },
-  scroll: { flex: 1 },
-  scrollContent: { padding: spacing.md, paddingBottom: spacing.xxl },
-  heroRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
     marginBottom: spacing.md,
   },
-  heroEmoji: {
-    fontSize: 28,
-  },
-  dateRange: {
-    fontFamily: fontFamily.ui,
-    fontSize: 13,
+  galleryWrap: {
+    marginBottom: spacing.md,
   },
   significanceCard: {
     borderWidth: 1,
@@ -203,25 +199,16 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     marginBottom: spacing.md,
   },
-  significanceLabel: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 0.5,
-    textTransform: 'uppercase',
-    marginBottom: spacing.xs,
-  },
   significanceText: {
     fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
-  },
-  bodySection: {
-    marginBottom: spacing.md,
+    fontSize: 15,
+    lineHeight: 25,
   },
   bodyText: {
     fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
+    fontSize: 15,
+    lineHeight: 25,
+    marginBottom: spacing.md,
   },
   verseCard: {
     borderWidth: 1,
@@ -236,25 +223,16 @@ const styles = StyleSheet.create({
   },
   verseRelevance: {
     fontFamily: fontFamily.body,
-    fontSize: 12,
-    lineHeight: 18,
+    fontSize: 13,
+    lineHeight: 20,
   },
   sourceSection: {
     marginTop: spacing.md,
-    paddingTop: spacing.md,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  sourceLabel: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 0.5,
-    textTransform: 'uppercase',
-    marginBottom: spacing.xs,
   },
   sourceText: {
     fontFamily: fontFamily.body,
-    fontSize: 12,
-    lineHeight: 18,
+    fontSize: 13,
+    lineHeight: 20,
   },
   gateCard: {
     borderWidth: 1,

--- a/app/src/screens/ConceptDetailScreen.tsx
+++ b/app/src/screens/ConceptDetailScreen.tsx
@@ -28,6 +28,7 @@ import { UpgradePrompt } from '../components/UpgradePrompt';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import type { ExploreStackParamList } from '../navigation/types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { DetailTabBar } from '../components/DetailTabBar';
 
 type Nav = StackNavigationProp<ExploreStackParamList, 'ConceptDetail'>;
 type Route = RouteProp<ExploreStackParamList, 'ConceptDetail'>;
@@ -105,30 +106,14 @@ function ConceptDetailScreen() {
 
       {/* Tab bar — only shown when journey data exists */}
       {hasJourney && (
-        <View style={[styles.tabBar, { backgroundColor: base.bgElevated }]}>
-          <TouchableOpacity
-            style={[styles.tab, activeTab === 'overview' && [styles.tabActive, { backgroundColor: base.gold + '25' }]]}
-            onPress={() => setActiveTab('overview')}
-            accessibilityRole="button"
-            accessibilityLabel="Overview tab"
-            accessibilityState={{ selected: activeTab === 'overview' }}
-          >
-            <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'overview' && { color: base.gold }]}>
-              Overview
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.tab, activeTab === 'journey' && [styles.tabActive, { backgroundColor: base.gold + '25' }]]}
-            onPress={() => setActiveTab('journey')}
-            accessibilityRole="button"
-            accessibilityLabel="Journey tab"
-            accessibilityState={{ selected: activeTab === 'journey' }}
-          >
-            <Text style={[styles.tabText, { color: base.textMuted }, activeTab === 'journey' && { color: base.gold }]}>
-              Journey
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <DetailTabBar
+          tabs={[
+            { key: 'overview', label: 'Overview' },
+            { key: 'journey', label: 'Journey' },
+          ]}
+          active={activeTab}
+          onChange={setActiveTab}
+        />
       )}
 
       {/* Journey tab */}
@@ -352,26 +337,6 @@ const styles = StyleSheet.create({
     width: 24,
   },
 
-  // Tab bar
-  tabBar: {
-    flexDirection: 'row',
-    marginHorizontal: spacing.md,
-    marginBottom: spacing.sm,
-    borderRadius: radii.md,
-    padding: 2,
-  },
-  tab: {
-    flex: 1,
-    paddingVertical: spacing.xs + 2,
-    alignItems: 'center',
-    borderRadius: radii.sm + 2,
-  },
-  tabActive: {
-  },
-  tabText: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-  },
   bottomSpacer: {
     height: spacing.xxl,
   },

--- a/app/src/screens/LifeTopicDetailScreen.tsx
+++ b/app/src/screens/LifeTopicDetailScreen.tsx
@@ -226,16 +226,16 @@ const styles = StyleSheet.create({
   },
   summaryText: {
     fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
+    fontSize: 15,
+    lineHeight: 25,
   },
   bodySection: {
     marginBottom: spacing.md,
   },
   bodyText: {
     fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
+    fontSize: 15,
+    lineHeight: 25,
   },
   gateCard: {
     borderWidth: 1,

--- a/app/src/screens/TimeTravelDetailScreen.tsx
+++ b/app/src/screens/TimeTravelDetailScreen.tsx
@@ -16,6 +16,7 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { InterpretationCard } from '../components/interpretations/InterpretationCard';
 import { BadgeChip } from '../components/BadgeChip';
 import { UpgradePrompt } from '../components/UpgradePrompt';
+import { DetailHeroHeader } from '../components/DetailHeroHeader';
 import { useVerseInterpretations } from '../hooks/useInterpretations';
 import { usePremium } from '../hooks/usePremium';
 import { useTheme, spacing, fontFamily, churchEras } from '../theme';
@@ -112,14 +113,12 @@ function TimeTravelDetailScreen() {
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <View style={styles.headerPad}>
-        <ScreenHeader
-          title="Through the Ages"
-          onBack={() => navigation.goBack()}
-        />
-        <Text style={[styles.verseRef, { color: base.gold }]}>{verseRef}</Text>
-      </View>
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]} edges={['top']}>
+      <DetailHeroHeader
+        title="Through the Ages"
+        subtitle={verseRef}
+        onBack={() => navigation.goBack()}
+      />
 
       <ScrollView ref={scrollRef} style={styles.scroll} contentContainerStyle={styles.scrollContent}>
         {interpretations.length === 0 ? (
@@ -203,12 +202,6 @@ function TimeTravelDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.md },
-  verseRef: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-    marginTop: spacing.xs,
-    marginBottom: spacing.sm,
-  },
   scroll: { flex: 1 },
   scrollContent: { padding: spacing.md, paddingBottom: spacing.xxl },
   eraSection: {


### PR DESCRIPTION
Phase 3 of 7 of the Glorify-level UI polish plan (parent #1269, spec #1360). Introduces the shared building blocks for detail-screen polish and applies them across the most visible detail screens + scholar-quote components so the pattern propagates everywhere they are used.

## Summary

### New shared components
- **`DetailHeroHeader`** — full-width hero with image + gradient overlay OR tinted gradient fallback, with back button overlaid at top-left. Gracefully falls back to the no-image variant when `imageUrl` is missing or fails to load.
- **`DetailSectionTitle`** — Cinzel section label with 3px gold bar accent (matches `ScreenHeader` / `BrowseSectionHeader` treatment from phases 1–2).
- **`MetadataPill`** — gold-bordered pill (gold@30 border, pill radius, spacing.sm/xs padding) for verse refs, date ranges, category labels, era badges.
- **`DetailTabBar`** — gold-underline active tab indicator (no full-width tab background highlight), replacing the ad-hoc tab implementation in ConceptDetail.

### Scholar-quote components upgraded in-place
Changes propagate to every screen already using them:
- **`ScholarQuoteCard`** — 3px gold left border + `tintWarm` background (was `bgElevated` + thin border). Used by `LifeTopicDetailScreen`.
- **`InterpretationCard`** — 3px gold left border + `tintWarm` background. Era color retained on the `eraBadge` + `eraDot` so eras still read at a glance. Used by `TimeTravelDetailScreen`.

### Detail screens polished
- **`ConceptDetailScreen`** — tab bar migrated to `DetailTabBar` (gold underline instead of gold background highlight).
- **`ArchaeologyDetailScreen`** — `DetailHeroHeader` with R2 hero image, `MetadataPill` row for category + date range, `DetailSectionTitle` for "Significance" / "Source", `GoldSeparator` between major sections, body typography bumped to `fontSize 15` / `lineHeight 25` per spec.
- **`TimeTravelDetailScreen`** — `DetailHeroHeader` (no-image variant) with the verse ref as subtitle.
- **`LifeTopicDetailScreen`** — body typography bumped to 15/25.

### Deliberately not in this PR
Phase 3 spec describes polish across all 17 detail screens. This PR delivers the foundation components + exemplar screens; the remaining 13 detail screens will naturally inherit the updated `ScholarQuoteCard` / `InterpretationCard` visuals where they use them, and can adopt `DetailSectionTitle` / `MetadataPill` / `DetailHeroHeader` in follow-up passes without churn. The issue explicitly says to apply polish "where it makes sense" and not to force hero headers — being selective here is intentional.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npx jest` — 429/429 suites, 3209/3209 tests passing
- [ ] Smoke-check navigation: Archaeology browse → detail (hero image fallback path)
- [ ] Smoke-check navigation: TimeTravel detail (no-image hero variant)
- [ ] Smoke-check ConceptDetail tab switcher in dark / sepia / light themes
- [ ] Smoke-check LifeTopicDetail scholar quote cards on all three themes

https://claude.ai/code/session_01GZ9uZpqxF3yTMHp6L1rUx5