### PR TITLE
UI polish 4/7 — HomeScreen breathing room + visual refinement (#1361)

### DIFF
--- a/app/src/components/ContinueReadingHero.tsx
+++ b/app/src/components/ContinueReadingHero.tsx
@@ -95,7 +95,7 @@ export function ContinueReadingHero({ mostRecent, onPress }: Props) {
     <TouchableOpacity
       activeOpacity={0.8}
       onPress={onPress}
-      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '1F' }]}
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '14' }]}
       accessibilityRole="button"
       accessibilityLabel={`${titleText}: ${subtitleText}. Tap to ${ctaText.toLowerCase()}`}
     >
@@ -174,16 +174,18 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   gradient: {
+    // Card #1361: stronger gradient — taller (bottom 50% of the image) and
+    // deeper shadow for a more dramatic fade-to-black into the text area.
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    height: 48,
+    height: Math.round(IMAGE_HEIGHT * 0.5),
     backgroundColor: 'transparent',
     shadowColor: '#000', // overlay-color: intentional (RN shadow must be #000 on iOS)
-    shadowOffset: { width: 0, height: -12 },
-    shadowOpacity: 0.5,
-    shadowRadius: 12,
+    shadowOffset: { width: 0, height: -16 },
+    shadowOpacity: 0.65,
+    shadowRadius: 16,
   },
   caption: {
     position: 'absolute',
@@ -230,8 +232,9 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   subtitle: {
-    fontFamily: fontFamily.ui,
-    fontSize: 13,
+    // Card #1361: EB Garamond italic for the book/chapter subtitle
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 14,
     marginTop: 2,
   },
   ctaButton: {

--- a/app/src/components/StreakBadge.tsx
+++ b/app/src/components/StreakBadge.tsx
@@ -1,10 +1,13 @@
 /**
  * StreakBadge — Understated reading streak counter for HomeScreen.
  * Renders only when streak > 0. Tap to share your streak.
+ *
+ * Card #1361 (UI polish phase 4): active streaks get a subtle gold glow
+ * via a shadow layer behind the badge.
  */
 
 import React from 'react';
-import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Flame, Share2 } from 'lucide-react-native';
 import { useTheme, spacing, fontFamily } from '../theme';
 import { shareStreak } from '../utils/shareVerse';
@@ -19,19 +22,23 @@ function StreakBadge({ streak }: Props) {
   if (streak < 1) return null;
 
   return (
-    <TouchableOpacity
-      onPress={() => shareStreak(streak)}
-      activeOpacity={0.7}
-      style={styles.container}
-      accessibilityRole="button"
-      accessibilityLabel={`${streak}-day reading streak. Tap to share.`}
-    >
-      <Flame size={13} color={base.gold} />
-      <Text style={[styles.label, { color: base.gold }]}>
-        {streak}-day streak
-      </Text>
-      <Share2 size={10} color={base.gold} style={styles.shareIcon} />
-    </TouchableOpacity>
+    <View style={styles.wrapper}>
+      {/* Subtle gold glow halo rendered behind the badge. */}
+      <View style={[styles.glow, { backgroundColor: base.gold }]} pointerEvents="none" />
+      <TouchableOpacity
+        onPress={() => shareStreak(streak)}
+        activeOpacity={0.7}
+        style={styles.container}
+        accessibilityRole="button"
+        accessibilityLabel={`${streak}-day reading streak. Tap to share.`}
+      >
+        <Flame size={13} color={base.gold} />
+        <Text style={[styles.label, { color: base.gold }]}>
+          {streak}-day streak
+        </Text>
+        <Share2 size={10} color={base.gold} style={styles.shareIcon} />
+      </TouchableOpacity>
+    </View>
   );
 }
 
@@ -40,12 +47,32 @@ export { MemoizedStreakBadge as StreakBadge };
 export default MemoizedStreakBadge;
 
 const styles = StyleSheet.create({
+  wrapper: {
+    alignSelf: 'flex-start',
+    marginTop: spacing.xs,
+    position: 'relative',
+  },
+  glow: {
+    position: 'absolute',
+    top: 2,
+    bottom: 2,
+    left: 4,
+    right: 4,
+    borderRadius: 999,
+    opacity: 0.12,
+    // iOS shadow for the glow halo. RN shadows must originate from a solid
+    // background, so this semi-opaque pill provides the substrate.
+    shadowColor: '#bfa050', // overlay-color: intentional (gold halo)
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.8,
+    shadowRadius: 8,
+    // Android needs elevation for glow effect
+    elevation: 4,
+  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
-    alignSelf: 'flex-start',
-    marginTop: spacing.xs,
   },
   label: {
     fontFamily: fontFamily.uiMedium,

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -29,6 +29,8 @@ import { ContinueReadingHero } from '../components/ContinueReadingHero';
 import { ProgressRow } from '../components/ProgressRow';
 import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../components/FeatureCard';
 import { MilestoneToast } from '../components/MilestoneToast';
+import { GoldSeparator } from '../components/GoldSeparator';
+import { DetailSectionTitle } from '../components/DetailSectionTitle';
 import { useSettingsStore } from '../stores';
 import { shareVerse } from '../utils/shareVerse';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
@@ -139,16 +141,19 @@ function HomeScreen() {
           <ContinueReadingHero mostRecent={mostRecent} onPress={handleContinuePress} />
         </View>
 
+        {/* Major-zone divider: greeting + hero → scripture engagement */}
+        <GoldSeparator marginBottom={spacing.lg} />
+
         {/* ── 3. Verse of the Day (typography-forward) ──── */}
         <TouchableOpacity
           activeOpacity={0.7}
           onPress={handleVersePress}
-          style={[styles.verseCard, { backgroundColor: base.bg3, borderColor: base.gold + '14' }]}
+          style={[styles.verseCard, { backgroundColor: base.tintParchment, borderColor: base.gold + '14' }]}
           accessibilityRole="button"
           accessibilityLabel={`Verse of the day: ${verse.ref}. ${verse.text}. Tap to read in context`}
         >
           <View style={styles.verseCardHeader}>
-            <Text style={[styles.verseCardLabel, { color: base.textMuted }]}>VERSE OF THE DAY</Text>
+            <Text style={[styles.verseCardLabel, { color: base.gold }]}>VERSE OF THE DAY</Text>
             <TouchableOpacity
               onPress={(e) => { e.stopPropagation(); shareVerse(verse.text, verse.ref, translation); }}
               hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
@@ -158,7 +163,9 @@ function HomeScreen() {
               <Share2 size={15} color={base.textMuted} />
             </TouchableOpacity>
           </View>
-          <Text style={[styles.verseCardRef, { color: base.gold }]}>{verse.ref}</Text>
+          <View style={[styles.verseCardRefPill, { borderColor: base.gold + '30' }]}>
+            <Text style={[styles.verseCardRefText, { color: base.gold }]}>{verse.ref}</Text>
+          </View>
           <Text style={[styles.verseCardText, { color: base.text }]}>{verse.text}</Text>
         </TouchableOpacity>
 
@@ -167,9 +174,14 @@ function HomeScreen() {
           <ActivePlanCard />
         </View>
 
+        {/* Major-zone divider: scripture engagement → exploration + stats */}
+        <GoldSeparator marginBottom={spacing.lg} />
+
         {/* ── 5. "From your study" / "Start exploring" carousel ── */}
         <View style={styles.carouselSection}>
-          <Text style={[styles.sectionLabel, { color: base.textMuted }]}>{carouselLabel}</Text>
+          <View style={styles.carouselLabelWrap}>
+            <DetailSectionTitle title={carouselLabel} transform="uppercase" />
+          </View>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -249,9 +261,9 @@ const styles = StyleSheet.create({
     marginBottom: 22,
   },
 
-  // Verse of the Day (#1091 restyle)
+  // Verse of the Day — Card #1361 polish: tintParchment bg, radii.xl, gold pill ref
   verseCard: {
-    borderRadius: radii.lg,
+    borderRadius: radii.xl,
     borderWidth: 1,
     paddingHorizontal: spacing.lg,
     paddingVertical: 28,
@@ -264,19 +276,27 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   verseCardLabel: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-    letterSpacing: 0.5,
-  },
-  verseCardRef: {
     fontFamily: fontFamily.displayMedium,
-    fontSize: 14,
+    fontSize: 11,
+    letterSpacing: 0.9,
+  },
+  verseCardRefPill: {
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
     marginBottom: spacing.sm,
+  },
+  verseCardRefText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    letterSpacing: 0.3,
   },
   verseCardText: {
     fontFamily: fontFamily.bodyItalic,
     fontSize: 20,
-    lineHeight: 32,
+    lineHeight: 34,
   },
 
   // Carousel section (#1093)
@@ -285,10 +305,7 @@ const styles = StyleSheet.create({
     marginHorizontal: -HORIZONTAL_PAD,
     paddingHorizontal: HORIZONTAL_PAD,
   },
-  sectionLabel: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-    letterSpacing: 0.5,
+  carouselLabelWrap: {
     marginBottom: spacing.sm,
   },
   carouselContent: {


### PR DESCRIPTION
Phase 4 of 7 of the Glorify-level UI polish plan (parent #1269, spec #1361). HomeScreen is the first impression after onboarding — it now reads with more breathing room, a cleaner hierarchy, and stronger branded accents.

## Summary

### HomeScreen (`app/src/screens/HomeScreen.tsx`)
- `GoldSeparator` between the three major zones (greeting + hero → scripture engagement → exploration + stats). Replaces the flat 22px gap with a visible gold divider on the zone boundaries.
- **Verse-of-the-Day card**:
  - `backgroundColor` → `tintParchment` (was flat `bg3`)
  - `borderRadius` → `radii.xl` (16px, Phase 1 token)
  - Scripture reference is now a gold-bordered pill (`gold@30` border, `radii.pill`)
  - Label promoted to Cinzel `displayMedium` in gold (was muted UI font)
  - Verse text `lineHeight` bumped 32 → 34 for easier reading
- Carousel label ("FROM YOUR STUDY" / "START EXPLORING") now uses the shared `DetailSectionTitle` with the 3px gold bar accent, matching `ScreenHeader` / `BrowseSectionHeader` across the app.

### `ContinueReadingHero`
- Gold border softened `gold@1F` (~12%) → `gold@14` (~8%) per spec.
- Gradient overlay strengthened: height 48px → 50% of image (~80px); `shadowOpacity` 0.5 → 0.65, `shadowOffset` −12 → −16, `shadowRadius` 12 → 16. Better separation between hero art and the CTA row.
- Subtitle (book + chapter title) → EB Garamond italic instead of the UI sans, matching the "body / reading" family intent for book/chapter text.

### `StreakBadge`
- Active streaks (`streak > 0`) get a subtle gold glow halo rendered behind the badge (`shadowColor` gold, `shadowRadius` 8, `elevation` 4). Unchanged when `streak < 1` — still returns `null`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npx jest` — 429/429 suites, 3209/3209 tests passing
- [ ] Smoke-check HomeScreen in all three themes (dark / sepia / light): zone separators read cleanly; VOTD card parchment tint looks balanced; streak badge glow not overpowering
- [ ] Smoke-check ContinueReadingHero gradient depth on devices with and without book/person imagery available
- [ ] Verify the carousel label still aligns with the first card's left edge after the `DetailSectionTitle` swap

https://claude.ai/code/session_01GZ9uZpqxF3yTMHp6L1rUx5