### PR TITLE
UI polish 5/7 — ChapterScreen reading experience refinement (#1362)

### DIFF
--- a/app/src/components/ChapterHeader.tsx
+++ b/app/src/components/ChapterHeader.tsx
@@ -4,6 +4,10 @@
  * Compact layout: title on its own line, subtitle + tappable pills
  * (timeline, map, notes, story context) flow together on the next line.
  * "About This Book" moved to ⓘ icon in ChapterNavBar.
+ *
+ * Card #1362 (UI polish phase 5): pill TouchableOpacities now carry a
+ * hitSlop for a larger effective touch target without changing the
+ * BadgeChip visuals (which are shared with other screens).
  */
 
 import React from 'react';
@@ -21,6 +25,9 @@ interface Props {
   onStoryPress?: () => void;
   storyActName?: string | null;
 }
+
+/** Shared hitSlop for header pills — effectively grows touch area to ~44px. */
+const PILL_HIT_SLOP = { top: 8, bottom: 8, left: 6, right: 6 };
 
 export function ChapterHeader({
   chapter, noteCount, onNotesPress,
@@ -48,19 +55,19 @@ export function ChapterHeader({
           ) : null}
 
           {chapter.timeline_link_text && onTimelinePress && (
-            <TouchableOpacity onPress={onTimelinePress}>
+            <TouchableOpacity onPress={onTimelinePress} hitSlop={PILL_HIT_SLOP}>
               <BadgeChip label={chapter.timeline_link_text} color={panels.hist.accent} />
             </TouchableOpacity>
           )}
 
           {chapter.map_story_link_text && onMapPress && (
-            <TouchableOpacity onPress={onMapPress}>
+            <TouchableOpacity onPress={onMapPress} hitSlop={PILL_HIT_SLOP}>
               <BadgeChip label={chapter.map_story_link_text} color={panels.poi.accent} />
             </TouchableOpacity>
           )}
 
           {storyActName && onStoryPress && (
-            <TouchableOpacity onPress={onStoryPress}>
+            <TouchableOpacity onPress={onStoryPress} hitSlop={PILL_HIT_SLOP}>
               <BadgeChip label={storyActName} color={testament.ot} />
             </TouchableOpacity>
           )}
@@ -68,6 +75,7 @@ export function ChapterHeader({
           {noteCount > 0 && (
             <TouchableOpacity
               onPress={onNotesPress}
+              hitSlop={PILL_HIT_SLOP}
               accessibilityLabel={`${noteCount} notes`}
               accessibilityRole="button"
             >

--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -25,6 +25,7 @@ import { RelatedContentCarousel } from './RelatedContentCarousel';
 import { MapChip } from './map/MapChip';
 import { PanelInfoSheet } from './PanelInfoSheet';
 import RelatedLifeTopics from './RelatedLifeTopics';
+import { GoldSeparator } from './GoldSeparator';
 
 export interface ChapterMeta {
   timeline_link_event?: string | null;
@@ -66,8 +67,22 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
   }, [navigation]);
 
   const sectionElements = useMemo(() => {
-    return sections.flatMap((sec) => {
-      const elements: React.ReactNode[] = [
+    return sections.flatMap((sec, secIdx) => {
+      const elements: React.ReactNode[] = [];
+
+      // Gold separator between SectionBlocks (not before the first one).
+      // Card #1362: replaces the hard bottom border previously on SectionBlock.
+      if (secIdx > 0) {
+        elements.push(
+          <GoldSeparator
+            key={`sep-${sec.id}`}
+            marginTop={spacing.md}
+            marginBottom={spacing.md}
+          />,
+        );
+      }
+
+      elements.push(
         <View
           key={sec.id}
           onLayout={(e) => {
@@ -131,7 +146,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
             )}
           />
         </View>,
-      ];
+      );
 
       // Inject coaching card after this section if applicable (hidden in focus mode)
       if (!display.focusMode && coaching.studyCoachEnabled && coaching.coachingTips.length > 0) {

--- a/app/src/components/SectionBlock.tsx
+++ b/app/src/components/SectionBlock.tsx
@@ -8,7 +8,7 @@
 
 import React, { useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { useTheme, spacing } from '../theme';
+import { spacing } from '../theme';
 import type { Section, SectionPanel, Verse, VHLGroup, ParsedRef } from '../types';
 import { SectionHeader } from './SectionHeader';
 import { VerseBlock } from './VerseBlock';
@@ -56,8 +56,6 @@ function SectionBlock({
   comparisonVerses, comparisonLabel, primaryLabel,
   redLetterVerses, onVerseLayout, highlightMap,
 }: Props) {
-  const { base } = useTheme();
-
   // Filter verses for this section
   const sectionVerses = verses.filter(
     (v) => v.verse_num >= section.verse_start && v.verse_num <= section.verse_end
@@ -88,7 +86,7 @@ function SectionBlock({
       : null;
 
   return (
-    <View style={[styles.container, { borderBottomColor: base.border + '60' }]}>
+    <View style={styles.container}>
       <SectionHeader header={section.header} explored={depthExplored} total={depthTotal} />
 
       <VerseBlock
@@ -126,7 +124,6 @@ export default MemoizedSectionBlock;
 
 const styles = StyleSheet.create({
   container: {
-    borderBottomWidth: 1,
     paddingBottom: spacing.sm,
   },
 });

--- a/app/src/components/SectionHeader.tsx
+++ b/app/src/components/SectionHeader.tsx
@@ -1,6 +1,10 @@
 /**
- * SectionHeader — Cinzel heading with gold accent and bottom border.
+ * SectionHeader — Cinzel heading with 3px gold bar accent.
  * Optional DepthDots indicator right-aligned when depth data provided.
+ *
+ * Card #1362 (UI polish phase 5): replaces the hard bottom-border with a
+ * left-side 3px gold bar accent, matching ScreenHeader / BrowseSectionHeader.
+ * GoldSeparator is rendered between SectionBlocks in the list itself.
  */
 
 import React from 'react';
@@ -17,7 +21,8 @@ interface Props {
 function SectionHeader({ header, explored, total }: Props) {
   const { base } = useTheme();
   return (
-    <View style={[styles.container, { borderBottomColor: base.border }]} accessibilityRole="header">
+    <View style={styles.container} accessibilityRole="header">
+      <View style={[styles.bar, { backgroundColor: base.gold }]} />
       <Text style={[styles.text, { color: base.gold }]} numberOfLines={2}>{header}</Text>
       {total != null && total > 0 ? (
         <View style={styles.depthWrap}>
@@ -35,18 +40,23 @@ export default MemoizedSectionHeader;
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    borderBottomWidth: 1,
     paddingHorizontal: spacing.md,
-    paddingTop: 32,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.sm,
+  },
+  bar: {
+    width: 3,
+    alignSelf: 'stretch',
+    minHeight: 16,
+    marginRight: spacing.sm,
+    borderRadius: 1.5,
   },
   text: {
     fontFamily: fontFamily.displayMedium,
     fontSize: 13,
     lineHeight: 20,
-    letterSpacing: 0.3,
+    letterSpacing: 0.4,
     flex: 1,
     marginRight: spacing.sm,
   },

--- a/app/src/components/VerseBlock.tsx
+++ b/app/src/components/VerseBlock.tsx
@@ -46,7 +46,9 @@ export const VerseBlock = React.memo(function VerseBlock({
   const { base } = useTheme();
   if (!verses.length) return null;
 
-  const lineHeight = fontSize * 1.6;
+  // Card #1362: 1.7× line-height per spec (was 1.6×) — improves reading ergonomics
+  // at the default 16px / 1.125× dynamic-type bump scales.
+  const lineHeight = fontSize * 1.7;
   const numSize = Math.max(11, fontSize * 0.65);
   const isComparing = !!comparisonVerses && comparisonVerses.length > 0;
 
@@ -143,7 +145,10 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   verseNum: {
-    fontFamily: fontFamily.display,
+    // Card #1362: verse numbers in uiMedium (was fontFamily.display) so the
+    // numbers read as UI chrome, not as mini-display type. Color is set inline
+    // to base.verseNum which is already the muted value.
+    fontFamily: fontFamily.uiMedium,
     marginRight: 4,
     minWidth: 28,
     textAlign: 'right',

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -12,6 +12,7 @@
 
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, Platform, UIManager, StyleSheet } from 'react-native';
+import { ChevronRight } from 'lucide-react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import type { Book } from '../types';
@@ -351,6 +352,23 @@ function ChapterScreen() {
             } : null}
           />
         </ChapterReaderProvider>
+
+        {/* Card #1362: subtle next-chapter hint at the bottom of the scroll.
+            Duplicates the swipe-next affordance for users who prefer tap. */}
+        {hasNext && (
+          <TouchableOpacity
+            onPress={goNext}
+            activeOpacity={0.7}
+            style={styles.nextChapterHint}
+            accessibilityRole="button"
+            accessibilityLabel={`Next chapter — ${bookData?.name ?? bookId} ${chapterNum + 1}`}
+          >
+            <Text style={[styles.nextChapterText, { color: base.textMuted }]}>
+              {`Next: ${bookData?.name ?? bookId} ${chapterNum + 1}`}
+            </Text>
+            <ChevronRight size={14} color={base.gold} />
+          </TouchableOpacity>
+        )}
       </ScrollView>
 
       {ttsHook.ttsActive && (
@@ -441,6 +459,19 @@ const styles = StyleSheet.create({
     marginBottom: spacing.xs,
   },
   lensGuidanceText: { fontFamily: fontFamily.ui, fontSize: 13, lineHeight: 20 },
+  nextChapterHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.md,
+  },
+  nextChapterText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    letterSpacing: 0.3,
+  },
 });
 
 export default withErrorBoundary(ChapterScreen);


### PR DESCRIPTION
Phase 5 of 7 of the Glorify-level UI polish plan (parent #1269, spec #1362). ChapterScreen is where ~90% of study time happens, so changes here are surgical and conservative — no scroll-behavior or panel-content edits.

## Summary

### `ChapterHeader`
The title block already used Cinzel (`displaySemiBold`) + EB Garamond italic subtitle + spec-compliant padding from prior work. This PR just adds a shared `hitSlop` to the pill `TouchableOpacity`s so the timeline / map / story / notes chips have ~44px effective touch targets without changing their visual size (`BadgeChip` is shared across screens).

### `SectionHeader`
- Replaced the hard bottom-border with a 3px gold left bar accent (matches `ScreenHeader` / `BrowseSectionHeader` / `DetailSectionTitle`).
- Increased top padding to `spacing.lg` so sections breathe.

### `SectionBlock` + `ChapterVerseList`
The inter-section divider is now a `GoldSeparator` rendered between adjacent `SectionBlock`s in the list itself (not a hairline on the block container). Same "section ended here" cue, softer and branded.

### `VerseBlock`
- Verse line-height bumped 1.6× → 1.7× per spec — improved reading ergonomics at 16px / dynamic-type bump scales.
- Verse numbers switched from `display` (Cinzel) to `uiMedium` so they read as UI chrome rather than mini-display type.

### `ChapterScreen`
- New subtle "Next: {BookName} {N+1}" tap target at the bottom of the scroll, with a gold chevron. Mirrors the existing swipe affordance for users who prefer tap, and gives the scroll a visible end. Only rendered when `hasNext`.

### Deliberately NOT touched
Per the card spec's explicit constraints on this screen:
- ScrollView behavior / scroll-restoration
- Panel expand / collapse logic
- `PanelContainer` internals
- `PanelRenderer` / panel content rendering

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npx jest` — 429/429 suites, 3209/3209 tests passing
- [ ] Smoke-check on iOS + Android — critical screen, scroll behavior must not regress
- [ ] Verify section-header gold bar + gold separator reads correctly in dark / sepia / light
- [ ] Verify `hitSlop` on header pills doesn't create accidental overlap with the subtitle text
- [ ] Read through a long chapter (e.g. Psalm 119, 1 Corinthians 13) and confirm line-height feels more comfortable, not sparse
- [ ] Tap the new "Next: ..." chip at the bottom of the scroll and confirm it advances the chapter without disrupting scroll-position restoration when coming back

https://claude.ai/code/session_01GZ9uZpqxF3yTMHp6L1rUx5