### PR TITLE
UI polish 6/7 — BookListScreen + ChapterListScreen picker flow (#1363)

### DIFF
--- a/app/__tests__/screens/ChapterListScreen.test.tsx
+++ b/app/__tests__/screens/ChapterListScreen.test.tsx
@@ -25,6 +25,7 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('lucide-react-native', () => ({
   ArrowRight: () => null,
+  Check: () => null,
 }));
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/app/src/screens/BookListScreen.tsx
+++ b/app/src/screens/BookListScreen.tsx
@@ -6,6 +6,14 @@
  *
  * Segment toggle replaces the old dropdown. Search bar filters across
  * both modes. Per-book progress bars show reading completion.
+ *
+ * Card #1363 (UI polish phase 6):
+ *   - Book rows now render as parchment-tinted cards with a 10% gold
+ *     border (shared browseCardStyle pattern), Cinzel book name.
+ *   - Testament toggle uses the shared BrowseFilterPill for visual
+ *     consistency with browse screens.
+ *   - Completed books show a gold checkmark instead of the "N/M" fraction.
+ *   - Genre section headers use BrowseSectionHeader (Cinzel + gold bar).
  */
 
 import React, { useState, useMemo, useRef, useCallback } from 'react';
@@ -13,11 +21,17 @@ import { View, Text, TouchableOpacity, SectionList, FlatList, StyleSheet } from 
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { useScrollToTop } from '@react-navigation/native';
+import { Check } from 'lucide-react-native';
 import type { ScreenNavProp } from '../navigation/types';
 import { useBooks, type BookWithProgress } from '../hooks/useBooks';
 import { useSettingsStore } from '../stores';
 import { SearchInput } from '../components/SearchInput';
-import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import {
+  browseCardStyle,
+  BrowseFilterPill,
+  BrowseSectionHeader,
+} from '../components/BrowseScreenTemplate';
+import { useTheme, spacing, fontFamily } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 // ── Tradition groupings (by book_order index) ────────────────────
@@ -42,33 +56,38 @@ const BookRow = React.memo(function BookRow({ book, onPress, base }: {
   onPress: (bookId: string) => void;
   base: ReturnType<typeof useTheme>['base'];
 }) {
+  const isComplete = book.chaptersRead >= book.total_chapters && book.total_chapters > 0;
+  const inProgress = book.chaptersRead > 0 && !isComplete;
+  const cardStyle = browseCardStyle(base);
   return (
     <TouchableOpacity
       onPress={() => onPress(book.id)}
-      style={[styles.bookRow, { borderBottomColor: base.border + '40' }]}
+      style={[styles.bookRowTouch, cardStyle]}
       accessibilityRole="button"
       accessibilityLabel={`${book.name}, ${book.chaptersRead > 0 ? `${book.chaptersRead} of ${book.total_chapters} chapters read` : `${book.total_chapters} chapters`}`}
     >
-      <View style={styles.bookRowContent}>
-        <View style={styles.bookRowHeader}>
-          <Text style={[styles.bookName, { color: base.text }, !book.is_live && { color: base.textMuted }]}>
-            {book.name}
-          </Text>
+      <View style={styles.bookRowHeader}>
+        <Text style={[styles.bookName, { color: base.gold }, !book.is_live && { color: base.textMuted }]}>
+          {book.name}
+        </Text>
+        {isComplete ? (
+          <Check size={14} color={base.gold} />
+        ) : (
           <Text style={[styles.chapterCount, { color: base.textMuted }]}>
-            {book.chaptersRead > 0
+            {inProgress
               ? `${book.chaptersRead}/${book.total_chapters}`
               : `${book.total_chapters} ch`}
           </Text>
-        </View>
-        {book.chaptersRead > 0 && (
-          <View style={[styles.progressTrack, { backgroundColor: base.border }]}>
-            <View style={[
-              styles.progressFill,
-              { width: `${(book.chaptersRead / book.total_chapters) * 100}%`, backgroundColor: base.gold + '50' },
-            ]} />
-          </View>
         )}
       </View>
+      {inProgress && (
+        <View style={[styles.progressTrack, { backgroundColor: base.border + '80' }]}>
+          <View style={[
+            styles.progressFill,
+            { width: `${(book.chaptersRead / book.total_chapters) * 100}%`, backgroundColor: base.gold },
+          ]} />
+        </View>
+      )}
     </TouchableOpacity>
   );
 });
@@ -137,13 +156,18 @@ function BookListScreen() {
       {/* OT/NT toggle (canonical mode only, no search) */}
       {mode === 'canonical' && !searchResults && (
         <View style={styles.testamentRow}>
-          {(['ot', 'nt'] as const).map((t) => (
-            <TouchableOpacity key={t} onPress={() => setTestament(t)} accessibilityRole="button" accessibilityLabel={t === 'ot' ? 'Old Testament' : 'New Testament'} accessibilityState={{ selected: testament === t }}>
-              <Text style={[styles.testamentLabel, { color: base.textMuted }, testament === t && [styles.testamentActive, { color: base.gold, borderBottomColor: base.gold }]]}>
-                {t === 'ot' ? 'Old Testament' : 'New Testament'}
-              </Text>
-            </TouchableOpacity>
-          ))}
+          <BrowseFilterPill
+            label="Old Testament"
+            active={testament === 'ot'}
+            onPress={() => setTestament('ot')}
+            role="tab"
+          />
+          <BrowseFilterPill
+            label="New Testament"
+            active={testament === 'nt'}
+            onPress={() => setTestament('nt')}
+            role="tab"
+          />
         </View>
       )}
 
@@ -190,11 +214,7 @@ function BookListScreen() {
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.listContent}
           renderSectionHeader={({ section }) => (
-            <View style={[styles.sectionHeader, { backgroundColor: base.bg }]}>
-              <Text style={[styles.sectionTitle, { color: base.textMuted }]}>
-                {section.title.toUpperCase()}
-              </Text>
-            </View>
+            <BrowseSectionHeader title={section.title.toUpperCase()} />
           )}
           renderItem={renderBookRow}
         />
@@ -234,42 +254,22 @@ const styles = StyleSheet.create({
   testamentRow: {
     flexDirection: 'row',
     paddingHorizontal: spacing.md,
-    gap: spacing.md,
+    gap: spacing.sm,
     marginBottom: spacing.sm,
-  },
-  testamentLabel: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 12,
-    paddingBottom: 3,
-  },
-  testamentActive: {
-    borderBottomWidth: 2,
   },
   searchRow: {
     paddingHorizontal: spacing.md,
     marginBottom: spacing.sm,
   },
   listContent: {
+    paddingHorizontal: spacing.md,
     paddingBottom: spacing.xxl,
   },
-  sectionHeader: {
+  bookRowTouch: {
+    // Card #1363: layered on top of browseCardStyle() (parchment tint + gold border).
+    // Padding overridden to preserve the compact vertical rhythm for long lists.
+    paddingVertical: spacing.sm,
     paddingHorizontal: spacing.md,
-    paddingTop: spacing.md,
-    paddingBottom: spacing.xs,
-  },
-  sectionTitle: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-    letterSpacing: 0.5,
-  },
-  bookRow: {
-    paddingHorizontal: spacing.md,
-    minHeight: MIN_TOUCH_TARGET,
-    justifyContent: 'center',
-    borderBottomWidth: 1,
-  },
-  bookRowContent: {
-    paddingVertical: 6,
   },
   bookRowHeader: {
     flexDirection: 'row',
@@ -277,10 +277,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   bookName: {
-    fontFamily: fontFamily.display,
-    fontSize: 14,
-  },
-  bookNameDim: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 15,
+    letterSpacing: 0.3,
   },
   chapterCount: {
     fontFamily: fontFamily.ui,
@@ -289,7 +288,8 @@ const styles = StyleSheet.create({
   progressTrack: {
     height: 2,
     borderRadius: 1,
-    marginTop: 4,
+    marginTop: spacing.xs,
+    overflow: 'hidden',
   },
   progressFill: {
     height: 2,

--- a/app/src/screens/ChapterListScreen.tsx
+++ b/app/src/screens/ChapterListScreen.tsx
@@ -4,13 +4,20 @@
  * Back button via ArrowLeft. No "· Live" label (dimmed chapters are
  * sufficient status indicator). Read progress shown as subtle background
  * tint on visited chapters. Difficulty dots shown beneath chapter number.
+ *
+ * Card #1363 (UI polish phase 6):
+ *   - Full-width tinted "About This Book" card in place of the small link.
+ *   - Chapter grid softer borders (8% gold), gold ring on the last-read
+ *     chapter, gold fill (+ checkmark) on completed chapters.
+ *   - New progress summary row above the grid: "X of Y chapters read"
+ *     with a gold progress bar.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { ArrowRight } from 'lucide-react-native';
+import { ArrowRight, Check } from 'lucide-react-native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { getBook, getDifficultyForBook } from '../db/content';
 import { getProgressForBook } from '../db/user';
@@ -27,17 +34,28 @@ function ChapterListScreen() {
   const { bookId } = route.params ?? {};
   const [book, setBook] = useState<Book | null>(null);
   const [visited, setVisited] = useState<Set<number>>(new Set());
+  const [lastRead, setLastRead] = useState<number | null>(null);
   const [difficulty, setDifficulty] = useState<Map<number, number>>(new Map());
 
   useEffect(() => {
     if (bookId) {
       getBook(bookId).then(setBook);
-      getProgressForBook(bookId).then((rows) =>
-        setVisited(new Set(rows.map((r) => r.chapter_num)))
-      );
+      getProgressForBook(bookId).then((rows) => {
+        setVisited(new Set(rows.map((r) => r.chapter_num)));
+        // Last-read: highest chapter number in the progress rows.
+        if (rows.length > 0) {
+          const maxCh = rows.reduce((m: number, r) => Math.max(m, r.chapter_num), 0);
+          setLastRead(maxCh);
+        }
+      });
       getDifficultyForBook(bookId).then(setDifficulty);
     }
   }, [bookId]);
+
+  const progressPct = useMemo(() => {
+    if (!book || book.total_chapters <= 0) return 0;
+    return Math.min(100, (visited.size / book.total_chapters) * 100);
+  }, [book, visited.size]);
 
   if (!book) return <View style={[styles.container, { backgroundColor: base.bg, justifyContent: 'center', alignItems: 'center' }]}><ActivityIndicator color={base.gold} /></View>;
 
@@ -53,21 +71,50 @@ function ChapterListScreen() {
           style={styles.headerSpacing}
         />
 
-        {/* About This Book */}
+        {/* Progress summary — only shown when user has started the book */}
+        {visited.size > 0 && (
+          <View style={styles.progressRow}>
+            <Text style={[styles.progressLabel, { color: base.textMuted }]}>
+              {`${visited.size} of ${book.total_chapters} chapters read`}
+            </Text>
+            <View style={[styles.progressTrack, { backgroundColor: base.border + '80' }]}>
+              <View
+                style={[
+                  styles.progressFill,
+                  { width: `${progressPct}%`, backgroundColor: base.gold },
+                ]}
+              />
+            </View>
+          </View>
+        )}
+
+        {/* About This Book — full-width tinted card */}
         <TouchableOpacity
           onPress={() => navigation.navigate('BookIntro', { bookId })}
-          style={styles.introLink}
+          style={[
+            styles.introCard,
+            {
+              backgroundColor: base.tintParchment,
+              borderColor: base.gold + '20',
+            },
+          ]}
           accessibilityLabel="About this book"
           accessibilityRole="button"
         >
-          <Text style={[styles.introLinkText, { color: base.gold }]}>About This Book</Text>
-          <ArrowRight size={13} color={base.gold} />
+          <View style={styles.introCardText}>
+            <Text style={[styles.introCardLabel, { color: base.gold }]}>About This Book</Text>
+            <Text style={[styles.introCardSubtitle, { color: base.textDim }]} numberOfLines={1}>
+              Genre, authorship, and key themes
+            </Text>
+          </View>
+          <ArrowRight size={16} color={base.gold} />
         </TouchableOpacity>
 
         {/* Chapter grid */}
         <View style={styles.grid}>
           {Array.from({ length: book.total_chapters }, (_, i) => i + 1).map((ch) => {
             const isVisited = visited.has(ch);
+            const isLastRead = ch === lastRead;
             const diff = difficulty.get(ch);
             return (
               <TouchableOpacity
@@ -76,8 +123,19 @@ function ChapterListScreen() {
                 disabled={!book.is_live}
                 style={[
                   styles.cell,
-                  { backgroundColor: base.bgElevated },
-                  isVisited && { backgroundColor: base.gold + '30' },
+                  {
+                    backgroundColor: base.bgElevated,
+                    borderColor: base.gold + '14', // ~8% opacity soft border
+                  },
+                  isVisited && {
+                    backgroundColor: base.gold + '22',
+                    borderColor: base.gold + '40',
+                  },
+                  isLastRead && {
+                    // Ring around the last-read chapter: thicker gold border.
+                    borderColor: base.gold,
+                    borderWidth: 2,
+                  },
                 ]}
               >
                 <Text style={[
@@ -87,6 +145,11 @@ function ChapterListScreen() {
                 ]}>
                   {ch}
                 </Text>
+                {isVisited && (
+                  <View style={styles.cellCheck} pointerEvents="none">
+                    <Check size={10} color={base.gold} />
+                  </View>
+                )}
                 {diff != null && diff > 1 && <DifficultyBadge level={diff} />}
               </TouchableOpacity>
             );
@@ -105,22 +168,53 @@ const styles = StyleSheet.create({
     padding: spacing.md,
   },
   headerSpacing: {
+    marginBottom: spacing.md,
+  },
+  progressRow: {
+    marginBottom: spacing.md,
+  },
+  progressLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.3,
     marginBottom: spacing.xs,
   },
-  introLink: {
+  progressTrack: {
+    height: 3,
+    borderRadius: 1.5,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: 3,
+    borderRadius: 1.5,
+  },
+  introCard: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 4,
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 2,
     marginBottom: spacing.lg,
   },
-  introLinkText: {
-    fontFamily: fontFamily.uiSemiBold,
-    fontSize: 13,
+  introCardText: {
+    flex: 1,
+  },
+  introCardLabel: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 14,
+    letterSpacing: 0.4,
+  },
+  introCardSubtitle: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 12,
+    marginTop: 2,
   },
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 4,
+    gap: 6,
   },
   cell: {
     width: MIN_TOUCH_TARGET,
@@ -128,10 +222,17 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: radii.sm,
+    borderWidth: 1,
+    position: 'relative',
   },
   cellText: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 14,
+  },
+  cellCheck: {
+    position: 'absolute',
+    top: 3,
+    right: 3,
   },
 });
 


### PR DESCRIPTION
Phase 6 of 7 of the Glorify-level UI polish plan (parent #1269, spec #1363). Polishes the primary navigation path into study content: `BookListScreen` and `ChapterListScreen`.

## Summary

### `BookListScreen`
- Book rows now render as parchment-tinted cards using the shared `browseCardStyle` from phase 2 (`tintParchment` bg, 10% gold border, `radii.lg`). Replaces the flat bottom-border row layout with individual cards per book, a 10–12px gap between them, and tighter vertical padding.
- Book name promoted to Cinzel `displayMedium` (was `fontFamily.display` 14px).
- Completed books (`chaptersRead === total_chapters`) now show a gold checkmark instead of "50/50" — cleaner completion affordance.
- OT / NT toggle migrated to `BrowseFilterPill` (`role="tab"`) for visual consistency with the browse screens.
- Genre-mode section headers use `BrowseSectionHeader` (Cinzel + gold bar) instead of the muted UI caps — matches `ScreenHeader` across the app.

### `ChapterListScreen`
- New progress summary row above the grid: "X of Y chapters read" with a gold progress bar. Only rendered when `visited.size > 0`.
- "About This Book" upgraded from a small inline link to a full-width parchment-tinted card with a gold label + italic subtitle + arrow. Harder to miss for first-time readers of a book.
- Chapter grid cells:
  - Added soft gold border (~8%) on unread cells
  - Clearer gold fill + gold checkmark badge on visited cells
  - 2px gold ring around the last-read chapter (visual "you are here" cue)

### Test updates
- `ChapterListScreen.test.tsx`: added `Check` icon to the `lucide-react-native` mock so the new completed-chapter checkmark renders as `null` in tests.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npx jest` — 429/429 suites, 3209/3209 tests passing
- [ ] Smoke-check BookListScreen canonical mode: completed books show checkmark, in-progress show "X/Y" + gold progress bar
- [ ] Smoke-check BookListScreen genre mode: Cinzel + gold-bar section headers ("LAW", "HISTORY", etc.)
- [ ] Smoke-check ChapterListScreen with partial progress: progress summary renders; last-read chapter has the gold ring; completed chapters have the checkmark
- [ ] Verify OT/NT pill widths don't wrap on narrow screens (pills are free-sized with `gap: spacing.sm`)
- [ ] Confirm dark / sepia / light theming for the new parchment cards and intro-card subtitle

https://claude.ai/code/session_01GZ9uZpqxF3yTMHp6L1rUx5