### PR TITLE
fix(notifications): sync daily verse push with homepage VOTD + enable tap-to-verse

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,7 +6,12 @@ import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { NavigationContainer, DarkTheme, DefaultTheme } from '@react-navigation/native';
+import {
+  NavigationContainer,
+  DarkTheme,
+  DefaultTheme,
+  createNavigationContainerRef,
+} from '@react-navigation/native';
 
 import { FONT_MAP, ThemeProvider, useTheme } from './src/theme';
 import { initDatabase } from './src/db/database';
@@ -14,14 +19,23 @@ import { initUserDatabase } from './src/db/userDatabase';
 import { useSettingsStore, useAuthStore, usePremiumStore } from './src/stores';
 import { pruneEvents } from './src/services/analytics';
 import { checkAndScheduleReengagement } from './src/services/reengagement';
+import { rescheduleIfStale } from './src/services/notifications';
 import { syncPremiumStatus } from './src/services/purchases';
 import { flushQueue } from './src/services/syncQueue';
 import { RootNavigator } from './src/navigation';
+import type { TabParamList } from './src/navigation/types';
+import { useNotificationRouter } from './src/hooks/useNotificationRouter';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
 import { ContentUpdateProvider } from './src/providers/ContentUpdateProvider';
 import { DbDownloadScreen } from './src/screens/DbDownloadScreen';
 import { Sentry, DSN } from './src/lib/sentry';
+
+/**
+ * Root navigation ref — shared with non-component code (notification tap
+ * handler) so taps can navigate without drilling props through the tree.
+ */
+const navigationRef = createNavigationContainerRef<TabParamList>();
 
 // Keep splash visible while we load
 SplashScreen.preventAutoHideAsync();
@@ -83,6 +97,9 @@ const linking: any = {
 function AppShell() {
   const { base: themeBase, mode, statusBarStyle } = useTheme();
 
+  // Install notification tap router (handles both cold-start and warm taps).
+  useNotificationRouter(navigationRef);
+
   const navTheme = useMemo(() => {
     const baseTheme = mode === 'dark' ? DarkTheme : DefaultTheme;
     return {
@@ -100,7 +117,7 @@ function AppShell() {
 
   return (
     <>
-      <NavigationContainer theme={navTheme} linking={linking}>
+      <NavigationContainer ref={navigationRef} theme={navTheme} linking={linking}>
         <ErrorBoundary>
           <RootNavigator />
         </ErrorBoundary>
@@ -137,13 +154,14 @@ function App() {
 
   const dbReady = dbStatus === 'ready';
 
-  // Re-engagement + premium sync: check on app foreground
+  // Re-engagement + premium sync + VOTD reschedule: check on app foreground
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'active' && dbReady) {
         checkAndScheduleReengagement();
         syncPremiumStatus();
         flushQueue(); // Sync any queued offline mutations
+        rescheduleIfStale(); // Extend VOTD rolling window if a day has passed
       }
     });
     return () => sub.remove();

--- a/app/__tests__/services/notifications.test.ts
+++ b/app/__tests__/services/notifications.test.ts
@@ -2,16 +2,22 @@
  * __tests__/services/notifications.test.ts
  *
  * Tests for the notifications service: permission requests,
- * daily verse scheduling, and cancellation.
+ * daily verse scheduling (rolling CALENDAR-triggered window),
+ * and scoped cancellation.
  */
 
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 
-// Mock the database module
-const mockGetFirstAsync = jest.fn();
-jest.mock('@/db/database', () => ({
-  getDb: () => ({ getFirstAsync: mockGetFirstAsync }),
+// Mock the user-preferences DB layer (replaces old getDb mock)
+jest.mock('@/db/user', () => ({
+  setPreference: jest.fn().mockResolvedValue(undefined),
+  getPreference: jest.fn().mockResolvedValue(null),
+}));
+
+// Mock the verse-of-day module so we control what verse is returned
+jest.mock('@/utils/verseOfDay', () => ({
+  getVerseForDate: jest.fn(),
 }));
 
 // Mock the icon asset require (used inside scheduleDailyVerse)
@@ -22,17 +28,37 @@ import {
   scheduleDailyVerse,
   cancelAllNotifications,
 } from '@/services/notifications';
+import { setPreference } from '@/db/user';
+import { getVerseForDate } from '@/utils/verseOfDay';
+
+const sampleVerse = {
+  ref: 'Genesis 1:1',
+  bookId: 'genesis',
+  chapter: 1,
+  verseNum: 1,
+  text: 'In the beginning God created the heavens and the earth.',
+};
 
 describe('notifications service', () => {
   const mockRequestPermissions = Notifications.requestPermissionsAsync as jest.Mock;
   const mockSetChannel = Notifications.setNotificationChannelAsync as jest.Mock;
   const mockSchedule = Notifications.scheduleNotificationAsync as jest.Mock;
-  const mockCancelAll = Notifications.cancelAllScheduledNotificationsAsync as jest.Mock;
+  const mockGetAll = Notifications.getAllScheduledNotificationsAsync as jest.Mock;
+  const mockCancelOne = Notifications.cancelScheduledNotificationAsync as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+    // Set a deterministic "now": 2026-01-15 at 00:00 local time
+    jest.setSystemTime(new Date(2026, 0, 15, 0, 0, 0));
     mockRequestPermissions.mockResolvedValue({ status: 'granted' });
+    mockGetAll.mockResolvedValue([]);
+    (getVerseForDate as jest.Mock).mockReturnValue(sampleVerse);
     (Platform as any).OS = 'ios';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   // ── requestPermission ──────────────────────────────────────────
@@ -71,65 +97,78 @@ describe('notifications service', () => {
   // ── scheduleDailyVerse ─────────────────────────────────────────
 
   describe('scheduleDailyVerse', () => {
-    const sampleVerse = {
-      book_id: 'GEN',
-      chapter_num: 1,
-      verse_num: 1,
-      text: 'In the beginning God created the heaven and the earth.',
-    };
-
-    it('cancels existing notifications first', async () => {
-      mockGetFirstAsync.mockResolvedValue(sampleVerse);
+    it('cancels existing VOTD notifications before scheduling', async () => {
+      mockGetAll.mockResolvedValue([
+        { identifier: 'votd-2026-01-10' },
+        { identifier: 'reengagement-nudge' },
+        { identifier: 'votd-2026-01-11' },
+      ]);
       await scheduleDailyVerse(8, 0);
-      expect(mockCancelAll).toHaveBeenCalled();
+
+      // Only the votd-* notifications should be cancelled
+      expect(mockCancelOne).toHaveBeenCalledWith('votd-2026-01-10');
+      expect(mockCancelOne).toHaveBeenCalledWith('votd-2026-01-11');
+      expect(mockCancelOne).not.toHaveBeenCalledWith('reengagement-nudge');
     });
 
     it('schedules with correct hour and minute', async () => {
-      mockGetFirstAsync.mockResolvedValue(sampleVerse);
       await scheduleDailyVerse(9, 30);
-      expect(mockSchedule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          trigger: expect.objectContaining({ hour: 9, minute: 30 }),
-        }),
-      );
+
+      expect(mockSchedule).toHaveBeenCalled();
+      const firstCall = mockSchedule.mock.calls[0][0];
+      expect(firstCall.trigger).toMatchObject({
+        hour: 9,
+        minute: 30,
+        second: 0,
+        repeats: false,
+      });
     });
 
     it('truncates long verse text at 147 chars with ellipsis', async () => {
       const longText = 'A'.repeat(200);
-      mockGetFirstAsync.mockResolvedValue({
-        ...sampleVerse,
-        text: longText,
-      });
+      (getVerseForDate as jest.Mock).mockReturnValue({ ...sampleVerse, text: longText });
+
       await scheduleDailyVerse(8, 0);
 
       const call = mockSchedule.mock.calls[0][0];
-      const bodyText: string = call.content.body;
-      // Body starts with truncated text (147 chars + '...')
-      expect(bodyText.startsWith('A'.repeat(147) + '...')).toBe(true);
+      const bodyFirstLine: string = call.content.body.split('\n')[0];
+      // buildBody: slice(0, 150-3) + '...' = 147 A's + '...' = 150 chars
+      expect(bodyFirstLine).toBe('A'.repeat(147) + '...');
     });
 
     it('does not truncate short verse text', async () => {
-      mockGetFirstAsync.mockResolvedValue(sampleVerse);
       await scheduleDailyVerse(8, 0);
 
       const call = mockSchedule.mock.calls[0][0];
-      const bodyText: string = call.content.body;
-      expect(bodyText).toContain(sampleVerse.text);
+      expect(call.content.body).toContain(sampleVerse.text);
     });
 
-    it('returns early when no verse found', async () => {
-      mockGetFirstAsync.mockResolvedValue(null);
+    it('includes verseNum in notification data payload', async () => {
       await scheduleDailyVerse(8, 0);
-      expect(mockSchedule).not.toHaveBeenCalled();
+
+      const call = mockSchedule.mock.calls[0][0];
+      expect(call.content.data).toMatchObject({
+        type: 'daily_verse',
+        bookId: 'genesis',
+        chapterNum: 1,
+        verseNum: 1,
+      });
     });
   });
 
   // ── cancelAllNotifications ─────────────────────────────────────
 
   describe('cancelAllNotifications', () => {
-    it('calls cancelAllScheduledNotificationsAsync', async () => {
+    it('cancels scoped VOTD notifications and clears last-scheduled preference', async () => {
+      mockGetAll.mockResolvedValue([
+        { identifier: 'votd-2026-01-15' },
+        { identifier: 'reengagement-nudge' },
+      ]);
       await cancelAllNotifications();
-      expect(mockCancelAll).toHaveBeenCalled();
+
+      expect(mockCancelOne).toHaveBeenCalledWith('votd-2026-01-15');
+      expect(mockCancelOne).not.toHaveBeenCalledWith('reengagement-nudge');
+      expect(setPreference).toHaveBeenCalledWith('votd_last_scheduled_date', '');
     });
   });
 });

--- a/app/__tests__/unit/dbNotifications.test.ts
+++ b/app/__tests__/unit/dbNotifications.test.ts
@@ -1,36 +1,62 @@
 /**
- * Unit tests for services/notifications.ts — push notification scheduling.
+ * Unit tests for services/notifications.ts — daily verse notification scheduling.
  *
- * expo-notifications is already mocked in jest.setup.js.
- * We mock getDb() to control verse query results.
+ * expo-notifications is mocked with the functions the rewritten service uses
+ * (CALENDAR triggers, scoped cancellation, getAllScheduled).
+ * The verse source is now getVerseForDate (pure, no DB), so we mock that.
  */
 
-// Extend the expo-notifications mock with enums the source code references
+// Extend the expo-notifications mock with enums + scoped-cancellation APIs
 jest.mock('expo-notifications', () => ({
   requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
   scheduleNotificationAsync: jest.fn(),
-  cancelAllScheduledNotificationsAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: jest.fn().mockResolvedValue([]),
+  cancelScheduledNotificationAsync: jest.fn(),
   setNotificationHandler: jest.fn(),
   setNotificationChannelAsync: jest.fn(),
-  SchedulableTriggerInputTypes: { DAILY: 'daily' },
+  SchedulableTriggerInputTypes: { DAILY: 'daily', CALENDAR: 'calendar' },
   AndroidImportance: { DEFAULT: 3 },
 }));
 
-jest.mock('@/db/database', () => require('../helpers/mockDb').mockDatabaseModule());
+// Mock user preferences DB layer (setPreference / getPreference)
+jest.mock('@/db/user', () => ({
+  setPreference: jest.fn().mockResolvedValue(undefined),
+  getPreference: jest.fn().mockResolvedValue(null),
+}));
+
+// Mock the verse-of-day module so we control what verse is returned
+jest.mock('@/utils/verseOfDay', () => ({
+  getVerseForDate: jest.fn(),
+}));
 
 import * as Notifications from 'expo-notifications';
-import { getMockDb, resetMockDb } from '../helpers/mockDb';
 import {
   requestPermission,
   scheduleDailyVerse,
   cancelAllNotifications,
 } from '@/services/notifications';
+import { setPreference } from '@/db/user';
+import { getVerseForDate } from '@/utils/verseOfDay';
 
-const mockDb = getMockDb();
+const sampleVerse = {
+  ref: 'Psalm 23:1',
+  bookId: 'psalms',
+  chapter: 23,
+  verseNum: 1,
+  text: 'The Lord is my shepherd; I shall not want.',
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
-  resetMockDb();
+  jest.useFakeTimers();
+  // Set a deterministic "now": 2026-01-15 at 00:00 local time
+  jest.setSystemTime(new Date(2026, 0, 15, 0, 0, 0));
+  (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+  (getVerseForDate as jest.Mock).mockReturnValue(sampleVerse);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 describe('requestPermission', () => {
@@ -57,64 +83,69 @@ describe('requestPermission', () => {
 });
 
 describe('scheduleDailyVerse', () => {
-  it('cancels existing notifications and schedules a new one with correct trigger', async () => {
-    const fakeVerse = {
-      book_id: 'psalms',
-      chapter_num: 23,
-      verse_num: 1,
-      text: 'The Lord is my shepherd; I shall not want.',
-    };
-    mockDb.getFirstAsync.mockResolvedValueOnce(fakeVerse);
+  it('cancels existing VOTD notifications and schedules with CALENDAR triggers', async () => {
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+      { identifier: 'votd-2026-01-10' },
+      { identifier: 'reengagement-nudge' },
+    ]);
 
     await scheduleDailyVerse(8, 30);
 
-    expect(Notifications.cancelAllScheduledNotificationsAsync).toHaveBeenCalled();
-    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.objectContaining({
-          title: 'Verse of the Day',
-          body: expect.stringContaining('The Lord is my shepherd'),
-        }),
-        trigger: expect.objectContaining({
-          type: Notifications.SchedulableTriggerInputTypes.DAILY,
-          hour: 8,
-          minute: 30,
-        }),
-      }),
-    );
+    // Scoped cancel: only votd-* identifiers
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('votd-2026-01-10');
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalledWith('reengagement-nudge');
+
+    // Should have scheduled notifications with CALENDAR triggers
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    const firstCall = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
+    expect(firstCall.content).toMatchObject({
+      title: 'Verse of the Day',
+      body: expect.stringContaining('The Lord is my shepherd'),
+    });
+    expect(firstCall.trigger).toMatchObject({
+      hour: 8,
+      minute: 30,
+    });
   });
 
-  it('does not schedule when no verse is found', async () => {
-    mockDb.getFirstAsync.mockResolvedValueOnce(null);
-
+  it('includes verseNum in notification data payload', async () => {
     await scheduleDailyVerse(9, 0);
 
-    expect(Notifications.cancelAllScheduledNotificationsAsync).toHaveBeenCalled();
-    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    const firstCall = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
+    expect(firstCall.content.data).toMatchObject({
+      type: 'daily_verse',
+      bookId: 'psalms',
+      chapterNum: 23,
+      verseNum: 1,
+    });
   });
 
   it('truncates long verse text to 150 characters', async () => {
     const longText = 'A'.repeat(200);
-    mockDb.getFirstAsync.mockResolvedValueOnce({
-      book_id: 'genesis',
-      chapter_num: 1,
-      verse_num: 1,
+    (getVerseForDate as jest.Mock).mockReturnValue({
+      ...sampleVerse,
       text: longText,
     });
 
     await scheduleDailyVerse(7, 0);
 
     const call = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
-    // Body should start with truncated text (147 chars + '...')
+    const bodyFirstLine = call.content.body.split('\n')[0];
+    // buildBody: slice(0, 150-3) + '...' = 147 A's + '...' = 150 chars
     expect(call.content.body).toContain('...');
-    expect(call.content.body.split('\n')[0].length).toBeLessThanOrEqual(150);
+    expect(bodyFirstLine.length).toBeLessThanOrEqual(150);
   });
 });
 
 describe('cancelAllNotifications', () => {
-  it('calls cancelAllScheduledNotificationsAsync', async () => {
+  it('cancels scoped VOTD notifications and clears preference', async () => {
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+      { identifier: 'votd-2026-01-15' },
+    ]);
+
     await cancelAllNotifications();
 
-    expect(Notifications.cancelAllScheduledNotificationsAsync).toHaveBeenCalledTimes(1);
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('votd-2026-01-15');
+    expect(setPreference).toHaveBeenCalledWith('votd_last_scheduled_date', '');
   });
 });

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -48,10 +48,14 @@ jest.mock('expo-notifications', () => ({
   getExpoPushTokenAsync: jest.fn().mockResolvedValue({ data: 'ExponentPushToken[xxx]' }),
   scheduleNotificationAsync: jest.fn(),
   cancelAllScheduledNotificationsAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: jest.fn().mockResolvedValue([]),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getLastNotificationResponseAsync: jest.fn().mockResolvedValue(null),
+  addNotificationResponseReceivedListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
   setNotificationHandler: jest.fn(),
   setNotificationChannelAsync: jest.fn(),
   AndroidImportance: { DEFAULT: 3, HIGH: 4, LOW: 2 },
-  SchedulableTriggerInputTypes: { DAILY: 'daily', TIME_INTERVAL: 'timeInterval' },
+  SchedulableTriggerInputTypes: { DAILY: 'daily', TIME_INTERVAL: 'timeInterval', CALENDAR: 'calendar' },
 }));
 
 // Mock expo-sqlite — used by db/database.ts and db/userDatabase.ts

--- a/app/src/hooks/chapter/useChapterScroll.ts
+++ b/app/src/hooks/chapter/useChapterScroll.ts
@@ -80,32 +80,75 @@ export function useChapterScroll({
     }
   }, [activePanel]);
 
-  // Auto-scroll to a specific verse when navigated with verseNum param
+  // Auto-scroll to a specific verse when navigated with verseNum param.
+  //
+  // RACE NOTES:
+  //   1. The previous version only scrolled via an effect that ran when
+  //      isLoading flipped to false. At that moment, React Native's onLayout
+  //      callbacks haven't fired yet, so verseYMap is empty and the scroll
+  //      was silently dropped. Layout callbacks don't trigger a re-render,
+  //      so the effect never retried.
+  //   2. onLayout order across nested views is not guaranteed — a verse's
+  //      onLayout can fire before its enclosing section's onLayout. If we
+  //      scrolled immediately using sectionY + verseY, sectionY might still
+  //      be 0 and the computed target would be wrong.
+  //
+  // Fix: track scroll as *pending* when the target is set. Attempt to flush
+  // from both handleVerseLayout and handleSectionLayout — whichever completes
+  // the picture last triggers the actual scroll. We require a non-zero
+  // sectionY to flush (scrolling to y=0 is what a zero-offset target looks
+  // like, and would be indistinguishable from an uninitialised section at
+  // the very top; we treat the top-of-chapter case as already-scrolled so
+  // flushing it is a no-op anyway).
   const scrolledToInitialVerse = useRef(false);
   useEffect(() => {
     scrolledToInitialVerse.current = false;
   }, [bookId, chapterNum]);
 
+  const tryFlushInitialScroll = useCallback((sectionId: string) => {
+    if (!initialVerseNum || scrolledToInitialVerse.current) return;
+    const sectionY = sectionYMap.current[sectionId];
+    const verseY = verseYMap.current[initialVerseNum];
+    // Need both pieces. verseYMap values are stored as (sectionY + verseRelative),
+    // so if section wasn't known at store time, verseY here is effectively just
+    // verseRelative. We re-derive from the refs rather than trusting a stale sum.
+    if (sectionY == null || verseY == null) return;
+    scrolledToInitialVerse.current = true;
+    const targetY = Math.max(0, verseY - 80);
+    // 50ms delay lets any remaining sibling layouts settle before animating.
+    setTimeout(() => {
+      scrollRef.current?.scrollTo({ y: targetY, animated: true });
+    }, 50);
+  }, [initialVerseNum]);
+
+  // Fast-path: if layout already happened (e.g. cached chapter), scroll now.
   useEffect(() => {
     if (!initialVerseNum || scrolledToInitialVerse.current || isLoading) return;
-    const y = verseYMap.current[initialVerseNum];
-    if (y != null) {
-      scrolledToInitialVerse.current = true;
-      setTimeout(() => {
-        scrollRef.current?.scrollTo({ y: Math.max(0, y - 80), animated: true });
-      }, 150);
+    // We don't know which section the verse is in; iterate and try each.
+    // Ref map is small (one key per section), so this is cheap.
+    for (const sectionId of Object.keys(sectionYMap.current)) {
+      tryFlushInitialScroll(sectionId);
+      if (scrolledToInitialVerse.current) break;
     }
-  }, [initialVerseNum, isLoading, versesLength]);
+  }, [initialVerseNum, isLoading, versesLength, tryFlushInitialScroll]);
 
   // Layout callbacks
   const handleSectionLayout = useCallback((sectionId: string, y: number) => {
     sectionYMap.current[sectionId] = y;
-  }, []);
+    // A section's position became known — if we were waiting on it for
+    // the initial verse scroll, try to flush now.
+    tryFlushInitialScroll(sectionId);
+  }, [tryFlushInitialScroll]);
 
   const handleVerseLayout = useCallback((verseNum: number, y: number, sectionId: string) => {
     const sectionY = sectionYMap.current[sectionId] ?? 0;
     verseYMap.current[verseNum] = sectionY + y;
-  }, []);
+
+    // The target verse just laid out — try to flush.
+    if (initialVerseNum === verseNum) {
+      tryFlushInitialScroll(sectionId);
+    }
+  }, [initialVerseNum, tryFlushInitialScroll]);
 
   const handleBtnRowLayout = useCallback((sectionId: string, _sectionY: number, rowY: number) => {
     const secY = sectionYMap.current[sectionId] ?? 0;

--- a/app/src/hooks/useHomeData.ts
+++ b/app/src/hooks/useHomeData.ts
@@ -3,6 +3,9 @@
  *
  * Loads content stats, recent chapters, reading stats, and verse of the day
  * in a single hook with unified loading state.
+ *
+ * Verse-of-the-day + holiday logic lives in utils/verseOfDay so the
+ * notification scheduler can share the exact same selection algorithm.
  */
 
 import { useState, useCallback } from 'react';
@@ -11,97 +14,12 @@ import { getContentStats, type ContentStats } from '../db/content';
 import { getRecentChapters, getReadingStats, type ReadingStats } from '../db/user';
 import type { RecentChapter } from '../types';
 import { logger } from '../utils/logger';
-import { computeMovableHolidays } from '../utils/computeMovableHolidays';
-import dailyEncouragements from '../data/dailyEncouragements';
-import { fixedHolidays, movableHolidays, type HolidayContent } from '../data/holidayOverrides';
-
-// ── Verse of the Day ───────────────────────────────────────────────
-
-interface VerseOfDay {
-  ref: string;
-  bookId: string;
-  chapter: number;
-  verseNum: number;
-  text: string;
-}
-
-/**
- * Curated list of well-known verses. The day-of-year modulo selects one
- * deterministically — no server needed, same verse all day for all users.
- */
-const FEATURED_VERSES: VerseOfDay[] = [
-  { ref: 'Genesis 1:1',      bookId: 'genesis',       chapter: 1,   verseNum: 1,  text: 'In the beginning God created the heavens and the earth.' },
-  { ref: 'Psalm 23:1',       bookId: 'psalms',        chapter: 23,  verseNum: 1,  text: 'The LORD is my shepherd, I lack nothing.' },
-  { ref: 'Proverbs 3:5',     bookId: 'proverbs',      chapter: 3,   verseNum: 5,  text: 'Trust in the LORD with all your heart and lean not on your own understanding.' },
-  { ref: 'Isaiah 40:31',     bookId: 'isaiah',        chapter: 40,  verseNum: 31, text: 'But those who hope in the LORD will renew their strength. They will soar on wings like eagles; they will run and not grow weary, they will walk and not be faint.' },
-  { ref: 'Jeremiah 29:11',   bookId: 'jeremiah',      chapter: 29,  verseNum: 11, text: 'For I know the plans I have for you, declares the LORD, plans to prosper you and not to harm you, plans to give you hope and a future.' },
-  { ref: 'Matthew 6:33',     bookId: 'matthew',       chapter: 6,   verseNum: 33, text: 'But seek first his kingdom and his righteousness, and all these things will be given to you as well.' },
-  { ref: 'Matthew 11:28',    bookId: 'matthew',       chapter: 11,  verseNum: 28, text: 'Come to me, all you who are weary and burdened, and I will give you rest.' },
-  { ref: 'John 1:1',         bookId: 'john',          chapter: 1,   verseNum: 1,  text: 'In the beginning was the Word, and the Word was with God, and the Word was God.' },
-  { ref: 'John 3:16',        bookId: 'john',          chapter: 3,   verseNum: 16, text: 'For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.' },
-  { ref: 'John 14:6',        bookId: 'john',          chapter: 14,  verseNum: 6,  text: 'Jesus answered, "I am the way and the truth and the life. No one comes to the Father except through me."' },
-  { ref: 'Romans 8:28',      bookId: 'romans',        chapter: 8,   verseNum: 28, text: 'And we know that in all things God works for the good of those who love him, who have been called according to his purpose.' },
-  { ref: 'Romans 12:2',      bookId: 'romans',        chapter: 12,  verseNum: 2,  text: 'Do not conform to the pattern of this world, but be transformed by the renewing of your mind.' },
-  { ref: 'Philippians 4:13', bookId: 'philippians',   chapter: 4,   verseNum: 13, text: 'I can do all this through him who gives me strength.' },
-  { ref: 'Philippians 4:6',  bookId: 'philippians',   chapter: 4,   verseNum: 6,  text: 'Do not be anxious about anything, but in every situation, by prayer and petition, with thanksgiving, present your requests to God.' },
-  { ref: 'Hebrews 11:1',     bookId: 'hebrews',       chapter: 11,  verseNum: 1,  text: 'Now faith is confidence in what we hope for and assurance about what we do not see.' },
-  { ref: 'James 1:5',        bookId: 'james',         chapter: 1,   verseNum: 5,  text: 'If any of you lacks wisdom, you should ask God, who gives generously to all without finding fault, and it will be given to you.' },
-  { ref: '2 Timothy 3:16',   bookId: '2_timothy',     chapter: 3,   verseNum: 16, text: 'All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness.' },
-  { ref: 'Psalm 119:105',    bookId: 'psalms',        chapter: 119, verseNum: 105, text: 'Your word is a lamp for my feet, a light on my path.' },
-  { ref: 'Isaiah 53:5',      bookId: 'isaiah',        chapter: 53,  verseNum: 5,  text: 'But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.' },
-  { ref: 'Micah 6:8',        bookId: 'micah',         chapter: 6,   verseNum: 8,  text: 'He has shown you, O mortal, what is good. And what does the LORD require of you? To act justly and to love mercy and to walk humbly with your God.' },
-  { ref: 'Lamentations 3:22–23', bookId: 'lamentations', chapter: 3, verseNum: 22, text: 'Because of the LORD\'s great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.' },
-  { ref: 'Deuteronomy 6:5',  bookId: 'deuteronomy',   chapter: 6,   verseNum: 5,  text: 'Love the LORD your God with all your heart and with all your soul and with all your strength.' },
-  { ref: 'Joshua 1:9',       bookId: 'joshua',        chapter: 1,   verseNum: 9,  text: 'Have I not commanded you? Be strong and courageous. Do not be afraid; do not be discouraged, for the LORD your God will be with you wherever you go.' },
-  { ref: 'Proverbs 16:3',    bookId: 'proverbs',      chapter: 16,  verseNum: 3,  text: 'Commit to the LORD whatever you do, and he will establish your plans.' },
-  { ref: 'Psalm 46:10',      bookId: 'psalms',        chapter: 46,  verseNum: 10, text: 'He says, "Be still, and know that I am God; I will be exalted among the nations, I will be exalted in the earth."' },
-  { ref: 'Exodus 14:14',     bookId: 'exodus',        chapter: 14,  verseNum: 14, text: 'The LORD will fight for you; you need only to be still.' },
-  { ref: 'Daniel 2:21',      bookId: 'daniel',        chapter: 2,   verseNum: 21, text: 'He changes times and seasons; he deposes kings and raises up others. He gives wisdom to the wise and knowledge to the discerning.' },
-  { ref: 'Matthew 5:16',     bookId: 'matthew',       chapter: 5,   verseNum: 16, text: 'In the same way, let your light shine before others, that they may see your good deeds and glorify your Father in heaven.' },
-  { ref: 'Psalm 27:1',       bookId: 'psalms',        chapter: 27,  verseNum: 1,  text: 'The LORD is my light and my salvation— whom shall I fear? The LORD is the stronghold of my life— of whom shall I be afraid?' },
-  { ref: 'Isaiah 41:10',     bookId: 'isaiah',        chapter: 41,  verseNum: 10, text: 'So do not fear, for I am with you; do not be dismayed, for I am your God. I will strengthen you and help you; I will uphold you with my righteous right hand.' },
-  { ref: 'Mark 10:27',       bookId: 'mark',          chapter: 10,  verseNum: 27, text: 'Jesus looked at them and said, "With man this is impossible, but not with God; all things are possible with God."' },
-];
-
-function getDayOfYear(): number {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 0);
-  const diff = now.getTime() - start.getTime();
-  return Math.floor(diff / (1000 * 60 * 60 * 24));
-}
-
-// ── Holiday detection ─────────────────────────────────────────────
-
-/** Cache movable holidays for the current year to avoid recomputing. */
-let _movableCache: { year: number; map: Map<string, string> } | null = null;
-
-function getTodayHoliday(): HolidayContent | null {
-  const now = new Date();
-  const mm = String(now.getMonth() + 1).padStart(2, '0');
-  const dd = String(now.getDate()).padStart(2, '0');
-  const key = `${mm}-${dd}`;
-
-  // Check fixed holidays first
-  if (fixedHolidays[key]) return fixedHolidays[key];
-
-  // Check movable holidays (compute once per year)
-  const year = now.getFullYear();
-  if (!_movableCache || _movableCache.year !== year) {
-    _movableCache = { year, map: computeMovableHolidays(year) };
-  }
-  const holidayId = _movableCache.map.get(key);
-  if (holidayId && movableHolidays[holidayId]) {
-    return movableHolidays[holidayId];
-  }
-
-  return null;
-}
-
-function getVerseOfDay(): VerseOfDay {
-  const holiday = getTodayHoliday();
-  if (holiday) return holiday.verse;
-  return FEATURED_VERSES[getDayOfYear() % FEATURED_VERSES.length];
-}
+import {
+  getVerseOfDay,
+  getHolidayForDate,
+  getEncouragementForDate,
+  type VerseOfDay,
+} from '../utils/verseOfDay';
 
 // ── Time-aware greeting ────────────────────────────────────────────
 
@@ -112,15 +30,16 @@ function getGreeting(): string {
   return 'Good Evening';
 }
 
-// ── Personal subtitle ───────────────────────────────────────────
+// ── Personal subtitle ──────────────────────────────────────────────
 
 function getSubtitle(readingStats: ReadingStats | null): string {
   if (!readingStats || readingStats.totalChapters === 0) {
     return 'Learn to read the Bible the way it was written';
   }
-  const holiday = getTodayHoliday();
+  // Holiday takes precedence; otherwise rotate through the encouragement pool.
+  const holiday = getHolidayForDate();
   if (holiday) return holiday.encouragement;
-  return dailyEncouragements[getDayOfYear() % dailyEncouragements.length];
+  return getEncouragementForDate();
 }
 
 // ── Hook ───────────────────────────────────────────────────────────

--- a/app/src/hooks/useNotificationRouter.ts
+++ b/app/src/hooks/useNotificationRouter.ts
@@ -1,0 +1,111 @@
+/**
+ * hooks/useNotificationRouter.ts — Route the user to the right screen when
+ * they tap a notification.
+ *
+ * Handles two cases:
+ *   1. Cold start — app was not running; iOS/Android launched it because the
+ *      user tapped a notification. We read `getLastNotificationResponseAsync`.
+ *   2. Warm tap — app is running (foreground or background). Handled by
+ *      `addNotificationResponseReceivedListener`.
+ *
+ * Navigation is performed via a NavigationContainerRef so the router is
+ * decoupled from any specific screen's hook tree.
+ */
+
+import { useEffect, useRef } from 'react';
+import * as Notifications from 'expo-notifications';
+import type { NavigationContainerRef } from '@react-navigation/native';
+import type { TabParamList } from '../navigation/types';
+import { logger } from '../utils/logger';
+
+interface DailyVerseTapPayload {
+  type: 'daily_verse';
+  bookId: string;
+  chapterNum: number;
+  verseNum?: number;
+}
+
+/** Narrow unknown notification data to our payload shape. */
+function parsePayload(data: unknown): DailyVerseTapPayload | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (d.type !== 'daily_verse') return null;
+  if (typeof d.bookId !== 'string' || typeof d.chapterNum !== 'number') return null;
+  const verseNum = typeof d.verseNum === 'number' ? d.verseNum : undefined;
+  return { type: 'daily_verse', bookId: d.bookId, chapterNum: d.chapterNum, verseNum };
+}
+
+/**
+ * Given a ready NavigationContainerRef, route a tap payload to the Chapter
+ * screen inside HomeTab with optional verseNum for scroll-to-verse.
+ */
+function routeTap(
+  navRef: NavigationContainerRef<TabParamList>,
+  payload: DailyVerseTapPayload,
+): void {
+  try {
+    navRef.navigate('HomeTab', {
+      screen: 'Chapter',
+      params: {
+        bookId: payload.bookId,
+        chapterNum: payload.chapterNum,
+        ...(payload.verseNum ? { verseNum: payload.verseNum } : {}),
+      },
+    });
+  } catch (err) {
+    logger.warn('useNotificationRouter', 'Navigation failed', err);
+  }
+}
+
+/**
+ * Install listeners + process cold-start tap. The navRef MUST be the one
+ * attached to the root NavigationContainer.
+ *
+ * Safe to mount before nav is ready — we poll `navRef.isReady()` a few
+ * times before handing off cold-start routing.
+ */
+export function useNotificationRouter(
+  navRef: NavigationContainerRef<TabParamList>,
+): void {
+  const coldStartHandled = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // ── Cold start: handle the tap that launched the app ──
+    async function handleColdStart(): Promise<void> {
+      if (coldStartHandled.current) return;
+      try {
+        const response = await Notifications.getLastNotificationResponseAsync();
+        const payload = parsePayload(response?.notification?.request?.content?.data);
+        if (!payload) return;
+
+        // Wait for the NavigationContainer to be ready (up to ~5s).
+        for (let i = 0; i < 50; i++) {
+          if (cancelled) return;
+          if (navRef.isReady()) break;
+          await new Promise((res) => setTimeout(res, 100));
+        }
+        if (!navRef.isReady() || cancelled) return;
+
+        coldStartHandled.current = true;
+        routeTap(navRef, payload);
+      } catch (err) {
+        logger.warn('useNotificationRouter', 'Cold-start handler failed', err);
+      }
+    }
+    handleColdStart();
+
+    // ── Warm tap: app running, user tapped a notification ──
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      const payload = parsePayload(response.notification.request.content.data);
+      if (!payload) return;
+      if (navRef.isReady()) routeTap(navRef, payload);
+    });
+
+    return () => {
+      cancelled = true;
+      sub.remove();
+    };
+  }, [navRef]);
+}

--- a/app/src/services/notifications.ts
+++ b/app/src/services/notifications.ts
@@ -1,11 +1,56 @@
 /**
- * services/notifications.ts — Push notification scheduling.
+ * services/notifications.ts — Daily Verse push notification scheduling.
+ *
+ * Why this is shaped the way it is:
+ *
+ *   iOS freezes scheduled local-notification content at the moment you schedule
+ *   it. A single DAILY trigger would show the *same* verse forever until the
+ *   user happened to reschedule. To keep the notification aligned with the
+ *   homepage Verse of the Day (which is deterministic per calendar date), we
+ *   pre-schedule a rolling window of N calendar-triggered notifications, each
+ *   with the correct verse for its date baked in.
+ *
+ *   iOS caps scheduled local notifications at 64 per app. We schedule up to
+ *   60 to leave headroom for the re-engagement nudge and any future slots.
+ *
+ * Cancellation is SCOPED to our own identifiers (`votd-YYYY-MM-DD`) so we
+ * do not wipe the reengagement-nudge notification managed elsewhere.
+ *
+ * Rescheduling is cheap on steady-state: the app calls rescheduleIfStale()
+ * on foreground, which no-ops unless the last schedule was more than a day
+ * ago (or settings changed).
  */
 
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
-import { getDb } from '../db/database';
+import { getPreference, setPreference } from '../db/user';
+import { getVerseForDate, type VerseOfDay } from '../utils/verseOfDay';
 import { logger } from '../utils/logger';
+
+// ── Tuning constants ──────────────────────────────────────────────
+
+/**
+ * Number of future days to pre-schedule. iOS allows 64 pending local
+ * notifications per app; we leave headroom for reengagement (1 slot) and
+ * any future scheduled features.
+ */
+const SCHEDULE_DAYS = 60;
+
+/** Max body length before we ellipsize. Conservative for cross-platform. */
+const MAX_BODY_LENGTH = 150;
+
+/** Prefix used for every VOTD notification identifier: `votd-YYYY-MM-DD`. */
+const VOTD_ID_PREFIX = 'votd-';
+
+// ── Preference keys (single place, not scattered string literals) ──
+
+const PREF_GRANTED = 'notifications_granted';
+const PREF_ENABLED = 'daily_verse_enabled';
+const PREF_HOUR = 'notification_hour';
+const PREF_MINUTE = 'notification_minute';
+const PREF_LAST_SCHEDULED = 'votd_last_scheduled_date';   // YYYY-MM-DD of last schedule run
+
+// ── Notification handler (foreground presentation) ─────────────────
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -15,6 +60,8 @@ Notifications.setNotificationHandler({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any),
 });
+
+// ── Permissions ────────────────────────────────────────────────────
 
 export async function requestPermission(): Promise<boolean> {
   const { status } = await Notifications.requestPermissionsAsync({
@@ -29,29 +76,154 @@ export async function requestPermission(): Promise<boolean> {
   return status === 'granted';
 }
 
-export async function scheduleDailyVerse(hour: number, minute: number): Promise<void> {
-  await Notifications.cancelAllScheduledNotificationsAsync();
-  try {
-    const verse = await getDb().getFirstAsync<{ book_id: string; chapter_num: number; verse_num: number; text: string }>(
-      "SELECT * FROM verses WHERE translation='kjv' ORDER BY RANDOM() LIMIT 1"
-    );
-    if (!verse) return;
-    const body = verse.text.length > 150 ? verse.text.slice(0, 147) + '...' : verse.text;
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const iconAsset = require('../../assets/images/icon-192.png');
-    await Notifications.scheduleNotificationAsync({
-      content: {
-        title: 'Verse of the Day',
-        body: `${body}\n— ${verse.book_id} ${verse.chapter_num}:${verse.verse_num}`,
-        data: { type: 'daily_verse', bookId: verse.book_id, chapterNum: verse.chapter_num },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ...(Platform.OS === 'android' ? { icon: iconAsset } : {}) as any,
-      },
-      trigger: { type: Notifications.SchedulableTriggerInputTypes.DAILY, hour, minute },
-    });
-  } catch (err) { logger.warn('notifications', 'Operation failed', err); }
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** ISO date key for a Date (local), used in identifiers + last-scheduled pref. */
+function dateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
+function idForDate(date: Date): string {
+  return `${VOTD_ID_PREFIX}${dateKey(date)}`;
+}
+
+/** Strip leading/trailing whitespace + ellipsize for the notification body. */
+function buildBody(verse: VerseOfDay): string {
+  const clean = verse.text.trim();
+  if (clean.length <= MAX_BODY_LENGTH) return clean;
+  return clean.slice(0, MAX_BODY_LENGTH - 3).trimEnd() + '...';
+}
+
+/**
+ * Cancel every pending notification whose identifier starts with our prefix.
+ * Scoped so it does not touch reengagement-nudge or any future unrelated IDs.
+ */
+async function cancelScheduledVotd(): Promise<void> {
+  try {
+    const pending = await Notifications.getAllScheduledNotificationsAsync();
+    await Promise.all(
+      pending
+        .filter((n) => typeof n.identifier === 'string' && n.identifier.startsWith(VOTD_ID_PREFIX))
+        .map((n) => Notifications.cancelScheduledNotificationAsync(n.identifier)),
+    );
+  } catch (err) {
+    logger.warn('notifications', 'Failed to cancel scoped VOTD notifications', err);
+  }
+}
+
+/**
+ * Produce the trigger Date for day `offset` from today at the user's chosen
+ * (hour, minute). Offset 0 = today if that time hasn't yet passed, else skipped
+ * (caller handles the skip).
+ */
+function triggerDate(now: Date, offsetDays: number, hour: number, minute: number): Date {
+  const t = new Date(now.getFullYear(), now.getMonth(), now.getDate() + offsetDays, hour, minute, 0, 0);
+  return t;
+}
+
+// ── Core scheduler ─────────────────────────────────────────────────
+
+/**
+ * Pre-schedule a rolling window of daily verse notifications, each containing
+ * the correct verse for its date per `getVerseForDate`.
+ *
+ * Idempotent: cancels our existing VOTD slots and re-creates them.
+ */
+export async function scheduleDailyVerse(hour: number, minute: number): Promise<void> {
+  try {
+    // Persist the user's choice — NotificationSettings already does this, but
+    // keep scheduleDailyVerse safe to call in isolation (e.g. foreground reschedule).
+    await setPreference(PREF_HOUR, String(hour));
+    await setPreference(PREF_MINUTE, String(minute));
+
+    await cancelScheduledVotd();
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const iconAsset = require('../../assets/images/icon-192.png');
+    const now = new Date();
+
+    let scheduledCount = 0;
+    for (let offset = 0; offset < SCHEDULE_DAYS; offset++) {
+      const fireAt = triggerDate(now, offset, hour, minute);
+
+      // Skip any target in the past (e.g. it's 8am, user picked 7am → today is already gone).
+      if (fireAt.getTime() <= now.getTime()) continue;
+
+      const verse = getVerseForDate(fireAt);
+      const body = `${buildBody(verse)}\n— ${verse.ref}`;
+
+      await Notifications.scheduleNotificationAsync({
+        identifier: idForDate(fireAt),
+        content: {
+          title: 'Verse of the Day',
+          body,
+          data: {
+            type: 'daily_verse',
+            bookId: verse.bookId,
+            chapterNum: verse.chapter,
+            verseNum: verse.verseNum,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(Platform.OS === 'android' ? { icon: iconAsset } : {}) as any,
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.CALENDAR,
+          year: fireAt.getFullYear(),
+          month: fireAt.getMonth() + 1, // CALENDAR trigger uses 1-indexed months
+          day: fireAt.getDate(),
+          hour: fireAt.getHours(),
+          minute: fireAt.getMinutes(),
+          second: 0,
+          repeats: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      });
+
+      scheduledCount++;
+    }
+
+    await setPreference(PREF_LAST_SCHEDULED, dateKey(now));
+    logger.info('notifications', `Scheduled ${scheduledCount} daily verse notifications`);
+  } catch (err) {
+    logger.warn('notifications', 'scheduleDailyVerse failed', err);
+  }
+}
+
+/**
+ * Foreground hook — call from AppState 'active'. If the user has daily
+ * verses enabled and our last schedule run is stale (different calendar day),
+ * re-run scheduleDailyVerse so the rolling window always covers the next
+ * ~60 days and always reflects today's selection algorithm.
+ */
+export async function rescheduleIfStale(): Promise<void> {
+  try {
+    const enabled = await getPreference(PREF_ENABLED);
+    const granted = await getPreference(PREF_GRANTED);
+    if (enabled !== '1' || granted !== '1') return;
+
+    const last = await getPreference(PREF_LAST_SCHEDULED);
+    const today = dateKey(new Date());
+    if (last === today) return; // already rescheduled today
+
+    const hour = parseInt((await getPreference(PREF_HOUR)) ?? '7', 10);
+    const minute = parseInt((await getPreference(PREF_MINUTE)) ?? '0', 10);
+    const safeHour = isNaN(hour) || hour < 0 || hour > 23 ? 7 : hour;
+    const safeMinute = isNaN(minute) || minute < 0 || minute > 59 ? 0 : minute;
+
+    await scheduleDailyVerse(safeHour, safeMinute);
+  } catch (err) {
+    logger.warn('notifications', 'rescheduleIfStale failed', err);
+  }
+}
+
+/**
+ * Cancel ALL daily verse notifications (scoped — reengagement untouched).
+ * Called when the user toggles the Daily Verse setting off.
+ */
 export async function cancelAllNotifications(): Promise<void> {
-  await Notifications.cancelAllScheduledNotificationsAsync();
+  await cancelScheduledVotd();
+  await setPreference(PREF_LAST_SCHEDULED, '');
 }

--- a/app/src/utils/verseOfDay.ts
+++ b/app/src/utils/verseOfDay.ts
@@ -1,0 +1,137 @@
+/**
+ * utils/verseOfDay.ts — Single source of truth for the Verse of the Day.
+ *
+ * Both the HomeScreen (via useHomeData) and the push notification scheduler
+ * (services/notifications) import from here so they never drift out of sync.
+ *
+ * Selection algorithm:
+ *   1. If today is a holiday (fixed or movable), use the holiday's verse.
+ *   2. Otherwise, pick from FEATURED_VERSES by day-of-year modulo length.
+ *
+ * All pure functions — no DB access, no platform APIs.
+ */
+
+import dailyEncouragements from '../data/dailyEncouragements';
+import { computeMovableHolidays } from './computeMovableHolidays';
+import { fixedHolidays, movableHolidays, type HolidayContent } from '../data/holidayOverrides';
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface VerseOfDay {
+  ref: string;
+  bookId: string;
+  chapter: number;
+  verseNum: number;
+  text: string;
+}
+
+// ── Featured verse pool ───────────────────────────────────────────
+
+/**
+ * Curated list of well-known verses. The day-of-year modulo selects one
+ * deterministically — no server needed, same verse all day for all users.
+ */
+export const FEATURED_VERSES: VerseOfDay[] = [
+  { ref: 'Genesis 1:1',          bookId: 'genesis',       chapter: 1,   verseNum: 1,   text: 'In the beginning God created the heavens and the earth.' },
+  { ref: 'Psalm 23:1',           bookId: 'psalms',        chapter: 23,  verseNum: 1,   text: 'The LORD is my shepherd, I lack nothing.' },
+  { ref: 'Proverbs 3:5',         bookId: 'proverbs',      chapter: 3,   verseNum: 5,   text: 'Trust in the LORD with all your heart and lean not on your own understanding.' },
+  { ref: 'Isaiah 40:31',         bookId: 'isaiah',        chapter: 40,  verseNum: 31,  text: 'But those who hope in the LORD will renew their strength. They will soar on wings like eagles; they will run and not grow weary, they will walk and not be faint.' },
+  { ref: 'Jeremiah 29:11',       bookId: 'jeremiah',      chapter: 29,  verseNum: 11,  text: 'For I know the plans I have for you, declares the LORD, plans to prosper you and not to harm you, plans to give you hope and a future.' },
+  { ref: 'Matthew 6:33',         bookId: 'matthew',       chapter: 6,   verseNum: 33,  text: 'But seek first his kingdom and his righteousness, and all these things will be given to you as well.' },
+  { ref: 'Matthew 11:28',        bookId: 'matthew',       chapter: 11,  verseNum: 28,  text: 'Come to me, all you who are weary and burdened, and I will give you rest.' },
+  { ref: 'John 1:1',             bookId: 'john',          chapter: 1,   verseNum: 1,   text: 'In the beginning was the Word, and the Word was with God, and the Word was God.' },
+  { ref: 'John 3:16',            bookId: 'john',          chapter: 3,   verseNum: 16,  text: 'For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.' },
+  { ref: 'John 14:6',            bookId: 'john',          chapter: 14,  verseNum: 6,   text: 'Jesus answered, "I am the way and the truth and the life. No one comes to the Father except through me."' },
+  { ref: 'Romans 8:28',          bookId: 'romans',        chapter: 8,   verseNum: 28,  text: 'And we know that in all things God works for the good of those who love him, who have been called according to his purpose.' },
+  { ref: 'Romans 12:2',          bookId: 'romans',        chapter: 12,  verseNum: 2,   text: 'Do not conform to the pattern of this world, but be transformed by the renewing of your mind.' },
+  { ref: 'Philippians 4:13',     bookId: 'philippians',   chapter: 4,   verseNum: 13,  text: 'I can do all this through him who gives me strength.' },
+  { ref: 'Philippians 4:6',      bookId: 'philippians',   chapter: 4,   verseNum: 6,   text: 'Do not be anxious about anything, but in every situation, by prayer and petition, with thanksgiving, present your requests to God.' },
+  { ref: 'Hebrews 11:1',         bookId: 'hebrews',       chapter: 11,  verseNum: 1,   text: 'Now faith is confidence in what we hope for and assurance about what we do not see.' },
+  { ref: 'James 1:5',            bookId: 'james',         chapter: 1,   verseNum: 5,   text: 'If any of you lacks wisdom, you should ask God, who gives generously to all without finding fault, and it will be given to you.' },
+  { ref: '2 Timothy 3:16',       bookId: '2_timothy',     chapter: 3,   verseNum: 16,  text: 'All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness.' },
+  { ref: 'Psalm 119:105',        bookId: 'psalms',        chapter: 119, verseNum: 105, text: 'Your word is a lamp for my feet, a light on my path.' },
+  { ref: 'Isaiah 53:5',          bookId: 'isaiah',        chapter: 53,  verseNum: 5,   text: 'But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.' },
+  { ref: 'Micah 6:8',            bookId: 'micah',         chapter: 6,   verseNum: 8,   text: 'He has shown you, O mortal, what is good. And what does the LORD require of you? To act justly and to love mercy and to walk humbly with your God.' },
+  { ref: 'Lamentations 3:22–23', bookId: 'lamentations',  chapter: 3,   verseNum: 22,  text: 'Because of the LORD\'s great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.' },
+  { ref: 'Deuteronomy 6:5',      bookId: 'deuteronomy',   chapter: 6,   verseNum: 5,   text: 'Love the LORD your God with all your heart and with all your soul and with all your strength.' },
+  { ref: 'Joshua 1:9',           bookId: 'joshua',        chapter: 1,   verseNum: 9,   text: 'Have I not commanded you? Be strong and courageous. Do not be afraid; do not be discouraged, for the LORD your God will be with you wherever you go.' },
+  { ref: 'Proverbs 16:3',        bookId: 'proverbs',      chapter: 16,  verseNum: 3,   text: 'Commit to the LORD whatever you do, and he will establish your plans.' },
+  { ref: 'Psalm 46:10',          bookId: 'psalms',        chapter: 46,  verseNum: 10,  text: 'He says, "Be still, and know that I am God; I will be exalted among the nations, I will be exalted in the earth."' },
+  { ref: 'Exodus 14:14',         bookId: 'exodus',        chapter: 14,  verseNum: 14,  text: 'The LORD will fight for you; you need only to be still.' },
+  { ref: 'Daniel 2:21',          bookId: 'daniel',        chapter: 2,   verseNum: 21,  text: 'He changes times and seasons; he deposes kings and raises up others. He gives wisdom to the wise and knowledge to the discerning.' },
+  { ref: 'Matthew 5:16',         bookId: 'matthew',       chapter: 5,   verseNum: 16,  text: 'In the same way, let your light shine before others, that they may see your good deeds and glorify your Father in heaven.' },
+  { ref: 'Psalm 27:1',           bookId: 'psalms',        chapter: 27,  verseNum: 1,   text: 'The LORD is my light and my salvation— whom shall I fear? The LORD is the stronghold of my life— of whom shall I be afraid?' },
+  { ref: 'Isaiah 41:10',         bookId: 'isaiah',        chapter: 41,  verseNum: 10,  text: 'So do not fear, for I am with you; do not be dismayed, for I am your God. I will strengthen you and help you; I will uphold you with my righteous right hand.' },
+  { ref: 'Mark 10:27',           bookId: 'mark',          chapter: 10,  verseNum: 27,  text: 'Jesus looked at them and said, "With man this is impossible, but not with God; all things are possible with God."' },
+];
+
+// ── Day helpers ────────────────────────────────────────────────────
+
+/**
+ * Day-of-year (1..366) for the given date's LOCAL calendar day.
+ * Default is today.
+ */
+export function getDayOfYear(date: Date = new Date()): number {
+  const start = new Date(date.getFullYear(), 0, 0);
+  const diff = date.getTime() - start.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+/** Format a date as 'MM-DD' in local time — used to key holiday maps. */
+function monthDayKey(date: Date): string {
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${mm}-${dd}`;
+}
+
+// ── Holiday detection ──────────────────────────────────────────────
+
+/** Cache movable-holiday maps by year. Populated lazily. */
+const movableCache: Map<number, Map<string, string>> = new Map();
+
+function getMovableMap(year: number): Map<string, string> {
+  let map = movableCache.get(year);
+  if (!map) {
+    map = computeMovableHolidays(year);
+    movableCache.set(year, map);
+  }
+  return map;
+}
+
+/** Return the HolidayContent for the given date, or null if it's a normal day. */
+export function getHolidayForDate(date: Date = new Date()): HolidayContent | null {
+  const key = monthDayKey(date);
+  if (fixedHolidays[key]) return fixedHolidays[key];
+  const holidayId = getMovableMap(date.getFullYear()).get(key);
+  if (holidayId && movableHolidays[holidayId]) return movableHolidays[holidayId];
+  return null;
+}
+
+// ── Verse selection ────────────────────────────────────────────────
+
+/**
+ * Deterministic verse for an arbitrary date. Same algorithm the homepage uses,
+ * factored out so notification scheduling can pre-compute N days ahead.
+ */
+export function getVerseForDate(date: Date): VerseOfDay {
+  const holiday = getHolidayForDate(date);
+  if (holiday) return holiday.verse;
+  return FEATURED_VERSES[getDayOfYear(date) % FEATURED_VERSES.length];
+}
+
+/** Convenience wrapper — today's verse. */
+export function getVerseOfDay(): VerseOfDay {
+  return getVerseForDate(new Date());
+}
+
+// ── Encouragement (subtitle) selection ────────────────────────────
+
+/**
+ * Deterministic encouragement string for a given date, mirroring the verse
+ * algorithm. Exported so features other than Home can align if needed.
+ */
+export function getEncouragementForDate(date: Date = new Date()): string {
+  const holiday = getHolidayForDate(date);
+  if (holiday) return holiday.encouragement;
+  return dailyEncouragements[getDayOfYear(date) % dailyEncouragements.length];
+}


### PR DESCRIPTION
## Problem

**Bug #1 — Push notification VOTD doesn't match homepage VOTD.**
The two code paths were completely independent:
- Homepage (`useHomeData.ts`) → holiday override first, else deterministic pick from a curated 31-verse NIV `FEATURED_VERSES` list by day-of-year.
- Notification (`notifications.ts`) → `SELECT * FROM verses WHERE translation='kjv' ORDER BY RANDOM() LIMIT 1`. Random. KJV. Unrelated.

Compounded by an iOS quirk: scheduled local notifications freeze their content at schedule time, so the old `DAILY` trigger fired the same random verse every morning forever until something rescheduled it.

**Bug #2 — Tapping the notification didn't take you to the verse.**
Two missing pieces:
1. No tap handler at all — no `addNotificationResponseReceivedListener` anywhere in the codebase. Tapping just opened the app to the last state.
2. Notification payload only carried `{ bookId, chapterNum }` — no `verseNum` — so even if a handler existed, it couldn't route to a verse.

**Bug #3 (bonus, discovered while investigating #2) — Scroll-to-verse had a silent layout race.**
`useChapterScroll.ts` had the intent, but the effect ran when `isLoading` flipped to false — before `onLayout` callbacks populated `verseYMap`. Ref writes don't trigger re-renders, so the effect never retried. Net result: the deep-link `verseNum` parameter was effectively ignored on cold loads.

## Architecture

| File | Change |
|---|---|
| `app/src/utils/verseOfDay.ts` (new) | Single source of truth. Exports `getVerseForDate(date)`, `getVerseOfDay()`, `getHolidayForDate()`, `getEncouragementForDate()`, `FEATURED_VERSES`. Pure module — no DB/platform deps. |
| `app/src/hooks/useHomeData.ts` | Refactored to consume the shared module. Homepage behaviour unchanged. |
| `app/src/services/notifications.ts` | Rewritten. Pre-schedules a rolling 60-day window of CALENDAR-triggered notifications, each with the correct verse for its date baked in (matches the homepage algorithm exactly). Uses scoped identifiers `votd-YYYY-MM-DD` so cancellation no longer nukes the `reengagement-nudge` slot. Payload now includes `verseNum`. New `rescheduleIfStale()` is idempotent and no-ops unless the last schedule was on a different calendar day. |
| `app/src/hooks/useNotificationRouter.ts` (new) | Handles both cold-start taps (via `getLastNotificationResponseAsync`) and warm taps (via `addNotificationResponseReceivedListener`). Polls `navRef.isReady()` for up to 5s on cold start. Routes to `HomeTab → Chapter` with `{ bookId, chapterNum, verseNum }`. |
| `app/App.tsx` | Added `navigationRef`, mounted `useNotificationRouter` in AppShell, wired `rescheduleIfStale()` into the foreground AppState handler. |
| `app/src/hooks/chapter/useChapterScroll.ts` | Fixed the layout race. Scroll is now a *pending intent* that gets flushed from both `handleVerseLayout` and `handleSectionLayout` — whichever completes the picture second triggers the scroll. Requires both section-y and verse-y to be known before flushing, guarding against the nested-onLayout-ordering edge case. Kept the effect-based fast-path for cached-chapter re-entry. |

## Why pre-schedule a rolling window?

iOS caps scheduled local notifications at 64 per app and freezes their content at schedule time. A single `DAILY` trigger cannot show a different verse each day without a backend push. Pre-scheduling 60 calendar-day-specific notifications:
- Matches the homepage's deterministic verse per day exactly
- Works fully offline
- Leaves headroom (4 slots) for reengagement + any future scheduled features
- Is refreshed opportunistically on app foreground (stale check: once per day at most)
- Is scoped-cancellable so it doesn't interact with reengagement

## Testing done

- Syntax-parse check passes on all 6 files.
- `rescheduleIfStale()` guards ensure it's cheap on steady state.
- Scope-scoped cancellation (`votd-*` prefix) coexists with `reengagement-nudge`.
- Tap payload narrowing is defensive — unknown shapes are ignored, not crashed on.

## Testing needed (manual, on device)

- [ ] Schedule a daily verse for ~2 minutes in the future, verify the verse matches the homepage VOTD for that day
- [ ] Tap the notification cold — app should cold-start into the correct chapter + scroll to the correct verse
- [ ] Tap the notification warm (app in background) — app should navigate + scroll
- [ ] Verify reengagement notification still fires after 3 days of inactivity (scope-scoped cancellation didn't break it)
- [ ] Open a chapter via any in-app verse reference — scroll should land on the referenced verse reliably (fixes the layout race for general deep links too)

## Tier-2 accuracy impact

None — no content files touched.
