### PR TITLE
fix: migrate all explore/scholar images from Wikimedia to R2 + add hotlink validator

### DIFF
--- a/_tools/build_sqlite.py
+++ b/_tools/build_sqlite.py
@@ -180,6 +180,17 @@ def main():
     if explore_src.exists():
         shutil.copy2(explore_src, explore_dst)
 
+    # Validate no Wikimedia hotlinks survived
+    from validate_image_urls import validate_file, BLOCKED_HOSTS
+    violations = validate_file(explore_dst) + validate_file(META / 'scholar-bios.json')
+    if violations:
+        print(f"\n  ✗ {len(violations)} blocked hotlink URL(s) found:")
+        for jp, url in violations:
+            print(f"    {jp}: {url[:80]}")
+        print("  Run: python _tools/download_explore_images.py && python _tools/upload_images_to_r2.py --priority")
+        sys.exit(1)
+    print("  [OK] image URLs: no blocked hotlinks")
+
     size = DB_PATH.stat().st_size
     print(f"\n{'='*60}")
     print(f"scripture.db: {size // 1024 // 1024}MB ({size // 1024}KB)")

--- a/_tools/download_explore_images.py
+++ b/_tools/download_explore_images.py
@@ -2,8 +2,8 @@
 """
 download_explore_images.py — Download and stage images for Explore screen panels.
 
-Downloads Doré Bible illustrations from creationism.org, the Stattler Maccabees
-from Wikimedia, and the Babylonian map tablet from Wikimedia. Stages them in
+Downloads images from Wikimedia Commons, Doré Bible illustrations from
+creationism.org, and other public domain sources. Stages them in
 _tools/art_staging/priority/ for upload to R2.
 
 Run from the repo root:
@@ -12,10 +12,12 @@ Run from the repo root:
 Then upload to R2:
     python _tools/upload_images_to_r2.py --priority
 
-Images are for:
+Images cover:
   - 4 tool panels (Map, Dictionary, Concordance, Topical Index)
-  - 12 period cards
-  - 8 redemptive arc (story) cards
+  - 12 period cards + 8 redemptive arc (story) cards
+  - 8 explore feature panels (Threads, Harmony, Debates, Life Topics,
+    Hermeneutic Lenses, Time Travel, Grammar, Content Library)
+  - 4 scholar portraits (Calvin, Catena/Aquinas, Robertson, MacArthur)
 """
 
 import os
@@ -92,6 +94,70 @@ DOWNLOADS = [
         "stattler-maccabees.jpg",
         "https://upload.wikimedia.org/wikipedia/commons/0/0b/Stattler-Machabeusze.jpg",
         "Period 10 (Intertestamental) — Stattler's Maccabees (1842)",
+    ),
+
+    # === EXPLORE PANEL IMAGES (Wikimedia → R2 migration) ===
+    (
+        "book-of-kells-chirho.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/9/98/Book_of_Kells_ChiRho_Folio_34R.png",
+        "Threads panel — Book of Kells Chi Rho illumination",
+    ),
+    (
+        "aachen-gospels-evangelists.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/3/36/Meister_der_Ada-Gruppe_002.jpg",
+        "Gospel Harmony panel — Aachen Gospels, the four Evangelists",
+    ),
+    (
+        "raphael-disputation.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/6/61/Disputa_del_Sacramento_%28Rafael%29.jpg",
+        "Debates panel — Raphael's Disputation of the Holy Sacrament",
+    ),
+    (
+        "bloch-sermon-on-mount.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/9/96/Bloch-SermonOnTheMount.jpg",
+        "Life Topics panel — Carl Bloch's Sermon on the Mount",
+    ),
+    (
+        "rembrandt-moses.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/4/4a/Rembrandt_Harmensz._van_Rijn_079.jpg",
+        "Hermeneutic Lenses panel — Rembrandt's Moses with the Tablets",
+    ),
+    (
+        "st-augustine-portrait.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/6/6b/St_Augustine_Portrait.jpg",
+        "Time Travel Reader panel — St. Augustine of Hippo",
+    ),
+    (
+        "martin-luther-cranach.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/9/9a/Martin_Luther_by_Cranach-restoration.tif",
+        "Time Travel Reader panel — Martin Luther by Cranach",
+    ),
+    (
+        "papyrus-46.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/5/5c/P46.jpg",
+        "Grammar panel — Papyrus 46, Greek NT manuscript",
+    ),
+
+    # === SCHOLAR PORTRAIT IMAGES (Wikimedia → R2 migration) ===
+    (
+        "john-calvin-holbein.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/c/c5/John_Calvin_by_Holbein.png",
+        "Scholar portrait — John Calvin by Holbein",
+    ),
+    (
+        "thomas-aquinas.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/e/e3/St-thomas-aquinas.jpg",
+        "Scholar portrait — Thomas Aquinas (Catena Aurea)",
+    ),
+    (
+        "archibald-robertson.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/3/37/Archibald_Thomas_Robertson.jpg",
+        "Scholar portrait — A.T. Robertson",
+    ),
+    (
+        "john-macarthur.jpg",
+        "https://upload.wikimedia.org/wikipedia/commons/d/da/John_F._MacArthur_Jr..JPG",
+        "Scholar portrait — John MacArthur",
     ),
 ]
 

--- a/_tools/validate_image_urls.py
+++ b/_tools/validate_image_urls.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+validate_image_urls.py — Ensure no Wikimedia hotlink URLs remain in content.
+
+Wikimedia blocks hotlinking from mobile apps (HTTP 403). All images must
+be hosted on R2 (contentcompanionstudy.com) or another owned CDN.
+
+Scans:
+  - content/meta/explore-images.json   (explore panel images)
+  - app/assets/explore-images.json     (bundled copy — must match source)
+  - content/meta/scholar-bios.json     (scholar portrait images)
+
+Exit codes:
+  0 = all clear
+  1 = blocked hotlink URLs found
+
+Usage:
+    python3 _tools/validate_image_urls.py
+
+Part of the build pipeline — called from build_sqlite.py.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+META = ROOT / 'content' / 'meta'
+ASSETS = ROOT / 'app' / 'assets'
+
+BLOCKED_HOSTS = [
+    'upload.wikimedia.org',
+    'upload.wikipedia.org',
+    'commons.wikimedia.org',
+]
+
+SCAN_TARGETS = [
+    META / 'explore-images.json',
+    ASSETS / 'explore-images.json',
+    META / 'scholar-bios.json',
+]
+
+
+def find_image_urls(obj, path=''):
+    """Recursively yield (json_path, url) for any key that looks like an image URL."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            child_path = f'{path}.{k}' if path else k
+            if k in ('url', 'image_url', 'image', 'portrait_url', 'src'):
+                if isinstance(v, str) and v.startswith('http'):
+                    yield child_path, v
+            else:
+                yield from find_image_urls(v, child_path)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            yield from find_image_urls(item, f'{path}[{i}]')
+
+
+def is_blocked(url):
+    """Return True if the URL uses a blocked host."""
+    for host in BLOCKED_HOSTS:
+        if host in url:
+            return True
+    return False
+
+
+def validate_file(path):
+    """Validate a single JSON file. Returns list of (path, url) violations."""
+    if not path.exists():
+        return []
+    try:
+        data = json.load(open(path, encoding='utf-8'))
+    except Exception as e:
+        print(f'  WARNING: Could not parse {path.name}: {e}')
+        return []
+
+    violations = []
+    for json_path, url in find_image_urls(data):
+        if is_blocked(url):
+            violations.append((json_path, url))
+    return violations
+
+
+def validate_manifest_sync():
+    """Verify content/meta/explore-images.json matches app/assets/explore-images.json."""
+    src = META / 'explore-images.json'
+    dst = ASSETS / 'explore-images.json'
+    if not src.exists() or not dst.exists():
+        return True  # Can't check if one doesn't exist
+
+    try:
+        src_data = json.load(open(src, encoding='utf-8'))
+        dst_data = json.load(open(dst, encoding='utf-8'))
+    except Exception:
+        return True
+
+    if json.dumps(src_data, sort_keys=True) != json.dumps(dst_data, sort_keys=True):
+        print('  DRIFT: content/meta/explore-images.json and app/assets/explore-images.json differ!')
+        print('         Run build_sqlite.py to sync, or fix the source of truth in content/meta/.')
+        return False
+    return True
+
+
+def main():
+    print('Image URL validation')
+    print('=' * 50)
+
+    total_violations = 0
+    for path in SCAN_TARGETS:
+        rel = path.relative_to(ROOT)
+        violations = validate_file(path)
+        if violations:
+            print(f'\n  FAIL: {rel} — {len(violations)} blocked hotlink URL(s):')
+            for json_path, url in violations:
+                # Truncate URL for readability
+                display_url = url if len(url) < 80 else url[:77] + '...'
+                print(f'    {json_path}: {display_url}')
+            total_violations += len(violations)
+        else:
+            print(f'  OK: {rel}')
+
+    synced = validate_manifest_sync()
+
+    if total_violations > 0:
+        print(f'\n✗ {total_violations} blocked hotlink URL(s) found.')
+        print('  All images must be hosted on R2 (contentcompanionstudy.com).')
+        print('  Run: python _tools/download_explore_images.py')
+        print('  Then: python _tools/upload_images_to_r2.py --priority')
+        sys.exit(1)
+
+    if not synced:
+        print('\n✗ Manifest drift detected.')
+        sys.exit(1)
+
+    print('\n✓ All image URLs are on owned infrastructure.')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -79,7 +79,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/Book_of_Kells_ChiRho_Folio_34R.png/400px-Book_of_Kells_ChiRho_Folio_34R.png",
+        "url": "https://contentcompanionstudy.com/art/book-of-kells-chirho.jpg",
         "caption": "Book of Kells Chi Rho — interlacing threads through Scripture",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -92,7 +92,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Meister_der_Ada-Gruppe_002.jpg/400px-Meister_der_Ada-Gruppe_002.jpg",
+        "url": "https://contentcompanionstudy.com/art/aachen-gospels-evangelists.jpg",
         "caption": "Aachen Gospels — the four Evangelists united",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -153,7 +153,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Disputa_del_Sacramento_%28Rafael%29.jpg/400px-Disputa_del_Sacramento_%28Rafael%29.jpg",
+        "url": "https://contentcompanionstudy.com/art/raphael-disputation.jpg",
         "caption": "Raphael's Disputa — theology debated across heaven and earth",
         "credit": "Raphael · Public domain"
       }
@@ -178,7 +178,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gutenberg_Bible%2C_Lenox_Copy%2C_New_York_Public_Library%2C_2009._Pic_01.jpg/400px-Gutenberg_Bible%2C_Lenox_Copy%2C_New_York_Public_Library%2C_2009._Pic_01.jpg",
+        "url": "https://contentcompanionstudy.com/art/gutenberg-bible.jpg",
         "caption": "Gutenberg Bible — the printed word transforms biblical scholarship",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -191,7 +191,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/Bloch-SermonOnTheMount.jpg/400px-Bloch-SermonOnTheMount.jpg",
+        "url": "https://contentcompanionstudy.com/art/bloch-sermon-on-mount.jpg",
         "caption": "Sermon on the Mount — wisdom for life's deepest questions",
         "credit": "Carl Bloch · Public domain"
       }
@@ -203,7 +203,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Rembrandt_Harmensz._van_Rijn_079.jpg/400px-Rembrandt_Harmensz._van_Rijn_079.jpg",
+        "url": "https://contentcompanionstudy.com/art/rembrandt-moses.jpg",
         "caption": "Rembrandt's Moses — different lenses see different truths",
         "credit": "Rembrandt · Public domain"
       }
@@ -228,12 +228,12 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/St_Augustine_Portrait.jpg/400px-St_Augustine_Portrait.jpg",
+        "url": "https://contentcompanionstudy.com/art/st-augustine-portrait.jpg",
         "caption": "Augustine of Hippo — the patristic era",
         "credit": "Public domain, via Wikimedia Commons"
       },
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Martin_Luther_by_Cranach-restoration.tif/lossy-page1-400px-Martin_Luther_by_Cranach-restoration.tif.jpg",
+        "url": "https://contentcompanionstudy.com/art/martin-luther-cranach.jpg",
         "caption": "Martin Luther — Reformation-era reading",
         "credit": "Lucas Cranach the Elder · Public domain"
       }
@@ -245,7 +245,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/P46.jpg/400px-P46.jpg",
+        "url": "https://contentcompanionstudy.com/art/papyrus-46.jpg",
         "caption": "Papyrus 46 — Greek verb forms preserved in ancient manuscripts",
         "credit": "Public domain, via Wikimedia Commons"
       }

--- a/content/meta/explore-images.json
+++ b/content/meta/explore-images.json
@@ -26,12 +26,13 @@
   "Map": {
     "count": 28,
     "noun": "journeys",
-    "contentType": "map_story",
-    "featured": [
-      "abram-call",
-      "exodus-plagues",
-      "paul-journey3",
-      "nativity"
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/map-babylonian-tablet.jpg",
+        "caption": "Babylonian cuneiform map tablet from Nippur, 1550–1450 BCE",
+        "credit": "Penn Museum · Public domain"
+      }
     ]
   },
   "ConceptBrowse": {
@@ -49,7 +50,14 @@
     "count": 110,
     "noun": "topics",
     "contentType": "topic",
-    "featured": []
+    "featured": [],
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg",
+        "caption": "Botticelli's St. Augustine in His Study",
+        "credit": "Sandro Botticelli · Public domain"
+      }
+    ]
   },
   "ProphecyBrowse": {
     "count": 50,
@@ -71,7 +79,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/Book_of_Kells_ChiRho_Folio_34R.png/400px-Book_of_Kells_ChiRho_Folio_34R.png",
+        "url": "https://contentcompanionstudy.com/art/book-of-kells-chirho.jpg",
         "caption": "Book of Kells Chi Rho — interlacing threads through Scripture",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -84,7 +92,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Meister_der_Ada-Gruppe_002.jpg/400px-Meister_der_Ada-Gruppe_002.jpg",
+        "url": "https://contentcompanionstudy.com/art/aachen-gospels-evangelists.jpg",
         "caption": "Aachen Gospels — the four Evangelists united",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -109,8 +117,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Codex_Sinaiticus_open_full.jpg/400px-Codex_Sinaiticus_open_full.jpg",
-        "caption": "Codex Sinaiticus — one of the oldest complete New Testaments",
+        "url": "https://contentcompanionstudy.com/art/Aleppo_Codex_Joshua_1_1.jpg",
+        "caption": "Aleppo Codex — oldest Hebrew Bible manuscript, Joshua 1:1",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -121,8 +129,8 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Aleppo_Codex_%28Deuteronomy%29.jpg/400px-Aleppo_Codex_%28Deuteronomy%29.jpg",
-        "caption": "The Aleppo Codex — the oldest near-complete Hebrew Bible manuscript",
+        "url": "https://contentcompanionstudy.com/art/gutenberg-bible.jpg",
+        "caption": "Gutenberg Bible — the first major book printed with movable type",
         "credit": "Public domain, via Wikimedia Commons"
       }
     ]
@@ -145,7 +153,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Disputa_del_Sacramento_%28Rafael%29.jpg/400px-Disputa_del_Sacramento_%28Rafael%29.jpg",
+        "url": "https://contentcompanionstudy.com/art/raphael-disputation.jpg",
         "caption": "Raphael's Disputa — theology debated across heaven and earth",
         "credit": "Raphael · Public domain"
       }
@@ -170,7 +178,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gutenberg_Bible%2C_Lenox_Copy%2C_New_York_Public_Library%2C_2009._Pic_01.jpg/400px-Gutenberg_Bible%2C_Lenox_Copy%2C_New_York_Public_Library%2C_2009._Pic_01.jpg",
+        "url": "https://contentcompanionstudy.com/art/gutenberg-bible.jpg",
         "caption": "Gutenberg Bible — the printed word transforms biblical scholarship",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -183,7 +191,7 @@
     "featured": [],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/Bloch-SermonOnTheMount.jpg/400px-Bloch-SermonOnTheMount.jpg",
+        "url": "https://contentcompanionstudy.com/art/bloch-sermon-on-mount.jpg",
         "caption": "Sermon on the Mount — wisdom for life's deepest questions",
         "credit": "Carl Bloch · Public domain"
       }
@@ -195,7 +203,7 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Rembrandt_Harmensz._van_Rijn_079.jpg/400px-Rembrandt_Harmensz._van_Rijn_079.jpg",
+        "url": "https://contentcompanionstudy.com/art/rembrandt-moses.jpg",
         "caption": "Rembrandt's Moses — different lenses see different truths",
         "credit": "Rembrandt · Public domain"
       }
@@ -220,12 +228,12 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/St_Augustine_Portrait.jpg/400px-St_Augustine_Portrait.jpg",
+        "url": "https://contentcompanionstudy.com/art/st-augustine-portrait.jpg",
         "caption": "Augustine of Hippo — the patristic era",
         "credit": "Public domain, via Wikimedia Commons"
       },
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Martin_Luther_by_Cranach-restoration.tif/lossy-page1-400px-Martin_Luther_by_Cranach-restoration.tif.jpg",
+        "url": "https://contentcompanionstudy.com/art/martin-luther-cranach.jpg",
         "caption": "Martin Luther — Reformation-era reading",
         "credit": "Lucas Cranach the Elder · Public domain"
       }
@@ -237,9 +245,63 @@
     "contentType": null,
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/P46.jpg/400px-P46.jpg",
+        "url": "https://contentcompanionstudy.com/art/papyrus-46.jpg",
         "caption": "Papyrus 46 — Greek verb forms preserved in ancient manuscripts",
         "credit": "Public domain, via Wikimedia Commons"
+      }
+    ]
+  },
+  "Periods": {
+    "count": 12,
+    "noun": "eras",
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-flood.jpg",
+        "caption": "The Deluge — Primeval History",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-red-sea.jpg",
+        "caption": "Crossing the Red Sea — Egypt & Exodus",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-solomon-judgment.jpg",
+        "caption": "Judgment of Solomon — United Kingdom",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-nativity.jpg",
+        "caption": "The Nativity — New Testament",
+        "credit": "Gustave Doré · Public domain"
+      }
+    ]
+  },
+  "RedemptiveArc": {
+    "count": 8,
+    "noun": "acts",
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-creation-light.jpg",
+        "caption": "The Creation of Light — Act 1: Creation",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-adam-eve.jpg",
+        "caption": "Driven Out of Eden — Act 2: Rebellion",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-david-goliath.jpg",
+        "caption": "David and Goliath — Act 4: Kingdom",
+        "credit": "Gustave Doré · Public domain"
+      },
+      {
+        "url": "https://contentcompanionstudy.com/art/dore-new-jerusalem.jpg",
+        "caption": "The New Jerusalem — Act 8: Restoration",
+        "credit": "Gustave Doré · Public domain"
       }
     ]
   }

--- a/content/meta/scholar-bios.json
+++ b/content/meta/scholar-bios.json
@@ -188,7 +188,7 @@
     ],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/John_Calvin_by_Holbein.png/400px-John_Calvin_by_Holbein.png",
+        "url": "https://contentcompanionstudy.com/art/john-calvin-holbein.jpg",
         "caption": "John Calvin — portrait by Hans Holbein",
         "credit": "Public domain, via Wikimedia Commons"
       }
@@ -223,7 +223,7 @@
     ],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e3/St-thomas-aquinas.jpg/400px-St-thomas-aquinas.jpg",
+        "url": "https://contentcompanionstudy.com/art/thomas-aquinas.jpg",
         "caption": "Thomas Aquinas — compiler of the Catena Aurea",
         "credit": "Carlo Crivelli · Public domain"
       }
@@ -638,7 +638,7 @@
     ],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/John_F._MacArthur_Jr..JPG/400px-John_F._MacArthur_Jr..JPG",
+        "url": "https://contentcompanionstudy.com/art/john-macarthur.jpg",
         "caption": "John MacArthur",
         "credit": "Photo: R. Huggins · CC0"
       }
@@ -853,7 +853,7 @@
     ],
     "images": [
       {
-        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Archibald_Thomas_Robertson.jpg/400px-Archibald_Thomas_Robertson.jpg",
+        "url": "https://contentcompanionstudy.com/art/archibald-robertson.jpg",
         "caption": "A.T. Robertson — New Testament Greek scholar",
         "credit": "Public domain, via Wikimedia Commons"
       }


### PR DESCRIPTION
## Problem

7 Explore screen panels were showing blank images in the TestFlight build: Grammar, Time Travel, Hermeneutic Lenses, Life Topics, Scholars, Threads, and Gospel Harmony. Two more (Content Library, Debates) were also broken but hadn't been flagged yet.

**Root cause:** All 9 panels still pointed at Wikimedia Commons hotlink URLs, which return HTTP 403. The R2 migration in PR #1345 was billed as "swap all Explore images to verified R2 URLs" but only migrated a subset — 12 out of 21 image URLs.

Additionally, ScholarBrowse's images are pulled from the `content_images` SQLite table (via `scholar-bios.json`), and all 4 featured scholar portraits were also Wikimedia URLs.

**Why it "worked before":** iOS `<Image>` caches aggressively. On devices that had previously loaded the images (before Wikimedia's block tightened), cached copies persisted across app updates. A fresh TestFlight install = empty cache = broken images.

## Audit Results

Full system audit found:
- **216 Wikimedia URLs** across all content JSON files (broader migration is a future epic)
- **13 Wikimedia URLs** directly affecting the Explore screen (9 manifest + 4 scholar portraits)
- **80 R2 URLs** working correctly
- **Two-manifest drift**: `content/meta/explore-images.json` and `app/assets/explore-images.json` had diverged — different images, different panels, different URLs

## What This PR Does

### 1. Reconciles the two manifests
`content/meta/explore-images.json` is now the single source of truth. It contains all 22 panels (including Periods and RedemptiveArc, which were previously only in `app/assets`). `build_sqlite.py` copies it to `app/assets/` during every build — this was already the case, but the source was stale.

### 2. Migrates all 13 Wikimedia URLs to R2 targets

**Explore manifest** (9 URLs):

| Panel | R2 filename |
|---|---|
| ThreadBrowse | `book-of-kells-chirho.jpg` |
| HarmonyBrowse | `aachen-gospels-evangelists.jpg` |
| DebateBrowse | `raphael-disputation.jpg` |
| ContentLibrary | `gutenberg-bible.jpg` (reuses existing) |
| LifeTopics | `bloch-sermon-on-mount.jpg` |
| LensBrowse | `rembrandt-moses.jpg` |
| TimeTravelBrowse | `st-augustine-portrait.jpg`, `martin-luther-cranach.jpg` |
| GrammarBrowse | `papyrus-46.jpg` |

**Scholar portraits** (4 URLs in `scholar-bios.json`):

| Scholar | R2 filename |
|---|---|
| Calvin | `john-calvin-holbein.jpg` |
| Catena (Aquinas) | `thomas-aquinas.jpg` |
| Robertson | `archibald-robertson.jpg` |
| MacArthur | `john-macarthur.jpg` |

### 3. Extends the download tool
`_tools/download_explore_images.py` now includes all 12 new images (8 explore + 4 scholar; ContentLibrary reuses existing R2 image). Run this locally to stage images for R2 upload.

### 4. Adds hotlink validator (regression guard)
`_tools/validate_image_urls.py` scans both manifests + scholar-bios for Wikimedia URLs and fails if any are found. Also checks for manifest drift between content/meta and app/assets. Wired into `build_sqlite.py` — the build now hard-fails if blocked URLs exist.

## Steps to Complete (run locally after merge)

```bash
cd ScriptureDeepDive
python _tools/download_explore_images.py          # Download 12 images to _tools/art_staging/priority/
python _tools/upload_images_to_r2.py --priority   # Upload to R2 bucket
python _tools/build_sqlite.py                     # Rebuild DB + sync manifests + validate
python _tools/validate_sqlite.py                  # Integrity check
eas update --branch production                    # Deploy (from app/ directory)
```

## Files Changed

| File | Change |
|---|---|
| `content/meta/explore-images.json` | Reconciled as single source of truth, all 22 panels, all R2 URLs |
| `app/assets/explore-images.json` | Synced to match (identical to content/meta) |
| `content/meta/scholar-bios.json` | 4 scholar portrait URLs → R2 |
| `_tools/download_explore_images.py` | +12 new image entries |
| `_tools/validate_image_urls.py` (new) | Hotlink validator + manifest drift check |
| `_tools/build_sqlite.py` | Wired hotlink validation into build pipeline |

## Future Work

The remaining ~207 Wikimedia URLs are in people/places/concepts/topics/etc. content files — a larger migration epic. This PR fixes the user-visible Explore screen breakage and establishes the tooling pattern for the broader migration.
