### PR TITLE
Pipeline: populate_journeys() builder (#1383)

### DIFF
--- a/_tools/build_sqlite.py
+++ b/_tools/build_sqlite.py
@@ -35,6 +35,7 @@ from build_sqlite_loaders import (
     populate_content_library, populate_life_topics, populate_hermeneutic_lenses,
     populate_archaeology, populate_historical_interpretations,
     populate_grammar_articles, populate_content_images,
+    populate_journeys,
     build_fts, compute_difficulty, build_supplemental_translations,
     AVAILABLE_TRANSLATIONS, BUNDLED_TRANSLATIONS,
 )
@@ -144,6 +145,10 @@ def main():
 
     print(f"  [OK] grammar_articles: {populate_grammar_articles(cur)} rows")
     print(f"  [OK] content_images: {populate_content_images(cur)} rows")
+
+    j, s, t = populate_journeys(cur)
+    print(f"  [OK] journeys: {j} journeys, {s} stops, {t} tags")
+
     print(f"  [OK] difficulty scores: {compute_difficulty(cur)} chapters rated")
 
     build_fts(cur)

--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -1657,6 +1657,83 @@ def build_fts(cur):
     cur.execute('INSERT INTO dictionary_fts(dictionary_fts) VALUES("rebuild")')
 
 
+def populate_journeys(cur):
+    """Load all journey JSON files into journeys, journey_stops, journey_tags tables."""
+    journeys_dir = ROOT / 'content' / 'meta' / 'journeys'
+    if not journeys_dir.exists():
+        return 0, 0, 0
+
+    count_journeys = 0
+    count_stops = 0
+    count_tags = 0
+
+    for journey_type in ['thematic', 'concept', 'person']:
+        type_dir = journeys_dir / journey_type
+        if not type_dir.exists():
+            continue
+
+        for json_file in sorted(type_dir.glob('*.json')):
+            data = _load_json(json_file)
+
+            cur.execute('''
+                INSERT INTO journeys
+                (id, journey_type, title, subtitle, description, lens_id, depth,
+                 sort_order, person_id, concept_id, era, tags, hero_image_url)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                data['id'],
+                data['journey_type'],
+                data['title'],
+                data.get('subtitle'),
+                data['description'],
+                data.get('lens_id'),
+                data.get('depth'),
+                data.get('sort_order', 0),
+                data.get('person_id'),
+                data.get('concept_id'),
+                data.get('era'),
+                json.dumps(data.get('tags', [])) if data.get('tags') else None,
+                data.get('hero_image_url'),
+            ))
+            count_journeys += 1
+
+            for stop in data.get('stops', []):
+                cur.execute('''
+                    INSERT INTO journey_stops
+                    (journey_id, stop_order, stop_type, label, ref, book_id,
+                     chapter_num, verse_start, verse_end, development, what_changes,
+                     linked_journey_id, linked_journey_intro, bridge_to_next)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    data['id'],
+                    stop['stop_order'],
+                    stop['stop_type'],
+                    stop.get('label'),
+                    stop.get('ref'),
+                    stop.get('book_id'),
+                    stop.get('chapter_num'),
+                    stop.get('verse_start'),
+                    stop.get('verse_end'),
+                    stop.get('development'),
+                    stop.get('what_changes'),
+                    stop.get('linked_journey_id'),
+                    stop.get('linked_journey_intro'),
+                    stop.get('bridge_to_next'),
+                ))
+                count_stops += 1
+
+            for tag in data.get('tags', []):
+                if isinstance(tag, dict) and 'type' in tag and 'id' in tag:
+                    cur.execute('''
+                        INSERT OR IGNORE INTO journey_tags
+                        (journey_id, tag_type, tag_id)
+                        VALUES (?, ?, ?)
+                    ''', (data['id'], tag['type'], tag['id']))
+                    count_tags += 1
+
+    return count_journeys, count_stops, count_tags
+
+
 # ---------------------------------------------------------------------------
 # Difficulty scoring
 # ---------------------------------------------------------------------------

--- a/_tools/validate_sqlite.py
+++ b/_tools/validate_sqlite.py
@@ -170,33 +170,26 @@ def main():
     check(f"{expected_people} people", q1(cur, "SELECT COUNT(*) FROM people") == expected_people)
     check(f"{expected_scholars} scholars", q1(cur, "SELECT COUNT(*) FROM scholars") == expected_scholars)
 
-    # People journeys (#1125)
-    pj_count = q1(cur, "SELECT COUNT(*) FROM people_journeys")
-    if pj_count and pj_count > 0:
-        # Every journey stage must reference a valid person
-        orphan_journeys = q(cur,
-            "SELECT pj.person_id FROM people_journeys pj "
-            "WHERE pj.person_id NOT IN (SELECT id FROM people)")
-        check("Journey stages reference valid people", len(orphan_journeys) == 0,
-              f"orphaned: {[r[0] for r in orphan_journeys[:5]]}")
+    # Journeys (#1383)
+    j_count = q1(cur, "SELECT COUNT(*) FROM journeys")
+    js_count = q1(cur, "SELECT COUNT(*) FROM journey_stops")
+    jt_count = q1(cur, "SELECT COUNT(*) FROM journey_tags")
+    if j_count and j_count > 0:
+        # Every journey stop must reference a valid journey
+        orphan_stops = q(cur,
+            "SELECT js.journey_id FROM journey_stops js "
+            "WHERE js.journey_id NOT IN (SELECT id FROM journeys)")
+        check("Journey stops reference valid journeys", len(orphan_stops) == 0,
+              f"orphaned: {[r[0] for r in orphan_stops[:5]]}")
 
-        # era cross-reference
-        bad_journey_eras = q(cur,
-            "SELECT pj.person_id, pj.era FROM people_journeys pj "
-            "WHERE pj.era IS NOT NULL AND pj.era NOT IN (SELECT id FROM eras)")
-        check("Journey eras reference valid eras", len(bad_journey_eras) == 0,
-              f"invalid: {[(r[0], r[1]) for r in bad_journey_eras[:5]]}")
+        # Every journey tag must reference a valid journey
+        orphan_tags = q(cur,
+            "SELECT jt.journey_id FROM journey_tags jt "
+            "WHERE jt.journey_id NOT IN (SELECT id FROM journeys)")
+        check("Journey tags reference valid journeys", len(orphan_tags) == 0,
+              f"orphaned: {[r[0] for r in orphan_tags[:5]]}")
 
-        # book_dir cross-reference
-        bad_journey_books = q(cur,
-            "SELECT pj.person_id, pj.book_dir FROM people_journeys pj "
-            "WHERE pj.book_dir IS NOT NULL AND pj.book_dir NOT IN (SELECT id FROM books)")
-        check("Journey book_dirs reference valid books", len(bad_journey_books) == 0,
-              f"invalid: {[(r[0], r[1]) for r in bad_journey_books[:5]]}")
-
-        people_with_journey = q1(cur,
-            "SELECT COUNT(DISTINCT person_id) FROM people_journeys")
-        print(f"  people_journeys: {pj_count} stages across {people_with_journey} people")
+    print(f"  journeys: {j_count or 0}, stops: {js_count or 0}, tags: {jt_count or 0}")
 
     # People legacy refs (#1125)
     plr_count = q1(cur, "SELECT COUNT(*) FROM people_legacy_refs")
@@ -398,9 +391,9 @@ def main():
               f"{len(bad_links)} chains with empty links")
     print(f"  prophecy_chains: {pc_count or 0}")
 
-    co_count = q1(cur, "SELECT COUNT(*) FROM concepts")
-    check("concepts table exists", co_count is not None, "table missing")
-    print(f"  concepts: {co_count or 0}")
+    j2_count = q1(cur, "SELECT COUNT(*) FROM journeys")
+    check("journeys table exists", j2_count is not None, "table missing")
+    print(f"  journeys: {j2_count or 0}")
 
     dp_count = q1(cur, "SELECT COUNT(*) FROM difficult_passages")
     check("difficult_passages table exists", dp_count is not None, "table missing")

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
   "content_hash": "d1d5fbec22de929b",
-  "build_time": "2026-04-16T16:47:31.058665Z"
+  "build_time": "2026-04-16T17:05:55.314615Z"
 }


### PR DESCRIPTION
## Summary

Closes #1383 (Phase 1 — Foundation for Epic #1379)

- **Add** `populate_journeys()` function to `build_sqlite_loaders.py` that reads journey JSON files from `content/meta/journeys/{thematic,concept,person}/*.json` and populates `journeys`, `journey_stops`, and `journey_tags` tables
- **Register** the loader in `build_sqlite.py` import and call
- **Update** `validate_sqlite.py` to validate the new journey tables instead of the removed `concepts` and `people_journeys` tables

## Verification

- `python _tools/build_sqlite.py` succeeds with `[OK] journeys: 0 journeys, 0 stops, 0 tags` (empty directories — content comes in later issues)
- `python _tools/validate_sqlite.py` passes all 88 checks, 0 failures

## Test plan

- [x] `build_sqlite.py` runs clean
- [x] `validate_sqlite.py` passes
- [ ] CI passes

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes