### PR TITLE
Content: author connective bridges for 20 concept journeys (#1388)

### DIFF
--- a/content/meta/journeys/concept/covenant.json
+++ b/content/meta/journeys/concept/covenant.json
@@ -87,7 +87,7 @@
       "what_changes": "God binds himself never to destroy by flood again. The rainbow serves as the covenant sign visible to both parties.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God's first covenant encompassed all creation with no conditions attached. But a universal promise, by its very breadth, lacked specificity. How would God's commitment to creation narrow into a relationship with a particular people? The answer begins with one man and an extraordinary night vision."
     },
     {
       "stop_order": 2,
@@ -102,7 +102,7 @@
       "what_changes": "Land, offspring, and blessing are promised. The covenant family that will mediate blessing to all nations begins here.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The covenant with Abraham was unconditional — a divine oath sealed by God alone passing between the pieces. But four centuries of silence and slavery in Egypt raised an urgent question: what would covenant loyalty demand of the people who bore Abraham's name? At Sinai, God answered with a covenant of a very different kind."
     },
     {
       "stop_order": 3,
@@ -117,7 +117,7 @@
       "what_changes": "Covenant identity becomes physically inscribed. The sign distinguishes Abraham's line from the nations.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Circumcision marked the body with covenant identity, but a physical sign on individuals could not sustain a whole nation's relationship with God. When Abraham's descendants multiplied into a people numbering in the hundreds of thousands, covenant life required something more: a corporate framework with obligations, boundaries, and a shared vocation."
     },
     {
       "stop_order": 4,
@@ -132,7 +132,7 @@
       "what_changes": "Israel becomes a 'kingdom of priests and a holy nation.' National identity is now covenantal identity.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The proposal at Sinai was breathtaking — Israel as a kingdom of priests — but a proposal requires ratification. The bilateral nature of this covenant meant both parties must bind themselves. What would seal such an agreement between a holy God and an imperfect people?"
     },
     {
       "stop_order": 5,
@@ -147,7 +147,7 @@
       "what_changes": "Blood becomes the medium of covenant ratification, establishing a pattern that persists through the entire sacrificial system.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Blood ratified the covenant between God and nation, but the Sinai arrangement said nothing about who would rule that nation. As Israel settled the land and demanded a king, God wove monarchy into the covenant framework, making a stunning promise to one royal house."
     },
     {
       "stop_order": 6,
@@ -162,7 +162,7 @@
       "what_changes": "The throne of David is promised permanence. Messianic expectation is anchored to a specific royal line.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God promised David an eternal throne, but David's successors proved faithless. King after king violated the covenant until the dynasty appeared extinct and the people languished in exile. In that darkest hour, Jeremiah dared to announce something unprecedented: not a repaired old covenant but an entirely new one."
     },
     {
       "stop_order": 7,
@@ -177,7 +177,7 @@
       "what_changes": "The problem of covenant-breaking is addressed at its root: the human heart. Universal knowledge of God is promised.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jeremiah promised a law written on hearts, but he left the mechanism unexplained. How exactly would God transform the inner life of his covenant people? Ezekiel, prophesying from among the exiles in Babylon, supplied the missing piece."
     },
     {
       "stop_order": 8,
@@ -192,7 +192,7 @@
       "what_changes": "The mechanism of covenant obedience shifts from external law to internal transformation by the Spirit.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The prophets envisioned new hearts and indwelling Spirit, but centuries passed with no fulfillment. When Jesus gathered his disciples for a final Passover meal, he took the cup and spoke words that collapsed every prophetic expectation into a single moment."
     },
     {
       "stop_order": 9,
@@ -207,7 +207,7 @@
       "what_changes": "The new covenant is inaugurated. The pattern of blood ratification from Exodus 24 reaches its fulfillment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus inaugurated the new covenant at the Last Supper, but its theological implications needed unpacking. How does the new covenant relate to the old? Is the Mosaic covenant simply discarded, or does the new one fulfill what the old always intended? The letter to the Hebrews takes up precisely this question."
     },
     {
       "stop_order": 10,

--- a/content/meta/journeys/concept/creation.json
+++ b/content/meta/journeys/concept/creation.json
@@ -59,7 +59,7 @@
       "what_changes": "The world is established as purposeful, ordered, and good. God is sovereign over all that exists; nothing rivals him.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The seven-day account presented creation as cosmic order shaped by divine speech. But a second, more intimate account zoomed in on one creature in particular — the one made from dust yet animated by the breath of God."
     },
     {
       "stop_order": 2,
@@ -74,7 +74,7 @@
       "what_changes": "Humanity is distinct: made of earth yet animated by divine breath. Image-bearing and dust-origin coexist.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Genesis established humanity as the pinnacle of creation, but what happens when that creation seems indifferent to human suffering? The wisdom tradition wrestled with this tension, and God's answer came not as explanation but as overwhelming display."
     },
     {
       "stop_order": 3,
@@ -89,7 +89,7 @@
       "what_changes": "Creation serves as theodicy. The incomprehensibility of the created order mirrors the incomprehensibility of divine governance.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God's speech from the whirlwind silenced Job's complaint with creation's mystery. But Israel's poets heard in that same creation a different voice — not silence but speech, a wordless testimony to the Creator's glory."
     },
     {
       "stop_order": 4,
@@ -104,7 +104,7 @@
       "what_changes": "The created order becomes a mode of divine communication. General revelation through nature complements special revelation through Torah.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The heavens declared God's glory, but the prophets looked further: beyond what creation reveals now to what creation will become. Isaiah announced something staggering — not merely the repair of the existing world but the making of an entirely new one."
     },
     {
       "stop_order": 5,
@@ -119,7 +119,7 @@
       "what_changes": "Creation theology gains an eschatological dimension. The original 'very good' will be exceeded by a new creation free from curse.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's vision of new heavens and new earth remained future, a prophetic promise awaiting its foundation. When the Gospel of John opened with words that echoed Genesis 1, it revealed that foundation: the creative Word was not an impersonal force but a person."
     },
     {
       "stop_order": 6,
@@ -134,7 +134,7 @@
       "what_changes": "Creation is christologically grounded. The one who will become incarnate is the same one through whom all things came into being.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "John identified the Word as the agent of creation, but Paul saw the present condition of that creation with unflinching honesty. The world made through the Word was not flourishing — it was groaning, caught between the first creation's fall and the new creation's dawn."
     },
     {
       "stop_order": 7,
@@ -149,7 +149,7 @@
       "what_changes": "Creation is not static but participates in the drama of redemption. The fall affected the entire created order; redemption will restore it.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul described creation groaning in labor pains, awaiting liberation. The book of Revelation answers that longing with a vision of the delivery itself — the moment when the old order passes away and God declares all things new."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/exile-return.json
+++ b/content/meta/journeys/concept/exile-return.json
@@ -83,7 +83,7 @@
       "what_changes": "The primal exile establishes the pattern: sin leads to separation from God's presence. All subsequent exiles echo this first expulsion.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Adam and Eve were driven from God's garden, but the story did not end at the cherubim's flaming sword. God's response to the primal exile was to call one man out of another kind of displacement — out of pagan Ur toward a promised homeland."
     },
     {
       "stop_order": 2,
@@ -98,7 +98,7 @@
       "what_changes": "Return from exile becomes linked to promise and faith. The land is both gift and destination.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Abraham journeyed from exile to promise, from Ur to Canaan. But his descendants did not stay in the land. Four centuries of Egyptian bondage created the need for a far more dramatic deliverance — the event that would define Israel's identity forever."
     },
     {
       "stop_order": 3,
@@ -113,7 +113,7 @@
       "what_changes": "Exodus becomes the controlling metaphor for all future deliverances. Every return from exile is a 'new exodus.'",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The exodus was the paradigmatic deliverance, the event every later generation would look back to. But the pattern of exile was not broken once for all. When the northern kingdom persisted in covenant-breaking, the same God who delivered from Egypt allowed Assyria to carry Israel away."
     },
     {
       "stop_order": 4,
@@ -128,7 +128,7 @@
       "what_changes": "Exile is shown to be covenant consequence, not arbitrary punishment. The prophetic warnings are vindicated.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Assyria scattered the northern tribes, and the theological autopsy was clear: covenant violation produces exile. A century later, the southern kingdom of Judah failed to learn the lesson. Babylon came, and what seemed impossible — the destruction of Jerusalem and its temple — became horrifying reality."
     },
     {
       "stop_order": 5,
@@ -143,7 +143,7 @@
       "what_changes": "The unthinkable happens: God's own house is destroyed. Every theological certainty — temple, monarchy, land — is removed.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Babylonian exile was the theological crisis of the Old Testament. With temple burned, monarchy ended, and people deported, every pillar of Israelite faith lay in ruins. Into that devastation, a prophetic voice spoke words of shattering comfort."
     },
     {
       "stop_order": 6,
@@ -158,7 +158,7 @@
       "what_changes": "The exile is not the final word. God's return to his people is described in language that echoes and surpasses the first exodus.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah announced a new exodus through the wilderness, a highway for God's return to his people. But prophetic poetry had to become political reality. When Cyrus of Persia issued his decree, the physical journey home could finally begin — though the spiritual homecoming remained incomplete."
     },
     {
       "stop_order": 7,
@@ -173,7 +173,7 @@
       "what_changes": "Physical return begins, but the spiritual restoration promised by the prophets remains incomplete. The second temple lacks the glory of the first.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The return under Cyrus was geographically real but theologically disappointing. The second temple lacked the glory of the first; the monarchy was not restored; the great prophetic promises of full restoration felt unfulfilled. Jesus told a story that recast the entire exile-and-return pattern in personal and spiritual terms."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/faith.json
+++ b/content/meta/journeys/concept/faith.json
@@ -63,7 +63,7 @@
       "what_changes": "Faith is established as the basis of right standing with God. Righteousness is credited, not earned.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Abraham's faith was personal and solitary — one man believing God under a starlit sky. But could an entire nation exercise that same trust? At the Red Sea, Israel faced a collective test of faith whose outcome would define their identity as a people."
     },
     {
       "stop_order": 2,
@@ -78,7 +78,7 @@
       "what_changes": "Faith becomes communal and responsive to divine action. The pattern is established: God acts, the people believe.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Israel believed at the Red Sea when God's power was on dramatic display. But what happens to faith when God seems absent, when the promised deliverance does not come? Habakkuk asked that question at the darkest moment of Judah's history and received an answer that would echo through the New Testament."
     },
     {
       "stop_order": 3,
@@ -93,7 +93,7 @@
       "what_changes": "Faith is defined against the backdrop of crisis. Trust in God persists even when circumstances contradict the promises.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Habakkuk declared that the righteous live by faith even when circumstances scream otherwise. Centuries later, Jesus encountered faith of extraordinary quality — not among Israel's religious leaders, but in a Roman military officer who understood authority and believed Jesus wielded it."
     },
     {
       "stop_order": 4,
@@ -108,7 +108,7 @@
       "what_changes": "Faith crosses ethnic boundaries. The expected people lack what an outsider possesses, foreshadowing the Gentile mission.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The centurion's faith amazed Jesus with its clarity and confidence. But the Gospels also make room for a messier kind of faith — the kind that wrestles with doubt in the same breath as belief."
     },
     {
       "stop_order": 5,
@@ -123,7 +123,7 @@
       "what_changes": "Faith is shown to be compatible with doubt. Honest struggling faith, not perfect certainty, is sufficient.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The father's cry — \"I believe; help my unbelief\" — acknowledged that faith and doubt can coexist. Paul returned to the primal example of Abraham to show that even the patriarch's faith involved trusting God against all visible evidence."
     },
     {
       "stop_order": 6,
@@ -138,7 +138,7 @@
       "what_changes": "Genesis 15:6 becomes the cornerstone of Pauline soteriology. Faith, not works of the law, is the instrument of justification.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul grounded justification in Abraham's faith, establishing the theological architecture. But the author of Hebrews stepped back to define faith itself — not just as an example to follow but as a fundamental orientation toward the unseen and the promised."
     },
     {
       "stop_order": 7,
@@ -153,7 +153,7 @@
       "what_changes": "Faith receives its most concentrated theological definition. It bridges the gap between promise and fulfillment, visible and invisible.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Hebrews defined faith and catalogued its heroes, but James raised a pointed challenge: what good is faith that produces no action? His argument does not contradict Paul but completes the picture, insisting that genuine trust in God always bears visible fruit."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/holiness.json
+++ b/content/meta/journeys/concept/holiness.json
@@ -63,7 +63,7 @@
       "what_changes": "Holiness is revealed as the fundamental attribute of God's presence. It creates a boundary that requires human response.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The burning bush revealed holiness as the defining attribute of God's presence, but one encounter at one location was insufficient for a whole nation. When all Israel assembled at Sinai, the holiness that Moses experienced alone became a corporate and terrifying reality."
     },
     {
       "stop_order": 2,
@@ -78,7 +78,7 @@
       "what_changes": "Holiness is shown to be dangerous to the unprepared. Separation and consecration become prerequisites for approaching God.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Sinai, holiness was dangerous — touch the mountain and die. But God did not simply want his people to fear him from a distance. He called them to mirror his holiness in their daily lives, transforming every aspect of existence into an expression of consecration."
     },
     {
       "stop_order": 3,
@@ -93,7 +93,7 @@
       "what_changes": "Holiness becomes a calling, not just a divine attribute. Israel's entire way of life — food, clothing, agriculture — is shaped by the holiness imperative.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Leviticus legislated holiness into food laws, purity codes, and agricultural practices. But the prophets glimpsed holiness at a deeper level. When Isaiah saw the LORD in the temple, the threefold cry of the seraphim revealed holiness as the essence of God's being — and exposed human uncleanness by contrast."
     },
     {
       "stop_order": 4,
@@ -108,7 +108,7 @@
       "what_changes": "The threefold repetition intensifies the concept to its absolute degree. Holiness produces both terror and cleansing.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's temple vision showed that encounter with the Holy One produces simultaneous terror and cleansing. But Israel's persistent failure to live as a holy people raised an urgent question: if the people continually profane God's name, who will vindicate it? Ezekiel answered from exile."
     },
     {
       "stop_order": 5,
@@ -123,7 +123,7 @@
       "what_changes": "Holiness becomes the driving motive of redemptive history. God acts 'for the sake of my holy name,' not for human deserving.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ezekiel declared that God would act for the sake of his own holy name, restoring Israel not because they deserved it but because his reputation demanded it. When Jesus appeared, he recast the holiness imperative in terms that shifted the focus from external ritual to internal character."
     },
     {
       "stop_order": 6,
@@ -138,7 +138,7 @@
       "what_changes": "Holiness is internalized. External purity codes give way to holiness of heart and motive.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus internalized holiness, moving the demand from dietary laws and purity codes to the heart and its motives. The apostle Peter took this same internalized call and extended it explicitly to the church — a new covenant community drawn from every nation."
     },
     {
       "stop_order": 7,
@@ -153,7 +153,7 @@
       "what_changes": "The holiness imperative crosses the covenant boundary. What was Israel's distinctive calling becomes the universal mark of God's people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Peter called the church to holiness in all conduct, quoting the ancient Levitical command. But the ultimate vision of holiness transcends even faithful human obedience. In Revelation, the ceaseless cry of the living creatures reveals holiness as the eternal atmosphere of God's presence."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/judgment.json
+++ b/content/meta/journeys/concept/judgment.json
@@ -67,7 +67,7 @@
       "what_changes": "The first comprehensive judgment establishes the pattern: divine patience has limits, and persistent evil calls forth devastating response.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The flood was universal in scope, wiping the slate of creation nearly clean. But not all judgment operates at that scale. The next major act of divine judgment was targeted — aimed at specific cities whose wickedness had reached a tipping point."
     },
     {
       "stop_order": 2,
@@ -82,7 +82,7 @@
       "what_changes": "Judgment becomes localized and specific. Particular communities bear the consequences of their particular sins.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Sodom and Gomorrah showed judgment falling on particular peoples for particular sins. But in Egypt, something new emerged: judgment wielded not as mere punishment but as a deliberate instrument of liberation for God's enslaved people."
     },
     {
       "stop_order": 3,
@@ -97,7 +97,7 @@
       "what_changes": "Judgment serves liberation. The plagues are not purposeless wrath but targeted acts that accomplish redemption.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The plagues served redemption, but they were directed outward — at Egypt, at Pharaoh, at foreign gods. Israel assumed that the Day of the LORD would always work in their favor. The prophet Amos shattered that assumption."
     },
     {
       "stop_order": 4,
@@ -112,7 +112,7 @@
       "what_changes": "Judgment turns inward toward God's own people. Covenant privilege does not exempt from covenant accountability.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Amos turned judgment inward toward Israel, but the mechanism remained unclear. How would God judge his own covenant people? Isaiah provided a disturbing answer: God would use a pagan empire as the rod of his anger — and then judge that empire too."
     },
     {
       "stop_order": 5,
@@ -127,7 +127,7 @@
       "what_changes": "Divine sovereignty encompasses pagan empires. God's use of nations does not excuse their moral culpability.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God wielded Assyria against the northern kingdom, then held Assyria accountable for its own arrogance. A century later, the same pattern repeated on a larger scale. Babylon became the instrument of judgment against Judah, and the exile Jeremiah had warned about finally arrived."
     },
     {
       "stop_order": 6,
@@ -142,7 +142,7 @@
       "what_changes": "Judgment is shown to be neither arbitrary nor disproportionate. The covenant spelled out the consequences in advance; judgment is covenant enforcement.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The exile fulfilled the covenant curses and vindicated the prophets. But the Old Testament's vision of judgment remained largely national and historical. When Jesus taught about final judgment, he made it universal, personal, and christological."
     },
     {
       "stop_order": 7,
@@ -157,7 +157,7 @@
       "what_changes": "Final judgment is christological and ethical. Care for the vulnerable is care for Christ himself; neglect is rejection of him.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus taught that the criterion of final judgment would be response to human need — and response to himself. The book of Revelation carries that vision to its ultimate conclusion: a throne before which all the dead stand, and books from which no one is omitted."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/kingship.json
+++ b/content/meta/journeys/concept/kingship.json
@@ -79,7 +79,7 @@
       "what_changes": "Kingship is linked to a specific tribe. The royal line is narrowed before Israel even becomes a nation.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jacob assigned the scepter to Judah, but centuries would pass before Israel had anything resembling a monarchy. When they finally stood at the threshold of nationhood, Moses laid down the constitutional limits that would distinguish Israel's king from every other ruler in the ancient world."
     },
     {
       "stop_order": 2,
@@ -94,7 +94,7 @@
       "what_changes": "Israelite kingship is defined as fundamentally different from pagan models. The king is under the law, not above it.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Moses defined a king constrained by Torah, but the actual demand for monarchy arose in a very different spirit. When Israel finally asked for a king, the request carried theological freight: were they rejecting God's direct rule?"
     },
     {
       "stop_order": 3,
@@ -109,7 +109,7 @@
       "what_changes": "The tension between divine and human kingship becomes explicit. Human monarchy is both concession and vehicle for God's purposes.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The people got their king — first Saul, then David. But God transformed the political concession into something far greater: a covenant promise that David's dynasty would endure forever."
     },
     {
       "stop_order": 4,
@@ -124,7 +124,7 @@
       "what_changes": "Kingship becomes covenantal. The Davidic line carries the weight of messianic expectation from this point forward.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Davidic covenant anchored messianic hope to a specific royal house, but that house was only as faithful as its occupants. Solomon's spectacular reign ended in spectacular failure, and the kingdom fractured under the weight of his idolatry."
     },
     {
       "stop_order": 5,
@@ -139,7 +139,7 @@
       "what_changes": "The failure of human kingship begins. Even the wisest king falls, yet the Davidic promise is not annulled.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The kingdom was torn, and centuries of mostly failed kings followed. Yet the prophets did not abandon hope — they intensified it, envisioning a coming ruler whose titles would exceed anything a merely human monarch could bear."
     },
     {
       "stop_order": 6,
@@ -154,7 +154,7 @@
       "what_changes": "The messianic king is described in terms that transcend human categories. Divine and human kingship converge in one figure.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah described a king bearing divine titles, but Daniel's night vision expanded the scope even further. The coming ruler would receive not just Israel's throne but universal, everlasting dominion over all peoples and nations."
     },
     {
       "stop_order": 7,
@@ -169,7 +169,7 @@
       "what_changes": "The kingdom vision becomes cosmic. The coming king's reign is not merely Israelite but universal and eternal.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Daniel's Son of Man received cosmic authority in heaven, but when the awaited king finally arrived on earth, he chose a mode of entry that confounded every expectation of power."
     },
     {
       "stop_order": 8,
@@ -184,7 +184,7 @@
       "what_changes": "The messianic king arrives, but on a donkey, not a war horse. Kingship is redefined through humility.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus entered Jerusalem on a donkey, redefining kingship through humility and suffering. But this was not the final act. The book of Revelation pulls back the curtain to reveal what that humble king truly is — and has always been."
     },
     {
       "stop_order": 9,

--- a/content/meta/journeys/concept/law-torah.json
+++ b/content/meta/journeys/concept/law-torah.json
@@ -59,7 +59,7 @@
       "what_changes": "Divine will is codified. Israel receives not merely guidance but binding covenant stipulations from the mouth of God.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Ten Commandments laid down the moral architecture of covenant life, but commandments alone can feel like cold stone. What transforms obedience from duty into devotion? Moses's farewell address answered: the law's deepest demand is not compliance but love."
     },
     {
       "stop_order": 2,
@@ -74,7 +74,7 @@
       "what_changes": "Torah observance is rooted in love, not mere obedience. The law is relational before it is regulatory.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Shema rooted Torah in love, but could that love be sustained across generations? Israel's poets discovered something the lawgiver had planted: a capacity for delight. In their hands, Torah ceased to be merely instruction and became the object of passionate affection."
     },
     {
       "stop_order": 3,
@@ -89,7 +89,7 @@
       "what_changes": "Torah piety is expressed as joy and desire. The psalmist celebrates the law rather than enduring it.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Psalm 19 celebrated the law's beauty, but the psalmists had more to say. One writer devoted the longest composition in the Psalter to a single subject — an acrostic meditation that exhausts the Hebrew alphabet in praise of God's instruction."
     },
     {
       "stop_order": 4,
@@ -104,7 +104,7 @@
       "what_changes": "Torah devotion reaches its literary peak. Every letter of the alphabet is pressed into service to praise God's instruction.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Israel's poets could celebrate the law, but the prophets saw a harsher reality: the people consistently failed to keep it. If the law was perfect but the human heart was not, something had to change — not the law itself, but where it was written."
     },
     {
       "stop_order": 5,
@@ -119,7 +119,7 @@
       "what_changes": "Torah is not abolished but internalized. The problem was never the law itself but the human heart's inability to keep it.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jeremiah promised the law inscribed on hearts, but what would that look like when the lawgiver himself appeared in the flesh? Jesus's relationship to Torah was the most contested question of his ministry, and he addressed it directly in his inaugural sermon."
     },
     {
       "stop_order": 6,
@@ -134,7 +134,7 @@
       "what_changes": "The law finds its intended goal in Christ. Fulfillment is neither abolition nor mere continuation but the realization of what Torah pointed toward.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus affirmed the law's enduring validity, but Paul faced a more complex pastoral question: if Christ fulfilled the law, what role does Torah play in the life of the believer? His answer began with a fierce defense of the law's goodness."
     },
     {
       "stop_order": 7,
@@ -149,7 +149,7 @@
       "what_changes": "The law is defended against antinomian misreading. Torah remains good; the diagnosis of failure lies in the human condition, not the divine instruction.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul defended the law as holy and good, yet insisted that it could not give what it demanded. If Torah diagnoses the disease but cannot cure it, what was its purpose in God's plan? Paul reached for an analogy from the ancient household."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/mercy-grace.json
+++ b/content/meta/journeys/concept/mercy-grace.json
@@ -55,7 +55,7 @@
       "what_changes": "God's character is revealed as fundamentally merciful. This formula becomes the most frequently quoted creed in the Old Testament.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God proclaimed himself merciful at Sinai, but would that mercy survive its first real test? Almost immediately, Israel's rebellion in the wilderness put the divine self-description to the proof."
     },
     {
       "stop_order": 2,
@@ -70,7 +70,7 @@
       "what_changes": "Mercy is shown to coexist with judgment. Pardon does not eliminate consequences but preserves the covenant relationship.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "In the wilderness, mercy coexisted with consequences. But could grace reach beyond communal pardon to cover individual moral catastrophe? The story of David's gravest sin pressed the question to its limit."
     },
     {
       "stop_order": 3,
@@ -85,7 +85,7 @@
       "what_changes": "Grace reaches into the most grievous moral failure. Even the king who should die by his own law receives mercy.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Nathan's declaration of pardon was dramatic but brief. Israel's worship tradition took that same mercy and shaped it into sustained meditation, exploring the emotional depth of God's compassion toward frail human beings."
     },
     {
       "stop_order": 4,
@@ -100,7 +100,7 @@
       "what_changes": "Mercy becomes intimate and parental. God's compassion is grounded in his knowledge of human frailty: 'He knows our frame.'",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The psalmist celebrated God's fatherly compassion toward Israel, but the prophets saw something even more startling: a God who agonized over the prospect of judgment, whose mercy was not calm detachment but fierce internal struggle."
     },
     {
       "stop_order": 5,
@@ -115,7 +115,7 @@
       "what_changes": "Grace is revealed as costly to God himself. Mercy is not indifference to sin but the triumph of love over just wrath.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Hosea revealed mercy as costly to God himself. But if God's compassion extends even to faithless Israel, where are its boundaries? The book of Jonah posed the most uncomfortable version of that question."
     },
     {
       "stop_order": 6,
@@ -130,7 +130,7 @@
       "what_changes": "Grace shatters national boundaries. The prophet who knows God's character resents its implications for the ungodly.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jonah discovered that grace has no national border. But when Jesus arrived, he pressed even further: grace is not merely reactive, pardoning those who return, but proactive, pursuing those who are still lost."
     },
     {
       "stop_order": 7,
@@ -145,7 +145,7 @@
       "what_changes": "Grace becomes active and seeking. God does not merely wait for the sinner's return but pursues the lost.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus's parables depicted a God who searches for the lost, but the theological framework for understanding this grace still needed articulation. Paul provided it with a formulation that became the cornerstone of Christian soteriology."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/mission.json
+++ b/content/meta/journeys/concept/mission.json
@@ -63,7 +63,7 @@
       "what_changes": "The purpose of Israel's calling is defined from the outset. Blessing is centrifugal: received in order to be given.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God blessed Abraham so that all the families of the earth would be blessed through him. But how would one family mediate blessing to the whole world? At Sinai, Israel received its job description: a kingdom of priests standing between God and the nations."
     },
     {
       "stop_order": 2,
@@ -78,7 +78,7 @@
       "what_changes": "National identity is missional. Israel exists not for its own sake but as a priestly bridge between God and the nations.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Israel was called to be a priestly nation mediating God's presence to the world. But did Israel fulfill that calling? The prophets saw both failure and future hope: the Servant of the LORD would carry the mission to its intended scope — a light reaching to the ends of the earth."
     },
     {
       "stop_order": 3,
@@ -93,7 +93,7 @@
       "what_changes": "Mission's scope becomes explicitly universal. The Servant's task is not merely to restore Israel but to bring salvation to the ends of the earth.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah envisioned salvation reaching to the earth's ends, but the book of Jonah tested whether Israel was willing to participate. Sent to preach to Nineveh — Israel's cruelest enemy — the reluctant prophet discovered that God's mercy has no national boundary."
     },
     {
       "stop_order": 4,
@@ -108,7 +108,7 @@
       "what_changes": "Mission to the nations is shown to be effective, even when the messenger is reluctant. Gentile repentance is genuine and accepted.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jonah's story showed that even a reluctant witness could be effective when God wills Gentile repentance. But the Old Testament's missional impulse remained largely centripetal — the nations were invited to come to Israel. Jesus reversed the direction entirely."
     },
     {
       "stop_order": 5,
@@ -123,7 +123,7 @@
       "what_changes": "Mission becomes the church's defining task. The Abrahamic promise of blessing to all families takes its final commissioning form.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Great Commission turned mission centrifugal: go to all nations. But Jesus also provided a map — a sequence of concentric circles expanding outward from Jerusalem to Judea, Samaria, and the ends of the earth."
     },
     {
       "stop_order": 6,
@@ -138,7 +138,7 @@
       "what_changes": "Mission has a geographic and demographic trajectory: from center to periphery, from familiar to foreign, from Jew to Gentile.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus mapped the mission's geographic trajectory; the book of Acts narrates its execution. The pivotal moment came when Paul and Barnabas, rejected by the synagogue, turned explicitly to the Gentiles — and grounded their decision in Isaiah's ancient prophecy."
     },
     {
       "stop_order": 7,
@@ -153,7 +153,7 @@
       "what_changes": "Isaiah's vision is enacted. The prophetic promise of universal mission becomes apostolic practice.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul enacted Isaiah's vision by planting churches across the Roman world. The book of Revelation shows the result: a numberless multitude from every nation, tribe, and language gathered before the throne, the Abrahamic promise at last fully realized."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/prophecy.json
+++ b/content/meta/journeys/concept/prophecy.json
@@ -83,7 +83,7 @@
       "what_changes": "The prophetic trajectory begins. A coming figure will defeat evil, though at personal cost. Redemptive history has a goal.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The protoevangelium planted a seed: a coming figure would crush the serpent at personal cost. But centuries passed before God established the institutional framework for prophetic communication. Moses became the prototype, and God promised that the prophetic office would continue through a successor \"like Moses.\""
     },
     {
       "stop_order": 2,
@@ -98,7 +98,7 @@
       "what_changes": "Prophetic office is institutionalized. The pattern is set: God communicates through appointed human mediators.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God promised to raise up prophets like Moses — human mediators who would speak divine words. When Elijah stood on Carmel, the prophetic office reached one of its most dramatic moments: a public, confrontational showdown that vindicated YHWH before the entire nation."
     },
     {
       "stop_order": 3,
@@ -113,7 +113,7 @@
       "what_changes": "The prophet becomes a public figure who confronts national apostasy. Prophetic ministry is not merely predictive but confrontational.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Elijah demonstrated that prophecy confronts national apostasy, but the writing prophets added a new dimension: detailed prediction of a coming figure. Isaiah's Immanuel oracle gave the messianic hope a name and a mystery — \"God with us\" in the form of a child."
     },
     {
       "stop_order": 4,
@@ -128,7 +128,7 @@
       "what_changes": "Prophecy becomes explicitly messianic. The coming figure is not merely a leader but 'God with us' in the most literal sense.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's Immanuel prophecy was rich in theological symbolism but sparse on timing. Daniel received something the earlier prophets had not: a revealed timeline. The seventy weeks gave prophetic expectation a chronological framework pointing toward an anointed one who would be \"cut off.\""
     },
     {
       "stop_order": 5,
@@ -143,7 +143,7 @@
       "what_changes": "Prophecy acquires temporal specificity. The divine plan operates on a revealed timeline, not arbitrary timing.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Daniel provided a timeline; Micah provided a birthplace. The prophetic tradition was accumulating specific details — not just the character and mission of the coming figure but the precise geographical location of his origin."
     },
     {
       "stop_order": 6,
@@ -158,7 +158,7 @@
       "what_changes": "Prophecy pinpoints geography. The specificity of Bethlehem will become a criterion for identifying the Messiah.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "By the close of the Old Testament, centuries of prophetic voices had assembled a composite portrait: a ruler from Bethlehem, born of a virgin, preceded by a messenger, anointed yet cut off. When the risen Jesus walked with two disciples on the Emmaus road, he showed them how every piece fit together."
     },
     {
       "stop_order": 7,
@@ -173,7 +173,7 @@
       "what_changes": "The entire prophetic corpus is revealed as christocentric. Every prophecy finds its coherence in one person.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "On the Emmaus road, Jesus declared all the Scriptures to be about himself. The book of Revelation distills that claim into a single principle that serves as the hermeneutical key to all prophecy: the testimony of Jesus is the very spirit of the prophetic word."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/redemption.json
+++ b/content/meta/journeys/concept/redemption.json
@@ -79,7 +79,7 @@
       "what_changes": "Redemption is first defined in terms of deliverance from slavery. God acts as kinsman-redeemer for an enslaved people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God declared himself Israel's kinsman-redeemer, delivering an entire people from slavery. But what did that cosmic act of redemption look like when scaled down to a single family's story? The book of Ruth gave the concept its most intimate and personal expression."
     },
     {
       "stop_order": 2,
@@ -94,7 +94,7 @@
       "what_changes": "Redemption takes on personal and relational dimensions. The redeemer acts out of loyalty and love, not mere legal obligation.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Boaz redeemed land and family out of personal loyalty. But when the exile shattered Israel's national life, the prophet Isaiah returned to the language of redemption on a grander scale — and made it startlingly intimate."
     },
     {
       "stop_order": 3,
@@ -109,7 +109,7 @@
       "what_changes": "Redemption becomes intimate and named. God redeems not a faceless mass but individuals known by name.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah declared Israel redeemed by name, but a question lingered: at what cost? In a surprising twist, the prophet announced that this redemption would come without price — not because it was cheap, but because God's sovereign authority alone would accomplish it."
     },
     {
       "stop_order": 4,
@@ -124,7 +124,7 @@
       "what_changes": "Redemption is shown to be purely gracious. No exchange is required; God's authority alone is sufficient.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah said God would redeem without money, relying on sheer divine power. But when Jesus appeared, he spoke of redemption in starkly different terms — not costless authority but the highest possible price."
     },
     {
       "stop_order": 5,
@@ -139,7 +139,7 @@
       "what_changes": "Redemption acquires its ultimate price. The redeemer pays not with silver or authority but with his own life.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus declared his life the ransom, but Paul pressed the logic further: what exactly were the redeemed being delivered from? The answer was not merely political oppression or social bondage but the deepest slavery of all — the curse that the law itself pronounced on all who failed to keep it."
     },
     {
       "stop_order": 6,
@@ -154,7 +154,7 @@
       "what_changes": "Redemption addresses the deepest bondage: not Egypt or Babylon but the curse of the law itself. The scope of redemption reaches its fullest extent.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul identified redemption from the law's curse as Christ's ultimate achievement. The final vision of Revelation shows the full scope of that ransom: not one nation delivered from one empire, but people from every tribe and tongue purchased by blood for God."
     },
     {
       "stop_order": 7,

--- a/content/meta/journeys/concept/resurrection.json
+++ b/content/meta/journeys/concept/resurrection.json
@@ -79,7 +79,7 @@
       "what_changes": "The first explicit hope of bodily vindication after death appears. Even before resurrection theology develops, the seed is planted.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Job's confession was a seed planted in barren ground — a solitary hope with no developed doctrine to support it. Centuries later, Isaiah watered that seed with a prophetic vision of death itself being swallowed up, placed within a great eschatological banquet on God's holy mountain."
     },
     {
       "stop_order": 2,
@@ -94,7 +94,7 @@
       "what_changes": "Death is declared temporary, not permanent. The prophetic vision includes the reversal of death itself.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah declared that God would swallow up death, but the imagery remained cosmic and vague. Ezekiel gave resurrection its most vivid and unforgettable picture: a valley of dry bones reassembled and reanimated by the breath of God."
     },
     {
       "stop_order": 3,
@@ -109,7 +109,7 @@
       "what_changes": "Resurrection imagery is applied to national restoration, but the language transcends metaphor. Death's reversal becomes thinkable.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ezekiel's vision used resurrection language for national restoration, but the concept was pushing toward individual application. Daniel took the final step, stating plainly that those who sleep in the dust of the earth will awake — some to everlasting life, some to everlasting contempt."
     },
     {
       "stop_order": 4,
@@ -124,7 +124,7 @@
       "what_changes": "Individual, bodily resurrection becomes an explicit eschatological expectation. The righteous and the wicked face different destinies.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Daniel's prophecy made individual resurrection an explicit expectation. But expectation is not yet event. Centuries of silence separated the promise from the morning when women arrived at a tomb and found it empty."
     },
     {
       "stop_order": 5,
@@ -139,7 +139,7 @@
       "what_changes": "Resurrection moves from prophecy to event. The hope of centuries becomes historical reality on the third day.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The empty tomb was the event, but the event needed witnesses and transmission. Within two decades of the resurrection, Paul was already citing a formal creed — a tradition received and passed on — that anchored the claim in named eyewitnesses."
     },
     {
       "stop_order": 6,
@@ -154,7 +154,7 @@
       "what_changes": "The resurrection is documented as tradition received and transmitted. Multiple witnesses establish its historicity.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul documented the resurrection as historical tradition, but he did not stop there. He drew out its cosmic implications: Christ's rising was not an isolated miracle but the firstfruits of a universal harvest that would encompass all who belong to him."
     },
     {
       "stop_order": 7,
@@ -169,7 +169,7 @@
       "what_changes": "Christ's resurrection guarantees the future resurrection of all believers. His rising is not an isolated event but the beginning of a harvest.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul called Christ's resurrection the firstfruits, guaranteeing a future harvest. The book of Revelation depicts that harvest: the faithful raised to life, reigning with Christ, death's grip finally and permanently broken."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/sacrifice-atonement.json
+++ b/content/meta/journeys/concept/sacrifice-atonement.json
@@ -83,7 +83,7 @@
       "what_changes": "The pattern of substitutionary covering is introduced. Sin requires a death to address its consequences.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God covered Adam and Eve with animal skins, but that first act of substitutionary covering was wordless and unexplained. The theology of sacrifice needed a dramatic test case — one that would reveal both the cost God demands and the provision he supplies."
     },
     {
       "stop_order": 2,
@@ -98,7 +98,7 @@
       "what_changes": "The principle of divine provision of the sacrifice is established. God himself will supply what he demands.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "On Moriah, God provided the ram. But the principle of substitution needed to scale from one family to an entire nation. When Israel groaned under Pharaoh, deliverance came through the blood of a different animal — a lamb whose death meant life for an entire people."
     },
     {
       "stop_order": 3,
@@ -113,7 +113,7 @@
       "what_changes": "Sacrifice becomes communal and commemorative. The annual Passover ritualizes Israel's foundational experience of redemption through blood.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Passover lamb protected Israel from destruction, but deliverance is not the same as ongoing atonement. Once settled in the land, Israel needed a comprehensive system for dealing with the sin that accumulated in daily life. Leviticus provided it in its most solemn ritual."
     },
     {
       "stop_order": 4,
@@ -128,7 +128,7 @@
       "what_changes": "National atonement is systematized. Two goats illustrate two aspects: propitiation (blood sprinkled) and expiation (sins removed).",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Day of Atonement established the annual cycle of national cleansing, but the rationale for blood sacrifice still needed explicit statement. Why blood? Why death? The next chapter of Leviticus supplies the theological explanation that underlies the entire system."
     },
     {
       "stop_order": 5,
@@ -143,7 +143,7 @@
       "what_changes": "Sacrifice is grounded in theology, not mere ritual. Blood represents life given in place of life forfeited.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Leviticus grounded sacrifice in the life that is in the blood. But the prophets began to see beyond the system to its culmination: a day when the sacrifice would not be an animal at all but a person who suffered willingly for others."
     },
     {
       "stop_order": 6,
@@ -158,7 +158,7 @@
       "what_changes": "Sacrifice becomes personal and prophetic. A single figure, not an animal, will accomplish what the entire sacrificial system pointed toward.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's Suffering Servant bore the sins of many, but centuries passed before anyone could identify that figure. When a wild prophet from the Judean desert finally pointed to a man and named him, every sacrificial thread in Scripture began to converge."
     },
     {
       "stop_order": 7,
@@ -173,7 +173,7 @@
       "what_changes": "The sacrifice is no longer prospective but present. The one to whom all lambs pointed has arrived.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "John the Baptist announced the Lamb of God, but the full theological significance of Christ's sacrifice required sustained reflection. The letter to the Hebrews provided it, arguing that what bulls and goats could never accomplish, Christ achieved once for all."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/shepherd.json
+++ b/content/meta/journeys/concept/shepherd.json
@@ -63,7 +63,7 @@
       "what_changes": "The shepherd metaphor is applied to God for the first time. Divine care is described in terms of the most familiar occupation in the ancient world.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jacob named God as his shepherd from the perspective of a long life's retrospect. His descendant David, who actually tended sheep before tending a nation, transformed that personal testimony into Israel's most beloved expression of trust."
     },
     {
       "stop_order": 2,
@@ -78,7 +78,7 @@
       "what_changes": "The shepherd image becomes Israel's defining expression of divine care. Every element of pastoral provision is theologized.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Psalm 23 celebrated God as the shepherd of the individual soul. But David himself was also a shepherd — not just of sheep but of God's people. The historical psalms connected David's pastoral background to his royal vocation."
     },
     {
       "stop_order": 3,
@@ -93,7 +93,7 @@
       "what_changes": "Human kingship is described as shepherding. The good king mirrors the divine shepherd's care for the flock.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "David shepherded Israel with skill and integrity, but the kings who followed him did not. By Ezekiel's day, Israel's leaders had so thoroughly failed as shepherds that God pronounced devastating judgment on them."
     },
     {
       "stop_order": 4,
@@ -108,7 +108,7 @@
       "what_changes": "The shepherd metaphor becomes a standard of judgment for leaders. Failed shepherding is covenant-breaking with the most vulnerable.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ezekiel condemned the false shepherds who fed themselves and neglected the flock. But the oracle did not end in condemnation — it pivoted to an astonishing promise: God himself would step in to do what human leaders had refused to do."
     },
     {
       "stop_order": 5,
@@ -123,7 +123,7 @@
       "what_changes": "God replaces failed human shepherds with himself. The divine shepherd will do what human leaders refused to do.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God promised to shepherd his scattered flock personally, seeking the lost and binding the injured. Centuries later, Jesus claimed that role with deliberate precision, identifying himself as the good shepherd and adding a dimension Ezekiel had not imagined: the shepherd laying down his life."
     },
     {
       "stop_order": 6,
@@ -138,7 +138,7 @@
       "what_changes": "Ezekiel 34's promise of God shepherding his flock is fulfilled christologically. The good shepherd is simultaneously divine and self-sacrificing.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus the good shepherd laid down his life for the sheep, combining Ezekiel's promised divine shepherd with Isaiah's suffering servant. After the resurrection and ascension, Peter described the ongoing relationship between the risen Christ and his people in the same pastoral language."
     },
     {
       "stop_order": 7,
@@ -153,7 +153,7 @@
       "what_changes": "The shepherd image extends to spiritual oversight. Christ shepherds not merely bodies and communities but souls.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Peter called Christ the \"Shepherd and Overseer of your souls,\" extending the metaphor from earthly care to spiritual guardianship. The book of Revelation completes the image with a paradox that captures the entire biblical story: the sacrificed Lamb becomes the eternal shepherd."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/spirit-of-god.json
+++ b/content/meta/journeys/concept/spirit-of-god.json
@@ -71,7 +71,7 @@
       "what_changes": "The Spirit is associated with creation and the bringing of order from chaos. Creative power is pneumatological from the beginning.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Spirit hovered over creation's waters as an agent of cosmic order. But for most of Israel's early history, the Spirit's work appeared far more limited — coming upon select individuals for particular moments of crisis, then withdrawing."
     },
     {
       "stop_order": 2,
@@ -86,7 +86,7 @@
       "what_changes": "The Spirit's work becomes charismatic — given for a task, then withdrawn. Empowerment is temporary and functional.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Spirit empowered judges for temporary tasks, but kingship demanded something more sustained. When God rejected Saul and chose David, the Spirit's transfer marked a new pattern: anointing linked to royal office, not just battlefield emergency."
     },
     {
       "stop_order": 3,
@@ -101,7 +101,7 @@
       "what_changes": "The Spirit is linked to anointing and kingship. The transfer marks divine election and rejection.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Spirit rushed upon David from the day of his anointing, but even David's experience was imperfect — hence his desperate prayer in Psalm 51: \"Do not take your Holy Spirit from me.\" The prophets looked ahead to a coming ruler on whom the Spirit would rest without measure."
     },
     {
       "stop_order": 4,
@@ -116,7 +116,7 @@
       "what_changes": "The messianic king will not merely receive the Spirit temporarily but will be permanently characterized by the Spirit's sevenfold endowment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah described the messianic branch bearing the Spirit's sevenfold fullness, but the Spirit's work would not be limited to one anointed ruler. Ezekiel's vision expanded the scope dramatically: the Spirit would breathe life into an entire dead nation."
     },
     {
       "stop_order": 5,
@@ -131,7 +131,7 @@
       "what_changes": "The Spirit's role expands from individual empowerment to corporate, national resurrection. The Spirit recreates what death has destroyed.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ezekiel saw the Spirit resurrect a nation; Joel went further still. The coming outpouring would not be restricted to kings, prophets, or even Israel alone — God would pour out his Spirit on all flesh, dissolving every barrier of age, gender, and social status."
     },
     {
       "stop_order": 6,
@@ -146,7 +146,7 @@
       "what_changes": "The Spirit's work will no longer be restricted to select leaders. Universal outpouring replaces occasional charismatic endowment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Joel's promise of universal outpouring hung in the air for centuries. When the day of Pentecost arrived, Peter stood before the astonished crowd and declared: \"This is what was spoken through the prophet Joel.\" The age of the Spirit had begun."
     },
     {
       "stop_order": 7,
@@ -161,7 +161,7 @@
       "what_changes": "The age of the Spirit begins. What was promised through the prophets becomes the permanent, universal experience of the church.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Pentecost the Spirit descended on the gathered community, but Paul drew out the deeper implication: the Spirit is not merely an experience of power but the defining mark of belonging to Christ. Without the Spirit, there is no Christian identity at all."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/suffering.json
+++ b/content/meta/journeys/concept/suffering.json
@@ -71,7 +71,7 @@
       "what_changes": "Suffering is established as universal and connected to human rebellion. The world as experienced is not the world as originally designed.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Genesis traced suffering to the fall, connecting pain to human rebellion. But the book of Job shattered the neat equation between sin and suffering. Here was a blameless man who lost everything — and the text refused to offer a tidy explanation."
     },
     {
       "stop_order": 2,
@@ -86,7 +86,7 @@
       "what_changes": "Suffering is revealed to be irreducible to simple moral calculus. The question 'Why do the righteous suffer?' is posed with full force.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Job's story exposed the limits of retribution theology, but it offered no resolution — only divine encounter. Israel's worship tradition took up the raw material of suffering and shaped it into something the community could voice together: the psalm of lament."
     },
     {
       "stop_order": 3,
@@ -101,7 +101,7 @@
       "what_changes": "Suffering becomes liturgical and prophetic. Lament is given a canonical form that later generations will use, including Jesus himself.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Psalm 22 gave liturgical form to the cry of abandonment, a prayer that moved from despair to praise. The prophets took the theme further still: Isaiah envisioned a figure whose suffering was not meaningless but vicarious, borne voluntarily for the healing of others."
     },
     {
       "stop_order": 4,
@@ -116,7 +116,7 @@
       "what_changes": "Suffering becomes vicarious and redemptive. One person's suffering can accomplish atonement for many.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's Suffering Servant bore the sins of many, transforming the meaning of pain from punishment to redemption. But could hope endure when an entire nation lay in ruins? The poet of Lamentations, writing from Jerusalem's ashes, discovered that it could."
     },
     {
       "stop_order": 5,
@@ -131,7 +131,7 @@
       "what_changes": "Suffering does not have the last word. Even in the worst imaginable circumstances, divine faithfulness endures.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Lamentations found steadfast love in the rubble of Jerusalem, but it could not explain how suffering would ultimately be resolved. When Jesus appeared, he did not explain suffering — he embraced it, announcing that the path to glory ran directly through the cross."
     },
     {
       "stop_order": 6,
@@ -146,7 +146,7 @@
       "what_changes": "Suffering becomes volitional and paradigmatic. The Messiah's suffering is not failure but divine necessity, and discipleship means following the same path.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus made suffering the way of discipleship: take up your cross and follow. Paul, writing from his own considerable experience of hardship, placed present suffering within an eschatological framework that changed everything."
     },
     {
       "stop_order": 7,
@@ -161,7 +161,7 @@
       "what_changes": "Suffering is set within an eschatological framework. Present pain is real but penultimate; glory is the final reality.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul declared present suffering incomparable to future glory. Peter completed the theological picture by teaching believers to see their suffering not as random misfortune but as participation in Christ's own experience — a mark of union with him."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/temple-presence.json
+++ b/content/meta/journeys/concept/temple-presence.json
@@ -71,7 +71,7 @@
       "what_changes": "Sacred space is first experienced as surprising encounter. God's presence is localized but unpredictable.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jacob stumbled upon sacred space by accident — God's presence surprised him at Bethel. But God did not intend his presence to remain a matter of chance encounter. He gave Moses detailed instructions for constructing a permanent dwelling in Israel's midst."
     },
     {
       "stop_order": 2,
@@ -86,7 +86,7 @@
       "what_changes": "God's presence becomes architecturally structured. The tabernacle is a portable Eden, mediating divine presence within the camp.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God commanded a sanctuary built to a heavenly pattern, but a blueprint is not yet a dwelling. The climactic question was whether God would actually take up residence. The answer came in a moment of overwhelming, visible glory."
     },
     {
       "stop_order": 3,
@@ -101,7 +101,7 @@
       "what_changes": "The promise of Exodus 25:8 is fulfilled. God's kavod — his weighty, luminous presence — takes up residence among his people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The glory that filled the tabernacle traveled with Israel through the wilderness. But when Solomon built a permanent house in Jerusalem, a critical transition occurred: the portable tent gave way to an immovable temple of stone."
     },
     {
       "stop_order": 4,
@@ -116,7 +116,7 @@
       "what_changes": "The tabernacle's portability gives way to permanence. Jerusalem becomes the fixed center of God's earthly presence.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Solomon's temple concentrated God's presence in Jerusalem, but that permanence created a dangerous illusion — the belief that God was bound to the building. Ezekiel witnessed the devastating truth: the glory of the LORD could leave."
     },
     {
       "stop_order": 5,
@@ -131,7 +131,7 @@
       "what_changes": "The temple without the glory is merely a building. God's presence is shown to be free, not captive to a structure.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The glory departed, the temple was destroyed, and Israel endured exile without a visible center of divine presence. Centuries passed. When God's presence returned, it came not in a building but in a body — the Word who \"tabernacled\" among us."
     },
     {
       "stop_order": 6,
@@ -146,7 +146,7 @@
       "what_changes": "God's presence is no longer mediated through a building but through a person. Jesus himself is the locus of divine glory.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "In Christ, God's presence was localized in one person for one generation. But after the ascension, something astonishing happened: the temple concept was radically democratized. Every believer became a dwelling place of the Holy Spirit."
     },
     {
       "stop_order": 7,
@@ -161,7 +161,7 @@
       "what_changes": "Every believer becomes a sacred space. The Spirit who filled tabernacle and temple now indwells each member of Christ's body.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul taught that the individual believer's body is a temple of the Spirit. But the trajectory of divine presence does not end with partial indwelling in a fallen world. Revelation envisions the day when the need for any temple — physical, personal, or communal — is transcended entirely."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/wisdom.json
+++ b/content/meta/journeys/concept/wisdom.json
@@ -55,7 +55,7 @@
       "what_changes": "Wisdom is anchored in theology, not mere pragmatism. True knowledge begins with right relationship to God.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Proverbs 1:7 established the fear of the LORD as wisdom's starting point, but the tradition did not stop at practical instruction. It reached for something far more ambitious: wisdom as a cosmic figure, present with God before the world began."
     },
     {
       "stop_order": 2,
@@ -70,7 +70,7 @@
       "what_changes": "Wisdom is elevated from practical skill to cosmic principle. The created order itself embodies divine wisdom.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Proverbs personified wisdom as present at creation, suggesting that the universe is structured by divine understanding. But the book of Job pushed back against any easy confidence in human access to that wisdom. If wisdom built the world, can mortals actually find her?"
     },
     {
       "stop_order": 3,
@@ -85,7 +85,7 @@
       "what_changes": "The limits of human wisdom are exposed. True wisdom is not achievable by human striving but received as divine gift.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Job concluded that wisdom belongs to God alone and comes to humans only as gift. Ecclesiastes pressed even harder, questioning whether the conventional wisdom tradition could account for life's apparent randomness and injustice."
     },
     {
       "stop_order": 4,
@@ -100,7 +100,7 @@
       "what_changes": "Wisdom literature gains its necessary counterpoint. Conventional wisdom cannot explain all of life's inequities.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Qoheleth declared everything \"vapor\" — elusive, fleeting, beyond human grasp. Yet his skepticism was not the final word. His own concluding counsel circled back, remarkably, to the very starting point of Israel's wisdom tradition."
     },
     {
       "stop_order": 5,
@@ -115,7 +115,7 @@
       "what_changes": "Skeptical wisdom circles back to faith. Even the most rigorous questioning ends at the same starting point as Proverbs 1:7.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ecclesiastes ended where Proverbs began: fear God and keep his commandments. But this closing of the Old Testament wisdom loop left an open question. If wisdom is cosmic and fear of the LORD is its beginning, what happens when the LORD himself walks the earth? Jesus claimed to be something greater than wisdom's greatest exemplar."
     },
     {
       "stop_order": 6,
@@ -130,7 +130,7 @@
       "what_changes": "Wisdom is no longer merely a tradition or a body of teaching but a person. Christological wisdom supersedes sapiential wisdom.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus declared himself greater than Solomon, but Paul went further still. The cross — the most foolish event in human reckoning — was in fact the supreme expression of divine wisdom, overturning every human category of what it means to be wise."
     },
     {
       "stop_order": 7,
@@ -145,7 +145,7 @@
       "what_changes": "The cross redefines wisdom entirely. What appears as ultimate folly — a crucified Messiah — is revealed as ultimate wisdom.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul declared the cross to be God's wisdom hidden in plain sight. The letter to the Colossians drew the ultimate conclusion: all the treasures of wisdom and knowledge are not scattered across books and traditions but gathered in one person."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/concept/word-of-god.json
+++ b/content/meta/journeys/concept/word-of-god.json
@@ -59,7 +59,7 @@
       "what_changes": "The word of God is established as performative and creative. What God speaks, exists. Language and reality are linked at the deepest level.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God's first speech created the cosmos, but his word was not only for making worlds. In the wilderness, Israel learned that the word that called light into being also sustains the life of those who hear it."
     },
     {
       "stop_order": 2,
@@ -74,7 +74,7 @@
       "what_changes": "The word of God is established as life-sustaining. Physical provision is secondary to the sustenance of divine speech.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Moses taught Israel to live by every word from God's mouth. But how does that word come? Not always in thunder and spectacle. Elijah discovered on a mountain that the most authoritative divine communication can arrive in the quietest possible form."
     },
     {
       "stop_order": 3,
@@ -89,7 +89,7 @@
       "what_changes": "The word of God is shown to come in unexpected modes. Divine communication need not be spectacular to be authoritative.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The still small voice spoke to one prophet on one mountain. But Isaiah announced a far broader principle: God's word, once spoken, carries an inherent power that guarantees its accomplishment across all of history."
     },
     {
       "stop_order": 4,
@@ -104,7 +104,7 @@
       "what_changes": "The word of God is declared effective and irrevocable. It cannot fail to accomplish what it was sent to do.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah compared the word to rain that never fails to water the earth. But Jeremiah added a more violent image: the same word that nurtures can also shatter. The word of God is not only gentle sustenance but also consuming fire."
     },
     {
       "stop_order": 5,
@@ -119,7 +119,7 @@
       "what_changes": "The word of God has destructive and transformative power. It cannot be domesticated or made comfortable.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The prophets knew the word of God as speech — creative, sustaining, shattering. But John's Gospel made a claim that reframed everything: the word that God spoke was not merely a message but a person, present with God from the very beginning."
     },
     {
       "stop_order": 6,
@@ -134,7 +134,7 @@
       "what_changes": "The word of God is revealed as personal and divine. The concept that began as divine speech becomes incarnate in Christ.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "John identified the Word as a person; the author of Hebrews explored what that personal Word does when it encounters the human heart. The result is the most vivid description of scripture's penetrating power in the entire New Testament."
     },
     {
       "stop_order": 7,
@@ -149,7 +149,7 @@
       "what_changes": "The word of God penetrates and judges the inner person. It is not merely informational but transformationally incisive.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Hebrews described the word as a sword that divides soul and spirit. In the final vision of Revelation, that sword-wielding Word rides forth as a conquering king, and the name on his robe connects every thread of the biblical story."
     },
     {
       "stop_order": 8,


### PR DESCRIPTION
## Summary

Closes #1388 (Phase 2B — Bridge authoring for Epic #1379)

Replaces all 142 `[BRIDGE TO AUTHOR]` placeholders across 20 concept journey files with substantive narrative bridges reflecting scholarly theological progression across the canon.

### Files modified
All 20 files in `content/meta/journeys/concept/`: covenant, law-torah, mercy-grace, creation, kingship, word-of-god, sacrifice-atonement, redemption, resurrection, judgment, temple-presence, spirit-of-god, holiness, faith, wisdom, suffering, shepherd, exile-return, mission, prophecy

## Verification
- Zero `[BRIDGE TO AUTHOR]` placeholders remaining
- `schema_validator.py` passes
- `build_sqlite.py` passes (50 journeys, 338 stops, 213 tags)
- `validate_sqlite.py` passes (90 checks, 0 failures)

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes