### PR TITLE
Content: author connective bridges for 30 person journeys (#1387)

### DIFF
--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "750e7dbf67dabf92",
-  "build_time": "2026-04-16T17:20:10.368400Z"
+  "content_hash": "76be55ec3148ad15",
+  "build_time": "2026-04-16T18:41:54.517903Z"
 }

--- a/content/meta/journeys/person/abraham.json
+++ b/content/meta/journeys/person/abraham.json
@@ -26,7 +26,7 @@
       "what_changes": "Faith begins with obedient response to God's voice, even when the destination is unknown.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Abram obeyed, uprooting his household from Haran and journeying into Canaan — a land he had never seen, promised to descendants he did not yet have. But famine struck almost immediately, and the man of faith made his first pragmatic compromise."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God preserves his promises even through our failures and faithlessness.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Back from Egypt with wealth but no heir, Abram faced the question that would define the next decades: God had promised land and offspring, but neither had materialized. Then God made the promise unmistakably concrete."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Righteousness comes through faith, and God himself guarantees his promises.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The covenant ceremony confirmed God's unilateral commitment, but it did not resolve the silence of Sarai's womb. After a decade of waiting, the household tried to help the promise along through human means."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Trying to manufacture God's promises through human scheming produces lasting consequences.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ishmael's birth brought a son but not the promised heir, and thirteen years of silence from God followed. When God finally spoke again, He demanded something visible — a mark on the body of every male in Abraham's household."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "God transforms identity and marks his people with visible signs of covenant belonging.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Circumcision bound the household to the covenant physically, but Abraham's next test would be moral. When God revealed the coming destruction of Sodom, where Lot had settled, Abraham stepped into an unprecedented role — intercessor."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "The righteous person stands in the gap, interceding even for those under judgment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Sodom's destruction confirmed that Abraham could not save the wicked by negotiation alone, yet God had remembered Lot for Abraham's sake. Now, against all biological possibility, the promise of a son was about to be fulfilled."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "God fulfills impossible promises in his own timing — nothing is too hard for the Lord.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaac's birth vindicated decades of waiting — laughter replaced doubt in Abraham's tent. But the greatest test was still ahead. God would ask Abraham to surrender the very son through whom the promise was supposed to continue."
     },
     {
       "stop_order": 8,
@@ -131,7 +131,7 @@
       "what_changes": "Supreme faith surrenders even the promise itself back to the Promiser, trusting God to provide.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The ram caught in the thicket spared Isaac's life, and Abraham descended Moriah with his faith refined to its essence: God himself would provide. The remaining years brought grief, practical matters, and the quiet work of securing the promise for the next generation."
     },
     {
       "stop_order": 9,

--- a/content/meta/journeys/person/barnabas.json
+++ b/content/meta/journeys/person/barnabas.json
@@ -26,7 +26,7 @@
       "what_changes": "The church recognizes character through actions — Barnabas's name becomes his nature.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The generosity that earned Joseph of Cyprus his new name — Barnabas, son of encouragement — would soon prove more than financial. When a former persecutor arrived in Jerusalem claiming conversion, every door was shut to him. Barnabas alone was willing to vouch."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "The encourager sees potential in people others fear — Barnabas's trust in Paul changes the course of Christian history.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Having introduced Paul to the apostles and later recruited him from Tarsus for the Antioch mission, Barnabas now stood beside him as the church commissioned its first intentional missionaries. Together they would carry the gospel beyond the familiar synagogues of the diaspora."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "The best mentors empower their protégés to surpass them — Barnabas gracefully yields the lead role.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The first journey proved that Gentiles would respond to the gospel in large numbers. But when planning the second trip, a sharp disagreement over John Mark's reliability exposed a fault line between Barnabas's instinct to restore and Paul's demand for reliability."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/daniel.json
+++ b/content/meta/journeys/person/daniel.json
@@ -26,7 +26,7 @@
       "what_changes": "Covenant faithfulness begins with small, daily choices — integrity in private precedes influence in public.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Daniel's refusal of the royal diet established a pattern: faithfulness in small matters preceded faithfulness in great ones. When the king's sleep was troubled by a dream no wise man could interpret, Daniel's God-given insight thrust him into the center of Babylonian power."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God reveals mysteries to the humble and governs the rise and fall of every empire in history.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Nebuchadnezzar's dream of the great statue revealed that empires rise and fall at God's direction. But the king's response to divine revelation was to build a golden statue demanding universal worship — setting the stage for a direct confrontation between imperial religion and covenant loyalty."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Faithful resistance to idolatry may lead into the fire — but God walks with his people through it.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The fiery furnace demonstrated that God could deliver his servants even from the most powerful ruler on earth. Decades later, under a new empire, an aging Daniel would face his own version of the same test — prayer to his God versus obedience to Persian law."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "When human law conflicts with divine command, the faithful choose God's authority and trust his deliverance.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Surviving the lions confirmed that the God of Israel exercised sovereignty over Persia just as he had over Babylon. Now the narrative shifts from Daniel's personal trials to his prophetic visions — sweeping revelations of kingdoms and a mysterious figure called the Son of Man."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Human empires are beastly and temporary — God's kingdom, given to the Son of Man, will never end.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The vision of one like a son of man receiving dominion from the Ancient of Days reframed everything Daniel had witnessed: the rise and fall of empires served a purpose beyond politics. His final visions would press further into the timeline of redemption, reaching toward an appointed end."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/david.json
+++ b/content/meta/journeys/person/david.json
@@ -26,7 +26,7 @@
       "what_changes": "God's choice defies human expectations — he looks at the heart, not the exterior.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The youngest son, passed over by his own father for the prophet's inspection, carried God's anointing back to the sheep fields with no army and no throne. His first public appearance would come not through politics but through a challenge no soldier in Israel dared to answer."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Faith in God's power, not superior weapons, defeats seemingly impossible opposition.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The giant's fall made David a national hero overnight — and a target. Saul's jealousy turned the palace into a death trap, and the anointed future king became a fugitive, learning to lead not from a throne but from caves and wilderness strongholds."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "The anointed king must wait in suffering before reigning — character is forged in the wilderness.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Years of running ended with Saul's death on Mount Gilboa. David's path to the throne was not a straight line — Judah crowned him first, and seven years of civil war passed before all twelve tribes acknowledged what God had declared years earlier in Bethlehem."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God's promises unfold gradually — partial fulfillment precedes full inheritance.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "With Jerusalem captured and the nation united, David brought the ark to his new capital. God's response exceeded anything David had imagined: not permission to build a temple, but a promise that David's house would endure forever."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "God's gifts always exceed our plans for him — the eternal throne surpasses any earthly temple.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The covenant promise was unconditional, but David's personal conduct was not exempt from consequences. A springtime glance from a rooftop set in motion a chain of adultery, murder, and prophetic confrontation that would fracture David's household for a generation."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "Even the greatest saints are capable of grievous sin — but genuine repentance receives genuine forgiveness.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Nathan's prophecy — 'the sword shall never depart from your house' — materialized in David's own son. Absalom's rebellion forced the king to flee Jerusalem barefoot and weeping, experiencing in his own body the cost of his sin against Uriah's household."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "Sin's consequences ripple through families — the sword Nathan prophesied never departs from David's house.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Absalom's death ended the rebellion but broke David's heart. The remaining years brought plague, a census of pride, and a threshing floor purchased for the temple his son would build. David's final words were poetry and instruction — pointing forward to the enduring house God had promised."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/person/deborah.json
+++ b/content/meta/journeys/person/deborah.json
@@ -26,7 +26,7 @@
       "what_changes": "God raises leaders regardless of gender — Deborah combines judicial, prophetic, and military authority.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Deborah's authority as judge and prophet was unquestioned, but Israel's oppression under Jabin of Hazor required more than legal rulings. When she summoned Barak to lead the army, the general agreed — on the condition that the prophetess go with him to the battlefield."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God uses unexpected people and unconventional means — the mighty general falls to a woman with a tent peg.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Sisera's army was routed, and the victory song Deborah and Barak composed became one of the oldest poems in Scripture. Its final line — 'the land had rest forty years' — marked the high point of Israel's obedience in the judges cycle."
     },
     {
       "stop_order": 3,

--- a/content/meta/journeys/person/elijah.json
+++ b/content/meta/journeys/person/elijah.json
@@ -26,7 +26,7 @@
       "what_changes": "God's prophet speaks with heaven's authority and is sustained by heaven's provision.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The drought Elijah announced was God's opening argument against Baal, the storm god Jezebel had installed as Israel's patron deity. But before the public confrontation, God sent his prophet away — to a brook, then to a foreign widow's house, where the prophet himself would learn to depend on the provision he proclaimed."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God provides through unlikely channels and demonstrates his power over death itself.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Three years of famine had weakened the nation but not Ahab's stubbornness. The widow's oil and her son's restored life confirmed that Israel's God ruled even in Sidon. Now it was time for the decisive contest — Elijah alone against 450 prophets of Baal on Carmel's summit."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "The question of every generation: 'How long will you waver between two opinions?' — God answers with fire.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Fire fell, the prophets of Baal were slaughtered, and rain returned to Israel. The victory was total — and utterly unsustainable. One threat from Jezebel sent the triumphant prophet running for his life into the same wilderness where Moses had once fled."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Even the mightiest prophet hits bottom — God meets exhaustion with presence, provision, and a renewed commission.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Horeb, God was not in the wind, earthquake, or fire, but in the quiet voice that recommissioned a depleted prophet. Elijah returned to Israel with new assignments — and discovered that the corruption of Ahab's house extended from temple politics to the judicial murder of a common farmer."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "God defends the powerless against royal injustice — no throne is above covenant law.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Naboth's vineyard revealed that royal power in Israel had become indistinguishable from pagan tyranny. Elijah's final confrontation with Ahab delivered God's verdict on the dynasty. The prophet's earthly work was nearly done, and his departure would be as dramatic as his ministry."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/elisha.json
+++ b/content/meta/journeys/person/elisha.json
@@ -26,7 +26,7 @@
       "what_changes": "Following God's call requires decisive action — there is no going back to the plow.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Elisha burned his plow and boiled his oxen — a decisive break with his former life. But he would spend years as Elijah's attendant before receiving any independent commission, learning that prophetic authority is not seized but inherited."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Persistence in following one's mentor and bold faith in asking receive a double portion of God's Spirit.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Elijah's fiery departure left Elisha holding the mantle — literally. His request for a double portion was not greed but the firstborn's legal claim on the prophetic inheritance. The parting of the Jordan confirmed that the same Spirit now rested on the successor."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Prophetic power serves everyday people — God cares about widows' debts and children's lives.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Where Elijah had been a solitary figure of confrontation, Elisha moved among the people — multiplying oil for widows, purifying poisoned stew, feeding crowds with a few loaves. But his most famous miracle would reach across the border to a foreign general."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God's grace crosses national boundaries and works through humble obedience, not impressive rituals.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Naaman's healing demonstrated that Israel's God showed mercy to outsiders while Gehazi's greed showed that proximity to a prophet guaranteed nothing. Elisha's influence continued through wars and regime changes, and remarkably, his prophetic power outlasted even his own death."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/esther.json
+++ b/content/meta/journeys/person/esther.json
@@ -26,7 +26,7 @@
       "what_changes": "God positions his people in places of influence through ordinary circumstances — providence wears no label.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Esther's elevation to queen of Persia seemed like personal good fortune — a Jewish orphan raised to the highest position a woman could hold in the empire. But Mordecai's refusal to bow before an ambitious courtier was about to transform her comfortable position into a deadly dilemma."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Providence places us where we are for purposes larger than our own comfort — courage is required.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Haman's plot to annihilate every Jew in the empire turned Esther's concealed identity from a social strategy into a matter of national survival. Mordecai's challenge was blunt: silence would not save her, and perhaps she had come to her position for precisely this moment."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Courage at the right moment reverses the plans of the wicked — those who plot destruction are destroyed by their own schemes.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Esther's approach to the king uninvited risked her life under Persian law. Her carefully staged banquets demonstrated that courage alone was not enough — wisdom, timing, and the providential coincidence of the king's sleepless night all converged to reverse an irrevocable decree."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/ezekiel.json
+++ b/content/meta/journeys/person/ezekiel.json
@@ -26,7 +26,7 @@
       "what_changes": "God's presence is not bound to sacred geography — he meets his people wherever they are, even in exile.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The throne-chariot vision by the Kebar canal established Ezekiel's authority among the exiles, but it also delivered an unwelcome message: God had not simply abandoned Jerusalem — He was about to judge it. The prophet's body would become the medium for that message."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "When words fail, embodied prophecy breaks through — the prophet's suffering mirrors the people's fate.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Lying on his side for months, cooking over dung, shaving his head with a sword — Ezekiel's sign-acts made Jerusalem's coming destruction visceral and unavoidable. But the hardest blow was still ahead: a vision of what was happening inside the temple itself."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God's patience has limits — persistent unfaithfulness drives his presence away from the very place he chose to dwell.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Watching the glory of the Lord rise from the cherubim and depart through the east gate, Ezekiel witnessed what no Israelite thought possible — God abandoning His own house. With the temple spiritually vacated, the prophet turned to pronounce judgment on the nations that had cheered Jerusalem's fall."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God's sovereignty extends over every empire — no nation acts outside his jurisdiction.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The oracles against the nations established that Israel's God judged all peoples, not just His covenant community. But judgment was never God's final word. In the most dramatic vision of Ezekiel's career, God would bring him to a valley floor carpeted with bones and ask the impossible question: can these bones live?"
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/ezra.json
+++ b/content/meta/journeys/person/ezra.json
@@ -26,7 +26,7 @@
       "what_changes": "The scribe-priest bridges exile and restoration — knowledge of God's word is the foundation for rebuilding.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ezra arrived in Jerusalem decades after the first wave of returnees had rebuilt the temple. His royal commission authorized him to teach the Law, appoint judges, and enforce Torah observance. But the journey itself — nine hundred miles through bandit territory without a military escort — would test the faith he planned to teach."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Faith means acting on what we profess — Ezra's public testimony becomes the basis for private trust.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The caravan arrived safely, vindicating Ezra's trust in God over imperial cavalry. But what he found in Jerusalem shattered him: widespread intermarriage with the surrounding peoples had blurred the boundaries that Torah existed to maintain, threatening the identity of the restored community."
     },
     {
       "stop_order": 3,

--- a/content/meta/journeys/person/gideon.json
+++ b/content/meta/journeys/person/gideon.json
@@ -26,7 +26,7 @@
       "what_changes": "God sees what we will become, not what we currently are, and calls us by our future identity.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The angel's greeting — 'the Lord is with you, mighty warrior' — must have sounded absurd to a man threshing wheat in a winepress to hide it from raiders. But before God would use Gideon against the Midianites, He required him to confront the idol in his own father's backyard."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God accommodates weak faith while building it — he works with people where they are.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Tearing down the Baal altar by night showed a courage still mixed with fear — but it was enough. God accepted the imperfect obedience and confirmed the mission with wet and dry fleece. Now 32,000 volunteers assembled, and God began the strangest military reduction in history."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God deliberately reduces human resources so that his power is unmistakable — victory belongs to the Lord.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Three hundred men with torches and jars routed an army too numerous to count, proving that Israel's deliverance came from God alone. But Gideon's story did not end at the battlefield. The people's desire to crown him king, and his own crafting of a golden ephod, planted seeds that would outlast the victory."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/isaac.json
+++ b/content/meta/journeys/person/isaac.json
@@ -26,7 +26,7 @@
       "what_changes": "God's promises are fulfilled not through human effort but through divine power.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaac was born into laughter and nearly died on a mountain — the two defining events of his childhood were entirely beyond his control. As he grew into manhood, the question was whether he would simply inherit Abraham's faith or discover his own relationship with the God who had spared him."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "The beloved son offered on the mountain foreshadows the ultimate sacrifice God will provide.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Bound on the altar and unbound by grace, Isaac carried the weight of being the promised son without any recorded protest. Years later, his father's servant arrived with Rebekah, and Isaac's marriage would become the vessel through which the covenant promises passed to the next generation."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God guides the faithful toward his purposes through providence, even in ordinary moments.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Rebekah's twin sons struggled in the womb, and the oracle declared the older would serve the younger — upending the patriarchal inheritance that Isaac embodied. As famine drove the family south, Isaac replayed his father's patterns: digging wells, clashing with neighbors, and receiving God's reaffirmation of the covenant."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Faithfulness and patience ultimately produce room to flourish, even amid opposition.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The wells Isaac dug were contested, abandoned, and finally accepted — a quiet metaphor for his patient faith. But the patriarch's final act would reveal the limits of his discernment: a blessing intended for Esau, a deception orchestrated by Rebekah, and a plan that God had already determined to redirect."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/isaiah.json
+++ b/content/meta/journeys/person/isaiah.json
@@ -26,7 +26,7 @@
       "what_changes": "Authentic ministry begins with a vision of God's holiness that exposes our unworthiness and compels our response.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The seraphim's coal burned away Isaiah's uncleanness, and the prophet answered 'Here am I — send me.' But the commission that followed was startling: he would preach to a people destined not to listen, until cities lay ruined and the land was utterly forsaken."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "The prophet speaks truth to power — whether the king listens determines the nation's fate.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah served as counsel and conscience to four kings across decades of Assyrian crisis. Ahaz refused to ask for a sign; Hezekiah's tunnel saved Jerusalem from siege. Through it all, Isaiah wove together immediate political counsel and oracles that reached far beyond any single reign."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God holds his own people to a higher standard — privilege brings responsibility, and empty worship provokes judgment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Isaiah's oracles against the nations — Babylon, Moab, Egypt, Tyre — established that the God of Israel judged all peoples. Yet threaded through the pronouncements of doom was an insistent counter-melody: a servant who would suffer, a remnant that would return, and a new creation beyond the wreckage."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/jacob.json
+++ b/content/meta/journeys/person/jacob.json
@@ -26,7 +26,7 @@
       "what_changes": "God's election works through unexpected people, but grasping for blessing through deception brings consequences.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jacob emerged from the womb grasping his brother's heel, and the grasping never stopped. Having purchased Esau's birthright for a bowl of stew, he now faced a richer prize — their blind father's irrevocable blessing. But this time he would need his mother's help and his brother's clothes."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Deception may gain the blessing but fractures relationships and forces exile.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The stolen blessing secured Jacob's future but destroyed his home. Fleeing Esau's murderous rage toward his uncle in Haran, Jacob stopped for the night at a place that would forever mark the boundary between the old life and the new — a stone pillow and a stairway to heaven."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God meets the fugitive with grace, confirming promises to those who don't yet deserve them.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Bethel, God confirmed to the fugitive the same promise made to Abraham and Isaac. Jacob vowed allegiance — conditionally, characteristically — and continued east. In Haran he would meet his match: an uncle whose cunning rivaled his own, and a woman he would work fourteen years to marry."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God uses even dysfunctional family dynamics to build the twelve tribes of his covenant people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Twenty years of Laban's manipulation transformed Jacob from a clever young man into a weathered patriarch with two wives, twelve children, and substantial flocks. But returning to Canaan meant facing the brother he had cheated. The night before the reunion, Jacob found himself wrestling someone who would not let go until dawn."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Transformation comes through struggling with God, not through human cleverness — and leaves its mark.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The stranger dislocated Jacob's hip and renamed him Israel — 'he struggles with God.' The man who had lived by his wits now walked with a limp. The next morning brought the dreaded reunion, and Esau's response was the last thing Jacob expected."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "Grace makes reconciliation possible where only enmity seemed certain.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Esau's embrace dissolved twenty years of fear, but Jacob's troubles were far from over. Settling near Shechem brought the horror of Dinah's assault and his sons' murderous revenge. Then came the deepest grief: the apparent death of his favorite son Joseph, mourned with a grief that refused to be comforted."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "The consequences of favoritism ripple through generations, but God is at work even in loss.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "For over twenty years Jacob believed Joseph was dead, torn by wild animals. Famine forced him to send his remaining sons to Egypt for grain — where the unthinkable awaited. The journey to Egypt would be his last migration, and it fulfilled a prophecy given to Abraham generations before."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/person/jeremiah.json
+++ b/content/meta/journeys/person/jeremiah.json
@@ -26,7 +26,7 @@
       "what_changes": "God's calling precedes our existence — age and ability are irrelevant to divine commission.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Called before birth and commissioned as a teenager, Jeremiah protested that he was too young. God touched his mouth and set him over nations. His first major public act would challenge the institution Judah trusted most — the temple itself."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Religious institutions are not immune to judgment — God values obedience over sacred real estate.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The temple sermon nearly cost Jeremiah his life. Declaring that God would destroy His own house as He had destroyed Shiloh was intolerable to a nation that treated the temple as a talisman. From this point on, faithfulness to his calling meant constant opposition from priests, prophets, and kings."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Faithfulness to God's message brings suffering — the prophet's pain mirrors God's grief over his people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jeremiah was beaten, stockaded, thrown into a cistern, and forbidden to enter the temple. His confessions reveal a man who cursed the day he was born yet could not stop speaking. In the darkest period of his suffering, God gave him the most luminous prophecy in the Hebrew Bible."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "The darkest hour contains the brightest promise — God's commitment to restoration is most visible when destruction seems certain.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The new covenant oracle — God's law written on hearts rather than stone — was spoken while Jeremiah sat in a guard's courtyard and Babylonian siege ramps rose against the walls. The promise pointed far beyond the immediate catastrophe, but the catastrophe still had to come."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "The prophet vindicated too late — 40 years of warning ignored, but the new covenant promise endures beyond the rubble.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jerusalem fell in 586 BC exactly as Jeremiah had warned for forty years. The Babylonians, recognizing him as a voice of surrender, offered him safe passage to Babylon. Instead he stayed with the remnant — only to be dragged against his will to Egypt by the very people he had tried to save."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/jesus.json
+++ b/content/meta/journeys/person/jesus.json
@@ -26,7 +26,7 @@
       "what_changes": "The King of kings enters the world in vulnerability and obscurity — God's power concealed in a cradle.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Angels announced his birth to shepherds, and magi followed a star to find him. But between the manger and the ministry lay thirty years of near-total silence. The one recorded glimpse comes from a Passover visit when the boy was twelve."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Even in childhood, Jesus knows who he is and whose he is — identity precedes ministry.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The twelve-year-old who astonished the temple teachers returned to Nazareth and lived in obscurity for eighteen more years. When he finally emerged, it was not to teach but to be baptized by his cousin John — an act of solidarity with sinful humanity that launched his public mission."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Anointing is followed by testing — the Son of God faces what Adam faced and prevails where Adam failed.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The heavens opened at his baptism; the wilderness closed around him in temptation. Having refused to seize power through spectacle, compromise, or force, Jesus returned to Galilee and began the ministry that would redefine every expectation Israel had for its Messiah."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "The kingdom of God breaks into the present through Jesus' words and works — but its nature surprises everyone.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Galilean ministry drew enormous crowds with its healings, exorcisms, and authoritative teaching. But Jesus consistently redirected popular enthusiasm away from political liberation. The feeding of five thousand and walking on water revealed a power the crowds wanted to harness — and a purpose they could not yet grasp."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Jesus provides what only God can provide — but his provision demands faith that goes deeper than full stomachs.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The crowds wanted a bread king; Jesus offered a harder teaching that thinned their ranks. When he asked his inner circle who they believed he was, Peter's confession — 'You are the Christ' — marked a turning point. Jesus began speaking openly about suffering and death, and then took three disciples up a mountain."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "The veil parts briefly — the disciples glimpse the glory hidden beneath the servant's form.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "On the mountain, Moses and Elijah appeared and the Father's voice confirmed what Peter had confessed below. But the transfiguration's glory was brief. Jesus set his face toward Jerusalem, knowing that the road from the mountain led to a cross."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "The king enters his capital — but on a donkey, not a war horse. His kingdom redefines power.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The crowds that spread palm branches and shouted 'Hosanna' expected a conquering king. Jesus wept over the city instead. The temple cleansing signaled not political revolution but prophetic judgment. Within days the hosannas would become a different kind of shouting."
     },
     {
       "stop_order": 8,
@@ -131,7 +131,7 @@
       "what_changes": "The servant-king institutes the new covenant through sacrificial love — the meal that defines the community.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At the last supper Jesus reinterpreted Passover around his own body and blood, transforming Israel's founding memorial into a covenant meal that pointed forward to his death. Then he led the disciples out into the night, to a garden where he had often prayed."
     },
     {
       "stop_order": 9,
@@ -146,7 +146,7 @@
       "what_changes": "The Son submits his human will to the Father's purpose — obedience at the point of greatest cost.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "In Gethsemane, sweat fell like drops of blood as Jesus asked for the cup to pass — and accepted it. Judas arrived with soldiers and a kiss. The disciples fled. The man who had calmed storms and raised the dead allowed himself to be bound and led away."
     },
     {
       "stop_order": 10,
@@ -161,7 +161,7 @@
       "what_changes": "The sinless one bears the world's sin — forsaken so that the forsaken might be reconciled.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The trials were a sequence of illegalities — from Caiaphas's nighttime court to Pilate's hand-washing to the crowd choosing Barabbas. Jesus was scourged, mocked, and crucified between two criminals. By three in the afternoon on Friday, the one who said 'I am the resurrection and the life' was dead."
     },
     {
       "stop_order": 11,
@@ -176,7 +176,7 @@
       "what_changes": "Death is not the final word — the resurrection vindicates Jesus' claims and inaugurates the new creation.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The stone was rolled away not to let Jesus out but to let the witnesses in. Over forty days he appeared to individuals, to small groups, and once to over five hundred. The resurrection was not a resuscitation but the beginning of a new creation. One final meeting remained."
     },
     {
       "stop_order": 12,

--- a/content/meta/journeys/person/john-ap.json
+++ b/content/meta/journeys/person/john-ap.json
@@ -26,7 +26,7 @@
       "what_changes": "Jesus calls passionate people and channels their intensity — thunder becomes the voice of love.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The fisherman who left his nets at Jesus's call did not yet know he would outlive every other apostle. Along with Peter and James, John was drawn into an inner circle that witnessed things the others did not — beginning with events that would shape his theology of glory and suffering."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Intimacy with Jesus deepens understanding — closeness to Christ is the foundation of all ministry.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "John was present at the transfiguration, at the raising of Jairus's daughter, and at Gethsemane. He described himself simply as 'the disciple whom Jesus loved.' That intimacy would be tested at the place where every other male disciple fled."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Faithfulness at the cross — staying when others flee — creates new bonds of family in God's kingdom.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Standing at the foot of the cross while others hid, John received Jesus's mother into his care — a personal commission from the dying Messiah. The eyewitness of the crucifixion would spend the rest of his life interpreting what he had seen, first in letters to scattered churches."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "The Son of Thunder becomes the Apostle of Love — a lifetime with Jesus transforms our deepest nature.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "John's epistles distilled decades of reflection into urgent simplicity: God is light, God is love, and the test of genuine faith is love made visible. But his final work would be neither pastoral letter nor memoir — it would be an apocalyptic vision received in exile."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/joseph-ot.json
+++ b/content/meta/journeys/person/joseph-ot.json
@@ -26,7 +26,7 @@
       "what_changes": "God-given vision can isolate before it elevates — faithfulness is tested by those closest to us.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Joseph's dreams of sheaves bowing and stars prostrating themselves made his brothers' resentment boil over. The favorite son's coat was stripped away and the dreamer was thrown into a pit. What happened next would set in motion a journey that neither Joseph nor his brothers could have foreseen."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Betrayal by those who should protect you is the deepest wound — but not the final word.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Sold to a caravan bound for Egypt, Joseph descended from beloved son to foreign slave in a matter of days. Yet even in Potiphar's household, the narrator insists that 'the Lord was with Joseph' — a claim about to be tested by a powerful woman's advances."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Integrity doesn't guarantee immediate vindication, but God's presence sustains the faithful in every circumstance.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Joseph's integrity cost him everything a second time. Falsely accused and imprisoned, he found himself in a dungeon with no advocate and no appeal. But the same interpretive gift that had annoyed his brothers in Canaan now surfaced in the dreams of two fellow prisoners."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God's gifts operate even in darkness, and forgotten faithfulness will be remembered in God's timing.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The cupbearer forgot Joseph for two full years — until the night Pharaoh's own sleep was troubled by dreams no Egyptian wise man could decode. Joseph was rushed from the dungeon, shaved, and brought before the most powerful ruler in the ancient world."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Sudden reversal from prison to palace — God's timing transforms suffering into strategic positioning.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Joseph's interpretation saved Egypt from famine and elevated him to second-in-command of the empire. But the famine also drove his brothers south for grain, setting up an encounter they never expected — their long-dead brother alive, powerful, and unrecognizable behind Egyptian clothing and language."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "True reconciliation requires evidence of transformed character, not just regret.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Joseph's elaborate tests — the silver cup, the threat to Benjamin, the demand for their father — were not cruelty but a careful probe of whether the men who had sold him had changed. Judah's willingness to take Benjamin's place answered the question, and Joseph could no longer contain himself."
     },
     {
       "stop_order": 7,

--- a/content/meta/journeys/person/joshua.json
+++ b/content/meta/journeys/person/joshua.json
@@ -26,7 +26,7 @@
       "what_changes": "Great leaders are formed through long seasons of faithful service under others.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "For forty years Joshua served as Moses's apprentice — military commander at Rephidim, attendant at Sinai, one of twelve spies sent into Canaan. He saw the promised land when the nation refused to enter it, and waited a generation for a second chance."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Faithful minority reports may be rejected in the moment but vindicated by God in time.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Only Joshua and Caleb survived the wilderness from the exodus generation, because only they had trusted God's promise over the giants' size. That trust, tested across four decades of wandering, became the credential for the commission that was coming."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God's work continues through new leaders — his presence, not the leader's ability, is the source of courage.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Moses laid hands on Joshua before all Israel and then climbed Nebo alone. The mantle of leadership passed not through dynasty but through faithfulness. God's first words to the new leader were a command repeated three times: be strong and courageous."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God fights for his people but demands holiness — sin in the camp has corporate consequences.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Jordan parted, Jericho's walls collapsed, and Ai fell on the second attempt after Achan's sin was purged. Campaign by campaign, Joshua led Israel into possession of the land — though significant pockets of resistance remained unconquered, a detail that would haunt subsequent generations."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "God keeps his promises down to specific parcels of land — every tribe receives its inheritance.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "With the major campaigns complete, Joshua oversaw the division of the land among the twelve tribes by sacred lot. The work of conquest gave way to the harder work of settlement. Joshua's final act would be to gather all Israel and force a choice."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/mary.json
+++ b/content/meta/journeys/person/mary.json
@@ -26,7 +26,7 @@
       "what_changes": "God's greatest work begins with humble consent — Mary's 'yes' opens the door for the incarnation.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The angel departed and Mary was left with an impossible pregnancy, a bewildered fiancé, and a song forming in her heart. She traveled immediately to her relative Elizabeth — the one person who could understand what it meant to carry a child announced by an angel."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God's revolution begins not with armies but with a mother's song and a baby's cry.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Magnificat poured out a theology of reversal — the mighty cast down, the humble exalted, the hungry filled. Then came the birth in Bethlehem, shepherds at midnight, and the long journey to Jerusalem for the rites that every firstborn son required."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "The privilege of bearing the Messiah includes the pain of watching him be rejected — joy and sorrow intertwine.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "In the temple, old Simeon took the infant and blessed God — then turned to Mary with words that lodged like a blade: 'a sword will pierce your own soul too.' She stored this alongside the angel's promise, carrying both as her son grew in wisdom and obscurity."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Mary's role shifts from mother to first disciple — pointing others to obey her son.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Cana, Mary's simple statement — 'they have no wine' — drew a response from Jesus that reframed their relationship: his hour had not yet come, but it was approaching. From this point Mary appears only at the margins of his public ministry, until the hour finally arrived at Golgotha."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/moses.json
+++ b/content/meta/journeys/person/moses.json
@@ -26,7 +26,7 @@
       "what_changes": "God's providence places his chosen instruments exactly where they need to be, even in enemy territory.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "A Hebrew infant hidden in a basket, drawn from the Nile by Pharaoh's own daughter — Moses grew up between two worlds, Egyptian privilege and Hebrew identity. When he tried to reconcile them with his own fists, killing an Egyptian overseer, both worlds rejected him."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God's preparation often involves stripping away human credentials and teaching dependence through obscurity.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Moses fled to Midian, married a shepherd's daughter, and spent forty years tending sheep in the wilderness. The man educated in all the wisdom of Egypt was being remade in silence and solitude. Then a bush burned without being consumed."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God calls reluctant people and equips them despite their objections — his power is perfected in weakness.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "God spoke from the fire, revealed his name, and commissioned the reluctant shepherd to confront the most powerful ruler in the world. Moses protested his inadequacy five times before setting out for Egypt with his brother Aaron and a staff that would become an instrument of divine power."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God's power confronts every rival claim to authority, and deliverance comes through substitutionary blood.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ten plagues systematically dismantled Egypt's gods — the Nile turned to blood, darkness covered the land of the sun god, death took every firstborn. Pharaoh's resistance broke on the night of Passover, and a nation of slaves walked out of four centuries of bondage."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Salvation is entirely God's work — and those he saves must learn daily dependence on his provision.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The sea parted, the army drowned, and Israel sang on the far shore. But the euphoria of deliverance gave way quickly to the demands of survival: no water, no food, no direction. God led them not toward Canaan but toward a mountain where he intended to make them his own people."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "The mediator stands between a holy God and a sinful people — a role that points to Christ.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "At Sinai, thunder and lightning framed the giving of the Law — ten words that would shape Western civilization, followed by ordinances that governed every dimension of community life. But Moses was on the mountain for forty days, and the people grew impatient."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "God desires to dwell among his people — and provides the means for a holy God to live with sinful humans.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The golden calf incident shattered the tablets and nearly ended the covenant before it began. Yet Moses interceded, God relented, and new tablets were carved. The tabernacle — God's portable dwelling among his people — was built according to the pattern shown on the mountain."
     },
     {
       "stop_order": 8,
@@ -131,7 +131,7 @@
       "what_changes": "Unbelief forfeits what God freely offers — even the greatest leaders face consequences for disobedience.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The tabernacle consecrated, the cloud leading by day and fire by night — Israel set out from Sinai toward the promised land. But the journey that should have taken weeks stretched into forty years. Complaints about food, challenges to Moses's authority, and fear of Canaan's inhabitants turned the wilderness into a proving ground."
     },
     {
       "stop_order": 9,
@@ -146,7 +146,7 @@
       "what_changes": "God himself vindicates those he has chosen to lead — rebellion against his appointed authority is rebellion against him.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Korah's rebellion challenged Moses's leadership directly: 'All the congregation is holy — why do you exalt yourself?' The earth opened and swallowed the challengers. Moses's authority was confirmed, but his own moment of failure at Meribah — striking the rock instead of speaking to it — meant he would see the promised land only from a distance."
     },
     {
       "stop_order": 10,

--- a/content/meta/journeys/person/nehemiah.json
+++ b/content/meta/journeys/person/nehemiah.json
@@ -26,7 +26,7 @@
       "what_changes": "Effective action begins with grief over what is broken and sustained prayer before God.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The news from Jerusalem shattered Nehemiah's composure: the walls were broken, the gates burned, and the returned exiles lived in disgrace. The cupbearer to the king of Persia wept, fasted, and prayed for four months before the king noticed his face and asked what was wrong."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Strategic planning combined with courageous faith turns despair into actionable vision.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Artaxerxes granted letters, timber, and safe passage — but no soldiers. Nehemiah arrived in Jerusalem, conducted a secret nighttime survey of the ruined walls, and then announced his plan to a demoralized population. Opposition materialized immediately from three directions."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Opposition to God's work is guaranteed — the answer is prayer, vigilance, and refusal to stop building.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Sanballat mocked, Tobiah threatened, and Geshem plotted assassination — yet the wall rose in fifty-two days, with builders working sword in one hand and trowel in the other. With the city secured, Nehemiah turned from construction to the harder task of rebuilding the community's covenant identity."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/paul.json
+++ b/content/meta/journeys/person/paul.json
@@ -26,7 +26,7 @@
       "what_changes": "The greatest opposition to the gospel can be transformed into its greatest advocacy — no one is beyond God's reach.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Saul of Tarsus was the early church's most effective enemy — a Pharisee with impeccable credentials, Roman citizenship, and the high priest's authorization to arrest followers of the Way. He was heading to Damascus to expand the crackdown when a light brighter than the midday sun knocked him to the ground."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Conversion overturns everything — the hunter becomes the hunted, and grace rewrites the most hostile biography.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Blinded on the road and healed by the very community he had come to destroy, Saul received a commission that inverted his entire identity: the persecutor would become the apostle to the Gentiles. But instead of immediately preaching, he withdrew."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Radical transformation requires time in the wilderness — God's deepest teaching happens away from public platforms.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul spent years in Arabia and then Tarsus — a period of theological reconstruction invisible to history but essential to everything that followed. When Barnabas recruited him for the Antioch church, the diaspora synagogue network became his launching pad."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "The Spirit initiates mission — human planning serves divine sending, and opposition is part of the plan.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The first missionary journey proved that Gentiles would respond to the gospel in large numbers — without becoming Jewish first. This success created a crisis: did Gentile believers need to be circumcised? The question that had simmered in Antioch now demanded an answer from the mother church in Jerusalem."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "The church's most important theological decision preserves the gospel's core: grace alone, faith alone.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The Jerusalem council's decision — no circumcision required, only minimal dietary accommodations — was the hinge moment for Christianity's identity as a universal faith rather than a Jewish sect. Freed from that constraint, Paul set out on journeys that would plant churches across Asia Minor and into Europe."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "The gospel crosses every boundary — geographic, ethnic, cultural, intellectual — transforming cities and provoking empires.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Corinth, Ephesus, Thessalonica, Philippi — Paul planted and nurtured churches across two continents, writing letters that addressed everything from sexual ethics to resurrection theology. But a conviction was growing that he must visit Jerusalem one more time, despite repeated warnings that chains awaited him there."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "Obedience to God's leading sometimes walks directly into chains — Paul's imprisonment is not failure but fulfillment.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Paul arrived in Jerusalem with a collection from the Gentile churches — a concrete symbol of unity between Jewish and Gentile believers. Within days, a riot in the temple courts led to his arrest by Roman soldiers. He would never be free again."
     },
     {
       "stop_order": 8,
@@ -131,7 +131,7 @@
       "what_changes": "Legal proceedings become evangelistic platforms — every courtroom is a pulpit for the one who lives to testify.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Two years in a Caesarean prison, a hearing before Felix, another before Festus, a dramatic defense before King Agrippa — and then the words that changed everything: 'I appeal to Caesar.' As a Roman citizen, Paul had the right, and the machinery of empire began moving him toward Rome."
     },
     {
       "stop_order": 9,
@@ -146,7 +146,7 @@
       "what_changes": "Acts ends with the gospel unhindered — not with Paul's freedom but with the Word's freedom. The mission continues.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The voyage to Rome featured a shipwreck on Malta, a viper that did not kill him, and finally arrival in the imperial capital — in chains, but with permission to receive visitors. From his rented quarters, Paul continued the work that prison walls could not contain."
     },
     {
       "stop_order": 10,

--- a/content/meta/journeys/person/peter.json
+++ b/content/meta/journeys/person/peter.json
@@ -26,7 +26,7 @@
       "what_changes": "Jesus calls imperfect people and transforms their ordinary skills into instruments of his kingdom.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Simon was a fisherman, blunt and impulsive, who left everything to follow an itinerant rabbi from Nazareth. For three years he watched, blundered, and occasionally glimpsed something the others missed. When Jesus asked who the disciples believed he was, Simon answered first."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Genuine revelation and profound misunderstanding can coexist — growth in faith is uneven.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Jesus called him Peter — the Rock — and declared that on this confession the church would be built. But within minutes Peter was rebuking Jesus for speaking about suffering and death, earning the sharpest rebuke in the Gospels: 'Get behind me, Satan.' The rock had much to learn about the kind of Messiah he had confessed."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Even the strongest declarations of loyalty can crumble under pressure — but failure is not final for those who repent.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "In the courtyard of the high priest, three times asked and three times denied. The rooster crowed, Jesus turned and looked at him, and Peter went out and wept bitterly. The man who had promised to die for Jesus could not even admit knowing him to a servant girl."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Grace doesn't just forgive — it restores and recommissions. Peter's failure becomes the foundation for deeper ministry.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "On the shore of Galilee, over a charcoal fire that echoed the courtyard's flames, Jesus asked three times: 'Do you love me?' Three denials met by three commissions — feed my lambs, tend my sheep, feed my sheep. Peter was restored not by erasing his failure but by being given work that required the very loyalty he had failed to show."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "The Spirit transforms cowardice into courage — the same person, empowered differently.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Fifty days after the resurrection, the Spirit fell and Peter — the denier — stood before thousands and preached with a boldness he had never possessed on his own. Three thousand believed. The fisherman had become the rock Jesus had named him."
     },
     {
       "stop_order": 6,
@@ -101,7 +101,7 @@
       "what_changes": "God uses visions and circumstances to demolish the theological assumptions of even his most faithful servants.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Peter's vision on a Joppa rooftop overturned a lifetime of kosher observance: 'What God has made clean, do not call common.' The visit to Cornelius's house that followed was the most consequential boundary-crossing since Jesus ate with tax collectors — a Roman centurion and his household received the same Spirit."
     },
     {
       "stop_order": 7,
@@ -116,7 +116,7 @@
       "what_changes": "Prayer accomplishes what human effort cannot — and God's deliverances often exceed what even the praying church expects.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Herod arrested Peter, executed James, and planned the same for Peter after Passover. An angel's midnight liberation — chains falling, gates opening on their own — demonstrated that the church's survival depended on something beyond human strategy. Peter's later years are glimpsed only in his letters."
     },
     {
       "stop_order": 8,

--- a/content/meta/journeys/person/ruth.json
+++ b/content/meta/journeys/person/ruth.json
@@ -26,7 +26,7 @@
       "what_changes": "Covenant loyalty (hesed) sometimes means choosing hardship and the unknown over the safe and familiar.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Naomi's bitterness was complete: husband dead, sons dead, a foreign land that had given her nothing but graves. She set out for Bethlehem empty. But Ruth's refusal to leave — 'your people shall be my people, and your God my God' — meant that Naomi would not return entirely alone."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God's providence works through 'coincidences' — Ruth 'happened' to glean in the right field at the right time.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Ruth's loyalty declared itself in words; now it proved itself in labor. Gleaning in a stranger's field was the work of the destitute, but the field belonged to Boaz — a relative of Naomi's dead husband and a man whose character matched his wealth. Providence was arranging what planning could not."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Redemption involves risk and vulnerability — Ruth puts herself forward, trusting Boaz's character.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Naomi's instructions sent Ruth to the threshing floor at night — a bold, culturally loaded act that put Ruth's reputation and Boaz's integrity on the line. Ruth's request — 'spread your wings over me, for you are a redeemer' — invoked not romance but covenant law."
     },
     {
       "stop_order": 4,

--- a/content/meta/journeys/person/samson.json
+++ b/content/meta/journeys/person/samson.json
@@ -26,7 +26,7 @@
       "what_changes": "God's calling begins before birth — but calling and character must grow together.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "An angel announced Samson's birth to a barren couple and prescribed a Nazirite vow: no razor, no wine, no unclean food. The child would begin to deliver Israel from the Philistines. But 'begin' was a careful word — Samson's strength would always outrun his judgment."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Extraordinary gifting without self-discipline creates a pattern of provocation and retaliation.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Samson's demand for a Philistine wife bewildered his parents but set the stage for the pattern that would define his life: extraordinary strength deployed through personal grievances. A lion torn apart, a riddle weaponized, and thirty men killed for their garments — all triggered by a wedding that fell apart."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "God uses even deeply flawed vessels to accomplish his purposes against the enemies of his people.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Foxes with torches, a donkey's jawbone, and a thousand Philistines slain — Samson's escalating one-man war made him Israel's most feared judge and most undisciplined leader. His appetites were as outsized as his strength, and the Philistines had learned that the way to defeat him ran through the women he could not resist."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Persistent compromise erodes spiritual strength — the one who defeats armies is undone by his own appetites.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Delilah's persistence succeeded where Philistine armies had failed. Samson's hair was cut, his strength departed, and his eyes were gouged out. Grinding grain in a Gaza prison, the strongest man in Israel was reduced to the work of an ox. But hair grows back, and Samson had one prayer left."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/samuel.json
+++ b/content/meta/journeys/person/samuel.json
@@ -26,7 +26,7 @@
       "what_changes": "God hears the prayers of the desperate and turns personal grief into national redemption.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Hannah's prayer, her vow, and her weaning gift — the boy Samuel was left at Shiloh in the care of the aging priest Eli, whose own sons were corrupt beyond correction. In that morally compromised household, God was preparing a new kind of leader."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "God speaks to those who are willing to listen — even children — and his word does not return empty.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The voice in the night called three times before Eli recognized what was happening and instructed the boy to answer. Samuel's first prophetic message was devastating: judgment on the house of Eli. From that night forward, all Israel recognized that a prophet had risen."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Spiritual renewal precedes national deliverance — a leader who prays accomplishes more than one who fights.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Samuel led Israel as the last judge — circuit-riding through Bethel, Gilgal, and Mizpah, adjudicating disputes and calling the nation back to exclusive worship of the Lord. Under his leadership the Philistine threat receded. But Samuel's sons, like Eli's, were corrupt, and the elders saw only one solution."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "God permits what he doesn't prefer, working his purposes even through his people's misguided choices.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Israel's demand for a king 'like all the nations' grieved Samuel and, God told him, amounted to a rejection not of Samuel but of divine kingship itself. Nevertheless, God instructed Samuel to give them what they asked for. The prophet's task now was to find and anoint the man God had chosen."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Outward appearance and initial humility do not guarantee lasting faithfulness.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Saul was tall, handsome, and initially humble — 'Am I not a Benjaminite, from the smallest tribe?' Samuel anointed him privately, then presented him publicly. But the prophet already carried a second, secret commission: when Saul failed — and Samuel was told he would — there was a shepherd boy in Bethlehem."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/saul.json
+++ b/content/meta/journeys/person/saul.json
@@ -26,7 +26,7 @@
       "what_changes": "God can use anyone — but anointing is not the same as ongoing obedience.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Saul was anointed in secret, confirmed by lot at Mizpah, and initially dismissed by skeptics. His first test came quickly — an Ammonite siege of Jabesh-gilead. The Spirit of God rushed upon him, and the reluctant king rallied all Israel for a decisive victory that silenced every doubter."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Spirit-empowered leadership produces decisive action and unites God's people around a common mission.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The early victories established Saul's military credentials, but kingship in Israel was not like kingship anywhere else. The king ruled under the prophet and under the Law. At Gilgal, waiting for Samuel to arrive and offer sacrifice before battle, Saul's patience ran out before the prophet did."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "Impatience with God's timing reveals a heart that trusts its own judgment over God's commands.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Samuel's rebuke was severe: 'You have done foolishly — your kingdom shall not continue.' But the verdict was not yet final. God gave Saul another chance to demonstrate obedience, this time with explicit instructions regarding the Amalekites: destroy everything, spare nothing."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "Partial obedience is disobedience — religious activity cannot substitute for genuine submission to God's word.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Saul spared King Agag and the best livestock, claiming the animals were for sacrifice. Samuel's response was the theological thesis of his prophetic career: 'To obey is better than sacrifice.' The kingdom was torn from Saul that day, though he would wear the crown for years to come."
     },
     {
       "stop_order": 5,
@@ -86,7 +86,7 @@
       "what_changes": "Jealousy unchecked becomes obsession — the one who should mentor the next generation instead tries to destroy him.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Rejected by God but still reigning, Saul watched a shepherd boy rise through his court — first as musician, then as giant-killer, then as his own son's closest friend. The king's admiration curdled into paranoia, and the remaining years of his reign became a single-minded pursuit of the man he knew would replace him."
     },
     {
       "stop_order": 6,

--- a/content/meta/journeys/person/solomon.json
+++ b/content/meta/journeys/person/solomon.json
@@ -26,7 +26,7 @@
       "what_changes": "Wisdom begins with knowing what to ask for — seeking God's priorities above personal ambition.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Solomon secured the throne through a combination of his mother's advocacy, Nathan's intervention, and David's final decree. His first act was to consolidate power; his second was to ask God for wisdom. At Gibeon, in a dream, God offered him anything — and Solomon chose the one gift that could sustain everything else."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "The temple fulfills God's desire to dwell among his people — but even Solomon acknowledges heaven cannot contain him.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The wisdom that resolved the dispute between two mothers established Solomon's reputation; the temple that rose on Mount Moriah established his legacy. Seven years of construction produced a building of breathtaking beauty — and when the ark was placed inside, the glory of the Lord filled the house so intensely that the priests could not stand to minister."
     },
     {
       "stop_order": 3,
@@ -56,7 +56,7 @@
       "what_changes": "The pinnacle of human wisdom and prosperity still points beyond itself to something greater.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "The temple complete, Solomon's kingdom entered its golden age — international trade, diplomatic marriages, legendary wealth, and a wisdom tradition that drew the Queen of Sheba from the ends of the earth. But the same diplomatic marriages that secured alliances introduced foreign worship into the heart of Jerusalem."
     },
     {
       "stop_order": 4,
@@ -71,7 +71,7 @@
       "what_changes": "No degree of wisdom immunizes against compromise — the heart that turns from exclusive devotion falls furthest.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Seven hundred wives and three hundred concubines turned Solomon's heart after other gods. The man who built the Lord's temple also built high places for Chemosh and Molech on the hills overlooking Jerusalem. God's response was not immediate destruction but a promise: the kingdom would be torn — not in Solomon's lifetime, but in his son's."
     },
     {
       "stop_order": 5,

--- a/content/meta/journeys/person/stephen.json
+++ b/content/meta/journeys/person/stephen.json
@@ -26,7 +26,7 @@
       "what_changes": "Practical service and spiritual power are not separate categories — Stephen embodies both.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Stephen was chosen to serve tables, but his gifts extended far beyond logistics. Full of grace and power, he performed signs among the people and debated with a fluency that his opponents could not match. Unable to refute him, they manufactured charges of blasphemy and dragged him before the Sanhedrin."
     },
     {
       "stop_order": 2,
@@ -41,7 +41,7 @@
       "what_changes": "Scripture rightly read becomes a mirror — Israel's history of rejecting prophets reaches its climax in rejecting Jesus.",
       "linked_journey_id": null,
       "linked_journey_intro": null,
-      "bridge_to_next": "[BRIDGE TO AUTHOR]"
+      "bridge_to_next": "Stephen's speech before the council was not a defense but a prosecution — a sweeping retelling of Israel's history that built toward a single devastating conclusion: 'You always resist the Holy Spirit. As your fathers did, so do you.' The council's rage was immediate and lethal."
     },
     {
       "stop_order": 3,


### PR DESCRIPTION
## Summary

Closes #1387 (Phase 2B — Bridge authoring for Epic #1379)

Replaces all 146 `[BRIDGE TO AUTHOR]` placeholders across 30 person journey files with substantive narrative bridges. Each bridge acknowledges the prior stage, signals movement, and raises the question the next stage answers.

### Persons covered (by era)
- **Patriarchs:** Abraham (8), Isaac (4), Jacob (7), Joseph (6)
- **Exodus:** Moses (9), Joshua (5)
- **Judges:** Deborah (2), Gideon (3), Samson (4), Ruth (3)
- **Kingdom:** Samuel (5), Saul (5), David (7), Solomon (4), Elijah (5)
- **Prophets:** Elisha (4), Isaiah (3), Jeremiah (5)
- **Exile:** Ezekiel (4), Daniel (5), Esther (3), Ezra (2), Nehemiah (3)
- **NT:** Jesus (11), Mary (4), Peter (7), John (4), Paul (9), Barnabas (3), Stephen (2)

### Commits (6 batches of 5 persons each)
1. Abraham, Barnabas, Daniel, David, Deborah
2. Elijah, Elisha, Esther, Ezekiel, Ezra
3. Gideon, Isaac, Isaiah, Jacob, Jeremiah
4. Jesus, John, Joseph, Joshua, Mary
5. Moses, Nehemiah, Paul, Peter, Ruth
6. Samson, Samuel, Saul, Solomon, Stephen

## Verification
- Zero `[BRIDGE TO AUTHOR]` placeholders remaining
- `schema_validator.py` passes (76 failures are pre-existing life-topic cross-refs, not journey-related)
- `build_sqlite.py` passes (50 journeys, 338 stops, 213 tags)
- `validate_sqlite.py` passes (90 checks, 0 failures)

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes