### PR TITLE
Content: thematic journey — From Garden to City (#1389)

### DIFF
--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "76be55ec3148ad15",
-  "build_time": "2026-04-16T18:41:54.517903Z"
+  "content_hash": "25dab5d56140f5bc",
+  "build_time": "2026-04-16T19:01:08.371247Z"
 }

--- a/content/meta/journeys/thematic/garden-to-city.json
+++ b/content/meta/journeys/thematic/garden-to-city.json
@@ -1,0 +1,90 @@
+{
+  "id": "garden-to-city",
+  "journey_type": "thematic",
+  "title": "From Garden to City",
+  "subtitle": "Eden lost, Eden restored as New Jerusalem",
+  "description": "The Bible opens in a garden and closes in a city. Between those two images stretches the entire story of Scripture — a narrative of loss, wandering, provisional dwelling, and ultimate restoration. In Eden, God walked with humanity in unmediated intimacy. By Revelation 21, that intimacy returns, but the setting has changed: not a garden for two but a city for nations, where the tree of life lines a river running through streets of gold. This journey traces the Bible's spatial theology — the places where God chooses to dwell and what those places reveal about his purposes. From the eastward exile of Genesis 3 to Abraham's tent-altars, from the portable tabernacle to Solomon's permanent temple, from the temple's destruction to its replacement by something the prophets could barely articulate, each stop marks a turning point in how God relates to the world he made. The arc is not a circle back to Eden but an escalation: what was lost in a garden is restored in a city, and what began with two people ends with every tribe and tongue.",
+  "lens_id": "narrative",
+  "depth": "long",
+  "sort_order": 1,
+  "person_id": null,
+  "concept_id": null,
+  "era": null,
+  "hero_image_url": null,
+  "tags": [
+    {
+      "type": "theme",
+      "id": "creation"
+    },
+    {
+      "type": "theme",
+      "id": "temple-presence"
+    },
+    {
+      "type": "theme",
+      "id": "redemption"
+    }
+  ],
+  "stops": [
+    {
+      "stop_order": 1,
+      "stop_type": "regular",
+      "label": "The Garden",
+      "ref": "Genesis 2:8-15",
+      "book_id": "genesis",
+      "chapter_num": 2,
+      "verse_start": 8,
+      "verse_end": 15,
+      "development": "Eden is not merely a paradise but a temple. The language of Genesis 2 echoes Israel's later sanctuary vocabulary: God 'places' the man in the garden as priests were 'placed' in the tabernacle; the man is to 'work and keep' it using the same Hebrew terms (abad and shamar) later applied to Levitical service. The garden faces east, as the tabernacle and temple would. A river flows out to water the earth, anticipating Ezekiel's temple river and Revelation's river of life. God walks in the garden in the cool of the day — the Hebrew suggests a regular, anticipated communion. This is the Bible's first portrait of divine dwelling: God and humanity sharing the same space without barrier, mediator, or veil.",
+      "what_changes": "Eden establishes the baseline — unmediated divine presence in a place of abundance. Every subsequent dwelling place in Scripture is measured against this original intimacy and found to be partial.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The fruit was eaten, the eyes were opened, and for the first time the humans hid from the God who had walked among them. What followed was not annihilation but exile — an eastward departure from the only home humanity had known, guarded now by a flaming sword."
+    },
+    {
+      "stop_order": 2,
+      "stop_type": "regular",
+      "label": "Exile from Eden",
+      "ref": "Genesis 3:22-24",
+      "book_id": "genesis",
+      "chapter_num": 3,
+      "verse_start": 22,
+      "verse_end": 24,
+      "development": "The expulsion from Eden is the Bible's founding spatial trauma. The cherubim stationed at the east entrance anticipate the cherubim embroidered on the tabernacle curtain and carved into the temple's inner sanctuary — guardians marking the boundary between holy space and the profane world outside. Humanity now lives east of Eden, separated from the tree of life and from the unguarded presence of God. Yet the exile is not total abandonment. God clothes the humans before sending them out — a provision that hints at future covering. The narrative does not end with a locked gate but with a question: how will God's presence return to a world that has been expelled from his dwelling?",
+      "what_changes": "The direct divine presence is lost. From this point forward, every encounter with God requires some form of mediation — altars, sacrifice, consecrated space, appointed intermediaries.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "East of Eden, humanity multiplied — and so did the distance from God. Within ten generations the earth was corrupt, and God started over with a flood. But the pattern of scattering accelerated, reaching its climax when humanity attempted to build its own substitute for the garden: a city with a tower reaching to heaven."
+    },
+    {
+      "stop_order": 3,
+      "stop_type": "regular",
+      "label": "Babel — The Failed City",
+      "ref": "Genesis 11:1-9",
+      "book_id": "genesis",
+      "chapter_num": 11,
+      "verse_start": 1,
+      "verse_end": 9,
+      "development": "Babel is the Bible's first city-building project, and it fails precisely because it attempts to recover what was lost in Eden through human engineering rather than divine initiative. The builders want a tower 'with its top in the heavens' — an artificial mountain to bridge the gap between earth and God's dwelling. They want to 'make a name' for themselves — to create their own identity apart from the God who names. The result is the opposite of what they intended: instead of unity, scattering; instead of a great name, confusion. The story establishes a crucial biblical principle: the city of God cannot be built from below. It must come down from above. This anti-temple, this counterfeit sacred mountain, stands as a warning against every human attempt to storm heaven.",
+      "what_changes": "Human ambition to rebuild sacred space on its own terms is judged. The city-as-dwelling-of-God is not abandoned as an idea — but it will require God's initiative, not humanity's engineering.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "From the scattering at Babel, God chose one family — not to build a city but to walk by faith toward a land they had never seen. Abraham would erect altars, not towers, and the promise attached to his name would be given, not seized."
+    },
+    {
+      "stop_order": 4,
+      "stop_type": "regular",
+      "label": "Abraham's Altars",
+      "ref": "Genesis 12:7-8",
+      "book_id": "genesis",
+      "chapter_num": 12,
+      "verse_start": 7,
+      "verse_end": 8,
+      "development": "Abraham's response to divine encounter is consistently spatial: he builds altars. At Shechem, between Bethel and Ai, at Hebron — each altar marks a place where heaven touched earth, however briefly. These are not temples but memorial points, portable sacred spaces for a nomadic people. Abraham does not attempt to recreate Eden or build Babel; he simply marks the places where God spoke. Hebrews 11 will later reveal what Abraham understood: he was 'looking forward to the city that has foundations, whose designer and builder is God.' The patriarch lived in tents precisely because he awaited a city he could not construct. His altars were signposts pointing toward a dwelling he would never see in his lifetime — but which his descendants would begin to approximate.",
+      "what_changes": "Sacred space becomes portable and promissory. Abraham's altars mark encounters but don't contain God. The dwelling of God is now a future hope, not a present reality.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "Four centuries of silence and slavery in Egypt separated Abraham's altars from the next great leap in God's dwelling plan. When Israel left Egypt, they carried gold and fabric — raw materials for something unprecedented: a tent where the Creator of the universe would take up residence among a nation of former slaves."
+    }
+  ]
+}

--- a/content/meta/journeys/thematic/garden-to-city.json
+++ b/content/meta/journeys/thematic/garden-to-city.json
@@ -85,6 +85,66 @@
       "linked_journey_id": null,
       "linked_journey_intro": null,
       "bridge_to_next": "Four centuries of silence and slavery in Egypt separated Abraham's altars from the next great leap in God's dwelling plan. When Israel left Egypt, they carried gold and fabric — raw materials for something unprecedented: a tent where the Creator of the universe would take up residence among a nation of former slaves."
+    },
+    {
+      "stop_order": 5,
+      "stop_type": "regular",
+      "label": "The Tabernacle",
+      "ref": "Exodus 40:34-38",
+      "book_id": "exodus",
+      "chapter_num": 40,
+      "verse_start": 34,
+      "verse_end": 38,
+      "development": "The tabernacle is Eden made portable. Its design recapitulates creation: the outer court corresponds to the visible world, the Holy Place to the heavens, and the Holy of Holies to God's own dwelling — complete with cherubim guardians echoing Eden's gate. The lampstand evokes the tree of life; the curtain fabrics depict a garden. But unlike Eden, access is restricted and mediated. Only priests enter the Holy Place; only the high priest enters the Holy of Holies, once a year, with blood. When the tabernacle was completed, the glory of the Lord filled it so completely that even Moses could not enter. God was dwelling among his people again — but through layers of linen, sacrifice, and consecration that underscored the distance sin had created.",
+      "what_changes": "For the first time since Eden, God has an address among his people. But the tabernacle's elaborate mediation system reveals that the old intimacy has not yet been restored — the veil marks the ongoing cost of the fall.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The tabernacle traveled with Israel through forty years of wilderness and the settlement of Canaan. But a tent suited to nomads seemed inadequate for a kingdom. When David captured Jerusalem, he dreamed of replacing fabric with stone — and God responded with a promise that reframed the entire project."
+    },
+    {
+      "stop_order": 6,
+      "stop_type": "regular",
+      "label": "Solomon's Temple",
+      "ref": "1 Kings 8:10-13",
+      "book_id": "1_kings",
+      "chapter_num": 8,
+      "verse_start": 10,
+      "verse_end": 13,
+      "development": "Solomon's temple translated the tabernacle's theology into permanent architecture on Mount Moriah — the same ridge where Abraham had offered Isaac and where the threshing floor of Araunah marked the place of divine mercy. The glory cloud that filled the temple at its dedication was the same presence that had filled the tabernacle and walked in Eden. Solomon's prayer of dedication acknowledged the paradox: 'Will God indeed dwell on the earth? Behold, heaven and the highest heaven cannot contain you; how much less this house that I have built!' The temple was simultaneously the most ambitious claim for divine presence on earth and a confession of its own inadequacy. It pointed beyond itself to a dwelling it could never fully embody.",
+      "what_changes": "God's dwelling becomes permanent and geographically fixed — tied to Jerusalem, to Zion, to a dynasty. The temple becomes the axis mundi of Israel's identity, but its permanence will prove provisional.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The temple stood for nearly four centuries, surviving schism, idolatry, and periodic reform. But the prophets saw what the worshippers refused to acknowledge: the glory was departing. Ezekiel watched it leave. Jeremiah warned that the temple had become a talisman. And yet, in the very oracles of judgment, the prophets described a future dwelling that would surpass anything Solomon had imagined."
+    },
+    {
+      "stop_order": 7,
+      "stop_type": "regular",
+      "label": "The Prophets' Vision",
+      "ref": "Ezekiel 47:1-12",
+      "book_id": "ezekiel",
+      "chapter_num": 47,
+      "verse_start": 1,
+      "verse_end": 12,
+      "development": "Ezekiel's temple vision is the most detailed architectural description in the Hebrew Bible, and it describes a building that was never constructed. From its threshold flows a river that deepens as it goes — ankle to knee to waist to swimming depth — and wherever it flows, the Dead Sea comes alive, trees bear fruit monthly, and their leaves are for healing. The imagery fuses temple and garden: Eden's river flows again, but now from a sanctuary. Isaiah similarly envisions a mountain where all nations stream to learn God's ways, where swords become plowshares. Jeremiah promises a new covenant written on hearts rather than stone — suggesting that the ultimate dwelling of God may not be a building at all. The prophets stretch Israel's imagination beyond architecture toward a presence that transforms creation itself.",
+      "what_changes": "The prophetic vision breaks the temple's walls. God's future dwelling will not be a building that contains his presence but a presence that transforms the entire landscape — rivers, trees, nations.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "Before the prophetic vision could be realized, the present temple had to fall. In 586 BC, Nebuchadnezzar's army burned Solomon's temple to the ground. The ark of the covenant vanished from history. Israel went into exile — east again, like Adam, away from the place where God had dwelt."
+    },
+    {
+      "stop_order": 8,
+      "stop_type": "regular",
+      "label": "Exile — Dwelling Lost",
+      "ref": "Psalm 137:1-4",
+      "book_id": "psalms",
+      "chapter_num": 137,
+      "verse_start": 1,
+      "verse_end": 4,
+      "development": "By the rivers of Babylon, the exiles confronted a theological crisis more devastating than military defeat: could God be worshipped without a temple? Could he be present without a place? The question 'How shall we sing the Lord's song in a foreign land?' was not merely emotional but ontological — it challenged everything Israel believed about sacred space. Yet exile became a crucible of theological innovation. The synagogue emerged as a place of prayer and study, untethered from sacrifice. The scribes preserved and edited the Torah. Most remarkably, the exiles discovered that God had followed them. Ezekiel's opening vision — the throne-chariot by the Kebar canal — demonstrated that the divine presence was not chained to Jerusalem's coordinates. God was mobile, as he had been in the tabernacle days.",
+      "what_changes": "The destruction of the temple forces a radical rethinking of divine presence. God is discovered in exile, in community, in text — anticipating a form of presence that no building can contain or lose.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The exiles returned, rebuilt a modest temple, and waited. The second temple stood for five centuries, but the rabbis acknowledged what was missing: the ark, the fire from heaven, the Shekinah glory. The holy of holies was an empty room. Israel waited for the presence to return — and when it did, it arrived not in a building but in a body."
     }
   ]
 }

--- a/content/meta/journeys/thematic/garden-to-city.json
+++ b/content/meta/journeys/thematic/garden-to-city.json
@@ -145,6 +145,51 @@
       "linked_journey_id": null,
       "linked_journey_intro": null,
       "bridge_to_next": "The exiles returned, rebuilt a modest temple, and waited. The second temple stood for five centuries, but the rabbis acknowledged what was missing: the ark, the fire from heaven, the Shekinah glory. The holy of holies was an empty room. Israel waited for the presence to return — and when it did, it arrived not in a building but in a body."
+    },
+    {
+      "stop_order": 9,
+      "stop_type": "regular",
+      "label": "The Word Made Flesh",
+      "ref": "John 1:14",
+      "book_id": "john",
+      "chapter_num": 1,
+      "verse_start": 14,
+      "verse_end": 14,
+      "development": "John's prologue makes an audacious claim: 'The Word became flesh and tabernacled among us, and we beheld his glory.' The Greek eskēnōsen deliberately echoes the Septuagint's language for the tabernacle — the skēnē. Jesus is the new temple, the place where God's glory dwells without veil or mediation. He told the religious leaders, 'Destroy this temple, and in three days I will raise it up,' speaking of his body. In Jesus, the progressive narrowing of sacred space reaches its focal point: from garden to land to city to temple to a single human life. The incarnation is not the abandonment of sacred space but its most concentrated expression — God dwelling not in a building that humans enter but in a person who enters human life.",
+      "what_changes": "Sacred space becomes a person. The long trajectory from garden to tabernacle to temple converges in Jesus — God's presence no longer mediated by architecture but embodied in flesh.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The temple-body was destroyed on a Friday afternoon and raised on a Sunday morning. The resurrection did not simply restore what the cross had broken — it inaugurated a new kind of sacred space entirely. The risen Christ would ascend, but his presence would not depart. It would multiply."
+    },
+    {
+      "stop_order": 10,
+      "stop_type": "regular",
+      "label": "Pentecost — The Spirit Poured Out",
+      "ref": "Acts 2:1-4",
+      "book_id": "acts",
+      "chapter_num": 2,
+      "verse_start": 1,
+      "verse_end": 4,
+      "development": "At Pentecost, the Spirit who had filled the tabernacle and the temple now filled people. The tongues of fire recall the pillar of fire that led Israel through the wilderness, but they rested on individual heads, not on a building. Paul would later make the implications explicit: 'Do you not know that you are God's temple and that God's Spirit dwells in you?' The gathered community — not any building — is now the locus of divine presence. The scattering of languages at Babel is reversed at Pentecost as people from every nation hear the gospel in their own tongue. What Babel fragmented, the Spirit reunites. The dwelling of God is no longer a place you travel to but a community you are baptized into.",
+      "what_changes": "Divine presence is democratized and distributed. Every believer becomes a temple; every gathered community becomes a dwelling place. Sacred space is no longer geographic but communal.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": "The early church met in homes, not temples. They carried the presence of God into every city Paul planted a church in — Corinth, Ephesus, Rome. But the New Testament ends not with a network of house churches but with a vision that dwarfs everything that came before: a city descending from heaven."
+    },
+    {
+      "stop_order": 11,
+      "stop_type": "regular",
+      "label": "The New Jerusalem",
+      "ref": "Revelation 21:1-5",
+      "book_id": "revelation",
+      "chapter_num": 21,
+      "verse_start": 1,
+      "verse_end": 5,
+      "development": "The Bible's final vision is a city — but a city unlike any that human hands have built. The New Jerusalem descends from heaven, fulfilling what Babel attempted and failed: a place where God and humanity dwell together. Its dimensions are cubic — the same shape as the Holy of Holies in Solomon's temple — suggesting that the entire city is now the innermost sanctuary. There is no temple in it, 'for the Lord God the Almighty and the Lamb are its temple.' The tree of life reappears, lining a river that flows from the throne — Eden's garden imagery woven into urban architecture. The nations bring their glory into it; its gates never shut. What began as a garden for two has become a city for the world. The long exile is over. God dwells with his people, face to face, and wipes every tear from their eyes.",
+      "what_changes": "The garden becomes a city, the temple becomes the whole city, and the veil is permanently removed. The trajectory that began in Genesis 2 reaches its destination: unmediated divine presence, now for all nations, never to be lost again.",
+      "linked_journey_id": null,
+      "linked_journey_intro": null,
+      "bridge_to_next": null
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #1389 (Phase 3 — Thematic journey for Epic #1379)

Creates "From Garden to City" — the opening thematic journey tracing the Bible's spatial theology from Eden to New Jerusalem.

### Journey: garden-to-city
- **Lens:** Narrative Arc
- **Depth:** Long (11 stops)
- **Arc:** Garden → Eden Exile → Babel → Abraham's Altars → Tabernacle → Solomon's Temple → Prophets' Vision → Exile → Incarnation → Pentecost → New Jerusalem

Each stop has full development (100-300 words), what_changes (50-100 words), and substantive bridges. No placeholders.

## Verification
- Schema validator passes (51 journey files)
- Build passes (51 journeys, 349 stops, 216 tags)
- SQLite validator passes (90 checks, 0 failures)

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes