### PR TITLE
UI: LinkedJourneySheet + useJourney hook (#1399)

### DIFF
--- a/app/__tests__/hooks/useJourney.test.ts
+++ b/app/__tests__/hooks/useJourney.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for useJourney hook.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/database', () => ({
+  getDb: () => ({
+    getFirstAsync: jest.fn().mockResolvedValue(null),
+    getAllAsync: jest.fn().mockResolvedValue([]),
+  }),
+}));
+
+jest.mock('@/db/user', () => ({
+  getPreference: jest.fn().mockResolvedValue(null),
+  setPreference: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetFirstAsync = jest.fn();
+const mockGetAllAsync = jest.fn();
+
+jest.mock('@/db/content/features', () => ({
+  getJourney: (...args: unknown[]) => mockGetFirstAsync(...args),
+  getJourneyStops: (...args: unknown[]) => mockGetAllAsync(...args),
+  getJourneyTags: (...args: unknown[]) => mockGetAllAsync(...args),
+}));
+
+import { useJourney } from '@/hooks/useJourney';
+
+describe('useJourney', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns loading initially then resolves', async () => {
+    mockGetFirstAsync.mockResolvedValue({
+      id: 'garden-to-city',
+      journey_type: 'thematic',
+      title: 'From Garden to City',
+      subtitle: null,
+      description: 'Test description',
+      lens_id: 'narrative',
+      depth: 'long',
+      sort_order: 1,
+      person_id: null,
+      concept_id: null,
+      era: null,
+      tags: null,
+      hero_image_url: null,
+    });
+    mockGetAllAsync.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useJourney('garden-to-city'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.journey).not.toBeNull();
+    expect(result.current.journey?.title).toBe('From Garden to City');
+  });
+
+  it('returns null journey for null id', async () => {
+    const { result } = renderHook(() => useJourney(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.journey).toBeNull();
+    expect(result.current.stops).toEqual([]);
+  });
+
+  it('loads stops alongside journey', async () => {
+    mockGetFirstAsync.mockResolvedValue({ id: 'test', title: 'Test' });
+    mockGetAllAsync
+      .mockResolvedValueOnce([
+        { id: 1, journey_id: 'test', stop_order: 1, label: 'Stop 1' },
+        { id: 2, journey_id: 'test', stop_order: 2, label: 'Stop 2' },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useJourney('test'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.stops).toHaveLength(2);
+  });
+});

--- a/app/src/components/LinkedJourneySheet.tsx
+++ b/app/src/components/LinkedJourneySheet.tsx
@@ -171,7 +171,7 @@ const styles = StyleSheet.create({
     marginRight: spacing.sm,
   },
   title: {
-    fontFamily: fontFamily.serif,
+    fontFamily: fontFamily.body,
     fontSize: 18,
   },
   subtitle: {
@@ -249,7 +249,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   stopLabel: {
-    fontFamily: fontFamily.serifBold,
+    fontFamily: fontFamily.bodySemiBold,
     fontSize: 15,
     marginBottom: 4,
   },

--- a/app/src/components/LinkedJourneySheet.tsx
+++ b/app/src/components/LinkedJourneySheet.tsx
@@ -1,0 +1,261 @@
+/**
+ * LinkedJourneySheet — Bottom sheet that presents a linked journey inline
+ * when tapping a stop_type: 'linked_journey' stop.
+ */
+
+import React, { useRef, useMemo, useCallback, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView, BackHandler } from 'react-native';
+import BottomSheet from '@gorhom/bottom-sheet';
+import { X } from 'lucide-react-native';
+import { useJourney } from '../hooks/useJourney';
+import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import type { JourneyStop } from '../types';
+
+interface Props {
+  visible: boolean;
+  linkedJourneyId: string | null;
+  linkedJourneyIntro: string | null;
+  onClose: () => void;
+  onNavigateToChapter: (bookId: string, chapterNum: number, verseNum?: number) => void;
+}
+
+function extractVerseNum(ref: string | null): number | undefined {
+  if (!ref) return undefined;
+  const m = ref.match(/:(\d+)/);
+  return m ? parseInt(m[1], 10) : undefined;
+}
+
+export function LinkedJourneySheet({
+  visible, linkedJourneyId, linkedJourneyIntro,
+  onClose, onNavigateToChapter,
+}: Props) {
+  const { base } = useTheme();
+  const sheetRef = useRef<BottomSheet>(null);
+  const { journey, stops, isLoading } = useJourney(visible ? linkedJourneyId : null);
+
+  const snapPoints = useMemo(() => ['70%', '95%'], []);
+
+  useEffect(() => {
+    if (visible) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [visible]);
+
+  // Android back button closes sheet
+  useEffect(() => {
+    if (!visible) return;
+    const handler = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true;
+    });
+    return () => handler.remove();
+  }, [visible, onClose]);
+
+  const handleStopPress = useCallback((stop: JourneyStop) => {
+    if (stop.book_id && stop.chapter_num) {
+      onNavigateToChapter(stop.book_id, stop.chapter_num, extractVerseNum(stop.ref));
+    }
+  }, [onNavigateToChapter]);
+
+  if (!visible) return null;
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onClose={onClose}
+      backgroundStyle={{ backgroundColor: base.bgElevated }}
+      handleIndicatorStyle={{ backgroundColor: base.textMuted, width: 40 }}
+    >
+      <View style={styles.header}>
+        <View style={styles.headerText}>
+          {journey && (
+            <>
+              <Text style={[styles.title, { color: base.text }]} numberOfLines={1}>
+                {journey.title}
+              </Text>
+              {journey.subtitle && (
+                <Text style={[styles.subtitle, { color: base.textMuted }]} numberOfLines={1}>
+                  {journey.subtitle}
+                </Text>
+              )}
+              {journey.lens_id && (
+                <View style={[styles.lensBadge, { backgroundColor: base.gold + '20' }]}>
+                  <Text style={[styles.lensText, { color: base.gold }]}>
+                    {journey.lens_id.replace(/_/g, ' ')}
+                  </Text>
+                </View>
+              )}
+            </>
+          )}
+        </View>
+        <TouchableOpacity
+          onPress={onClose}
+          style={styles.closeBtn}
+          hitSlop={8}
+          accessibilityLabel="Close linked journey"
+          accessibilityRole="button"
+        >
+          <X size={20} color={base.textMuted} />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        {linkedJourneyIntro && (
+          <Text style={[styles.intro, { color: base.text }]}>
+            {linkedJourneyIntro}
+          </Text>
+        )}
+
+        {isLoading && (
+          <Text style={[styles.loading, { color: base.textMuted }]}>Loading...</Text>
+        )}
+
+        {stops.map((stop) => {
+          if (stop.stop_type === 'linked_journey') return null;
+
+          return (
+            <View key={stop.stop_order} style={styles.stopRow}>
+              <View style={styles.spine}>
+                <View style={[styles.dot, { backgroundColor: base.gold }]} />
+                {stop.stop_order < stops.length && (
+                  <View style={[styles.line, { backgroundColor: base.border }]} />
+                )}
+              </View>
+              <TouchableOpacity
+                style={[styles.stopCard, { backgroundColor: base.bg, borderColor: base.border }]}
+                onPress={() => handleStopPress(stop)}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={`${stop.label}: ${stop.ref}`}
+              >
+                {stop.ref && (
+                  <Text style={[styles.stopRef, { color: base.gold }]}>{stop.ref}</Text>
+                )}
+                {stop.label && (
+                  <Text style={[styles.stopLabel, { color: base.text }]}>{stop.label}</Text>
+                )}
+                {stop.development && (
+                  <Text style={[styles.stopDev, { color: base.textMuted }]} numberOfLines={4}>
+                    {stop.development}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          );
+        })}
+      </ScrollView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#3333',
+  },
+  headerText: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.serif,
+    fontSize: 18,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    marginTop: 2,
+  },
+  lensBadge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radii.sm,
+    marginTop: 6,
+  },
+  lensText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    textTransform: 'capitalize',
+  },
+  closeBtn: {
+    width: MIN_TOUCH_TARGET,
+    height: MIN_TOUCH_TARGET,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  intro: {
+    fontFamily: fontFamily.ui,
+    fontSize: 14,
+    lineHeight: 21,
+    marginVertical: spacing.md,
+    fontStyle: 'italic',
+  },
+  loading: {
+    fontFamily: fontFamily.ui,
+    fontSize: 14,
+    textAlign: 'center',
+    marginVertical: spacing.lg,
+  },
+  stopRow: {
+    flexDirection: 'row',
+    marginBottom: spacing.sm,
+  },
+  spine: {
+    width: 24,
+    alignItems: 'center',
+    paddingTop: 6,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  line: {
+    width: 2,
+    flex: 1,
+    marginTop: 4,
+  },
+  stopCard: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm,
+    marginLeft: spacing.xs,
+  },
+  stopRef: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    marginBottom: 4,
+  },
+  stopLabel: {
+    fontFamily: fontFamily.serifBold,
+    fontSize: 15,
+    marginBottom: 4,
+  },
+  stopDev: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+});

--- a/app/src/db/content/features.ts
+++ b/app/src/db/content/features.ts
@@ -1,9 +1,9 @@
 /**
- * db/content/features.ts — Prophecy chains, concepts, difficult passages.
+ * db/content/features.ts — Prophecy chains, concepts, difficult passages, journeys.
  */
 
 import { getDb } from '../database';
-import type { ProphecyChain, Concept, DifficultPassage } from '../../types';
+import type { ProphecyChain, Concept, DifficultPassage, Journey, JourneyStop, JourneyTag } from '../../types';
 import { escapeLike } from '../../utils/escapeLike';
 
 // ── Prophecy Chains ────────────────────────────────────────────────
@@ -92,5 +92,48 @@ export async function getDifficultPassagesForChapter(
     `SELECT * FROM difficult_passages
      WHERE related_chapters_json LIKE ? ESCAPE '\\' AND related_chapters_json LIKE ? ESCAPE '\\'`,
     [`%"book_dir":"${safeBook}"%`, `%"chapter_num":${Number(chapterNum)}%`]
+  );
+}
+
+// ── Journeys (#1379) ──────────────────────────────────────────────
+
+export async function getJourney(id: string): Promise<Journey | null> {
+  return getDb().getFirstAsync<Journey>(
+    'SELECT * FROM journeys WHERE id = ?',
+    [id]
+  );
+}
+
+export async function getJourneyStops(journeyId: string): Promise<JourneyStop[]> {
+  return getDb().getAllAsync<JourneyStop>(
+    'SELECT * FROM journey_stops WHERE journey_id = ? ORDER BY stop_order',
+    [journeyId]
+  );
+}
+
+export async function getJourneyTags(journeyId: string): Promise<JourneyTag[]> {
+  return getDb().getAllAsync<JourneyTag>(
+    'SELECT * FROM journey_tags WHERE journey_id = ?',
+    [journeyId]
+  );
+}
+
+export async function getAllJourneys(): Promise<Journey[]> {
+  return getDb().getAllAsync<Journey>(
+    'SELECT * FROM journeys ORDER BY journey_type, sort_order, title'
+  );
+}
+
+export async function getJourneysByType(journeyType: string): Promise<Journey[]> {
+  return getDb().getAllAsync<Journey>(
+    'SELECT * FROM journeys WHERE journey_type = ? ORDER BY sort_order, title',
+    [journeyType]
+  );
+}
+
+export async function getJourneysByLens(lensId: string): Promise<Journey[]> {
+  return getDb().getAllAsync<Journey>(
+    'SELECT * FROM journeys WHERE lens_id = ? ORDER BY sort_order, title',
+    [lensId]
   );
 }

--- a/app/src/hooks/useJourney.ts
+++ b/app/src/hooks/useJourney.ts
@@ -1,0 +1,58 @@
+/**
+ * useJourney — Load a single journey with its stops and tags.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { getJourney, getJourneyStops, getJourneyTags } from '../db/content/features';
+import { logger } from '../utils/logger';
+import type { Journey, JourneyStop, JourneyTag } from '../types';
+
+interface UseJourneyResult {
+  journey: Journey | null;
+  stops: JourneyStop[];
+  tags: JourneyTag[];
+  isLoading: boolean;
+}
+
+export function useJourney(journeyId: string | null): UseJourneyResult {
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [stops, setStops] = useState<JourneyStop[]>([]);
+  const [tags, setTags] = useState<JourneyTag[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const cancelRef = useRef(false);
+
+  useEffect(() => {
+    cancelRef.current = false;
+    if (!journeyId) {
+      setJourney(null);
+      setStops([]);
+      setTags([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    (async () => {
+      try {
+        const [j, s, t] = await Promise.all([
+          getJourney(journeyId),
+          getJourneyStops(journeyId),
+          getJourneyTags(journeyId),
+        ]);
+        if (cancelRef.current) return;
+        setJourney(j);
+        setStops(s);
+        setTags(t);
+      } catch (err) {
+        if (cancelRef.current) return;
+        logger.error('useJourney', 'Failed to load journey', err);
+      } finally {
+        if (!cancelRef.current) setIsLoading(false);
+      }
+    })();
+
+    return () => { cancelRef.current = true; };
+  }, [journeyId]);
+
+  return { journey, stops, tags, isLoading };
+}

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -177,6 +177,51 @@ export interface PersonLegacyRef {
   note: string | null;
 }
 
+// ── Unified Journeys (#1379) ─────────────────────────────────────
+
+export type JourneyType = 'person' | 'concept' | 'thematic';
+export type StopType = 'regular' | 'linked_journey';
+
+export interface Journey {
+  id: string;
+  journey_type: JourneyType;
+  title: string;
+  subtitle: string | null;
+  description: string;
+  lens_id: string | null;
+  depth: 'short' | 'medium' | 'long' | null;
+  sort_order: number;
+  person_id: string | null;
+  concept_id: string | null;
+  era: string | null;
+  tags: string | null;
+  hero_image_url: string | null;
+}
+
+export interface JourneyStop {
+  id: number;
+  journey_id: string;
+  stop_order: number;
+  stop_type: StopType;
+  label: string | null;
+  ref: string | null;
+  book_id: string | null;
+  chapter_num: number | null;
+  verse_start: number | null;
+  verse_end: number | null;
+  development: string | null;
+  what_changes: string | null;
+  linked_journey_id: string | null;
+  linked_journey_intro: string | null;
+  bridge_to_next: string | null;
+}
+
+export interface JourneyTag {
+  journey_id: string;
+  tag_type: string;
+  tag_id: string;
+}
+
 /** Row from redemptive_acts table (#1118). */
 export interface RedemptiveAct {
   id: string;


### PR DESCRIPTION
## Summary

Closes #1399 (Phase 4 — UI for Epic #1379)

### New files
- **`app/src/hooks/useJourney.ts`** — Hook that loads a journey with stops and tags from the unified tables via parallel `Promise.all`
- **`app/src/components/LinkedJourneySheet.tsx`** — Bottom sheet component using `@gorhom/bottom-sheet` for inline linked journey presentation
- **`app/__tests__/hooks/useJourney.test.ts`** — 3 tests for the hook

### Modified files
- **`app/src/types/content.ts`** — Added `Journey`, `JourneyStop`, `JourneyTag` types
- **`app/src/db/content/features.ts`** — Added 6 DB query functions for the unified journey tables

### LinkedJourneySheet features
- 70%/95% snap points
- Pull-down to close
- Android back button closes sheet (not screen)
- Header with title, subtitle, lens badge, close button
- Timeline rendering of stops with spine dots/lines
- Tappable stops navigate to chapter with verse

## Test plan
- [x] useJourney hook tests pass (3/3)
- [x] Full test suite passes (430 suites, 3212 tests)
- [ ] CI passes
- [ ] Device smoke test with linked journey stops (to be validated in #1400)

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes