### PR TITLE
UI: unified JourneyDetailScreen + JourneyStopsTimeline (#1400)

### DIFF
--- a/app/__tests__/hooks/useJourneyDetail.test.ts
+++ b/app/__tests__/hooks/useJourneyDetail.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for useJourneyDetail hook.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/database', () => ({
+  getDb: () => ({
+    getFirstAsync: jest.fn().mockResolvedValue(null),
+    getAllAsync: jest.fn().mockResolvedValue([]),
+  }),
+}));
+
+jest.mock('@/db/user', () => ({
+  getPreference: jest.fn().mockResolvedValue(null),
+  setPreference: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetJourney = jest.fn();
+const mockGetJourneyStops = jest.fn();
+const mockGetJourneyTags = jest.fn();
+
+jest.mock('@/db/content/features', () => ({
+  getJourney: (...args: unknown[]) => mockGetJourney(...args),
+  getJourneyStops: (...args: unknown[]) => mockGetJourneyStops(...args),
+  getJourneyTags: (...args: unknown[]) => mockGetJourneyTags(...args),
+}));
+
+import { useJourneyDetail } from '@/hooks/useJourneyDetail';
+
+const mockJourney = {
+  id: 'garden-to-city',
+  journey_type: 'thematic',
+  title: 'From Garden to City',
+  subtitle: 'Eden lost, Eden restored',
+  description: 'A journey through sacred space.',
+  lens_id: 'narrative',
+  depth: 'long',
+  sort_order: 1,
+  person_id: null,
+  concept_id: null,
+  era: null,
+  tags: null,
+  hero_image_url: null,
+};
+
+const mockStops = [
+  { id: 1, journey_id: 'garden-to-city', stop_order: 1, stop_type: 'regular', label: 'The Garden', ref: 'Genesis 2:8', book_id: 'genesis', chapter_num: 2, development: 'Eden is a temple.', what_changes: 'Baseline.', bridge_to_next: 'Bridge text.', linked_journey_id: null, linked_journey_intro: null, verse_start: 8, verse_end: 15 },
+  { id: 2, journey_id: 'garden-to-city', stop_order: 2, stop_type: 'regular', label: 'Exile', ref: 'Genesis 3:24', book_id: 'genesis', chapter_num: 3, development: 'Expelled.', what_changes: 'Lost.', bridge_to_next: null, linked_journey_id: null, linked_journey_intro: null, verse_start: 24, verse_end: 24 },
+];
+
+describe('useJourneyDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetJourney.mockResolvedValue(mockJourney);
+    mockGetJourneyStops.mockResolvedValue(mockStops);
+    mockGetJourneyTags.mockResolvedValue([]);
+  });
+
+  it('loads journey with stops and computes reading time', async () => {
+    const { result } = renderHook(() => useJourneyDetail('garden-to-city'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.journey?.title).toBe('From Garden to City');
+    expect(result.current.stops).toHaveLength(2);
+    expect(result.current.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns empty state for undefined journeyId', async () => {
+    const { result } = renderHook(() => useJourneyDetail(undefined));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.journey).toBeNull();
+    expect(result.current.stops).toEqual([]);
+  });
+
+  it('resolves linked journey lookups', async () => {
+    const stopsWithLinked = [
+      ...mockStops,
+      { id: 3, journey_id: 'garden-to-city', stop_order: 3, stop_type: 'linked_journey', linked_journey_id: 'abraham', linked_journey_intro: 'See Abraham', label: null, ref: null, book_id: null, chapter_num: null, development: null, what_changes: null, bridge_to_next: null, verse_start: null, verse_end: null },
+    ];
+    mockGetJourneyStops.mockResolvedValue(stopsWithLinked);
+    mockGetJourney
+      .mockResolvedValueOnce(mockJourney)
+      .mockResolvedValueOnce({ id: 'abraham', title: 'Abraham' });
+
+    const { result } = renderHook(() => useJourneyDetail('garden-to-city'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.linkedJourneyLookups.get('abraham')?.title).toBe('Abraham');
+  });
+});

--- a/app/src/components/JourneyStopsTimeline.tsx
+++ b/app/src/components/JourneyStopsTimeline.tsx
@@ -1,0 +1,247 @@
+/**
+ * JourneyStopsTimeline — Vertical timeline rendering journey stops,
+ * bridges, and linked journey indicators.
+ *
+ * Evolved from ConceptJourney.tsx to support the unified journey model.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { ChevronRight, Link2 } from 'lucide-react-native';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import type { JourneyStop } from '../types';
+
+interface Props {
+  stops: JourneyStop[];
+  isPremium: boolean;
+  freeStopCount?: number;
+  linkedJourneyTitles?: Map<string, string>;
+  onNavigateToChapter: (bookId: string, chapterNum: number, verseNum?: number) => void;
+  onLinkedJourneyPress?: (linkedJourneyId: string, intro: string | null) => void;
+}
+
+export function JourneyStopsTimeline({
+  stops, isPremium, freeStopCount = 3,
+  linkedJourneyTitles,
+  onNavigateToChapter, onLinkedJourneyPress,
+}: Props) {
+  const { base } = useTheme();
+
+  if (!stops || stops.length === 0) return null;
+
+  const visibleStops = isPremium ? stops : stops.slice(0, freeStopCount);
+
+  return (
+    <View style={styles.container}>
+      {visibleStops.map((stop, idx) => {
+        const isLast = idx === visibleStops.length - 1;
+
+        if (stop.stop_type === 'linked_journey' && stop.linked_journey_id) {
+          const linkedTitle = linkedJourneyTitles?.get(stop.linked_journey_id) ?? 'Linked Journey';
+          return (
+            <View key={`linked-${stop.stop_order}`} style={styles.row}>
+              <View style={styles.spine}>
+                <View style={[styles.dot, { backgroundColor: base.gold, borderColor: base.gold + '40' }]} />
+                {!isLast && <View style={[styles.line, { backgroundColor: base.goldDim + '60' }]} />}
+              </View>
+              <TouchableOpacity
+                style={[styles.linkedCard, { backgroundColor: base.gold + '10', borderColor: base.gold + '30' }]}
+                activeOpacity={0.7}
+                onPress={() => onLinkedJourneyPress?.(stop.linked_journey_id!, stop.linked_journey_intro)}
+              >
+                <View style={styles.linkedHeader}>
+                  <Link2 size={14} color={base.gold} />
+                  <Text style={[styles.linkedTitle, { color: base.gold }]}>{linkedTitle}</Text>
+                </View>
+                {stop.linked_journey_intro && (
+                  <Text style={[styles.linkedIntro, { color: base.textDim }]} numberOfLines={3}>
+                    {stop.linked_journey_intro}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          );
+        }
+
+        const vm = stop.ref?.match(/:(\d+)/);
+        const verseNum = vm ? parseInt(vm[1], 10) : undefined;
+
+        return (
+          <View key={`stop-${stop.stop_order}`}>
+            <View style={styles.row}>
+              <View style={styles.spine}>
+                <View style={[styles.dot, { backgroundColor: base.gold, borderColor: base.goldDim }]} />
+                {!isLast && <View style={[styles.line, { backgroundColor: base.goldDim + '60' }]} />}
+              </View>
+              <TouchableOpacity
+                style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.gold + '18' }]}
+                activeOpacity={0.7}
+                onPress={() => stop.book_id && stop.chapter_num && onNavigateToChapter(stop.book_id, stop.chapter_num, verseNum)}
+              >
+                <View style={styles.cardHeader}>
+                  {stop.ref && (
+                    <View style={[styles.refBadge, { backgroundColor: base.gold + '20' }]}>
+                      <Text style={[styles.refText, { color: base.gold }]}>{stop.ref}</Text>
+                    </View>
+                  )}
+                  <ChevronRight size={14} color={base.textMuted} />
+                </View>
+                {stop.label && (
+                  <Text style={[styles.label, { color: base.text }]}>{stop.label}</Text>
+                )}
+                {stop.development && (
+                  <Text style={[styles.development, { color: base.textDim }]}>{stop.development}</Text>
+                )}
+                {stop.what_changes && (
+                  <View style={[styles.changesBox, { backgroundColor: base.gold + '0A', borderLeftColor: base.gold + '40' }]}>
+                    <Text style={[styles.changesTitle, { color: base.gold }]}>What Changes</Text>
+                    <Text style={[styles.changesText, { color: base.textDim }]}>{stop.what_changes}</Text>
+                  </View>
+                )}
+              </TouchableOpacity>
+            </View>
+
+            {/* Bridge to next stop */}
+            {stop.bridge_to_next && !isLast && (
+              <View style={styles.bridgeRow}>
+                <View style={styles.bridgeSpine}>
+                  <View style={[styles.bridgeLine, { backgroundColor: base.goldDim + '40' }]} />
+                </View>
+                <Text style={[styles.bridgeText, { color: base.textMuted }]}>
+                  {stop.bridge_to_next}
+                </Text>
+              </View>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const DOT_SIZE = 12;
+const LINE_WIDTH = 2;
+const SPINE_WIDTH = DOT_SIZE + spacing.md;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+  },
+  spine: {
+    width: SPINE_WIDTH,
+    alignItems: 'center',
+    paddingTop: 2,
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    borderWidth: 2,
+  },
+  line: {
+    flex: 1,
+    width: LINE_WIDTH,
+    marginTop: 2,
+  },
+  card: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    padding: spacing.sm,
+    marginBottom: spacing.sm,
+    marginLeft: spacing.xs,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+  refBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.sm,
+  },
+  refText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  label: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 15,
+    marginBottom: spacing.xs,
+  },
+  development: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    lineHeight: 20,
+    marginBottom: spacing.sm,
+  },
+  changesBox: {
+    borderLeftWidth: 2,
+    borderRadius: radii.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  changesTitle: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  changesText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  linkedCard: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    padding: spacing.sm,
+    marginBottom: spacing.sm,
+    marginLeft: spacing.xs,
+    borderStyle: 'dashed',
+  },
+  linkedHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  linkedTitle: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+  },
+  linkedIntro: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+    fontStyle: 'italic',
+  },
+  bridgeRow: {
+    flexDirection: 'row',
+    marginBottom: spacing.sm,
+  },
+  bridgeSpine: {
+    width: SPINE_WIDTH,
+    alignItems: 'center',
+  },
+  bridgeLine: {
+    flex: 1,
+    width: LINE_WIDTH,
+  },
+  bridgeText: {
+    flex: 1,
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+    lineHeight: 19,
+    marginLeft: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
+});

--- a/app/src/hooks/useJourneyDetail.ts
+++ b/app/src/hooks/useJourneyDetail.ts
@@ -1,0 +1,95 @@
+/**
+ * useJourneyDetail — Load a journey with stops, tags, and linked journey lookups.
+ */
+
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { getJourney, getJourneyStops, getJourneyTags } from '../db/content/features';
+import { logger } from '../utils/logger';
+import type { Journey, JourneyStop, JourneyTag } from '../types';
+
+interface LinkedJourneyLookup {
+  id: string;
+  title: string;
+}
+
+interface UseJourneyDetailResult {
+  journey: Journey | null;
+  stops: JourneyStop[];
+  tags: JourneyTag[];
+  linkedJourneyLookups: Map<string, LinkedJourneyLookup>;
+  readingTimeMinutes: number;
+  isLoading: boolean;
+}
+
+function estimateReadingTime(stops: JourneyStop[]): number {
+  let words = 0;
+  for (const s of stops) {
+    if (s.development) words += s.development.split(/\s+/).length;
+    if (s.what_changes) words += s.what_changes.split(/\s+/).length;
+    if (s.bridge_to_next) words += s.bridge_to_next.split(/\s+/).length;
+  }
+  return Math.max(1, Math.round(words / 200));
+}
+
+export function useJourneyDetail(journeyId: string | undefined): UseJourneyDetailResult {
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [stops, setStops] = useState<JourneyStop[]>([]);
+  const [tags, setTags] = useState<JourneyTag[]>([]);
+  const [linkedLookups, setLinkedLookups] = useState<Map<string, LinkedJourneyLookup>>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+  const cancelRef = useRef(false);
+
+  useEffect(() => {
+    cancelRef.current = false;
+    if (!journeyId) {
+      setJourney(null);
+      setStops([]);
+      setTags([]);
+      setLinkedLookups(new Map());
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    (async () => {
+      try {
+        const [j, s, t] = await Promise.all([
+          getJourney(journeyId),
+          getJourneyStops(journeyId),
+          getJourneyTags(journeyId),
+        ]);
+        if (cancelRef.current) return;
+
+        // Resolve linked journey titles
+        const linkedIds = s
+          .filter((st) => st.stop_type === 'linked_journey' && st.linked_journey_id)
+          .map((st) => st.linked_journey_id!);
+        const uniqueIds = [...new Set(linkedIds)];
+        const lookups = new Map<string, LinkedJourneyLookup>();
+        await Promise.all(
+          uniqueIds.map(async (id) => {
+            const linked = await getJourney(id);
+            if (linked) lookups.set(id, { id: linked.id, title: linked.title });
+          }),
+        );
+        if (cancelRef.current) return;
+
+        setJourney(j);
+        setStops(s);
+        setTags(t);
+        setLinkedLookups(lookups);
+      } catch (err) {
+        if (cancelRef.current) return;
+        logger.error('useJourneyDetail', 'Failed to load journey detail', err);
+      } finally {
+        if (!cancelRef.current) setIsLoading(false);
+      }
+    })();
+
+    return () => { cancelRef.current = true; };
+  }, [journeyId]);
+
+  const readingTimeMinutes = useMemo(() => estimateReadingTime(stops), [stops]);
+
+  return { journey, stops, tags, linkedJourneyLookups: linkedLookups, readingTimeMinutes, isLoading };
+}

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -14,6 +14,7 @@ const PeriodsScreen = lazySuspense(() => import('../screens/PeriodsScreen'));
 const RedemptiveArcScreen = lazySuspense(() => import('../screens/RedemptiveArcScreen'));
 const PersonJourneyScreen = lazySuspense(() => import('../screens/PersonJourneyScreen'));
 const JourneyBrowseScreen = lazySuspense(() => import('../screens/JourneyBrowseScreen'));
+const JourneyDetailScreen = lazySuspense(() => import('../screens/JourneyDetailScreen'));
 const WordStudyBrowseScreen = lazySuspense(() => import('../screens/WordStudyBrowseScreen'));
 const WordStudyDetailScreen = lazySuspense(() => import('../screens/WordStudyDetailScreen'));
 const ScholarBrowseScreen = lazySuspense(() => import('../screens/ScholarBrowseScreen'));
@@ -74,6 +75,7 @@ export function ExploreStack() {
       <Stack.Screen name="RedemptiveArc" component={RedemptiveArcScreen} />
       <Stack.Screen name="PersonJourney" component={PersonJourneyScreen} />
       <Stack.Screen name="JourneyBrowse" component={JourneyBrowseScreen} />
+      <Stack.Screen name="JourneyDetail" component={JourneyDetailScreen} />
       <Stack.Screen name="WordStudyBrowse" component={WordStudyBrowseScreen} />
       <Stack.Screen name="WordStudyDetail" component={WordStudyDetailScreen} />
       <Stack.Screen name="ScholarBrowse" component={ScholarBrowseScreen} />

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -95,6 +95,7 @@ export type ExploreStackParamList = {
   RedemptiveArc: undefined;
   PersonJourney: { personId: string };
   JourneyBrowse: { tab?: 'people' | 'concepts' } | undefined;
+  JourneyDetail: { journeyId: string };
   Concordance: {
     strongs?: string;
     original?: string;

--- a/app/src/screens/JourneyDetailScreen.tsx
+++ b/app/src/screens/JourneyDetailScreen.tsx
@@ -1,0 +1,232 @@
+/**
+ * JourneyDetailScreen — Unified screen for person, concept, and thematic journeys.
+ *
+ * Layout: hero header → metadata row → description → stops timeline → tags.
+ * Premium-gated: first 3 stops free, rest behind paywall.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { useJourneyDetail } from '../hooks/useJourneyDetail';
+import { usePremium } from '../hooks/usePremium';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { JourneyStopsTimeline } from '../components/JourneyStopsTimeline';
+import { LinkedJourneySheet } from '../components/LinkedJourneySheet';
+import { UpgradePrompt } from '../components/UpgradePrompt';
+import { BadgeChip } from '../components/BadgeChip';
+import { useTheme, spacing, fontFamily } from '../theme';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+
+const FREE_STOP_COUNT = 3;
+
+function JourneyDetailScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'JourneyDetail'>>();
+  const route = useRoute<ScreenRouteProp<'Explore', 'JourneyDetail'>>();
+  const { journeyId } = route.params ?? {};
+  const { journey, stops, tags, linkedJourneyLookups, readingTimeMinutes, isLoading } = useJourneyDetail(journeyId);
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
+
+  const [linkedSheetJourneyId, setLinkedSheetJourneyId] = useState<string | null>(null);
+  const [linkedSheetIntro, setLinkedSheetIntro] = useState<string | null>(null);
+
+  const handleNavigateToChapter = useCallback((bookId: string, chapterNum: number, verseNum?: number) => {
+    navigation.navigate('Chapter', {
+      bookId,
+      chapterNum,
+      ...(verseNum ? { verseNum } : {}),
+    });
+  }, [navigation]);
+
+  const handleLinkedJourneyPress = useCallback((linkedId: string, intro: string | null) => {
+    if (!isPremium) {
+      showUpgrade('feature', 'Linked Journeys');
+      return;
+    }
+    setLinkedSheetJourneyId(linkedId);
+    setLinkedSheetIntro(intro);
+  }, [isPremium, showUpgrade]);
+
+  const handleLinkedSheetClose = useCallback(() => {
+    setLinkedSheetJourneyId(null);
+    setLinkedSheetIntro(null);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <View style={styles.loadingPad}>
+          <LoadingSkeleton lines={8} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!journey) return null;
+
+  const linkedTitles = new Map<string, string>();
+  for (const [id, lookup] of linkedJourneyLookups) {
+    linkedTitles.set(id, lookup.title);
+  }
+
+  const depthLabel = journey.depth ? journey.depth.charAt(0).toUpperCase() + journey.depth.slice(1) : null;
+  const lensLabel = journey.lens_id ? journey.lens_id.replace(/_/g, ' ') : null;
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <ScreenHeader
+          title={journey.title}
+          subtitle={journey.subtitle ?? undefined}
+          onBack={() => navigation.goBack()}
+          style={styles.header}
+        />
+
+        {/* Metadata row */}
+        <View style={styles.metaRow}>
+          {lensLabel && (
+            <BadgeChip label={lensLabel} color={base.gold} />
+          )}
+          <Text style={[styles.metaText, { color: base.textMuted }]}>
+            {stops.length} stops · {readingTimeMinutes} min read
+          </Text>
+          {depthLabel && (
+            <Text style={[styles.metaText, { color: base.textMuted }]}>
+              · {depthLabel}
+            </Text>
+          )}
+        </View>
+
+        {/* Description / Introduction */}
+        {journey.description ? (
+          <Text style={[styles.description, { color: base.text }]}>
+            {journey.description}
+          </Text>
+        ) : null}
+
+        {/* Stops Timeline */}
+        <View style={styles.timelineSection}>
+          <JourneyStopsTimeline
+            stops={stops}
+            isPremium={isPremium}
+            freeStopCount={FREE_STOP_COUNT}
+            linkedJourneyTitles={linkedTitles}
+            onNavigateToChapter={handleNavigateToChapter}
+            onLinkedJourneyPress={handleLinkedJourneyPress}
+          />
+        </View>
+
+        {/* Premium gate */}
+        {!isPremium && stops.length > FREE_STOP_COUNT && (
+          <View style={styles.gateSection}>
+            <Text style={[styles.gateText, { color: base.textMuted }]}>
+              {stops.length - FREE_STOP_COUNT} more stops available with Premium
+            </Text>
+          </View>
+        )}
+
+        {/* Tags */}
+        {tags.length > 0 && (
+          <View style={styles.tagsSection}>
+            <Text style={[styles.sectionTitle, { color: base.text }]}>Explore Deeper</Text>
+            <View style={styles.tagRow}>
+              {tags.map((tag) => (
+                <BadgeChip
+                  key={`${tag.tag_type}-${tag.tag_id}`}
+                  label={tag.tag_id.replace(/-/g, ' ')}
+                  color={base.textMuted}
+                />
+              ))}
+            </View>
+          </View>
+        )}
+      </ScrollView>
+
+      {upgradeRequest && (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
+      )}
+
+      <LinkedJourneySheet
+        visible={linkedSheetJourneyId !== null}
+        linkedJourneyId={linkedSheetJourneyId}
+        linkedJourneyIntro={linkedSheetIntro}
+        onClose={handleLinkedSheetClose}
+        onNavigateToChapter={handleNavigateToChapter}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingPad: {
+    padding: spacing.lg,
+  },
+  scrollContent: {
+    paddingBottom: spacing.xl * 2,
+  },
+  header: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.xs,
+    marginBottom: spacing.md,
+  },
+  metaText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+  },
+  description: {
+    fontFamily: fontFamily.body,
+    fontSize: 15,
+    lineHeight: 24,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  timelineSection: {
+    paddingHorizontal: spacing.md,
+  },
+  gateSection: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  gateText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  tagsSection: {
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.lg,
+  },
+  sectionTitle: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 16,
+    marginBottom: spacing.sm,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+});
+
+export default withErrorBoundary(JourneyDetailScreen);


### PR DESCRIPTION
## Summary

Closes #1400 (Phase 4 — UI for Epic #1379)

### New files
- **`app/src/screens/JourneyDetailScreen.tsx`** — Unified screen for all 3 journey types (person, concept, thematic). Layout: header → metadata row (lens badge, stop count, reading time, depth) → description → stops timeline → tags
- **`app/src/components/JourneyStopsTimeline.tsx`** — Evolved from `ConceptJourney.tsx`. Renders regular stops with timeline spine, bridges in italic, linked journey stops with dashed border and link icon. Premium-gated: first 3 stops free
- **`app/src/hooks/useJourneyDetail.ts`** — Loads journey + stops + tags, resolves linked journey titles, estimates reading time
- **`app/__tests__/hooks/useJourneyDetail.test.ts`** — 3 tests

### Modified files
- **`app/src/navigation/types.ts`** — Added `JourneyDetail: { journeyId: string }` route
- **`app/src/navigation/ExploreStack.tsx`** — Registered JourneyDetailScreen

## Test plan
- [x] useJourneyDetail hook tests pass (3/3)
- [x] Full test suite passes (431 suites, 3215 tests)
- [x] TypeScript clean, lint clean
- [ ] CI passes

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes