### PR TITLE
UI: redesigned JourneyBrowseScreen with three tabs (#1401)

### DIFF
--- a/app/__tests__/hooks/useJourneyBrowse.test.ts
+++ b/app/__tests__/hooks/useJourneyBrowse.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for rewritten useJourneyBrowse hook (unified journeys table).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/database', () => ({
+  getDb: () => ({
+    getFirstAsync: jest.fn().mockResolvedValue(null),
+    getAllAsync: jest.fn().mockResolvedValue([]),
+  }),
+}));
+
+jest.mock('@/db/user', () => ({
+  getPreference: jest.fn().mockResolvedValue(null),
+  setPreference: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetAllJourneys = jest.fn();
+jest.mock('@/db/content/features', () => ({
+  getAllJourneys: (...args: unknown[]) => mockGetAllJourneys(...args),
+}));
+
+import { useJourneyBrowse } from '@/hooks/useJourneyBrowse';
+
+const mockJourneys = [
+  { id: 'abraham', journey_type: 'person', title: 'Abraham', subtitle: 'Father of the faithful', lens_id: 'biographical', depth: 'long', sort_order: 0, person_id: 'abraham', concept_id: null, era: 'patriarchs', tags: null, hero_image_url: null, description: '' },
+  { id: 'covenant', journey_type: 'concept', title: 'Covenant', subtitle: null, lens_id: 'theological', depth: 'long', sort_order: 0, person_id: null, concept_id: 'covenant', era: null, tags: null, hero_image_url: null, description: '' },
+  { id: 'garden-to-city', journey_type: 'thematic', title: 'From Garden to City', subtitle: 'Eden to New Jerusalem', lens_id: 'narrative', depth: 'long', sort_order: 1, person_id: null, concept_id: null, era: null, tags: null, hero_image_url: null, description: '' },
+];
+
+describe('useJourneyBrowse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllJourneys.mockResolvedValue(mockJourneys);
+  });
+
+  it('loads and categorizes journeys by type', async () => {
+    const { result } = renderHook(() => useJourneyBrowse());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.allJourneys).toHaveLength(3);
+    expect(result.current.personJourneys).toHaveLength(1);
+    expect(result.current.conceptJourneys).toHaveLength(1);
+    expect(result.current.thematicJourneys).toHaveLength(1);
+  });
+
+  it('extracts unique lens IDs', async () => {
+    const { result } = renderHook(() => useJourneyBrowse());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.lensIds).toContain('biographical');
+    expect(result.current.lensIds).toContain('theological');
+    expect(result.current.lensIds).toContain('narrative');
+  });
+
+  it('returns empty state when no journeys', async () => {
+    mockGetAllJourneys.mockResolvedValue([]);
+    const { result } = renderHook(() => useJourneyBrowse());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.allJourneys).toEqual([]);
+    expect(result.current.lensIds).toEqual([]);
+  });
+});

--- a/app/__tests__/screens/ExploreMenuScreen.test.tsx
+++ b/app/__tests__/screens/ExploreMenuScreen.test.tsx
@@ -11,8 +11,11 @@ jest.mock('@/db/content', () => ({
 
 jest.mock('@/hooks/useJourneyBrowse', () => ({
   useJourneyBrowse: jest.fn().mockReturnValue({
+    allJourneys: [],
     personJourneys: [],
     conceptJourneys: [],
+    thematicJourneys: [],
+    lensIds: [],
     isLoading: false,
   }),
 }));

--- a/app/src/components/JourneyBrowseSection.tsx
+++ b/app/src/components/JourneyBrowseSection.tsx
@@ -2,10 +2,10 @@
  * JourneyBrowseSection — Journeys section for ExploreMenuScreen.
  *
  * Two horizontal rows:
- *   Row A: Person Journeys — avatar-style cards (30 people)
- *   Row B: Concept Journeys — text-forward cards (20 concepts)
+ *   Row A: Person Journeys — avatar-style cards
+ *   Row B: Thematic + Concept Journeys — text-forward cards
  *
- * Part of Journeys on Explore feature.
+ * Rewritten for Epic #1379 unified journey model.
  */
 
 import React, { useCallback } from 'react';
@@ -14,187 +14,101 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { ScreenNavProp } from '../navigation/types';
-import { useJourneyBrowse, type PersonJourneyEntry, type ConceptJourneyEntry } from '../hooks/useJourneyBrowse';
+import { useJourneyBrowse, type JourneyBrowseEntry } from '../hooks/useJourneyBrowse';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 
-// ── Person Card ────────────────────────────────────────────────────
-
-function PersonJourneyCard({
-  entry,
-  eraColor,
-  onPress,
-}: {
-  entry: PersonJourneyEntry;
-  eraColor: string;
-  onPress: () => void;
-}) {
+function PersonCard({ entry, onPress }: { entry: JourneyBrowseEntry; onPress: () => void }) {
   const { base } = useTheme();
-
   return (
     <TouchableOpacity
-      style={[styles.personCard, { backgroundColor: base.bgElevated, borderColor: eraColor + '20' }]}
+      style={[styles.personCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '20' }]}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
-      accessibilityLabel={`${entry.name} journey, ${entry.stageCount} stages`}
+      accessibilityLabel={`${entry.title} journey`}
     >
-      {/* Avatar circle with initial */}
-      <View style={[styles.avatar, { backgroundColor: eraColor + '30', borderColor: eraColor + '40' }]}>
-        <Text style={[styles.avatarText, { color: eraColor }]}>
-          {entry.name.charAt(0)}
-        </Text>
+      <View style={[styles.avatar, { backgroundColor: base.gold + '30', borderColor: base.gold + '40' }]}>
+        <Text style={[styles.avatarText, { color: base.gold }]}>{entry.title.charAt(0)}</Text>
       </View>
-      <Text style={[styles.personName, { color: base.text }]} numberOfLines={1}>
-        {entry.name}
-      </Text>
-      {entry.role ? (
-        <Text style={[styles.personRole, { color: base.textMuted }]} numberOfLines={1}>
-          {entry.role}
-        </Text>
-      ) : null}
-      <Text style={[styles.stageCount, { color: eraColor }]}>
-        {entry.stageCount} stages
-      </Text>
+      <Text style={[styles.personName, { color: base.text }]} numberOfLines={1}>{entry.title}</Text>
+      {entry.subtitle && (
+        <Text style={[styles.personRole, { color: base.textMuted }]} numberOfLines={1}>{entry.subtitle}</Text>
+      )}
     </TouchableOpacity>
   );
 }
 
-// ── Concept Card ───────────────────────────────────────────────────
-
-function ConceptJourneyCard({
-  entry,
-  onPress,
-}: {
-  entry: ConceptJourneyEntry;
-  onPress: () => void;
-}) {
+function JourneyCard({ entry, onPress }: { entry: JourneyBrowseEntry; onPress: () => void }) {
   const { base } = useTheme();
-
-  const rangeText = entry.firstLabel && entry.lastLabel
-    ? `${entry.firstLabel} → ${entry.lastLabel}`
-    : '';
-
   return (
     <TouchableOpacity
       style={[styles.conceptCard, { backgroundColor: base.bgElevated, borderColor: base.border }]}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
-      accessibilityLabel={`${entry.title} journey, ${entry.stopCount} stops`}
+      accessibilityLabel={`${entry.title} journey`}
     >
-      <Text style={[styles.conceptTitle, { color: base.gold }]} numberOfLines={1}>
-        {entry.title}
-      </Text>
-      {rangeText ? (
-        <Text style={[styles.conceptRange, { color: base.textMuted }]} numberOfLines={1}>
-          {rangeText}
+      <Text style={[styles.conceptTitle, { color: base.gold }]} numberOfLines={1}>{entry.title}</Text>
+      {entry.subtitle && (
+        <Text style={[styles.conceptRange, { color: base.textMuted }]} numberOfLines={1}>{entry.subtitle}</Text>
+      )}
+      {entry.lensId && (
+        <Text style={[styles.stageCount, { color: base.textDim }]}>
+          {entry.lensId.replace(/_/g, ' ')}
         </Text>
-      ) : null}
-      <Text style={[styles.stageCount, { color: base.textDim }]}>
-        {entry.stopCount} stops
-      </Text>
+      )}
     </TouchableOpacity>
   );
 }
 
-// ── Section Component ──────────────────────────────────────────────
-
 export function JourneyBrowseSection() {
   const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'ExploreMenu'>>();
-  const { personJourneys, conceptJourneys, isLoading } = useJourneyBrowse();
+  const { personJourneys, thematicJourneys, conceptJourneys, isLoading } = useJourneyBrowse();
 
-  const handlePersonPress = useCallback((personId: string) => {
-    navigation.navigate('PersonJourney', { personId });
+  const handleJourneyPress = useCallback((journeyId: string) => {
+    navigation.navigate('JourneyDetail', { journeyId });
   }, [navigation]);
 
-  const handleConceptPress = useCallback((conceptId: string) => {
-    navigation.navigate('ConceptDetail', { conceptId, initialTab: 'journey' });
-  }, [navigation]);
-
-  const handleBrowseAll = useCallback((tab?: 'people' | 'concepts') => {
+  const handleBrowseAll = useCallback((tab?: 'people' | 'lenses' | 'featured') => {
     navigation.navigate('JourneyBrowse', { tab });
   }, [navigation]);
 
-  if (isLoading || (personJourneys.length === 0 && conceptJourneys.length === 0)) {
+  if (isLoading || (personJourneys.length === 0 && thematicJourneys.length === 0 && conceptJourneys.length === 0)) {
     return null;
   }
 
-  // Map era strings to theme era colors
-  const getEraColor = (era: string | null): string => {
-    if (!era) return base.gold;
-    // The eras record is in theme/colors but we use the palette-transformed version
-    return base.gold; // Simplified — the era badge handles its own color
-  };
+  const otherJourneys = [...thematicJourneys, ...conceptJourneys];
 
   return (
     <View style={styles.container}>
-      {/* ── Person Journeys Row ── */}
       {personJourneys.length > 0 && (
         <View style={styles.rowContainer}>
           <View style={styles.rowHeader}>
-            <Text style={[styles.rowLabel, { color: base.textMuted }]}>
-              PEOPLE
-            </Text>
-            <TouchableOpacity
-              onPress={() => handleBrowseAll('people')}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityRole="button"
-              accessibilityLabel={`Browse all ${personJourneys.length} person journeys`}
-            >
-              <Text style={[styles.browseAll, { color: base.gold }]}>
-                {personJourneys.length} journeys ›
-              </Text>
+            <Text style={[styles.rowLabel, { color: base.textMuted }]}>PEOPLE</Text>
+            <TouchableOpacity onPress={() => handleBrowseAll('people')} hitSlop={8}>
+              <Text style={[styles.browseAll, { color: base.gold }]}>{personJourneys.length} journeys ›</Text>
             </TouchableOpacity>
           </View>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-          >
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.carouselContent} decelerationRate="fast">
             {personJourneys.map((entry) => (
-              <PersonJourneyCard
-                key={entry.personId}
-                entry={entry}
-                eraColor={getEraColor(entry.era)}
-                onPress={() => handlePersonPress(entry.personId)}
-              />
+              <PersonCard key={entry.id} entry={entry} onPress={() => handleJourneyPress(entry.id)} />
             ))}
           </ScrollView>
         </View>
       )}
 
-      {/* ── Concept Journeys Row ── */}
-      {conceptJourneys.length > 0 && (
+      {otherJourneys.length > 0 && (
         <View style={styles.rowContainer}>
           <View style={styles.rowHeader}>
-            <Text style={[styles.rowLabel, { color: base.textMuted }]}>
-              CONCEPTS
-            </Text>
-            <TouchableOpacity
-              onPress={() => handleBrowseAll('concepts')}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityRole="button"
-              accessibilityLabel={`Browse all ${conceptJourneys.length} concept journeys`}
-            >
-              <Text style={[styles.browseAll, { color: base.gold }]}>
-                {conceptJourneys.length} journeys ›
-              </Text>
+            <Text style={[styles.rowLabel, { color: base.textMuted }]}>JOURNEYS</Text>
+            <TouchableOpacity onPress={() => handleBrowseAll('lenses')} hitSlop={8}>
+              <Text style={[styles.browseAll, { color: base.gold }]}>{otherJourneys.length} journeys ›</Text>
             </TouchableOpacity>
           </View>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-          >
-            {conceptJourneys.map((entry) => (
-              <ConceptJourneyCard
-                key={entry.conceptId}
-                entry={entry}
-                onPress={() => handleConceptPress(entry.conceptId)}
-              />
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.carouselContent} decelerationRate="fast">
+            {otherJourneys.map((entry) => (
+              <JourneyCard key={entry.id} entry={entry} onPress={() => handleJourneyPress(entry.id)} />
             ))}
           </ScrollView>
         </View>
@@ -203,39 +117,21 @@ export function JourneyBrowseSection() {
   );
 }
 
-// ── Styles ──────────────────────────────────────────────────────────
-
 const PERSON_CARD_WIDTH = 120;
 const CONCEPT_CARD_WIDTH = 160;
 
 const styles = StyleSheet.create({
-  container: {
-    gap: spacing.md,
-  },
-  rowContainer: {
-    gap: spacing.sm,
-  },
+  container: { gap: spacing.md },
+  rowContainer: { gap: spacing.sm },
   rowHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     paddingHorizontal: 20,
   },
-  rowLabel: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-    letterSpacing: 0.5,
-  },
-  browseAll: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 11,
-  },
-  carouselContent: {
-    paddingHorizontal: 20,
-    gap: spacing.sm,
-  },
-
-  // Person card
+  rowLabel: { fontFamily: fontFamily.uiMedium, fontSize: 11, letterSpacing: 0.5 },
+  browseAll: { fontFamily: fontFamily.uiMedium, fontSize: 11 },
+  carouselContent: { paddingHorizontal: 20, gap: spacing.sm },
   personCard: {
     width: PERSON_CARD_WIDTH,
     borderRadius: radii.lg,
@@ -244,51 +140,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   avatar: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    borderWidth: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: spacing.xs,
+    width: 44, height: 44, borderRadius: 22, borderWidth: 1,
+    alignItems: 'center', justifyContent: 'center', marginBottom: spacing.xs,
   },
-  avatarText: {
-    fontFamily: fontFamily.displaySemiBold,
-    fontSize: 18,
-  },
-  personName: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 12,
-    textAlign: 'center',
-  },
-  personRole: {
-    fontFamily: fontFamily.ui,
-    fontSize: 10,
-    textAlign: 'center',
-    marginTop: 1,
-  },
-  stageCount: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 10,
-    marginTop: spacing.xs,
-  },
-
-  // Concept card
+  avatarText: { fontFamily: fontFamily.displaySemiBold, fontSize: 18 },
+  personName: { fontFamily: fontFamily.uiMedium, fontSize: 12, textAlign: 'center' },
+  personRole: { fontFamily: fontFamily.ui, fontSize: 10, textAlign: 'center', marginTop: 1 },
+  stageCount: { fontFamily: fontFamily.uiMedium, fontSize: 10, marginTop: spacing.xs },
   conceptCard: {
     width: CONCEPT_CARD_WIDTH,
     borderRadius: radii.lg,
     borderWidth: 1,
     padding: spacing.sm + 4,
   },
-  conceptTitle: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 13,
-    marginBottom: 2,
-  },
-  conceptRange: {
-    fontFamily: fontFamily.ui,
-    fontSize: 10,
-    lineHeight: 14,
-    marginBottom: spacing.xs,
-  },
+  conceptTitle: { fontFamily: fontFamily.uiMedium, fontSize: 13, marginBottom: 2 },
+  conceptRange: { fontFamily: fontFamily.ui, fontSize: 10, lineHeight: 14, marginBottom: spacing.xs },
 });

--- a/app/src/hooks/useJourneyBrowse.ts
+++ b/app/src/hooks/useJourneyBrowse.ts
@@ -1,79 +1,81 @@
 /**
- * useJourneyBrowse — Data for the Journeys section on ExploreMenuScreen.
+ * useJourneyBrowse — Load all journeys from the unified journeys table
+ * for the three-tab JourneyBrowseScreen.
  *
- * Loads person journeys (from people_journeys table) and concept journeys
- * (from concepts table, filtered to those with journey_stops) in parallel.
- *
- * Part of Journeys on Explore feature.
+ * Rewritten for Epic #1379 unified journey model.
  */
 
-import { useState, useEffect } from 'react';
-import { getPeopleWithJourneys } from '../db/content';
+import { useState, useEffect, useMemo } from 'react';
+import { getAllJourneys } from '../db/content/features';
 import { logger } from '../utils/logger';
-import { useConcepts, type Concept } from './useConceptData';
+import type { Journey } from '../types';
 
-export interface PersonJourneyEntry {
-  personId: string;
-  name: string;
-  era: string | null;
-  role: string | null;
-  stageCount: number;
-}
-
-export interface ConceptJourneyEntry {
-  conceptId: string;
+export interface JourneyBrowseEntry {
+  id: string;
+  journeyType: 'person' | 'concept' | 'thematic';
   title: string;
-  stopCount: number;
-  firstLabel: string;
-  lastLabel: string;
+  subtitle: string | null;
+  lensId: string | null;
+  depth: string | null;
+  personId: string | null;
+  conceptId: string | null;
 }
 
 export interface JourneyBrowseData {
-  personJourneys: PersonJourneyEntry[];
-  conceptJourneys: ConceptJourneyEntry[];
+  allJourneys: JourneyBrowseEntry[];
+  personJourneys: JourneyBrowseEntry[];
+  conceptJourneys: JourneyBrowseEntry[];
+  thematicJourneys: JourneyBrowseEntry[];
+  lensIds: string[];
   isLoading: boolean;
 }
 
-export function useJourneyBrowse(): JourneyBrowseData {
-  const [personJourneys, setPersonJourneys] = useState<PersonJourneyEntry[]>([]);
-  const [isLoadingPeople, setIsLoadingPeople] = useState(true);
-  const { concepts, loading: conceptsLoading } = useConcepts();
+function toEntry(j: Journey): JourneyBrowseEntry {
+  return {
+    id: j.id,
+    journeyType: j.journey_type,
+    title: j.title,
+    subtitle: j.subtitle,
+    lensId: j.lens_id,
+    depth: j.depth,
+    personId: j.person_id,
+    conceptId: j.concept_id,
+  };
+}
 
-  // Load person journeys
+export function useJourneyBrowse(): JourneyBrowseData {
+  const [allJourneys, setAllJourneys] = useState<JourneyBrowseEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
   useEffect(() => {
-    getPeopleWithJourneys()
-      .then((rows) => {
-        setPersonJourneys(
-          rows.map((r) => ({
-            personId: r.person_id,
-            name: r.name,
-            era: r.era,
-            role: r.role,
-            stageCount: r.stage_count,
-          })),
-        );
-      })
-      .catch((err) => {
-        logger.warn('useJourneyBrowse', 'Failed to load person journeys', err);
-      })
-      .finally(() => setIsLoadingPeople(false));
+    getAllJourneys()
+      .then((rows) => setAllJourneys(rows.map(toEntry)))
+      .catch((err) => logger.warn('useJourneyBrowse', 'Failed to load journeys', err))
+      .finally(() => setIsLoading(false));
   }, []);
 
-  // Derive concept journeys from the concepts hook (already loaded)
-  const conceptJourneys: ConceptJourneyEntry[] = concepts
-    .filter((c: Concept) => c.journey_stops && c.journey_stops.length > 0)
-    .map((c: Concept) => ({
-      conceptId: c.id,
-      title: c.title,
-      stopCount: c.journey_stops.length,
-      firstLabel: c.journey_stops[0]?.label ?? '',
-      lastLabel: c.journey_stops[c.journey_stops.length - 1]?.label ?? '',
-    }))
-    .sort((a, b) => b.stopCount - a.stopCount);
+  const personJourneys = useMemo(
+    () => allJourneys.filter((j) => j.journeyType === 'person').sort((a, b) => a.title.localeCompare(b.title)),
+    [allJourneys],
+  );
 
-  return {
-    personJourneys,
-    conceptJourneys,
-    isLoading: isLoadingPeople || conceptsLoading,
-  };
+  const conceptJourneys = useMemo(
+    () => allJourneys.filter((j) => j.journeyType === 'concept'),
+    [allJourneys],
+  );
+
+  const thematicJourneys = useMemo(
+    () => allJourneys.filter((j) => j.journeyType === 'thematic'),
+    [allJourneys],
+  );
+
+  const lensIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const j of allJourneys) {
+      if (j.lensId) set.add(j.lensId);
+    }
+    return [...set].sort();
+  }, [allJourneys]);
+
+  return { allJourneys, personJourneys, conceptJourneys, thematicJourneys, lensIds, isLoading };
 }

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -94,7 +94,7 @@ export type ExploreStackParamList = {
   Periods: undefined;
   RedemptiveArc: undefined;
   PersonJourney: { personId: string };
-  JourneyBrowse: { tab?: 'people' | 'concepts' } | undefined;
+  JourneyBrowse: { tab?: 'lenses' | 'people' | 'featured'; filterLens?: string } | undefined;
   JourneyDetail: { journeyId: string };
   Concordance: {
     strongs?: string;

--- a/app/src/screens/JourneyBrowseScreen.tsx
+++ b/app/src/screens/JourneyBrowseScreen.tsx
@@ -1,213 +1,307 @@
 /**
- * JourneyBrowseScreen — Full-screen list of all person + concept journeys.
+ * JourneyBrowseScreen — Three-tab browse for all 60 journeys.
  *
- * Two tabs: People (30 entries) and Concepts (20 entries).
- * Each row shows name, stage/stop count, era/range, and chevron.
- * Taps navigate to PersonJourney or ConceptDetail (journey tab).
+ * Tab 1: Lenses — horizontal lens pill row + vertical list grouped by lens
+ * Tab 2: People — alphabetical list of 30 person journeys
+ * Tab 3: Featured — curated highlights (start here, seasonal, popular)
  *
- * Part of Journeys on Explore feature.
- *
- * Card #1359 (UI polish phase 2): migrated to shared BrowseScreenTemplate.
- * The People/Concepts tab switcher now uses BrowseFilterPill for consistency
- * with other browse screens; row-level layout is preserved.
+ * Redesigned for Epic #1379 unified journey model.
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import {
-  View, Text, TouchableOpacity, StyleSheet,
+  View, Text, TouchableOpacity, FlatList, StyleSheet, SectionList,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { ChevronRight } from 'lucide-react-native';
+import { ChevronRight, Lock, Compass, Users, Star } from 'lucide-react-native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
-import { useJourneyBrowse, type PersonJourneyEntry, type ConceptJourneyEntry } from '../hooks/useJourneyBrowse';
-import {
-  BrowseScreenTemplate,
-  BrowseFilterPill,
-} from '../components/BrowseScreenTemplate';
+import { useJourneyBrowse, type JourneyBrowseEntry } from '../hooks/useJourneyBrowse';
+import { usePremium } from '../hooks/usePremium';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { UpgradePrompt } from '../components/UpgradePrompt';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
-type Tab = 'people' | 'concepts';
-type AnyJourneyEntry = PersonJourneyEntry | ConceptJourneyEntry;
+type Tab = 'lenses' | 'people' | 'featured';
+
+const FEATURED_IDS = ['garden-to-city', 'gospel-resurrections', 'why-does-god-allow-suffering'];
+const SEASONAL_IDS = ['holy-week-day-by-day'];
+const START_HERE_ID = 'garden-to-city';
 
 function JourneyBrowseScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'JourneyBrowse'>>();
   const route = useRoute<ScreenRouteProp<'Explore', 'JourneyBrowse'>>();
-  const initialTab = route.params?.tab ?? 'people';
+  const initialTab: Tab = (route.params as { tab?: Tab })?.tab ?? 'lenses';
   const [activeTab, setActiveTab] = useState<Tab>(initialTab);
-  const { personJourneys, conceptJourneys, isLoading } = useJourneyBrowse();
+  const [activeLens, setActiveLens] = useState<string | null>(null);
+  const { allJourneys, personJourneys, lensIds, isLoading } = useJourneyBrowse();
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
 
-  const handlePersonPress = useCallback((personId: string) => {
-    navigation.navigate('PersonJourney', { personId });
-  }, [navigation]);
-
-  const handleConceptPress = useCallback((conceptId: string) => {
-    navigation.navigate('ConceptDetail', { conceptId, initialTab: 'journey' });
-  }, [navigation]);
-
-  const renderPersonItem = useCallback((item: PersonJourneyEntry) => (
-    <TouchableOpacity
-      style={[styles.row, { borderBottomColor: base.border }]}
-      onPress={() => handlePersonPress(item.personId)}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={`${item.name}, ${item.stageCount} stages`}
-    >
-      <View style={[styles.avatar, { backgroundColor: base.gold + '18', borderColor: base.gold + '30' }]}>
-        <Text style={[styles.avatarText, { color: base.gold }]}>
-          {item.name.charAt(0)}
-        </Text>
-      </View>
-      <View style={styles.rowCenter}>
-        <Text style={[styles.rowTitle, { color: base.text }]}>{item.name}</Text>
-        <Text style={[styles.rowSubtitle, { color: base.textMuted }]}>
-          {[item.role, item.era].filter(Boolean).join(' · ')}
-        </Text>
-      </View>
-      <View style={styles.rowRight}>
-        <Text style={[styles.countBadge, { color: base.gold }]}>
-          {item.stageCount} stages
-        </Text>
-        <ChevronRight size={14} color={base.textMuted} />
-      </View>
-    </TouchableOpacity>
-  ), [base, handlePersonPress]);
-
-  const renderConceptItem = useCallback((item: ConceptJourneyEntry) => (
-    <TouchableOpacity
-      style={[styles.row, { borderBottomColor: base.border }]}
-      onPress={() => handleConceptPress(item.conceptId)}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={`${item.title}, ${item.stopCount} stops`}
-    >
-      <View style={[styles.conceptIcon, { backgroundColor: base.gold + '12' }]}>
-        <Text style={[styles.conceptIconText, { color: base.gold }]}>◆</Text>
-      </View>
-      <View style={styles.rowCenter}>
-        <Text style={[styles.rowTitle, { color: base.text }]}>{item.title}</Text>
-        {item.firstLabel && item.lastLabel ? (
-          <Text style={[styles.rowSubtitle, { color: base.textMuted }]} numberOfLines={1}>
-            {item.firstLabel} → {item.lastLabel}
-          </Text>
-        ) : null}
-      </View>
-      <View style={styles.rowRight}>
-        <Text style={[styles.countBadge, { color: base.gold }]}>
-          {item.stopCount} stops
-        </Text>
-        <ChevronRight size={14} color={base.textMuted} />
-      </View>
-    </TouchableOpacity>
-  ), [base, handleConceptPress]);
-
-  const data: AnyJourneyEntry[] = activeTab === 'people' ? personJourneys : conceptJourneys;
-
-  const renderItem = useCallback(({ item }: { item: AnyJourneyEntry }) => {
-    if (activeTab === 'people') {
-      return renderPersonItem(item as PersonJourneyEntry);
+  const handlePress = useCallback((entry: JourneyBrowseEntry) => {
+    if (!isPremium) {
+      showUpgrade('feature', 'Guided Journeys');
+      return;
     }
-    return renderConceptItem(item as ConceptJourneyEntry);
-  }, [activeTab, renderPersonItem, renderConceptItem]);
+    navigation.navigate('JourneyDetail', { journeyId: entry.id });
+  }, [isPremium, showUpgrade, navigation]);
 
-  const keyExtractor = useCallback((item: AnyJourneyEntry) => {
-    return activeTab === 'people'
-      ? (item as PersonJourneyEntry).personId
-      : (item as ConceptJourneyEntry).conceptId;
-  }, [activeTab]);
+  // Lenses tab data
+  const lensFiltered = useMemo(() => {
+    if (!activeLens) return allJourneys;
+    return allJourneys.filter((j) => j.lensId === activeLens);
+  }, [allJourneys, activeLens]);
 
-  const filterBar = (
-    <View style={styles.tabRow}>
-      <BrowseFilterPill
-        label={`People (${personJourneys.length})`}
-        active={activeTab === 'people'}
-        onPress={() => setActiveTab('people')}
-        role="tab"
-      />
-      <BrowseFilterPill
-        label={`Concepts (${conceptJourneys.length})`}
-        active={activeTab === 'concepts'}
-        onPress={() => setActiveTab('concepts')}
-        role="tab"
-      />
-    </View>
-  );
+  // People tab data — alphabetical sections
+  const peopleSections = useMemo(() => {
+    const map = new Map<string, JourneyBrowseEntry[]>();
+    for (const j of personJourneys) {
+      const letter = j.title.charAt(0).toUpperCase();
+      if (!map.has(letter)) map.set(letter, []);
+      map.get(letter)!.push(j);
+    }
+    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([title, data]) => ({ title, data }));
+  }, [personJourneys]);
+
+  // Featured tab data
+  const featuredJourneys = useMemo(() => allJourneys.filter((j) => FEATURED_IDS.includes(j.id)), [allJourneys]);
+  const seasonalJourneys = useMemo(() => allJourneys.filter((j) => SEASONAL_IDS.includes(j.id)), [allJourneys]);
+  const startHere = useMemo(() => allJourneys.find((j) => j.id === START_HERE_ID) ?? null, [allJourneys]);
+
+  const renderRow = useCallback((entry: JourneyBrowseEntry) => (
+    <TouchableOpacity
+      key={entry.id}
+      style={[styles.row, { borderBottomColor: base.border }]}
+      onPress={() => handlePress(entry)}
+      activeOpacity={0.7}
+    >
+      <View style={styles.rowContent}>
+        <Text style={[styles.rowTitle, { color: base.text }]} numberOfLines={1}>{entry.title}</Text>
+        {entry.subtitle && (
+          <Text style={[styles.rowSubtitle, { color: base.textMuted }]} numberOfLines={1}>{entry.subtitle}</Text>
+        )}
+        <View style={styles.rowMeta}>
+          {entry.lensId && (
+            <Text style={[styles.lensPill, { color: base.gold }]}>
+              {entry.lensId.replace(/_/g, ' ')}
+            </Text>
+          )}
+          {entry.depth && (
+            <Text style={[styles.depthText, { color: base.textMuted }]}>{entry.depth}</Text>
+          )}
+        </View>
+      </View>
+      {isPremium ? (
+        <ChevronRight size={16} color={base.textMuted} />
+      ) : (
+        <Lock size={14} color={base.textMuted} />
+      )}
+    </TouchableOpacity>
+  ), [base, handlePress, isPremium]);
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
+        <View style={styles.loadingPad}><LoadingSkeleton lines={8} /></View>
+      </SafeAreaView>
+    );
+  }
 
   return (
-    <BrowseScreenTemplate
-      title="Journeys"
-      loading={isLoading}
-      filterBar={filterBar}
-      data={data}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      emptyMessage={activeTab === 'people' ? 'No journeys available.' : 'No concept journeys available.'}
-      contentContainerStyle={styles.listContent}
-    />
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScreenHeader title="Journeys" onBack={() => navigation.goBack()} />
+
+      {/* Tab bar */}
+      <View style={[styles.tabBar, { borderBottomColor: base.border }]}>
+        {([
+          { key: 'lenses' as Tab, label: 'Lenses', Icon: Compass },
+          { key: 'people' as Tab, label: 'People', Icon: Users },
+          { key: 'featured' as Tab, label: 'Featured', Icon: Star },
+        ]).map(({ key, label, Icon }) => (
+          <TouchableOpacity
+            key={key}
+            style={[styles.tab, activeTab === key && { borderBottomColor: base.gold, borderBottomWidth: 2 }]}
+            onPress={() => setActiveTab(key)}
+          >
+            <Icon size={14} color={activeTab === key ? base.gold : base.textMuted} />
+            <Text style={[styles.tabLabel, { color: activeTab === key ? base.gold : base.textMuted }]}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Lenses tab */}
+      {activeTab === 'lenses' && (
+        <View style={styles.flex}>
+          {/* Lens pill row */}
+          <FlatList
+            horizontal
+            data={[null, ...lensIds]}
+            keyExtractor={(item) => item ?? 'all'}
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.pillRow}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={[
+                  styles.pill,
+                  { borderColor: (activeLens === item || (item === null && activeLens === null)) ? base.gold : base.border },
+                  (activeLens === item || (item === null && activeLens === null)) && { backgroundColor: base.gold + '15' },
+                ]}
+                onPress={() => setActiveLens(item)}
+              >
+                <Text style={[styles.pillText, { color: (activeLens === item || (item === null && activeLens === null)) ? base.gold : base.textMuted }]}>
+                  {item ? item.replace(/_/g, ' ') : 'All'}
+                </Text>
+              </TouchableOpacity>
+            )}
+          />
+          <FlatList
+            data={lensFiltered}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => renderRow(item)}
+            contentContainerStyle={styles.listContent}
+          />
+        </View>
+      )}
+
+      {/* People tab */}
+      {activeTab === 'people' && (
+        <SectionList
+          sections={peopleSections}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => renderRow(item)}
+          renderSectionHeader={({ section }) => (
+            <View style={[styles.sectionHeader, { backgroundColor: base.bg }]}>
+              <Text style={[styles.sectionHeaderText, { color: base.gold }]}>{section.title}</Text>
+            </View>
+          )}
+          stickySectionHeadersEnabled
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+
+      {/* Featured tab */}
+      {activeTab === 'featured' && (
+        <SectionList
+          sections={[
+            ...(startHere ? [{ title: 'Start Here', data: [startHere] }] : []),
+            ...(seasonalJourneys.length > 0 ? [{ title: 'In Season', data: seasonalJourneys }] : []),
+            ...(featuredJourneys.length > 0 ? [{ title: 'Popular', data: featuredJourneys }] : []),
+          ]}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => renderRow(item)}
+          renderSectionHeader={({ section }) => (
+            <View style={styles.featuredHeader}>
+              <Text style={[styles.featuredHeaderText, { color: base.text }]}>{section.title}</Text>
+            </View>
+          )}
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+
+      {upgradeRequest && (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
+      )}
+    </SafeAreaView>
   );
 }
 
-export default withErrorBoundary(JourneyBrowseScreen);
-
 const styles = StyleSheet.create({
-  tabRow: {
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  loadingPad: { padding: spacing.lg },
+  tabBar: {
     flexDirection: 'row',
-    gap: spacing.sm,
-    paddingBottom: spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.md,
+  },
+  tab: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: spacing.sm,
+  },
+  tabLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  pillRow: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: 8,
+  },
+  pill: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+  },
+  pillText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+    textTransform: 'capitalize',
   },
   listContent: {
-    paddingBottom: spacing.xxl,
+    paddingBottom: spacing.xl * 2,
   },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: spacing.sm + 4,
-    paddingHorizontal: spacing.lg,
-    borderBottomWidth: 1,
-    gap: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  avatar: {
-    width: 38,
-    height: 38,
-    borderRadius: 19,
-    borderWidth: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarText: {
-    fontFamily: fontFamily.displaySemiBold,
-    fontSize: 16,
-  },
-  conceptIcon: {
-    width: 38,
-    height: 38,
-    borderRadius: radii.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  conceptIconText: {
-    fontSize: 14,
-  },
-  rowCenter: {
-    flex: 1,
-  },
+  rowContent: { flex: 1, marginRight: spacing.sm },
   rowTitle: {
-    fontFamily: fontFamily.uiMedium,
-    fontSize: 14,
+    fontFamily: fontFamily.body,
+    fontSize: 16,
   },
   rowSubtitle: {
     fontFamily: fontFamily.ui,
-    fontSize: 11,
-    marginTop: 1,
+    fontSize: 13,
+    marginTop: 2,
   },
-  rowRight: {
+  rowMeta: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
+    gap: 8,
+    marginTop: 4,
   },
-  countBadge: {
+  lensPill: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 11,
+    textTransform: 'capitalize',
+  },
+  depthText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+  sectionHeader: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+  },
+  sectionHeaderText: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 14,
+    letterSpacing: 0.5,
+  },
+  featuredHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.xs,
+  },
+  featuredHeaderText: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 16,
   },
 });
+
+export default withErrorBoundary(JourneyBrowseScreen);


### PR DESCRIPTION
## Summary

Closes #1401 (Phase 4 — UI for Epic #1379)

Redesigns JourneyBrowseScreen with three tabs for browsing all 60 journeys.

### Changes
- **`useJourneyBrowse.ts`** — Rewritten against unified `journeys` table. Returns allJourneys, personJourneys, conceptJourneys, thematicJourneys, lensIds
- **`JourneyBrowseScreen.tsx`** — Three-tab layout:
  - **Lenses** — horizontal lens pill filter + vertical list
  - **People** — alphabetical SectionList with sticky headers
  - **Featured** — Start Here, In Season, Popular sections
- **`JourneyBrowseSection.tsx`** — Rewritten for unified model (person cards + journey cards)
- **`types.ts`** — Updated JourneyBrowse params to `lenses | people | featured`
- **Tests** — 3 new hook tests + updated ExploreMenuScreen mock

### Premium gating
Browse is free; tapping a journey shows upgrade prompt if not premium.

## Test plan
- [x] TypeScript clean
- [x] Lint clean (0 warnings)
- [x] useJourneyBrowse tests pass (3/3)
- [x] Full suite passes (432 suites, 3218 tests)
- [ ] CI passes

https://claude.ai/code/session_01Qj6otahNBTSak3fdYhFpes