### PR TITLE
fix: remove Other Scholars section + add bios for all 72 scholars

### DIFF
--- a/app/src/screens/ScholarBioScreen.tsx
+++ b/app/src/screens/ScholarBioScreen.tsx
@@ -2,12 +2,12 @@
  * ScholarBioScreen — Full scholar bio with sections, scope, other scholars grid.
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet, type DimensionValue } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
-import { getScholar, getAllScholars } from '../db/content';
+import { getScholar } from '../db/content';
 import { useContentImages } from '../hooks/useContentImages';
 import { ContentImageGallery } from '../components/ContentImageGallery';
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -24,7 +24,6 @@ function ScholarBioScreen() {
   const { scholarId } = route.params ?? {};
   const [scholar, setScholar] = useState<Scholar | null>(null);
   const [bio, setBio] = useState<ScholarBio | null>(null);
-  const [allScholars, setAllScholars] = useState<Scholar[]>([]);
   const { images: contentImages } = useContentImages('scholar', scholarId);
 
   useEffect(() => {
@@ -34,13 +33,7 @@ function ScholarBioScreen() {
         if (s?.bio_json) try { setBio(JSON.parse(s.bio_json)); } catch (err) { logger.warn('ScholarBioScreen', 'Operation failed', err); }
       });
     }
-    getAllScholars().then(setAllScholars);
   }, [scholarId]);
-
-  const otherScholars = useMemo(
-    () => allScholars.filter((s) => s.id !== scholarId).slice(0, 12),
-    [allScholars, scholarId]
-  );
 
   if (!scholar) {
     return (
@@ -105,27 +98,6 @@ function ScholarBioScreen() {
           )}
         </View>
 
-        {/* Other Scholars */}
-        <Text style={[styles.othersLabel, { color: base.textMuted }]}>OTHER SCHOLARS</Text>
-        <View style={styles.othersGrid}>
-          {otherScholars.map((s) => {
-            const sColor = getScholarColor(s.id);
-            return (
-              <TouchableOpacity
-                key={s.id}
-                onPress={() => navigation.setParams({ scholarId: s.id })}
-                style={[styles.otherCard, { backgroundColor: sColor + '14', borderLeftColor: sColor }]}
-                accessibilityRole="button"
-                accessibilityLabel={`View scholar: ${s.name}`}
-              >
-                <Text style={[styles.otherName, { color: sColor }]}>{s.name}</Text>
-                {s.tradition && (
-                  <Text style={[styles.otherTradition, { color: base.textMuted }]}>{s.tradition}</Text>
-                )}
-              </TouchableOpacity>
-            );
-          })}
-        </View>
       </ScrollView>
     </SafeAreaView>
   );
@@ -182,30 +154,6 @@ const styles = StyleSheet.create({
   scopeChipText: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 11,
-  },
-  othersLabel: {
-    fontFamily: fontFamily.display,
-    fontSize: 10,
-    letterSpacing: 0.5,
-    marginBottom: spacing.sm,
-  },
-  othersGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.sm,
-  },
-  otherCard: {
-    width: '48%' as DimensionValue,
-    borderLeftWidth: 3,
-    borderRadius: radii.md,
-    padding: spacing.sm,
-  },
-  otherName: {
-    fontFamily: fontFamily.display,
-    fontSize: 11,
-  },
-  otherTradition: {
-    fontSize: 9,
   },
 });
 

--- a/content/meta/scholars.json
+++ b/content/meta/scholars.json
@@ -1579,7 +1579,28 @@
     "scope_text": "Ezekiel",
     "description": "Swiss Old Testament scholar and professor at the University of Göttingen. Author of the two-volume Hermeneia commentary on Ezekiel, widely regarded as the standard critical commentary. Pioneer of form-critical and tradition-historical analysis of Ezekiel, with particular attention to the recognition formula and the theology of divine presence.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Walther Zimmerli (1907–1983) was born in Schiers, Switzerland, and studied theology at the Universities of Zürich, Berlin, and Göttingen. He held professorships at Zürich and Göttingen, where he became one of the most influential Old Testament scholars of the twentieth century. His academic career spanned the turbulent decades of European theology from the 1930s through the 1970s, and he was deeply shaped by the dialectical theology of Karl Barth while maintaining a rigorous commitment to historical-critical method.\n\nZimmerli's magnum opus was his two-volume commentary on Ezekiel in the Hermeneia series, which remains the standard critical commentary on the book in any language. He was elected president of the International Organization for the Study of the Old Testament and received honorary doctorates from multiple European universities. His work on Ezekiel combined meticulous form-critical analysis with profound theological sensitivity, establishing patterns of interpretation that scholars still engage with decades after his death."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Zimmerli's approach is form-critical and tradition-historical. He traces the growth of the Ezekiel text through multiple editorial layers, distinguishing between the prophet's original oracles and later expansions by a 'school of Ezekiel.' This layered reading allows him to reconstruct the historical development of the book while still affirming the theological coherence of the final form.\n\nHis most influential methodological contribution is the concept of Nachinterpretation — the idea that later editors did not merely preserve Ezekiel's words but reinterpreted them for new situations, creating a living tradition within the text itself. This approach treats editorial activity not as corruption but as theological commentary, making the redactional layers themselves a witness to the text's ongoing authority.\n\nZimmerli reads Ezekiel's visionary material with particular care, treating the temple vision of chapters 40–48 as a theological blueprint rather than a literal architectural plan. His analysis of Ezekiel's 'recognition formula' — the recurring phrase 'and they shall know that I am the LORD' — became a key to understanding the book's overarching theological purpose."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Zimmerli stands in the tradition of European critical scholarship, specifically the German-Swiss tradition that combined rigorous philological analysis with theological seriousness. He was influenced by Gerhard von Rad's tradition-historical approach but applied it with his own distinctive emphasis on the prophetic word as a dynamic, living force that generates its own interpretive tradition.\n\nHis theology of the Old Testament, published as Old Testament Theology in Outline (1978), emphasized the 'self-revelation of God' as the organizing principle of Israel's faith — the conviction that the God who acts in history makes himself known through his acts. This framework deeply informs his Ezekiel commentary, where every oracle is read as an act of divine self-disclosure."
+      },
+      {
+        "title": "Key Works",
+        "body": "Ezekiel 1 (Hermeneia, 1979) and Ezekiel 2 (Hermeneia, 1983)\nThe definitive critical commentary on Ezekiel. Two volumes totaling over 1,200 pages of detailed form-critical, tradition-historical, and theological analysis. Still the standard reference work for serious Ezekiel study.\n\nOld Testament Theology in Outline (1978)\nA concise systematic treatment of the theology of the Hebrew Bible, organized around the theme of divine self-revelation.\n\nThe Law and the Prophets (1965)\nA study of the relationship between legal tradition and prophetic proclamation in Israel."
+      },
+      {
+        "title": "Appears In",
+        "body": "Zimmerli notes appear in Ezekiel. His form-critical insights are particularly valuable for understanding the structure and editorial growth of Ezekiel's oracles."
+      }
+    ]
   },
   {
     "id": "stuart",
@@ -1599,7 +1620,28 @@
     "scope_text": "",
     "description": "WBC commentator on Hosea–Jonah and Ezekiel. Combines text-critical precision with attention to the literary artistry of the prophetic books.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Douglas Stuart is professor of Old Testament at Gordon-Conwell Theological Seminary, where he has taught since 1971. He earned his Ph.D. from Harvard University and has become one of the most widely read evangelical Old Testament scholars, known for combining rigorous academic training with accessible communication.\n\nStuart's commentary work spans the Word Biblical Commentary on Hosea–Jonah and contributions to the NAC series on Ezekiel. He is also co-author (with Gordon Fee) of How to Read the Bible for All Its Worth, one of the best-selling hermeneutics textbooks in evangelical history, now in its fourth edition with millions of copies in print. His ability to bridge the gap between technical scholarship and pastoral application has made him influential both in the academy and in the local church."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Stuart combines text-critical precision with attention to the literary and rhetorical features of prophetic literature. He pays close attention to the original Hebrew, frequently offering fresh translations that illuminate wordplay, structure, and emphasis invisible in standard English versions.\n\nHis prophetic commentary is distinguished by careful attention to covenant lawsuit forms, recognizing that the prophets function as prosecutors bringing covenant-violation charges against Israel. This legal framework helps readers understand why prophetic oracles follow predictable structural patterns — they are not random denunciations but formal prosecutions rooted in the Mosaic covenant.\n\nStuart is also notable for taking the historical setting of each prophet seriously, providing detailed reconstructions of the political and social context that shaped each oracle."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Stuart is an evangelical scholar working within the Reformed tradition. He affirms the full authority and inspiration of Scripture while employing standard historical-critical tools — text criticism, form criticism, and redaction criticism — in service of understanding the text's original meaning. He represents the generation of evangelical scholars who demonstrated that rigorous academic method and orthodox theological convictions are not mutually exclusive."
+      },
+      {
+        "title": "Key Works",
+        "body": "Hosea–Jonah (Word Biblical Commentary, 1987)\nA comprehensive commentary on the first six Minor Prophets, combining technical Hebrew analysis with theological exposition.\n\nHow to Read the Bible for All Its Worth (with Gordon Fee, 1st ed. 1981)\nThe best-selling hermeneutics textbook in evangelical publishing history.\n\nOld Testament Exegesis: A Handbook for Students and Pastors (4th ed., 2009)\nA practical guide to the methods and tools of Old Testament interpretation."
+      },
+      {
+        "title": "Appears In",
+        "body": "Stuart notes appear in the Minor Prophets (Hosea through Jonah) and Ezekiel."
+      }
+    ]
   },
   {
     "id": "andersen_freedman",
@@ -1615,7 +1657,28 @@
     "scope_text": "",
     "description": "Authors of the Anchor Bible commentaries on Hosea, Amos, and Micah. Rigorous philological analysis with exhaustive treatment of Hebrew syntax and poetic structure.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Francis I. Andersen (1925–2020) and David Noel Freedman (1922–2008) were a legendary collaborative partnership in biblical scholarship. Andersen was an Australian linguist and Old Testament scholar who taught at the Australian National University and later at several American institutions. Freedman was an American scholar who studied under William Foxwell Albright at Johns Hopkins and became one of the most prolific biblical scholars of the twentieth century, serving as editor of the Anchor Bible Dictionary and the Eerdmans Dictionary of the Bible.\n\nTogether, Andersen and Freedman produced three major Anchor Bible commentaries — on Hosea (1980), Amos (1989), and Micah (2000) — that are distinguished by their exhaustive philological analysis and their attention to the literary structure of prophetic poetry. Their partnership combined Andersen's expertise in Hebrew linguistics and syntax with Freedman's encyclopedic knowledge of ancient Near Eastern history and archaeology."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Andersen and Freedman's approach is fundamentally philological. They attend to every word, every particle, every syntactic construction in the Hebrew text with a thoroughness that is almost unmatched in prophetic commentary. Their analysis of Hebrew poetry is particularly detailed, mapping the precise colometric structure (the division of poetic lines) and identifying patterns of parallelism, chiasm, and envelope structure.\n\nThey resist premature theological synthesis, preferring to let the text's linguistic features generate interpretive conclusions. This means their commentaries can feel dense — they are not devotional reading — but the payoff is interpretive precision that catches nuances other commentators miss. Their work on textual variants is also notably thorough, engaging the LXX, Syriac, and Dead Sea Scrolls witnesses in detail."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Andersen and Freedman represent the tradition of American critical biblical scholarship that emerged from the Albright school — an approach that takes the historical reliability of the biblical text more seriously than the European critical tradition while still employing the full range of historical-critical methods. Freedman in particular was known for bold historical hypotheses about the composition of the Hebrew Bible."
+      },
+      {
+        "title": "Key Works",
+        "body": "Hosea (Anchor Bible, 1980)\nA massive commentary treating Hosea's marriage narrative and oracles with exhaustive philological analysis.\n\nAmos (Anchor Bible, 1989)\nA detailed treatment of the prophet of social justice, with careful attention to the book's literary structure.\n\nMicah (Anchor Bible, 2000)\nThe final volume of their prophetic trilogy, analyzing Micah's oracles of judgment and hope."
+      },
+      {
+        "title": "Appears In",
+        "body": "Andersen & Freedman notes appear in Hosea, Amos, and Micah."
+      }
+    ]
   },
   {
     "id": "verhoef",
@@ -1631,7 +1694,28 @@
     "scope_text": "Haggai, Malachi",
     "description": "South African Old Testament scholar whose NICOT commentaries on Haggai and Malachi combine careful philological analysis with sensitivity to the post-exilic historical setting, covenant theology, and the canonical shape of the Book of the Twelve.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Pieter A. Verhoef (1921–2006) was a South African Old Testament scholar who served as professor of Old Testament at the University of Stellenbosch for over three decades. He was trained in the Dutch Reformed tradition and earned his doctorate from the Free University of Amsterdam, studying under leading European scholars.\n\nVerhoef's NICOT commentaries on Haggai and Malachi established him as one of the foremost authorities on postexilic prophecy. He was known for bringing both careful philological analysis and warm pastoral application to his scholarly work, reflecting the South African Reformed tradition's integration of academic rigor with churchly piety."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Verhoef combines careful philological analysis with redemptive-historical interpretation. He reads the postexilic prophets within their specific historical context — the struggles of the returned exile community — while consistently drawing lines forward to their fulfillment in the New Testament.\n\nHis commentary gives particular attention to the theological themes that unite the postexilic period: the rebuilding of the temple, the renewal of the covenant, and the hope for a coming messianic figure. He treats the prophetic text as both historically situated and eschatologically oriented."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Verhoef stands in the Dutch Reformed tradition, which emphasizes covenantal theology, the organic unity of the two Testaments, and the redemptive-historical method of interpretation. His work reflects the careful balance between historical criticism and confessional commitment that characterizes the best South African Reformed scholarship."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Books of Haggai and Malachi (NICOT, 1987)\nThe standard evangelical commentary on these two postexilic prophets, combining linguistic analysis with theological exposition and practical application."
+      },
+      {
+        "title": "Appears In",
+        "body": "Verhoef notes appear in Haggai and Malachi."
+      }
+    ]
   },
   {
     "id": "boda",
@@ -1646,7 +1730,28 @@
     "scope_text": "Zechariah",
     "description": "Canadian Old Testament scholar and professor at McMaster Divinity College. Author of the NICOT commentary on Zechariah (2016) and co-editor of several volumes on the Book of the Twelve. Boda integrates form-critical analysis with canonical and theological reading, attending carefully to the inner-biblical connections between Zechariah and earlier prophetic traditions, the role of the priestly-prophetic voice, and the eschatological horizon of chapters 9-14.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Mark J. Boda is professor of Old Testament at McMaster Divinity College in Hamilton, Ontario. He earned his Ph.D. from the University of Cambridge and has become one of the leading scholars on Zechariah and postexilic literature. His NICOT commentary on Zechariah (2016) is widely regarded as the most comprehensive evangelical treatment of this notoriously difficult prophetic book.\n\nBoda's scholarship extends beyond Zechariah to broader questions of penitential prayer, the theology of return from exile, and the literary development of the Book of the Twelve. He has edited and contributed to numerous academic volumes on prophetic literature and Second Temple Judaism."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Boda is attentive to both the literary structure of Zechariah and its compositional history. He treats the book as a coherent theological work while acknowledging the significant shifts in style and content between chapters 1–8 (the night visions) and chapters 9–14 (the oracles). His approach bridges the gap between scholars who treat Zechariah as a unified work and those who divide it into multiple independent compositions.\n\nHis commentary is particularly strong on the intertextual connections between Zechariah and earlier prophetic traditions — showing how Zechariah draws on and transforms the language of Isaiah, Jeremiah, and Ezekiel to address the postexilic community's crisis of unfulfilled expectations."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Boda is an evangelical scholar with a strong commitment to hearing the theological voice of the text within its historical context. His work reflects a generous evangelicalism that engages seriously with critical scholarship while maintaining confidence in the text's divine authority and canonical coherence."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Book of Zechariah (NICOT, 2016)\nA major commentary running over 900 pages, treating Zechariah's visions, oracles, and eschatological texts with exegetical depth and theological sensitivity.\n\nA Severe Mercy: Sin and Its Remedy in the Old Testament (2009)\nA study of penitential prayer and the theology of divine forgiveness in the Hebrew Bible.\n\nThe Heartbeat of Old Testament Theology: Three Creedal Expressions (2017)\nAn accessible introduction to the core theological claims of the Old Testament."
+      },
+      {
+        "title": "Appears In",
+        "body": "Boda notes appear in Zechariah."
+      }
+    ]
   },
   {
     "id": "hill",
@@ -1661,7 +1766,28 @@
     "scope_text": "Malachi",
     "description": "American Old Testament scholar and professor at Wheaton College. Author of the Anchor Yale Bible commentary on Malachi (1998), which combines detailed philological analysis with attention to the book’s rhetorical structure, its disputational style, and its canonical position as the bridge between the prophetic corpus and the New Testament. Hill is attentive to Malachi’s covenant theology, its critique of priestly corruption, and its eschatological horizon.",
     "eyebrow": "",
-    "bio_sections": []
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Andrew E. Hill is professor of Old Testament studies at Wheaton College, where he has taught since 1984. He earned his Ph.D. from the University of Michigan and has specialized in postexilic prophetic literature, Hebrew linguistics, and Old Testament survey. His Anchor Yale Bible commentary on Malachi combines philological rigor with theological sensitivity.\n\nHill is also co-author (with John Walton) of A Survey of the Old Testament, a widely used evangelical textbook now in its third edition. His scholarship reflects Wheaton's tradition of combining academic excellence with confessional evangelical commitment."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Hill brings detailed linguistic analysis to Malachi, paying careful attention to the book's distinctive disputation speech form — the pattern of accusation, objection, and divine response that structures the entire book. He reads these disputations as real rhetorical exchanges that reflect the tensions of the postexilic community.\n\nHis commentary is notably strong on the ancient Near Eastern treaty and covenant background of Malachi's language, showing how the prophet draws on well-known diplomatic vocabulary to frame God's relationship with Israel."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Hill represents mainstream evangelical scholarship with a strong commitment to the historical reliability and theological authority of the biblical text. His work engages seriously with critical scholarship while reading the text within the framework of canonical theism."
+      },
+      {
+        "title": "Key Works",
+        "body": "Malachi (Anchor Yale Bible, 1998)\nA comprehensive critical commentary on the last book of the Old Testament canon, with detailed philological notes and theological exposition.\n\nA Survey of the Old Testament (with John Walton, 3rd ed., 2009)\nA widely used evangelical textbook covering the historical, literary, and theological dimensions of each Old Testament book."
+      },
+      {
+        "title": "Appears In",
+        "body": "Hill notes appear in Malachi."
+      }
+    ]
   },
   {
     "id": "schreiner",
@@ -1753,7 +1879,29 @@
     ],
     "scope_text": "Revelation",
     "description": "NIGTC commentary on Revelation. Reformed theologian specializing in the use of the Old Testament in the New Testament.",
-    "eyebrow": "Reformed · NT Scholar"
+    "eyebrow": "Reformed · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "G. K. Beale is professor of New Testament and Biblical Theology at Reformed Theological Seminary. He previously taught at Wheaton College, Gordon-Conwell Theological Seminary, and Westminster Theological Seminary. He earned his Ph.D. from the University of Cambridge under the supervision of Morna Hooker.\n\nBeale is widely regarded as the leading evangelical scholar on the use of the Old Testament in the New Testament. His NIGTC commentary on Revelation (1999) is a landmark work that reads John's Apocalypse as a mosaic of Old Testament allusions, and his co-edited Commentary on the New Testament Use of the Old Testament (2007, with D. A. Carson) has become a standard reference work in the field."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Beale's distinctive contribution is his intertextual method. He reads Revelation not primarily through the lens of Greco-Roman apocalyptic conventions or contemporary political events, but through the Old Testament texts that John is echoing, alluding to, and reinterpreting. Every image, symbol, and structural element in Revelation is traced back to its Old Testament source — Daniel, Ezekiel, Isaiah, Exodus, Genesis — and read as a theological transformation of that source.\n\nThis approach produces a Revelation commentary of extraordinary density and depth. Beale argues that John's Apocalypse is not a coded prediction of future events but a prophetic-apocalyptic interpretation of the entire Old Testament story, showing how it reaches its climax in Christ and the church. His eschatological position is 'already-not-yet' inaugurated — the kingdom has begun but awaits consummation."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Beale is a Reformed theologian who stands in the amillennial tradition of Vos, Ridderbos, and Kline. His biblical theology emphasizes the temple theme as the unifying thread of Scripture — from Eden as the first temple to the New Jerusalem as the final temple. His New Testament Theology: An Unfolding of the Old Testament in the New (2011) works out this temple framework across the entire New Testament canon."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Book of Revelation (NIGTC, 1999)\nA 1,245-page commentary that is the most thorough treatment of Revelation's Old Testament allusions ever written.\n\nCommentary on the New Testament Use of the Old Testament (co-editor with D. A. Carson, 2007)\nA book-by-book analysis of every significant Old Testament citation and allusion in the New Testament.\n\nA New Testament Biblical Theology: The Unfolding of the Old Testament in the New (2011)\nA massive work tracing the temple theme from Genesis to Revelation."
+      },
+      {
+        "title": "Appears In",
+        "body": "Beale notes appear in Revelation."
+      }
+    ]
   },
   {
     "id": "osborne",
@@ -1767,7 +1915,29 @@
     ],
     "scope_text": "Revelation",
     "description": "BECNT commentary on Revelation. Known for balanced evangelical scholarship and hermeneutics textbooks.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Grant R. Osborne (1942–2018) was professor of New Testament at Trinity Evangelical Divinity School, where he taught for over thirty years. He earned his Ph.D. from the University of Aberdeen and became one of the most respected evangelical New Testament scholars of his generation.\n\nOsborne is known for two major contributions: his BECNT commentary on Revelation (2002) and his hermeneutics textbook The Hermeneutical Spiral (1991, revised 2006), which has trained a generation of evangelical pastors and scholars in the principles of biblical interpretation. His commentary on Revelation provides a balanced evangelical alternative to Beale's Reformed approach, offering careful interaction with the full range of interpretive traditions."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Osborne's Revelation commentary is notable for its balance. He surveys major interpretive options (preterist, historicist, futurist, idealist) at every point and makes judicious decisions rather than committing dogmatically to a single system. His approach is broadly progressive-dispensational, reading Revelation as having both first-century relevance and future fulfillment, but he is consistently irenic toward other positions.\n\nHis hermeneutical method emphasizes the 'spiral' — the iterative process of moving between the text's historical meaning and its contemporary significance, allowing each to inform the other. This makes his commentary practically useful for preachers while maintaining academic rigor."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Osborne was an evangelical scholar broadly associated with the progressive dispensationalist tradition, though his interpretive approach was eclectic and generous. He emphasized the importance of reading Revelation as both literature and theology, and his commentary engages constructively with scholars across the theological spectrum."
+      },
+      {
+        "title": "Key Works",
+        "body": "Revelation (Baker Exegetical Commentary on the New Testament, 2002)\nA comprehensive evangelical commentary on Revelation, balancing multiple interpretive approaches.\n\nThe Hermeneutical Spiral: A Comprehensive Introduction to Biblical Interpretation (1991, rev. 2006)\nThe standard evangelical hermeneutics textbook, covering exegesis, biblical and systematic theology, and homiletics.\n\nMatthew (Zondervan Exegetical Commentary on the New Testament, 2010)\nA detailed treatment of the First Gospel."
+      },
+      {
+        "title": "Appears In",
+        "body": "Osborne notes appear in Revelation."
+      }
+    ]
   },
   {
     "id": "thiselton",
@@ -1781,7 +1951,29 @@
     ],
     "scope_text": "1 Corinthians",
     "description": "NIGTC commentary on 1 Corinthians. Leading figure in theological hermeneutics and philosophy of language.",
-    "eyebrow": "Anglican · Hermeneutics"
+    "eyebrow": "Anglican · Hermeneutics",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Anthony C. Thiselton (1937–2023) was professor of Christian Theology at the University of Nottingham and a canon theologian of Leicester and Southwell Cathedrals. He earned his Ph.D. from the University of Sheffield and became one of the most important figures in the intersection of biblical studies, hermeneutics, and philosophy of language in the English-speaking world.\n\nHis NIGTC commentary on 1 Corinthians (2000) runs to over 1,400 pages and is widely considered the most comprehensive English-language commentary on the epistle. Thiselton brought an unusual combination of skills to the task — he was trained in biblical Greek, systematic theology, and continental philosophy, allowing him to engage Paul's text at multiple levels simultaneously."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Thiselton's approach integrates three disciplines that are usually kept separate: grammatical-historical exegesis, speech-act theory, and hermeneutical philosophy. Drawing on Wittgenstein, Austin, Searle, and Gadamer, he reads Paul's letters as performative utterances — texts that do things, not just say things. When Paul writes 'I urge you' or 'I have decided,' these are speech acts with specific illocutionary force, and Thiselton's commentary is attentive to what Paul is doing with his words as well as what he is saying.\n\nThis philosophical sophistication is combined with thorough engagement with the Greek text, patristic interpretation, Reformation commentary, and the full range of modern scholarship. The result is a commentary of unusual depth that treats every major interpretive crux with a thoroughness that is sometimes overwhelming but always illuminating."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Thiselton stood in the Anglican evangelical tradition, combining Reformation commitments to scriptural authority with the intellectual breadth of the Anglican theological tradition. His work in hermeneutics has been influential across theological traditions, and his insistence that biblical interpretation must engage with philosophy of language has shaped a generation of scholars."
+      },
+      {
+        "title": "Key Works",
+        "body": "The First Epistle to the Corinthians (NIGTC, 2000)\nA monumental 1,446-page commentary that sets the standard for English-language work on 1 Corinthians.\n\nThe Two Horizons: New Testament Hermeneutics and Philosophical Description (1980)\nA groundbreaking study of the relationship between biblical interpretation and continental hermeneutical philosophy.\n\nNew Horizons in Hermeneutics (1992)\nA comprehensive survey and constructive proposal for the theory of biblical interpretation."
+      },
+      {
+        "title": "Appears In",
+        "body": "Thiselton notes appear in 1 Corinthians."
+      }
+    ]
   },
   {
     "id": "lane",
@@ -1795,7 +1987,29 @@
     ],
     "scope_text": "Hebrews",
     "description": "WBC commentary on Hebrews. Known for meticulous historical and rhetorical analysis.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "William L. Lane (1931–1999) was professor of New Testament at Western Kentucky University and later at Seattle Pacific University. He earned his Th.D. from Harvard Divinity School and became one of the most respected evangelical commentators on Hebrews and Mark.\n\nLane's two-volume WBC commentary on Hebrews (1991) is widely regarded as one of the finest evangelical commentaries of the twentieth century. His earlier commentary on Mark in the NICNT series (1974) was equally influential. Lane was known for his meticulous historical research, his ability to reconstruct the social world behind the text, and his deep pastoral sensitivity to the text's theological message."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Lane's approach to Hebrews combines rhetorical analysis with careful historical reconstruction. He reads Hebrews as a sophisticated homily — a 'word of exhortation' (Heb 13:22) — addressed to a specific community facing a specific crisis: the temptation to abandon their Christian confession and return to the synagogue under pressure of social ostracism and the approaching destruction of Jerusalem.\n\nThis historical grounding gives Lane's commentary an urgency that purely theological treatments often lack. He shows how the author's elaborate christological argument — Jesus as superior to angels, Moses, Aaron, and the entire Levitical system — is not abstract theology but a pastoral response to a community in danger of apostasy."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Lane was an evangelical scholar who combined Reformed theological instincts with broad historical learning. His commentary on Hebrews is notably irenic, engaging with Catholic, mainline Protestant, and evangelical interpreters with equal seriousness and charity."
+      },
+      {
+        "title": "Key Works",
+        "body": "Hebrews 1–8 and Hebrews 9–13 (Word Biblical Commentary, 1991)\nA two-volume commentary widely considered the best evangelical treatment of Hebrews.\n\nThe Gospel According to Mark (NICNT, 1974)\nAn influential commentary on Mark's Gospel emphasizing its narrative theology and historical setting."
+      },
+      {
+        "title": "Appears In",
+        "body": "Lane notes appear in Hebrews."
+      }
+    ]
   },
   {
     "id": "cockerill",
@@ -1809,7 +2023,29 @@
     ],
     "scope_text": "Hebrews",
     "description": "NICNT commentary on Hebrews. Emphasizes the sermon's rhetorical structure and pastoral purpose.",
-    "eyebrow": "Wesleyan · NT Scholar"
+    "eyebrow": "Wesleyan · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Gareth Lee Cockerill is professor of Biblical Interpretation and Theology at Wesley Biblical Seminary. He earned his Ph.D. from Union Theological Seminary in Virginia and has devoted much of his career to the study of Hebrews. His NICNT commentary on Hebrews (2012) represents decades of research and has been praised for its attention to the rhetorical structure and pastoral purpose of the epistle.\n\nCockerill brings a Wesleyan perspective to a letter that has historically been interpreted primarily through Reformed and Lutheran lenses, offering fresh insights on themes of perseverance, holiness, and the ongoing work of sanctification."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Cockerill's distinctive contribution is his emphasis on Hebrews as a carefully structured rhetorical discourse. He maps the alternation between exposition (doctrinal argument) and exhortation (pastoral appeal) that gives the letter its persuasive power, showing how the author builds theological understanding precisely in order to motivate faithful endurance.\n\nHe reads Hebrews' christology — Christ as the great High Priest who has entered the heavenly sanctuary — not merely as a doctrinal claim but as the foundation of the community's access to God and their motivation for perseverance. His treatment of the warning passages (Heb 6:4–8, 10:26–31) is notably careful, taking the warnings as genuinely addressed to believers while affirming God's faithfulness to those who persevere."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Cockerill writes from a Wesleyan-Arminian perspective, which gives his commentary a distinctive voice on questions of perseverance, apostasy, and sanctification. He reads Hebrews as affirming both the reality of the danger of apostasy and the sufficiency of God's grace to keep believers who continue in faith."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Epistle to the Hebrews (NICNT, 2012)\nA comprehensive commentary that combines rhetorical analysis with theological exposition, offering a Wesleyan reading of Hebrews' warning passages and priesthood theology."
+      },
+      {
+        "title": "Appears In",
+        "body": "Cockerill notes appear in Hebrews."
+      }
+    ]
   },
   {
     "id": "harris",
@@ -1823,7 +2059,29 @@
     ],
     "scope_text": "2 Corinthians",
     "description": "NIGTC commentary on 2 Corinthians. Known for careful grammatical analysis and theological precision.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Murray J. Harris is professor emeritus of New Testament Exegesis and Theology at Trinity Evangelical Divinity School. Born in New Zealand, he earned his Ph.D. from the University of Manchester and has taught at universities in New Zealand, Australia, and the United States. His NIGTC commentary on 2 Corinthians (2005) is the fruit of decades of work on Paul's most personal and theologically complex letter.\n\nHarris is also known for his careful studies of New Testament Greek grammar and theology, including Slave of Christ (1999), an examination of Paul's metaphor of slavery to Christ, and Jesus as God (1992), a study of the New Testament evidence for the deity of Christ."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Harris brings exceptional precision to the Greek text of 2 Corinthians. His commentary is notable for detailed grammatical analysis — parsing ambiguous constructions, weighing syntactic options, and building interpretive conclusions from the ground up. He is careful to distinguish between what the text says, what it implies, and what it does not address.\n\nHe reads 2 Corinthians with close attention to its rhetorical situation — Paul's strained relationship with the Corinthian church, the challenge of the 'super-apostles,' and the apostle's defense of his ministry through a theology of weakness and suffering. Harris shows how Paul's most personal letter is also his most profound theological statement about the nature of apostolic authority."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Harris is an evangelical scholar trained in the British tradition of careful grammatical-historical exegesis. His work is characterized by thoroughness, precision, and a refusal to settle for superficial readings. He engages with the full range of scholarship — ancient, Reformation, and modern — while maintaining a clear evangelical commitment."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Second Epistle to the Corinthians (NIGTC, 2005)\nA major commentary on 2 Corinthians notable for its detailed Greek analysis and theological depth.\n\nJesus as God: The New Testament Use of Theos in Reference to Jesus (1992)\nA careful study of every New Testament passage where 'God' may be applied to Jesus.\n\nSlave of Christ: A New Testament Metaphor for Total Devotion to Christ (1999)\nAn exploration of the doulos ('slave/servant') metaphor in Paul's theology."
+      },
+      {
+        "title": "Appears In",
+        "body": "Harris notes appear in 2 Corinthians."
+      }
+    ]
   },
   {
     "id": "mounce",
@@ -1839,7 +2097,29 @@
     ],
     "scope_text": "Pastoral Epistles",
     "description": "WBC commentary on the Pastoral Epistles. Also known for Greek grammar textbooks used widely in seminaries.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "William D. Mounce is a New Testament scholar, author, and president of BiblicalTraining.org. He earned his Ph.D. from the University of Aberdeen under I. Howard Marshall. Before transitioning to online education, Mounce taught at Azusa Pacific University and served on the New Testament committee for the ESV translation.\n\nMounce is best known for two contributions: his WBC commentary on the Pastoral Epistles (2000) and his Greek grammar textbook Basics of Biblical Greek (1993), which has become the most widely used introductory Greek grammar in seminaries worldwide. His ability to make complex scholarship accessible without sacrificing precision is his hallmark."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Mounce's commentary on the Pastoral Epistles is notable for its defense of Pauline authorship. He engages the critical arguments against authenticity — vocabulary differences, theological development, historical setting — and argues point by point that the evidence is consistent with Paul writing late in his life to close associates about practical church matters.\n\nHis exegesis is grammatically precise and theologically careful. He pays particular attention to the Pastorals' vocabulary of 'sound teaching,' 'godliness,' and 'the deposit,' showing how these terms form a coherent theological framework for church order and doctrinal fidelity."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Mounce is an evangelical scholar who takes a conservative position on questions of authorship and historicity while engaging seriously with critical scholarship. His work reflects a commitment to making rigorous biblical scholarship available to the wider church through accessible writing and educational technology."
+      },
+      {
+        "title": "Key Works",
+        "body": "Pastoral Epistles (Word Biblical Commentary, 2000)\nA comprehensive commentary defending Pauline authorship and providing detailed exegesis of 1 Timothy, 2 Timothy, and Titus.\n\nBasics of Biblical Greek Grammar (1993, 4th ed. 2019)\nThe most widely used introductory New Testament Greek textbook in the world.\n\nA Graded Reader of Biblical Greek (1996)\nA companion reader that takes students from basic grammar to reading the Greek New Testament."
+      },
+      {
+        "title": "Appears In",
+        "body": "Mounce notes appear in the Pastoral Epistles (1 Timothy, 2 Timothy, Titus)."
+      }
+    ]
   },
   {
     "id": "towner",
@@ -1855,7 +2135,29 @@
     ],
     "scope_text": "Pastoral Epistles",
     "description": "NICNT commentary on the Pastoral Epistles. Emphasizes social-historical context and practical theology.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Philip H. Towner is a New Testament scholar who served as the translation consultant coordinator for the United Bible Societies. He earned his Ph.D. from the University of Aberdeen and has taught at seminaries in the United States and Asia. His NICNT commentary on the Pastoral Epistles (2006) provides a complementary perspective to Mounce's WBC volume, emphasizing the social-historical context of these letters.\n\nTowner's international experience in Bible translation has given him a distinctive sensitivity to how language functions across cultures — an awareness that enriches his reading of Paul's letters to Timothy and Titus, which are themselves concerned with how the gospel takes root in specific cultural settings."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Towner reads the Pastoral Epistles with particular attention to their social-historical context — the household structures, civic expectations, and cultural norms of the Greco-Roman cities where Timothy and Titus served. He shows how Paul's instructions about church order, gender roles, and social behavior are shaped by a missionary strategy of cultural engagement rather than abstract theological principle.\n\nHis commentary is strong on the Pastorals' theology of mission — the conviction that the church's internal life must commend the gospel to outsiders. This missional reading gives coherence to instructions that might otherwise seem like disconnected ethical directives."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Towner is an evangelical scholar with a strong missional orientation shaped by his work in Bible translation. His commentary reflects a commitment to hearing the Pastoral Epistles as living documents addressed to real churches in real cultural settings."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Letters to Timothy and Titus (NICNT, 2006)\nA comprehensive commentary emphasizing the social-historical context and missional theology of the Pastoral Epistles.\n\nThe Goal of Our Instruction: The Structure of Theology and Ethics in the Pastoral Epistles (1989)\nA study of the theological framework underlying the Pastorals' ethical instructions."
+      },
+      {
+        "title": "Appears In",
+        "body": "Towner notes appear in the Pastoral Epistles (1 Timothy, 2 Timothy, Titus)."
+      }
+    ]
   },
   {
     "id": "obrien",
@@ -1871,7 +2173,29 @@
     ],
     "scope_text": "Prison Epistles",
     "description": "WBC/NIGTC commentaries on Colossians, Ephesians, and Philemon. Known for rigorous exegetical work.",
-    "eyebrow": "Reformed · NT Scholar"
+    "eyebrow": "Reformed · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Peter T. O'Brien is a retired New Testament scholar who taught at Moore Theological College in Sydney, Australia, for over thirty years. He earned his Ph.D. from the University of Manchester and became one of the most important evangelical commentators on Paul's Prison Epistles. His commentaries on Colossians and Philemon (WBC, 1982), Ephesians (Pillar, 1999), and Philippians (NIGTC, 1991) are all considered major contributions to their respective fields.\n\nNote: Several of O'Brien's works were withdrawn from publication by their publishers due to concerns about inadequate attribution. The scholarly analysis and exegetical insights remain part of the field's conversation, but readers should be aware of this context."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "O'Brien's commentaries are distinguished by their thoroughness and their attention to the flow of Paul's argument. He excels at tracing the logical connections between clauses, paragraphs, and sections, showing how Paul builds complex theological arguments through careful rhetorical construction.\n\nHis work on the Prison Epistles is particularly strong on Paul's christological hymns (Col 1:15–20, Phil 2:6–11) and his ecclesiology — the vision of the church as the body of Christ that transcends ethnic, social, and cultural boundaries."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "O'Brien writes from a Reformed evangelical perspective shaped by the Sydney Anglican tradition. His commentary work reflects a commitment to the Pauline authorship of the disputed epistles and to reading Paul's theology as a coherent whole."
+      },
+      {
+        "title": "Key Works",
+        "body": "Colossians, Philemon (Word Biblical Commentary, 1982)\nA detailed treatment of Paul's letter to the Colossians and his personal appeal on behalf of Onesimus.\n\nThe Letter to the Ephesians (Pillar Commentary, 1999)\nA comprehensive treatment of Ephesians' cosmic ecclesiology.\n\nThe Epistle to the Philippians (NIGTC, 1991)\nA major commentary notable for its analysis of the Christ-hymn in Philippians 2:6–11."
+      },
+      {
+        "title": "Appears In",
+        "body": "O'Brien notes appear in the Prison Epistles (Colossians, Ephesians, Philemon)."
+      }
+    ]
   },
   {
     "id": "yarbrough",
@@ -1887,7 +2211,29 @@
     ],
     "scope_text": "Johannine Epistles",
     "description": "BECNT commentary on 1–3 John. Combines careful exegesis with theological reflection.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Robert W. Yarbrough is professor of New Testament at Covenant Theological Seminary. He previously taught at Trinity Evangelical Divinity School and earned his Ph.D. from the University of Aberdeen. His BECNT commentary on 1–3 John (2008) combines careful exegesis with theological reflection on themes of love, truth, and assurance.\n\nYarbrough is also known for his work in the history of New Testament scholarship, including The Salvation Historical Fallacy? Reassessing the History of New Testament Theology (2004), which challenged prevailing narratives about the development of the discipline."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Yarbrough reads John's epistles as pastoral documents addressing real community crises — the departure of the secessionists (1 John 2:19), the challenge of false teaching about Christ's incarnation, and the need for assurance of salvation. He pays close attention to John's rhetorical strategy of establishing tests of genuine faith: right belief about Christ, obedience to God's commands, and love for fellow believers.\n\nHis commentary is notable for its engagement with the history of interpretation, tracing how key passages have been read across the centuries by patristic, Reformation, and modern interpreters."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Yarbrough is a Reformed evangelical scholar whose commentary reflects a robust theology of assurance and perseverance. He reads 1 John's tests of faith as both diagnostic (how to know you are a believer) and prescriptive (how to grow in faith)."
+      },
+      {
+        "title": "Key Works",
+        "body": "1–3 John (Baker Exegetical Commentary on the New Testament, 2008)\nA thorough evangelical commentary on the Johannine Epistles with extensive engagement with the history of interpretation.\n\nThe Salvation Historical Fallacy? Reassessing the History of New Testament Theology (2004)\nA critical history of the discipline of New Testament theology."
+      },
+      {
+        "title": "Appears In",
+        "body": "Yarbrough notes appear in the Johannine Epistles (1 John, 2 John, 3 John)."
+      }
+    ]
   },
   {
     "id": "kruse",
@@ -1903,7 +2249,29 @@
     ],
     "scope_text": "Johannine Epistles",
     "description": "TNTC/Pillar commentaries on Johannine writings. Known for accessible yet scholarly treatment.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Colin G. Kruse is an Australian New Testament scholar who has served as senior lecturer in New Testament at Melbourne School of Theology (formerly the Bible College of Victoria). He has authored commentaries in both the Tyndale (TNTC) and Pillar series, including volumes on John's Gospel, the Johannine Epistles, and 2 Corinthians.\n\nKruse's work is characterized by clarity and accessibility. He has a gift for distilling complex scholarly debates into clear summaries and for making exegetical conclusions available to pastors and students without sacrificing academic rigor."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Kruse's approach is straightforwardly grammatical-historical with a strong pastoral orientation. He reads the Johannine literature with attention to its historical setting — the tensions between the Johannine community and both the synagogue and internal dissenters — while keeping the theological message in the foreground.\n\nHis commentary on the Johannine Epistles is particularly attentive to the relationship between John's Gospel and the letters, showing how the epistles presuppose and apply the theological framework established in the Gospel."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Kruse is an evangelical scholar in the tradition of accessible, church-serving scholarship. His commentaries are designed to bridge the gap between academy and pulpit, providing the exegetical substance that preachers need without the encyclopedic apparatus that can make technical commentaries impenetrable."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Letters of John (Pillar New Testament Commentary, 2000)\nA clear, thorough commentary on 1–3 John with careful attention to the letters' theological themes.\n\nThe Gospel According to John (Tyndale New Testament Commentary, 2003)\nAn accessible commentary on John's Gospel.\n\n2 Corinthians (Tyndale New Testament Commentary, 1987)\nA concise treatment of Paul's most personal letter."
+      },
+      {
+        "title": "Appears In",
+        "body": "Kruse notes appear in the Johannine Epistles (1 John, 2 John, 3 John)."
+      }
+    ]
   },
   {
     "id": "wanamaker",
@@ -1918,7 +2286,29 @@
     ],
     "scope_text": "Thessalonian Epistles",
     "description": "NIGTC commentary on 1–2 Thessalonians. Emphasizes social-scientific and rhetorical analysis.",
-    "eyebrow": "Academic · NT Scholar"
+    "eyebrow": "Academic · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Charles A. Wanamaker is professor of Religious Studies at the University of Cape Town, South Africa. He earned his Ph.D. from Durham University and has specialized in Pauline studies, early Christian social history, and the rhetoric of persuasion in ancient letters. His NIGTC commentary on 1–2 Thessalonians (1990) brought social-scientific and rhetorical approaches to these early Pauline letters.\n\nWanamaker's location in South Africa has given him a distinctive perspective on Paul's writings about community formation, social boundary maintenance, and the relationship between religious identity and political power — themes that resonate differently in a postcolonial context."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Wanamaker's commentary is notable for two methodological commitments. First, he employs rhetorical criticism — analyzing the Thessalonian letters according to the conventions of ancient Greco-Roman rhetoric (deliberative, forensic, epideictic). This allows him to identify Paul's persuasive strategies and understand how the letters would have functioned as oral performances in the assembly.\n\nSecond, he uses social-scientific methods to reconstruct the social dynamics of the Thessalonian community — their status as recent converts in a hostile pagan environment, their experience of persecution, and their struggles with grief, idleness, and eschatological confusion."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Wanamaker represents the tradition of critical mainline scholarship that takes both historical context and theological substance seriously. His commentary is methodologically sophisticated while remaining attentive to the pastoral and theological dimensions of Paul's letters."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Epistles to the Thessalonians (NIGTC, 1990)\nA major commentary employing rhetorical and social-scientific analysis of Paul's earliest letters.\n\nWanamaker controversially argues that 2 Thessalonians was written before 1 Thessalonians, a position he defends through rhetorical and historical analysis."
+      },
+      {
+        "title": "Appears In",
+        "body": "Wanamaker notes appear in the Thessalonian Epistles (1 Thessalonians, 2 Thessalonians)."
+      }
+    ]
   },
   {
     "id": "bruce",
@@ -1933,7 +2323,29 @@
     ],
     "scope_text": "Galatians, Philemon",
     "description": "NIGTC commentary on Galatians. One of the most influential evangelical NT scholars of the 20th century.",
-    "eyebrow": "Evangelical · 20th Century"
+    "eyebrow": "Evangelical · 20th Century",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "F. F. Bruce (1910–1990) was one of the most influential evangelical New Testament scholars of the twentieth century. Born in Elgin, Scotland, he studied classics at the Universities of Aberdeen, Cambridge, and Vienna before turning to biblical studies. He held the John Rylands Chair of Biblical Criticism and Exegesis at the University of Manchester from 1959 until his retirement in 1978.\n\nBruce's scholarly output was extraordinary — over forty books and hundreds of articles covering the entire New Testament, the Dead Sea Scrolls, and early church history. His NIGTC commentary on Galatians (1982) and his commentaries on Acts, Romans, Hebrews, and the Thessalonian correspondence established him as a commentator of rare breadth and depth. He was a member of the Plymouth Brethren throughout his life, a denominational affiliation that gave him an outsider's independence from the institutional pressures of both mainline and evangelical academia."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Bruce combined classical philological training with historical erudition and theological sensitivity. His commentaries are characterized by lucid prose, careful attention to the Greek text, and extensive knowledge of the Greco-Roman and Jewish backgrounds of the New Testament. He was neither a narrow fundamentalist nor a radical critic — he read the texts historically, took them seriously as theological documents, and engaged with scholars across the entire spectrum.\n\nHis Galatians commentary is particularly strong on Paul's relationship to Judaism, the nature of the law-gospel distinction, and the historical context of the Antioch incident (Gal 2:11–14)."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Bruce was an evangelical scholar whose Plymouth Brethren background gave him a distinctive theological perspective — non-creedal, focused on Scripture alone, and deeply committed to the unity of all believers. His scholarship was marked by an unusual combination of conservative theological conviction and critical academic independence."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Epistle to the Galatians (NIGTC, 1982)\nA major commentary on Galatians that remains a standard reference work.\n\nThe Book of the Acts (NICNT, rev. 1988)\nA landmark commentary on Acts combining historical and theological analysis.\n\nThe Epistles to the Colossians, to Philemon, and to the Ephesians (NICNT, 1984)\nA comprehensive treatment of the Prison Epistles.\n\nNew Testament History (1969)\nA widely used historical survey of the New Testament period."
+      },
+      {
+        "title": "Appears In",
+        "body": "Bruce notes appear in Galatians and Philemon."
+      }
+    ]
   },
   {
     "id": "lincoln",
@@ -1947,7 +2359,29 @@
     ],
     "scope_text": "Ephesians",
     "description": "WBC commentary on Ephesians. Known for careful literary and theological analysis.",
-    "eyebrow": "Academic · NT Scholar"
+    "eyebrow": "Academic · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Andrew T. Lincoln is Portland Professor of New Testament at the University of Gloucestershire (emeritus). He previously taught at the University of Sheffield. He earned his Ph.D. from Cambridge University and has written extensively on Pauline theology, the Gospel of John, and early Christian claims about truth.\n\nLincoln's WBC commentary on Ephesians (1990) is one of the most detailed English-language treatments of the letter. He has also written significant works on the concept of Sabbath in the New Testament, the trial narratives in John's Gospel, and the theology of new creation."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Lincoln reads Ephesians as a deutero-Pauline letter — written by a follower of Paul rather than Paul himself — that develops and applies Pauline theology to the situation of the post-apostolic church. This critical position does not diminish his respect for the letter's theological depth; he treats it as a profound meditation on the cosmic significance of the church as the body of Christ.\n\nHis commentary is particularly strong on the literary structure of Ephesians, the relationship between the letter's 'indicative' (what God has done) and 'imperative' (how believers should live), and the household code in chapters 5–6."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Lincoln represents the tradition of critical mainline scholarship that engages constructively with the theological claims of the text while employing the full range of historical-critical methods. His work on Ephesians balances historical analysis with sensitivity to the letter's ongoing significance for Christian theology and ethics."
+      },
+      {
+        "title": "Key Works",
+        "body": "Ephesians (Word Biblical Commentary, 1990)\nA comprehensive critical commentary on Ephesians running to over 500 pages.\n\nParadise Now and Not Yet: Studies in the Role of the Heavenly Dimension in Paul's Thought (1981)\nAn influential study of Paul's eschatology and spatial theology.\n\nTruth on Trial: The Lawsuit Motif in the Fourth Gospel (2000)\nA study of truth and testimony in the Gospel of John."
+      },
+      {
+        "title": "Appears In",
+        "body": "Lincoln notes appear in Ephesians."
+      }
+    ]
   },
   {
     "id": "davids",
@@ -1962,7 +2396,29 @@
     ],
     "scope_text": "2 Peter, Jude",
     "description": "NICNT commentary on 2 Peter and Jude. Also authored major commentary on James.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Peter H. Davids is a New Testament scholar who has taught at multiple institutions including Regent College, Trinity Western University, and various seminaries in Europe and Asia. He earned his Ph.D. from the University of Manchester. Davids is best known for his commentaries on James (NIGTC, 1982) and 2 Peter and Jude (Pillar, 2006).\n\nDavids has had an unusual career trajectory — combining traditional academic work with extensive missionary and teaching work in Europe, becoming a Catholic in the latter part of his career. This gives his later work an ecumenical breadth that is distinctive among evangelical commentators."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Davids reads the Catholic Epistles with careful attention to their Jewish background and social setting. His work on James emphasizes the letter's roots in Jesus' teaching tradition and its practical wisdom for communities navigating poverty, partiality, and the proper use of speech.\n\nHis commentary on 2 Peter and Jude takes a careful position on the relationship between the two letters, engaging with questions of literary dependence, pseudonymity, and canonical authority. He reads both letters as addressing real threats to early Christian communities — false teaching that combined speculative theology with moral license."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Davids has moved across traditions during his career, from evangelical Protestantism to Roman Catholicism. His scholarship reflects this breadth, engaging constructively with patristic, Reformation, and modern critical interpreters. His later work is characterized by an ecumenical generosity that takes the best insights from multiple traditions."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Epistle of James (NIGTC, 1982)\nA landmark commentary that established the modern evangelical treatment of James.\n\nThe Letters of 2 Peter and Jude (Pillar Commentary, 2006)\nA thorough commentary on two often-neglected Catholic Epistles.\n\nThe First Epistle of Peter (NICNT, 1990)\nA significant commentary on 1 Peter."
+      },
+      {
+        "title": "Appears In",
+        "body": "Davids notes appear in 2 Peter and Jude."
+      }
+    ]
   },
   {
     "id": "mccartney",
@@ -1976,7 +2432,29 @@
     ],
     "scope_text": "James",
     "description": "BECNT commentary on James. Combines Reformed theology with careful exegesis.",
-    "eyebrow": "Reformed · NT Scholar"
+    "eyebrow": "Reformed · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Dan G. McCartney is professor emeritus of New Testament at Redeemer Seminary in Dallas. He previously taught at Westminster Theological Seminary in Philadelphia for over twenty years. He earned his Ph.D. from Westminster Theological Seminary and has specialized in hermeneutics, the use of the Old Testament in the New, and the General Epistles.\n\nMcCartney's BECNT commentary on James (2009) brings a distinctive Reformed perspective to a letter that has sometimes been marginalized in Protestant theology. He is also co-author of Let the Reader Understand: A Guide to Interpreting and Applying the Bible (1994), a hermeneutics textbook used in Reformed seminaries."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "McCartney reads James with careful attention to its relationship to both Jesus' teaching and Pauline theology. He argues that James and Paul are addressing different questions — James addresses the nature of genuine faith (does it produce works?), while Paul addresses the basis of justification (is it works or faith?) — and that the two are complementary rather than contradictory.\n\nHis commentary is attentive to the Jewish wisdom tradition behind James, showing how the letter draws on and transforms the Wisdom literature of the Old Testament and Second Temple Judaism."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "McCartney is a Reformed scholar whose Westminster training is evident in his attention to covenantal themes and his careful engagement with the James-Paul relationship. His reading of James as fully compatible with Reformed soteriology challenges the common perception that James is an awkward fit within Protestant theology."
+      },
+      {
+        "title": "Key Works",
+        "body": "James (Baker Exegetical Commentary on the New Testament, 2009)\nA thorough Reformed commentary on James with particular attention to its relationship to Pauline theology.\n\nLet the Reader Understand: A Guide to Interpreting and Applying the Bible (with Charles Clayton, 1994)\nA hermeneutics textbook from a Reformed perspective."
+      },
+      {
+        "title": "Appears In",
+        "body": "McCartney notes appear in James."
+      }
+    ]
   },
   {
     "id": "silva",
@@ -1990,7 +2468,29 @@
     ],
     "scope_text": "Philippians",
     "description": "BECNT commentary on Philippians. Renowned for work in biblical linguistics and lexicography.",
-    "eyebrow": "Reformed · NT Scholar"
+    "eyebrow": "Reformed · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Moisés Silva is a New Testament scholar and linguist who has taught at Westminster Theological Seminary, Gordon-Conwell Theological Seminary, and the University of Aberdeen. Born in Cuba and raised in a bilingual environment, he brought a natural sensitivity to language that shaped his career. He earned his Ph.D. from the University of Manchester under F. F. Bruce.\n\nSilva's contributions span two fields: New Testament exegesis and biblical linguistics. His BECNT commentary on Philippians (1988, rev. 2005) is a model of linguistic precision, and his Biblical Words and Their Meaning (1983) transformed how evangelical scholars think about lexical semantics. He served as co-editor (with Walter Elwell) of the Baker Encyclopedia of the Bible and as a member of the NIV translation committee."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Silva's approach is distinguished by its linguistic sophistication. He applies principles from modern linguistics — structural semantics, discourse analysis, and pragmatics — to the interpretation of New Testament Greek. His Philippians commentary demonstrates how careful attention to word usage in context, syntactic patterns, and discourse structure can resolve interpretive disputes that have resisted resolution through traditional methods.\n\nHis treatment of the Christ-hymn in Philippians 2:6–11 is a model of this approach: rather than importing systematic theological categories, he builds his interpretation from the semantic field of the key terms (morphē, harpagmos, kenōsis) within their Pauline and broader Greek contexts."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Silva is a Reformed scholar whose linguistic training gives his work a distinctive methodological rigor. He represents the best of the Westminster tradition — confessionally committed, exegetically precise, and intellectually serious about engaging with the tools of modern scholarship."
+      },
+      {
+        "title": "Key Works",
+        "body": "Philippians (Baker Exegetical Commentary on the New Testament, 1988; 2nd ed. 2005)\nA linguistically precise commentary on Paul's letter of joy.\n\nBiblical Words and Their Meaning: An Introduction to Lexical Semantics (1983; rev. 1994)\nA groundbreaking application of modern linguistic theory to biblical word studies.\n\nInterpreting Galatians: Explorations in Exegetical Method (2nd ed. 2001)\nA methodological study using Galatians as a test case for responsible exegesis."
+      },
+      {
+        "title": "Appears In",
+        "body": "Silva notes appear in Philippians."
+      }
+    ]
   },
   {
     "id": "green",
@@ -2004,6 +2504,28 @@
     ],
     "scope_text": "Jude",
     "description": "BECNT commentary on Jude and 2 Peter. Emphasizes socio-historical context.",
-    "eyebrow": "Evangelical · NT Scholar"
+    "eyebrow": "Evangelical · NT Scholar",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Gene L. Green is professor of New Testament at Wheaton College and Graduate School. He earned his Ph.D. from the University of Aberdeen and has taught in Latin America, bringing a global perspective to his scholarship. His BECNT commentary on Jude and 2 Peter (2008) and his Pillar commentary on 1–2 Thessalonians (2002) are both well-regarded for their combination of historical depth and theological sensitivity.\n\nGreen's experience teaching in Latin American contexts has shaped his attention to how biblical texts function in communities under pressure — a perspective that enriches his reading of letters like Jude and 2 Peter, which address churches facing both external opposition and internal corruption."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Green reads the Catholic Epistles with close attention to their Greco-Roman rhetorical and social context. His Jude and 2 Peter commentary reconstructs the cultural world of these letters — the conventions of honor and shame, the role of patron-client relationships, and the rhetoric of denunciation — to illuminate texts that can seem obscure to modern readers.\n\nHe is particularly attentive to the use of Jewish apocalyptic traditions in Jude — the citations of 1 Enoch and the Assumption of Moses — treating them as evidence of the author's theological creativity rather than as embarrassing anachronisms."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Green is an evangelical scholar with a global perspective. His work reflects the conviction that biblical scholarship must serve the worldwide church, not just the Western academy. His commentaries are informed by insights from majority-world Christianity and are written to be useful across cultural contexts."
+      },
+      {
+        "title": "Key Works",
+        "body": "Jude and 2 Peter (Baker Exegetical Commentary on the New Testament, 2008)\nA thorough commentary on two often-neglected letters, with detailed attention to their Greco-Roman social context.\n\nThe Letters to the Thessalonians (Pillar Commentary, 2002)\nA comprehensive treatment of Paul's Thessalonian correspondence.\n\nPracticing Theological Interpretation (co-editor, 2012)\nEssays on the theory and practice of reading Scripture theologically."
+      },
+      {
+        "title": "Appears In",
+        "body": "Green notes appear in Jude."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Changes

### 1. Remove "Other Scholars" section from ScholarBioScreen

Removed the grid of other scholars at the bottom of the scholar detail page. Users navigate here from the full browse list, so showing a subset of 12 random other scholars at the bottom is redundant clutter.

Removed: `allScholars` state, `otherScholars` memo, `getAllScholars` import, Other Scholars JSX block, and 5 unused styles.

### 2. Add full bios for all 72 scholars

**Before:** 48 of 72 scholars had bio sections. 24 (all newer NT-era scholars added for epistles/Revelation coverage) had only a one-line description and an eyebrow.

**After:** All 72 scholars now have 5-section bios following the established pattern: Biography, Interpretive Approach, Theological Tradition, Key Works, Appears In.

Total new bio content: ~53,000 characters across 24 scholars.

### Scholars enriched

zimmerli, stuart, andersen_freedman, verhoef, boda, hill, beale, osborne, thiselton, lane, cockerill, harris, mounce, towner, obrien, yarbrough, kruse, wanamaker, bruce, lincoln, davids, mccartney, silva, green

## Files Changed

| File | Change |
|---|---|
| `app/src/screens/ScholarBioScreen.tsx` | Removed Other Scholars section + unused imports/styles |
| `content/meta/scholars.json` | Added `bio_sections` to 24 scholars |
