### PR TITLE
fix: disable new arch to unblock MapLibre v10 (map crash on TestFlight)

### DIFF
--- a/app/__tests__/components/MapChipDispatcher.test.tsx
+++ b/app/__tests__/components/MapChipDispatcher.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
 import { MapChip } from '@/components/map/MapChip';
+import { __resetMapNativeProbeForTests } from '@/utils/isMapNativeAvailable';
 import type { MapStory, Place } from '@/types';
 
 const story: MapStory = {
@@ -18,6 +19,10 @@ const story: MapStory = {
 
 describe('MapChip (dispatcher)', () => {
   const original = (NativeModules as any).MLRNModule;
+
+  beforeEach(() => {
+    __resetMapNativeProbeForTests();
+  });
 
   afterEach(() => {
     (NativeModules as any).MLRNModule = original;

--- a/app/__tests__/screens/MapScreenDispatcher.test.tsx
+++ b/app/__tests__/screens/MapScreenDispatcher.test.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 import { renderWithProviders } from '../helpers/renderWithProviders';
 import MapScreen from '@/screens/MapScreen';
+import { __resetMapNativeProbeForTests } from '@/utils/isMapNativeAvailable';
 
 const navigation: any = { navigate: jest.fn(), goBack: jest.fn() };
 const route: any = { params: {}, key: 'map-1', name: 'Map' };
 
 describe('MapScreen (dispatcher)', () => {
   const original = (NativeModules as any).MLRNModule;
+
+  beforeEach(() => {
+    __resetMapNativeProbeForTests();
+  });
 
   afterEach(() => {
     (NativeModules as any).MLRNModule = original;

--- a/app/__tests__/unit/isMapNativeAvailable.test.ts
+++ b/app/__tests__/unit/isMapNativeAvailable.test.ts
@@ -8,10 +8,21 @@
  */
 
 import { NativeModules } from 'react-native';
-import { isMapNativeAvailable } from '@/utils/isMapNativeAvailable';
+import {
+  isMapNativeAvailable,
+  __resetMapNativeProbeForTests,
+} from '@/utils/isMapNativeAvailable';
 
 describe('isMapNativeAvailable', () => {
   const originalModule = (NativeModules as any).MLRNModule;
+
+  beforeEach(() => {
+    // The probe memoises its result for production efficiency. Tests
+    // that mutate NativeModules.MLRNModule per case must clear that
+    // memoisation between cases or they'll see whichever result the
+    // first case produced.
+    __resetMapNativeProbeForTests();
+  });
 
   afterEach(() => {
     (NativeModules as any).MLRNModule = originalModule;

--- a/app/app.json
+++ b/app/app.json
@@ -2,13 +2,12 @@
   "expo": {
     "name": "Companion Study",
     "slug": "companion-study",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "default",
     "icon": "./assets/images/icon-512.png",
     "scheme": "scripture",
     "userInterfaceStyle": "dark",
     "backgroundColor": "#0c0a07",
-    "newArchEnabled": true,
     "assetBundlePatterns": [
       "**/*"
     ],
@@ -23,7 +22,7 @@
       "infoPlist": {
         "UIBackgroundModes": [ "audio" ],
         "ITSAppUsesNonExemptEncryption": false,
-        "NSLocationWhenInUseUsageDescription": "This app does not currently use your location."
+        "NSLocationWhenInUseUsageDescription": "Used to centre the biblical map on your current location when you tap the locate control."
       }
     },
     "android": {
@@ -39,6 +38,13 @@
       "bundler": "metro"
     },
     "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": { "newArchEnabled": false },
+          "android": { "newArchEnabled": false }
+        }
+      ],
       "expo-font",
       "expo-screen-orientation",
       [
@@ -67,4 +73,4 @@
     },
     "owner": "skahz"
   }
-}
+}

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -280,6 +280,30 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+// Make InteractionManager.runAfterInteractions execute its callback
+// synchronously. In production, RN drains the interaction queue after
+// gestures/animations finish; in jsdom there's no such loop, so any
+// code deferred behind runAfterInteractions would silently never run.
+// Returning a cancel handle preserves the API surface for code that
+// stores it for cleanup.
+//
+// We mock the internal module path because RN's top-level
+// `InteractionManager` export pulls `.default` from this file. Both
+// the named import (`import { InteractionManager } from 'react-native'`)
+// and the direct import resolve here.
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => {
+  const api = {
+    runAfterInteractions: (cb) => {
+      if (typeof cb === 'function') cb();
+      return { cancel: () => undefined };
+    },
+    createInteractionHandle: () => 0,
+    clearInteractionHandle: () => undefined,
+    setDeadline: () => undefined,
+  };
+  return { __esModule: true, default: api, ...api };
+});
+
 // ── Navigation mocks ──────────────────────────────────────────────
 
 jest.mock('@react-navigation/native', () => {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,7 @@
         "expo-asset": "~12.0.12",
         "expo-auth-session": "~7.0.10",
         "expo-av": "^16.0.8",
+        "expo-build-properties": "~1.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-crypto": "~15.0.8",
         "expo-dev-client": "~6.0.20",
@@ -43,11 +44,10 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
-        "react-native-reanimated": "~4.1.1",
+        "react-native-reanimated": "3.19.5",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
-        "react-native-worklets": "0.5.1",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -7480,6 +7480,53 @@
         }
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-1.0.10.tgz",
+      "integrity": "sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-clipboard": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
@@ -12732,30 +12779,38 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
-      "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
+      "version": "3.19.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.5.tgz",
+      "integrity": "sha512-bd4AwIkBAaY4BjrgpSoKjEaRG/tXD756F5nGuiH5IMBSKN8tRdUEA8hWZCyIo/R6/kha/tVSoCqodVUACh7ZWw==",
       "license": "MIT",
       "dependencies": {
-        "react-native-is-edge-to-edge": "^1.2.1",
-        "semver": "^7.7.2"
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4",
+        "react-native-is-edge-to-edge": "1.1.7"
       },
       "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "0.78 - 0.82",
-        "react-native-worklets": "0.5 - 0.8"
+        "react-native": "*"
       }
     },
-    "node_modules/react-native-reanimated/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -12796,42 +12851,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-worklets": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
-      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "semver": "7.7.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-worklets/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/commander": {

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "expo-asset": "~12.0.12",
     "expo-auth-session": "~7.0.10",
     "expo-av": "^16.0.8",
+    "expo-build-properties": "~1.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-crypto": "~15.0.8",
     "expo-dev-client": "~6.0.20",
@@ -51,11 +52,10 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-reanimated": "~4.1.1",
+    "react-native-reanimated": "3.19.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
-    "react-native-worklets": "0.5.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/app/src/components/map/MapErrorBoundary.tsx
+++ b/app/src/components/map/MapErrorBoundary.tsx
@@ -1,0 +1,53 @@
+/**
+ * MapErrorBoundary — Inner boundary around the lazy MapLibre subtree.
+ *
+ * The dispatcher (MapScreen.tsx) gates on isMapNativeAvailable() before
+ * rendering the native MapView, but that gate only checks whether the
+ * native module *exists*. It cannot detect a partially-broken module
+ * (e.g. MapLibre v10 under the New Architecture, where MLRNModule is
+ * registered but MLRNMapView throws at fabric-component instantiation).
+ *
+ * When that happens we want to:
+ *   1. Catch the render-time error inside the lazy subtree.
+ *   2. Show MapUnavailableCard with a diagnostic instead of the generic
+ *      "Something went wrong" screen.
+ *   3. NOT retry. The outer ScreenErrorBoundary's retry would re-mount
+ *      the native screen and crash again on the same tick — an infinite
+ *      loop. This boundary stays in fallback for the rest of the
+ *      screen's lifetime; the user must navigate away and back.
+ */
+
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { MapUnavailableCard } from './MapUnavailableCard';
+import { logger } from '../../utils/logger';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class MapErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    logger.error('MapErrorBoundary', error.message, {
+      error,
+      componentStack: info.componentStack,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <MapUnavailableCard reason={this.state.error?.message} />;
+    }
+    return this.props.children;
+  }
+}

--- a/app/src/components/map/MapUnavailableCard.tsx
+++ b/app/src/components/map/MapUnavailableCard.tsx
@@ -1,11 +1,16 @@
 /**
  * MapUnavailableCard — Friendly placeholder shown when MapLibre's native
  * module isn't linked into the current binary (Expo Go, or a dev build
- * created before the MapLibre plugin was added to app.json).
+ * created before the MapLibre plugin was added to app.json), or when the
+ * native module loaded but threw during render (caught by MapErrorBoundary).
  *
  * Matches the parchment aesthetic of the real map: bgElevated card with
  * a gold border and a short explanation of the limitation plus a link
  * to the Expo docs on development builds.
+ *
+ * The optional `reason` prop is shown only in __DEV__ builds and is the
+ * lifeline that turns "the map screen is broken" into something
+ * diagnosable without an Xcode device-log session.
  */
 
 import React from 'react';
@@ -15,7 +20,12 @@ import { useTheme, spacing, radii, fontFamily } from '../../theme';
 
 const DEV_BUILD_DOCS_URL = 'https://docs.expo.dev/develop/development-builds/introduction/';
 
-export function MapUnavailableCard() {
+interface Props {
+  /** Optional diagnostic reason; rendered only in __DEV__ builds. */
+  reason?: string;
+}
+
+export function MapUnavailableCard({ reason }: Props = {}) {
   const { base } = useTheme();
   return (
     <View style={[styles.container, { backgroundColor: base.bg }]}>
@@ -45,6 +55,14 @@ export function MapUnavailableCard() {
             How to create a development build →
           </Text>
         </TouchableOpacity>
+        {__DEV__ && reason ? (
+          <Text
+            style={[styles.diagnostic, { color: base.textMuted }]}
+            numberOfLines={4}
+          >
+            {reason}
+          </Text>
+        ) : null}
       </View>
     </View>
   );
@@ -83,5 +101,12 @@ const styles = StyleSheet.create({
   link: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 13,
+  },
+  diagnostic: {
+    fontFamily: fontFamily.body,
+    fontSize: 10,
+    marginTop: spacing.md,
+    textAlign: 'center',
+    opacity: 0.7,
   },
 });

--- a/app/src/hooks/useMapTileCache.ts
+++ b/app/src/hooks/useMapTileCache.ts
@@ -17,6 +17,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { InteractionManager } from 'react-native';
 import { OfflineManager } from '@maplibre/maplibre-react-native';
 import { isMapNativeAvailable } from '../utils/isMapNativeAvailable';
 import { logger } from '../utils/logger';
@@ -49,36 +50,49 @@ export function useMapTileCache(styleURL: string) {
     // native module isn't linked. Skip silently in Expo Go.
     if (!isMapNativeAvailable()) return;
 
-    (async () => {
-      try {
-        await OfflineManager.setMaximumAmbientCacheSize(AMBIENT_CACHE_BYTES);
-      } catch (err) {
-        logger.warn('useMapTileCache', 'Failed to set ambient cache size', err);
-      }
+    // Defer cache work until after the MapView has finished its initial
+    // mount + interaction frame. The native side serialises offline-pack
+    // creation and view registration poorly on first launch — running
+    // them on the same tick has been observed to crash the map subtree
+    // on iOS. runAfterInteractions queues onto the JS interaction
+    // manager so the work happens after navigation and first paint.
+    const handle = InteractionManager.runAfterInteractions(() => {
+      (async () => {
+        try {
+          await OfflineManager.setMaximumAmbientCacheSize(AMBIENT_CACHE_BYTES);
+        } catch (err) {
+          logger.warn('useMapTileCache', 'Failed to set ambient cache size', err);
+        }
 
-      try {
-        const existing = await OfflineManager.getPack(PACK_NAME);
-        if (existing) return;
+        try {
+          const existing = await OfflineManager.getPack(PACK_NAME);
+          if (existing) return;
 
-        await OfflineManager.createPack(
-          {
-            name: PACK_NAME,
-            styleURL,
-            minZoom: PACK_MIN_ZOOM,
-            maxZoom: PACK_MAX_ZOOM,
-            bounds: [BIBLICAL_BOUNDS.ne, BIBLICAL_BOUNDS.sw],
-          },
-          // Progress and error listeners are required by the v10 API but
-          // we don't surface either to the user — the download runs in
-          // the background. Log errors for diagnosis only.
-          () => undefined,
-          (_pack, err) => {
-            logger.warn('useMapTileCache', 'Offline pack error', err);
-          },
-        );
-      } catch (err) {
-        logger.warn('useMapTileCache', 'Failed to create offline pack', err);
-      }
-    })();
+          await OfflineManager.createPack(
+            {
+              name: PACK_NAME,
+              styleURL,
+              minZoom: PACK_MIN_ZOOM,
+              maxZoom: PACK_MAX_ZOOM,
+              bounds: [BIBLICAL_BOUNDS.ne, BIBLICAL_BOUNDS.sw],
+            },
+            // Progress and error listeners are required by the v10 API but
+            // we don't surface either to the user — the download runs in
+            // the background. Log errors for diagnosis only.
+            () => undefined,
+            (_pack, err) => {
+              logger.warn('useMapTileCache', 'Offline pack error', err);
+            },
+          );
+        } catch (err) {
+          logger.warn('useMapTileCache', 'Failed to create offline pack', err);
+        }
+      })();
+    });
+
+    return () => {
+      // Cancel the deferred work if the screen unmounts before it ran.
+      handle.cancel();
+    };
   }, [styleURL]);
 }

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -20,8 +20,9 @@
 
 import React, { Suspense } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
-import { isMapNativeAvailable } from '../utils/isMapNativeAvailable';
+import { isMapNativeAvailable, getMapUnavailableReason } from '../utils/isMapNativeAvailable';
 import { MapUnavailableCard } from '../components/map/MapUnavailableCard';
+import { MapErrorBoundary } from '../components/map/MapErrorBoundary';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import { useTheme } from '../theme';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
@@ -62,12 +63,14 @@ const MapScreenNative = React.lazy(() => import('./MapScreenNative'));
 
 function MapScreen(props: Props) {
   if (!isMapNativeAvailable()) {
-    return <MapUnavailableCard />;
+    return <MapUnavailableCard reason={getMapUnavailableReason() ?? undefined} />;
   }
   return (
-    <Suspense fallback={<LazyFallback />}>
-      <MapScreenNative {...props} />
-    </Suspense>
+    <MapErrorBoundary>
+      <Suspense fallback={<LazyFallback />}>
+        <MapScreenNative {...props} />
+      </Suspense>
+    </MapErrorBoundary>
   );
 }
 

--- a/app/src/utils/isMapNativeAvailable.ts
+++ b/app/src/utils/isMapNativeAvailable.ts
@@ -41,9 +41,17 @@ function probe(): boolean {
     // builds via the static import graph. We exercise the cheapest API
     // surface MapLibre exposes (setConnected) — if that throws, the
     // native side is broken in some way we can't render around.
+    //
+    // If `setConnected` is missing entirely (older versions of the
+    // library, or test mocks that don't include it) we treat that as
+    // success: the presence of MLRNModule is sufficient evidence that
+    // the native side is wired up. The probe is here to catch *throws*,
+    // not API-shape drift.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const MapLibreGL = require('@maplibre/maplibre-react-native').default;
-    MapLibreGL.setConnected(true);
+    if (typeof MapLibreGL?.setConnected === 'function') {
+      MapLibreGL.setConnected(true);
+    }
     return true;
   } catch (err) {
     _probeError = err instanceof Error ? err.message : String(err);
@@ -69,6 +77,22 @@ export function getMapUnavailableReason(): string | null {
   // null when the component mounts before the gate is checked.
   isMapNativeAvailable();
   return _probeError;
+}
+
+/**
+ * Test-only helper to clear the memoised probe state between cases.
+ * The probe deliberately memoises so production callers can hit it from
+ * render paths without paying for a re-probe each time, but that
+ * memoisation has to be reset between test cases that mutate
+ * NativeModules.MLRNModule.
+ *
+ * Guarded against accidental production use — calling this in a non-test
+ * environment is a no-op.
+ */
+export function __resetMapNativeProbeForTests(): void {
+  if (process.env.NODE_ENV !== 'test') return;
+  _probeResult = null;
+  _probeError = null;
 }
 
 /**

--- a/app/src/utils/isMapNativeAvailable.ts
+++ b/app/src/utils/isMapNativeAvailable.ts
@@ -1,49 +1,83 @@
 /**
  * isMapNativeAvailable — True when MapLibre's native module is linked
- * into the current app binary.
+ * AND can be safely exercised from JS in the current binary.
  *
- * Returns `false` in Expo Go and in dev/preview builds that were created
- * before the `@maplibre/maplibre-react-native` Expo plugin was added. The
- * library itself logs a noisy console.error when the native module is
- * missing; rendering any MapLibre component in that state throws
- * "Element type is invalid" because `requireNativeComponent('MLRNMapView')`
- * resolves to undefined.
+ * Returns `false` in three cases:
+ *   1. Expo Go and dev/preview builds created before the
+ *      `@maplibre/maplibre-react-native` Expo plugin was added — the
+ *      MLRNModule singleton simply doesn't exist.
+ *   2. Builds where the module is registered but broken (e.g. MapLibre
+ *      v10 under the React Native New Architecture, where MLRNModule
+ *      passes the presence check but MLRNMapView throws at fabric
+ *      component instantiation). Just probing `NativeModules?.MLRNModule`
+ *      isn't enough — we have to *use* the module to find out.
+ *   3. Any other native error during the one-shot probe.
+ *
+ * The probe runs once per app lifetime and the result is memoised, so
+ * this is cheap to call from render paths.
  *
  * Consumers should branch on this check and render a friendly fallback
- * rather than letting the map tree crash.
+ * (MapUnavailableCard) rather than letting the map tree crash. For
+ * defence in depth, MapErrorBoundary catches anything that slips past
+ * this gate during render.
  */
 
 import { NativeModules } from 'react-native';
+import { logger } from './logger';
 
-export function isMapNativeAvailable(): boolean {
-  // `MLRNModule` is the singleton MapLibre registers at bridge init. If
-  // it's null, no MapLibre native code is loaded and we must bail before
-  // any MapView / ShapeSource / Camera renders.
-  return NativeModules?.MLRNModule != null;
-}
+let _probeResult: boolean | null = null;
+let _probeError: string | null = null;
 
-/**
- * One-time MapLibre module init. Call before the first <MapView> render.
- *
- * `setConnected(true)` tells the SDK it can make network requests for
- * tiles and style JSON. Without this call, MapView may throw or render
- * a blank canvas on first mount.
- *
- * Safe to call multiple times — the flag is idempotent and the dynamic
- * require only evaluates once.
- */
-let _mapLibreInitDone = false;
-export function ensureMapLibreInit(): void {
-  if (_mapLibreInitDone) return;
-  if (!isMapNativeAvailable()) return;
+function probe(): boolean {
+  // Cheap presence check first — saves us from even trying to require()
+  // the JS module in Expo Go.
+  if (NativeModules?.MLRNModule == null) {
+    _probeError = 'MLRNModule native module not registered';
+    return false;
+  }
+
   try {
-    // Dynamic require so the native module isn't pulled into Expo Go builds
+    // Dynamic require so the native module isn't pulled into Expo Go
+    // builds via the static import graph. We exercise the cheapest API
+    // surface MapLibre exposes (setConnected) — if that throws, the
+    // native side is broken in some way we can't render around.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const MapLibreGL = require('@maplibre/maplibre-react-native').default;
     MapLibreGL.setConnected(true);
-    _mapLibreInitDone = true;
-  } catch {
-    // Swallow — if the module isn't available, isMapNativeAvailable()
-    // will gate rendering downstream.
+    return true;
+  } catch (err) {
+    _probeError = err instanceof Error ? err.message : String(err);
+    logger.warn('isMapNativeAvailable', 'MapLibre probe failed', err);
+    return false;
   }
+}
+
+export function isMapNativeAvailable(): boolean {
+  if (_probeResult === null) {
+    _probeResult = probe();
+  }
+  return _probeResult;
+}
+
+/**
+ * Diagnostic accessor for MapUnavailableCard so the dev build can surface
+ * the actual failure reason rather than asking the user (or future you)
+ * to spelunk Xcode device logs.
+ */
+export function getMapUnavailableReason(): string | null {
+  // Force the probe to run if it hasn't yet so callers don't get a stale
+  // null when the component mounts before the gate is checked.
+  isMapNativeAvailable();
+  return _probeError;
+}
+
+/**
+ * One-time MapLibre module init. Now a no-op preserved for backwards
+ * compatibility — the probe in `isMapNativeAvailable` already calls
+ * `setConnected(true)` on the success path. Kept exported so existing
+ * `ensureMapLibreInit()` call sites continue to compile.
+ */
+export function ensureMapLibreInit(): void {
+  // Probe is the init. Calling it is idempotent.
+  isMapNativeAvailable();
 }


### PR DESCRIPTION
## Problem

The map screen has crashed on TestFlight since the MapLibre swap. Tapping into Map from the Explore menu navigates to `MapScreen` → lazy-loads `MapScreenNative` → mounts `<MapView>` → native crash.

Root cause: **MapLibre v10 × React Native New Architecture incompatibility.** The library maintainers themselves state v10 only supports new arch through the interoperability layer, with known issues, and recommend v11 (still beta) for new-arch apps.

## Strategy

Rather than chase a beta into production, this PR disables the New Architecture for both platforms via `expo-build-properties`. We will revisit when MapLibre v11 hits stable, ideally bundled with the SDK 55 upgrade. Tracking issue: **TODO — open after merge**.

## Reanimated implications

Reanimated 4 only works on the New Architecture. Disabling new arch without downgrading Reanimated would crash the app on launch (worse than the current crash on map open).

This PR therefore also downgrades:
- `react-native-reanimated` from `~4.1.1` → `3.19.5` (last stable v3, supports RN ≥ 0.78)
- Removes `react-native-worklets@0.5.1` (Reanimated 4 dep, breaks Reanimated 3 if present)

The Reanimated API surface used in `src/` is exactly 4 files (`ChapterSkeleton`, `ContentImageGallery`, `LoadingSkeleton`, `useTreeCamera`) using only `useSharedValue`, `useAnimatedStyle`, `withTiming`, and `runOnJS`. All four APIs are identical between v3 and v4 — **no source changes needed**.

## Cleanup items bundled in this PR

| # | What | Why |
|---|------|-----|
| 1 | New `MapErrorBoundary` inside Suspense | Outer `ScreenErrorBoundary` would loop on retry — re-mounting the native screen would re-crash. Inner boundary stays in fallback for the rest of the screen lifetime. |
| 2 | `isMapNativeAvailable` now probes the module | Old check only verified `MLRNModule` presence. New probe calls `setConnected(true)` in a try/catch so it catches the "registered but broken" failure mode. |
| 3 | `getMapUnavailableReason()` exposed | Surfaces the actual error reason on `MapUnavailableCard` (gated on `__DEV__`) — turns "map broken" into something diagnosable without Xcode device logs. |
| 4 | `useMapTileCache` deferred behind `InteractionManager` | `OfflineManager.createPack` running on the same tick as `<MapView>` mount has been observed to crash on iOS. Cleanup cancels the deferred work if the user navigates away. |
| 5 | Honest `NSLocationWhenInUseUsageDescription` | MapLibre's iOS SDK can trigger CoreLocation at init in some build configs. App Review flags strings that contradict actual usage. |
| 6 | `version` bump `1.0.0` → `1.0.1` | Forces a fresh native binary. Prevents stale OTA from landing new-arch-dependent JS onto the old binary. |

## Verified, not fixed (pre-existing, correct as-is)

- **Bounds tuple ordering in `useMapTileCache.createPack`** — verified against MapLibre v10.2.0's `OfflineManager.ts` line 76: `bounds: [[neLng, neLat], [swLng, swLat]]`. Our code passes `[BIBLICAL_BOUNDS.ne, BIBLICAL_BOUNDS.sw]` with `ne: [55, 45]` (= NE corner of biblical region in `[lng, lat]`). Correct.
- **`fitBounds` argument order in `MapScreenNative`** — verified against `Camera.tsx` line 118: `fitBounds(ne, sw, ...)`. Both call sites pass `[maxLon, maxLat]` then `[minLon, minLat]`. Correct.

## Test plan

Local validation done in this PR:
- [x] `app.json` and `package.json` validate as JSON
- [x] All edited files preserve repo line-ending convention (LF for source, CRLF for `app.json`)
- [x] Diff stat is sane (210 +, 75 −, 1 new file)

Native binary validation **requires an EAS build** (no Mac in CI):
- [ ] `eas build --platform ios --profile preview` succeeds
- [ ] TestFlight install succeeds (`runtimeVersion` policy is `appVersion`, so `1.0.1` cannot pick up a `1.0.0` OTA — guaranteed fresh binary)
- [ ] Tap into Map from Explore menu — should now load the parchment map
- [ ] Map → tap a place → place detail card appears
- [ ] Map → tap a story chip → camera fits bounds, story panel appears
- [ ] Existing animations still work: chapter skeleton pulse, image gallery pinch, loading skeleton
- [ ] Genealogy tree pan/pinch still works (uses `runOnJS` from Reanimated)

## Follow-ups (separate issues, not in this PR)

- [ ] Open tracking issue: "Migrate to MapLibre v11 + re-enable new arch (target: before SDK 55 upgrade)" — P2
- [ ] `sentryDsn` is empty in `app.json` — separate ticket worth opening for proper crash reporting

## Apply the `tier2` label after opening

Per the project's tier-2 accuracy check workflow.
