### PR TITLE
feat(ai-partner): build embeddings pipeline (#1447)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ _tools/art_staging/
 
 # Local-only source data (Card #1271) — see _data/README.md
 _data/openbible/*.jsonl
+
+# Amicus embeddings pipeline (Card #1447) — never tracked; rebuilt by
+# _tools/build_embeddings.py and merged into scripture.db by #1448.
+embeddings.db
+_tools/embedding_manifest.json

--- a/_tools/build_embeddings.py
+++ b/_tools/build_embeddings.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+build_embeddings.py — Amicus embeddings pipeline orchestrator.
+
+Chunks all Companion Study content, generates vector embeddings via OpenAI's
+`text-embedding-3-small` API, and writes them to `embeddings.db`. The build
+orchestrator (`build_sqlite.py`) merges `embeddings.db` into `scripture.db`.
+
+Usage:
+    python _tools/build_embeddings.py                # full rebuild
+    python _tools/build_embeddings.py --incremental  # only re-embeds changed chunks
+    python _tools/build_embeddings.py --dry-run      # print counts + cost, no API calls
+    python _tools/build_embeddings.py --source section_panel  # restrict to one source type
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import signal
+import sqlite3
+import struct
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+# Ensure stdout can handle UTF-8 (Windows cp1252 default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / '_tools'))
+
+from build_embeddings_chunks import iter_all_chunks, SOURCE_CHUNKERS  # noqa: E402
+
+EMBEDDINGS_DB = ROOT / 'embeddings.db'
+MANIFEST_PATH = ROOT / '_tools' / 'embedding_manifest.json'
+
+MODEL_NAME = 'text-embedding-3-small'
+EMBEDDING_DIM = 1536
+BATCH_SIZE = 100
+# OpenAI pricing for text-embedding-3-small: $0.02 per 1M tokens.
+PRICE_PER_MILLION_TOKENS = 0.02
+# Rough heuristic: 1 token ≈ 4 characters for English prose. Good enough for
+# dry-run cost estimation; the real API call returns exact token usage.
+CHARS_PER_TOKEN_HEURISTIC = 4
+
+
+# ── Manifest helpers ──────────────────────────────────────────────────
+
+def load_manifest() -> dict:
+    if MANIFEST_PATH.exists():
+        try:
+            return json.loads(MANIFEST_PATH.read_text(encoding='utf-8'))
+        except json.JSONDecodeError:
+            pass
+    return {'chunks': {}, 'dirty_chapters': []}
+
+
+def save_manifest(manifest: dict) -> None:
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_PATH.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding='utf-8'
+    )
+
+
+def content_hash(chunk: dict) -> str:
+    """Stable SHA256 over (text, metadata). Used for incremental dedup."""
+    payload = json.dumps(
+        {'text': chunk['text'], 'metadata': chunk['metadata']},
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode('utf-8')
+    return hashlib.sha256(payload).hexdigest()
+
+
+# ── DB helpers ────────────────────────────────────────────────────────
+
+def open_embeddings_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(EMBEDDINGS_DB))
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS embedding_chunks (
+            chunk_id      TEXT PRIMARY KEY,
+            source_type   TEXT NOT NULL,
+            source_id     TEXT NOT NULL,
+            text          TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            content_hash  TEXT NOT NULL,
+            embedding     BLOB NOT NULL
+        )
+    ''')
+    conn.execute('''
+        CREATE INDEX IF NOT EXISTS idx_source
+            ON embedding_chunks(source_type, source_id)
+    ''')
+    conn.commit()
+    return conn
+
+
+def existing_hashes(conn: sqlite3.Connection) -> dict[str, str]:
+    return dict(conn.execute(
+        'SELECT chunk_id, content_hash FROM embedding_chunks'
+    ).fetchall())
+
+
+def upsert_chunk(conn: sqlite3.Connection, chunk: dict, ch: str, emb: list[float]) -> None:
+    blob = struct.pack(f'<{len(emb)}f', *emb)
+    conn.execute(
+        '''INSERT INTO embedding_chunks
+           (chunk_id, source_type, source_id, text, metadata_json, content_hash, embedding)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(chunk_id) DO UPDATE SET
+               source_type = excluded.source_type,
+               source_id   = excluded.source_id,
+               text        = excluded.text,
+               metadata_json = excluded.metadata_json,
+               content_hash  = excluded.content_hash,
+               embedding     = excluded.embedding''',
+        (
+            chunk['chunk_id'], chunk['source_type'], chunk['source_id'],
+            chunk['text'], json.dumps(chunk['metadata'], sort_keys=True),
+            ch, blob,
+        ),
+    )
+
+
+# ── Embedding API ─────────────────────────────────────────────────────
+
+def embed_batch(texts: list[str], api_key: str) -> list[list[float]]:
+    """Call OpenAI embeddings endpoint. Retries 3× on 429/5xx with backoff."""
+    import urllib.request
+    import urllib.error
+
+    body = json.dumps({'model': MODEL_NAME, 'input': texts}).encode('utf-8')
+    delay = 1.0
+    for attempt in range(3):
+        req = urllib.request.Request(
+            'https://api.openai.com/v1/embeddings',
+            data=body,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {api_key}',
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read().decode('utf-8'))
+            vectors = [item['embedding'] for item in payload['data']]
+            for v in vectors:
+                if len(v) != EMBEDDING_DIM:
+                    raise RuntimeError(
+                        f'Unexpected embedding dim {len(v)}, expected {EMBEDDING_DIM}'
+                    )
+            return vectors
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and attempt < 2:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+        except urllib.error.URLError:
+            if attempt < 2:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+    raise RuntimeError('embed_batch: exhausted retries')
+
+
+# ── Main build ────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--incremental', action='store_true',
+                   help='Only re-embed chunks whose content_hash changed')
+    p.add_argument('--dry-run', action='store_true',
+                   help='Print chunk count + estimated cost; no API calls')
+    p.add_argument('--source', choices=sorted(SOURCE_CHUNKERS.keys()),
+                   help='Restrict chunking to one source type')
+    p.add_argument('--yes', action='store_true',
+                   help='Skip the cost-prompt confirmation (for CI/automation)')
+    return p.parse_args(argv)
+
+
+def gather_chunks(source_filter: str | None) -> list[dict]:
+    return list(iter_all_chunks(source_filter=source_filter))
+
+
+def summarize_by_source(chunks: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for c in chunks:
+        counts[c['source_type']] = counts.get(c['source_type'], 0) + 1
+    return counts
+
+
+def estimate_cost(chunks: Iterable[dict]) -> tuple[int, float]:
+    total_chars = sum(len(c['text']) for c in chunks)
+    tokens = total_chars // CHARS_PER_TOKEN_HEURISTIC
+    cost_usd = tokens / 1_000_000 * PRICE_PER_MILLION_TOKENS
+    return tokens, cost_usd
+
+
+def print_dry_run(chunks: list[dict]) -> None:
+    counts = summarize_by_source(chunks)
+    total = sum(counts.values())
+    tokens, cost = estimate_cost(chunks)
+    print('  [DRY RUN] Chunk counts by source:')
+    for src in sorted(counts):
+        print(f'    {src:<26} {counts[src]:>6}')
+    print(f'    {"TOTAL":<26} {total:>6}')
+    print(f'  [DRY RUN] Estimated tokens: ~{tokens:,}')
+    print(f'  [DRY RUN] Estimated cost:   ~${cost:.4f} USD '
+          f'(at ${PRICE_PER_MILLION_TOKENS}/1M tokens)')
+
+
+def run_build(
+    chunks: list[dict],
+    api_key: str,
+    incremental: bool,
+) -> None:
+    conn = open_embeddings_db()
+    existing = existing_hashes(conn)
+    manifest = load_manifest()
+
+    # Determine which chunks actually need re-embedding.
+    work_items: list[tuple[dict, str]] = []
+    skipped = 0
+    for chunk in chunks:
+        ch = content_hash(chunk)
+        if incremental and existing.get(chunk['chunk_id']) == ch:
+            skipped += 1
+            continue
+        work_items.append((chunk, ch))
+
+    if not work_items:
+        print('  [OK] Nothing to do — every chunk already current.')
+        conn.close()
+        return
+
+    print(f'  [INFO] To embed: {len(work_items)}  (skipped {skipped} up-to-date)')
+
+    # Allow graceful Ctrl-C: commit after each batch so next run resumes.
+    stopped = {'flag': False}
+
+    def _handle_sigint(_sig, _frm):
+        stopped['flag'] = True
+        print('\n  [WARN] Ctrl-C received — finishing current batch then stopping.')
+
+    previous = signal.signal(signal.SIGINT, _handle_sigint)
+
+    try:
+        for start in range(0, len(work_items), BATCH_SIZE):
+            batch = work_items[start:start + BATCH_SIZE]
+            texts = [item[0]['text'] for item in batch]
+            vectors = embed_batch(texts, api_key)
+            for (chunk, ch), vec in zip(batch, vectors):
+                upsert_chunk(conn, chunk, ch, vec)
+                manifest.setdefault('chunks', {})[chunk['chunk_id']] = ch
+            conn.commit()
+            save_manifest(manifest)
+            print(f'  [OK] Batch {start // BATCH_SIZE + 1}: '
+                  f'{start + len(batch)}/{len(work_items)} chunks embedded')
+            if stopped['flag']:
+                break
+    finally:
+        signal.signal(signal.SIGINT, previous)
+        conn.close()
+
+    # Clear dirty_chapters after a successful full pass.
+    if not stopped['flag']:
+        manifest['dirty_chapters'] = []
+        save_manifest(manifest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    print('=' * 60)
+    print('Amicus: Building embeddings')
+    print('=' * 60)
+
+    chunks = gather_chunks(args.source)
+    if not chunks:
+        print('  [WARN] No chunks collected — is content/ present?')
+        return 0
+
+    if args.dry_run:
+        print_dry_run(chunks)
+        return 0
+
+    api_key = os.environ.get('OPENAI_API_KEY')
+    if not api_key:
+        print('  [ERROR] OPENAI_API_KEY is not set.')
+        print('          Set it in your shell (never commit a key to the repo).')
+        return 1
+
+    _tokens, cost = estimate_cost(chunks)
+    if not args.incremental and not args.yes and cost > 0.50:
+        print_dry_run(chunks)
+        try:
+            answer = input('Continue? [y/N] ').strip().lower()
+        except EOFError:
+            answer = 'n'
+        if answer not in ('y', 'yes'):
+            print('  [ABORT] User declined.')
+            return 1
+
+    # --incremental implies we only embed the diff. Without it we clear the
+    # target table so stale chunks (deleted sources) don't linger.
+    if not args.incremental and EMBEDDINGS_DB.exists():
+        EMBEDDINGS_DB.unlink()
+
+    run_build(chunks, api_key=api_key, incremental=args.incremental)
+    size = EMBEDDINGS_DB.stat().st_size if EMBEDDINGS_DB.exists() else 0
+    print(f"\n  [DONE] embeddings.db: {size // 1024}KB")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/_tools/build_embeddings_chunks.py
+++ b/_tools/build_embeddings_chunks.py
@@ -1,0 +1,499 @@
+"""
+build_embeddings_chunks.py — Chunker module for Amicus embeddings pipeline.
+
+One function per source type. Each chunker reads content JSON files from the
+repo and yields dicts of the form:
+
+    {
+        'chunk_id':    'section_panel:genesis-1-s1-sarna',
+        'source_type': 'section_panel',
+        'source_id':   'genesis-1-s1-sarna',
+        'metadata':    { ... see README in #1447 ... },
+        'text':        '...plain text the embedder will consume...',
+    }
+
+Chunk IDs are deterministic — `{source_type}:{source_id}` — so two rebuilds
+produce an identical chunk_id set. No UUIDs, no hashes in the id.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+# Re-use the project's book registry so we walk content/<book_dir>/*.json in a
+# canonical order rather than whatever the filesystem gives us.
+from content_writer import REGISTRY
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTENT = ROOT / 'content'
+META = CONTENT / 'meta'
+
+# Panel types worth embedding. We skip purely structural panels like bare
+# verse ranges or image lists where the text payload is negligible.
+SECTION_PANEL_TYPES = {
+    'heb', 'ctx', 'hist', 'cross', 'mac', 'calvin', 'netbible', 'sarna',
+    'alter', 'hubbard', 'waltke', 'robertson', 'catena', 'marcus', 'rhoads',
+    'keener', 'milgrom', 'ashley', 'craigie', 'tigay', 'hess', 'howard',
+    'block', 'oswalt', 'walton', 'wright',
+}
+CHAPTER_PANEL_TYPES = {
+    'lit', 'themes', 'ppl', 'trans', 'src', 'rec',
+    'hebtext', 'thread', 'tx', 'debate',
+}
+
+
+def _flatten_text(value: Any) -> str:
+    """Recursively flatten a JSON panel value to plain text for embedding."""
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        return '\n'.join(part for part in (_flatten_text(v) for v in value) if part)
+    if isinstance(value, dict):
+        parts = []
+        for k, v in value.items():
+            t = _flatten_text(v)
+            if t:
+                parts.append(f'{k}: {t}' if not isinstance(v, (dict, list)) else t)
+        return '\n'.join(parts)
+    return ''
+
+
+def _panel_scholar_id(panel_type: str) -> str | None:
+    """Map a panel_type to the scholar_id it represents, if any."""
+    mapping = {
+        'mac': 'macarthur', 'calvin': 'calvin', 'netbible': 'netbible',
+        'sarna': 'sarna', 'alter': 'alter', 'hubbard': 'hubbard',
+        'waltke': 'waltke', 'robertson': 'robertson', 'catena': 'catena',
+        'marcus': 'marcus', 'rhoads': 'rhoads', 'keener': 'keener',
+        'milgrom': 'milgrom', 'ashley': 'ashley', 'craigie': 'craigie',
+        'tigay': 'tigay', 'hess': 'hess', 'howard': 'howard',
+        'block': 'block', 'oswalt': 'oswalt', 'walton': 'walton',
+        'wright': 'wright',
+    }
+    return mapping.get(panel_type)
+
+
+def _load_scholar_traditions() -> dict[str, str]:
+    """Build a {scholar_id: tradition} lookup from meta/scholars.json."""
+    path = META / 'scholars.json'
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return {}
+    out: dict[str, str] = {}
+    for entry in data if isinstance(data, list) else []:
+        sid = entry.get('id')
+        tradition = entry.get('tradition')
+        if sid and tradition:
+            out[sid] = tradition
+    return out
+
+
+# ── Source chunkers ───────────────────────────────────────────────────
+
+def chunk_section_panels(scholar_traditions: dict[str, str]) -> Iterator[dict]:
+    """One chunk per (section, panel_type) across all chapter files."""
+    for book_dir, _name, _total, live, _testament, _td in REGISTRY:
+        if live <= 0:
+            continue
+        book_path = CONTENT / book_dir
+        if not book_path.is_dir():
+            continue
+        for ch_file in sorted(book_path.glob('*.json')):
+            try:
+                data = json.loads(ch_file.read_text(encoding='utf-8'))
+            except json.JSONDecodeError:
+                continue
+            chapter_num = data.get('chapter_num')
+            if not isinstance(chapter_num, int):
+                continue
+            for section in data.get('sections', []):
+                section_num = section.get('section_num')
+                if not isinstance(section_num, int):
+                    continue
+                verse_start = section.get('verse_start')
+                verse_end = section.get('verse_end')
+                for panel_type, content in (section.get('panels') or {}).items():
+                    if panel_type not in SECTION_PANEL_TYPES:
+                        continue
+                    text = _flatten_text(content).strip()
+                    if not text:
+                        continue
+                    scholar_id = _panel_scholar_id(panel_type)
+                    source_id = f'{book_dir}-{chapter_num}-s{section_num}-{panel_type}'
+                    yield {
+                        'chunk_id': f'section_panel:{source_id}',
+                        'source_type': 'section_panel',
+                        'source_id': source_id,
+                        'text': text,
+                        'metadata': {
+                            'scholar_id': scholar_id,
+                            'tradition': scholar_traditions.get(scholar_id) if scholar_id else None,
+                            'book_id': book_dir,
+                            'chapter_num': chapter_num,
+                            'verse_start': verse_start,
+                            'verse_end': verse_end,
+                            'panel_type': panel_type,
+                        },
+                    }
+
+
+def chunk_chapter_panels(scholar_traditions: dict[str, str]) -> Iterator[dict]:
+    """One chunk per (chapter, panel_type) across all chapter files."""
+    for book_dir, _name, _total, live, _testament, _td in REGISTRY:
+        if live <= 0:
+            continue
+        book_path = CONTENT / book_dir
+        if not book_path.is_dir():
+            continue
+        for ch_file in sorted(book_path.glob('*.json')):
+            try:
+                data = json.loads(ch_file.read_text(encoding='utf-8'))
+            except json.JSONDecodeError:
+                continue
+            chapter_num = data.get('chapter_num')
+            if not isinstance(chapter_num, int):
+                continue
+            for panel_type, content in (data.get('chapter_panels') or {}).items():
+                if panel_type not in CHAPTER_PANEL_TYPES:
+                    continue
+                text = _flatten_text(content).strip()
+                if not text:
+                    continue
+                source_id = f'{book_dir}-{chapter_num}-{panel_type}'
+                yield {
+                    'chunk_id': f'chapter_panel:{source_id}',
+                    'source_type': 'chapter_panel',
+                    'source_id': source_id,
+                    'text': text,
+                    'metadata': {
+                        'scholar_id': None,
+                        'tradition': None,
+                        'book_id': book_dir,
+                        'chapter_num': chapter_num,
+                        'verse_start': None,
+                        'verse_end': None,
+                        'panel_type': panel_type,
+                    },
+                }
+
+
+def chunk_word_studies() -> Iterator[dict]:
+    """One chunk per word study entry."""
+    path = META / 'word-studies.json'
+    if not path.exists():
+        return
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for entry in data if isinstance(data, list) else []:
+        wid = entry.get('id')
+        if not wid:
+            continue
+        text_parts = [
+            entry.get('original', ''),
+            entry.get('transliteration', ''),
+            ', '.join(entry.get('glosses', []) or []),
+            entry.get('range', ''),
+            entry.get('note', ''),
+        ]
+        text = '\n'.join(p for p in text_parts if p).strip()
+        if not text:
+            continue
+        yield {
+            'chunk_id': f'word_study:{wid}',
+            'source_type': 'word_study',
+            'source_id': wid,
+            'text': text,
+            'metadata': {
+                'scholar_id': None,
+                'tradition': None,
+                'book_id': None,
+                'chapter_num': None,
+                'verse_start': None,
+                'verse_end': None,
+                'panel_type': None,
+            },
+        }
+
+
+def chunk_lexicon_entries() -> Iterator[dict]:
+    """One chunk per Hebrew + Greek lexicon entry."""
+    for language, filename, prefix in (
+        ('hebrew', 'lexicon-hebrew.json', 'heb'),
+        ('greek', 'lexicon-greek.json', 'grk'),
+    ):
+        path = META / filename
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError:
+            continue
+        for entry in data if isinstance(data, list) else []:
+            strongs = entry.get('strongs')
+            if not strongs:
+                continue
+            definition = entry.get('definition') or {}
+            short = definition.get('short', '') if isinstance(definition, dict) else ''
+            full_parts = []
+            for d in (definition.get('full') or []) if isinstance(definition, dict) else []:
+                if isinstance(d, dict):
+                    full_parts.append(d.get('text', ''))
+                    for sub in d.get('subs') or []:
+                        if isinstance(sub, dict):
+                            full_parts.append(sub.get('text', ''))
+            text = '\n'.join(p for p in [
+                entry.get('lemma', ''),
+                entry.get('transliteration', ''),
+                entry.get('pos', ''),
+                short,
+                '\n'.join(full_parts),
+            ] if p).strip()
+            if not text:
+                continue
+            source_id = f'{prefix}-{strongs}'
+            yield {
+                'chunk_id': f'lexicon_entry:{source_id}',
+                'source_type': 'lexicon_entry',
+                'source_id': source_id,
+                'text': text,
+                'metadata': {
+                    'scholar_id': None,
+                    'tradition': None,
+                    'book_id': None,
+                    'chapter_num': None,
+                    'verse_start': None,
+                    'verse_end': None,
+                    'panel_type': language,
+                },
+            }
+
+
+def chunk_debate_topics() -> Iterator[dict]:
+    """One chunk per debate topic (covering all positions)."""
+    path = META / 'debate-topics.json'
+    if not path.exists():
+        return
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for entry in data if isinstance(data, list) else []:
+        tid = entry.get('id')
+        if not tid:
+            continue
+        positions = []
+        for pos in entry.get('positions') or []:
+            if not isinstance(pos, dict):
+                continue
+            positions.append('\n'.join(p for p in [
+                f"Position: {pos.get('label', '')}",
+                f"Argument: {pos.get('argument', '')}",
+                f"Strengths: {pos.get('strengths', '')}",
+                f"Weaknesses: {pos.get('weaknesses', '')}",
+            ] if p.strip(': ')))
+        text = '\n\n'.join(p for p in [
+            entry.get('title', ''),
+            entry.get('question', ''),
+            entry.get('context', ''),
+            *positions,
+        ] if p).strip()
+        if not text:
+            continue
+        yield {
+            'chunk_id': f'debate_topic:{tid}',
+            'source_type': 'debate_topic',
+            'source_id': tid,
+            'text': text,
+            'metadata': {
+                'scholar_id': None,
+                'tradition': None,
+                'book_id': entry.get('book_id'),
+                'chapter_num': (entry.get('chapters') or [None])[0] if entry.get('chapters') else None,
+                'verse_start': None,
+                'verse_end': None,
+                'panel_type': entry.get('category'),
+            },
+        }
+
+
+def chunk_cross_ref_thread_notes() -> Iterator[dict]:
+    """One chunk per thread note inside cross-refs threads."""
+    path = META / 'cross-refs.json'
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return
+    threads = data.get('threads') if isinstance(data, dict) else data
+    for thread in threads or []:
+        tid = thread.get('id')
+        if not tid:
+            continue
+        for idx, note in enumerate(thread.get('chain') or []):
+            if not isinstance(note, dict):
+                continue
+            ref = note.get('ref', '')
+            body = note.get('note', '')
+            text = f'{thread.get("theme", "")}\n{ref}: {body}'.strip()
+            if not text:
+                continue
+            source_id = f'{tid}-{idx}'
+            yield {
+                'chunk_id': f'cross_ref_thread_note:{source_id}',
+                'source_type': 'cross_ref_thread_note',
+                'source_id': source_id,
+                'text': text,
+                'metadata': {
+                    'scholar_id': None,
+                    'tradition': None,
+                    'book_id': None,
+                    'chapter_num': None,
+                    'verse_start': None,
+                    'verse_end': None,
+                    'panel_type': None,
+                },
+            }
+
+
+def chunk_journey_stops() -> Iterator[dict]:
+    """One chunk per journey stop, including connective text (bridge_to_next)."""
+    journeys_root = META / 'journeys'
+    if not journeys_root.is_dir():
+        return
+    for journey_type_dir in sorted(journeys_root.iterdir()):
+        if not journey_type_dir.is_dir():
+            continue
+        journey_type = journey_type_dir.name
+        for jf in sorted(journey_type_dir.glob('*.json')):
+            try:
+                data = json.loads(jf.read_text(encoding='utf-8'))
+            except json.JSONDecodeError:
+                continue
+            jid = data.get('id')
+            if not jid:
+                continue
+            for stop in data.get('stops') or []:
+                if not isinstance(stop, dict):
+                    continue
+                order = stop.get('stop_order')
+                if not isinstance(order, int):
+                    continue
+                text_parts = [
+                    stop.get('label', ''),
+                    stop.get('ref', ''),
+                    stop.get('development', ''),
+                    stop.get('what_changes', ''),
+                    stop.get('bridge_to_next') or '',
+                ]
+                text = '\n'.join(p for p in text_parts if p).strip()
+                if not text:
+                    continue
+                source_id = f'{journey_type}-{jid}-{order}'
+                yield {
+                    'chunk_id': f'journey_stop:{source_id}',
+                    'source_type': 'journey_stop',
+                    'source_id': source_id,
+                    'text': text,
+                    'metadata': {
+                        'scholar_id': None,
+                        'tradition': None,
+                        'book_id': stop.get('book_id'),
+                        'chapter_num': stop.get('chapter_num'),
+                        'verse_start': stop.get('verse_start'),
+                        'verse_end': stop.get('verse_end'),
+                        'panel_type': journey_type,
+                    },
+                }
+
+
+_FRONTMATTER_RE = re.compile(r'^---\n(.*?)\n---\n(.*)$', re.DOTALL)
+
+
+def _parse_meta_faq(path: Path) -> tuple[dict, str] | None:
+    """Parse a meta_faq markdown file with YAML-ish frontmatter. Returns
+    (frontmatter_dict, body_text) or None if unparseable."""
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except OSError:
+        return None
+    m = _FRONTMATTER_RE.match(raw)
+    if not m:
+        return None
+    fm_block, body = m.group(1), m.group(2)
+    frontmatter: dict[str, Any] = {}
+    for line in fm_block.splitlines():
+        if ':' not in line:
+            continue
+        key, _, value = line.partition(':')
+        frontmatter[key.strip()] = value.strip()
+    return frontmatter, body.strip()
+
+
+def chunk_meta_faq() -> Iterator[dict]:
+    """One chunk per editorial meta-FAQ article."""
+    faq_dir = CONTENT / 'meta_faq'
+    if not faq_dir.is_dir():
+        return
+    for md in sorted(faq_dir.glob('*.md')):
+        parsed = _parse_meta_faq(md)
+        if parsed is None:
+            continue
+        fm, body = parsed
+        fid = fm.get('id') or md.stem
+        title = fm.get('title', '')
+        tags = fm.get('tags', '')
+        text = f'{title}\n{body}'.strip()
+        if not text:
+            continue
+        yield {
+            'chunk_id': f'meta_faq:{fid}',
+            'source_type': 'meta_faq',
+            'source_id': fid,
+            'text': text,
+            'metadata': {
+                'scholar_id': None,
+                'tradition': None,
+                'book_id': None,
+                'chapter_num': None,
+                'verse_start': None,
+                'verse_end': None,
+                'panel_type': tags or None,
+            },
+        }
+
+
+# ── Top-level dispatcher ──────────────────────────────────────────────
+
+SOURCE_CHUNKERS: dict[str, Any] = {
+    'section_panel': chunk_section_panels,
+    'chapter_panel': chunk_chapter_panels,
+    'word_study': chunk_word_studies,
+    'lexicon_entry': chunk_lexicon_entries,
+    'debate_topic': chunk_debate_topics,
+    'cross_ref_thread_note': chunk_cross_ref_thread_notes,
+    'journey_stop': chunk_journey_stops,
+    'meta_faq': chunk_meta_faq,
+}
+
+
+def iter_all_chunks(source_filter: str | None = None) -> Iterator[dict]:
+    """Yield every chunk across every source type, in a stable order.
+
+    If `source_filter` is supplied, only chunks from that source type are
+    yielded (useful for `--source foo` in the CLI).
+    """
+    scholar_traditions = _load_scholar_traditions()
+    for source_type, fn in SOURCE_CHUNKERS.items():
+        if source_filter and source_filter != source_type:
+            continue
+        if source_type in ('section_panel', 'chapter_panel'):
+            yield from fn(scholar_traditions)
+        else:
+            yield from fn()

--- a/_tools/content_writer.py
+++ b/_tools/content_writer.py
@@ -297,12 +297,38 @@ def save_chapter(book_dir, ch, data):
     with open(out_path, 'w', encoding='utf-8') as f:
         json.dump(chapter, f, ensure_ascii=False, indent=2)
 
+    _mark_chapter_dirty(book_dir, ch)
+
     sec_panel_count = sum(len(s['panels']) for s in chapter['sections'])
     ch_panel_count = len(chapter['chapter_panels'])
     print(f'  [OK] Saved {book_dir} {ch} → {out_path}  '
           f'({len(chapter["sections"])} sections, {sec_panel_count} sec panels, '
           f'{ch_panel_count} ch panels)')
     return out_path
+
+
+def _mark_chapter_dirty(book_dir: str, ch: int) -> None:
+    """Record this chapter in _tools/embedding_manifest.json under
+    `dirty_chapters` so `build_embeddings.py --incremental` knows to
+    re-chunk + re-embed it on the next run.
+    """
+    chapter_id = f'{book_dir}-{ch}'
+    manifest_path = os.path.join(ROOT, '_tools', 'embedding_manifest.json')
+    manifest = {'chunks': {}, 'dirty_chapters': []}
+    if os.path.exists(manifest_path):
+        try:
+            with open(manifest_path, 'r', encoding='utf-8') as f:
+                manifest = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    manifest.setdefault('dirty_chapters', [])
+    if chapter_id not in manifest['dirty_chapters']:
+        manifest['dirty_chapters'].append(chapter_id)
+    try:
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+    except OSError:
+        pass
 
 
 # ── Section panel normalisation ──────────────────────────────────────

--- a/_tools/test_build_embeddings.py
+++ b/_tools/test_build_embeddings.py
@@ -1,0 +1,135 @@
+"""Unit tests for _tools/build_embeddings.py and build_embeddings_chunks.py.
+
+Run locally with:
+    python3 _tools/test_build_embeddings.py
+
+All tests work against real repo content and do not make network calls.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import build_embeddings  # noqa: E402
+import build_embeddings_chunks as chunks_mod  # noqa: E402
+
+
+class ChunkerTests(unittest.TestCase):
+    """The chunker output must be deterministic, complete, and well-formed."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.chunks = list(chunks_mod.iter_all_chunks())
+
+    def test_nonempty(self) -> None:
+        self.assertGreater(len(self.chunks), 1000,
+                           'expected tens of thousands of chunks from real corpus')
+
+    def test_every_chunk_has_text(self) -> None:
+        for c in self.chunks:
+            self.assertTrue(c['text'], f'empty text on chunk {c["chunk_id"]}')
+
+    def test_chunk_ids_are_unique_and_deterministic(self) -> None:
+        ids = [c['chunk_id'] for c in self.chunks]
+        self.assertEqual(len(ids), len(set(ids)), 'duplicate chunk_id detected')
+        ids2 = [c['chunk_id'] for c in chunks_mod.iter_all_chunks()]
+        self.assertEqual(ids, ids2,
+                         'iter_all_chunks is not deterministic between calls')
+
+    def test_chunk_id_format(self) -> None:
+        """chunk_id must be `{source_type}:{source_id}`."""
+        for c in self.chunks:
+            expected = f'{c["source_type"]}:{c["source_id"]}'
+            self.assertEqual(c['chunk_id'], expected)
+
+    def test_metadata_shape(self) -> None:
+        required = {
+            'scholar_id', 'tradition', 'book_id', 'chapter_num',
+            'verse_start', 'verse_end', 'panel_type',
+        }
+        for c in self.chunks:
+            self.assertEqual(set(c['metadata'].keys()), required,
+                             f'metadata keys mismatch for {c["chunk_id"]}')
+
+    def test_source_filter(self) -> None:
+        ws = list(chunks_mod.iter_all_chunks(source_filter='word_study'))
+        self.assertGreater(len(ws), 0)
+        for c in ws:
+            self.assertEqual(c['source_type'], 'word_study')
+
+    def test_counts_match_spec_rough(self) -> None:
+        """Chunk counts per source should be in the ballpark called out in
+        #1447. ±20% is plenty for this sanity check; see the dry-run output
+        for exact numbers."""
+        counts: dict[str, int] = {}
+        for c in self.chunks:
+            counts[c['source_type']] = counts.get(c['source_type'], 0) + 1
+        self.assertGreaterEqual(counts.get('word_study', 0), 40)
+        self.assertGreaterEqual(counts.get('debate_topic', 0), 200)
+        self.assertGreaterEqual(counts.get('lexicon_entry', 0), 10_000)
+        self.assertGreaterEqual(counts.get('section_panel', 0), 5_000)
+
+
+class ContentHashTests(unittest.TestCase):
+    def test_hash_is_stable(self) -> None:
+        chunk = {
+            'chunk_id': 'x:y',
+            'source_type': 'x',
+            'source_id': 'y',
+            'text': 'hello world',
+            'metadata': {'book_id': 'genesis', 'chapter_num': 1},
+        }
+        self.assertEqual(build_embeddings.content_hash(chunk),
+                         build_embeddings.content_hash(chunk))
+
+    def test_hash_changes_with_text(self) -> None:
+        base = {
+            'chunk_id': 'x:y', 'source_type': 'x', 'source_id': 'y',
+            'text': 'a', 'metadata': {},
+        }
+        other = dict(base, text='b')
+        self.assertNotEqual(build_embeddings.content_hash(base),
+                            build_embeddings.content_hash(other))
+
+
+class DbUpsertTests(unittest.TestCase):
+    def test_upsert_roundtrip_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_embeddings.EMBEDDINGS_DB = Path(tmp) / 'e.db'
+            conn = build_embeddings.open_embeddings_db()
+            chunk = {
+                'chunk_id': 'word_study:foo',
+                'source_type': 'word_study',
+                'source_id': 'foo',
+                'text': 't',
+                'metadata': {'k': 1},
+            }
+            vec = [0.0] * build_embeddings.EMBEDDING_DIM
+            build_embeddings.upsert_chunk(conn, chunk, 'abc', vec)
+            build_embeddings.upsert_chunk(conn, chunk, 'abc', vec)
+            conn.commit()
+            row = conn.execute('SELECT COUNT(*) FROM embedding_chunks').fetchone()
+            self.assertEqual(row[0], 1, 'upsert should be idempotent on chunk_id')
+            stored = conn.execute(
+                'SELECT embedding FROM embedding_chunks WHERE chunk_id=?',
+                ('word_study:foo',),
+            ).fetchone()[0]
+            unpacked = struct.unpack(
+                f'<{build_embeddings.EMBEDDING_DIM}f', stored,
+            )
+            self.assertEqual(len(unpacked), build_embeddings.EMBEDDING_DIM)
+            conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #1447. Phase 1 of epic #1446.

## Summary
- New `_tools/build_embeddings.py` orchestrator + `build_embeddings_chunks.py` chunker module.
- Chunks every live source type into deterministic `{source_type}:{source_id}` chunks.
- Embeds via OpenAI `text-embedding-3-small` (1536-dim) into a standalone `embeddings.db`.
- Checkpoints after every batch, resumes from last commit on `--incremental` and after SIGINT.
- Cost-guardrail prompt fires on full rebuilds estimated >$0.50.
- `save_chapter()` now records dirty chapters into the gitignored manifest.

## Dry-run chunk counts
```
section_panel         16160  (spec ~16,000)
chapter_panel          8841  (spec ~7,500)
word_study               46  (spec 46)
lexicon_entry         13655  (spec 13,655)
debate_topic            307  (spec 308)
cross_ref_thread_note   321  (spec ~200)
journey_stop            424  (spec "existing")
meta_faq                  0  (authored in #1449)
TOTAL                 39754  — est $0.10 @ $0.02/1M tok
```

## Test plan
- [x] `python3 _tools/build_embeddings.py --dry-run` prints counts per source + USD estimate
- [x] `python3 _tools/build_embeddings.py` fails fast with clear message when `OPENAI_API_KEY` is absent
- [x] `python3 _tools/build_embeddings.py --dry-run --source word_study` restricts to one source
- [x] `python3 _tools/test_build_embeddings.py` — 10 unit tests pass (determinism, schema, upsert)
- [x] `python3 _tools/build_sqlite.py` + `python3 _tools/validate_sqlite.py` still pass unchanged
- [ ] Full embedding run + resume-from-Ctrl-C — requires real `OPENAI_API_KEY`, verified by reviewer

## Out of scope
- Merging `embeddings.db` into `scripture.db` — #1448
- Client-side vector search — #1451
- Runtime query embedding via proxy — #1450

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe