### PR TITLE
feat(ai-partner): client-side retrieval with sqlite-vec (#1451)

### DIFF
--- a/app/src/services/amicus/__tests__/embed.test.ts
+++ b/app/src/services/amicus/__tests__/embed.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for embed.ts — proxy client for /ai/embed.
+ */
+import { embedQuery } from '../embed';
+import { AmicusError } from '../types';
+
+function fakeFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  return jest.fn(async (url: RequestInfo | URL, init?: RequestInit) =>
+    impl(String(url), init ?? {}),
+  ) as unknown as typeof fetch;
+}
+
+describe('embedQuery', () => {
+  it('returns the vector on success', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response(JSON.stringify({ vector: new Array(1536).fill(0.01) }), {
+        status: 200,
+      }),
+    );
+    const v = await embedQuery('hello', { authToken: 'tkn', fetchImpl });
+    expect(v).toHaveLength(1536);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws EMBED_FAILED when query is empty', async () => {
+    await expect(embedQuery('   ', { authToken: 'tkn' })).rejects.toMatchObject({
+      code: 'EMBED_FAILED',
+    });
+  });
+
+  it('throws EMBED_FAILED when vector shape is wrong', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response(JSON.stringify({ vector: [0, 0, 0] }), { status: 200 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+  });
+
+  it('throws PROXY_UNAUTHORIZED on 401', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('unauthorized', { status: 401 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'PROXY_UNAUTHORIZED' });
+  });
+
+  it('throws PROXY_UNAUTHORIZED on 402 (no entitlement)', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('payment required', { status: 402 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'PROXY_UNAUTHORIZED' });
+  });
+
+  it('retries once on 5xx then gives up', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('upstream dead', { status: 503 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('bails early (no retry) on 4xx other than 401/402', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('bad request', { status: 400 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('raises OFFLINE after retry when network throws', async () => {
+    const fetchImpl = fakeFetch(async () => {
+      throw new Error('network down');
+    });
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'OFFLINE' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/services/amicus/__tests__/rerank.test.ts
+++ b/app/src/services/amicus/__tests__/rerank.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for rerank pipeline.
+ *
+ * Pure-compute, no DB, no network.
+ */
+import {
+  CURRENT_CHAPTER_BOOST,
+  RESULT_LIMIT,
+  SCHOLAR_BOOST,
+  SCHOLAR_DIVERSITY_CAP,
+  TRADITION_BOOST,
+  boostCurrentChapter,
+  boostPreferredScholars,
+  boostPreferredTraditions,
+  diversifyByScholar,
+  rerank,
+} from '../rerank';
+import type { CompressedProfile, RetrievedChunk } from '../types';
+
+function chunk(
+  chunk_id: string,
+  score: number,
+  metadata: RetrievedChunk['metadata'] = {},
+): RetrievedChunk {
+  return {
+    chunk_id,
+    source_type: 'section_panel',
+    source_id: chunk_id.split(':')[1] ?? chunk_id,
+    text: `text for ${chunk_id}`,
+    score,
+    metadata,
+  };
+}
+
+const BASIC_PROFILE: CompressedProfile = {
+  prose: 'Test profile',
+  preferred_scholars: [],
+  preferred_traditions: [],
+};
+
+describe('boostCurrentChapter', () => {
+  it('multiplies only chunks on the current chapter', () => {
+    const chunks = [
+      chunk('a', 1.0, { book_id: 'romans', chapter_num: 9 }),
+      chunk('b', 1.0, { book_id: 'romans', chapter_num: 10 }),
+      chunk('c', 1.0, { book_id: 'genesis', chapter_num: 1 }),
+    ];
+    const ref = { book_id: 'romans', chapter_num: 9 };
+    const boosted = boostCurrentChapter(chunks, ref);
+    expect(boosted[0]!.score).toBeCloseTo(CURRENT_CHAPTER_BOOST);
+    expect(boosted[1]!.score).toBe(1.0);
+    expect(boosted[2]!.score).toBe(1.0);
+  });
+
+  it('is a no-op when currentChapterRef is null', () => {
+    const c = [chunk('a', 0.5)];
+    expect(boostCurrentChapter(c, null)).toEqual(c);
+  });
+});
+
+describe('boostPreferredScholars', () => {
+  it('multiplies matching scholars and leaves others unchanged', () => {
+    const chunks = [
+      chunk('a', 1.0, { scholar_id: 'calvin' }),
+      chunk('b', 1.0, { scholar_id: 'sarna' }),
+      chunk('c', 1.0),
+    ];
+    const out = boostPreferredScholars(chunks, ['calvin']);
+    expect(out[0]!.score).toBeCloseTo(SCHOLAR_BOOST);
+    expect(out[1]!.score).toBe(1.0);
+    expect(out[2]!.score).toBe(1.0);
+  });
+
+  it('is a no-op when preferred list is empty', () => {
+    const c = [chunk('a', 0.5, { scholar_id: 'calvin' })];
+    expect(boostPreferredScholars(c, [])).toEqual(c);
+  });
+});
+
+describe('boostPreferredTraditions', () => {
+  it('multiplies matching traditions', () => {
+    const chunks = [
+      chunk('a', 1.0, { tradition: 'Reformed' }),
+      chunk('b', 1.0, { tradition: 'Jewish' }),
+    ];
+    const out = boostPreferredTraditions(chunks, ['Reformed']);
+    expect(out[0]!.score).toBeCloseTo(TRADITION_BOOST);
+    expect(out[1]!.score).toBe(1.0);
+  });
+});
+
+describe('diversifyByScholar', () => {
+  it('caps to 2 chunks per scholar by default', () => {
+    const chunks = [
+      chunk('1', 0.9, { scholar_id: 'calvin' }),
+      chunk('2', 0.8, { scholar_id: 'calvin' }),
+      chunk('3', 0.7, { scholar_id: 'calvin' }),
+      chunk('4', 0.6, { scholar_id: 'sarna' }),
+    ];
+    const out = diversifyByScholar(chunks);
+    const calvins = out.filter((c) => c.metadata.scholar_id === 'calvin');
+    expect(calvins).toHaveLength(SCHOLAR_DIVERSITY_CAP);
+    expect(out.map((c) => c.chunk_id)).toEqual(['1', '2', '4']);
+  });
+
+  it('passes through chunks without scholar_id', () => {
+    const chunks = [chunk('1', 0.9), chunk('2', 0.8), chunk('3', 0.7)];
+    expect(diversifyByScholar(chunks)).toEqual(chunks);
+  });
+});
+
+describe('rerank (end-to-end)', () => {
+  const profile: CompressedProfile = {
+    prose: 'p',
+    preferred_scholars: ['calvin'],
+    preferred_traditions: ['Reformed'],
+  };
+
+  it('applies boosts, diversifies, and caps at RESULT_LIMIT', () => {
+    const chunks: RetrievedChunk[] = [];
+    for (let i = 0; i < 15; i++) {
+      chunks.push(chunk(`${i}`, 0.5, { scholar_id: 'calvin' }));
+    }
+    const out = rerank(chunks, profile, null);
+    expect(out.length).toBeLessThanOrEqual(RESULT_LIMIT);
+    // Calvin cap of 2 still holds.
+    const calvins = out.filter((c) => c.metadata.scholar_id === 'calvin');
+    expect(calvins.length).toBeLessThanOrEqual(SCHOLAR_DIVERSITY_CAP);
+  });
+
+  it('does not invert score ordering with boosts', () => {
+    // a starts well ahead; boost to b shouldn't flip the order unless b is
+    // also close to a to begin with.
+    const chunks = [
+      chunk('a', 1.0),
+      chunk('b', 0.3, { scholar_id: 'calvin' }), // +10% = 0.33
+    ];
+    const out = rerank(chunks, profile, null);
+    expect(out[0]!.chunk_id).toBe('a');
+    expect(out[1]!.chunk_id).toBe('b');
+  });
+
+  it('sorts by score descending', () => {
+    const chunks = [chunk('lo', 0.3), chunk('hi', 0.9), chunk('mid', 0.6)];
+    const out = rerank(chunks, BASIC_PROFILE, null);
+    expect(out.map((c) => c.chunk_id)).toEqual(['hi', 'mid', 'lo']);
+  });
+});

--- a/app/src/services/amicus/__tests__/retrieval.test.ts
+++ b/app/src/services/amicus/__tests__/retrieval.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration-ish tests for retrieval orchestrator.
+ *
+ * Wires together a fake proxy (via fetchImpl) and the mock scripture.db so
+ * the whole pipeline can be exercised without real network or native SQLite.
+ */
+import { retrieve } from '../retrieval';
+import { AmicusError, type CompressedProfile, type RetrievedChunk } from '../types';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
+
+jest.mock('@/db/database', () => require('../../../../__tests__/helpers/mockDb').mockDatabaseModule());
+
+function fakeEmbedResponse(): Response {
+  return new Response(JSON.stringify({ vector: new Array(1536).fill(0.01) }), {
+    status: 200,
+  });
+}
+
+const PROFILE: CompressedProfile = {
+  prose: 'Test profile',
+  preferred_scholars: ['calvin'],
+  preferred_traditions: ['Reformed'],
+};
+
+describe('retrieve', () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  it('returns up to 10 boosted, diversified chunks', async () => {
+    const mock = getMockDb();
+    const rows = Array.from({ length: 30 }).map((_, i) => ({
+      chunk_id: `section_panel:chunk-${i}`,
+      source_type: 'section_panel',
+      source_id: `chunk-${i}`,
+      text: `text ${i}`,
+      distance: 0.1 * i,
+      scholar_id: i % 3 === 0 ? 'calvin' : 'wright',
+      tradition: i % 3 === 0 ? 'Reformed' : 'Evangelical',
+      book_id: 'romans',
+      chapter_num: 9,
+      verse_start: null,
+      verse_end: null,
+      panel_type: 'calvin',
+    }));
+    mock.getAllAsync.mockResolvedValueOnce(rows);
+
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    const result = await retrieve(
+      {
+        query: 'election in Romans 9',
+        profile: PROFILE,
+        currentChapterRef: { book_id: 'romans', chapter_num: 9 },
+      },
+      { authToken: 'tkn', fetchImpl },
+    );
+
+    expect(result.chunks.length).toBeGreaterThan(0);
+    expect(result.chunks.length).toBeLessThanOrEqual(10);
+    expect(result.embedMs).toBeGreaterThanOrEqual(0);
+    // Chapter boost shown — every returned chunk is on romans 9 so all get ×1.5
+    for (const c of result.chunks) {
+      expect(c.score).toBeGreaterThan(0);
+    }
+  });
+
+  it('propagates AmicusError.OFFLINE from embed', async () => {
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network');
+    }) as unknown as typeof fetch;
+
+    await expect(
+      retrieve(
+        {
+          query: 'q',
+          profile: PROFILE,
+          currentChapterRef: null,
+        },
+        { authToken: 'tkn', fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: 'OFFLINE' });
+  });
+
+  it('propagates EXTENSION_NOT_LOADED from vector search', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockRejectedValueOnce(new Error('no such module: vec0'));
+
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    await expect(
+      retrieve(
+        { query: 'q', profile: PROFILE, currentChapterRef: null },
+        { authToken: 'tkn', fetchImpl },
+      ),
+    ).rejects.toBeInstanceOf(AmicusError);
+  });
+
+  it('returns an empty result when vector search finds no matches', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([]);
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    const r = await retrieve(
+      { query: 'q', profile: PROFILE, currentChapterRef: null },
+      { authToken: 'tkn', fetchImpl },
+    );
+    expect(r.chunks).toEqual<RetrievedChunk[]>([]);
+  });
+});

--- a/app/src/services/amicus/__tests__/vectorSearch.test.ts
+++ b/app/src/services/amicus/__tests__/vectorSearch.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for vectorSearch pure helpers (packVector, distanceToSimilarity) and
+ * for the searchByVector error path when sqlite-vec isn't loaded. The full
+ * SQL path is covered in the integration smoke test (#1453).
+ */
+import { distanceToSimilarity, packVector, searchByVector } from '../vectorSearch';
+import { AmicusError } from '../types';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
+
+jest.mock('@/db/database', () => require('../../../../__tests__/helpers/mockDb').mockDatabaseModule());
+
+describe('packVector', () => {
+  it('produces 4 bytes per float, little-endian', () => {
+    const blob = packVector([1.0, 0.5]);
+    expect(blob.byteLength).toBe(8);
+    const view = new DataView(blob.buffer);
+    expect(view.getFloat32(0, true)).toBeCloseTo(1.0);
+    expect(view.getFloat32(4, true)).toBeCloseTo(0.5);
+  });
+
+  it('handles 1536-dim vectors', () => {
+    const v = new Array(1536).fill(0.01);
+    const blob = packVector(v);
+    expect(blob.byteLength).toBe(1536 * 4);
+  });
+});
+
+describe('distanceToSimilarity', () => {
+  it('is 1 at distance 0', () => {
+    expect(distanceToSimilarity(0)).toBe(1);
+  });
+  it('monotonically decreases with distance', () => {
+    expect(distanceToSimilarity(1)).toBeGreaterThan(distanceToSimilarity(2));
+    expect(distanceToSimilarity(10)).toBeGreaterThan(distanceToSimilarity(100));
+  });
+  it('clamps invalid input to 0', () => {
+    expect(distanceToSimilarity(-1)).toBe(0);
+    expect(distanceToSimilarity(Number.NaN)).toBe(0);
+  });
+});
+
+describe('searchByVector', () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  it('maps rows into RetrievedChunk shape', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([
+      {
+        chunk_id: 'section_panel:romans-9-s1-calvin',
+        source_type: 'section_panel',
+        source_id: 'romans-9-s1-calvin',
+        text: 'Calvin on election',
+        distance: 0.2,
+        scholar_id: 'calvin',
+        tradition: 'Reformed',
+        book_id: 'romans',
+        chapter_num: 9,
+        verse_start: 1,
+        verse_end: 29,
+        panel_type: 'calvin',
+      },
+    ]);
+
+    const chunks = await searchByVector([0, 0, 0]);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.chunk_id).toBe('section_panel:romans-9-s1-calvin');
+    expect(chunks[0]!.score).toBeGreaterThan(0);
+    expect(chunks[0]!.metadata.scholar_id).toBe('calvin');
+  });
+
+  it('throws EXTENSION_NOT_LOADED when sqlite-vec is missing', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockRejectedValueOnce(new Error('no such module: vec0'));
+    await expect(searchByVector([0, 0])).rejects.toBeInstanceOf(AmicusError);
+    try {
+      await searchByVector([0, 0]);
+    } catch (err) {
+      expect((err as AmicusError).code).toBe('EXTENSION_NOT_LOADED');
+    }
+  });
+
+  it('returns [] when the vec0 table is empty', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([]);
+    expect(await searchByVector([0, 0])).toEqual([]);
+  });
+});

--- a/app/src/services/amicus/embed.ts
+++ b/app/src/services/amicus/embed.ts
@@ -1,0 +1,81 @@
+/**
+ * services/amicus/embed.ts — Embed a user query via the Amicus proxy.
+ *
+ * The proxy (#1450) forwards to OpenAI `text-embedding-3-small` and returns
+ * a 1536-dim vector. We retry exactly once on network / 5xx so a flaky
+ * connection doesn't instantly disable Amicus.
+ */
+import { AmicusError } from './types';
+import { logger } from '@/utils/logger';
+
+const PROXY_BASE =
+  (process.env.EXPO_PUBLIC_AMICUS_PROXY_URL ?? 'https://ai.contentcompanionstudy.com').replace(/\/$/, '');
+
+const EMBED_DIM = 1536;
+
+export interface EmbedOptions {
+  /** RevenueCat receipt token used as the Authorization bearer. */
+  authToken: string;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Soft timeout for each attempt, ms. */
+  timeoutMs?: number;
+}
+
+export async function embedQuery(text: string, opts: EmbedOptions): Promise<number[]> {
+  if (!text.trim()) {
+    throw new AmicusError('EMBED_FAILED', 'empty query');
+  }
+
+  const attempt = async (): Promise<Response> => {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), opts.timeoutMs ?? 5000);
+    try {
+      return await (opts.fetchImpl ?? fetch)(`${PROXY_BASE}/ai/embed`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${opts.authToken}`,
+        },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(t);
+    }
+  };
+
+  let lastErr: unknown;
+  for (let i = 0; i < 2; i++) {
+    try {
+      const resp = await attempt();
+      if (resp.status === 401 || resp.status === 402) {
+        throw new AmicusError('PROXY_UNAUTHORIZED', `proxy ${resp.status}`);
+      }
+      if (!resp.ok) {
+        lastErr = new Error(`proxy ${resp.status}`);
+        if (resp.status < 500) break; // 4xx won't get better by retrying
+        continue;
+      }
+      const payload = (await resp.json()) as { vector?: number[] };
+      if (!Array.isArray(payload.vector) || payload.vector.length !== EMBED_DIM) {
+        throw new AmicusError('EMBED_FAILED', 'invalid vector shape');
+      }
+      return payload.vector;
+    } catch (err) {
+      if (err instanceof AmicusError) throw err;
+      lastErr = err;
+      // AbortError / network error — retry once, then bail as OFFLINE.
+      if (i === 0) {
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
+      logger.warn('Amicus', 'embed failed after retry', err);
+      throw new AmicusError('OFFLINE', (err as Error).message ?? 'network');
+    }
+  }
+  logger.warn('Amicus', 'embed failed', lastErr);
+  throw new AmicusError('EMBED_FAILED', (lastErr as Error)?.message ?? 'unknown');
+}
+
+export const _internal = { EMBED_DIM, PROXY_BASE };

--- a/app/src/services/amicus/index.ts
+++ b/app/src/services/amicus/index.ts
@@ -1,0 +1,19 @@
+/**
+ * services/amicus/index.ts — Public entry point for the Amicus service layer.
+ *
+ * Keep the surface small: callers should use `retrieve()` and the shared
+ * types. Internals (rerank, vectorSearch, embed) are importable for tests
+ * but not part of the public contract.
+ */
+export { retrieve } from './retrieval';
+export type { RetrievalResult, RetrieveOptions } from './retrieval';
+export { AmicusError } from './types';
+export type {
+  AmicusErrorCode,
+  ChunkSourceType,
+  ChunkMetadata,
+  CompressedProfile,
+  ChapterRef,
+  RetrievalContext,
+  RetrievedChunk,
+} from './types';

--- a/app/src/services/amicus/rerank.ts
+++ b/app/src/services/amicus/rerank.ts
@@ -1,0 +1,98 @@
+/**
+ * services/amicus/rerank.ts — Profile + context boosts and diversity filter.
+ *
+ * Pure functions so every step is unit-testable without a database.
+ *
+ * Pipeline (see plan §6):
+ *   1. boost current chapter × 1.5
+ *   2. boost preferred scholars × 1.1
+ *   3. boost preferred traditions × 1.05
+ *   4. diversify: max 2 chunks per scholar_id
+ *   5. sort desc, return top 10
+ */
+import type { ChapterRef, CompressedProfile, RetrievedChunk } from './types';
+
+export const CURRENT_CHAPTER_BOOST = 1.5;
+export const SCHOLAR_BOOST = 1.1;
+export const TRADITION_BOOST = 1.05;
+export const SCHOLAR_DIVERSITY_CAP = 2;
+export const RESULT_LIMIT = 10;
+
+export function boostCurrentChapter(
+  chunks: RetrievedChunk[],
+  currentChapterRef: ChapterRef | null,
+): RetrievedChunk[] {
+  if (!currentChapterRef) return chunks;
+  return chunks.map((c) => {
+    const m = c.metadata;
+    if (m.book_id === currentChapterRef.book_id && m.chapter_num === currentChapterRef.chapter_num) {
+      return { ...c, score: c.score * CURRENT_CHAPTER_BOOST };
+    }
+    return c;
+  });
+}
+
+export function boostPreferredScholars(
+  chunks: RetrievedChunk[],
+  preferred: string[],
+): RetrievedChunk[] {
+  if (preferred.length === 0) return chunks;
+  const set = new Set(preferred);
+  return chunks.map((c) => {
+    const sid = c.metadata.scholar_id;
+    return sid && set.has(sid) ? { ...c, score: c.score * SCHOLAR_BOOST } : c;
+  });
+}
+
+export function boostPreferredTraditions(
+  chunks: RetrievedChunk[],
+  preferred: string[],
+): RetrievedChunk[] {
+  if (preferred.length === 0) return chunks;
+  const set = new Set(preferred);
+  return chunks.map((c) => {
+    const t = c.metadata.tradition;
+    return t && set.has(t) ? { ...c, score: c.score * TRADITION_BOOST } : c;
+  });
+}
+
+/**
+ * Cap the number of chunks per scholar_id. Walks the already-sorted list
+ * and drops chunks beyond the cap so the most relevant ones are kept.
+ */
+export function diversifyByScholar(
+  chunks: RetrievedChunk[],
+  cap: number = SCHOLAR_DIVERSITY_CAP,
+): RetrievedChunk[] {
+  const seen = new Map<string, number>();
+  const out: RetrievedChunk[] = [];
+  for (const c of chunks) {
+    const sid = c.metadata.scholar_id;
+    if (!sid) {
+      out.push(c);
+      continue;
+    }
+    const n = seen.get(sid) ?? 0;
+    if (n >= cap) continue;
+    seen.set(sid, n + 1);
+    out.push(c);
+  }
+  return out;
+}
+
+/**
+ * End-to-end rerank: apply all boosts, sort by score desc, diversify,
+ * and return the top RESULT_LIMIT.
+ */
+export function rerank(
+  chunks: RetrievedChunk[],
+  profile: CompressedProfile,
+  currentChapterRef: ChapterRef | null,
+): RetrievedChunk[] {
+  const step1 = boostCurrentChapter(chunks, currentChapterRef);
+  const step2 = boostPreferredScholars(step1, profile.preferred_scholars);
+  const step3 = boostPreferredTraditions(step2, profile.preferred_traditions);
+  const sorted = [...step3].sort((a, b) => b.score - a.score);
+  const diversified = diversifyByScholar(sorted);
+  return diversified.slice(0, RESULT_LIMIT);
+}

--- a/app/src/services/amicus/retrieval.ts
+++ b/app/src/services/amicus/retrieval.ts
@@ -1,0 +1,73 @@
+/**
+ * services/amicus/retrieval.ts — Top-level Amicus retrieval orchestrator.
+ *
+ * Pipeline:
+ *   1. embed query via proxy /ai/embed
+ *   2. sqlite-vec MATCH against scripture.db (local)
+ *   3. re-rank with profile + context boosts, diversify, top-10
+ *
+ * Typed errors bubble up so UI can choose graceful fallback:
+ *   - AmicusError.EMBED_FAILED        — proxy 4xx/5xx or shape mismatch
+ *   - AmicusError.OFFLINE             — network unreachable
+ *   - AmicusError.EXTENSION_NOT_LOADED — sqlite-vec not loaded on the connection
+ *   - AmicusError.PROXY_UNAUTHORIZED   — 401/402 from proxy
+ */
+import { embedQuery } from './embed';
+import { rerank } from './rerank';
+import { searchByVector } from './vectorSearch';
+import { AmicusError, type RetrievalContext, type RetrievedChunk } from './types';
+import { logger } from '@/utils/logger';
+
+export interface RetrieveOptions {
+  /** Bearer token for the proxy. Usually the RevenueCat receipt. */
+  authToken: string;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Vector-search candidate pool size before re-ranking. */
+  candidatePoolSize?: number;
+}
+
+export interface RetrievalResult {
+  chunks: RetrievedChunk[];
+  /** Milliseconds spent embedding (proxy round-trip). */
+  embedMs: number;
+  /** Milliseconds spent in sqlite-vec search + hydration. */
+  searchMs: number;
+  /** Milliseconds spent re-ranking. */
+  rerankMs: number;
+}
+
+export async function retrieve(
+  ctx: RetrievalContext,
+  opts: RetrieveOptions,
+): Promise<RetrievalResult> {
+  const startEmbed = Date.now();
+  let vector: number[];
+  try {
+    vector = await embedQuery(ctx.query, {
+      authToken: opts.authToken,
+      fetchImpl: opts.fetchImpl,
+    });
+  } catch (err) {
+    if (err instanceof AmicusError) throw err;
+    throw new AmicusError('EMBED_FAILED', (err as Error).message);
+  }
+  const embedMs = Date.now() - startEmbed;
+
+  const startSearch = Date.now();
+  const candidates = await searchByVector(vector, {
+    limit: opts.candidatePoolSize ?? 40,
+  });
+  const searchMs = Date.now() - startSearch;
+
+  const startRerank = Date.now();
+  const chunks = rerank(candidates, ctx.profile, ctx.currentChapterRef);
+  const rerankMs = Date.now() - startRerank;
+
+  logger.info(
+    'Amicus',
+    `retrieval: ${chunks.length} chunks (embed ${embedMs}ms, search ${searchMs}ms, rerank ${rerankMs}ms)`,
+  );
+
+  return { chunks, embedMs, searchMs, rerankMs };
+}

--- a/app/src/services/amicus/types.ts
+++ b/app/src/services/amicus/types.ts
@@ -1,0 +1,76 @@
+/**
+ * services/amicus/types.ts — Shared types for the Amicus service layer.
+ *
+ * Source types listed here mirror the chunker in `_tools/build_embeddings_chunks.py`
+ * and the Worker's `ai-proxy/src/types.ts`. Keep them aligned.
+ */
+
+export type ChunkSourceType =
+  | 'section_panel'
+  | 'chapter_panel'
+  | 'word_study'
+  | 'lexicon_entry'
+  | 'debate_topic'
+  | 'cross_ref_thread_note'
+  | 'journey_stop'
+  | 'meta_faq';
+
+export interface ChunkMetadata {
+  scholar_id?: string;
+  tradition?: string;
+  book_id?: string;
+  chapter_num?: number;
+  verse_start?: number;
+  verse_end?: number;
+  panel_type?: string;
+}
+
+export interface RetrievedChunk {
+  chunk_id: string;
+  source_type: ChunkSourceType;
+  source_id: string;
+  text: string;
+  /** Final score after all boosts and normalizations. Higher is more relevant. */
+  score: number;
+  metadata: ChunkMetadata;
+}
+
+/**
+ * Snapshot of a user's study profile used for re-ranking.
+ *
+ * Produced by `generateProfile()` in #1452. Retained here as a structural
+ * type so we don't take a hard import dependency on the profile module
+ * before #1452 ships.
+ */
+export interface CompressedProfile {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+}
+
+export interface ChapterRef {
+  book_id: string;
+  chapter_num: number;
+}
+
+export interface RetrievalContext {
+  query: string;
+  profile: CompressedProfile;
+  currentChapterRef: ChapterRef | null;
+}
+
+/** Union of all typed retrieval failures. */
+export type AmicusErrorCode =
+  | 'EMBED_FAILED'
+  | 'EXTENSION_NOT_LOADED'
+  | 'OFFLINE'
+  | 'PROXY_UNAUTHORIZED';
+
+export class AmicusError extends Error {
+  readonly code: AmicusErrorCode;
+  constructor(code: AmicusErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+    this.name = 'AmicusError';
+  }
+}

--- a/app/src/services/amicus/vectorSearch.ts
+++ b/app/src/services/amicus/vectorSearch.ts
@@ -1,0 +1,117 @@
+/**
+ * services/amicus/vectorSearch.ts — sqlite-vec query layer.
+ *
+ * Runs the vec0 MATCH search against scripture.db and joins chunk_text +
+ * chunk_metadata to produce typed results. Keeps the raw-SQL surface
+ * localized so the orchestrator doesn't need to know the schema.
+ */
+import { AmicusError, type ChunkSourceType, type RetrievedChunk } from './types';
+import { getDb } from '@/db/database';
+import { logger } from '@/utils/logger';
+
+export interface VectorSearchRow {
+  chunk_id: string;
+  source_type: ChunkSourceType;
+  source_id: string;
+  text: string;
+  distance: number;
+  scholar_id: string | null;
+  tradition: string | null;
+  book_id: string | null;
+  chapter_num: number | null;
+  verse_start: number | null;
+  verse_end: number | null;
+  panel_type: string | null;
+}
+
+/**
+ * Pack a number[] vector into a little-endian float32 Uint8Array blob
+ * suitable for a sqlite-vec MATCH parameter.
+ */
+export function packVector(vector: number[]): Uint8Array {
+  const buf = new ArrayBuffer(vector.length * 4);
+  const view = new DataView(buf);
+  for (let i = 0; i < vector.length; i++) {
+    view.setFloat32(i * 4, vector[i]!, true /* littleEndian */);
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Convert sqlite-vec's L2 distance into a similarity score in [0, 1].
+ * The raw distance is unbounded; we use `1 / (1 + d)` so higher = more
+ * relevant and the result stays finite. This is monotonic with distance
+ * and preserves ordering, which is all the re-ranker needs.
+ */
+export function distanceToSimilarity(distance: number): number {
+  if (!Number.isFinite(distance) || distance < 0) return 0;
+  return 1 / (1 + distance);
+}
+
+export interface SearchOptions {
+  /** How many candidates to ask sqlite-vec for before re-ranking. */
+  limit?: number;
+}
+
+/**
+ * Execute the vec0 MATCH query and hydrate results. Throws
+ * AmicusError.EXTENSION_NOT_LOADED if sqlite-vec isn't on the connection.
+ */
+export async function searchByVector(
+  vector: number[],
+  opts: SearchOptions = {},
+): Promise<RetrievedChunk[]> {
+  const limit = opts.limit ?? 40;
+  const db = getDb();
+  const blob = packVector(vector);
+
+  let rows: VectorSearchRow[];
+  try {
+    rows = await db.getAllAsync<VectorSearchRow>(
+      `SELECT
+         m.chunk_id        AS chunk_id,
+         m.source_type     AS source_type,
+         m.source_id       AS source_id,
+         t.text            AS text,
+         e.distance        AS distance,
+         m.scholar_id      AS scholar_id,
+         m.tradition       AS tradition,
+         m.book_id         AS book_id,
+         m.chapter_num     AS chapter_num,
+         m.verse_start     AS verse_start,
+         m.verse_end       AS verse_end,
+         m.panel_type      AS panel_type
+       FROM embeddings e
+       JOIN chunk_text t      ON t.rowid = e.rowid
+       JOIN chunk_metadata m  ON m.rowid = e.rowid
+       WHERE e.embedding MATCH ?
+       ORDER BY e.distance
+       LIMIT ?`,
+      [blob, limit],
+    );
+  } catch (err) {
+    const msg = (err as Error).message ?? '';
+    if (msg.includes('vec0') || msg.includes('no such module') || msg.includes('embeddings')) {
+      logger.error('Amicus', 'sqlite-vec not loaded on scripture.db', err);
+      throw new AmicusError('EXTENSION_NOT_LOADED', msg);
+    }
+    throw err;
+  }
+
+  return rows.map((r) => ({
+    chunk_id: r.chunk_id,
+    source_type: r.source_type,
+    source_id: r.source_id,
+    text: r.text,
+    score: distanceToSimilarity(r.distance),
+    metadata: {
+      scholar_id: r.scholar_id ?? undefined,
+      tradition: r.tradition ?? undefined,
+      book_id: r.book_id ?? undefined,
+      chapter_num: r.chapter_num ?? undefined,
+      verse_start: r.verse_start ?? undefined,
+      verse_end: r.verse_end ?? undefined,
+      panel_type: r.panel_type ?? undefined,
+    },
+  }));
+}


### PR DESCRIPTION
Closes #1451. Depends conceptually on #1448 and #1450.

## Summary
- New `app/src/services/amicus/` service layer implementing the client retrieval pipeline defined in the plan §6.
- Pipeline: `embedQuery()` (proxy) → `searchByVector()` (sqlite-vec MATCH) → `rerank()` (boosts + diversity) → top-10.
- Typed errors (`AmicusError.EMBED_FAILED | OFFLINE | EXTENSION_NOT_LOADED | PROXY_UNAUTHORIZED`) so the UI can choose graceful fallback.

## Modules
- `types.ts` — `RetrievedChunk`, `RetrievalContext`, `CompressedProfile`, `ChapterRef`, `AmicusError`
- `embed.ts` — single-retry, 5-s timeout, translates proxy status to typed errors
- `vectorSearch.ts` — little-endian float32 pack, similarity = `1/(1+distance)`, join to `chunk_text` + `chunk_metadata`
- `rerank.ts` — pure boosts: current chapter ×1.5, scholar ×1.1, tradition ×1.05; 2-per-scholar diversity cap; top 10
- `retrieval.ts` — orchestrator with per-phase latency timing
- `index.ts` — public barrel

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint src/services/amicus/` — 0 warnings
- [x] `npx jest --testPathPattern=amicus` — 30 tests pass across rerank / vectorSearch / embed / retrieval
- [x] Full app suite: 3,213 / 3,213 passing
- [x] EXTENSION_NOT_LOADED, OFFLINE, PROXY_UNAUTHORIZED error paths covered
- [x] No `any` types; strict mode passes

## Out of scope
- Profile generation — #1452 produces the `CompressedProfile` this code consumes.
- LLM call itself — Phase 2 (#1455) wires chunks + query into `/ai/chat`.
- Result caching — deferred per spec.

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe