### PR TITLE
feat(ai-partner): compressed profile generator (#1452)

### DIFF
--- a/app/__tests__/db/userDatabase.test.ts
+++ b/app/__tests__/db/userDatabase.test.ts
@@ -78,7 +78,7 @@ describe('userDatabase', () => {
       jest.resetModules();
       // Simulate all migrations already applied
       mockGetAllAsync.mockResolvedValueOnce(
-        Array.from({ length: 14 }, (_, i) => ({ version: i + 1 })),
+        Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
       );
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
@@ -93,8 +93,8 @@ describe('userDatabase', () => {
       mockGetAllAsync.mockResolvedValueOnce([{ version: 1 }]);
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
-      // Should run 13 remaining migrations (2 through 14)
-      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(13);
+      // Should run 14 remaining migrations (2 through 15)
+      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(14);
     });
 
     it('throws on migration failure', async () => {

--- a/app/__tests__/unit/userDatabase.test.ts
+++ b/app/__tests__/unit/userDatabase.test.ts
@@ -66,9 +66,9 @@ describe('userDatabase', () => {
   });
 
   it('skips already-applied migrations', async () => {
-    // Simulate all 14 migrations already applied
+    // Simulate all 15 migrations already applied
     mockGetAllAsync.mockResolvedValue(
-      Array.from({ length: 14 }, (_, i) => ({ version: i + 1 })),
+      Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
     );
 
     const { initUserDatabase } = require('@/db/userDatabase');

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -483,6 +483,19 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE flagged_content ADD COLUMN synced INTEGER NOT NULL DEFAULT 0;
     `,
   },
+  {
+    version: 15,
+    description: 'Amicus — compressed profile cache (#1452)',
+    sql: `
+      CREATE TABLE IF NOT EXISTS partner_profile_cache (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        profile_prose TEXT NOT NULL,
+        raw_signals_hash TEXT NOT NULL,
+        raw_signals_json TEXT NOT NULL DEFAULT '{}',
+        generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `,
+  },
 ];
 
 /**

--- a/app/src/services/amicus/profile/__tests__/generator.test.ts
+++ b/app/src/services/amicus/profile/__tests__/generator.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the profile generator — hashing + cache invalidation semantics.
+ *
+ * We stub collectSignals() rather than driving the real SQL path, so the
+ * tests exercise generator-level logic (hashing, cache hit, cache expiry,
+ * force refresh) without depending on mock-call ordering.
+ */
+import { clearProfile, generateProfile, hashRawSignals } from '../generator';
+import type { RawSignals } from '../types';
+import {
+  getMockUserDb,
+  resetMockUserDb,
+} from '../../../../../__tests__/helpers/mockUserDb';
+import { resetMockDb } from '../../../../../__tests__/helpers/mockDb';
+
+jest.mock(
+  '@/db/userDatabase',
+  () => require('../../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+jest.mock(
+  '@/db/database',
+  () => require('../../../../../__tests__/helpers/mockDb').mockDatabaseModule(),
+);
+
+// Stub collectSignals so we can control exactly what generateProfile sees.
+const STUB_SIGNALS: RawSignals = {
+  total_chapters_read: 120,
+  last_30_day_chapters: 30,
+  top_scholars_opened: [
+    { scholar_id: 'calvin', open_count: 40 },
+    { scholar_id: 'sarna', open_count: 25 },
+  ],
+  tradition_distribution: { Reformed: 0.6, Jewish: 0.3 },
+  genre_distribution: { epistle: 0.4, narrative: 0.4, wisdom: 0.2 },
+  completed_journeys: ['garden_to_city'],
+  active_journey: 'holy_week',
+  recent_chapters: [
+    { book_id: 'romans', chapter_num: 9, last_visit: '2026-04-17T12:00:00.000Z' },
+  ],
+  current_focus: { book_id: 'romans', chapters_in_range: 7, days_in_range: 14 },
+};
+
+jest.mock('../signals', () => {
+  const actual = jest.requireActual<typeof import('../signals')>('../signals');
+  return {
+    ...actual,
+    collectSignals: jest.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockedSignals = require('../signals') as { collectSignals: jest.Mock };
+
+beforeEach(() => {
+  resetMockUserDb();
+  resetMockDb();
+  mockedSignals.collectSignals.mockResolvedValue(STUB_SIGNALS);
+});
+
+describe('hashRawSignals', () => {
+  it('is deterministic for identical signal objects', async () => {
+    const a = await hashRawSignals(STUB_SIGNALS);
+    const b = await hashRawSignals(STUB_SIGNALS);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('changes when any field changes', async () => {
+    const base = await hashRawSignals(STUB_SIGNALS);
+    const mutated = await hashRawSignals({
+      ...STUB_SIGNALS,
+      total_chapters_read: 121,
+    });
+    expect(base).not.toBe(mutated);
+  });
+
+  it('is key-order-independent', async () => {
+    const reordered: RawSignals = {
+      current_focus: STUB_SIGNALS.current_focus,
+      active_journey: STUB_SIGNALS.active_journey,
+      recent_chapters: STUB_SIGNALS.recent_chapters,
+      completed_journeys: STUB_SIGNALS.completed_journeys,
+      genre_distribution: STUB_SIGNALS.genre_distribution,
+      tradition_distribution: STUB_SIGNALS.tradition_distribution,
+      top_scholars_opened: STUB_SIGNALS.top_scholars_opened,
+      last_30_day_chapters: STUB_SIGNALS.last_30_day_chapters,
+      total_chapters_read: STUB_SIGNALS.total_chapters_read,
+    };
+    expect(await hashRawSignals(STUB_SIGNALS)).toBe(await hashRawSignals(reordered));
+  });
+});
+
+describe('generateProfile', () => {
+  it('writes and returns a fresh profile on cache miss', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue(null);
+
+    const profile = await generateProfile();
+    expect(profile.prose).toMatch(/chapters total/);
+    expect(profile.preferred_scholars).toContain('calvin');
+    expect(profile.preferred_traditions).toContain('Reformed');
+    expect(profile.raw_signals_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('short-circuits on cache hit with matching hash', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'cached prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).toBe('cached prose');
+    expect(user.runAsync).not.toHaveBeenCalled();
+  });
+
+  it('regenerates on hash mismatch', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'stale prose',
+      raw_signals_hash: 'different-hash-value',
+      raw_signals_json: '{}',
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).not.toBe('stale prose');
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('regenerates on expired cache (>7 days)', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'very old prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).not.toBe('very old prose');
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('force=true bypasses the cache even on match', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'cached prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile(true);
+    expect(profile.prose).not.toBe('cached prose');
+  });
+
+  it('stores the signals JSON so inspection can round-trip', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue(null);
+    await generateProfile();
+    const [, bindings] = user.runAsync.mock.calls[0]!;
+    // bindings = [prose, hash, json, ts]
+    const stored = JSON.parse(bindings[2] as string) as RawSignals;
+    expect(stored.total_chapters_read).toBe(120);
+  });
+});
+
+describe('clearProfile', () => {
+  it('deletes the singleton row', async () => {
+    await clearProfile();
+    const user = getMockUserDb();
+    expect(user.runAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM partner_profile_cache/),
+    );
+  });
+});

--- a/app/src/services/amicus/profile/__tests__/templates.test.ts
+++ b/app/src/services/amicus/profile/__tests__/templates.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for prose assembly templates.
+ *
+ * Pure function — no DB or network.
+ */
+import { MAX_PROSE_CHARS, assembleProfile } from '../templates';
+import type { RawSignals } from '../types';
+
+function signals(overrides: Partial<RawSignals> = {}): RawSignals {
+  return {
+    total_chapters_read: 0,
+    last_30_day_chapters: 0,
+    top_scholars_opened: [],
+    tradition_distribution: {},
+    genre_distribution: {},
+    completed_journeys: [],
+    active_journey: null,
+    recent_chapters: [],
+    current_focus: null,
+    ...overrides,
+  };
+}
+
+describe('assembleProfile', () => {
+  it('produces a minimal prose for new users (thin profile)', () => {
+    const out = assembleProfile(signals());
+    expect(out.prose).toContain('New to Companion Study');
+    expect(out.preferred_scholars).toEqual([]);
+    expect(out.preferred_traditions).toEqual([]);
+  });
+
+  it('adds current-chapter clause for new users if they have one', () => {
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 0,
+        recent_chapters: [
+          { book_id: 'genesis', chapter_num: 3, last_visit: new Date().toISOString() },
+        ],
+      }),
+    );
+    expect(out.prose).toMatch(/Genesis 3/);
+  });
+
+  it('builds a full thick profile with boosts', () => {
+    const recent = new Date().toISOString();
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 123,
+        current_focus: { book_id: 'romans', chapters_in_range: 7, days_in_range: 14 },
+        top_scholars_opened: [
+          { scholar_id: 'calvin', open_count: 40 },
+          { scholar_id: 'sarna', open_count: 18 },
+          { scholar_id: 'wright', open_count: 5 }, // below threshold
+        ],
+        tradition_distribution: { Reformed: 0.55, Jewish: 0.25 },
+        completed_journeys: ['garden_to_city'],
+        active_journey: 'holy_week',
+        recent_chapters: [
+          { book_id: 'romans', chapter_num: 9, last_visit: recent },
+        ],
+      }),
+    );
+    expect(out.prose).toMatch(/123 chapters total/);
+    expect(out.prose).toMatch(/Romans/);
+    expect(out.prose).toMatch(/Calvin and Sarna/);
+    expect(out.prose).toMatch(/Reformed/);
+    expect(out.prose).toMatch(/Holy Week/);
+    expect(out.preferred_scholars).toEqual(['calvin', 'sarna']);
+    expect(out.preferred_traditions).toEqual(['Reformed']);
+  });
+
+  it('omits tradition clause when no tradition clears 30%', () => {
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 10,
+        tradition_distribution: { Reformed: 0.2, Jewish: 0.2, Evangelical: 0.2 },
+      }),
+    );
+    expect(out.prose).not.toMatch(/perspectives/);
+    expect(out.preferred_traditions).toEqual([]);
+  });
+
+  it('truncates oversized input', () => {
+    const bigCompleted = Array.from({ length: 50 }, (_, i) => `journey_${i}`);
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 9999,
+        completed_journeys: bigCompleted,
+        active_journey: 'x'.repeat(400),
+      }),
+    );
+    expect(out.prose.length).toBeLessThanOrEqual(MAX_PROSE_CHARS);
+  });
+
+  it('omits current-reading when last visit is older than 24h', () => {
+    const stale = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 5,
+        recent_chapters: [{ book_id: 'john', chapter_num: 1, last_visit: stale }],
+      }),
+    );
+    expect(out.prose).not.toMatch(/Currently reading/);
+  });
+});

--- a/app/src/services/amicus/profile/generator.ts
+++ b/app/src/services/amicus/profile/generator.ts
@@ -1,0 +1,175 @@
+/**
+ * services/amicus/profile/generator.ts — Entry point for compressed-profile
+ * generation, caching, inspection, and reset.
+ *
+ * The cache lives in user.db's `partner_profile_cache` table (singleton row,
+ * id=1). A regenerated profile is written in place; we never accumulate
+ * rows.
+ */
+import { collectSignals } from './signals';
+import { assembleProfile } from './templates';
+import type {
+  CompressedProfile,
+  ProfileForInspection,
+  RawSignals,
+} from './types';
+import { logger } from '@/utils/logger';
+import { getUserDb } from '@/db/userDatabase';
+
+const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface CachedRow {
+  profile_prose: string;
+  raw_signals_hash: string;
+  raw_signals_json: string;
+  generated_at: string;
+}
+
+export async function generateProfile(force = false): Promise<CompressedProfile> {
+  const signals = await collectSignals();
+  const hash = await hashRawSignals(signals);
+
+  if (!force) {
+    const cached = await readCache();
+    if (cached && cached.raw_signals_hash === hash && !isExpired(cached.generated_at)) {
+      logger.info('AmicusProfile', 'cache hit');
+      return rehydrateFromCache(cached);
+    }
+  }
+
+  const assembled = assembleProfile(signals);
+  const now = new Date().toISOString();
+  const profile: CompressedProfile = {
+    prose: assembled.prose,
+    preferred_scholars: assembled.preferred_scholars,
+    preferred_traditions: assembled.preferred_traditions,
+    generated_at: now,
+    raw_signals_hash: hash,
+  };
+
+  await writeCache(profile, signals);
+  return profile;
+}
+
+export async function getProfileForInspection(): Promise<ProfileForInspection> {
+  const profile = await generateProfile(false);
+  const signals = await loadCachedSignals();
+  return {
+    prose: profile.prose,
+    preferred_scholars: profile.preferred_scholars,
+    preferred_traditions: profile.preferred_traditions,
+    generated_at: profile.generated_at,
+    raw_signals: signals ?? (await collectSignals()),
+  };
+}
+
+export async function clearProfile(): Promise<void> {
+  await getUserDb().runAsync('DELETE FROM partner_profile_cache');
+  logger.info('AmicusProfile', 'cache cleared');
+}
+
+// ── Internals ─────────────────────────────────────────────────────────
+
+async function readCache(): Promise<CachedRow | null> {
+  try {
+    const row = await getUserDb().getFirstAsync<CachedRow>(
+      'SELECT profile_prose, raw_signals_hash, raw_signals_json, generated_at '
+        + 'FROM partner_profile_cache WHERE id = 1',
+    );
+    return row ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadCachedSignals(): Promise<RawSignals | null> {
+  const row = await readCache();
+  if (!row || !row.raw_signals_json) return null;
+  try {
+    return JSON.parse(row.raw_signals_json) as RawSignals;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  profile: CompressedProfile,
+  signals: RawSignals,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO partner_profile_cache
+       (id, profile_prose, raw_signals_hash, raw_signals_json, generated_at)
+     VALUES (1, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       profile_prose    = excluded.profile_prose,
+       raw_signals_hash = excluded.raw_signals_hash,
+       raw_signals_json = excluded.raw_signals_json,
+       generated_at     = excluded.generated_at`,
+    [
+      profile.prose,
+      profile.raw_signals_hash,
+      JSON.stringify(signals),
+      profile.generated_at,
+    ],
+  );
+}
+
+function rehydrateFromCache(row: CachedRow): CompressedProfile {
+  let preferred_scholars: string[] = [];
+  let preferred_traditions: string[] = [];
+  try {
+    const parsed = JSON.parse(row.raw_signals_json) as RawSignals;
+    preferred_scholars = (parsed.top_scholars_opened ?? [])
+      .filter((s) => s.open_count >= 10)
+      .map((s) => s.scholar_id);
+    preferred_traditions = pickTraditionsAboveThreshold(parsed.tradition_distribution);
+  } catch {
+    /* ignore — worst case we omit boosts and regenerate on next cycle */
+  }
+  return {
+    prose: row.profile_prose,
+    preferred_scholars,
+    preferred_traditions,
+    generated_at: row.generated_at,
+    raw_signals_hash: row.raw_signals_hash,
+  };
+}
+
+function pickTraditionsAboveThreshold(
+  distribution: Record<string, number> | undefined,
+): string[] {
+  if (!distribution) return [];
+  return Object.entries(distribution)
+    .filter(([, share]) => share >= 0.3)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => name);
+}
+
+function isExpired(generatedAt: string): boolean {
+  const t = Date.parse(generatedAt);
+  if (!Number.isFinite(t)) return true;
+  return Date.now() - t > CACHE_MAX_AGE_MS;
+}
+
+/**
+ * SHA-256 over a canonical JSON encoding of the signals object. Keys are
+ * sorted so semantically identical signals produce the same hash.
+ */
+export async function hashRawSignals(signals: RawSignals): Promise<string> {
+  const canonical = canonicalize(signals);
+  const data = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return '{' + entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',') + '}';
+}

--- a/app/src/services/amicus/profile/index.ts
+++ b/app/src/services/amicus/profile/index.ts
@@ -1,0 +1,17 @@
+/**
+ * services/amicus/profile/index.ts — Public entry point.
+ */
+export {
+  generateProfile,
+  getProfileForInspection,
+  clearProfile,
+  hashRawSignals,
+} from './generator';
+export type {
+  CompressedProfile,
+  ProfileForInspection,
+  RawSignals,
+  ScholarEngagement,
+  RecentChapter,
+  CurrentFocus,
+} from './types';

--- a/app/src/services/amicus/profile/signals.ts
+++ b/app/src/services/amicus/profile/signals.ts
@@ -1,0 +1,198 @@
+/**
+ * services/amicus/profile/signals.ts — Pull engagement signals from user.db.
+ *
+ * All queries are deterministic so the same database state produces the same
+ * hash. Signals cover reading progress, scholar opens, tradition/genre
+ * distribution, journey state, and current study focus.
+ */
+import type {
+  CurrentFocus,
+  RawSignals,
+  RecentChapter,
+  ScholarEngagement,
+} from './types';
+import { getUserDb } from '@/db/userDatabase';
+import { getDb } from '@/db/database';
+import { logger } from '@/utils/logger';
+
+const RECENT_WINDOW_DAYS = 30;
+const CURRENT_FOCUS_WINDOW_DAYS = 14;
+const CURRENT_FOCUS_MIN_CHAPTERS = 3;
+const TOP_SCHOLARS_LIMIT = 5;
+const SCHOLAR_ENGAGEMENT_FLOOR = 10;
+
+export async function collectSignals(): Promise<RawSignals> {
+  const [totals, recent30, scholars, traditions, genres, journeys, recentChapters, focus] =
+    await Promise.all([
+      getTotalChaptersRead(),
+      getChaptersReadInLastDays(RECENT_WINDOW_DAYS),
+      getTopScholarsOpened(TOP_SCHOLARS_LIMIT),
+      getTraditionDistribution(),
+      getGenreDistribution(),
+      getJourneyState(),
+      getRecentChapters(10),
+      getCurrentFocus(),
+    ]);
+
+  return {
+    total_chapters_read: totals,
+    last_30_day_chapters: recent30,
+    top_scholars_opened: scholars,
+    tradition_distribution: traditions,
+    genre_distribution: genres,
+    completed_journeys: journeys.completed,
+    active_journey: journeys.active,
+    recent_chapters: recentChapters,
+    current_focus: focus,
+  };
+}
+
+export async function getTotalChaptersRead(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM reading_progress WHERE completed_at IS NOT NULL',
+  );
+  return row?.n ?? 0;
+}
+
+export async function getChaptersReadInLastDays(days: number): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM reading_progress
+     WHERE completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)`,
+    [`-${days} days`],
+  );
+  return row?.n ?? 0;
+}
+
+export async function getTopScholarsOpened(limit: number): Promise<ScholarEngagement[]> {
+  try {
+    const rows = await getUserDb().getAllAsync<ScholarEngagement>(
+      `SELECT scholar_id, COUNT(*) AS open_count
+       FROM scholar_opens
+       GROUP BY scholar_id
+       ORDER BY open_count DESC
+       LIMIT ?`,
+      [limit],
+    );
+    return rows;
+  } catch (err) {
+    // scholar_opens is a future engagement table — return empty until it exists.
+    logger.info('AmicusProfile', `scholar_opens unavailable: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+export async function getTraditionDistribution(): Promise<Record<string, number>> {
+  const scholars = await getTopScholarsOpened(100);
+  if (scholars.length === 0) return {};
+
+  const ids = scholars.map((s) => s.scholar_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = await getDb().getAllAsync<{ tradition: string | null; id: string }>(
+    `SELECT id, tradition FROM scholars WHERE id IN (${placeholders})`,
+    ids,
+  );
+  const traditionById = new Map(rows.map((r) => [r.id, r.tradition]));
+
+  const totals = new Map<string, number>();
+  let grand = 0;
+  for (const s of scholars) {
+    const t = traditionById.get(s.scholar_id);
+    if (!t) continue;
+    totals.set(t, (totals.get(t) ?? 0) + s.open_count);
+    grand += s.open_count;
+  }
+  if (grand === 0) return {};
+
+  const result: Record<string, number> = {};
+  for (const [k, v] of totals) result[k] = v / grand;
+  return result;
+}
+
+export async function getGenreDistribution(): Promise<Record<string, number>> {
+  const rows = await getDb().getAllAsync<{ genre: string | null; n: number }>(
+    `SELECT b.genre AS genre, COUNT(*) AS n
+     FROM books b
+     JOIN reading_progress rp ON rp.book_id = b.id
+     WHERE rp.completed_at IS NOT NULL
+     GROUP BY b.genre`,
+  );
+  const totals: Record<string, number> = {};
+  let grand = 0;
+  for (const r of rows) {
+    if (!r.genre) continue;
+    totals[r.genre] = (totals[r.genre] ?? 0) + r.n;
+    grand += r.n;
+  }
+  if (grand === 0) return {};
+  for (const k of Object.keys(totals)) totals[k] = (totals[k] ?? 0) / grand;
+  return totals;
+}
+
+export async function getJourneyState(): Promise<{
+  completed: string[];
+  active: string | null;
+}> {
+  try {
+    const completedRows = await getUserDb().getAllAsync<{ journey_id: string }>(
+      'SELECT journey_id FROM journey_progress WHERE completed_at IS NOT NULL ORDER BY completed_at',
+    );
+    const activeRow = await getUserDb().getFirstAsync<{ journey_id: string }>(
+      `SELECT journey_id FROM journey_progress
+       WHERE completed_at IS NULL
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+    );
+    return {
+      completed: completedRows.map((r) => r.journey_id),
+      active: activeRow?.journey_id ?? null,
+    };
+  } catch (err) {
+    // journey_progress not yet populated for this user — safe to skip.
+    logger.info('AmicusProfile', `journey_progress unavailable: ${(err as Error).message}`);
+    return { completed: [], active: null };
+  }
+}
+
+export async function getRecentChapters(limit: number): Promise<RecentChapter[]> {
+  const rows = await getUserDb().getAllAsync<RecentChapter>(
+    `SELECT book_id, chapter_num, completed_at AS last_visit
+     FROM reading_progress
+     WHERE completed_at IS NOT NULL
+     ORDER BY completed_at DESC
+     LIMIT ?`,
+    [limit],
+  );
+  return rows;
+}
+
+/**
+ * A "current focus" is detected when the user has read ≥N chapters of a single
+ * book in the last M days. Gives the profile a useful hook like "recently
+ * focused on Romans" without requiring explicit user declaration.
+ */
+export async function getCurrentFocus(): Promise<CurrentFocus | null> {
+  const rows = await getUserDb().getAllAsync<{
+    book_id: string;
+    n: number;
+    first: string;
+  }>(
+    `SELECT book_id, COUNT(*) AS n, MIN(completed_at) AS first
+     FROM reading_progress
+     WHERE completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)
+     GROUP BY book_id
+     ORDER BY n DESC
+     LIMIT 1`,
+    [`-${CURRENT_FOCUS_WINDOW_DAYS} days`],
+  );
+  const top = rows[0];
+  if (!top || top.n < CURRENT_FOCUS_MIN_CHAPTERS) return null;
+  return {
+    book_id: top.book_id,
+    chapters_in_range: top.n,
+    days_in_range: CURRENT_FOCUS_WINDOW_DAYS,
+  };
+}
+
+export { SCHOLAR_ENGAGEMENT_FLOOR };

--- a/app/src/services/amicus/profile/templates.ts
+++ b/app/src/services/amicus/profile/templates.ts
@@ -1,0 +1,133 @@
+/**
+ * services/amicus/profile/templates.ts — Prose assembly from signals.
+ *
+ * Each section is optional and is added only when its signal is meaningful.
+ * For thin profiles (new users) the output is deliberately minimal so that
+ * Amicus does not over-personalize based on scant data.
+ */
+import { SCHOLAR_ENGAGEMENT_FLOOR } from './signals';
+import type { RawSignals } from './types';
+
+const TRADITION_THRESHOLD = 0.3;
+const MAX_PROSE_CHARS = 800; // hard upper bound; ~200 tokens at 4 chars/token
+
+interface AssembledPieces {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+}
+
+export function assembleProfile(signals: RawSignals): AssembledPieces {
+  const sentences: string[] = [];
+  const preferredScholars: string[] = [];
+  const preferredTraditions: string[] = [];
+
+  // Thin profile path
+  if (signals.total_chapters_read === 0) {
+    sentences.push(
+      'New to Companion Study; no established study patterns yet.',
+    );
+    if (signals.recent_chapters.length > 0) {
+      const r = signals.recent_chapters[0]!;
+      sentences.push(`Currently reading ${capitalize(r.book_id)} ${r.chapter_num}.`);
+    }
+    return {
+      prose: truncate(sentences.join(' ')),
+      preferred_scholars: [],
+      preferred_traditions: [],
+    };
+  }
+
+  // 1. Baseline
+  sentences.push(`Studied ${signals.total_chapters_read} chapters total.`);
+
+  // 2. Recent focus
+  if (signals.current_focus) {
+    sentences.push(
+      `Recently focused on ${capitalize(signals.current_focus.book_id)}` +
+        ` (${signals.current_focus.chapters_in_range} chapters in the last` +
+        ` ${signals.current_focus.days_in_range} days).`,
+    );
+  }
+
+  // 3. Scholar affinity
+  const meaningfulScholars = signals.top_scholars_opened.filter(
+    (s) => s.open_count >= SCHOLAR_ENGAGEMENT_FLOOR,
+  );
+  if (meaningfulScholars.length > 0) {
+    const top2 = meaningfulScholars.slice(0, 2).map((s) => s.scholar_id);
+    sentences.push(
+      `Engages deeply with ${top2.map(capitalize).join(' and ')}.`,
+    );
+    preferredScholars.push(...meaningfulScholars.map((s) => s.scholar_id));
+  }
+
+  // 4. Tradition lean
+  const topTradition = pickTopTradition(signals.tradition_distribution);
+  if (topTradition) {
+    sentences.push(
+      `Shows interest in ${topTradition.name} perspectives.`,
+    );
+    preferredTraditions.push(topTradition.name);
+  }
+
+  // 5. Journey state
+  if (signals.completed_journeys.length > 0 || signals.active_journey) {
+    const parts: string[] = [];
+    if (signals.completed_journeys.length > 0) {
+      const names = signals.completed_journeys.slice(-2).map(capitalize).join(' and ');
+      parts.push(`Completed ${names}`);
+    }
+    if (signals.active_journey) {
+      parts.push(`currently on ${capitalize(signals.active_journey)}`);
+    }
+    sentences.push(parts.join(', ') + '.');
+  }
+
+  // 6. Current position (only if within last 24h)
+  const newest = signals.recent_chapters[0];
+  if (newest && isWithin24h(newest.last_visit)) {
+    sentences.push(
+      `Currently reading ${capitalize(newest.book_id)} ${newest.chapter_num}.`,
+    );
+  }
+
+  return {
+    prose: truncate(sentences.join(' ')),
+    preferred_scholars: preferredScholars,
+    preferred_traditions: preferredTraditions,
+  };
+}
+
+function pickTopTradition(
+  distribution: Record<string, number>,
+): { name: string; share: number } | null {
+  let best: { name: string; share: number } | null = null;
+  for (const [name, share] of Object.entries(distribution)) {
+    if (share < TRADITION_THRESHOLD) continue;
+    if (!best || share > best.share) {
+      best = { name, share };
+    }
+  }
+  return best;
+}
+
+function capitalize(s: string): string {
+  return s
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function isWithin24h(iso: string): boolean {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return Date.now() - t < 24 * 60 * 60 * 1000;
+}
+
+function truncate(s: string): string {
+  if (s.length <= MAX_PROSE_CHARS) return s;
+  return s.slice(0, MAX_PROSE_CHARS - 1).replace(/\s\S*$/, '') + '…';
+}
+
+export { MAX_PROSE_CHARS };

--- a/app/src/services/amicus/profile/types.ts
+++ b/app/src/services/amicus/profile/types.ts
@@ -1,0 +1,56 @@
+/**
+ * services/amicus/profile/types.ts — Profile generator types.
+ *
+ * `CompressedProfile` here is the full runtime shape; the leaner public
+ * version exported from `services/amicus/types.ts` is a strict subset
+ * to keep the retrieval service decoupled from the cache.
+ */
+
+export interface ScholarEngagement {
+  scholar_id: string;
+  open_count: number;
+}
+
+export interface RecentChapter {
+  book_id: string;
+  chapter_num: number;
+  last_visit: string;
+}
+
+export interface CurrentFocus {
+  book_id: string;
+  chapters_in_range: number;
+  days_in_range: number;
+}
+
+export interface RawSignals {
+  total_chapters_read: number;
+  last_30_day_chapters: number;
+  top_scholars_opened: ScholarEngagement[];
+  tradition_distribution: Record<string, number>;
+  genre_distribution: Record<string, number>;
+  completed_journeys: string[];
+  active_journey: string | null;
+  recent_chapters: RecentChapter[];
+  current_focus: CurrentFocus | null;
+}
+
+export interface CompressedProfile {
+  /** 100-200 token prose summary sent to Amicus and displayed in settings. */
+  prose: string;
+  /** Flat lists used by the re-ranker (kept in sync with the prose). */
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+  /** ISO timestamp of when the prose was generated. */
+  generated_at: string;
+  /** SHA-256 of the raw signals used — for cache invalidation. */
+  raw_signals_hash: string;
+}
+
+export interface ProfileForInspection {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+  generated_at: string;
+  raw_signals: RawSignals;
+}


### PR DESCRIPTION
Closes #1452. Phase 1 of epic #1446.

## Summary
- New `app/src/services/amicus/profile/` generator — deterministic, on-device, caches in `user.db`.
- Migration v15 adds `partner_profile_cache` (singleton row, id=1).
- Profile is user-inspectable via `getProfileForInspection()` for the forthcoming Settings screen (#1459).
- `clearProfile()` wipes the cache (backs the "Clear Amicus History" button).

## Signals
Reads only from already-existing tables (or future tables with graceful fallback):
- `reading_progress` — total chapters, last-30-day count, recent chapters, current focus
- `scholar_opens` (future) — top 5 scholars ≥10 opens trigger the scholar clause
- `scholars` + `books` — tradition + genre distribution via joins on user reads
- `journey_progress` (future) — completed + active journeys

## Caching
- SHA-256 over sorted-key canonical JSON of the raw signals.
- Cache hit when hash matches and `generated_at` < 7 days old.
- `force=true` bypasses.
- Singleton row — never accumulates.

## Test plan
- [x] Migration v15 appended; existing user DB tests updated (14 → 15)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — 3,199 tests pass (16 new)
- [x] Thick profile / thin profile / truncation / 24h window / cache hit / miss / expire / force all covered
- [x] `hashRawSignals` deterministic + key-order-independent
- [x] `clearProfile` DELETE verified
- [x] No `any` types; strict mode passes

## Out of scope
- New engagement tables (e.g. scholar_opens) — generator degrades to empty for these today
- Background auto-refresh — first-use regeneration is enough for v1
- Sending the profile to the proxy — consumed by #1451's retrieve()

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe