### PR TITLE
feat(ai-partner): Phase 1 E2E smoke test behind feature flag (#1453)

### DIFF
--- a/app/__tests__/db/userDatabase.test.ts
+++ b/app/__tests__/db/userDatabase.test.ts
@@ -78,7 +78,7 @@ describe('userDatabase', () => {
       jest.resetModules();
       // Simulate all migrations already applied
       mockGetAllAsync.mockResolvedValueOnce(
-        Array.from({ length: 14 }, (_, i) => ({ version: i + 1 })),
+        Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
       );
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
@@ -93,8 +93,8 @@ describe('userDatabase', () => {
       mockGetAllAsync.mockResolvedValueOnce([{ version: 1 }]);
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
-      // Should run 13 remaining migrations (2 through 14)
-      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(13);
+      // Should run 14 remaining migrations (2 through 15)
+      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(14);
     });
 
     it('throws on migration failure', async () => {

--- a/app/__tests__/unit/userDatabase.test.ts
+++ b/app/__tests__/unit/userDatabase.test.ts
@@ -66,9 +66,9 @@ describe('userDatabase', () => {
   });
 
   it('skips already-applied migrations', async () => {
-    // Simulate all 14 migrations already applied
+    // Simulate all 15 migrations already applied
     mockGetAllAsync.mockResolvedValue(
-      Array.from({ length: 14 }, (_, i) => ({ version: i + 1 })),
+      Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
     );
 
     const { initUserDatabase } = require('@/db/userDatabase');

--- a/app/src/constants/featureFlags.ts
+++ b/app/src/constants/featureFlags.ts
@@ -1,0 +1,25 @@
+/**
+ * constants/featureFlags.ts — Central feature-flag registry.
+ *
+ * Flags here are resolved at bundle time from `process.env` (Expo inlines
+ * EXPO_PUBLIC_* vars). Default values are always the production-safe side
+ * so a misconfigured build never leaks a dev-only feature.
+ */
+
+function isDev(): boolean {
+  // `__DEV__` is a React Native / Expo global. Typecheck without pulling in
+  // RN types at this module level.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+  return Boolean((globalThis as any).__DEV__);
+}
+
+export const featureFlags = {
+  /**
+   * Amicus E2E smoke test screen (Card #1453). Dev-only by construction —
+   * only visible when `__DEV__` is true AND `EXPO_PUBLIC_AMICUS_SMOKE=true`.
+   */
+  AMICUS_SMOKE_TEST:
+    isDev() && process.env.EXPO_PUBLIC_AMICUS_SMOKE === 'true',
+} as const;
+
+export type FeatureFlag = keyof typeof featureFlags;

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -483,6 +483,19 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE flagged_content ADD COLUMN synced INTEGER NOT NULL DEFAULT 0;
     `,
   },
+  {
+    version: 15,
+    description: 'Amicus — compressed profile cache (#1452)',
+    sql: `
+      CREATE TABLE IF NOT EXISTS partner_profile_cache (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        profile_prose TEXT NOT NULL,
+        raw_signals_hash TEXT NOT NULL,
+        raw_signals_json TEXT NOT NULL DEFAULT '{}',
+        generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `,
+  },
 ];
 
 /**

--- a/app/src/navigation/MoreStack.tsx
+++ b/app/src/navigation/MoreStack.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import MoreMenuScreen from '../screens/MoreMenuScreen';
 import { useTheme } from '../theme';
+import { featureFlags } from '../constants/featureFlags';
 import type { MoreStackParamList } from './types';
 import { lazySuspense } from './lazySuspense';
 
@@ -22,6 +23,7 @@ const ForgotPasswordScreen = lazySuspense(() => import('../screens/ForgotPasswor
 const UserProfileScreen = lazySuspense(() => import('../screens/UserProfileScreen'));
 const NotificationPrefsScreen = lazySuspense(() => import('../screens/NotificationPrefsScreen'));
 const NotificationFeedScreen = lazySuspense(() => import('../screens/NotificationFeedScreen'));
+const AmicusSmokeScreen = lazySuspense(() => import('../screens/dev/AmicusSmokeScreen'));
 
 const Stack = createStackNavigator<MoreStackParamList>();
 
@@ -47,6 +49,9 @@ export function MoreStack() {
       <Stack.Screen name="UserProfile" component={UserProfileScreen} />
       <Stack.Screen name="NotificationPrefs" component={NotificationPrefsScreen} />
       <Stack.Screen name="NotificationFeed" component={NotificationFeedScreen} />
+      {featureFlags.AMICUS_SMOKE_TEST && (
+        <Stack.Screen name="AmicusSmoke" component={AmicusSmokeScreen} />
+      )}
     </Stack.Navigator>
   );
 }

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -120,6 +120,7 @@ export type MoreStackParamList = {
   UserProfile: undefined;
   NotificationPrefs: undefined;
   NotificationFeed: undefined;
+  AmicusSmoke: undefined;
 };
 
 export type SearchStackParamList = {

--- a/app/src/screens/dev/AmicusSmokeScreen.tsx
+++ b/app/src/screens/dev/AmicusSmokeScreen.tsx
@@ -1,0 +1,200 @@
+/**
+ * screens/dev/AmicusSmokeScreen.tsx — Dev-only harness UI for the Amicus
+ * smoke test (Card #1453). Guarded by featureFlags.AMICUS_SMOKE_TEST; never
+ * registered in production builds.
+ *
+ * Minimal styling on purpose — this is an internal utility, not a feature.
+ */
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { logger } from '@/utils/logger';
+import {
+  runSmokeTest,
+  type QueryResult,
+  type SmokeReport,
+} from '@/services/amicus/__smoke__/runSmokeTest';
+
+export default function AmicusSmokeScreen(): React.ReactElement {
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState<{ index: number; total: number } | null>(null);
+  const [report, setReport] = useState<SmokeReport | null>(null);
+  const [authToken] = useState<string>(
+    process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '',
+  );
+
+  const run = useCallback(async () => {
+    if (!authToken) {
+      Alert.alert(
+        'Missing auth token',
+        'Set EXPO_PUBLIC_AMICUS_DEV_TOKEN in your dev env or paste a RevenueCat receipt.',
+      );
+      return;
+    }
+    setRunning(true);
+    setReport(null);
+    setProgress({ index: 0, total: 10 });
+    try {
+      const r = await runSmokeTest({
+        authToken,
+        onProgress: (i) => setProgress({ index: i + 1, total: 10 }),
+      });
+      setReport(r);
+    } catch (err) {
+      logger.error('Amicus', 'smoke test crashed', err);
+      Alert.alert('Smoke test failed', (err as Error).message);
+    } finally {
+      setRunning(false);
+      setProgress(null);
+    }
+  }, [authToken]);
+
+  const copyReport = useCallback(async () => {
+    if (!report) return;
+    await Clipboard.setStringAsync(JSON.stringify(report, null, 2));
+    Alert.alert('Report copied', 'JSON copied to clipboard.');
+  }, [report]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.header}>Amicus Smoke Test (Dev Only)</Text>
+      <Text style={styles.subtle}>
+        Runs 10 canned queries through the full Phase 1 pipeline. Dev-only
+        screen; not visible in production.
+      </Text>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Auth token (RevenueCat receipt)</Text>
+        <Text numberOfLines={1} style={styles.mono}>
+          {authToken ? `${authToken.slice(0, 10)}…` : '(unset)'}
+        </Text>
+      </View>
+
+      <Pressable
+        onPress={run}
+        disabled={running}
+        style={[styles.button, running && styles.buttonDisabled]}
+      >
+        <Text style={styles.buttonText}>
+          {running ? 'Running…' : 'Run all 10 queries'}
+        </Text>
+      </Pressable>
+
+      {progress && (
+        <View style={styles.progress}>
+          <ActivityIndicator />
+          <Text style={styles.subtle}>
+            {progress.index} / {progress.total}
+          </Text>
+        </View>
+      )}
+
+      {report && (
+        <View style={styles.reportBox}>
+          <Text style={styles.header}>
+            {report.passed} / {report.total} passed · p95 {report.latency_ms_p95}ms
+          </Text>
+          <Pressable onPress={copyReport} style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>Copy JSON report</Text>
+          </Pressable>
+          {report.results.map((r) => (
+            <ResultRow key={r.query_id} result={r} />
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+function ResultRow({ result }: { result: QueryResult }): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const marker = result.passed ? '✓' : '✗';
+  return (
+    <Pressable onPress={() => setExpanded((x) => !x)} style={styles.resultRow}>
+      <Text style={[styles.resultTitle, !result.passed && styles.resultFail]}>
+        {marker} {result.query_id} — {result.query}
+      </Text>
+      <Text style={styles.subtle}>
+        {result.latency_ms}ms · in {result.tokens_in} · out {result.tokens_out}
+        {result.gap_signal?.gap ? ' · gap' : ''}
+      </Text>
+      {expanded && (
+        <View style={styles.details}>
+          {result.failures.length > 0 && (
+            <Text style={styles.resultFail}>Failures:</Text>
+          )}
+          {result.failures.map((f, i) => (
+            <Text key={i} style={styles.resultFail}>
+              • {f}
+            </Text>
+          ))}
+          <Text style={styles.subtle}>Citations:</Text>
+          {result.citations.length === 0 ? (
+            <Text style={styles.subtle}>  (none)</Text>
+          ) : (
+            result.citations.map((c) => (
+              <Text key={c} style={styles.mono}>
+                {'  '}{c}
+              </Text>
+            ))
+          )}
+          <Text style={styles.subtle}>Preview:</Text>
+          <Text style={styles.mono}>{result.raw_response_preview}</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 16 },
+  header: { fontSize: 18, fontWeight: '600', marginBottom: 8 },
+  subtle: { color: '#666', fontSize: 12, marginVertical: 2 },
+  row: { marginBottom: 12 },
+  label: { fontSize: 13, marginBottom: 4 },
+  mono: { fontFamily: 'Courier', fontSize: 11 },
+  button: {
+    backgroundColor: '#222',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginVertical: 8,
+  },
+  buttonDisabled: { opacity: 0.5 },
+  buttonText: { color: '#fff', fontSize: 15 },
+  secondaryButton: {
+    marginVertical: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#999',
+    borderRadius: 6,
+    alignItems: 'center',
+  },
+  secondaryButtonText: { color: '#333', fontSize: 13 },
+  progress: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginVertical: 12,
+  },
+  reportBox: { marginTop: 16 },
+  resultRow: {
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ddd',
+  },
+  resultTitle: { fontSize: 13, marginBottom: 2 },
+  resultFail: { color: '#c00' },
+  details: { marginTop: 6, paddingLeft: 8 },
+});

--- a/app/src/services/amicus/__smoke__/__tests__/runSmokeTest.test.ts
+++ b/app/src/services/amicus/__smoke__/__tests__/runSmokeTest.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the smoke-test helpers. The full end-to-end path requires a
+ * live proxy and is exercised manually via AmicusSmokeScreen; here we cover
+ * the parsers and config loader.
+ */
+import {
+  CANNED_QUERIES,
+  extractCitations,
+  extractTrailingJson,
+} from '../runSmokeTest';
+
+describe('canned_queries.json', () => {
+  it('has 10 queries', () => {
+    expect(CANNED_QUERIES).toHaveLength(10);
+  });
+
+  it('all queries have unique ids', () => {
+    const ids = CANNED_QUERIES.map((q) => q.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every query has the required fields', () => {
+    for (const q of CANNED_QUERIES) {
+      expect(q.query).toBeTruthy();
+      expect(q.expected_citations).toBeDefined();
+      expect(Array.isArray(q.expected_citations.must_include_any_of)).toBe(true);
+      expect(Array.isArray(q.expected_citations.must_include_source_types)).toBe(true);
+      expect(Array.isArray(q.expected_citations.must_not_include)).toBe(true);
+      expect(q.expected_behavior).toBeTruthy();
+    }
+  });
+
+  it('includes a gap-test query (q06 — Coptic Orthodox)', () => {
+    const gapTest = CANNED_QUERIES.find((q) => q.expected_behavior.includes('corpus gap'));
+    expect(gapTest).toBeDefined();
+  });
+});
+
+describe('extractCitations', () => {
+  it('extracts bracketed citations', () => {
+    expect(
+      extractCitations('As Calvin explains [section_panel:romans-9-s1-calvin], election...'),
+    ).toEqual(['section_panel:romans-9-s1-calvin']);
+  });
+
+  it('dedupes repeated citations', () => {
+    const out = extractCitations(
+      'See [word_study:hesed] and again [word_study:hesed] in Psalm 23.',
+    );
+    expect(out).toEqual(['word_study:hesed']);
+  });
+
+  it('returns empty array when no citations', () => {
+    expect(extractCitations('No citations here.')).toEqual([]);
+  });
+});
+
+describe('extractTrailingJson', () => {
+  it('parses {"gap": true, ...}', () => {
+    const out = extractTrailingJson(
+      'Sorry, I don\'t have that.\n{"gap": true, "gap_type": "content", "topic": "x"}',
+    );
+    expect(out).toEqual({ gap: true, gap_type: 'content', topic: 'x' });
+  });
+
+  it('parses {"gap": false}', () => {
+    expect(extractTrailingJson('answer.\n{"gap": false}')).toEqual({
+      gap: false,
+    });
+  });
+
+  it('returns null with no trailing JSON', () => {
+    expect(extractTrailingJson('answer without JSON')).toBeNull();
+  });
+});

--- a/app/src/services/amicus/__smoke__/canned_queries.json
+++ b/app/src/services/amicus/__smoke__/canned_queries.json
@@ -1,0 +1,126 @@
+[
+  {
+    "id": "q01",
+    "query": "Why do Reformed and Jewish scholars read election theology differently?",
+    "current_chapter_ref": { "book_id": "romans", "chapter_num": 9 },
+    "expected_citations": {
+      "must_include_any_of": [
+        "section_panel:romans-9-s1-calvin",
+        "section_panel:romans-9-s2-calvin",
+        "chapter_panel:romans-9-debate"
+      ],
+      "must_include_source_types": ["section_panel", "debate_topic"],
+      "must_not_include": []
+    },
+    "expected_behavior": "multi-source synthesis with citations"
+  },
+  {
+    "id": "q02",
+    "query": "What does the Hebrew word chesed mean and where does it appear?",
+    "current_chapter_ref": null,
+    "expected_citations": {
+      "must_include_any_of": [
+        "word_study:hesed",
+        "lexicon_entry:heb-H2617"
+      ],
+      "must_include_source_types": ["word_study", "lexicon_entry"],
+      "must_not_include": []
+    },
+    "expected_behavior": "single-source lexicon + word-study lookup"
+  },
+  {
+    "id": "q03",
+    "query": "Are the days of Genesis 1 literal 24-hour periods or a literary framework?",
+    "current_chapter_ref": { "book_id": "genesis", "chapter_num": 1 },
+    "expected_citations": {
+      "must_include_any_of": [
+        "debate_topic:the-nature-of-the-days-yom"
+      ],
+      "must_include_source_types": ["debate_topic"],
+      "must_not_include": []
+    },
+    "expected_behavior": "debate topic with multiple positions"
+  },
+  {
+    "id": "q04",
+    "query": "How does Hebrews 10 connect the Day of Atonement to the cross?",
+    "current_chapter_ref": { "book_id": "hebrews", "chapter_num": 10 },
+    "expected_citations": {
+      "must_include_any_of": [
+        "cross_ref_thread_note:substitutionary-sacrifice-3"
+      ],
+      "must_include_source_types": ["cross_ref_thread_note"],
+      "must_not_include": []
+    },
+    "expected_behavior": "cross-testament typological reading"
+  },
+  {
+    "id": "q05",
+    "query": "What is the journey stop for Genesis 22 in Christ in the OT?",
+    "current_chapter_ref": { "book_id": "genesis", "chapter_num": 22 },
+    "expected_citations": {
+      "must_include_any_of": [],
+      "must_include_source_types": ["journey_stop"],
+      "must_not_include": []
+    },
+    "expected_behavior": "journey stop retrieval"
+  },
+  {
+    "id": "q06",
+    "query": "What do Coptic Orthodox theologians say about Romans 9?",
+    "current_chapter_ref": { "book_id": "romans", "chapter_num": 9 },
+    "expected_citations": {
+      "must_include_any_of": [],
+      "must_include_source_types": [],
+      "must_not_include": []
+    },
+    "expected_behavior": "corpus gap — expect gap_signal {gap: true}"
+  },
+  {
+    "id": "q07",
+    "query": "What is the difference between formal and dynamic equivalence translations?",
+    "current_chapter_ref": null,
+    "expected_citations": {
+      "must_include_any_of": ["meta_faq:formal-vs-dynamic-equivalence"],
+      "must_include_source_types": ["meta_faq"],
+      "must_not_include": []
+    },
+    "expected_behavior": "meta-FAQ editorial lookup"
+  },
+  {
+    "id": "q08",
+    "query": "Who was Melchizedek and why does Hebrews make so much of him?",
+    "current_chapter_ref": { "book_id": "hebrews", "chapter_num": 7 },
+    "expected_citations": {
+      "must_include_any_of": [],
+      "must_include_source_types": ["section_panel"],
+      "must_not_include": []
+    },
+    "expected_behavior": "character study with scriptural arc"
+  },
+  {
+    "id": "q09",
+    "query": "What does archaeology tell us about the walls of Jericho?",
+    "current_chapter_ref": { "book_id": "joshua", "chapter_num": 6 },
+    "expected_citations": {
+      "must_include_any_of": [],
+      "must_include_source_types": ["section_panel", "chapter_panel"],
+      "must_not_include": []
+    },
+    "expected_behavior": "archaeology + historical context"
+  },
+  {
+    "id": "q10",
+    "query": "How does the Septuagint differ from the Masoretic Text of Psalms?",
+    "current_chapter_ref": null,
+    "expected_citations": {
+      "must_include_any_of": [
+        "meta_faq:septuagint-lxx",
+        "meta_faq:masoretic-text"
+      ],
+      "must_include_source_types": ["meta_faq"],
+      "must_not_include": []
+    },
+    "expected_behavior": "textual-transmission question"
+  }
+]

--- a/app/src/services/amicus/__smoke__/runSmokeTest.ts
+++ b/app/src/services/amicus/__smoke__/runSmokeTest.ts
@@ -1,0 +1,323 @@
+/**
+ * services/amicus/__smoke__/runSmokeTest.ts — dev harness for the Phase 1
+ * end-to-end smoke test.
+ *
+ * Iterates the 10 canned queries, drives the full client pipeline through
+ * proxy /ai/chat, and produces a structured report. Designed to be invoked
+ * from the AmicusSmokeScreen dev UI and consumed either visually or as JSON.
+ */
+import { retrieve } from '@/services/amicus/retrieval';
+import { generateProfile } from '@/services/amicus/profile/generator';
+import type { ChunkSourceType, RetrievedChunk } from '@/services/amicus/types';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const CANNED_QUERIES = require('./canned_queries.json') as CannedQuery[];
+
+export interface CannedQuery {
+  id: string;
+  query: string;
+  current_chapter_ref: { book_id: string; chapter_num: number } | null;
+  expected_citations: {
+    must_include_any_of: string[];
+    must_include_source_types: ChunkSourceType[];
+    must_not_include: string[];
+  };
+  expected_behavior: string;
+}
+
+export interface QueryResult {
+  query_id: string;
+  query: string;
+  passed: boolean;
+  citations: string[];
+  source_types: ChunkSourceType[];
+  latency_ms: number;
+  tokens_in: number;
+  tokens_out: number;
+  gap_signal: { gap: boolean; gap_type?: string; topic?: string } | null;
+  failures: string[];
+  raw_response_preview: string;
+}
+
+export interface SmokeReport {
+  started_at: string;
+  finished_at: string;
+  total: number;
+  passed: number;
+  gap_tests_passed: number;
+  latency_ms_p50: number;
+  latency_ms_p95: number;
+  results: QueryResult[];
+}
+
+const CHAT_URL_DEFAULT = (
+  process.env.EXPO_PUBLIC_AMICUS_PROXY_URL ?? 'https://ai.contentcompanionstudy.com'
+).replace(/\/$/, '') + '/ai/chat';
+
+export interface RunOptions {
+  authToken: string;
+  chatUrl?: string;
+  fetchImpl?: typeof fetch;
+  /** Progress callback fired as each query completes. */
+  onProgress?: (index: number, result: QueryResult) => void;
+}
+
+export async function runSmokeTest(opts: RunOptions): Promise<SmokeReport> {
+  const startedAt = new Date().toISOString();
+  const results: QueryResult[] = [];
+  const profile = await generateProfile(false);
+  const chatUrl = opts.chatUrl ?? CHAT_URL_DEFAULT;
+
+  for (let i = 0; i < CANNED_QUERIES.length; i++) {
+    const q = CANNED_QUERIES[i]!;
+    const result = await runOne(q, profile, opts.authToken, chatUrl, opts.fetchImpl);
+    results.push(result);
+    opts.onProgress?.(i, result);
+  }
+
+  const latencies = results.map((r) => r.latency_ms).sort((a, b) => a - b);
+  const p50 = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
+  const p95 = latencies[Math.floor(latencies.length * 0.95)] ?? 0;
+  const passed = results.filter((r) => r.passed).length;
+  const gapTestIds = new Set(
+    CANNED_QUERIES.filter((q) => q.expected_behavior.includes('corpus gap')).map(
+      (q) => q.id,
+    ),
+  );
+  const gapTests = results.filter((r) => gapTestIds.has(r.query_id));
+
+  return {
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    total: results.length,
+    passed,
+    gap_tests_passed: gapTests.filter((r) => r.gap_signal?.gap).length,
+    latency_ms_p50: p50,
+    latency_ms_p95: p95,
+    results,
+  };
+}
+
+export function summarize(report: SmokeReport): string {
+  return (
+    `Amicus Smoke Report — ${report.passed}/${report.total} passed, ` +
+    `p50 ${report.latency_ms_p50}ms p95 ${report.latency_ms_p95}ms. ` +
+    `Started ${report.started_at}.`
+  );
+}
+
+// ── One-query runner ──────────────────────────────────────────────────
+
+async function runOne(
+  q: CannedQuery,
+  profile: Awaited<ReturnType<typeof generateProfile>>,
+  authToken: string,
+  chatUrl: string,
+  fetchImpl?: typeof fetch,
+): Promise<QueryResult> {
+  const failures: string[] = [];
+  const started = Date.now();
+  let citations: string[] = [];
+  let sourceTypes: ChunkSourceType[] = [];
+  let tokensIn = 0;
+  let tokensOut = 0;
+  let gapSignal: QueryResult['gap_signal'] = null;
+  let preview = '';
+
+  try {
+    const retrieved = await retrieve(
+      {
+        query: q.query,
+        profile,
+        currentChapterRef: q.current_chapter_ref,
+      },
+      { authToken, fetchImpl },
+    );
+
+    const chunks: RetrievedChunk[] = retrieved.chunks;
+    const accumulated = await streamChat({
+      authToken,
+      chatUrl,
+      fetchImpl,
+      chat: {
+        query: q.query,
+        retrieved_chunks: chunks.map((c) => ({
+          chunk_id: c.chunk_id,
+          source_type: c.source_type,
+          text: c.text,
+          metadata: c.metadata,
+        })),
+        profile_summary: profile.prose,
+        current_chapter_ref: q.current_chapter_ref
+          ? `${q.current_chapter_ref.book_id}/${q.current_chapter_ref.chapter_num}`
+          : null,
+        model_tier: 'haiku',
+        conversation_history: [],
+      },
+    });
+
+    citations = extractCitations(accumulated.text);
+    sourceTypes = Array.from(new Set(chunks.map((c) => c.source_type)));
+    tokensIn = accumulated.tokens_in;
+    tokensOut = accumulated.tokens_out;
+    gapSignal = extractTrailingJson(accumulated.text);
+    preview = accumulated.text.slice(0, 220);
+
+    // Assert against expectations
+    const isGapTest = q.expected_behavior.includes('corpus gap');
+    if (isGapTest) {
+      if (!gapSignal?.gap) failures.push('expected gap_signal.gap=true, got none');
+    } else {
+      assertCitations(q, citations, sourceTypes, failures);
+    }
+  } catch (err) {
+    failures.push(`retrieval error: ${(err as Error).message ?? String(err)}`);
+  }
+
+  const latency = Date.now() - started;
+  return {
+    query_id: q.id,
+    query: q.query,
+    passed: failures.length === 0,
+    citations,
+    source_types: sourceTypes,
+    latency_ms: latency,
+    tokens_in: tokensIn,
+    tokens_out: tokensOut,
+    gap_signal: gapSignal,
+    failures,
+    raw_response_preview: preview,
+  };
+}
+
+function assertCitations(
+  q: CannedQuery,
+  citations: string[],
+  sourceTypes: ChunkSourceType[],
+  failures: string[],
+): void {
+  const cset = new Set(citations);
+  const anyOf = q.expected_citations.must_include_any_of;
+  if (anyOf.length > 0 && !anyOf.some((c) => cset.has(c))) {
+    failures.push(
+      `none of must_include_any_of present: ${anyOf.join(', ')}`,
+    );
+  }
+  const tset = new Set(sourceTypes);
+  for (const t of q.expected_citations.must_include_source_types) {
+    if (!tset.has(t)) failures.push(`missing source_type: ${t}`);
+  }
+  for (const forbidden of q.expected_citations.must_not_include) {
+    if (cset.has(forbidden)) failures.push(`forbidden citation: ${forbidden}`);
+  }
+}
+
+// ── Streaming chat + token accounting ─────────────────────────────────
+
+interface ChatPayload {
+  query: string;
+  retrieved_chunks: unknown[];
+  profile_summary: string;
+  current_chapter_ref: string | null;
+  model_tier: 'haiku' | 'sonnet';
+  conversation_history: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+async function streamChat(args: {
+  authToken: string;
+  chatUrl: string;
+  fetchImpl?: typeof fetch;
+  chat: ChatPayload;
+}): Promise<{ text: string; tokens_in: number; tokens_out: number }> {
+  const resp = await (args.fetchImpl ?? fetch)(args.chatUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${args.authToken}`,
+    },
+    body: JSON.stringify(args.chat),
+  });
+  if (!resp.ok || !resp.body) {
+    throw new Error(`chat proxy ${resp.status}`);
+  }
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = '';
+  let tokensIn = 0;
+  let tokensOut = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    const text = decoder.decode(value, { stream: true });
+    for (const line of text.split('\n')) {
+      if (!line.startsWith('data:')) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === '[DONE]') continue;
+      try {
+        const ev = JSON.parse(payload) as {
+          type?: string;
+          delta?: { text?: string };
+          message?: { usage?: { input_tokens?: number; output_tokens?: number } };
+          usage?: { input_tokens?: number; output_tokens?: number };
+        };
+        if (ev.type === 'content_block_delta' && ev.delta?.text) {
+          accumulated += ev.delta.text;
+        }
+        const usage = ev.message?.usage ?? ev.usage;
+        if (usage) {
+          tokensIn += usage.input_tokens ?? 0;
+          tokensOut += usage.output_tokens ?? 0;
+        }
+      } catch {
+        /* non-JSON — ignore */
+      }
+    }
+  }
+  return { text: accumulated, tokens_in: tokensIn, tokens_out: tokensOut };
+}
+
+// ── Parsing helpers ───────────────────────────────────────────────────
+
+/** Pulls `[source_type:source_id]`-style citations out of free text. */
+export function extractCitations(text: string): string[] {
+  const out = new Set<string>();
+  const re = /\[([a-z_]+:[A-Za-z0-9_\-.]+)]/g;
+  for (const match of text.matchAll(re)) {
+    if (match[1]) out.add(match[1]);
+  }
+  return Array.from(out);
+}
+
+export function extractTrailingJson(
+  text: string,
+): { gap: boolean; gap_type?: string; topic?: string } | null {
+  const trimmed = text.trim();
+  if (!trimmed.endsWith('}')) return null;
+  let depth = 0;
+  let start = -1;
+  for (let i = trimmed.length - 1; i >= 0; i--) {
+    const c = trimmed[i];
+    if (c === '}') depth++;
+    else if (c === '{') {
+      depth--;
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+    }
+  }
+  if (start < 0) return null;
+  try {
+    const parsed = JSON.parse(trimmed.slice(start)) as Record<string, unknown>;
+    if (typeof parsed.gap !== 'boolean') return null;
+    return {
+      gap: parsed.gap,
+      gap_type: typeof parsed.gap_type === 'string' ? parsed.gap_type : undefined,
+      topic: typeof parsed.topic === 'string' ? parsed.topic : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export { CANNED_QUERIES };

--- a/app/src/services/amicus/__tests__/embed.test.ts
+++ b/app/src/services/amicus/__tests__/embed.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for embed.ts — proxy client for /ai/embed.
+ */
+import { embedQuery } from '../embed';
+import { AmicusError } from '../types';
+
+function fakeFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  return jest.fn(async (url: RequestInfo | URL, init?: RequestInit) =>
+    impl(String(url), init ?? {}),
+  ) as unknown as typeof fetch;
+}
+
+describe('embedQuery', () => {
+  it('returns the vector on success', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response(JSON.stringify({ vector: new Array(1536).fill(0.01) }), {
+        status: 200,
+      }),
+    );
+    const v = await embedQuery('hello', { authToken: 'tkn', fetchImpl });
+    expect(v).toHaveLength(1536);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws EMBED_FAILED when query is empty', async () => {
+    await expect(embedQuery('   ', { authToken: 'tkn' })).rejects.toMatchObject({
+      code: 'EMBED_FAILED',
+    });
+  });
+
+  it('throws EMBED_FAILED when vector shape is wrong', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response(JSON.stringify({ vector: [0, 0, 0] }), { status: 200 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+  });
+
+  it('throws PROXY_UNAUTHORIZED on 401', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('unauthorized', { status: 401 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'PROXY_UNAUTHORIZED' });
+  });
+
+  it('throws PROXY_UNAUTHORIZED on 402 (no entitlement)', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('payment required', { status: 402 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'PROXY_UNAUTHORIZED' });
+  });
+
+  it('retries once on 5xx then gives up', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('upstream dead', { status: 503 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('bails early (no retry) on 4xx other than 401/402', async () => {
+    const fetchImpl = fakeFetch(async () =>
+      new Response('bad request', { status: 400 }),
+    );
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toBeInstanceOf(AmicusError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('raises OFFLINE after retry when network throws', async () => {
+    const fetchImpl = fakeFetch(async () => {
+      throw new Error('network down');
+    });
+    await expect(
+      embedQuery('hi', { authToken: 'tkn', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'OFFLINE' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/services/amicus/__tests__/rerank.test.ts
+++ b/app/src/services/amicus/__tests__/rerank.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for rerank pipeline.
+ *
+ * Pure-compute, no DB, no network.
+ */
+import {
+  CURRENT_CHAPTER_BOOST,
+  RESULT_LIMIT,
+  SCHOLAR_BOOST,
+  SCHOLAR_DIVERSITY_CAP,
+  TRADITION_BOOST,
+  boostCurrentChapter,
+  boostPreferredScholars,
+  boostPreferredTraditions,
+  diversifyByScholar,
+  rerank,
+} from '../rerank';
+import type { CompressedProfile, RetrievedChunk } from '../types';
+
+function chunk(
+  chunk_id: string,
+  score: number,
+  metadata: RetrievedChunk['metadata'] = {},
+): RetrievedChunk {
+  return {
+    chunk_id,
+    source_type: 'section_panel',
+    source_id: chunk_id.split(':')[1] ?? chunk_id,
+    text: `text for ${chunk_id}`,
+    score,
+    metadata,
+  };
+}
+
+const BASIC_PROFILE: CompressedProfile = {
+  prose: 'Test profile',
+  preferred_scholars: [],
+  preferred_traditions: [],
+};
+
+describe('boostCurrentChapter', () => {
+  it('multiplies only chunks on the current chapter', () => {
+    const chunks = [
+      chunk('a', 1.0, { book_id: 'romans', chapter_num: 9 }),
+      chunk('b', 1.0, { book_id: 'romans', chapter_num: 10 }),
+      chunk('c', 1.0, { book_id: 'genesis', chapter_num: 1 }),
+    ];
+    const ref = { book_id: 'romans', chapter_num: 9 };
+    const boosted = boostCurrentChapter(chunks, ref);
+    expect(boosted[0]!.score).toBeCloseTo(CURRENT_CHAPTER_BOOST);
+    expect(boosted[1]!.score).toBe(1.0);
+    expect(boosted[2]!.score).toBe(1.0);
+  });
+
+  it('is a no-op when currentChapterRef is null', () => {
+    const c = [chunk('a', 0.5)];
+    expect(boostCurrentChapter(c, null)).toEqual(c);
+  });
+});
+
+describe('boostPreferredScholars', () => {
+  it('multiplies matching scholars and leaves others unchanged', () => {
+    const chunks = [
+      chunk('a', 1.0, { scholar_id: 'calvin' }),
+      chunk('b', 1.0, { scholar_id: 'sarna' }),
+      chunk('c', 1.0),
+    ];
+    const out = boostPreferredScholars(chunks, ['calvin']);
+    expect(out[0]!.score).toBeCloseTo(SCHOLAR_BOOST);
+    expect(out[1]!.score).toBe(1.0);
+    expect(out[2]!.score).toBe(1.0);
+  });
+
+  it('is a no-op when preferred list is empty', () => {
+    const c = [chunk('a', 0.5, { scholar_id: 'calvin' })];
+    expect(boostPreferredScholars(c, [])).toEqual(c);
+  });
+});
+
+describe('boostPreferredTraditions', () => {
+  it('multiplies matching traditions', () => {
+    const chunks = [
+      chunk('a', 1.0, { tradition: 'Reformed' }),
+      chunk('b', 1.0, { tradition: 'Jewish' }),
+    ];
+    const out = boostPreferredTraditions(chunks, ['Reformed']);
+    expect(out[0]!.score).toBeCloseTo(TRADITION_BOOST);
+    expect(out[1]!.score).toBe(1.0);
+  });
+});
+
+describe('diversifyByScholar', () => {
+  it('caps to 2 chunks per scholar by default', () => {
+    const chunks = [
+      chunk('1', 0.9, { scholar_id: 'calvin' }),
+      chunk('2', 0.8, { scholar_id: 'calvin' }),
+      chunk('3', 0.7, { scholar_id: 'calvin' }),
+      chunk('4', 0.6, { scholar_id: 'sarna' }),
+    ];
+    const out = diversifyByScholar(chunks);
+    const calvins = out.filter((c) => c.metadata.scholar_id === 'calvin');
+    expect(calvins).toHaveLength(SCHOLAR_DIVERSITY_CAP);
+    expect(out.map((c) => c.chunk_id)).toEqual(['1', '2', '4']);
+  });
+
+  it('passes through chunks without scholar_id', () => {
+    const chunks = [chunk('1', 0.9), chunk('2', 0.8), chunk('3', 0.7)];
+    expect(diversifyByScholar(chunks)).toEqual(chunks);
+  });
+});
+
+describe('rerank (end-to-end)', () => {
+  const profile: CompressedProfile = {
+    prose: 'p',
+    preferred_scholars: ['calvin'],
+    preferred_traditions: ['Reformed'],
+  };
+
+  it('applies boosts, diversifies, and caps at RESULT_LIMIT', () => {
+    const chunks: RetrievedChunk[] = [];
+    for (let i = 0; i < 15; i++) {
+      chunks.push(chunk(`${i}`, 0.5, { scholar_id: 'calvin' }));
+    }
+    const out = rerank(chunks, profile, null);
+    expect(out.length).toBeLessThanOrEqual(RESULT_LIMIT);
+    // Calvin cap of 2 still holds.
+    const calvins = out.filter((c) => c.metadata.scholar_id === 'calvin');
+    expect(calvins.length).toBeLessThanOrEqual(SCHOLAR_DIVERSITY_CAP);
+  });
+
+  it('does not invert score ordering with boosts', () => {
+    // a starts well ahead; boost to b shouldn't flip the order unless b is
+    // also close to a to begin with.
+    const chunks = [
+      chunk('a', 1.0),
+      chunk('b', 0.3, { scholar_id: 'calvin' }), // +10% = 0.33
+    ];
+    const out = rerank(chunks, profile, null);
+    expect(out[0]!.chunk_id).toBe('a');
+    expect(out[1]!.chunk_id).toBe('b');
+  });
+
+  it('sorts by score descending', () => {
+    const chunks = [chunk('lo', 0.3), chunk('hi', 0.9), chunk('mid', 0.6)];
+    const out = rerank(chunks, BASIC_PROFILE, null);
+    expect(out.map((c) => c.chunk_id)).toEqual(['hi', 'mid', 'lo']);
+  });
+});

--- a/app/src/services/amicus/__tests__/retrieval.test.ts
+++ b/app/src/services/amicus/__tests__/retrieval.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration-ish tests for retrieval orchestrator.
+ *
+ * Wires together a fake proxy (via fetchImpl) and the mock scripture.db so
+ * the whole pipeline can be exercised without real network or native SQLite.
+ */
+import { retrieve } from '../retrieval';
+import { AmicusError, type CompressedProfile, type RetrievedChunk } from '../types';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
+
+jest.mock('@/db/database', () => require('../../../../__tests__/helpers/mockDb').mockDatabaseModule());
+
+function fakeEmbedResponse(): Response {
+  return new Response(JSON.stringify({ vector: new Array(1536).fill(0.01) }), {
+    status: 200,
+  });
+}
+
+const PROFILE: CompressedProfile = {
+  prose: 'Test profile',
+  preferred_scholars: ['calvin'],
+  preferred_traditions: ['Reformed'],
+};
+
+describe('retrieve', () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  it('returns up to 10 boosted, diversified chunks', async () => {
+    const mock = getMockDb();
+    const rows = Array.from({ length: 30 }).map((_, i) => ({
+      chunk_id: `section_panel:chunk-${i}`,
+      source_type: 'section_panel',
+      source_id: `chunk-${i}`,
+      text: `text ${i}`,
+      distance: 0.1 * i,
+      scholar_id: i % 3 === 0 ? 'calvin' : 'wright',
+      tradition: i % 3 === 0 ? 'Reformed' : 'Evangelical',
+      book_id: 'romans',
+      chapter_num: 9,
+      verse_start: null,
+      verse_end: null,
+      panel_type: 'calvin',
+    }));
+    mock.getAllAsync.mockResolvedValueOnce(rows);
+
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    const result = await retrieve(
+      {
+        query: 'election in Romans 9',
+        profile: PROFILE,
+        currentChapterRef: { book_id: 'romans', chapter_num: 9 },
+      },
+      { authToken: 'tkn', fetchImpl },
+    );
+
+    expect(result.chunks.length).toBeGreaterThan(0);
+    expect(result.chunks.length).toBeLessThanOrEqual(10);
+    expect(result.embedMs).toBeGreaterThanOrEqual(0);
+    // Chapter boost shown — every returned chunk is on romans 9 so all get ×1.5
+    for (const c of result.chunks) {
+      expect(c.score).toBeGreaterThan(0);
+    }
+  });
+
+  it('propagates AmicusError.OFFLINE from embed', async () => {
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network');
+    }) as unknown as typeof fetch;
+
+    await expect(
+      retrieve(
+        {
+          query: 'q',
+          profile: PROFILE,
+          currentChapterRef: null,
+        },
+        { authToken: 'tkn', fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: 'OFFLINE' });
+  });
+
+  it('propagates EXTENSION_NOT_LOADED from vector search', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockRejectedValueOnce(new Error('no such module: vec0'));
+
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    await expect(
+      retrieve(
+        { query: 'q', profile: PROFILE, currentChapterRef: null },
+        { authToken: 'tkn', fetchImpl },
+      ),
+    ).rejects.toBeInstanceOf(AmicusError);
+  });
+
+  it('returns an empty result when vector search finds no matches', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([]);
+    const fetchImpl = jest.fn(async () => fakeEmbedResponse()) as unknown as typeof fetch;
+
+    const r = await retrieve(
+      { query: 'q', profile: PROFILE, currentChapterRef: null },
+      { authToken: 'tkn', fetchImpl },
+    );
+    expect(r.chunks).toEqual<RetrievedChunk[]>([]);
+  });
+});

--- a/app/src/services/amicus/__tests__/vectorSearch.test.ts
+++ b/app/src/services/amicus/__tests__/vectorSearch.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for vectorSearch pure helpers (packVector, distanceToSimilarity) and
+ * for the searchByVector error path when sqlite-vec isn't loaded. The full
+ * SQL path is covered in the integration smoke test (#1453).
+ */
+import { distanceToSimilarity, packVector, searchByVector } from '../vectorSearch';
+import { AmicusError } from '../types';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
+
+jest.mock('@/db/database', () => require('../../../../__tests__/helpers/mockDb').mockDatabaseModule());
+
+describe('packVector', () => {
+  it('produces 4 bytes per float, little-endian', () => {
+    const blob = packVector([1.0, 0.5]);
+    expect(blob.byteLength).toBe(8);
+    const view = new DataView(blob.buffer);
+    expect(view.getFloat32(0, true)).toBeCloseTo(1.0);
+    expect(view.getFloat32(4, true)).toBeCloseTo(0.5);
+  });
+
+  it('handles 1536-dim vectors', () => {
+    const v = new Array(1536).fill(0.01);
+    const blob = packVector(v);
+    expect(blob.byteLength).toBe(1536 * 4);
+  });
+});
+
+describe('distanceToSimilarity', () => {
+  it('is 1 at distance 0', () => {
+    expect(distanceToSimilarity(0)).toBe(1);
+  });
+  it('monotonically decreases with distance', () => {
+    expect(distanceToSimilarity(1)).toBeGreaterThan(distanceToSimilarity(2));
+    expect(distanceToSimilarity(10)).toBeGreaterThan(distanceToSimilarity(100));
+  });
+  it('clamps invalid input to 0', () => {
+    expect(distanceToSimilarity(-1)).toBe(0);
+    expect(distanceToSimilarity(Number.NaN)).toBe(0);
+  });
+});
+
+describe('searchByVector', () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  it('maps rows into RetrievedChunk shape', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([
+      {
+        chunk_id: 'section_panel:romans-9-s1-calvin',
+        source_type: 'section_panel',
+        source_id: 'romans-9-s1-calvin',
+        text: 'Calvin on election',
+        distance: 0.2,
+        scholar_id: 'calvin',
+        tradition: 'Reformed',
+        book_id: 'romans',
+        chapter_num: 9,
+        verse_start: 1,
+        verse_end: 29,
+        panel_type: 'calvin',
+      },
+    ]);
+
+    const chunks = await searchByVector([0, 0, 0]);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.chunk_id).toBe('section_panel:romans-9-s1-calvin');
+    expect(chunks[0]!.score).toBeGreaterThan(0);
+    expect(chunks[0]!.metadata.scholar_id).toBe('calvin');
+  });
+
+  it('throws EXTENSION_NOT_LOADED when sqlite-vec is missing', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockRejectedValueOnce(new Error('no such module: vec0'));
+    await expect(searchByVector([0, 0])).rejects.toBeInstanceOf(AmicusError);
+    try {
+      await searchByVector([0, 0]);
+    } catch (err) {
+      expect((err as AmicusError).code).toBe('EXTENSION_NOT_LOADED');
+    }
+  });
+
+  it('returns [] when the vec0 table is empty', async () => {
+    const mock = getMockDb();
+    mock.getAllAsync.mockResolvedValueOnce([]);
+    expect(await searchByVector([0, 0])).toEqual([]);
+  });
+});

--- a/app/src/services/amicus/embed.ts
+++ b/app/src/services/amicus/embed.ts
@@ -1,0 +1,81 @@
+/**
+ * services/amicus/embed.ts — Embed a user query via the Amicus proxy.
+ *
+ * The proxy (#1450) forwards to OpenAI `text-embedding-3-small` and returns
+ * a 1536-dim vector. We retry exactly once on network / 5xx so a flaky
+ * connection doesn't instantly disable Amicus.
+ */
+import { AmicusError } from './types';
+import { logger } from '@/utils/logger';
+
+const PROXY_BASE =
+  (process.env.EXPO_PUBLIC_AMICUS_PROXY_URL ?? 'https://ai.contentcompanionstudy.com').replace(/\/$/, '');
+
+const EMBED_DIM = 1536;
+
+export interface EmbedOptions {
+  /** RevenueCat receipt token used as the Authorization bearer. */
+  authToken: string;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Soft timeout for each attempt, ms. */
+  timeoutMs?: number;
+}
+
+export async function embedQuery(text: string, opts: EmbedOptions): Promise<number[]> {
+  if (!text.trim()) {
+    throw new AmicusError('EMBED_FAILED', 'empty query');
+  }
+
+  const attempt = async (): Promise<Response> => {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), opts.timeoutMs ?? 5000);
+    try {
+      return await (opts.fetchImpl ?? fetch)(`${PROXY_BASE}/ai/embed`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${opts.authToken}`,
+        },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(t);
+    }
+  };
+
+  let lastErr: unknown;
+  for (let i = 0; i < 2; i++) {
+    try {
+      const resp = await attempt();
+      if (resp.status === 401 || resp.status === 402) {
+        throw new AmicusError('PROXY_UNAUTHORIZED', `proxy ${resp.status}`);
+      }
+      if (!resp.ok) {
+        lastErr = new Error(`proxy ${resp.status}`);
+        if (resp.status < 500) break; // 4xx won't get better by retrying
+        continue;
+      }
+      const payload = (await resp.json()) as { vector?: number[] };
+      if (!Array.isArray(payload.vector) || payload.vector.length !== EMBED_DIM) {
+        throw new AmicusError('EMBED_FAILED', 'invalid vector shape');
+      }
+      return payload.vector;
+    } catch (err) {
+      if (err instanceof AmicusError) throw err;
+      lastErr = err;
+      // AbortError / network error — retry once, then bail as OFFLINE.
+      if (i === 0) {
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
+      logger.warn('Amicus', 'embed failed after retry', err);
+      throw new AmicusError('OFFLINE', (err as Error).message ?? 'network');
+    }
+  }
+  logger.warn('Amicus', 'embed failed', lastErr);
+  throw new AmicusError('EMBED_FAILED', (lastErr as Error)?.message ?? 'unknown');
+}
+
+export const _internal = { EMBED_DIM, PROXY_BASE };

--- a/app/src/services/amicus/index.ts
+++ b/app/src/services/amicus/index.ts
@@ -1,0 +1,19 @@
+/**
+ * services/amicus/index.ts — Public entry point for the Amicus service layer.
+ *
+ * Keep the surface small: callers should use `retrieve()` and the shared
+ * types. Internals (rerank, vectorSearch, embed) are importable for tests
+ * but not part of the public contract.
+ */
+export { retrieve } from './retrieval';
+export type { RetrievalResult, RetrieveOptions } from './retrieval';
+export { AmicusError } from './types';
+export type {
+  AmicusErrorCode,
+  ChunkSourceType,
+  ChunkMetadata,
+  CompressedProfile,
+  ChapterRef,
+  RetrievalContext,
+  RetrievedChunk,
+} from './types';

--- a/app/src/services/amicus/profile/__tests__/generator.test.ts
+++ b/app/src/services/amicus/profile/__tests__/generator.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the profile generator — hashing + cache invalidation semantics.
+ *
+ * We stub collectSignals() rather than driving the real SQL path, so the
+ * tests exercise generator-level logic (hashing, cache hit, cache expiry,
+ * force refresh) without depending on mock-call ordering.
+ */
+import { clearProfile, generateProfile, hashRawSignals } from '../generator';
+import type { RawSignals } from '../types';
+import {
+  getMockUserDb,
+  resetMockUserDb,
+} from '../../../../../__tests__/helpers/mockUserDb';
+import { resetMockDb } from '../../../../../__tests__/helpers/mockDb';
+
+jest.mock(
+  '@/db/userDatabase',
+  () => require('../../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+jest.mock(
+  '@/db/database',
+  () => require('../../../../../__tests__/helpers/mockDb').mockDatabaseModule(),
+);
+
+// Stub collectSignals so we can control exactly what generateProfile sees.
+const STUB_SIGNALS: RawSignals = {
+  total_chapters_read: 120,
+  last_30_day_chapters: 30,
+  top_scholars_opened: [
+    { scholar_id: 'calvin', open_count: 40 },
+    { scholar_id: 'sarna', open_count: 25 },
+  ],
+  tradition_distribution: { Reformed: 0.6, Jewish: 0.3 },
+  genre_distribution: { epistle: 0.4, narrative: 0.4, wisdom: 0.2 },
+  completed_journeys: ['garden_to_city'],
+  active_journey: 'holy_week',
+  recent_chapters: [
+    { book_id: 'romans', chapter_num: 9, last_visit: '2026-04-17T12:00:00.000Z' },
+  ],
+  current_focus: { book_id: 'romans', chapters_in_range: 7, days_in_range: 14 },
+};
+
+jest.mock('../signals', () => {
+  const actual = jest.requireActual<typeof import('../signals')>('../signals');
+  return {
+    ...actual,
+    collectSignals: jest.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockedSignals = require('../signals') as { collectSignals: jest.Mock };
+
+beforeEach(() => {
+  resetMockUserDb();
+  resetMockDb();
+  mockedSignals.collectSignals.mockResolvedValue(STUB_SIGNALS);
+});
+
+describe('hashRawSignals', () => {
+  it('is deterministic for identical signal objects', async () => {
+    const a = await hashRawSignals(STUB_SIGNALS);
+    const b = await hashRawSignals(STUB_SIGNALS);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('changes when any field changes', async () => {
+    const base = await hashRawSignals(STUB_SIGNALS);
+    const mutated = await hashRawSignals({
+      ...STUB_SIGNALS,
+      total_chapters_read: 121,
+    });
+    expect(base).not.toBe(mutated);
+  });
+
+  it('is key-order-independent', async () => {
+    const reordered: RawSignals = {
+      current_focus: STUB_SIGNALS.current_focus,
+      active_journey: STUB_SIGNALS.active_journey,
+      recent_chapters: STUB_SIGNALS.recent_chapters,
+      completed_journeys: STUB_SIGNALS.completed_journeys,
+      genre_distribution: STUB_SIGNALS.genre_distribution,
+      tradition_distribution: STUB_SIGNALS.tradition_distribution,
+      top_scholars_opened: STUB_SIGNALS.top_scholars_opened,
+      last_30_day_chapters: STUB_SIGNALS.last_30_day_chapters,
+      total_chapters_read: STUB_SIGNALS.total_chapters_read,
+    };
+    expect(await hashRawSignals(STUB_SIGNALS)).toBe(await hashRawSignals(reordered));
+  });
+});
+
+describe('generateProfile', () => {
+  it('writes and returns a fresh profile on cache miss', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue(null);
+
+    const profile = await generateProfile();
+    expect(profile.prose).toMatch(/chapters total/);
+    expect(profile.preferred_scholars).toContain('calvin');
+    expect(profile.preferred_traditions).toContain('Reformed');
+    expect(profile.raw_signals_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('short-circuits on cache hit with matching hash', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'cached prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).toBe('cached prose');
+    expect(user.runAsync).not.toHaveBeenCalled();
+  });
+
+  it('regenerates on hash mismatch', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'stale prose',
+      raw_signals_hash: 'different-hash-value',
+      raw_signals_json: '{}',
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).not.toBe('stale prose');
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('regenerates on expired cache (>7 days)', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'very old prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const profile = await generateProfile();
+    expect(profile.prose).not.toBe('very old prose');
+    expect(user.runAsync).toHaveBeenCalled();
+  });
+
+  it('force=true bypasses the cache even on match', async () => {
+    const hash = await hashRawSignals(STUB_SIGNALS);
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue({
+      profile_prose: 'cached prose',
+      raw_signals_hash: hash,
+      raw_signals_json: JSON.stringify(STUB_SIGNALS),
+      generated_at: new Date().toISOString(),
+    });
+
+    const profile = await generateProfile(true);
+    expect(profile.prose).not.toBe('cached prose');
+  });
+
+  it('stores the signals JSON so inspection can round-trip', async () => {
+    const user = getMockUserDb();
+    user.getFirstAsync.mockResolvedValue(null);
+    await generateProfile();
+    const [, bindings] = user.runAsync.mock.calls[0]!;
+    // bindings = [prose, hash, json, ts]
+    const stored = JSON.parse(bindings[2] as string) as RawSignals;
+    expect(stored.total_chapters_read).toBe(120);
+  });
+});
+
+describe('clearProfile', () => {
+  it('deletes the singleton row', async () => {
+    await clearProfile();
+    const user = getMockUserDb();
+    expect(user.runAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM partner_profile_cache/),
+    );
+  });
+});

--- a/app/src/services/amicus/profile/__tests__/templates.test.ts
+++ b/app/src/services/amicus/profile/__tests__/templates.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for prose assembly templates.
+ *
+ * Pure function — no DB or network.
+ */
+import { MAX_PROSE_CHARS, assembleProfile } from '../templates';
+import type { RawSignals } from '../types';
+
+function signals(overrides: Partial<RawSignals> = {}): RawSignals {
+  return {
+    total_chapters_read: 0,
+    last_30_day_chapters: 0,
+    top_scholars_opened: [],
+    tradition_distribution: {},
+    genre_distribution: {},
+    completed_journeys: [],
+    active_journey: null,
+    recent_chapters: [],
+    current_focus: null,
+    ...overrides,
+  };
+}
+
+describe('assembleProfile', () => {
+  it('produces a minimal prose for new users (thin profile)', () => {
+    const out = assembleProfile(signals());
+    expect(out.prose).toContain('New to Companion Study');
+    expect(out.preferred_scholars).toEqual([]);
+    expect(out.preferred_traditions).toEqual([]);
+  });
+
+  it('adds current-chapter clause for new users if they have one', () => {
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 0,
+        recent_chapters: [
+          { book_id: 'genesis', chapter_num: 3, last_visit: new Date().toISOString() },
+        ],
+      }),
+    );
+    expect(out.prose).toMatch(/Genesis 3/);
+  });
+
+  it('builds a full thick profile with boosts', () => {
+    const recent = new Date().toISOString();
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 123,
+        current_focus: { book_id: 'romans', chapters_in_range: 7, days_in_range: 14 },
+        top_scholars_opened: [
+          { scholar_id: 'calvin', open_count: 40 },
+          { scholar_id: 'sarna', open_count: 18 },
+          { scholar_id: 'wright', open_count: 5 }, // below threshold
+        ],
+        tradition_distribution: { Reformed: 0.55, Jewish: 0.25 },
+        completed_journeys: ['garden_to_city'],
+        active_journey: 'holy_week',
+        recent_chapters: [
+          { book_id: 'romans', chapter_num: 9, last_visit: recent },
+        ],
+      }),
+    );
+    expect(out.prose).toMatch(/123 chapters total/);
+    expect(out.prose).toMatch(/Romans/);
+    expect(out.prose).toMatch(/Calvin and Sarna/);
+    expect(out.prose).toMatch(/Reformed/);
+    expect(out.prose).toMatch(/Holy Week/);
+    expect(out.preferred_scholars).toEqual(['calvin', 'sarna']);
+    expect(out.preferred_traditions).toEqual(['Reformed']);
+  });
+
+  it('omits tradition clause when no tradition clears 30%', () => {
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 10,
+        tradition_distribution: { Reformed: 0.2, Jewish: 0.2, Evangelical: 0.2 },
+      }),
+    );
+    expect(out.prose).not.toMatch(/perspectives/);
+    expect(out.preferred_traditions).toEqual([]);
+  });
+
+  it('truncates oversized input', () => {
+    const bigCompleted = Array.from({ length: 50 }, (_, i) => `journey_${i}`);
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 9999,
+        completed_journeys: bigCompleted,
+        active_journey: 'x'.repeat(400),
+      }),
+    );
+    expect(out.prose.length).toBeLessThanOrEqual(MAX_PROSE_CHARS);
+  });
+
+  it('omits current-reading when last visit is older than 24h', () => {
+    const stale = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const out = assembleProfile(
+      signals({
+        total_chapters_read: 5,
+        recent_chapters: [{ book_id: 'john', chapter_num: 1, last_visit: stale }],
+      }),
+    );
+    expect(out.prose).not.toMatch(/Currently reading/);
+  });
+});

--- a/app/src/services/amicus/profile/generator.ts
+++ b/app/src/services/amicus/profile/generator.ts
@@ -1,0 +1,175 @@
+/**
+ * services/amicus/profile/generator.ts — Entry point for compressed-profile
+ * generation, caching, inspection, and reset.
+ *
+ * The cache lives in user.db's `partner_profile_cache` table (singleton row,
+ * id=1). A regenerated profile is written in place; we never accumulate
+ * rows.
+ */
+import { collectSignals } from './signals';
+import { assembleProfile } from './templates';
+import type {
+  CompressedProfile,
+  ProfileForInspection,
+  RawSignals,
+} from './types';
+import { logger } from '@/utils/logger';
+import { getUserDb } from '@/db/userDatabase';
+
+const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface CachedRow {
+  profile_prose: string;
+  raw_signals_hash: string;
+  raw_signals_json: string;
+  generated_at: string;
+}
+
+export async function generateProfile(force = false): Promise<CompressedProfile> {
+  const signals = await collectSignals();
+  const hash = await hashRawSignals(signals);
+
+  if (!force) {
+    const cached = await readCache();
+    if (cached && cached.raw_signals_hash === hash && !isExpired(cached.generated_at)) {
+      logger.info('AmicusProfile', 'cache hit');
+      return rehydrateFromCache(cached);
+    }
+  }
+
+  const assembled = assembleProfile(signals);
+  const now = new Date().toISOString();
+  const profile: CompressedProfile = {
+    prose: assembled.prose,
+    preferred_scholars: assembled.preferred_scholars,
+    preferred_traditions: assembled.preferred_traditions,
+    generated_at: now,
+    raw_signals_hash: hash,
+  };
+
+  await writeCache(profile, signals);
+  return profile;
+}
+
+export async function getProfileForInspection(): Promise<ProfileForInspection> {
+  const profile = await generateProfile(false);
+  const signals = await loadCachedSignals();
+  return {
+    prose: profile.prose,
+    preferred_scholars: profile.preferred_scholars,
+    preferred_traditions: profile.preferred_traditions,
+    generated_at: profile.generated_at,
+    raw_signals: signals ?? (await collectSignals()),
+  };
+}
+
+export async function clearProfile(): Promise<void> {
+  await getUserDb().runAsync('DELETE FROM partner_profile_cache');
+  logger.info('AmicusProfile', 'cache cleared');
+}
+
+// ── Internals ─────────────────────────────────────────────────────────
+
+async function readCache(): Promise<CachedRow | null> {
+  try {
+    const row = await getUserDb().getFirstAsync<CachedRow>(
+      'SELECT profile_prose, raw_signals_hash, raw_signals_json, generated_at '
+        + 'FROM partner_profile_cache WHERE id = 1',
+    );
+    return row ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadCachedSignals(): Promise<RawSignals | null> {
+  const row = await readCache();
+  if (!row || !row.raw_signals_json) return null;
+  try {
+    return JSON.parse(row.raw_signals_json) as RawSignals;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  profile: CompressedProfile,
+  signals: RawSignals,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO partner_profile_cache
+       (id, profile_prose, raw_signals_hash, raw_signals_json, generated_at)
+     VALUES (1, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       profile_prose    = excluded.profile_prose,
+       raw_signals_hash = excluded.raw_signals_hash,
+       raw_signals_json = excluded.raw_signals_json,
+       generated_at     = excluded.generated_at`,
+    [
+      profile.prose,
+      profile.raw_signals_hash,
+      JSON.stringify(signals),
+      profile.generated_at,
+    ],
+  );
+}
+
+function rehydrateFromCache(row: CachedRow): CompressedProfile {
+  let preferred_scholars: string[] = [];
+  let preferred_traditions: string[] = [];
+  try {
+    const parsed = JSON.parse(row.raw_signals_json) as RawSignals;
+    preferred_scholars = (parsed.top_scholars_opened ?? [])
+      .filter((s) => s.open_count >= 10)
+      .map((s) => s.scholar_id);
+    preferred_traditions = pickTraditionsAboveThreshold(parsed.tradition_distribution);
+  } catch {
+    /* ignore — worst case we omit boosts and regenerate on next cycle */
+  }
+  return {
+    prose: row.profile_prose,
+    preferred_scholars,
+    preferred_traditions,
+    generated_at: row.generated_at,
+    raw_signals_hash: row.raw_signals_hash,
+  };
+}
+
+function pickTraditionsAboveThreshold(
+  distribution: Record<string, number> | undefined,
+): string[] {
+  if (!distribution) return [];
+  return Object.entries(distribution)
+    .filter(([, share]) => share >= 0.3)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => name);
+}
+
+function isExpired(generatedAt: string): boolean {
+  const t = Date.parse(generatedAt);
+  if (!Number.isFinite(t)) return true;
+  return Date.now() - t > CACHE_MAX_AGE_MS;
+}
+
+/**
+ * SHA-256 over a canonical JSON encoding of the signals object. Keys are
+ * sorted so semantically identical signals produce the same hash.
+ */
+export async function hashRawSignals(signals: RawSignals): Promise<string> {
+  const canonical = canonicalize(signals);
+  const data = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return '{' + entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',') + '}';
+}

--- a/app/src/services/amicus/profile/index.ts
+++ b/app/src/services/amicus/profile/index.ts
@@ -1,0 +1,17 @@
+/**
+ * services/amicus/profile/index.ts — Public entry point.
+ */
+export {
+  generateProfile,
+  getProfileForInspection,
+  clearProfile,
+  hashRawSignals,
+} from './generator';
+export type {
+  CompressedProfile,
+  ProfileForInspection,
+  RawSignals,
+  ScholarEngagement,
+  RecentChapter,
+  CurrentFocus,
+} from './types';

--- a/app/src/services/amicus/profile/signals.ts
+++ b/app/src/services/amicus/profile/signals.ts
@@ -1,0 +1,198 @@
+/**
+ * services/amicus/profile/signals.ts — Pull engagement signals from user.db.
+ *
+ * All queries are deterministic so the same database state produces the same
+ * hash. Signals cover reading progress, scholar opens, tradition/genre
+ * distribution, journey state, and current study focus.
+ */
+import type {
+  CurrentFocus,
+  RawSignals,
+  RecentChapter,
+  ScholarEngagement,
+} from './types';
+import { getUserDb } from '@/db/userDatabase';
+import { getDb } from '@/db/database';
+import { logger } from '@/utils/logger';
+
+const RECENT_WINDOW_DAYS = 30;
+const CURRENT_FOCUS_WINDOW_DAYS = 14;
+const CURRENT_FOCUS_MIN_CHAPTERS = 3;
+const TOP_SCHOLARS_LIMIT = 5;
+const SCHOLAR_ENGAGEMENT_FLOOR = 10;
+
+export async function collectSignals(): Promise<RawSignals> {
+  const [totals, recent30, scholars, traditions, genres, journeys, recentChapters, focus] =
+    await Promise.all([
+      getTotalChaptersRead(),
+      getChaptersReadInLastDays(RECENT_WINDOW_DAYS),
+      getTopScholarsOpened(TOP_SCHOLARS_LIMIT),
+      getTraditionDistribution(),
+      getGenreDistribution(),
+      getJourneyState(),
+      getRecentChapters(10),
+      getCurrentFocus(),
+    ]);
+
+  return {
+    total_chapters_read: totals,
+    last_30_day_chapters: recent30,
+    top_scholars_opened: scholars,
+    tradition_distribution: traditions,
+    genre_distribution: genres,
+    completed_journeys: journeys.completed,
+    active_journey: journeys.active,
+    recent_chapters: recentChapters,
+    current_focus: focus,
+  };
+}
+
+export async function getTotalChaptersRead(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM reading_progress WHERE completed_at IS NOT NULL',
+  );
+  return row?.n ?? 0;
+}
+
+export async function getChaptersReadInLastDays(days: number): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM reading_progress
+     WHERE completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)`,
+    [`-${days} days`],
+  );
+  return row?.n ?? 0;
+}
+
+export async function getTopScholarsOpened(limit: number): Promise<ScholarEngagement[]> {
+  try {
+    const rows = await getUserDb().getAllAsync<ScholarEngagement>(
+      `SELECT scholar_id, COUNT(*) AS open_count
+       FROM scholar_opens
+       GROUP BY scholar_id
+       ORDER BY open_count DESC
+       LIMIT ?`,
+      [limit],
+    );
+    return rows;
+  } catch (err) {
+    // scholar_opens is a future engagement table — return empty until it exists.
+    logger.info('AmicusProfile', `scholar_opens unavailable: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+export async function getTraditionDistribution(): Promise<Record<string, number>> {
+  const scholars = await getTopScholarsOpened(100);
+  if (scholars.length === 0) return {};
+
+  const ids = scholars.map((s) => s.scholar_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = await getDb().getAllAsync<{ tradition: string | null; id: string }>(
+    `SELECT id, tradition FROM scholars WHERE id IN (${placeholders})`,
+    ids,
+  );
+  const traditionById = new Map(rows.map((r) => [r.id, r.tradition]));
+
+  const totals = new Map<string, number>();
+  let grand = 0;
+  for (const s of scholars) {
+    const t = traditionById.get(s.scholar_id);
+    if (!t) continue;
+    totals.set(t, (totals.get(t) ?? 0) + s.open_count);
+    grand += s.open_count;
+  }
+  if (grand === 0) return {};
+
+  const result: Record<string, number> = {};
+  for (const [k, v] of totals) result[k] = v / grand;
+  return result;
+}
+
+export async function getGenreDistribution(): Promise<Record<string, number>> {
+  const rows = await getDb().getAllAsync<{ genre: string | null; n: number }>(
+    `SELECT b.genre AS genre, COUNT(*) AS n
+     FROM books b
+     JOIN reading_progress rp ON rp.book_id = b.id
+     WHERE rp.completed_at IS NOT NULL
+     GROUP BY b.genre`,
+  );
+  const totals: Record<string, number> = {};
+  let grand = 0;
+  for (const r of rows) {
+    if (!r.genre) continue;
+    totals[r.genre] = (totals[r.genre] ?? 0) + r.n;
+    grand += r.n;
+  }
+  if (grand === 0) return {};
+  for (const k of Object.keys(totals)) totals[k] = (totals[k] ?? 0) / grand;
+  return totals;
+}
+
+export async function getJourneyState(): Promise<{
+  completed: string[];
+  active: string | null;
+}> {
+  try {
+    const completedRows = await getUserDb().getAllAsync<{ journey_id: string }>(
+      'SELECT journey_id FROM journey_progress WHERE completed_at IS NOT NULL ORDER BY completed_at',
+    );
+    const activeRow = await getUserDb().getFirstAsync<{ journey_id: string }>(
+      `SELECT journey_id FROM journey_progress
+       WHERE completed_at IS NULL
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+    );
+    return {
+      completed: completedRows.map((r) => r.journey_id),
+      active: activeRow?.journey_id ?? null,
+    };
+  } catch (err) {
+    // journey_progress not yet populated for this user — safe to skip.
+    logger.info('AmicusProfile', `journey_progress unavailable: ${(err as Error).message}`);
+    return { completed: [], active: null };
+  }
+}
+
+export async function getRecentChapters(limit: number): Promise<RecentChapter[]> {
+  const rows = await getUserDb().getAllAsync<RecentChapter>(
+    `SELECT book_id, chapter_num, completed_at AS last_visit
+     FROM reading_progress
+     WHERE completed_at IS NOT NULL
+     ORDER BY completed_at DESC
+     LIMIT ?`,
+    [limit],
+  );
+  return rows;
+}
+
+/**
+ * A "current focus" is detected when the user has read ≥N chapters of a single
+ * book in the last M days. Gives the profile a useful hook like "recently
+ * focused on Romans" without requiring explicit user declaration.
+ */
+export async function getCurrentFocus(): Promise<CurrentFocus | null> {
+  const rows = await getUserDb().getAllAsync<{
+    book_id: string;
+    n: number;
+    first: string;
+  }>(
+    `SELECT book_id, COUNT(*) AS n, MIN(completed_at) AS first
+     FROM reading_progress
+     WHERE completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)
+     GROUP BY book_id
+     ORDER BY n DESC
+     LIMIT 1`,
+    [`-${CURRENT_FOCUS_WINDOW_DAYS} days`],
+  );
+  const top = rows[0];
+  if (!top || top.n < CURRENT_FOCUS_MIN_CHAPTERS) return null;
+  return {
+    book_id: top.book_id,
+    chapters_in_range: top.n,
+    days_in_range: CURRENT_FOCUS_WINDOW_DAYS,
+  };
+}
+
+export { SCHOLAR_ENGAGEMENT_FLOOR };

--- a/app/src/services/amicus/profile/templates.ts
+++ b/app/src/services/amicus/profile/templates.ts
@@ -1,0 +1,133 @@
+/**
+ * services/amicus/profile/templates.ts — Prose assembly from signals.
+ *
+ * Each section is optional and is added only when its signal is meaningful.
+ * For thin profiles (new users) the output is deliberately minimal so that
+ * Amicus does not over-personalize based on scant data.
+ */
+import { SCHOLAR_ENGAGEMENT_FLOOR } from './signals';
+import type { RawSignals } from './types';
+
+const TRADITION_THRESHOLD = 0.3;
+const MAX_PROSE_CHARS = 800; // hard upper bound; ~200 tokens at 4 chars/token
+
+interface AssembledPieces {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+}
+
+export function assembleProfile(signals: RawSignals): AssembledPieces {
+  const sentences: string[] = [];
+  const preferredScholars: string[] = [];
+  const preferredTraditions: string[] = [];
+
+  // Thin profile path
+  if (signals.total_chapters_read === 0) {
+    sentences.push(
+      'New to Companion Study; no established study patterns yet.',
+    );
+    if (signals.recent_chapters.length > 0) {
+      const r = signals.recent_chapters[0]!;
+      sentences.push(`Currently reading ${capitalize(r.book_id)} ${r.chapter_num}.`);
+    }
+    return {
+      prose: truncate(sentences.join(' ')),
+      preferred_scholars: [],
+      preferred_traditions: [],
+    };
+  }
+
+  // 1. Baseline
+  sentences.push(`Studied ${signals.total_chapters_read} chapters total.`);
+
+  // 2. Recent focus
+  if (signals.current_focus) {
+    sentences.push(
+      `Recently focused on ${capitalize(signals.current_focus.book_id)}` +
+        ` (${signals.current_focus.chapters_in_range} chapters in the last` +
+        ` ${signals.current_focus.days_in_range} days).`,
+    );
+  }
+
+  // 3. Scholar affinity
+  const meaningfulScholars = signals.top_scholars_opened.filter(
+    (s) => s.open_count >= SCHOLAR_ENGAGEMENT_FLOOR,
+  );
+  if (meaningfulScholars.length > 0) {
+    const top2 = meaningfulScholars.slice(0, 2).map((s) => s.scholar_id);
+    sentences.push(
+      `Engages deeply with ${top2.map(capitalize).join(' and ')}.`,
+    );
+    preferredScholars.push(...meaningfulScholars.map((s) => s.scholar_id));
+  }
+
+  // 4. Tradition lean
+  const topTradition = pickTopTradition(signals.tradition_distribution);
+  if (topTradition) {
+    sentences.push(
+      `Shows interest in ${topTradition.name} perspectives.`,
+    );
+    preferredTraditions.push(topTradition.name);
+  }
+
+  // 5. Journey state
+  if (signals.completed_journeys.length > 0 || signals.active_journey) {
+    const parts: string[] = [];
+    if (signals.completed_journeys.length > 0) {
+      const names = signals.completed_journeys.slice(-2).map(capitalize).join(' and ');
+      parts.push(`Completed ${names}`);
+    }
+    if (signals.active_journey) {
+      parts.push(`currently on ${capitalize(signals.active_journey)}`);
+    }
+    sentences.push(parts.join(', ') + '.');
+  }
+
+  // 6. Current position (only if within last 24h)
+  const newest = signals.recent_chapters[0];
+  if (newest && isWithin24h(newest.last_visit)) {
+    sentences.push(
+      `Currently reading ${capitalize(newest.book_id)} ${newest.chapter_num}.`,
+    );
+  }
+
+  return {
+    prose: truncate(sentences.join(' ')),
+    preferred_scholars: preferredScholars,
+    preferred_traditions: preferredTraditions,
+  };
+}
+
+function pickTopTradition(
+  distribution: Record<string, number>,
+): { name: string; share: number } | null {
+  let best: { name: string; share: number } | null = null;
+  for (const [name, share] of Object.entries(distribution)) {
+    if (share < TRADITION_THRESHOLD) continue;
+    if (!best || share > best.share) {
+      best = { name, share };
+    }
+  }
+  return best;
+}
+
+function capitalize(s: string): string {
+  return s
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function isWithin24h(iso: string): boolean {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return Date.now() - t < 24 * 60 * 60 * 1000;
+}
+
+function truncate(s: string): string {
+  if (s.length <= MAX_PROSE_CHARS) return s;
+  return s.slice(0, MAX_PROSE_CHARS - 1).replace(/\s\S*$/, '') + '…';
+}
+
+export { MAX_PROSE_CHARS };

--- a/app/src/services/amicus/profile/types.ts
+++ b/app/src/services/amicus/profile/types.ts
@@ -1,0 +1,56 @@
+/**
+ * services/amicus/profile/types.ts — Profile generator types.
+ *
+ * `CompressedProfile` here is the full runtime shape; the leaner public
+ * version exported from `services/amicus/types.ts` is a strict subset
+ * to keep the retrieval service decoupled from the cache.
+ */
+
+export interface ScholarEngagement {
+  scholar_id: string;
+  open_count: number;
+}
+
+export interface RecentChapter {
+  book_id: string;
+  chapter_num: number;
+  last_visit: string;
+}
+
+export interface CurrentFocus {
+  book_id: string;
+  chapters_in_range: number;
+  days_in_range: number;
+}
+
+export interface RawSignals {
+  total_chapters_read: number;
+  last_30_day_chapters: number;
+  top_scholars_opened: ScholarEngagement[];
+  tradition_distribution: Record<string, number>;
+  genre_distribution: Record<string, number>;
+  completed_journeys: string[];
+  active_journey: string | null;
+  recent_chapters: RecentChapter[];
+  current_focus: CurrentFocus | null;
+}
+
+export interface CompressedProfile {
+  /** 100-200 token prose summary sent to Amicus and displayed in settings. */
+  prose: string;
+  /** Flat lists used by the re-ranker (kept in sync with the prose). */
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+  /** ISO timestamp of when the prose was generated. */
+  generated_at: string;
+  /** SHA-256 of the raw signals used — for cache invalidation. */
+  raw_signals_hash: string;
+}
+
+export interface ProfileForInspection {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+  generated_at: string;
+  raw_signals: RawSignals;
+}

--- a/app/src/services/amicus/rerank.ts
+++ b/app/src/services/amicus/rerank.ts
@@ -1,0 +1,98 @@
+/**
+ * services/amicus/rerank.ts — Profile + context boosts and diversity filter.
+ *
+ * Pure functions so every step is unit-testable without a database.
+ *
+ * Pipeline (see plan §6):
+ *   1. boost current chapter × 1.5
+ *   2. boost preferred scholars × 1.1
+ *   3. boost preferred traditions × 1.05
+ *   4. diversify: max 2 chunks per scholar_id
+ *   5. sort desc, return top 10
+ */
+import type { ChapterRef, CompressedProfile, RetrievedChunk } from './types';
+
+export const CURRENT_CHAPTER_BOOST = 1.5;
+export const SCHOLAR_BOOST = 1.1;
+export const TRADITION_BOOST = 1.05;
+export const SCHOLAR_DIVERSITY_CAP = 2;
+export const RESULT_LIMIT = 10;
+
+export function boostCurrentChapter(
+  chunks: RetrievedChunk[],
+  currentChapterRef: ChapterRef | null,
+): RetrievedChunk[] {
+  if (!currentChapterRef) return chunks;
+  return chunks.map((c) => {
+    const m = c.metadata;
+    if (m.book_id === currentChapterRef.book_id && m.chapter_num === currentChapterRef.chapter_num) {
+      return { ...c, score: c.score * CURRENT_CHAPTER_BOOST };
+    }
+    return c;
+  });
+}
+
+export function boostPreferredScholars(
+  chunks: RetrievedChunk[],
+  preferred: string[],
+): RetrievedChunk[] {
+  if (preferred.length === 0) return chunks;
+  const set = new Set(preferred);
+  return chunks.map((c) => {
+    const sid = c.metadata.scholar_id;
+    return sid && set.has(sid) ? { ...c, score: c.score * SCHOLAR_BOOST } : c;
+  });
+}
+
+export function boostPreferredTraditions(
+  chunks: RetrievedChunk[],
+  preferred: string[],
+): RetrievedChunk[] {
+  if (preferred.length === 0) return chunks;
+  const set = new Set(preferred);
+  return chunks.map((c) => {
+    const t = c.metadata.tradition;
+    return t && set.has(t) ? { ...c, score: c.score * TRADITION_BOOST } : c;
+  });
+}
+
+/**
+ * Cap the number of chunks per scholar_id. Walks the already-sorted list
+ * and drops chunks beyond the cap so the most relevant ones are kept.
+ */
+export function diversifyByScholar(
+  chunks: RetrievedChunk[],
+  cap: number = SCHOLAR_DIVERSITY_CAP,
+): RetrievedChunk[] {
+  const seen = new Map<string, number>();
+  const out: RetrievedChunk[] = [];
+  for (const c of chunks) {
+    const sid = c.metadata.scholar_id;
+    if (!sid) {
+      out.push(c);
+      continue;
+    }
+    const n = seen.get(sid) ?? 0;
+    if (n >= cap) continue;
+    seen.set(sid, n + 1);
+    out.push(c);
+  }
+  return out;
+}
+
+/**
+ * End-to-end rerank: apply all boosts, sort by score desc, diversify,
+ * and return the top RESULT_LIMIT.
+ */
+export function rerank(
+  chunks: RetrievedChunk[],
+  profile: CompressedProfile,
+  currentChapterRef: ChapterRef | null,
+): RetrievedChunk[] {
+  const step1 = boostCurrentChapter(chunks, currentChapterRef);
+  const step2 = boostPreferredScholars(step1, profile.preferred_scholars);
+  const step3 = boostPreferredTraditions(step2, profile.preferred_traditions);
+  const sorted = [...step3].sort((a, b) => b.score - a.score);
+  const diversified = diversifyByScholar(sorted);
+  return diversified.slice(0, RESULT_LIMIT);
+}

--- a/app/src/services/amicus/retrieval.ts
+++ b/app/src/services/amicus/retrieval.ts
@@ -1,0 +1,73 @@
+/**
+ * services/amicus/retrieval.ts — Top-level Amicus retrieval orchestrator.
+ *
+ * Pipeline:
+ *   1. embed query via proxy /ai/embed
+ *   2. sqlite-vec MATCH against scripture.db (local)
+ *   3. re-rank with profile + context boosts, diversify, top-10
+ *
+ * Typed errors bubble up so UI can choose graceful fallback:
+ *   - AmicusError.EMBED_FAILED        — proxy 4xx/5xx or shape mismatch
+ *   - AmicusError.OFFLINE             — network unreachable
+ *   - AmicusError.EXTENSION_NOT_LOADED — sqlite-vec not loaded on the connection
+ *   - AmicusError.PROXY_UNAUTHORIZED   — 401/402 from proxy
+ */
+import { embedQuery } from './embed';
+import { rerank } from './rerank';
+import { searchByVector } from './vectorSearch';
+import { AmicusError, type RetrievalContext, type RetrievedChunk } from './types';
+import { logger } from '@/utils/logger';
+
+export interface RetrieveOptions {
+  /** Bearer token for the proxy. Usually the RevenueCat receipt. */
+  authToken: string;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Vector-search candidate pool size before re-ranking. */
+  candidatePoolSize?: number;
+}
+
+export interface RetrievalResult {
+  chunks: RetrievedChunk[];
+  /** Milliseconds spent embedding (proxy round-trip). */
+  embedMs: number;
+  /** Milliseconds spent in sqlite-vec search + hydration. */
+  searchMs: number;
+  /** Milliseconds spent re-ranking. */
+  rerankMs: number;
+}
+
+export async function retrieve(
+  ctx: RetrievalContext,
+  opts: RetrieveOptions,
+): Promise<RetrievalResult> {
+  const startEmbed = Date.now();
+  let vector: number[];
+  try {
+    vector = await embedQuery(ctx.query, {
+      authToken: opts.authToken,
+      fetchImpl: opts.fetchImpl,
+    });
+  } catch (err) {
+    if (err instanceof AmicusError) throw err;
+    throw new AmicusError('EMBED_FAILED', (err as Error).message);
+  }
+  const embedMs = Date.now() - startEmbed;
+
+  const startSearch = Date.now();
+  const candidates = await searchByVector(vector, {
+    limit: opts.candidatePoolSize ?? 40,
+  });
+  const searchMs = Date.now() - startSearch;
+
+  const startRerank = Date.now();
+  const chunks = rerank(candidates, ctx.profile, ctx.currentChapterRef);
+  const rerankMs = Date.now() - startRerank;
+
+  logger.info(
+    'Amicus',
+    `retrieval: ${chunks.length} chunks (embed ${embedMs}ms, search ${searchMs}ms, rerank ${rerankMs}ms)`,
+  );
+
+  return { chunks, embedMs, searchMs, rerankMs };
+}

--- a/app/src/services/amicus/types.ts
+++ b/app/src/services/amicus/types.ts
@@ -1,0 +1,76 @@
+/**
+ * services/amicus/types.ts — Shared types for the Amicus service layer.
+ *
+ * Source types listed here mirror the chunker in `_tools/build_embeddings_chunks.py`
+ * and the Worker's `ai-proxy/src/types.ts`. Keep them aligned.
+ */
+
+export type ChunkSourceType =
+  | 'section_panel'
+  | 'chapter_panel'
+  | 'word_study'
+  | 'lexicon_entry'
+  | 'debate_topic'
+  | 'cross_ref_thread_note'
+  | 'journey_stop'
+  | 'meta_faq';
+
+export interface ChunkMetadata {
+  scholar_id?: string;
+  tradition?: string;
+  book_id?: string;
+  chapter_num?: number;
+  verse_start?: number;
+  verse_end?: number;
+  panel_type?: string;
+}
+
+export interface RetrievedChunk {
+  chunk_id: string;
+  source_type: ChunkSourceType;
+  source_id: string;
+  text: string;
+  /** Final score after all boosts and normalizations. Higher is more relevant. */
+  score: number;
+  metadata: ChunkMetadata;
+}
+
+/**
+ * Snapshot of a user's study profile used for re-ranking.
+ *
+ * Produced by `generateProfile()` in #1452. Retained here as a structural
+ * type so we don't take a hard import dependency on the profile module
+ * before #1452 ships.
+ */
+export interface CompressedProfile {
+  prose: string;
+  preferred_scholars: string[];
+  preferred_traditions: string[];
+}
+
+export interface ChapterRef {
+  book_id: string;
+  chapter_num: number;
+}
+
+export interface RetrievalContext {
+  query: string;
+  profile: CompressedProfile;
+  currentChapterRef: ChapterRef | null;
+}
+
+/** Union of all typed retrieval failures. */
+export type AmicusErrorCode =
+  | 'EMBED_FAILED'
+  | 'EXTENSION_NOT_LOADED'
+  | 'OFFLINE'
+  | 'PROXY_UNAUTHORIZED';
+
+export class AmicusError extends Error {
+  readonly code: AmicusErrorCode;
+  constructor(code: AmicusErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+    this.name = 'AmicusError';
+  }
+}

--- a/app/src/services/amicus/vectorSearch.ts
+++ b/app/src/services/amicus/vectorSearch.ts
@@ -1,0 +1,117 @@
+/**
+ * services/amicus/vectorSearch.ts — sqlite-vec query layer.
+ *
+ * Runs the vec0 MATCH search against scripture.db and joins chunk_text +
+ * chunk_metadata to produce typed results. Keeps the raw-SQL surface
+ * localized so the orchestrator doesn't need to know the schema.
+ */
+import { AmicusError, type ChunkSourceType, type RetrievedChunk } from './types';
+import { getDb } from '@/db/database';
+import { logger } from '@/utils/logger';
+
+export interface VectorSearchRow {
+  chunk_id: string;
+  source_type: ChunkSourceType;
+  source_id: string;
+  text: string;
+  distance: number;
+  scholar_id: string | null;
+  tradition: string | null;
+  book_id: string | null;
+  chapter_num: number | null;
+  verse_start: number | null;
+  verse_end: number | null;
+  panel_type: string | null;
+}
+
+/**
+ * Pack a number[] vector into a little-endian float32 Uint8Array blob
+ * suitable for a sqlite-vec MATCH parameter.
+ */
+export function packVector(vector: number[]): Uint8Array {
+  const buf = new ArrayBuffer(vector.length * 4);
+  const view = new DataView(buf);
+  for (let i = 0; i < vector.length; i++) {
+    view.setFloat32(i * 4, vector[i]!, true /* littleEndian */);
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Convert sqlite-vec's L2 distance into a similarity score in [0, 1].
+ * The raw distance is unbounded; we use `1 / (1 + d)` so higher = more
+ * relevant and the result stays finite. This is monotonic with distance
+ * and preserves ordering, which is all the re-ranker needs.
+ */
+export function distanceToSimilarity(distance: number): number {
+  if (!Number.isFinite(distance) || distance < 0) return 0;
+  return 1 / (1 + distance);
+}
+
+export interface SearchOptions {
+  /** How many candidates to ask sqlite-vec for before re-ranking. */
+  limit?: number;
+}
+
+/**
+ * Execute the vec0 MATCH query and hydrate results. Throws
+ * AmicusError.EXTENSION_NOT_LOADED if sqlite-vec isn't on the connection.
+ */
+export async function searchByVector(
+  vector: number[],
+  opts: SearchOptions = {},
+): Promise<RetrievedChunk[]> {
+  const limit = opts.limit ?? 40;
+  const db = getDb();
+  const blob = packVector(vector);
+
+  let rows: VectorSearchRow[];
+  try {
+    rows = await db.getAllAsync<VectorSearchRow>(
+      `SELECT
+         m.chunk_id        AS chunk_id,
+         m.source_type     AS source_type,
+         m.source_id       AS source_id,
+         t.text            AS text,
+         e.distance        AS distance,
+         m.scholar_id      AS scholar_id,
+         m.tradition       AS tradition,
+         m.book_id         AS book_id,
+         m.chapter_num     AS chapter_num,
+         m.verse_start     AS verse_start,
+         m.verse_end       AS verse_end,
+         m.panel_type      AS panel_type
+       FROM embeddings e
+       JOIN chunk_text t      ON t.rowid = e.rowid
+       JOIN chunk_metadata m  ON m.rowid = e.rowid
+       WHERE e.embedding MATCH ?
+       ORDER BY e.distance
+       LIMIT ?`,
+      [blob, limit],
+    );
+  } catch (err) {
+    const msg = (err as Error).message ?? '';
+    if (msg.includes('vec0') || msg.includes('no such module') || msg.includes('embeddings')) {
+      logger.error('Amicus', 'sqlite-vec not loaded on scripture.db', err);
+      throw new AmicusError('EXTENSION_NOT_LOADED', msg);
+    }
+    throw err;
+  }
+
+  return rows.map((r) => ({
+    chunk_id: r.chunk_id,
+    source_type: r.source_type,
+    source_id: r.source_id,
+    text: r.text,
+    score: distanceToSimilarity(r.distance),
+    metadata: {
+      scholar_id: r.scholar_id ?? undefined,
+      tradition: r.tradition ?? undefined,
+      book_id: r.book_id ?? undefined,
+      chapter_num: r.chapter_num ?? undefined,
+      verse_start: r.verse_start ?? undefined,
+      verse_end: r.verse_end ?? undefined,
+      panel_type: r.panel_type ?? undefined,
+    },
+  }));
+}


### PR DESCRIPTION
Closes #1453. Depends on #1447, #1448, #1450, #1451, #1452.

## Summary
- New dev-only harness for the Phase 1 end-to-end smoke test.
- 10 canned queries span multi-source synthesis, lexicon lookup, debate topic, cross-testament typology, journey stops, corpus gap (q06, expected to fire `gap_signal.gap=true`), meta-FAQ, character study, archaeology, and textual transmission.
- Hidden in production by `featureFlags.AMICUS_SMOKE_TEST` (requires `__DEV__` **and** `EXPO_PUBLIC_AMICUS_SMOKE=true`).

## New modules
- `app/src/constants/featureFlags.ts` — the flag registry (first occupant is `AMICUS_SMOKE_TEST`).
- `app/src/services/amicus/__smoke__/canned_queries.json` — 10 queries w/ expected citations + source types.
- `app/src/services/amicus/__smoke__/runSmokeTest.ts` — harness: retrieves, streams chat, extracts citations, parses gap_signal, builds SmokeReport with p50/p95 latency.
- `app/src/screens/dev/AmicusSmokeScreen.tsx` — minimal utility UI: Run button, expandable per-query rows, Copy-JSON-to-clipboard.

## Wiring
- `app/src/navigation/types.ts` — adds `AmicusSmoke` to `MoreStackParamList`.
- `app/src/navigation/MoreStack.tsx` — lazy-registered only when the flag is on.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 3,239 tests pass (10 new: canned-query shape, citation extraction, trailing-JSON parsing)
- [x] Feature flag invisible in production builds (flag evaluates false)
- [x] Report JSON structure round-trips through clipboard
- [ ] **Reviewer runs the harness in a dev build against staging proxy** — target ≥9/10 pass and p95 <5s (Phase 1 exit criterion). Full run requires live RevenueCat receipt + staging Worker; instructions are in this PR body.

## How to run locally
1. `cd app && EXPO_PUBLIC_AMICUS_SMOKE=true EXPO_PUBLIC_AMICUS_DEV_TOKEN=<receipt> EXPO_PUBLIC_AMICUS_PROXY_URL=https://ai-staging.contentcompanionstudy.com npm run dev`
2. Nav: More → AmicusSmoke
3. Tap "Run all 10 queries"
4. Copy JSON report and paste into this PR comment when done

## Out of scope
- Production accuracy audit pipeline — #1468 (Phase 5)
- Any beta-user distribution — handled separately
- UI polish — this is an internal utility

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe