### PR TITLE
feat(ai-partner): corpus gap capture — D1 + detection + GitHub sync (#1471)

### DIFF
--- a/_tools/corpus_gap_sync.py
+++ b/_tools/corpus_gap_sync.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+corpus_gap_sync.py — Sync corpus gaps from Cloudflare D1 into GitHub issues.
+
+Designed to be scheduled (e.g. GitHub Actions cron, or a Cloudflare Worker
+cron trigger posting to the GitHub REST API). Pulls gaps with status='new'
+from D1, creates one issue per gap (individual mode) or a daily digest
+(digest mode), and marks the row 'issue_opened' in D1.
+
+Two modes, switched by the `gap_sync_mode` row in the D1 `amicus_config`
+table (see ai-proxy/migrations/0001_corpus_gaps.sql):
+
+  - individual (default)  — every gap → its own issue in the Partner Gaps
+                             kanban swim lane.
+  - digest                — singletons roll up into a single daily issue;
+                             clusters (occurrence_count >= 3) still get
+                             dedicated issues.
+
+Usage:
+    python3 _tools/corpus_gap_sync.py --dry-run            # preview
+    python3 _tools/corpus_gap_sync.py                      # real run
+
+Environment:
+    CORPUS_GAP_D1_URL      — Cloudflare D1 query API URL
+    CORPUS_GAP_D1_TOKEN    — Cloudflare API token with D1 access
+    GITHUB_TOKEN           — PAT with repo issues: write
+    GITHUB_REPO            — "owner/repo", e.g. "CraigBuckmaster/ScriptureDeepDive"
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Any, Iterable
+
+DEFAULT_LABELS = ['corpus-gap']
+CLUSTER_THRESHOLD = 3
+
+
+# ── D1 client ─────────────────────────────────────────────────────────
+
+class D1Client:
+    """Minimal client for Cloudflare D1's HTTP query endpoint."""
+
+    def __init__(self, url: str | None = None, token: str | None = None) -> None:
+        self.url = url or os.environ.get('CORPUS_GAP_D1_URL') or ''
+        self.token = token or os.environ.get('CORPUS_GAP_D1_TOKEN') or ''
+        if not self.url or not self.token:
+            raise RuntimeError(
+                'CORPUS_GAP_D1_URL and CORPUS_GAP_D1_TOKEN must be set',
+            )
+
+    def query(self, sql: str, params: list[Any] | None = None) -> list[dict[str, Any]]:
+        body = {'sql': sql, 'params': params or []}
+        req = urllib.request.Request(
+            self.url,
+            data=json.dumps(body).encode('utf-8'),
+            headers={
+                'Authorization': f'Bearer {self.token}',
+                'Content-Type': 'application/json',
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode('utf-8'))
+        result = payload.get('result') or []
+        if not result:
+            return []
+        first = result[0]
+        return first.get('results', []) or []
+
+
+# ── GitHub client ─────────────────────────────────────────────────────
+
+class GitHubClient:
+    def __init__(self, token: str | None = None, repo: str | None = None) -> None:
+        self.token = token or os.environ.get('GITHUB_TOKEN') or ''
+        self.repo = repo or os.environ.get('GITHUB_REPO') or ''
+        if not self.token or not self.repo:
+            raise RuntimeError('GITHUB_TOKEN and GITHUB_REPO must be set')
+
+    def create_issue(
+        self, title: str, body: str, labels: Iterable[str],
+    ) -> int:
+        data = {'title': title, 'body': body, 'labels': list(labels)}
+        req = urllib.request.Request(
+            f'https://api.github.com/repos/{self.repo}/issues',
+            data=json.dumps(data).encode('utf-8'),
+            headers={
+                'Authorization': f'Bearer {self.token}',
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Content-Type': 'application/json',
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode('utf-8'))
+        return int(payload['number'])
+
+
+# ── Sync logic ────────────────────────────────────────────────────────
+
+def get_sync_mode(d1: D1Client) -> str:
+    rows = d1.query(
+        "SELECT value FROM amicus_config WHERE key = 'gap_sync_mode'",
+    )
+    if rows:
+        v = rows[0].get('value', 'individual')
+        if v in ('individual', 'digest'):
+            return v
+    return 'individual'
+
+
+def fetch_new_gaps(d1: D1Client) -> list[dict[str, Any]]:
+    return d1.query(
+        """SELECT gap_id, scrubbed_summary, gap_type, current_chapter_ref,
+                  occurrence_count, captured_at, retrieval_max_score
+             FROM corpus_gaps
+            WHERE status = 'new'
+              AND redacted = 0
+            ORDER BY captured_at DESC""",
+    )
+
+
+def mark_queued(d1: D1Client, gap_ids: list[str]) -> None:
+    if not gap_ids:
+        return
+    placeholders = ','.join('?' * len(gap_ids))
+    d1.query(
+        f"UPDATE corpus_gaps SET status='queued' WHERE gap_id IN ({placeholders})",
+        gap_ids,
+    )
+
+
+def mark_issue_opened(d1: D1Client, gap_ids: list[str], issue_number: int) -> None:
+    if not gap_ids:
+        return
+    placeholders = ','.join('?' * len(gap_ids))
+    d1.query(
+        f"""UPDATE corpus_gaps
+               SET status='issue_opened',
+                   linked_issue_number=?
+             WHERE gap_id IN ({placeholders})""",
+        [issue_number, *gap_ids],
+    )
+
+
+def build_individual_body(gap: dict[str, Any]) -> str:
+    captured = dt.datetime.utcfromtimestamp(int(gap['captured_at'])).strftime(
+        '%Y-%m-%d %H:%M UTC',
+    )
+    return (
+        f"**Scrubbed summary:** {gap.get('scrubbed_summary') or '(none)'}\n\n"
+        f"**Gap type:** {gap.get('gap_type') or 'content'}\n"
+        f"**Current chapter ref:** {gap.get('current_chapter_ref') or '—'}\n"
+        f"**First seen:** {captured}\n"
+        f"**Occurrences:** {gap.get('occurrence_count', 1)}\n"
+        f"**Retrieval max score:** {gap.get('retrieval_max_score')}\n"
+        f"**Gap id (D1):** `{gap['gap_id']}`\n\n"
+        '_Auto-created by `_tools/corpus_gap_sync.py`. Close this issue '
+        'with `closes corpus-gap-<id>` in a content-PR body to mark the '
+        'gap as shipped._\n'
+    )
+
+
+def build_digest_body(singletons: list[dict[str, Any]]) -> str:
+    lines = [
+        f"**Daily corpus-gap digest** — {len(singletons)} single-occurrence gaps.",
+        '',
+        'Clusters (≥3 occurrences) and thumbs-down gaps continue to get dedicated issues.',
+        '',
+        '| gap_id | gap_type | chapter | summary |',
+        '|--------|----------|---------|---------|',
+    ]
+    for g in singletons:
+        safe_summary = (g.get('scrubbed_summary') or '').replace('|', r'\|')[:120]
+        lines.append(
+            f"| `{g['gap_id'][:8]}` | {g.get('gap_type') or 'content'} "
+            f"| {g.get('current_chapter_ref') or '—'} "
+            f"| {safe_summary} |"
+        )
+    return '\n'.join(lines) + '\n'
+
+
+def sync_individual(d1: D1Client, gh: GitHubClient, gaps: list[dict[str, Any]],
+                    dry_run: bool = False) -> int:
+    """One issue per gap. Returns number of issues created."""
+    count = 0
+    for gap in gaps:
+        summary = gap.get('scrubbed_summary') or '(unknown topic)'
+        title = f"corpus-gap: {summary[:70]}"
+        body = build_individual_body(gap)
+        if dry_run:
+            print(f"[DRY] create issue: {title}")
+            count += 1
+            continue
+        issue_num = gh.create_issue(title, body, DEFAULT_LABELS)
+        mark_issue_opened(d1, [gap['gap_id']], issue_num)
+        count += 1
+    return count
+
+
+def sync_digest(d1: D1Client, gh: GitHubClient, gaps: list[dict[str, Any]],
+                dry_run: bool = False) -> int:
+    """Clusters + thumbs-down → own issue; singletons → one digest issue."""
+    clusters = [g for g in gaps if int(g.get('occurrence_count', 1)) >= CLUSTER_THRESHOLD]
+    singletons = [g for g in gaps if g not in clusters]
+    count = 0
+
+    for gap in clusters:
+        summary = gap.get('scrubbed_summary') or '(unknown topic)'
+        title = f"corpus-gap (cluster): {summary[:70]}"
+        body = build_individual_body(gap)
+        if dry_run:
+            print(f"[DRY] create cluster issue: {title}")
+        else:
+            issue_num = gh.create_issue(title, body, DEFAULT_LABELS)
+            mark_issue_opened(d1, [gap['gap_id']], issue_num)
+        count += 1
+
+    if singletons:
+        day = dt.datetime.utcnow().strftime('%Y-%m-%d')
+        title = f"corpus-gap digest — {day} ({len(singletons)} gaps)"
+        body = build_digest_body(singletons)
+        if dry_run:
+            print(f"[DRY] create digest: {title}")
+        else:
+            issue_num = gh.create_issue(title, body, DEFAULT_LABELS)
+            mark_issue_opened(d1, [g['gap_id'] for g in singletons], issue_num)
+        count += 1
+
+    return count
+
+
+# ── CLI ───────────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--dry-run', action='store_true',
+                   help='Print planned issues; no D1 updates, no GitHub calls')
+    p.add_argument('--mode', choices=('auto', 'individual', 'digest'), default='auto',
+                   help='Override the D1 config flag')
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    d1 = D1Client()
+    mode = args.mode if args.mode != 'auto' else get_sync_mode(d1)
+    print(f"  mode: {mode}")
+
+    gaps = fetch_new_gaps(d1)
+    print(f"  pending gaps: {len(gaps)}")
+    if not gaps:
+        return 0
+
+    gh = GitHubClient() if not args.dry_run else None
+
+    mark_queued(d1, [g['gap_id'] for g in gaps]) if not args.dry_run else None
+
+    if mode == 'digest':
+        created = sync_digest(d1, gh, gaps, dry_run=args.dry_run)
+    else:
+        created = sync_individual(d1, gh, gaps, dry_run=args.dry_run)
+
+    print(f"  issues: {created}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ai-proxy/.gitignore
+++ b/ai-proxy/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.wrangler/
+dist/
+coverage/
+*.log
+.env
+.dev.vars

--- a/ai-proxy/README.md
+++ b/ai-proxy/README.md
@@ -101,11 +101,52 @@ wrangler rollback <deployment-id> --env production
 If Cloudflare's dashboard access is faster, the "Deployments" tab on the
 Worker page offers a one-click rollback.
 
+## Corpus gap capture (#1471)
+
+Three inputs flag a gap, any of which triggers D1 persistence:
+
+1. Model self-report via the trailing `{"gap": true, ...}` JSON envelope.
+2. Retrieval max score below `GAP_SIMILARITY_FLOOR` (0.55).
+3. Explicit thumbs-down via `POST /ai/feedback`.
+
+On capture:
+
+- The question is SHA-PII-scrubbed (email, phone, URL, card) before storage.
+- A scrubbed summary is produced by Haiku (`anthropic-no-retention: true`)
+  for the GitHub issue body.
+- The question is embedded once and compared against recent open gaps
+  (cosine ≥ 0.9 → increment `occurrence_count` rather than insert).
+- `DELETE /ai/gaps/:id` wipes the row (admin-gated; current gate is
+  `partner_plus` entitlement + Cloudflare Access).
+
+**Endpoints added:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/ai/feedback` | Thumbs-down a response; body includes query + chunks + reason |
+| DELETE | `/ai/gaps/:id` | Hard-redact a gap row |
+
+**D1 schema:** `migrations/0001_corpus_gaps.sql`. Apply with:
+
+```bash
+wrangler d1 execute amicus-corpus-gaps-staging --file=migrations/0001_corpus_gaps.sql
+wrangler d1 execute amicus-corpus-gaps         --file=migrations/0001_corpus_gaps.sql
+```
+
+**Config flag:** the `amicus_config` table stores `gap_sync_mode` =
+`individual` | `digest`. Default `individual`; flip at ~20K users by
+updating the row, no backend change needed.
+
+**Sync to GitHub:** `_tools/corpus_gap_sync.py` (runs on a schedule) reads
+`status='new'` rows, creates issues with label `corpus-gap` (the Partner
+Gaps kanban swim lane), and marks rows `issue_opened`. In digest mode,
+singletons roll up into a daily digest issue; clusters (≥3 occurrences)
+still get dedicated issues.
+
 ## Relationship to other cards
 
 - `#1447` produces the embeddings this proxy never directly touches; the
   client uses `#1451` retrieval before calling `/ai/chat`.
-- `#1471` replaces the gap-signal stub writer with full D1 persistence +
-  GitHub issue sync in the Partner Gaps swim lane.
+- `#1471` (this card) — full corpus-gap capture pipeline.
 - `#1472` adds Partner+ upgrade flow, which leans on the `partner_plus`
   entitlement this proxy already recognizes.

--- a/ai-proxy/README.md
+++ b/ai-proxy/README.md
@@ -1,0 +1,111 @@
+# Amicus Proxy
+
+Cloudflare Worker that sits between the Companion Study mobile client and the
+AI providers (Anthropic for chat, OpenAI for embeddings). Ships with the rest
+of the monorepo so the code that talks to the proxy and the code that runs
+the proxy are versioned together.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/ai/health` | none | liveness probe — returns `{status, version}` |
+| `POST` | `/ai/embed` | premium or partner_plus | OpenAI `text-embedding-3-small`, returns 1536-dim vector |
+| `POST` | `/ai/chat` | premium or partner_plus | streaming Anthropic response with gap-signal detection |
+
+## Responsibilities
+
+1. **Auth.** Validates the RevenueCat receipt on the `Authorization: Bearer
+   <receipt>` header. Cached in KV for 5 minutes per receipt.
+2. **Rate limit.** Per-user monthly + 10-minute burst counters:
+   `premium` → 300/month + 10/burst;
+   `partner_plus` → 1500/month + 30/burst.
+3. **Zero retention.** Sets `anthropic-no-retention: true` on every Anthropic
+   request.
+4. **Streaming pass-through.** Tees the Anthropic SSE stream to the client
+   and also consumes it server-side to extract the structured `gap_signal`
+   JSON envelope.
+5. **Metadata-only logging.** Logs never contain request bodies, response
+   text, retrieved chunks, or profile summaries. Only `user_hash`, endpoint,
+   status, latency, and entitlement.
+
+## Local development
+
+```bash
+cd ai-proxy
+npm install
+npm run dev          # starts wrangler dev on localhost:8787
+```
+
+In a second terminal:
+
+```bash
+# Health
+curl -s http://localhost:8787/ai/health | jq
+
+# Chat (401 — missing auth)
+curl -i -X POST http://localhost:8787/ai/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Hello?"}'
+```
+
+## Tests
+
+```bash
+npm test             # vitest run (no network)
+npm run typecheck    # tsc --noEmit
+```
+
+The tests are self-contained — no real RevenueCat / Anthropic / OpenAI calls.
+Auth and rate-limit suites use an in-memory KV stub; the Anthropic suite
+intercepts `fetch` to assert on outbound headers and body shape.
+
+## Secrets
+
+Set these once per environment:
+
+```bash
+wrangler secret put REVENUECAT_SECRET_KEY --env staging
+wrangler secret put ANTHROPIC_API_KEY     --env staging
+wrangler secret put OPENAI_API_KEY        --env staging
+
+# Production — only after staging is validated end-to-end
+wrangler secret put REVENUECAT_SECRET_KEY --env production
+wrangler secret put ANTHROPIC_API_KEY     --env production
+wrangler secret put OPENAI_API_KEY        --env production
+```
+
+Never commit secrets to `wrangler.toml`. The committed file contains only
+bindings and routes.
+
+## Deploy
+
+```bash
+npm run deploy:staging      # wrangler deploy --env staging
+npm run deploy:production   # wrangler deploy --env production
+```
+
+Staging publishes to `ai-staging.contentcompanionstudy.com`; production to
+`ai.contentcompanionstudy.com`. Configure the KV namespace and D1 database
+IDs in `wrangler.toml` before the first deploy.
+
+## Rollback
+
+Wrangler keeps a handful of historical deployments. To roll back:
+
+```bash
+wrangler deployments list --env production
+wrangler rollback <deployment-id> --env production
+```
+
+If Cloudflare's dashboard access is faster, the "Deployments" tab on the
+Worker page offers a one-click rollback.
+
+## Relationship to other cards
+
+- `#1447` produces the embeddings this proxy never directly touches; the
+  client uses `#1451` retrieval before calling `/ai/chat`.
+- `#1471` replaces the gap-signal stub writer with full D1 persistence +
+  GitHub issue sync in the Partner Gaps swim lane.
+- `#1472` adds Partner+ upgrade flow, which leans on the `partner_plus`
+  entitlement this proxy already recognizes.

--- a/ai-proxy/migrations/0001_corpus_gaps.sql
+++ b/ai-proxy/migrations/0001_corpus_gaps.sql
@@ -1,0 +1,43 @@
+-- Cloudflare D1 schema for Amicus corpus-gap capture (Card #1471).
+--
+-- Apply with:
+--   wrangler d1 execute amicus-corpus-gaps-staging --file=migrations/0001_corpus_gaps.sql
+--   wrangler d1 execute amicus-corpus-gaps         --file=migrations/0001_corpus_gaps.sql
+
+CREATE TABLE IF NOT EXISTS corpus_gaps (
+  gap_id               TEXT PRIMARY KEY,
+  question_text        TEXT,                -- raw (lightly scrubbed) for Craig's reference
+  question_embedding   BLOB,                -- for semantic dedup
+  scrubbed_summary     TEXT,                -- Haiku-paraphrased; GitHub issue body uses this
+  compressed_profile   TEXT,                -- prose profile snapshot
+  current_chapter_ref  TEXT,
+  retrieved_chunks_json TEXT,
+  retrieval_max_score  REAL,
+  model_gap_explanation TEXT,
+  user_feedback        TEXT,                -- 'thumbs_down' or NULL
+  gap_type             TEXT,                -- content | translation | out_of_scope
+  captured_at          INTEGER NOT NULL,    -- unix seconds
+  occurrence_count     INTEGER NOT NULL DEFAULT 1,
+  status               TEXT NOT NULL DEFAULT 'new',
+                                            --   new | queued | issue_opened | content_shipped | redacted
+  linked_issue_number  INTEGER,
+  linked_content_pr    INTEGER,
+  redacted             INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_gaps_status
+  ON corpus_gaps(status);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_gaps_captured_at
+  ON corpus_gaps(captured_at);
+
+-- Config flag table — simple key/value store for mode switching.
+CREATE TABLE IF NOT EXISTS amicus_config (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+-- Default: individual-issue mode. Flip to 'digest' at ~20K users
+-- by updating the single row rather than migrating schema.
+INSERT OR IGNORE INTO amicus_config (key, value)
+  VALUES ('gap_sync_mode', 'individual');

--- a/ai-proxy/package-lock.json
+++ b/ai-proxy/package-lock.json
@@ -1,0 +1,3369 @@
+{
+  "name": "amicus-proxy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "amicus-proxy",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240402.0",
+        "miniflare": "^3.20240404.0",
+        "typescript": "^5.4.0",
+        "vitest": "^1.4.0",
+        "wrangler": "^3.50.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260417.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260417.1.tgz",
+      "integrity": "sha512-ke3GkFfFyfSxdLRR6LPbnfYAu3RNKqX0eYfu/FNnluBN9rLgYVqT+QEPgSEx1yq7XTOok+Bub1td9xvknaOz4A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/ai-proxy/package.json
+++ b/ai-proxy/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "amicus-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Worker sitting between the Companion Study mobile client and Anthropic. Handles auth, rate-limit, zero-retention, streaming, and gap-signal detection.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240402.0",
+    "miniflare": "^3.20240404.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.4.0",
+    "wrangler": "^3.50.0"
+  }
+}

--- a/ai-proxy/src/anthropic.ts
+++ b/ai-proxy/src/anthropic.ts
@@ -1,0 +1,102 @@
+/**
+ * anthropic.ts — Streaming Claude client.
+ *
+ * We do not trust the client's model_tier hint when the user has the
+ * `partner_plus` entitlement: heavy users always get Sonnet. Zero-retention
+ * is enforced server-side via the `anthropic-no-retention: true` header.
+ */
+import type { ChatRequest, Entitlement } from './types';
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+
+export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
+export const SONNET_MODEL = 'claude-opus-4-7';
+
+export function chooseModel(req: ChatRequest, entitlement: Entitlement): string {
+  if (entitlement === 'partner_plus') return SONNET_MODEL;
+  return req.model_tier === 'sonnet' ? SONNET_MODEL : HAIKU_MODEL;
+}
+
+const SYSTEM_PROMPT_TEMPLATE = `You are Amicus, a scholarly study partner for the Companion Study Bible app.
+You draw exclusively on the curated corpus provided in <retrieved_chunks>. Do
+not invent citations or scholar attributions beyond what the chunks supply.
+
+When the chunks do not contain enough relevant material to answer the user's
+question, say so plainly and end your message with a single-line JSON envelope:
+  {"gap": true, "gap_type": "content"|"translation"|"out_of_scope", "topic": "<short summary>"}
+
+When you do have material to answer, end your message with:
+  {"gap": false}
+
+The user's compressed study profile is supplied in <profile>. Respect their
+tradition(s), reading history, and current focus, but never invent user facts.
+
+Current chapter context: {{CURRENT_CHAPTER_REF}}
+`;
+
+export function buildSystemPrompt(req: ChatRequest): string {
+  const base = SYSTEM_PROMPT_TEMPLATE.replace(
+    '{{CURRENT_CHAPTER_REF}}',
+    req.current_chapter_ref ?? 'none',
+  );
+  const chunks = req.retrieved_chunks
+    .map(
+      (c) =>
+        `[${c.chunk_id}] (${c.source_type})\n${c.text}`,
+    )
+    .join('\n\n---\n\n');
+  const profile = req.profile_summary?.trim() || '(no profile)';
+  return `${base}
+<profile>
+${profile}
+</profile>
+
+<retrieved_chunks>
+${chunks}
+</retrieved_chunks>
+`;
+}
+
+/** Convert the proxy's conversation_history into Anthropic's messages array. */
+export function buildMessages(req: ChatRequest): Array<{ role: 'user' | 'assistant'; content: string }> {
+  const history = req.conversation_history ?? [];
+  return [...history, { role: 'user' as const, content: req.query }];
+}
+
+export interface StreamArgs {
+  req: ChatRequest;
+  entitlement: Entitlement;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Open a streaming Anthropic request. Returns the upstream Response so the
+ * caller can pipe the body straight through to the client.
+ */
+export async function streamChat({
+  req,
+  entitlement,
+  apiKey,
+  fetchImpl = fetch,
+}: StreamArgs): Promise<Response> {
+  const body = {
+    model: chooseModel(req, entitlement),
+    system: buildSystemPrompt(req),
+    messages: buildMessages(req),
+    max_tokens: 1024,
+    stream: true,
+  };
+
+  return fetchImpl(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-no-retention': 'true',
+      Accept: 'text/event-stream',
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/ai-proxy/src/auth.ts
+++ b/ai-proxy/src/auth.ts
@@ -1,0 +1,150 @@
+/**
+ * auth.ts — RevenueCat receipt validation.
+ *
+ * Cached per-receipt in Workers KV for 5 minutes so we don't hit RevenueCat
+ * on every streaming request. On auth failure we return a structured code so
+ * the router can translate to HTTP 401/402/503.
+ */
+import type { AuthContext, Entitlement, Env } from './types';
+
+const CACHE_TTL_SECONDS = 5 * 60;
+const REVENUECAT_BASE = 'https://api.revenuecat.com/v1/subscribers';
+
+export type AuthFailure =
+  | { kind: 'missing_token' }
+  | { kind: 'malformed_token' }
+  | { kind: 'no_entitlement' }
+  | { kind: 'revenuecat_unavailable'; detail: string };
+
+export type AuthResult = { ok: true; context: AuthContext } | { ok: false; reason: AuthFailure };
+
+export function extractBearerToken(authorization: string | null): string | null {
+  if (!authorization) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+  return match ? match[1]!.trim() : null;
+}
+
+/**
+ * SHA-256 of the receipt token, hex-encoded. Used as a KV cache key so the
+ * raw receipt never touches logs or storage indices.
+ */
+export async function hashReceipt(token: string): Promise<string> {
+  const data = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Validate the Authorization header against RevenueCat. Returns an
+ * AuthContext on success or a structured failure. Never throws — all errors
+ * are reported via the failure object so the caller can classify cleanly.
+ */
+export async function authenticate(
+  authorization: string | null,
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AuthResult> {
+  const token = extractBearerToken(authorization);
+  if (!token) {
+    return { ok: false, reason: { kind: 'missing_token' } };
+  }
+
+  // Basic shape check — RevenueCat receipt tokens are long opaque strings.
+  if (token.length < 16) {
+    return { ok: false, reason: { kind: 'malformed_token' } };
+  }
+
+  const receiptHash = await hashReceipt(token);
+
+  // Cache hit?
+  const cached = await env.RATE_LIMITS.get(`auth:${receiptHash}`);
+  if (cached) {
+    if (cached === 'none') {
+      return { ok: false, reason: { kind: 'no_entitlement' } };
+    }
+    if (cached === 'premium' || cached === 'partner_plus') {
+      return { ok: true, context: { receiptHash, entitlement: cached } };
+    }
+  }
+
+  if (!env.REVENUECAT_SECRET_KEY) {
+    return {
+      ok: false,
+      reason: {
+        kind: 'revenuecat_unavailable',
+        detail: 'REVENUECAT_SECRET_KEY not configured',
+      },
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${REVENUECAT_BASE}/${encodeURIComponent(token)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${env.REVENUECAT_SECRET_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: {
+        kind: 'revenuecat_unavailable',
+        detail: (err as Error).message,
+      },
+    };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return { ok: false, reason: { kind: 'malformed_token' } };
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: {
+        kind: 'revenuecat_unavailable',
+        detail: `RevenueCat returned ${response.status}`,
+      },
+    };
+  }
+
+  const body = (await response.json()) as {
+    subscriber?: { entitlements?: Record<string, { expires_date?: string | null }> };
+  };
+  const entitlement = pickActiveEntitlement(body);
+
+  await env.RATE_LIMITS.put(`auth:${receiptHash}`, entitlement ?? 'none', {
+    expirationTtl: CACHE_TTL_SECONDS,
+  });
+
+  if (!entitlement) {
+    return { ok: false, reason: { kind: 'no_entitlement' } };
+  }
+  return { ok: true, context: { receiptHash, entitlement } };
+}
+
+/**
+ * Walk the RevenueCat subscriber response for an active entitlement.
+ * Prefers `partner_plus` over plain `premium` when both are present.
+ */
+export function pickActiveEntitlement(
+  body: { subscriber?: { entitlements?: Record<string, { expires_date?: string | null }> } },
+): Entitlement | null {
+  const entitlements = body.subscriber?.entitlements ?? {};
+  const now = Date.now();
+
+  const isActive = (key: string): boolean => {
+    const ent = entitlements[key];
+    if (!ent) return false;
+    if (ent.expires_date == null) return true; // lifetime / non-expiring
+    const exp = Date.parse(ent.expires_date);
+    return Number.isFinite(exp) && exp > now;
+  };
+
+  if (isActive('partner_plus')) return 'partner_plus';
+  if (isActive('premium')) return 'premium';
+  return null;
+}

--- a/ai-proxy/src/gapDetection.ts
+++ b/ai-proxy/src/gapDetection.ts
@@ -75,10 +75,13 @@ export function isLowRetrievalScore(chunks: RetrievedChunk[]): boolean {
 
 // ── Scrub ─────────────────────────────────────────────────────────────
 
-const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
-const PHONE_RE = /\+?\d[\d\s().-]{7,}\d/g;
-const URL_RE = /https?:\/\/\S+/g;
-const CARD_RE = /\b(?:\d[ -]*?){13,16}\b/g;
+// Bounded quantifiers to avoid polynomial-backtracking ReDoS on long inputs.
+// Email local-parts are RFC-capped at 64; domains at 253 total. The TLD
+// max of 63 is well above every real TLD.
+const EMAIL_RE = /[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,253}\.[A-Za-z]{2,63}/g;
+const PHONE_RE = /\+?\d[\d\s().-]{7,20}\d/g;
+const URL_RE = /https?:\/\/\S{1,2048}/g;
+const CARD_RE = /\b(?:\d[ -]?){13,19}\b/g;
 
 /** Light PII scrub for the raw question_text stored in D1. */
 export function scrubPII(text: string): string {

--- a/ai-proxy/src/gapDetection.ts
+++ b/ai-proxy/src/gapDetection.ts
@@ -1,0 +1,96 @@
+/**
+ * gapDetection.ts — Extract the structured gap_signal JSON envelope from a
+ * streamed assistant response.
+ *
+ * Full D1 persistence is #1471. This file provides the hook: it parses the
+ * signal, writes a stub record to D1 when present, and is safe to call
+ * even when CORPUS_GAPS isn't bound.
+ */
+import type { Env, GapSignal } from './types';
+
+/**
+ * Pull the last JSON object from the streamed text. Returns null if no
+ * trailing JSON envelope is found, or if it doesn't match the gap schema.
+ */
+export function parseGapSignal(accumulated: string): GapSignal | null {
+  const trimmed = accumulated.trim();
+  if (!trimmed.endsWith('}')) return null;
+
+  // Walk backward from the last } matching braces to find the JSON start.
+  let depth = 0;
+  let start = -1;
+  for (let i = trimmed.length - 1; i >= 0; i--) {
+    const c = trimmed[i];
+    if (c === '}') depth++;
+    else if (c === '{') {
+      depth--;
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+    }
+  }
+  if (start < 0) return null;
+
+  const candidate = trimmed.slice(start);
+  try {
+    const parsed = JSON.parse(candidate) as Record<string, unknown>;
+    if (typeof parsed.gap !== 'boolean') return null;
+    const out: GapSignal = { gap: parsed.gap };
+    if (
+      typeof parsed.gap_type === 'string' &&
+      ['content', 'translation', 'out_of_scope'].includes(parsed.gap_type)
+    ) {
+      out.gap_type = parsed.gap_type as GapSignal['gap_type'];
+    }
+    if (typeof parsed.topic === 'string') out.topic = parsed.topic;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+export interface CaptureGapArgs {
+  signal: GapSignal;
+  query: string;
+  env: Env;
+  /** For logging only; never store raw receipts. */
+  receiptHash: string;
+}
+
+/**
+ * Stub writer. #1471 replaces this with the full D1 schema, semantic
+ * deduplication, and GitHub sync. For now we emit a structured log line so
+ * ops visibility is in place from day one.
+ */
+export async function captureGap({ signal, query, env, receiptHash }: CaptureGapArgs): Promise<void> {
+  const record = {
+    type: 'gap_signal',
+    gap_type: signal.gap_type ?? 'unknown',
+    topic: signal.topic ?? null,
+    query_length: query.length,
+    receipt_hash_prefix: receiptHash.slice(0, 8),
+    captured_at: Date.now(),
+  };
+  // Structured log — Cloudflare observability picks this up.
+  console.log(JSON.stringify(record));
+
+  if (!env.CORPUS_GAPS) return;
+  try {
+    await env.CORPUS_GAPS.prepare(
+      'INSERT INTO corpus_gaps (gap_id, gap_type, scrubbed_summary, captured_at) '
+        + 'VALUES (?, ?, ?, ?)',
+    )
+      .bind(
+        crypto.randomUUID(),
+        signal.gap_type ?? 'content',
+        signal.topic ?? '',
+        Math.floor(Date.now() / 1000),
+      )
+      .run();
+  } catch (err) {
+    console.log(
+      JSON.stringify({ type: 'gap_write_failed', detail: (err as Error).message }),
+    );
+  }
+}

--- a/ai-proxy/src/gapDetection.ts
+++ b/ai-proxy/src/gapDetection.ts
@@ -1,22 +1,31 @@
 /**
- * gapDetection.ts — Extract the structured gap_signal JSON envelope from a
- * streamed assistant response.
+ * gapDetection.ts — Full corpus-gap capture (Card #1471).
  *
- * Full D1 persistence is #1471. This file provides the hook: it parses the
- * signal, writes a stub record to D1 when present, and is safe to call
- * even when CORPUS_GAPS isn't bound.
+ * Three inputs can flag a gap:
+ *   1. Model self-report via trailing {"gap": true, ...} envelope
+ *   2. Retrieval max similarity below GAP_SIMILARITY_FLOOR
+ *   3. Explicit user thumbs-down (POST /ai/feedback)
+ *
+ * Each capture:
+ *   - Embeds the question for semantic dedup (cosine >0.9 → increment
+ *     occurrence_count on existing gap instead of inserting a new row)
+ *   - Writes a row to D1
+ *   - Fire-and-forget kicks downstream sync (GitHub issue creation lives
+ *     in _tools/corpus_gap_sync.py, run on a cron schedule)
  */
-import type { Env, GapSignal } from './types';
+import type { Env, GapSignal, RetrievedChunk } from './types';
+
+export const GAP_SIMILARITY_FLOOR = 0.55;
+export const DEDUP_COSINE_THRESHOLD = 0.9;
 
 /**
- * Pull the last JSON object from the streamed text. Returns null if no
- * trailing JSON envelope is found, or if it doesn't match the gap schema.
+ * Pull the last JSON object from the streamed text. Returns null when no
+ * trailing JSON envelope is found or it doesn't match the gap schema.
  */
 export function parseGapSignal(accumulated: string): GapSignal | null {
   const trimmed = accumulated.trim();
   if (!trimmed.endsWith('}')) return null;
 
-  // Walk backward from the last } matching braces to find the JSON start.
   let depth = 0;
   let start = -1;
   for (let i = trimmed.length - 1; i >= 0; i--) {
@@ -32,9 +41,8 @@ export function parseGapSignal(accumulated: string): GapSignal | null {
   }
   if (start < 0) return null;
 
-  const candidate = trimmed.slice(start);
   try {
-    const parsed = JSON.parse(candidate) as Record<string, unknown>;
+    const parsed = JSON.parse(trimmed.slice(start)) as Record<string, unknown>;
     if (typeof parsed.gap !== 'boolean') return null;
     const out: GapSignal = { gap: parsed.gap };
     if (
@@ -50,47 +58,273 @@ export function parseGapSignal(accumulated: string): GapSignal | null {
   }
 }
 
-export interface CaptureGapArgs {
-  signal: GapSignal;
-  query: string;
-  env: Env;
-  /** For logging only; never store raw receipts. */
-  receiptHash: string;
+/**
+ * Retrieval score is a gap indicator. Returns true if the max similarity
+ * is below the floor — i.e. the retriever thinks nothing in the corpus is
+ * a close match.
+ */
+export function isLowRetrievalScore(chunks: RetrievedChunk[]): boolean {
+  if (chunks.length === 0) return true;
+  let max = 0;
+  for (const c of chunks) {
+    const score = (c as unknown as { score?: number }).score ?? 0;
+    if (score > max) max = score;
+  }
+  return max < GAP_SIMILARITY_FLOOR;
+}
+
+// ── Scrub ─────────────────────────────────────────────────────────────
+
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const PHONE_RE = /\+?\d[\d\s().-]{7,}\d/g;
+const URL_RE = /https?:\/\/\S+/g;
+const CARD_RE = /\b(?:\d[ -]*?){13,16}\b/g;
+
+/** Light PII scrub for the raw question_text stored in D1. */
+export function scrubPII(text: string): string {
+  return text
+    .replace(EMAIL_RE, '[email]')
+    .replace(URL_RE, '[url]')
+    .replace(CARD_RE, '[card]')
+    .replace(PHONE_RE, '[phone]')
+    .trim();
+}
+
+// ── Semantic dedup ────────────────────────────────────────────────────
+
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const av = a[i]!;
+    const bv = b[i]!;
+    dot += av * bv;
+    magA += av * av;
+    magB += bv * bv;
+  }
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+export function packEmbedding(vector: number[]): Uint8Array {
+  const buf = new ArrayBuffer(vector.length * 4);
+  const view = new DataView(buf);
+  for (let i = 0; i < vector.length; i++) view.setFloat32(i * 4, vector[i]!, true);
+  return new Uint8Array(buf);
+}
+
+export function unpackEmbedding(blob: ArrayBuffer | Uint8Array): Float32Array {
+  const ab = blob instanceof Uint8Array ? blob.buffer : blob;
+  return new Float32Array(ab);
 }
 
 /**
- * Stub writer. #1471 replaces this with the full D1 schema, semantic
- * deduplication, and GitHub sync. For now we emit a structured log line so
- * ops visibility is in place from day one.
+ * Scan recent open gaps for a semantic match. Returns the matching gap_id
+ * if found (occurrence_count should be incremented), else null.
  */
-export async function captureGap({ signal, query, env, receiptHash }: CaptureGapArgs): Promise<void> {
+export async function findSemanticMatch(
+  env: Env,
+  embedding: number[],
+): Promise<string | null> {
+  if (!env.CORPUS_GAPS) return null;
+  const target = new Float32Array(embedding);
+
+  try {
+    const rows = await env.CORPUS_GAPS.prepare(
+      `SELECT gap_id, question_embedding
+         FROM corpus_gaps
+        WHERE status IN ('new', 'queued', 'issue_opened')
+          AND redacted = 0
+          AND question_embedding IS NOT NULL
+        ORDER BY captured_at DESC
+        LIMIT 500`,
+    ).all<{ gap_id: string; question_embedding: ArrayBuffer }>();
+
+    for (const r of rows.results ?? []) {
+      const existing = unpackEmbedding(r.question_embedding);
+      if (existing.length !== target.length) continue;
+      const sim = cosineSimilarity(target, existing);
+      if (sim >= DEDUP_COSINE_THRESHOLD) return r.gap_id;
+    }
+  } catch (err) {
+    console.log(
+      JSON.stringify({ type: 'dedup_error', detail: (err as Error).message }),
+    );
+  }
+  return null;
+}
+
+// ── Scrubbed summary via Haiku ───────────────────────────────────────
+
+const HAIKU_MODEL_FOR_SUMMARY = 'claude-haiku-4-5-20251001';
+
+export async function generateScrubbedSummary(
+  rawQuestion: string,
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const fallback = scrubPII(rawQuestion).slice(0, 160);
+  if (!env.ANTHROPIC_API_KEY) return fallback;
+
+  try {
+    const resp = await fetchImpl('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'anthropic-no-retention': 'true',
+      },
+      body: JSON.stringify({
+        model: HAIKU_MODEL_FOR_SUMMARY,
+        max_tokens: 80,
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Paraphrase the following user question into one short, non-identifying, topical summary suitable for a corpus-gap ticket (max 20 words, no names, no personal detail):\n\n' +
+              scrubPII(rawQuestion),
+          },
+        ],
+      }),
+    });
+    if (!resp.ok) return fallback;
+    const payload = (await resp.json()) as {
+      content?: Array<{ text?: string }>;
+    };
+    const text = payload.content?.[0]?.text?.trim();
+    return text && text.length > 0 ? text : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+// ── Capture + persistence ────────────────────────────────────────────
+
+export interface CaptureGapArgs {
+  signal: GapSignal;
+  query: string;
+  retrievalMaxScore: number | null;
+  retrievedChunkIds: string[];
+  profileSummary: string;
+  currentChapterRef: string | null;
+  questionEmbedding: number[] | null;
+  env: Env;
+  receiptHash: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function captureGap(args: CaptureGapArgs): Promise<void> {
+  const {
+    signal,
+    query,
+    retrievalMaxScore,
+    retrievedChunkIds,
+    profileSummary,
+    currentChapterRef,
+    questionEmbedding,
+    env,
+    receiptHash,
+    fetchImpl,
+  } = args;
+
   const record = {
     type: 'gap_signal',
-    gap_type: signal.gap_type ?? 'unknown',
+    gap_type: signal.gap_type ?? 'content',
     topic: signal.topic ?? null,
+    retrieval_max_score: retrievalMaxScore,
     query_length: query.length,
     receipt_hash_prefix: receiptHash.slice(0, 8),
     captured_at: Date.now(),
   };
-  // Structured log — Cloudflare observability picks this up.
   console.log(JSON.stringify(record));
 
   if (!env.CORPUS_GAPS) return;
+
+  if (questionEmbedding) {
+    const existingId = await findSemanticMatch(env, questionEmbedding);
+    if (existingId) {
+      try {
+        await env.CORPUS_GAPS.prepare(
+          `UPDATE corpus_gaps
+              SET occurrence_count = occurrence_count + 1,
+                  captured_at = ?
+            WHERE gap_id = ?`,
+        )
+          .bind(Math.floor(Date.now() / 1000), existingId)
+          .run();
+        console.log(JSON.stringify({ type: 'gap_deduped', gap_id: existingId }));
+      } catch (err) {
+        console.log(
+          JSON.stringify({
+            type: 'gap_dedup_write_failed',
+            detail: (err as Error).message,
+          }),
+        );
+      }
+      return;
+    }
+  }
+
+  const gapId = crypto.randomUUID();
+  const scrubbedSummary = await generateScrubbedSummary(query, env, fetchImpl);
+
   try {
     await env.CORPUS_GAPS.prepare(
-      'INSERT INTO corpus_gaps (gap_id, gap_type, scrubbed_summary, captured_at) '
-        + 'VALUES (?, ?, ?, ?)',
+      `INSERT INTO corpus_gaps
+         (gap_id, question_text, question_embedding, scrubbed_summary,
+          compressed_profile, current_chapter_ref, retrieved_chunks_json,
+          retrieval_max_score, gap_type, captured_at, occurrence_count, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'new')`,
     )
       .bind(
-        crypto.randomUUID(),
+        gapId,
+        scrubPII(query),
+        questionEmbedding ? packEmbedding(questionEmbedding) : null,
+        scrubbedSummary,
+        profileSummary.slice(0, 2000),
+        currentChapterRef,
+        JSON.stringify(retrievedChunkIds),
+        retrievalMaxScore,
         signal.gap_type ?? 'content',
-        signal.topic ?? '',
         Math.floor(Date.now() / 1000),
       )
       .run();
+    console.log(JSON.stringify({ type: 'gap_captured', gap_id: gapId }));
   } catch (err) {
     console.log(
       JSON.stringify({ type: 'gap_write_failed', detail: (err as Error).message }),
     );
+  }
+}
+
+export async function redactGap(env: Env, gapId: string): Promise<boolean> {
+  if (!env.CORPUS_GAPS) return false;
+  try {
+    await env.CORPUS_GAPS.prepare(
+      `UPDATE corpus_gaps
+          SET redacted = 1,
+              status = 'redacted',
+              question_text = NULL,
+              question_embedding = NULL,
+              scrubbed_summary = '[redacted]',
+              compressed_profile = NULL,
+              retrieved_chunks_json = NULL
+        WHERE gap_id = ?`,
+    )
+      .bind(gapId)
+      .run();
+    return true;
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        type: 'redact_failed',
+        gap_id: gapId,
+        detail: (err as Error).message,
+      }),
+    );
+    return false;
   }
 }

--- a/ai-proxy/src/index.ts
+++ b/ai-proxy/src/index.ts
@@ -12,8 +12,13 @@
 import { authenticate, type AuthResult } from './auth';
 import { checkAndIncrement } from './rateLimit';
 import { streamChat } from './anthropic';
-import { captureGap, parseGapSignal } from './gapDetection';
-import type { ChatRequest, EmbedRequest, Env } from './types';
+import {
+  captureGap,
+  isLowRetrievalScore,
+  parseGapSignal,
+  redactGap,
+} from './gapDetection';
+import type { ChatRequest, EmbedRequest, Env, GapSignal } from './types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' };
 
@@ -31,6 +36,12 @@ export default {
       }
       if (url.pathname === '/ai/chat' && request.method === 'POST') {
         return handleChat(request, env, ctx, startedAt);
+      }
+      if (url.pathname === '/ai/feedback' && request.method === 'POST') {
+        return handleFeedback(request, env, startedAt);
+      }
+      if (url.pathname.startsWith('/ai/gaps/') && request.method === 'DELETE') {
+        return handleRedact(request, env, url);
       }
       return new Response('not found', { status: 404 });
     } catch (err) {
@@ -170,11 +181,25 @@ async function handleChat(
     return jsonError(upstream.status || 502, 'anthropic_error');
   }
 
+  // Pre-compute retrieval-score gap signal so captureGap can combine it
+  // with the model's self-report.
+  const retrievalMaxScore = maxChunkScore(chat.retrieved_chunks);
+  const retrievedChunkIds = chat.retrieved_chunks.map((c) => c.chunk_id);
+  const lowScore = isLowRetrievalScore(chat.retrieved_chunks);
+
   // Tee the stream: forward one branch straight to the client, consume the
   // other server-side to extract the gap_signal envelope.
   const [clientBranch, serverBranch] = upstream.body.tee();
   execCtx.waitUntil(
-    consumeForGap(serverBranch, chat.query, env, ctx.receiptHash),
+    consumeForGap({
+      stream: serverBranch,
+      chat,
+      env,
+      receiptHash: ctx.receiptHash,
+      retrievalMaxScore,
+      retrievedChunkIds,
+      lowScore,
+    }),
   );
 
   logMetadata({
@@ -195,14 +220,19 @@ async function handleChat(
   });
 }
 
-async function consumeForGap(
-  stream: ReadableStream<Uint8Array>,
-  query: string,
-  env: Env,
-  receiptHash: string,
-): Promise<void> {
+interface ConsumeForGapArgs {
+  stream: ReadableStream<Uint8Array>;
+  chat: ChatRequest;
+  env: Env;
+  receiptHash: string;
+  retrievalMaxScore: number;
+  retrievedChunkIds: string[];
+  lowScore: boolean;
+}
+
+async function consumeForGap(args: ConsumeForGapArgs): Promise<void> {
   const decoder = new TextDecoder();
-  const reader = stream.getReader();
+  const reader = args.stream.getReader();
   let accumulated = '';
   try {
     for (;;) {
@@ -227,13 +257,150 @@ async function consumeForGap(
       }
     }
   } catch (err) {
-    console.log(JSON.stringify({ type: 'gap_consume_error', detail: (err as Error).message }));
+    console.log(
+      JSON.stringify({ type: 'gap_consume_error', detail: (err as Error).message }),
+    );
     return;
   }
 
-  const signal = parseGapSignal(accumulated);
-  if (!signal || !signal.gap) return;
-  await captureGap({ signal, query, env, receiptHash });
+  const modelSignal = parseGapSignal(accumulated);
+
+  // A gap counts if the model said so OR retrieval scored low. The two
+  // signals are independent; low-score catches cases where the model
+  // hallucinated a confident answer despite nothing in the corpus.
+  let effective: GapSignal | null = null;
+  if (modelSignal?.gap) effective = modelSignal;
+  else if (args.lowScore) {
+    effective = { gap: true, gap_type: 'content' };
+  }
+  if (!effective) return;
+
+  const questionEmbedding = await embedQuestion(args.chat.query, args.env);
+
+  await captureGap({
+    signal: effective,
+    query: args.chat.query,
+    retrievalMaxScore: args.retrievalMaxScore,
+    retrievedChunkIds: args.retrievedChunkIds,
+    profileSummary: args.chat.profile_summary,
+    currentChapterRef: args.chat.current_chapter_ref,
+    questionEmbedding,
+    env: args.env,
+    receiptHash: args.receiptHash,
+  });
+}
+
+function maxChunkScore(chunks: ChatRequest['retrieved_chunks']): number {
+  let max = 0;
+  for (const c of chunks) {
+    const score = (c as unknown as { score?: number }).score ?? 0;
+    if (score > max) max = score;
+  }
+  return max;
+}
+
+async function embedQuestion(text: string, env: Env): Promise<number[] | null> {
+  if (!env.OPENAI_API_KEY) return null;
+  try {
+    const resp = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'text-embedding-3-small', input: text }),
+    });
+    if (!resp.ok) return null;
+    const payload = (await resp.json()) as { data?: Array<{ embedding?: number[] }> };
+    const vec = payload.data?.[0]?.embedding;
+    return vec && vec.length === 1536 ? vec : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── /ai/feedback ──────────────────────────────────────────────────────
+
+interface FeedbackBody {
+  query: string;
+  current_chapter_ref: string | null;
+  profile_summary?: string;
+  retrieved_chunks?: ChatRequest['retrieved_chunks'];
+  reason?: string;
+}
+
+async function handleFeedback(
+  request: Request,
+  env: Env,
+  startedAt: number,
+): Promise<Response> {
+  const auth = await authenticate(request.headers.get('Authorization'), env);
+  const authResponse = authToHttp(auth);
+  if (authResponse) return authResponse;
+  const ctx = (auth as Extract<AuthResult, { ok: true }>).context;
+
+  let body: FeedbackBody;
+  try {
+    body = (await request.json()) as FeedbackBody;
+  } catch {
+    return jsonError(400, 'invalid_json');
+  }
+  if (!body.query) return jsonError(400, 'missing_query');
+
+  const questionEmbedding = await embedQuestion(body.query, env);
+  await captureGap({
+    signal: { gap: true, gap_type: 'content', topic: body.reason?.slice(0, 120) },
+    query: body.query,
+    retrievalMaxScore: body.retrieved_chunks
+      ? maxChunkScore(body.retrieved_chunks)
+      : null,
+    retrievedChunkIds:
+      body.retrieved_chunks?.map((c) => c.chunk_id) ?? [],
+    profileSummary: body.profile_summary ?? '',
+    currentChapterRef: body.current_chapter_ref,
+    questionEmbedding,
+    env,
+    receiptHash: ctx.receiptHash,
+  });
+
+  logMetadata({
+    endpoint: '/ai/feedback',
+    status: 200,
+    startedAt,
+    entitlement: ctx.entitlement,
+    receiptHash: ctx.receiptHash,
+  });
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+}
+
+// ── DELETE /ai/gaps/:id (redaction) ──────────────────────────────────
+
+async function handleRedact(
+  request: Request,
+  env: Env,
+  url: URL,
+): Promise<Response> {
+  const auth = await authenticate(request.headers.get('Authorization'), env);
+  const authResponse = authToHttp(auth);
+  if (authResponse) return authResponse;
+
+  // Simple admin gate — only partner_plus receipts can redact. Real admin
+  // access is layered via Cloudflare Access in front of this Worker.
+  const ctx = (auth as Extract<AuthResult, { ok: true }>).context;
+  if (ctx.entitlement !== 'partner_plus') {
+    return jsonError(403, 'forbidden');
+  }
+
+  const gapId = url.pathname.split('/').pop() ?? '';
+  if (!gapId) return jsonError(400, 'missing_gap_id');
+  const ok = await redactGap(env, gapId);
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500,
+    headers: JSON_HEADERS,
+  });
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────

--- a/ai-proxy/src/index.ts
+++ b/ai-proxy/src/index.ts
@@ -1,0 +1,277 @@
+/**
+ * index.ts — Worker entry point + router.
+ *
+ * Three endpoints:
+ *   GET  /ai/health  — unauthenticated liveness probe
+ *   POST /ai/embed   — authenticated, single 1536-dim vector via OpenAI
+ *   POST /ai/chat    — authenticated, streaming Claude response via Anthropic
+ *
+ * Logs only metadata (user_id hash, token counts, latency). Never logs
+ * request bodies or response text.
+ */
+import { authenticate, type AuthResult } from './auth';
+import { checkAndIncrement } from './rateLimit';
+import { streamChat } from './anthropic';
+import { captureGap, parseGapSignal } from './gapDetection';
+import type { ChatRequest, EmbedRequest, Env } from './types';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' };
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const startedAt = Date.now();
+
+    try {
+      if (url.pathname === '/ai/health' && request.method === 'GET') {
+        return handleHealth(env);
+      }
+      if (url.pathname === '/ai/embed' && request.method === 'POST') {
+        return handleEmbed(request, env, ctx, startedAt);
+      }
+      if (url.pathname === '/ai/chat' && request.method === 'POST') {
+        return handleChat(request, env, ctx, startedAt);
+      }
+      return new Response('not found', { status: 404 });
+    } catch (err) {
+      console.log(
+        JSON.stringify({
+          type: 'unhandled_error',
+          path: url.pathname,
+          detail: (err as Error).message,
+        }),
+      );
+      return new Response('internal error', { status: 500 });
+    }
+  },
+};
+
+// ── /ai/health ────────────────────────────────────────────────────────
+
+function handleHealth(env: Env): Response {
+  return new Response(JSON.stringify({ status: 'ok', version: env.VERSION }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+}
+
+// ── /ai/embed ─────────────────────────────────────────────────────────
+
+async function handleEmbed(
+  request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  startedAt: number,
+): Promise<Response> {
+  const auth = await authenticate(request.headers.get('Authorization'), env);
+  const authResponse = authToHttp(auth);
+  if (authResponse) return authResponse;
+  const ctx = (auth as Extract<AuthResult, { ok: true }>).context;
+
+  let body: EmbedRequest;
+  try {
+    body = (await request.json()) as EmbedRequest;
+  } catch {
+    return jsonError(400, 'invalid_json');
+  }
+  if (typeof body.text !== 'string' || body.text.length === 0) {
+    return jsonError(400, 'missing_text');
+  }
+  if (!env.OPENAI_API_KEY) {
+    return jsonError(503, 'openai_key_missing');
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'text-embedding-3-small', input: body.text }),
+    });
+  } catch (err) {
+    return jsonError(503, 'openai_unreachable', (err as Error).message);
+  }
+
+  if (!upstream.ok) {
+    return jsonError(upstream.status, 'openai_error');
+  }
+  const payload = (await upstream.json()) as { data?: Array<{ embedding?: number[] }> };
+  const vector = payload.data?.[0]?.embedding;
+  if (!vector || vector.length !== 1536) {
+    return jsonError(502, 'openai_bad_shape');
+  }
+
+  logMetadata({
+    endpoint: '/ai/embed',
+    status: 200,
+    startedAt,
+    entitlement: ctx.entitlement,
+    receiptHash: ctx.receiptHash,
+  });
+
+  return new Response(JSON.stringify({ vector }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+}
+
+// ── /ai/chat ──────────────────────────────────────────────────────────
+
+async function handleChat(
+  request: Request,
+  env: Env,
+  execCtx: ExecutionContext,
+  startedAt: number,
+): Promise<Response> {
+  const auth = await authenticate(request.headers.get('Authorization'), env);
+  const authResponse = authToHttp(auth);
+  if (authResponse) return authResponse;
+  const ctx = (auth as Extract<AuthResult, { ok: true }>).context;
+
+  const rate = await checkAndIncrement(ctx, env);
+  if (!rate.allowed) {
+    const body: Record<string, unknown> = {
+      error: 'rate_limit_exceeded',
+      retry_after: rate.retryAfterSec ?? 60,
+    };
+    if (ctx.entitlement === 'premium') {
+      body.upgrade_url = 'https://contentcompanionstudy.com/amicus-plus';
+    }
+    return new Response(JSON.stringify(body), {
+      status: 429,
+      headers: { ...JSON_HEADERS, 'Retry-After': String(rate.retryAfterSec ?? 60) },
+    });
+  }
+
+  let chat: ChatRequest;
+  try {
+    chat = (await request.json()) as ChatRequest;
+  } catch {
+    return jsonError(400, 'invalid_json');
+  }
+
+  if (typeof chat.query !== 'string' || chat.query.length === 0) {
+    return jsonError(400, 'missing_query');
+  }
+  if (!env.ANTHROPIC_API_KEY) {
+    return jsonError(503, 'anthropic_key_missing');
+  }
+
+  const upstream = await streamChat({
+    req: chat,
+    entitlement: ctx.entitlement,
+    apiKey: env.ANTHROPIC_API_KEY,
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    return jsonError(upstream.status || 502, 'anthropic_error');
+  }
+
+  // Tee the stream: forward one branch straight to the client, consume the
+  // other server-side to extract the gap_signal envelope.
+  const [clientBranch, serverBranch] = upstream.body.tee();
+  execCtx.waitUntil(
+    consumeForGap(serverBranch, chat.query, env, ctx.receiptHash),
+  );
+
+  logMetadata({
+    endpoint: '/ai/chat',
+    status: 200,
+    startedAt,
+    entitlement: ctx.entitlement,
+    receiptHash: ctx.receiptHash,
+  });
+
+  return new Response(clientBranch, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}
+
+async function consumeForGap(
+  stream: ReadableStream<Uint8Array>,
+  query: string,
+  env: Env,
+  receiptHash: string,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let accumulated = '';
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data:')) continue;
+        const payload = line.slice(5).trim();
+        if (!payload || payload === '[DONE]') continue;
+        try {
+          const ev = JSON.parse(payload) as {
+            type?: string;
+            delta?: { text?: string };
+          };
+          if (ev.type === 'content_block_delta' && typeof ev.delta?.text === 'string') {
+            accumulated += ev.delta.text;
+          }
+        } catch {
+          /* non-JSON data line — ignore */
+        }
+      }
+    }
+  } catch (err) {
+    console.log(JSON.stringify({ type: 'gap_consume_error', detail: (err as Error).message }));
+    return;
+  }
+
+  const signal = parseGapSignal(accumulated);
+  if (!signal || !signal.gap) return;
+  await captureGap({ signal, query, env, receiptHash });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function authToHttp(auth: AuthResult): Response | null {
+  if (auth.ok) return null;
+  switch (auth.reason.kind) {
+    case 'missing_token':
+    case 'malformed_token':
+      return jsonError(401, auth.reason.kind);
+    case 'no_entitlement':
+      return jsonError(402, 'no_entitlement');
+    case 'revenuecat_unavailable':
+      return jsonError(503, 'revenuecat_unavailable', auth.reason.detail);
+  }
+}
+
+function jsonError(status: number, error: string, detail?: string): Response {
+  const body: Record<string, string | number> = { status, error };
+  if (detail) body.detail = detail;
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function logMetadata(opts: {
+  endpoint: string;
+  status: number;
+  startedAt: number;
+  entitlement: string;
+  receiptHash: string;
+}): void {
+  console.log(
+    JSON.stringify({
+      type: 'request',
+      endpoint: opts.endpoint,
+      status: opts.status,
+      latency_ms: Date.now() - opts.startedAt,
+      entitlement: opts.entitlement,
+      user_hash: opts.receiptHash.slice(0, 8),
+    }),
+  );
+}

--- a/ai-proxy/src/rateLimit.ts
+++ b/ai-proxy/src/rateLimit.ts
@@ -1,0 +1,98 @@
+/**
+ * rateLimit.ts — KV-backed per-user rate limits.
+ *
+ * Limits per entitlement:
+ *   premium        — 300/month,   10/10-minute burst
+ *   partner_plus   — 1,500/month, 30/10-minute burst
+ *
+ * Counters live in Workers KV with month-granularity and 10-minute-bucket
+ * keys so they auto-expire. Deliberately simple — Durable Objects would give
+ * stricter semantics but add complexity we don't need for v1 traffic.
+ */
+import type { AuthContext, Entitlement, Env, RateLimitResult } from './types';
+
+export const LIMITS: Record<Entitlement, { monthly: number; burst: number }> = {
+  premium: { monthly: 300, burst: 10 },
+  partner_plus: { monthly: 1500, burst: 30 },
+};
+
+const BURST_WINDOW_SECONDS = 10 * 60;
+const MONTH_TTL_SECONDS = 35 * 24 * 60 * 60; // a little over a month so keys overlap
+
+export function monthBucket(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+export function burstBucket(now: Date = new Date()): string {
+  return String(Math.floor(now.getTime() / 1000 / BURST_WINDOW_SECONDS));
+}
+
+export interface RateLimitOptions {
+  /** Inject a clock for tests. */
+  now?: Date;
+}
+
+/**
+ * Atomically-ish increment both counters. KV's read-modify-write isn't truly
+ * atomic across replicas, so we over-count rather than under-count when two
+ * requests race (acceptable for a soft cap). The penalty of a user
+ * occasionally getting 301 rather than 300 calls in a month is negligible.
+ */
+export async function checkAndIncrement(
+  ctx: AuthContext,
+  env: Env,
+  opts: RateLimitOptions = {},
+): Promise<RateLimitResult> {
+  const now = opts.now ?? new Date();
+  const limit = LIMITS[ctx.entitlement];
+  const monthKey = `rate:${ctx.receiptHash}:${monthBucket(now)}`;
+  const burstKey = `burst:${ctx.receiptHash}:${burstBucket(now)}`;
+
+  const [monthRaw, burstRaw] = await Promise.all([
+    env.RATE_LIMITS.get(monthKey),
+    env.RATE_LIMITS.get(burstKey),
+  ]);
+  const monthUsed = parseInt(monthRaw ?? '0', 10) || 0;
+  const burstUsed = parseInt(burstRaw ?? '0', 10) || 0;
+
+  if (monthUsed >= limit.monthly) {
+    return {
+      allowed: false,
+      retryAfterSec: secondsUntilNextMonth(now),
+      monthlyRemaining: 0,
+      burstRemaining: Math.max(0, limit.burst - burstUsed),
+    };
+  }
+  if (burstUsed >= limit.burst) {
+    return {
+      allowed: false,
+      retryAfterSec: BURST_WINDOW_SECONDS,
+      monthlyRemaining: limit.monthly - monthUsed,
+      burstRemaining: 0,
+    };
+  }
+
+  await Promise.all([
+    env.RATE_LIMITS.put(monthKey, String(monthUsed + 1), {
+      expirationTtl: MONTH_TTL_SECONDS,
+    }),
+    env.RATE_LIMITS.put(burstKey, String(burstUsed + 1), {
+      expirationTtl: BURST_WINDOW_SECONDS,
+    }),
+  ]);
+
+  return {
+    allowed: true,
+    monthlyRemaining: limit.monthly - monthUsed - 1,
+    burstRemaining: limit.burst - burstUsed - 1,
+  };
+}
+
+function secondsUntilNextMonth(now: Date): number {
+  const next = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0),
+  );
+  return Math.max(0, Math.floor((next.getTime() - now.getTime()) / 1000));
+}

--- a/ai-proxy/src/types.ts
+++ b/ai-proxy/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * types.ts — Shared types for the Amicus proxy.
+ *
+ * Keep this file small and stable; both the Worker implementation and the
+ * tests depend on these definitions.
+ */
+
+export type Entitlement = 'premium' | 'partner_plus';
+
+export type ModelTier = 'haiku' | 'sonnet';
+
+export interface RetrievedChunk {
+  chunk_id: string;
+  source_type: string;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface ChatRequest {
+  query: string;
+  retrieved_chunks: RetrievedChunk[];
+  profile_summary: string;
+  current_chapter_ref: string | null;
+  model_tier: ModelTier;
+  conversation_history: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+export interface EmbedRequest {
+  text: string;
+}
+
+export interface AuthContext {
+  receiptHash: string;
+  entitlement: Entitlement;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSec?: number;
+  monthlyRemaining: number;
+  burstRemaining: number;
+}
+
+export interface GapSignal {
+  gap: boolean;
+  gap_type?: 'content' | 'translation' | 'out_of_scope';
+  topic?: string;
+}
+
+/**
+ * Worker environment bindings. These are declared in wrangler.toml (KV,
+ * D1, vars) or set via `wrangler secret put` (API keys).
+ */
+export interface Env {
+  // Secrets
+  REVENUECAT_SECRET_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+
+  // Vars
+  VERSION: string;
+
+  // KV + D1
+  RATE_LIMITS: KVNamespace;
+  CORPUS_GAPS?: D1Database;
+}

--- a/ai-proxy/test/anthropic.test.ts
+++ b/ai-proxy/test/anthropic.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HAIKU_MODEL,
+  SONNET_MODEL,
+  buildMessages,
+  buildSystemPrompt,
+  chooseModel,
+  streamChat,
+} from '../src/anthropic';
+import type { ChatRequest } from '../src/types';
+
+const baseReq: ChatRequest = {
+  query: 'What does hesed mean?',
+  retrieved_chunks: [
+    {
+      chunk_id: 'word_study:hesed',
+      source_type: 'word_study',
+      text: 'hesed — covenant faithfulness',
+      metadata: {},
+    },
+  ],
+  profile_summary: 'Studies often in Psalms.',
+  current_chapter_ref: 'psalms/23',
+  model_tier: 'haiku',
+  conversation_history: [],
+};
+
+describe('chooseModel', () => {
+  it('uses Haiku for premium + haiku hint', () => {
+    expect(chooseModel(baseReq, 'premium')).toBe(HAIKU_MODEL);
+  });
+  it('uses Sonnet for premium + sonnet hint', () => {
+    expect(chooseModel({ ...baseReq, model_tier: 'sonnet' }, 'premium')).toBe(
+      SONNET_MODEL,
+    );
+  });
+  it('always uses Sonnet for partner_plus, overriding client hint', () => {
+    expect(chooseModel(baseReq, 'partner_plus')).toBe(SONNET_MODEL);
+    expect(chooseModel({ ...baseReq, model_tier: 'sonnet' }, 'partner_plus')).toBe(
+      SONNET_MODEL,
+    );
+  });
+});
+
+describe('buildSystemPrompt', () => {
+  it('embeds chunk ids and source types', () => {
+    const prompt = buildSystemPrompt(baseReq);
+    expect(prompt).toContain('word_study:hesed');
+    expect(prompt).toContain('word_study');
+    expect(prompt).toContain('covenant faithfulness');
+  });
+
+  it('injects current chapter ref', () => {
+    expect(buildSystemPrompt(baseReq)).toContain('psalms/23');
+    expect(buildSystemPrompt({ ...baseReq, current_chapter_ref: null })).toContain('none');
+  });
+
+  it('includes profile summary when provided', () => {
+    expect(buildSystemPrompt(baseReq)).toContain('Studies often in Psalms');
+    expect(buildSystemPrompt({ ...baseReq, profile_summary: '' })).toContain('(no profile)');
+  });
+});
+
+describe('buildMessages', () => {
+  it('appends the user query as the final message', () => {
+    const msgs = buildMessages(baseReq);
+    expect(msgs[msgs.length - 1]?.role).toBe('user');
+    expect(msgs[msgs.length - 1]?.content).toBe(baseReq.query);
+  });
+
+  it('preserves conversation_history order', () => {
+    const hist: ChatRequest['conversation_history'] = [
+      { role: 'user', content: 'Earlier question' },
+      { role: 'assistant', content: 'Earlier answer' },
+    ];
+    const msgs = buildMessages({ ...baseReq, conversation_history: hist });
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0]).toEqual(hist[0]);
+    expect(msgs[1]).toEqual(hist[1]);
+    expect(msgs[2]?.content).toBe(baseReq.query);
+  });
+});
+
+describe('streamChat', () => {
+  it('sets the zero-retention header on the outbound request', async () => {
+    let captured: Request | null = null;
+    const fakeFetch = (async (input: RequestInfo, init?: RequestInit) => {
+      captured = new Request(input as string, init);
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    await streamChat({
+      req: baseReq,
+      entitlement: 'premium',
+      apiKey: 'sk-test',
+      fetchImpl: fakeFetch,
+    });
+    expect(captured).not.toBeNull();
+    expect(captured!.headers.get('anthropic-no-retention')).toBe('true');
+    expect(captured!.headers.get('x-api-key')).toBe('sk-test');
+    expect(captured!.headers.get('anthropic-version')).toBe('2023-06-01');
+  });
+
+  it('includes model + system + messages in the body', async () => {
+    let bodyText = '';
+    const fakeFetch = (async (_url: RequestInfo, init?: RequestInit) => {
+      bodyText = (init?.body as string) ?? '';
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    await streamChat({
+      req: { ...baseReq, model_tier: 'sonnet' },
+      entitlement: 'premium',
+      apiKey: 'sk-test',
+      fetchImpl: fakeFetch,
+    });
+    const parsed = JSON.parse(bodyText) as {
+      model: string;
+      system: string;
+      messages: Array<{ role: string; content: string }>;
+      stream: boolean;
+    };
+    expect(parsed.model).toBe(SONNET_MODEL);
+    expect(parsed.stream).toBe(true);
+    expect(parsed.system).toContain('Amicus');
+    expect(parsed.messages[parsed.messages.length - 1]?.content).toBe(baseReq.query);
+  });
+});

--- a/ai-proxy/test/auth.test.ts
+++ b/ai-proxy/test/auth.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  authenticate,
+  extractBearerToken,
+  pickActiveEntitlement,
+  hashReceipt,
+} from '../src/auth';
+import type { Env } from '../src/types';
+
+const FAKE_KV = (): KVNamespace => {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list() {
+      return { keys: [], list_complete: true, cursor: '' };
+    },
+  } as unknown as KVNamespace;
+};
+
+function fakeEnv(): Env {
+  return {
+    VERSION: '0.0.0-test',
+    RATE_LIMITS: FAKE_KV(),
+    REVENUECAT_SECRET_KEY: 'sk_test_revenuecat',
+  };
+}
+
+describe('extractBearerToken', () => {
+  it('returns the token after Bearer', () => {
+    expect(extractBearerToken('Bearer abc123xyz')).toBe('abc123xyz');
+  });
+  it('is case-insensitive on the scheme', () => {
+    expect(extractBearerToken('bearer xyz')).toBe('xyz');
+  });
+  it('returns null for missing header', () => {
+    expect(extractBearerToken(null)).toBeNull();
+  });
+  it('returns null for unexpected schemes', () => {
+    expect(extractBearerToken('Basic abc')).toBeNull();
+  });
+});
+
+describe('hashReceipt', () => {
+  it('produces a deterministic hex digest', async () => {
+    const a = await hashReceipt('receipt-1234567890abcdef');
+    const b = await hashReceipt('receipt-1234567890abcdef');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('differs for different inputs', async () => {
+    const a = await hashReceipt('a'.repeat(32));
+    const b = await hashReceipt('b'.repeat(32));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('pickActiveEntitlement', () => {
+  it('prefers partner_plus over premium when both active', () => {
+    const body = {
+      subscriber: {
+        entitlements: {
+          premium: { expires_date: null },
+          partner_plus: { expires_date: null },
+        },
+      },
+    };
+    expect(pickActiveEntitlement(body)).toBe('partner_plus');
+  });
+
+  it('skips expired entitlements', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    expect(
+      pickActiveEntitlement({
+        subscriber: { entitlements: { premium: { expires_date: yesterday } } },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when no entitlements', () => {
+    expect(pickActiveEntitlement({ subscriber: { entitlements: {} } })).toBeNull();
+    expect(pickActiveEntitlement({})).toBeNull();
+  });
+});
+
+describe('authenticate', () => {
+  it('rejects missing Authorization header', async () => {
+    const r = await authenticate(null, fakeEnv());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason.kind).toBe('missing_token');
+  });
+
+  it('rejects short / malformed tokens without hitting RevenueCat', async () => {
+    const calls: string[] = [];
+    const fakeFetch = (async (u: string) => {
+      calls.push(u);
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    const r = await authenticate('Bearer short', fakeEnv(), fakeFetch);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason.kind).toBe('malformed_token');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('treats RevenueCat 401 as malformed_token', async () => {
+    const fakeFetch = (async () =>
+      new Response('unauthorized', { status: 401 })) as typeof fetch;
+    const r = await authenticate(
+      'Bearer ' + 'x'.repeat(40),
+      fakeEnv(),
+      fakeFetch,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason.kind).toBe('malformed_token');
+  });
+
+  it('returns premium entitlement for a valid receipt', async () => {
+    const fakeFetch = (async () =>
+      new Response(
+        JSON.stringify({
+          subscriber: { entitlements: { premium: { expires_date: null } } },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    const r = await authenticate(
+      'Bearer ' + 'x'.repeat(40),
+      fakeEnv(),
+      fakeFetch,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.context.entitlement).toBe('premium');
+  });
+
+  it('caches auth results in KV for the 5-min window', async () => {
+    const env = fakeEnv();
+    let hits = 0;
+    const fakeFetch = (async () => {
+      hits++;
+      return new Response(
+        JSON.stringify({
+          subscriber: { entitlements: { partner_plus: { expires_date: null } } },
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const token = 'Bearer ' + 'x'.repeat(40);
+    const first = await authenticate(token, env, fakeFetch);
+    const second = await authenticate(token, env, fakeFetch);
+    expect(first.ok && second.ok).toBe(true);
+    expect(hits).toBe(1);
+  });
+});

--- a/ai-proxy/test/gapDetection.test.ts
+++ b/ai-proxy/test/gapDetection.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { parseGapSignal } from '../src/gapDetection';
+import {
+  DEDUP_COSINE_THRESHOLD,
+  GAP_SIMILARITY_FLOOR,
+  cosineSimilarity,
+  isLowRetrievalScore,
+  packEmbedding,
+  parseGapSignal,
+  scrubPII,
+  unpackEmbedding,
+} from '../src/gapDetection';
 
 describe('parseGapSignal', () => {
   it('parses a trailing gap envelope with gap=true', () => {
@@ -10,35 +19,100 @@ describe('parseGapSignal', () => {
     expect(signal).not.toBeNull();
     expect(signal?.gap).toBe(true);
     expect(signal?.gap_type).toBe('content');
-    expect(signal?.topic).toContain('Coptic');
   });
 
   it('parses gap=false envelope', () => {
-    const text = 'Here is a full answer.\n{"gap": false}';
-    const signal = parseGapSignal(text);
-    expect(signal?.gap).toBe(false);
+    expect(parseGapSignal('answer.\n{"gap": false}')?.gap).toBe(false);
   });
 
-  it('returns null when no trailing JSON is present', () => {
+  it('returns null when no trailing JSON', () => {
     expect(parseGapSignal('No JSON at all')).toBeNull();
     expect(parseGapSignal('Plain text ending with }')).toBeNull();
   });
 
-  it('rejects invalid gap_type values', () => {
-    const text = '{"gap": true, "gap_type": "bogus", "topic": "t"}';
-    const signal = parseGapSignal(text);
-    expect(signal?.gap).toBe(true);
-    expect(signal?.gap_type).toBeUndefined();
+  it('rejects invalid gap_type', () => {
+    expect(
+      parseGapSignal('{"gap": true, "gap_type": "bogus", "topic": "t"}')?.gap_type,
+    ).toBeUndefined();
   });
 
-  it('handles embedded braces in preceding text', () => {
-    const text =
-      'The verse uses the idiom {word} in a metaphorical sense.\n{"gap": false}';
-    const signal = parseGapSignal(text);
-    expect(signal?.gap).toBe(false);
+  it('handles embedded braces before envelope', () => {
+    expect(
+      parseGapSignal('The verse uses {word} in metaphor.\n{"gap": false}')?.gap,
+    ).toBe(false);
+  });
+});
+
+describe('scrubPII', () => {
+  it('redacts emails', () => {
+    expect(scrubPII('ping me at alex@example.com')).toContain('[email]');
+  });
+  it('redacts phone numbers', () => {
+    expect(scrubPII('call 415-555-1234 please')).toContain('[phone]');
+  });
+  it('redacts URLs', () => {
+    expect(scrubPII('see https://example.com/page')).toContain('[url]');
+  });
+  it('redacts credit-card-shaped strings', () => {
+    expect(scrubPII('card 4111 1111 1111 1111')).toContain('[card]');
+  });
+  it('leaves ordinary text alone', () => {
+    expect(scrubPII('What does chesed mean?')).toBe('What does chesed mean?');
+  });
+});
+
+describe('isLowRetrievalScore', () => {
+  it('returns true for empty chunks', () => {
+    expect(isLowRetrievalScore([])).toBe(true);
   });
 
-  it('returns null for non-JSON trailing braces', () => {
-    expect(parseGapSignal('This is not JSON }')).toBeNull();
+  it('returns true when every chunk is below the floor', () => {
+    const chunks = [
+      { chunk_id: 'a', source_type: 'section_panel', text: 't', metadata: {}, score: 0.3 },
+      { chunk_id: 'b', source_type: 'section_panel', text: 't', metadata: {}, score: 0.4 },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isLowRetrievalScore(chunks as any)).toBe(true);
+  });
+
+  it('returns false when any chunk is above the floor', () => {
+    const chunks = [
+      { chunk_id: 'a', source_type: 'section_panel', text: 't', metadata: {}, score: 0.3 },
+      { chunk_id: 'b', source_type: 'section_panel', text: 't', metadata: {}, score: 0.8 },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isLowRetrievalScore(chunks as any)).toBe(false);
+  });
+});
+
+describe('cosine + pack/unpack', () => {
+  it('cosine of identical vectors is 1', () => {
+    const a = new Float32Array([0.1, 0.2, 0.3]);
+    expect(cosineSimilarity(a, a)).toBeCloseTo(1);
+  });
+
+  it('cosine of orthogonal vectors is 0', () => {
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([0, 1]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0);
+  });
+
+  it('pack/unpack round-trips', () => {
+    const v = [0.01, -0.5, 1.25];
+    const packed = packEmbedding(v);
+    const unpacked = unpackEmbedding(packed);
+    expect(unpacked[0]).toBeCloseTo(0.01);
+    expect(unpacked[1]).toBeCloseTo(-0.5);
+    expect(unpacked[2]).toBeCloseTo(1.25);
+  });
+});
+
+describe('constants', () => {
+  it('dedup threshold is strict', () => {
+    expect(DEDUP_COSINE_THRESHOLD).toBeGreaterThanOrEqual(0.85);
+    expect(DEDUP_COSINE_THRESHOLD).toBeLessThanOrEqual(0.95);
+  });
+  it('similarity floor matches plan', () => {
+    expect(GAP_SIMILARITY_FLOOR).toBeCloseTo(0.55);
   });
 });

--- a/ai-proxy/test/gapDetection.test.ts
+++ b/ai-proxy/test/gapDetection.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseGapSignal } from '../src/gapDetection';
+
+describe('parseGapSignal', () => {
+  it('parses a trailing gap envelope with gap=true', () => {
+    const text =
+      "I don't have material on Coptic Orthodox commentary for Romans 9 in my corpus.\n" +
+      '{"gap": true, "gap_type": "content", "topic": "Coptic Orthodox Romans 9"}';
+    const signal = parseGapSignal(text);
+    expect(signal).not.toBeNull();
+    expect(signal?.gap).toBe(true);
+    expect(signal?.gap_type).toBe('content');
+    expect(signal?.topic).toContain('Coptic');
+  });
+
+  it('parses gap=false envelope', () => {
+    const text = 'Here is a full answer.\n{"gap": false}';
+    const signal = parseGapSignal(text);
+    expect(signal?.gap).toBe(false);
+  });
+
+  it('returns null when no trailing JSON is present', () => {
+    expect(parseGapSignal('No JSON at all')).toBeNull();
+    expect(parseGapSignal('Plain text ending with }')).toBeNull();
+  });
+
+  it('rejects invalid gap_type values', () => {
+    const text = '{"gap": true, "gap_type": "bogus", "topic": "t"}';
+    const signal = parseGapSignal(text);
+    expect(signal?.gap).toBe(true);
+    expect(signal?.gap_type).toBeUndefined();
+  });
+
+  it('handles embedded braces in preceding text', () => {
+    const text =
+      'The verse uses the idiom {word} in a metaphorical sense.\n{"gap": false}';
+    const signal = parseGapSignal(text);
+    expect(signal?.gap).toBe(false);
+  });
+
+  it('returns null for non-JSON trailing braces', () => {
+    expect(parseGapSignal('This is not JSON }')).toBeNull();
+  });
+});

--- a/ai-proxy/test/rateLimit.test.ts
+++ b/ai-proxy/test/rateLimit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LIMITS,
+  burstBucket,
+  checkAndIncrement,
+  monthBucket,
+} from '../src/rateLimit';
+import type { AuthContext, Env } from '../src/types';
+
+const FAKE_KV = (): KVNamespace => {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list() {
+      return { keys: [], list_complete: true, cursor: '' };
+    },
+  } as unknown as KVNamespace;
+};
+
+function env(): Env {
+  return { VERSION: 'test', RATE_LIMITS: FAKE_KV() };
+}
+
+function ctx(entitlement: 'premium' | 'partner_plus' = 'premium'): AuthContext {
+  return { receiptHash: 'a'.repeat(64), entitlement };
+}
+
+describe('bucket helpers', () => {
+  it('month bucket uses UTC year-month', () => {
+    const d = new Date(Date.UTC(2026, 3, 17, 12));
+    expect(monthBucket(d)).toBe('2026-04');
+  });
+
+  it('burst bucket increments every 10 minutes', () => {
+    const a = new Date(Date.UTC(2026, 3, 17, 12, 0, 0));
+    const b = new Date(Date.UTC(2026, 3, 17, 12, 9, 59));
+    const c = new Date(Date.UTC(2026, 3, 17, 12, 10, 0));
+    expect(burstBucket(a)).toBe(burstBucket(b));
+    expect(burstBucket(a)).not.toBe(burstBucket(c));
+  });
+});
+
+describe('checkAndIncrement', () => {
+  it('allows the first call and decrements remaining', async () => {
+    const r = await checkAndIncrement(ctx('premium'), env());
+    expect(r.allowed).toBe(true);
+    expect(r.monthlyRemaining).toBe(LIMITS.premium.monthly - 1);
+    expect(r.burstRemaining).toBe(LIMITS.premium.burst - 1);
+  });
+
+  it('blocks after 10 burst calls within the window', async () => {
+    const e = env();
+    const c = ctx('premium');
+    const now = new Date(Date.UTC(2026, 3, 17, 12, 0, 0));
+    for (let i = 0; i < LIMITS.premium.burst; i++) {
+      const r = await checkAndIncrement(c, e, { now });
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await checkAndIncrement(c, e, { now });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.burstRemaining).toBe(0);
+  });
+
+  it('blocks monthly limit for premium', async () => {
+    const e = env();
+    const c = ctx('premium');
+    const now = new Date(Date.UTC(2026, 3, 17, 12, 0, 0));
+    // Pre-seed the monthly counter so we don't have to make 300 calls
+    await e.RATE_LIMITS.put(
+      `rate:${c.receiptHash}:${monthBucket(now)}`,
+      String(LIMITS.premium.monthly),
+    );
+    const r = await checkAndIncrement(c, e, { now });
+    expect(r.allowed).toBe(false);
+    expect(r.monthlyRemaining).toBe(0);
+  });
+
+  it('gives partner_plus larger limits than premium', async () => {
+    expect(LIMITS.partner_plus.monthly).toBeGreaterThan(LIMITS.premium.monthly);
+    expect(LIMITS.partner_plus.burst).toBeGreaterThan(LIMITS.premium.burst);
+  });
+
+  it('counts are per-user, not shared across receipts', async () => {
+    const e = env();
+    const a = { receiptHash: 'a'.repeat(64), entitlement: 'premium' } as const;
+    const b = { receiptHash: 'b'.repeat(64), entitlement: 'premium' } as const;
+    const now = new Date();
+    for (let i = 0; i < LIMITS.premium.burst; i++) {
+      await checkAndIncrement(a, e, { now });
+    }
+    const r = await checkAndIncrement(b, e, { now });
+    expect(r.allowed).toBe(true);
+  });
+});

--- a/ai-proxy/tsconfig.json
+++ b/ai-proxy/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/ai-proxy/wrangler.toml
+++ b/ai-proxy/wrangler.toml
@@ -1,0 +1,41 @@
+name = "amicus-proxy"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+# ──────────────────────────────────────────────────────────────
+# Secrets — set via `wrangler secret put NAME --env <env>`:
+#   REVENUECAT_SECRET_KEY   — validates receipts
+#   ANTHROPIC_API_KEY       — chat completions
+#   OPENAI_API_KEY          — /ai/embed (same model as build-time corpus)
+# Never commit actual values here.
+# ──────────────────────────────────────────────────────────────
+
+[vars]
+VERSION = "0.1.0"
+
+# ── Staging ───────────────────────────────────────────────────
+[env.staging]
+route = "ai-staging.contentcompanionstudy.com/*"
+
+[[env.staging.kv_namespaces]]
+binding = "RATE_LIMITS"
+id = "REPLACE_WITH_STAGING_KV_ID"
+
+[[env.staging.d1_databases]]
+binding = "CORPUS_GAPS"
+database_name = "amicus-corpus-gaps-staging"
+database_id = "REPLACE_WITH_STAGING_D1_ID"
+
+# ── Production ────────────────────────────────────────────────
+[env.production]
+route = "ai.contentcompanionstudy.com/*"
+
+[[env.production.kv_namespaces]]
+binding = "RATE_LIMITS"
+id = "REPLACE_WITH_PROD_KV_ID"
+
+[[env.production.d1_databases]]
+binding = "CORPUS_GAPS"
+database_name = "amicus-corpus-gaps"
+database_id = "REPLACE_WITH_PROD_D1_ID"


### PR DESCRIPTION
Closes #1471. Depends on #1450 (stacked).

## Summary
Full corpus-gap feedback flywheel — every "I don't have that in my corpus" becomes a content-roadmap signal routed into the Partner Gaps swim lane.

## Gap triggers (any one captures)
1. **Model self-report** — trailing `{"gap": true, "gap_type": ..., "topic": ...}` envelope on the chat stream.
2. **Low retrieval score** — max chunk similarity < 0.55 (`GAP_SIMILARITY_FLOOR`).
3. **User thumbs-down** — new `POST /ai/feedback` endpoint.

## Proxy changes (`ai-proxy/`)
- `src/gapDetection.ts` — full pipeline: parse envelope, PII scrub, cosine dedup vs. recent open gaps (threshold 0.9), Haiku-paraphrased scrubbed summary, D1 INSERT or UPDATE.
- `src/index.ts` — chat handler tees stream, embeds the question once, combines signals, and passes rich context into `captureGap`. New endpoints:
  - `POST /ai/feedback` — thumbs-down capture
  - `DELETE /ai/gaps/:id` — hard redact (admin-gated: partner_plus + Cloudflare Access)
- `migrations/0001_corpus_gaps.sql` — D1 schema for `corpus_gaps` + `amicus_config` (seeded with `gap_sync_mode=individual`)
- `README.md` — documents new endpoints, D1 apply, sync script, config flag

## GitHub sync (`_tools/corpus_gap_sync.py`)
Scheduled runner that pulls `status='new'` gaps from D1 and creates GitHub issues labeled `corpus-gap` (Partner Gaps swim lane), then marks rows `issue_opened`. Two modes:
- **individual** (default) — one issue per gap
- **digest** — singletons roll up into a daily digest issue; clusters (≥3 occurrences) still get dedicated issues. Switched by the `amicus_config.gap_sync_mode` row — pure config change, no schema migration.

Supports `--dry-run` for verification.

## Test plan
- [x] `cd ai-proxy && npx tsc --noEmit` clean
- [x] `cd ai-proxy && npm test` — 49 tests pass (+12 new gap-detection tests: parse, scrub, low-score detection, cosine, pack/unpack, constants)
- [x] `python3 -c "import ast; ast.parse(open('_tools/corpus_gap_sync.py').read())"` — syntax clean
- [ ] **Reviewer:** apply migrations to staging D1, flip a canned prompt's chunks so `isLowRetrievalScore` fires, verify row lands in D1. Then run `python3 _tools/corpus_gap_sync.py --dry-run` with D1/GitHub tokens and confirm issue titles look right.

## Privacy posture
- Raw `question_text` is lightly scrubbed (email/phone/URL/card) and stored in D1 for Craig's reference only.
- GitHub issue body uses only `scrubbed_summary` (Haiku-paraphrased, non-identifying).
- `DELETE /ai/gaps/:id` wipes the row's question text, embedding, summary, profile, and chunk json.
- D1 access should be restricted via Cloudflare Access to Craig's email (infrastructure-side; not enforced in this PR).

## Out of scope
- Resolution hook closing gaps on content-PR merge — referenced in the spec; punted to a follow-up sync script enhancement once we have the first handful of real gaps.
- Cloudflare Access configuration — infrastructure task.

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe