### PR TITLE
feat(ai-partner): Amicus conversation persistence (#1457)

### DIFF
--- a/app/__tests__/db/amicus/mutations.test.ts
+++ b/app/__tests__/db/amicus/mutations.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for Amicus write mutations (#1457).
+ */
+import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+import {
+  appendAmicusMessage,
+  clearAllAmicusData,
+  createAmicusThread,
+  deleteAmicusThread,
+  incrementAmicusUsage,
+  toggleThreadPin,
+  updateThreadTitle,
+} from '@/db/userMutations';
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('createAmicusThread', () => {
+  it('inserts with provided id + title + optional chapter_ref', async () => {
+    await createAmicusThread({
+      threadId: 't-1',
+      title: 'First',
+      chapterRef: 'romans:9',
+    });
+    const mock = getMockUserDb();
+    const [sql, bindings] = mock.runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_threads/);
+    expect(bindings).toEqual(['t-1', 'First', 'romans:9']);
+  });
+
+  it('defaults chapterRef to null', async () => {
+    await createAmicusThread({ threadId: 't-2', title: 'No chapter' });
+    const [, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(bindings[2]).toBeNull();
+  });
+});
+
+describe('appendAmicusMessage', () => {
+  it('inserts message + updates parent thread in a transaction', async () => {
+    await appendAmicusMessage({
+      messageId: 'm1',
+      threadId: 't1',
+      role: 'user',
+      content: 'hi',
+    });
+    const mock = getMockUserDb();
+    expect(mock.withTransactionAsync).toHaveBeenCalledTimes(1);
+    // Two runAsync calls inside the tx: insert + update
+    expect(mock.runAsync.mock.calls.length).toBe(2);
+    expect(String(mock.runAsync.mock.calls[0]![0])).toMatch(/INSERT INTO amicus_messages/);
+    expect(String(mock.runAsync.mock.calls[1]![0])).toMatch(/UPDATE amicus_threads/);
+  });
+
+  it('serializes citations and follow-ups to JSON', async () => {
+    await appendAmicusMessage({
+      messageId: 'm2',
+      threadId: 't1',
+      role: 'assistant',
+      content: 'answer',
+      citations: [
+        { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
+      ],
+      followUps: ['follow-up 1'],
+    });
+    const [, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(JSON.parse(bindings[4] as string)).toHaveLength(1);
+    expect(JSON.parse(bindings[5] as string)).toEqual(['follow-up 1']);
+  });
+});
+
+describe('updateThreadTitle', () => {
+  it('issues UPDATE with the new title', async () => {
+    await updateThreadTitle('t1', 'New title');
+    const [sql, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/UPDATE amicus_threads/);
+    expect(bindings).toEqual(['New title', 't1']);
+  });
+});
+
+describe('toggleThreadPin', () => {
+  it('flips 0 → 1 and returns true', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ pinned: 0 });
+    const result = await toggleThreadPin('t1');
+    expect(result).toBe(true);
+    const [sql, bindings] = mock.runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/SET pinned = \?/);
+    expect(bindings[0]).toBe(1);
+  });
+
+  it('flips 1 → 0 and returns false', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ pinned: 1 });
+    const result = await toggleThreadPin('t1');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the thread does not exist', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await toggleThreadPin('missing')).toBe(false);
+  });
+});
+
+describe('deleteAmicusThread', () => {
+  it('issues DELETE on thread_id (CASCADE handles messages)', async () => {
+    await deleteAmicusThread('t1');
+    const [sql] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/DELETE FROM amicus_threads/);
+  });
+});
+
+describe('clearAllAmicusData', () => {
+  it('runs DELETE for all three tables inside a transaction', async () => {
+    await clearAllAmicusData();
+    const mock = getMockUserDb();
+    expect(mock.withTransactionAsync).toHaveBeenCalledTimes(1);
+    const sqls = mock.runAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(sqls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/DELETE FROM amicus_messages/),
+        expect.stringMatching(/DELETE FROM amicus_threads/),
+        expect.stringMatching(/DELETE FROM amicus_usage/),
+      ]),
+    );
+  });
+});
+
+describe('incrementAmicusUsage', () => {
+  it('upserts today row', async () => {
+    await incrementAmicusUsage();
+    const [sql] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_usage/);
+    expect(String(sql)).toMatch(/ON CONFLICT\(day\) DO UPDATE/);
+  });
+});

--- a/app/__tests__/db/amicus/queries.test.ts
+++ b/app/__tests__/db/amicus/queries.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for Amicus read queries (#1457).
+ */
+import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+jest.mock('@/db/database', () =>
+  require('../../helpers/mockDb').mockDatabaseModule(),
+);
+
+import {
+  getAmicusThread,
+  getAmicusUsageThisMonth,
+  getAmicusUsageToday,
+  listAmicusMessages,
+  listAmicusThreads,
+} from '@/db/userQueries';
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('listAmicusThreads', () => {
+  it('hydrates pinned boolean and orders pinned-first', async () => {
+    const userDb = getMockUserDb();
+    userDb.getAllAsync.mockResolvedValueOnce([
+      {
+        thread_id: 'pinned',
+        title: 'Pinned thread',
+        chapter_ref: null,
+        pinned: 1,
+        created_at: '2026-04-17',
+        last_message_at: '2026-04-17',
+      },
+      {
+        thread_id: 'normal',
+        title: 'Normal thread',
+        chapter_ref: 'romans:9',
+        pinned: 0,
+        created_at: '2026-04-16',
+        last_message_at: '2026-04-16',
+      },
+    ]);
+    const threads = await listAmicusThreads();
+    expect(threads).toHaveLength(2);
+    expect(threads[0]!.pinned).toBe(true);
+    expect(threads[1]!.pinned).toBe(false);
+    // Verify we called with DESC ordering in SQL
+    const [sql] = userDb.getAllAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/pinned DESC/);
+    expect(String(sql)).toMatch(/last_message_at DESC/);
+  });
+});
+
+describe('getAmicusThread', () => {
+  it('returns null when missing', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await getAmicusThread('missing')).toBeNull();
+  });
+
+  it('hydrates pinned correctly', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      thread_id: 't1',
+      title: 'T1',
+      chapter_ref: null,
+      pinned: 1,
+      created_at: 'x',
+      last_message_at: 'x',
+    });
+    const t = await getAmicusThread('t1');
+    expect(t?.pinned).toBe(true);
+  });
+});
+
+describe('listAmicusMessages', () => {
+  it('hydrates citations + follow-ups JSON', async () => {
+    const citations = [
+      { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
+    ];
+    const followUps = ['What about faith?', 'Why Romans 9?'];
+    getMockUserDb().getAllAsync.mockResolvedValueOnce([
+      {
+        message_id: 'm1',
+        thread_id: 't1',
+        role: 'assistant',
+        content: 'Hello',
+        citations_json: JSON.stringify(citations),
+        follow_ups_json: JSON.stringify(followUps),
+        created_at: 'x',
+      },
+    ]);
+    const msgs = await listAmicusMessages('t1');
+    expect(msgs[0]!.citations).toEqual(citations);
+    expect(msgs[0]!.follow_ups).toEqual(followUps);
+  });
+
+  it('tolerates null/invalid JSON', async () => {
+    getMockUserDb().getAllAsync.mockResolvedValueOnce([
+      {
+        message_id: 'm2',
+        thread_id: 't1',
+        role: 'user',
+        content: 'Q?',
+        citations_json: null,
+        follow_ups_json: 'not-json',
+        created_at: 'x',
+      },
+    ]);
+    const msgs = await listAmicusMessages('t1');
+    expect(msgs[0]!.citations).toEqual([]);
+    expect(msgs[0]!.follow_ups).toEqual([]);
+  });
+});
+
+describe('usage queries', () => {
+  it('getAmicusUsageToday returns 0 when no row', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await getAmicusUsageToday()).toBe(0);
+  });
+
+  it('getAmicusUsageToday returns the count', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ query_count: 17 });
+    expect(await getAmicusUsageToday()).toBe(17);
+  });
+
+  it('getAmicusUsageThisMonth sums via SQL', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ total: 42 });
+    expect(await getAmicusUsageThisMonth()).toBe(42);
+    const [sql] = mock.getFirstAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/SUM\(query_count\)/);
+    expect(String(sql)).toMatch(/strftime\('%Y-%m-01', 'now'\)/);
+  });
+});

--- a/app/__tests__/db/userDatabase.test.ts
+++ b/app/__tests__/db/userDatabase.test.ts
@@ -78,7 +78,7 @@ describe('userDatabase', () => {
       jest.resetModules();
       // Simulate all migrations already applied
       mockGetAllAsync.mockResolvedValueOnce(
-        Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
+        Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
       );
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
@@ -93,8 +93,8 @@ describe('userDatabase', () => {
       mockGetAllAsync.mockResolvedValueOnce([{ version: 1 }]);
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
-      // Should run 14 remaining migrations (2 through 15)
-      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(14);
+      // Should run 15 remaining migrations (2 through 16)
+      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(15);
     });
 
     it('throws on migration failure', async () => {

--- a/app/__tests__/unit/userDatabase.test.ts
+++ b/app/__tests__/unit/userDatabase.test.ts
@@ -66,9 +66,9 @@ describe('userDatabase', () => {
   });
 
   it('skips already-applied migrations', async () => {
-    // Simulate all 15 migrations already applied
+    // Simulate all 16 migrations already applied
     mockGetAllAsync.mockResolvedValue(
-      Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
+      Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
     );
 
     const { initUserDatabase } = require('@/db/userDatabase');

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -496,6 +496,41 @@ const MIGRATIONS: Migration[] = [
       );
     `,
   },
+  {
+    version: 16,
+    description: 'Amicus — threads, messages, and usage (#1457)',
+    sql: `
+      CREATE TABLE IF NOT EXISTS amicus_threads (
+        thread_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        chapter_ref TEXT,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_message_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_amicus_threads_pinned_last
+        ON amicus_threads(pinned DESC, last_message_at DESC);
+
+      CREATE TABLE IF NOT EXISTS amicus_messages (
+        message_id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES amicus_threads(thread_id) ON DELETE CASCADE,
+        role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+        content TEXT NOT NULL,
+        citations_json TEXT,
+        follow_ups_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_amicus_messages_thread
+        ON amicus_messages(thread_id, created_at);
+
+      CREATE TABLE IF NOT EXISTS amicus_usage (
+        day TEXT PRIMARY KEY,
+        query_count INTEGER NOT NULL DEFAULT 0
+      );
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -367,3 +367,107 @@ export async function resetToNewUser(): Promise<void> {
   await db.runAsync('DELETE FROM plan_progress');
   await db.runAsync("UPDATE reading_plans SET started_at = NULL, completed_at = NULL, abandoned_at = NULL WHERE started_at IS NOT NULL");
 }
+
+// ── Amicus threads + messages + usage (#1457) ───────────────────────
+
+export interface CreateAmicusThreadArgs {
+  threadId: string;           // caller-generated UUID
+  title: string;
+  chapterRef?: string | null;
+}
+
+export async function createAmicusThread(args: CreateAmicusThreadArgs): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_threads (thread_id, title, chapter_ref)
+     VALUES (?, ?, ?)`,
+    [args.threadId, args.title, args.chapterRef ?? null],
+  );
+  logger.info('Amicus', `created thread ${args.threadId}`);
+}
+
+export interface AppendAmicusMessageArgs {
+  messageId: string;
+  threadId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: Array<{
+    chunk_id: string; source_type: string; display_label: string; scholar_id?: string;
+  }>;
+  followUps?: string[];
+}
+
+export async function appendAmicusMessage(args: AppendAmicusMessageArgs): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      `INSERT INTO amicus_messages
+         (message_id, thread_id, role, content, citations_json, follow_ups_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        args.messageId,
+        args.threadId,
+        args.role,
+        args.content,
+        args.citations ? JSON.stringify(args.citations) : null,
+        args.followUps ? JSON.stringify(args.followUps) : null,
+      ],
+    );
+    await db.runAsync(
+      `UPDATE amicus_threads
+          SET last_message_at = datetime('now')
+        WHERE thread_id = ?`,
+      [args.threadId],
+    );
+  });
+}
+
+export async function updateThreadTitle(
+  threadId: string, title: string,
+): Promise<void> {
+  await getUserDb().runAsync(
+    'UPDATE amicus_threads SET title = ? WHERE thread_id = ?',
+    [title, threadId],
+  );
+}
+
+export async function toggleThreadPin(threadId: string): Promise<boolean> {
+  const db = getUserDb();
+  const row = await db.getFirstAsync<{ pinned: number }>(
+    'SELECT pinned FROM amicus_threads WHERE thread_id = ?',
+    [threadId],
+  );
+  if (!row) return false;
+  const next = row.pinned === 1 ? 0 : 1;
+  await db.runAsync(
+    'UPDATE amicus_threads SET pinned = ? WHERE thread_id = ?',
+    [next, threadId],
+  );
+  return next === 1;
+}
+
+export async function deleteAmicusThread(threadId: string): Promise<void> {
+  // CASCADE handles amicus_messages.
+  await getUserDb().runAsync(
+    'DELETE FROM amicus_threads WHERE thread_id = ?',
+    [threadId],
+  );
+  logger.info('Amicus', `deleted thread ${threadId}`);
+}
+
+export async function clearAllAmicusData(): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync('DELETE FROM amicus_messages');
+    await db.runAsync('DELETE FROM amicus_threads');
+    await db.runAsync('DELETE FROM amicus_usage');
+  });
+  logger.info('Amicus', 'cleared all amicus data');
+}
+
+export async function incrementAmicusUsage(): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_usage (day, query_count)
+     VALUES (strftime('%Y-%m-%d', 'now'), 1)
+     ON CONFLICT(day) DO UPDATE SET query_count = query_count + 1`,
+  );
+}

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -7,7 +7,11 @@
 
 import { chapterPrefix, formatVerseRef } from '../utils/verseRef';
 import { escapeLike } from '../utils/escapeLike';
-import type { UserNote, ReadingProgress, Bookmark, RecentChapter, StudyCollection, StudySession, StudySessionEvent } from '../types';
+import type {
+  UserNote, ReadingProgress, Bookmark, RecentChapter,
+  StudyCollection, StudySession, StudySessionEvent,
+  AmicusThread, AmicusMessage, AmicusCitation,
+} from '../types';
 import { getDb } from './database';
 import { getUserDb } from './userDatabase';
 
@@ -493,4 +497,118 @@ export async function isTopicBookmarked(topicId: string): Promise<boolean> {
     [topicId],
   );
   return (row?.count ?? 0) > 0;
+}
+
+// ── Amicus threads + messages + usage (#1457) ───────────────────────
+
+interface AmicusThreadRow {
+  thread_id: string;
+  title: string;
+  chapter_ref: string | null;
+  pinned: number;
+  created_at: string;
+  last_message_at: string;
+}
+
+interface AmicusMessageRow {
+  message_id: string;
+  thread_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations_json: string | null;
+  follow_ups_json: string | null;
+  created_at: string;
+}
+
+function hydrateThread(row: AmicusThreadRow): AmicusThread {
+  return {
+    thread_id: row.thread_id,
+    title: row.title,
+    chapter_ref: row.chapter_ref,
+    pinned: row.pinned === 1,
+    created_at: row.created_at,
+    last_message_at: row.last_message_at,
+  };
+}
+
+function hydrateMessage(row: AmicusMessageRow): AmicusMessage {
+  let citations: AmicusCitation[] = [];
+  let follow_ups: string[] = [];
+  if (row.citations_json) {
+    try {
+      const parsed = JSON.parse(row.citations_json);
+      if (Array.isArray(parsed)) citations = parsed as AmicusCitation[];
+    } catch {
+      /* ignore */
+    }
+  }
+  if (row.follow_ups_json) {
+    try {
+      const parsed = JSON.parse(row.follow_ups_json);
+      if (Array.isArray(parsed)) follow_ups = parsed as string[];
+    } catch {
+      /* ignore */
+    }
+  }
+  return {
+    message_id: row.message_id,
+    thread_id: row.thread_id,
+    role: row.role,
+    content: row.content,
+    citations,
+    follow_ups,
+    created_at: row.created_at,
+  };
+}
+
+export async function listAmicusThreads(
+  limit = 50, offset = 0,
+): Promise<AmicusThread[]> {
+  const rows = await getUserDb().getAllAsync<AmicusThreadRow>(
+    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
+       FROM amicus_threads
+      ORDER BY pinned DESC, last_message_at DESC
+      LIMIT ? OFFSET ?`,
+    [limit, offset],
+  );
+  return rows.map(hydrateThread);
+}
+
+export async function getAmicusThread(
+  threadId: string,
+): Promise<AmicusThread | null> {
+  const row = await getUserDb().getFirstAsync<AmicusThreadRow>(
+    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
+       FROM amicus_threads WHERE thread_id = ?`,
+    [threadId],
+  );
+  return row ? hydrateThread(row) : null;
+}
+
+export async function listAmicusMessages(
+  threadId: string,
+): Promise<AmicusMessage[]> {
+  const rows = await getUserDb().getAllAsync<AmicusMessageRow>(
+    `SELECT message_id, thread_id, role, content, citations_json, follow_ups_json, created_at
+       FROM amicus_messages WHERE thread_id = ? ORDER BY created_at ASC`,
+    [threadId],
+  );
+  return rows.map(hydrateMessage);
+}
+
+export async function getAmicusUsageToday(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ query_count: number }>(
+    "SELECT query_count FROM amicus_usage WHERE day = strftime('%Y-%m-%d', 'now')",
+  );
+  return row?.query_count ?? 0;
+}
+
+export async function getAmicusUsageThisMonth(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ total: number }>(
+    `SELECT COALESCE(SUM(query_count), 0) AS total
+       FROM amicus_usage
+      WHERE day >= strftime('%Y-%m-01', 'now')
+        AND day <  strftime('%Y-%m-01', 'now', '+1 month')`,
+  );
+  return row?.total ?? 0;
 }

--- a/app/src/hooks/useAmicusThreads.ts
+++ b/app/src/hooks/useAmicusThreads.ts
@@ -1,0 +1,124 @@
+/**
+ * hooks/useAmicusThreads.ts — Data hook for the Amicus thread list.
+ *
+ * Thin wrapper around listAmicusThreads + the thread mutations. Uses
+ * local React state (no global cache needed — thread list is screen-local).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deleteAmicusThread,
+  toggleThreadPin,
+  updateThreadTitle,
+} from '../db/userMutations';
+import { listAmicusThreads } from '../db/userQueries';
+import type { AmicusThread } from '../types';
+import { logger } from '../utils/logger';
+
+export interface UseAmicusThreadsResult {
+  threads: AmicusThread[];
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+  actions: {
+    pin: (threadId: string) => Promise<void>;
+    unpin: (threadId: string) => Promise<void>;
+    remove: (threadId: string) => Promise<void>;
+    rename: (threadId: string, title: string) => Promise<void>;
+  };
+}
+
+export function useAmicusThreads(limit = 50): UseAmicusThreadsResult {
+  const [threads, setThreads] = useState<AmicusThread[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const rows = await listAmicusThreads(limit, 0);
+      setThreads(rows);
+    } catch (err) {
+      logger.error('Amicus', 'listAmicusThreads failed', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const pin = useCallback(
+    async (threadId: string) => {
+      const current = threads.find((t) => t.thread_id === threadId);
+      if (!current || current.pinned) {
+        await refresh();
+        return;
+      }
+      // Optimistic update
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, pinned: true } : t)),
+      );
+      try {
+        await toggleThreadPin(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'pin failed', err);
+        await refresh();
+      }
+    },
+    [threads, refresh],
+  );
+
+  const unpin = useCallback(
+    async (threadId: string) => {
+      const current = threads.find((t) => t.thread_id === threadId);
+      if (!current || !current.pinned) {
+        await refresh();
+        return;
+      }
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, pinned: false } : t)),
+      );
+      try {
+        await toggleThreadPin(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'unpin failed', err);
+        await refresh();
+      }
+    },
+    [threads, refresh],
+  );
+
+  const remove = useCallback(
+    async (threadId: string) => {
+      setThreads((prev) => prev.filter((t) => t.thread_id !== threadId));
+      try {
+        await deleteAmicusThread(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'remove failed', err);
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  const rename = useCallback(
+    async (threadId: string, title: string) => {
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, title } : t)),
+      );
+      try {
+        await updateThreadTitle(threadId, title);
+      } catch (err) {
+        logger.error('Amicus', 'rename failed', err);
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  return {
+    threads,
+    isLoading,
+    refresh,
+    actions: { pin, unpin, remove, rename },
+  };
+}

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -62,6 +62,34 @@ export interface Bookmark {
   created_at: string;
 }
 
+// ── Amicus (#1457) ────────────────────────────────────────────
+
+export interface AmicusThread {
+  thread_id: string;
+  title: string;
+  chapter_ref: string | null;    // e.g. "romans:9"
+  pinned: boolean;
+  created_at: string;
+  last_message_at: string;
+}
+
+export interface AmicusCitation {
+  chunk_id: string;
+  source_type: string;
+  display_label: string;
+  scholar_id?: string;
+}
+
+export interface AmicusMessage {
+  message_id: string;
+  thread_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations: AmicusCitation[];
+  follow_ups: string[];
+  created_at: string;
+}
+
 // ══════════════════════════════════════════════════════════════
 // COMPUTED / JOINED TYPES
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #1457. Phase 2 of epic #1446. Stacked on #1452.

## Summary
Persistence foundation for Amicus — threads, messages, usage. Local-only to `user.db`; never synced (Supabase phase 14 may revisit).

## Migration v16
```sql
CREATE TABLE amicus_threads (thread_id PK, title, chapter_ref, pinned, created_at, last_message_at);
CREATE TABLE amicus_messages (message_id PK, thread_id FK CASCADE, role, content, citations_json, follow_ups_json, created_at);
CREATE TABLE amicus_usage (day PK, query_count);
```

## New API surface
**Queries** — `listAmicusThreads`, `getAmicusThread`, `listAmicusMessages`, `getAmicusUsageToday`, `getAmicusUsageThisMonth`.
**Mutations** — `createAmicusThread`, `appendAmicusMessage` (tx: insert + touch parent), `updateThreadTitle`, `toggleThreadPin`, `deleteAmicusThread`, `clearAllAmicusData`, `incrementAmicusUsage`.
**Types** — `AmicusThread`, `AmicusMessage`, `AmicusCitation`.
**Hook** — `useAmicusThreads()` with optimistic pin/unpin/remove/rename.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 3,218 tests pass
- [x] 19 new tests cover: pinned ordering, JSON hydration, transaction behavior, dedup of pin toggle, cascade delete, usage upsert
- [x] Migration count tests bumped 15 → 16

## Out of scope
- UI (#1454, #1455) — this PR is the pure data layer.
- Usage enforcement (#1460) — reads `getAmicusUsageThisMonth`.

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe