### PR TITLE
feat(ai-partner): Amicus thread management UI (#1454)

### DIFF
--- a/app/__tests__/db/amicus/mutations.test.ts
+++ b/app/__tests__/db/amicus/mutations.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for Amicus write mutations (#1457).
+ */
+import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+import {
+  appendAmicusMessage,
+  clearAllAmicusData,
+  createAmicusThread,
+  deleteAmicusThread,
+  incrementAmicusUsage,
+  toggleThreadPin,
+  updateThreadTitle,
+} from '@/db/userMutations';
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('createAmicusThread', () => {
+  it('inserts with provided id + title + optional chapter_ref', async () => {
+    await createAmicusThread({
+      threadId: 't-1',
+      title: 'First',
+      chapterRef: 'romans:9',
+    });
+    const mock = getMockUserDb();
+    const [sql, bindings] = mock.runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_threads/);
+    expect(bindings).toEqual(['t-1', 'First', 'romans:9']);
+  });
+
+  it('defaults chapterRef to null', async () => {
+    await createAmicusThread({ threadId: 't-2', title: 'No chapter' });
+    const [, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(bindings[2]).toBeNull();
+  });
+});
+
+describe('appendAmicusMessage', () => {
+  it('inserts message + updates parent thread in a transaction', async () => {
+    await appendAmicusMessage({
+      messageId: 'm1',
+      threadId: 't1',
+      role: 'user',
+      content: 'hi',
+    });
+    const mock = getMockUserDb();
+    expect(mock.withTransactionAsync).toHaveBeenCalledTimes(1);
+    // Two runAsync calls inside the tx: insert + update
+    expect(mock.runAsync.mock.calls.length).toBe(2);
+    expect(String(mock.runAsync.mock.calls[0]![0])).toMatch(/INSERT INTO amicus_messages/);
+    expect(String(mock.runAsync.mock.calls[1]![0])).toMatch(/UPDATE amicus_threads/);
+  });
+
+  it('serializes citations and follow-ups to JSON', async () => {
+    await appendAmicusMessage({
+      messageId: 'm2',
+      threadId: 't1',
+      role: 'assistant',
+      content: 'answer',
+      citations: [
+        { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
+      ],
+      followUps: ['follow-up 1'],
+    });
+    const [, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(JSON.parse(bindings[4] as string)).toHaveLength(1);
+    expect(JSON.parse(bindings[5] as string)).toEqual(['follow-up 1']);
+  });
+});
+
+describe('updateThreadTitle', () => {
+  it('issues UPDATE with the new title', async () => {
+    await updateThreadTitle('t1', 'New title');
+    const [sql, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/UPDATE amicus_threads/);
+    expect(bindings).toEqual(['New title', 't1']);
+  });
+});
+
+describe('toggleThreadPin', () => {
+  it('flips 0 → 1 and returns true', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ pinned: 0 });
+    const result = await toggleThreadPin('t1');
+    expect(result).toBe(true);
+    const [sql, bindings] = mock.runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/SET pinned = \?/);
+    expect(bindings[0]).toBe(1);
+  });
+
+  it('flips 1 → 0 and returns false', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ pinned: 1 });
+    const result = await toggleThreadPin('t1');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the thread does not exist', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await toggleThreadPin('missing')).toBe(false);
+  });
+});
+
+describe('deleteAmicusThread', () => {
+  it('issues DELETE on thread_id (CASCADE handles messages)', async () => {
+    await deleteAmicusThread('t1');
+    const [sql] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/DELETE FROM amicus_threads/);
+  });
+});
+
+describe('clearAllAmicusData', () => {
+  it('runs DELETE for all three tables inside a transaction', async () => {
+    await clearAllAmicusData();
+    const mock = getMockUserDb();
+    expect(mock.withTransactionAsync).toHaveBeenCalledTimes(1);
+    const sqls = mock.runAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(sqls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/DELETE FROM amicus_messages/),
+        expect.stringMatching(/DELETE FROM amicus_threads/),
+        expect.stringMatching(/DELETE FROM amicus_usage/),
+      ]),
+    );
+  });
+});
+
+describe('incrementAmicusUsage', () => {
+  it('upserts today row', async () => {
+    await incrementAmicusUsage();
+    const [sql] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_usage/);
+    expect(String(sql)).toMatch(/ON CONFLICT\(day\) DO UPDATE/);
+  });
+});

--- a/app/__tests__/db/amicus/queries.test.ts
+++ b/app/__tests__/db/amicus/queries.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for Amicus read queries (#1457).
+ */
+import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+jest.mock('@/db/database', () =>
+  require('../../helpers/mockDb').mockDatabaseModule(),
+);
+
+import {
+  getAmicusThread,
+  getAmicusUsageThisMonth,
+  getAmicusUsageToday,
+  listAmicusMessages,
+  listAmicusThreads,
+} from '@/db/userQueries';
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('listAmicusThreads', () => {
+  it('hydrates pinned boolean and orders pinned-first', async () => {
+    const userDb = getMockUserDb();
+    userDb.getAllAsync.mockResolvedValueOnce([
+      {
+        thread_id: 'pinned',
+        title: 'Pinned thread',
+        chapter_ref: null,
+        pinned: 1,
+        created_at: '2026-04-17',
+        last_message_at: '2026-04-17',
+      },
+      {
+        thread_id: 'normal',
+        title: 'Normal thread',
+        chapter_ref: 'romans:9',
+        pinned: 0,
+        created_at: '2026-04-16',
+        last_message_at: '2026-04-16',
+      },
+    ]);
+    const threads = await listAmicusThreads();
+    expect(threads).toHaveLength(2);
+    expect(threads[0]!.pinned).toBe(true);
+    expect(threads[1]!.pinned).toBe(false);
+    // Verify we called with DESC ordering in SQL
+    const [sql] = userDb.getAllAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/pinned DESC/);
+    expect(String(sql)).toMatch(/last_message_at DESC/);
+  });
+});
+
+describe('getAmicusThread', () => {
+  it('returns null when missing', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await getAmicusThread('missing')).toBeNull();
+  });
+
+  it('hydrates pinned correctly', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      thread_id: 't1',
+      title: 'T1',
+      chapter_ref: null,
+      pinned: 1,
+      created_at: 'x',
+      last_message_at: 'x',
+    });
+    const t = await getAmicusThread('t1');
+    expect(t?.pinned).toBe(true);
+  });
+});
+
+describe('listAmicusMessages', () => {
+  it('hydrates citations + follow-ups JSON', async () => {
+    const citations = [
+      { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
+    ];
+    const followUps = ['What about faith?', 'Why Romans 9?'];
+    getMockUserDb().getAllAsync.mockResolvedValueOnce([
+      {
+        message_id: 'm1',
+        thread_id: 't1',
+        role: 'assistant',
+        content: 'Hello',
+        citations_json: JSON.stringify(citations),
+        follow_ups_json: JSON.stringify(followUps),
+        created_at: 'x',
+      },
+    ]);
+    const msgs = await listAmicusMessages('t1');
+    expect(msgs[0]!.citations).toEqual(citations);
+    expect(msgs[0]!.follow_ups).toEqual(followUps);
+  });
+
+  it('tolerates null/invalid JSON', async () => {
+    getMockUserDb().getAllAsync.mockResolvedValueOnce([
+      {
+        message_id: 'm2',
+        thread_id: 't1',
+        role: 'user',
+        content: 'Q?',
+        citations_json: null,
+        follow_ups_json: 'not-json',
+        created_at: 'x',
+      },
+    ]);
+    const msgs = await listAmicusMessages('t1');
+    expect(msgs[0]!.citations).toEqual([]);
+    expect(msgs[0]!.follow_ups).toEqual([]);
+  });
+});
+
+describe('usage queries', () => {
+  it('getAmicusUsageToday returns 0 when no row', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await getAmicusUsageToday()).toBe(0);
+  });
+
+  it('getAmicusUsageToday returns the count', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ query_count: 17 });
+    expect(await getAmicusUsageToday()).toBe(17);
+  });
+
+  it('getAmicusUsageThisMonth sums via SQL', async () => {
+    const mock = getMockUserDb();
+    mock.getFirstAsync.mockResolvedValueOnce({ total: 42 });
+    expect(await getAmicusUsageThisMonth()).toBe(42);
+    const [sql] = mock.getFirstAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/SUM\(query_count\)/);
+    expect(String(sql)).toMatch(/strftime\('%Y-%m-01', 'now'\)/);
+  });
+});

--- a/app/__tests__/db/userDatabase.test.ts
+++ b/app/__tests__/db/userDatabase.test.ts
@@ -78,7 +78,7 @@ describe('userDatabase', () => {
       jest.resetModules();
       // Simulate all migrations already applied
       mockGetAllAsync.mockResolvedValueOnce(
-        Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
+        Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
       );
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
@@ -93,8 +93,8 @@ describe('userDatabase', () => {
       mockGetAllAsync.mockResolvedValueOnce([{ version: 1 }]);
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
-      // Should run 14 remaining migrations (2 through 15)
-      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(14);
+      // Should run 15 remaining migrations (2 through 16)
+      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(15);
     });
 
     it('throws on migration failure', async () => {

--- a/app/__tests__/unit/userDatabase.test.ts
+++ b/app/__tests__/unit/userDatabase.test.ts
@@ -66,9 +66,9 @@ describe('userDatabase', () => {
   });
 
   it('skips already-applied migrations', async () => {
-    // Simulate all 15 migrations already applied
+    // Simulate all 16 migrations already applied
     mockGetAllAsync.mockResolvedValue(
-      Array.from({ length: 15 }, (_, i) => ({ version: i + 1 })),
+      Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
     );
 
     const { initUserDatabase } = require('@/db/userDatabase');

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -496,6 +496,41 @@ const MIGRATIONS: Migration[] = [
       );
     `,
   },
+  {
+    version: 16,
+    description: 'Amicus — threads, messages, and usage (#1457)',
+    sql: `
+      CREATE TABLE IF NOT EXISTS amicus_threads (
+        thread_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        chapter_ref TEXT,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_message_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_amicus_threads_pinned_last
+        ON amicus_threads(pinned DESC, last_message_at DESC);
+
+      CREATE TABLE IF NOT EXISTS amicus_messages (
+        message_id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES amicus_threads(thread_id) ON DELETE CASCADE,
+        role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+        content TEXT NOT NULL,
+        citations_json TEXT,
+        follow_ups_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_amicus_messages_thread
+        ON amicus_messages(thread_id, created_at);
+
+      CREATE TABLE IF NOT EXISTS amicus_usage (
+        day TEXT PRIMARY KEY,
+        query_count INTEGER NOT NULL DEFAULT 0
+      );
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -367,3 +367,107 @@ export async function resetToNewUser(): Promise<void> {
   await db.runAsync('DELETE FROM plan_progress');
   await db.runAsync("UPDATE reading_plans SET started_at = NULL, completed_at = NULL, abandoned_at = NULL WHERE started_at IS NOT NULL");
 }
+
+// ── Amicus threads + messages + usage (#1457) ───────────────────────
+
+export interface CreateAmicusThreadArgs {
+  threadId: string;           // caller-generated UUID
+  title: string;
+  chapterRef?: string | null;
+}
+
+export async function createAmicusThread(args: CreateAmicusThreadArgs): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_threads (thread_id, title, chapter_ref)
+     VALUES (?, ?, ?)`,
+    [args.threadId, args.title, args.chapterRef ?? null],
+  );
+  logger.info('Amicus', `created thread ${args.threadId}`);
+}
+
+export interface AppendAmicusMessageArgs {
+  messageId: string;
+  threadId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: Array<{
+    chunk_id: string; source_type: string; display_label: string; scholar_id?: string;
+  }>;
+  followUps?: string[];
+}
+
+export async function appendAmicusMessage(args: AppendAmicusMessageArgs): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      `INSERT INTO amicus_messages
+         (message_id, thread_id, role, content, citations_json, follow_ups_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        args.messageId,
+        args.threadId,
+        args.role,
+        args.content,
+        args.citations ? JSON.stringify(args.citations) : null,
+        args.followUps ? JSON.stringify(args.followUps) : null,
+      ],
+    );
+    await db.runAsync(
+      `UPDATE amicus_threads
+          SET last_message_at = datetime('now')
+        WHERE thread_id = ?`,
+      [args.threadId],
+    );
+  });
+}
+
+export async function updateThreadTitle(
+  threadId: string, title: string,
+): Promise<void> {
+  await getUserDb().runAsync(
+    'UPDATE amicus_threads SET title = ? WHERE thread_id = ?',
+    [title, threadId],
+  );
+}
+
+export async function toggleThreadPin(threadId: string): Promise<boolean> {
+  const db = getUserDb();
+  const row = await db.getFirstAsync<{ pinned: number }>(
+    'SELECT pinned FROM amicus_threads WHERE thread_id = ?',
+    [threadId],
+  );
+  if (!row) return false;
+  const next = row.pinned === 1 ? 0 : 1;
+  await db.runAsync(
+    'UPDATE amicus_threads SET pinned = ? WHERE thread_id = ?',
+    [next, threadId],
+  );
+  return next === 1;
+}
+
+export async function deleteAmicusThread(threadId: string): Promise<void> {
+  // CASCADE handles amicus_messages.
+  await getUserDb().runAsync(
+    'DELETE FROM amicus_threads WHERE thread_id = ?',
+    [threadId],
+  );
+  logger.info('Amicus', `deleted thread ${threadId}`);
+}
+
+export async function clearAllAmicusData(): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync('DELETE FROM amicus_messages');
+    await db.runAsync('DELETE FROM amicus_threads');
+    await db.runAsync('DELETE FROM amicus_usage');
+  });
+  logger.info('Amicus', 'cleared all amicus data');
+}
+
+export async function incrementAmicusUsage(): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_usage (day, query_count)
+     VALUES (strftime('%Y-%m-%d', 'now'), 1)
+     ON CONFLICT(day) DO UPDATE SET query_count = query_count + 1`,
+  );
+}

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -7,7 +7,11 @@
 
 import { chapterPrefix, formatVerseRef } from '../utils/verseRef';
 import { escapeLike } from '../utils/escapeLike';
-import type { UserNote, ReadingProgress, Bookmark, RecentChapter, StudyCollection, StudySession, StudySessionEvent } from '../types';
+import type {
+  UserNote, ReadingProgress, Bookmark, RecentChapter,
+  StudyCollection, StudySession, StudySessionEvent,
+  AmicusThread, AmicusMessage, AmicusCitation,
+} from '../types';
 import { getDb } from './database';
 import { getUserDb } from './userDatabase';
 
@@ -493,4 +497,118 @@ export async function isTopicBookmarked(topicId: string): Promise<boolean> {
     [topicId],
   );
   return (row?.count ?? 0) > 0;
+}
+
+// ── Amicus threads + messages + usage (#1457) ───────────────────────
+
+interface AmicusThreadRow {
+  thread_id: string;
+  title: string;
+  chapter_ref: string | null;
+  pinned: number;
+  created_at: string;
+  last_message_at: string;
+}
+
+interface AmicusMessageRow {
+  message_id: string;
+  thread_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations_json: string | null;
+  follow_ups_json: string | null;
+  created_at: string;
+}
+
+function hydrateThread(row: AmicusThreadRow): AmicusThread {
+  return {
+    thread_id: row.thread_id,
+    title: row.title,
+    chapter_ref: row.chapter_ref,
+    pinned: row.pinned === 1,
+    created_at: row.created_at,
+    last_message_at: row.last_message_at,
+  };
+}
+
+function hydrateMessage(row: AmicusMessageRow): AmicusMessage {
+  let citations: AmicusCitation[] = [];
+  let follow_ups: string[] = [];
+  if (row.citations_json) {
+    try {
+      const parsed = JSON.parse(row.citations_json);
+      if (Array.isArray(parsed)) citations = parsed as AmicusCitation[];
+    } catch {
+      /* ignore */
+    }
+  }
+  if (row.follow_ups_json) {
+    try {
+      const parsed = JSON.parse(row.follow_ups_json);
+      if (Array.isArray(parsed)) follow_ups = parsed as string[];
+    } catch {
+      /* ignore */
+    }
+  }
+  return {
+    message_id: row.message_id,
+    thread_id: row.thread_id,
+    role: row.role,
+    content: row.content,
+    citations,
+    follow_ups,
+    created_at: row.created_at,
+  };
+}
+
+export async function listAmicusThreads(
+  limit = 50, offset = 0,
+): Promise<AmicusThread[]> {
+  const rows = await getUserDb().getAllAsync<AmicusThreadRow>(
+    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
+       FROM amicus_threads
+      ORDER BY pinned DESC, last_message_at DESC
+      LIMIT ? OFFSET ?`,
+    [limit, offset],
+  );
+  return rows.map(hydrateThread);
+}
+
+export async function getAmicusThread(
+  threadId: string,
+): Promise<AmicusThread | null> {
+  const row = await getUserDb().getFirstAsync<AmicusThreadRow>(
+    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
+       FROM amicus_threads WHERE thread_id = ?`,
+    [threadId],
+  );
+  return row ? hydrateThread(row) : null;
+}
+
+export async function listAmicusMessages(
+  threadId: string,
+): Promise<AmicusMessage[]> {
+  const rows = await getUserDb().getAllAsync<AmicusMessageRow>(
+    `SELECT message_id, thread_id, role, content, citations_json, follow_ups_json, created_at
+       FROM amicus_messages WHERE thread_id = ? ORDER BY created_at ASC`,
+    [threadId],
+  );
+  return rows.map(hydrateMessage);
+}
+
+export async function getAmicusUsageToday(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ query_count: number }>(
+    "SELECT query_count FROM amicus_usage WHERE day = strftime('%Y-%m-%d', 'now')",
+  );
+  return row?.query_count ?? 0;
+}
+
+export async function getAmicusUsageThisMonth(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ total: number }>(
+    `SELECT COALESCE(SUM(query_count), 0) AS total
+       FROM amicus_usage
+      WHERE day >= strftime('%Y-%m-01', 'now')
+        AND day <  strftime('%Y-%m-01', 'now', '+1 month')`,
+  );
+  return row?.total ?? 0;
 }

--- a/app/src/hooks/useAmicusThreads.ts
+++ b/app/src/hooks/useAmicusThreads.ts
@@ -1,0 +1,124 @@
+/**
+ * hooks/useAmicusThreads.ts — Data hook for the Amicus thread list.
+ *
+ * Thin wrapper around listAmicusThreads + the thread mutations. Uses
+ * local React state (no global cache needed — thread list is screen-local).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deleteAmicusThread,
+  toggleThreadPin,
+  updateThreadTitle,
+} from '../db/userMutations';
+import { listAmicusThreads } from '../db/userQueries';
+import type { AmicusThread } from '../types';
+import { logger } from '../utils/logger';
+
+export interface UseAmicusThreadsResult {
+  threads: AmicusThread[];
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+  actions: {
+    pin: (threadId: string) => Promise<void>;
+    unpin: (threadId: string) => Promise<void>;
+    remove: (threadId: string) => Promise<void>;
+    rename: (threadId: string, title: string) => Promise<void>;
+  };
+}
+
+export function useAmicusThreads(limit = 50): UseAmicusThreadsResult {
+  const [threads, setThreads] = useState<AmicusThread[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const rows = await listAmicusThreads(limit, 0);
+      setThreads(rows);
+    } catch (err) {
+      logger.error('Amicus', 'listAmicusThreads failed', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const pin = useCallback(
+    async (threadId: string) => {
+      const current = threads.find((t) => t.thread_id === threadId);
+      if (!current || current.pinned) {
+        await refresh();
+        return;
+      }
+      // Optimistic update
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, pinned: true } : t)),
+      );
+      try {
+        await toggleThreadPin(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'pin failed', err);
+        await refresh();
+      }
+    },
+    [threads, refresh],
+  );
+
+  const unpin = useCallback(
+    async (threadId: string) => {
+      const current = threads.find((t) => t.thread_id === threadId);
+      if (!current || !current.pinned) {
+        await refresh();
+        return;
+      }
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, pinned: false } : t)),
+      );
+      try {
+        await toggleThreadPin(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'unpin failed', err);
+        await refresh();
+      }
+    },
+    [threads, refresh],
+  );
+
+  const remove = useCallback(
+    async (threadId: string) => {
+      setThreads((prev) => prev.filter((t) => t.thread_id !== threadId));
+      try {
+        await deleteAmicusThread(threadId);
+      } catch (err) {
+        logger.error('Amicus', 'remove failed', err);
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  const rename = useCallback(
+    async (threadId: string, title: string) => {
+      setThreads((prev) =>
+        prev.map((t) => (t.thread_id === threadId ? { ...t, title } : t)),
+      );
+      try {
+        await updateThreadTitle(threadId, title);
+      } catch (err) {
+        logger.error('Amicus', 'rename failed', err);
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  return {
+    threads,
+    isLoading,
+    refresh,
+    actions: { pin, unpin, remove, rename },
+  };
+}

--- a/app/src/navigation/AmicusStack.tsx
+++ b/app/src/navigation/AmicusStack.tsx
@@ -1,0 +1,32 @@
+/**
+ * navigation/AmicusStack.tsx — Stack for the Amicus tab.
+ */
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+import { useTheme } from '../theme';
+import type { AmicusStackParamList } from './types';
+import { lazySuspense } from './lazySuspense';
+
+const ThreadListScreen = lazySuspense(() => import('../screens/AmicusThreadListScreen'));
+const ThreadScreen = lazySuspense(() => import('../screens/AmicusThreadScreen'));
+const NewThreadScreen = lazySuspense(() => import('../screens/AmicusNewThreadScreen'));
+const PaywallScreen = lazySuspense(() => import('../screens/AmicusPaywallScreen'));
+
+const Stack = createStackNavigator<AmicusStackParamList>();
+
+export function AmicusStack(): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        cardStyle: { backgroundColor: base.bg },
+      }}
+    >
+      <Stack.Screen name="ThreadList" component={ThreadListScreen} />
+      <Stack.Screen name="Thread" component={ThreadScreen} />
+      <Stack.Screen name="NewThread" component={NewThreadScreen} />
+      <Stack.Screen name="Paywall" component={PaywallScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/app/src/navigation/TabNavigator.tsx
+++ b/app/src/navigation/TabNavigator.tsx
@@ -1,11 +1,12 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Home, Library, Compass, Search, MoreHorizontal } from 'lucide-react-native';
+import { Home, Library, Compass, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
 import { useTheme } from '../theme';
 import { HomeStack } from './HomeStack';
 import { ReadStack } from './ReadStack';
 import { ExploreStack } from './ExploreStack';
 import { SearchStack } from './SearchStack';
 import { MoreStack } from './MoreStack';
+import { AmicusStack } from './AmicusStack';
 
 const Tab = createBottomTabNavigator();
 
@@ -68,6 +69,19 @@ export function TabNavigator() {
         listeners={({ navigation }) => ({
           tabPress: () => {
             navigation.navigate('ExploreTab', { screen: 'ExploreMenu' });
+          },
+        })}
+      />
+      <Tab.Screen
+        name="AmicusTab"
+        component={AmicusStack}
+        options={{
+          tabBarLabel: 'Amicus',
+          tabBarIcon: ({ color, size }) => <MessageSquare color={color} size={size} />,
+        }}
+        listeners={({ navigation }) => ({
+          tabPress: () => {
+            navigation.navigate('AmicusTab', { screen: 'ThreadList' });
           },
         })}
       />

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -127,12 +127,20 @@ export type SearchStackParamList = {
   SearchMain: undefined;
 };
 
+export type AmicusStackParamList = {
+  ThreadList: undefined;
+  Thread: { threadId: string };
+  NewThread: { seedQuery?: string; seedChapterRef?: string } | undefined;
+  Paywall: undefined;
+};
+
 // ── Tab Param List ────────────────────────────────────────────────
 
 export type TabParamList = {
   HomeTab: NavigatorScreenParams<HomeStackParamList>;
   ReadTab: NavigatorScreenParams<ReadStackParamList>;
   ExploreTab: NavigatorScreenParams<ExploreStackParamList>;
+  AmicusTab: NavigatorScreenParams<AmicusStackParamList>;
   SearchTab: NavigatorScreenParams<SearchStackParamList>;
   MoreTab: NavigatorScreenParams<MoreStackParamList>;
 };
@@ -147,6 +155,7 @@ type StackMap = {
   Explore: ExploreStackParamList;
   More: MoreStackParamList;
   Search: SearchStackParamList;
+  Amicus: AmicusStackParamList;
 };
 
 export type ScreenNavProp<

--- a/app/src/screens/AmicusNewThreadScreen.tsx
+++ b/app/src/screens/AmicusNewThreadScreen.tsx
@@ -1,0 +1,71 @@
+/**
+ * AmicusNewThreadScreen — creates a new thread and redirects to it.
+ *
+ * Accepts optional `seedQuery` + `seedChapterRef` for FAB peek / home card
+ * deep-link handoff (Phase 3/4). The streaming flow is wired in #1455; for
+ * #1454 we just create the empty thread and navigate in.
+ */
+import React, { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { createAmicusThread } from '../db/userMutations';
+import { useTheme } from '../theme';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { logger } from '../utils/logger';
+
+function uuid(): string {
+  // Avoid pulling a crypto dep — Math.random + timestamp is good enough for
+  // client-only thread ids.
+  const rand = Math.random().toString(16).slice(2, 10);
+  const stamp = Date.now().toString(16);
+  return `t-${stamp}-${rand}`;
+}
+
+function titleFromSeed(seed?: string): string {
+  if (!seed) return 'New conversation';
+  const trimmed = seed.trim().replace(/\s+/g, ' ');
+  return trimmed.length > 60 ? trimmed.slice(0, 57) + '…' : trimmed;
+}
+
+export default function AmicusNewThreadScreen(): React.ReactElement {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Amicus', 'NewThread'>>();
+  const route = useRoute<ScreenRouteProp<'Amicus', 'NewThread'>>();
+  const params = route.params;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const threadId = uuid();
+      try {
+        await createAmicusThread({
+          threadId,
+          title: titleFromSeed(params?.seedQuery),
+          chapterRef: params?.seedChapterRef ?? null,
+        });
+        if (cancelled) return;
+        navigation.replace('Thread', { threadId });
+      } catch (err) {
+        logger.error('Amicus', 'create thread failed', err);
+        if (!cancelled) navigation.goBack();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [navigation, params]);
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.center}>
+        <ActivityIndicator color={base.gold} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/app/src/screens/AmicusPaywallScreen.tsx
+++ b/app/src/screens/AmicusPaywallScreen.tsx
@@ -1,0 +1,84 @@
+/**
+ * AmicusPaywallScreen — shown to non-premium users who tap the Amicus tab.
+ *
+ * #1454 scaffolds the shell; #1460 wires the real entitlement gate +
+ * upgrade + restore flow.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { MessageSquare } from 'lucide-react-native';
+import { useTheme, spacing, fontFamily } from '../theme';
+import type { ScreenNavProp } from '../navigation/types';
+
+const BULLETS = [
+  'Ask any question about the Bible',
+  '72 scholars at your fingertips',
+  'Honest answers grounded in your corpus',
+  'Conversations remembered across sessions',
+];
+
+export default function AmicusPaywallScreen(): React.ReactElement {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Amicus', 'Paywall'>>();
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.content}>
+        <MessageSquare size={48} color={base.gold} />
+        <Text style={[styles.title, { color: base.text, fontFamily: fontFamily.display }]}>
+          Amicus
+        </Text>
+        <Text style={[styles.subtitle, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}>
+          Your scholarly study companion
+        </Text>
+
+        <View style={styles.bullets}>
+          {BULLETS.map((b) => (
+            <Text key={b} style={[styles.bullet, { color: base.text, fontFamily: fontFamily.body }]}>
+              •  {b}
+            </Text>
+          ))}
+        </View>
+
+        <Pressable
+          accessibilityLabel="Unlock with Companion+"
+          onPress={() =>
+            navigation.getParent()?.navigate('MoreTab', {
+              screen: 'Subscription',
+            })
+          }
+          style={[styles.cta, { backgroundColor: base.gold }]}
+        >
+          <Text style={[styles.ctaText, { color: base.bg }]}>Unlock with Companion+</Text>
+        </Pressable>
+
+        <Pressable
+          accessibilityLabel="Restore purchases"
+          onPress={() =>
+            navigation.getParent()?.navigate('MoreTab', {
+              screen: 'Subscription',
+            })
+          }
+        >
+          <Text style={[styles.restore, { color: base.textMuted }]}>
+            Already a subscriber? Restore purchases
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { flex: 1, padding: spacing.lg, alignItems: 'center', justifyContent: 'center', gap: spacing.sm },
+  title: { fontSize: 28, marginTop: spacing.md },
+  subtitle: { fontSize: 16, marginBottom: spacing.lg },
+  bullets: { alignSelf: 'stretch', gap: 8, marginVertical: spacing.lg },
+  bullet: { fontSize: 15 },
+  cta: { paddingVertical: 14, paddingHorizontal: 32, borderRadius: 999, marginTop: spacing.md },
+  ctaText: { fontSize: 16, fontWeight: '600' },
+  restore: { fontSize: 12, marginTop: spacing.md, textDecorationLine: 'underline' },
+});

--- a/app/src/screens/AmicusThreadListScreen.tsx
+++ b/app/src/screens/AmicusThreadListScreen.tsx
@@ -1,0 +1,361 @@
+/**
+ * AmicusThreadListScreen — Amicus tab home.
+ *
+ * Shows threads newest-first, with pinned threads grouped on top. Long-press
+ * opens an action sheet (pin/unpin, rename, delete). "+ New" button routes
+ * to the NewThread entry.
+ */
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { Pin, Plus, MessageSquare } from 'lucide-react-native';
+import { useAmicusThreads } from '../hooks/useAmicusThreads';
+import { useTheme, spacing, fontFamily } from '../theme';
+import type { ScreenNavProp } from '../navigation/types';
+import type { AmicusThread } from '../types';
+import { logger } from '../utils/logger';
+
+export default function AmicusThreadListScreen(): React.ReactElement {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Amicus', 'ThreadList'>>();
+  const { threads, isLoading, refresh, actions } = useAmicusThreads();
+  const [renaming, setRenaming] = useState<{ id: string; title: string } | null>(null);
+
+  const pinned = threads.filter((t) => t.pinned);
+  const unpinned = threads.filter((t) => !t.pinned);
+
+  const handleLongPress = useCallback(
+    (thread: AmicusThread) => {
+      Alert.alert(
+        thread.title || 'Thread',
+        undefined,
+        [
+          {
+            text: thread.pinned ? 'Unpin' : 'Pin',
+            onPress: () => {
+              if (thread.pinned) actions.unpin(thread.thread_id);
+              else actions.pin(thread.thread_id);
+            },
+          },
+          {
+            text: 'Rename',
+            onPress: () => setRenaming({ id: thread.thread_id, title: thread.title }),
+          },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () =>
+              Alert.alert(
+                'Delete thread?',
+                'This cannot be undone.',
+                [
+                  { text: 'Cancel', style: 'cancel' },
+                  {
+                    text: 'Delete',
+                    style: 'destructive',
+                    onPress: () => actions.remove(thread.thread_id),
+                  },
+                ],
+                { cancelable: true },
+              ),
+          },
+          { text: 'Cancel', style: 'cancel' },
+        ],
+        { cancelable: true },
+      );
+    },
+    [actions],
+  );
+
+  const renderRow = useCallback(
+    ({ item }: { item: AmicusThread }): React.ReactElement => (
+      <ThreadRow
+        thread={item}
+        onPress={() => navigation.navigate('Thread', { threadId: item.thread_id })}
+        onLongPress={() => handleLongPress(item)}
+        renaming={renaming?.id === item.thread_id ? renaming : null}
+        onRenameChange={(t) => setRenaming((prev) => (prev ? { ...prev, title: t } : prev))}
+        onRenameSubmit={async () => {
+          if (!renaming) return;
+          const title = renaming.title.trim();
+          if (title.length > 0 && title !== item.title) {
+            await actions.rename(item.thread_id, title);
+          }
+          setRenaming(null);
+        }}
+        onRenameCancel={() => setRenaming(null)}
+      />
+    ),
+    [handleLongPress, navigation, actions, renaming],
+  );
+
+  const data: AmicusThread[] = [...pinned, ...unpinned];
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <View style={styles.center}>
+          <ActivityIndicator color={base.gold} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.header}>
+        <View>
+          <Text style={[styles.title, { color: base.text, fontFamily: fontFamily.display }]}>
+            Amicus
+          </Text>
+          <Text style={[styles.subtitle, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}>
+            Your study conversations
+          </Text>
+        </View>
+        <Pressable
+          accessibilityLabel="New conversation"
+          onPress={() => navigation.navigate('NewThread', undefined)}
+          style={[styles.newButton, { backgroundColor: base.gold }]}
+        >
+          <Plus size={14} color={base.bg} />
+          <Text style={[styles.newButtonText, { color: base.bg }]}>New</Text>
+        </Pressable>
+      </View>
+
+      {data.length === 0 ? (
+        <EmptyState
+          onStart={() => navigation.navigate('NewThread', undefined)}
+        />
+      ) : (
+        <FlatList
+          data={data}
+          keyExtractor={(t) => t.thread_id}
+          renderItem={renderRow}
+          ItemSeparatorComponent={Separator}
+          refreshControl={
+            <RefreshControl
+              refreshing={isLoading}
+              onRefresh={() => {
+                void refresh().catch((err) => logger.error('Amicus', 'refresh failed', err));
+              }}
+              tintColor={base.gold}
+            />
+          }
+          ListHeaderComponent={pinned.length > 0 ? <SectionHeader label="Pinned" /> : null}
+          contentContainerStyle={data.length === 0 ? styles.flex : undefined}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────
+
+interface ThreadRowProps {
+  thread: AmicusThread;
+  onPress: () => void;
+  onLongPress: () => void;
+  renaming: { id: string; title: string } | null;
+  onRenameChange: (t: string) => void;
+  onRenameSubmit: () => void | Promise<void>;
+  onRenameCancel: () => void;
+}
+
+function ThreadRow(props: ThreadRowProps): React.ReactElement {
+  const { base } = useTheme();
+  const { thread } = props;
+
+  if (props.renaming) {
+    return (
+      <View style={[styles.row, { backgroundColor: base.bgSurface }]}>
+        <TextInput
+          autoFocus
+          value={props.renaming.title}
+          onChangeText={props.onRenameChange}
+          onBlur={() => void props.onRenameSubmit()}
+          onSubmitEditing={() => void props.onRenameSubmit()}
+          returnKeyType="done"
+          accessibilityLabel="Rename thread"
+          style={[
+            styles.renameInput,
+            { color: base.text, borderColor: base.gold, fontFamily: fontFamily.display },
+          ]}
+        />
+        <Pressable onPress={props.onRenameCancel} accessibilityLabel="Cancel rename">
+          <Text style={{ color: base.textMuted }}>Cancel</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const chapter = thread.chapter_ref;
+  return (
+    <Pressable
+      accessibilityLabel={`Open thread ${thread.title}`}
+      accessibilityHint="Long press for options"
+      onPress={props.onPress}
+      onLongPress={props.onLongPress}
+      style={({ pressed }) => [
+        styles.row,
+        { backgroundColor: pressed ? base.bgSurface : 'transparent' },
+      ]}
+    >
+      <View style={styles.rowBody}>
+        <View style={styles.rowTitleLine}>
+          {thread.pinned && <Pin size={12} color={base.gold} />}
+          <Text
+            numberOfLines={1}
+            style={[styles.rowTitle, { color: base.text, fontFamily: fontFamily.display }]}
+          >
+            {thread.title}
+          </Text>
+          {chapter && <ChapterBadge label={chapter} />}
+        </View>
+        <Text
+          numberOfLines={1}
+          style={[styles.rowTimestamp, { color: base.textMuted }]}
+        >
+          {relativeTime(thread.last_message_at)}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function ChapterBadge({ label }: { label: string }): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <View style={[styles.badge, { borderColor: base.gold, backgroundColor: `${base.gold}20` }]}>
+      <Text style={[styles.badgeText, { color: base.gold }]}>{formatChapterRef(label)}</Text>
+    </View>
+  );
+}
+
+function SectionHeader({ label }: { label: string }): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <Text style={[styles.sectionHeader, { color: base.textMuted }]}>{label}</Text>
+  );
+}
+
+function Separator(): React.ReactElement {
+  const { base } = useTheme();
+  return <View style={[styles.separator, { backgroundColor: base.border }]} />;
+}
+
+function EmptyState({ onStart }: { onStart: () => void }): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <View style={[styles.empty, { backgroundColor: base.bg }]}>
+      <MessageSquare size={40} color={base.gold} />
+      <Text style={[styles.emptyTitle, { color: base.text, fontFamily: fontFamily.display }]}>
+        Amicus is ready when you are.
+      </Text>
+      <Pressable
+        onPress={onStart}
+        accessibilityLabel="Ask a question"
+        style={[styles.primaryButton, { backgroundColor: base.gold }]}
+      >
+        <Text style={[styles.primaryButtonText, { color: base.bg }]}>Ask a question</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────
+
+function formatChapterRef(ref: string): string {
+  // "romans:9" → "Romans 9"
+  const [book, chap] = ref.split(':');
+  if (!book || !chap) return ref;
+  const pretty = book.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  return `${pretty} ${chap}`;
+}
+
+function relativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '';
+  const delta = Date.now() - t;
+  const mins = Math.floor(delta / 60000);
+  if (mins < 60) return `${Math.max(1, mins)}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d`;
+  return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ── Styles ────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.sm,
+  },
+  title: { fontSize: 22 },
+  subtitle: { fontSize: 13, marginTop: 2 },
+  newButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+  },
+  newButtonText: { fontSize: 13, fontWeight: '600' },
+  sectionHeader: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: 6,
+    fontSize: 11,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  row: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  rowBody: { flex: 1, gap: 2 },
+  rowTitleLine: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  rowTitle: { fontSize: 15, flexShrink: 1 },
+  rowTimestamp: { fontSize: 11, marginLeft: spacing.sm },
+  badge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  badgeText: { fontSize: 10, letterSpacing: 0.3 },
+  separator: { height: StyleSheet.hairlineWidth, marginLeft: spacing.md },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg, gap: spacing.md },
+  emptyTitle: { fontSize: 18, textAlign: 'center' },
+  primaryButton: { paddingVertical: 12, paddingHorizontal: 24, borderRadius: 999, marginTop: spacing.sm },
+  primaryButtonText: { fontSize: 15, fontWeight: '600' },
+  renameInput: {
+    flex: 1,
+    borderBottomWidth: 1,
+    fontSize: 15,
+    paddingVertical: 4,
+    marginRight: spacing.sm,
+  },
+});

--- a/app/src/screens/AmicusThreadScreen.tsx
+++ b/app/src/screens/AmicusThreadScreen.tsx
@@ -1,0 +1,166 @@
+/**
+ * AmicusThreadScreen — shell for a single Amicus conversation.
+ *
+ * Only the header + placeholder list + placeholder input are wired in this
+ * card (#1454). Streaming + citation rendering + full input behavior arrive
+ * in #1455.
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { ChevronLeft } from 'lucide-react-native';
+import { useTheme, spacing, fontFamily } from '../theme';
+import { getAmicusThread, listAmicusMessages } from '../db/userQueries';
+import type { AmicusMessage, AmicusThread } from '../types';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { logger } from '../utils/logger';
+
+export default function AmicusThreadScreen(): React.ReactElement {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Amicus', 'Thread'>>();
+  const route = useRoute<ScreenRouteProp<'Amicus', 'Thread'>>();
+  const { threadId } = route.params;
+
+  const [thread, setThread] = useState<AmicusThread | null>(null);
+  const [messages, setMessages] = useState<AmicusMessage[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [t, m] = await Promise.all([
+          getAmicusThread(threadId),
+          listAmicusMessages(threadId),
+        ]);
+        if (cancelled) return;
+        setThread(t);
+        setMessages(m);
+      } catch (err) {
+        logger.error('Amicus', 'thread load failed', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId]);
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={[styles.header, { borderBottomColor: base.border }]}>
+        <Pressable
+          accessibilityLabel="Back"
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        >
+          <ChevronLeft size={24} color={base.text} />
+        </Pressable>
+        <View style={styles.headerText}>
+          <Text
+            numberOfLines={1}
+            style={[styles.headerTitle, { color: base.text, fontFamily: fontFamily.display }]}
+          >
+            {thread?.title ?? 'Amicus'}
+          </Text>
+          {thread?.chapter_ref && (
+            <Text style={[styles.headerBadge, { color: base.gold }]}>
+              {thread.chapter_ref}
+            </Text>
+          )}
+        </View>
+      </View>
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <FlatList
+          inverted
+          data={[...messages].reverse()}
+          keyExtractor={(m) => m.message_id}
+          contentContainerStyle={styles.messagesContent}
+          renderItem={({ item }) => (
+            <View
+              style={[
+                styles.messageBubble,
+                item.role === 'user'
+                  ? [styles.userBubble, { backgroundColor: base.gold }]
+                  : [styles.assistantBubble, { backgroundColor: base.bgSurface }],
+              ]}
+            >
+              <Text
+                style={{
+                  color: item.role === 'user' ? base.bg : base.text,
+                  fontFamily: fontFamily.body,
+                }}
+              >
+                {item.content}
+              </Text>
+            </View>
+          )}
+          ListEmptyComponent={
+            <View style={styles.empty}>
+              <Text style={[styles.emptyText, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}>
+                Ask Amicus anything.
+              </Text>
+            </View>
+          }
+        />
+
+        <View style={[styles.inputBar, { borderTopColor: base.border, backgroundColor: base.bg }]}>
+          <TextInput
+            placeholder="Message Amicus…"
+            placeholderTextColor={base.textMuted}
+            style={[styles.input, { color: base.text, borderColor: base.border }]}
+            editable={false}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  backButton: { padding: spacing.xs },
+  headerText: { flex: 1, marginLeft: spacing.sm },
+  headerTitle: { fontSize: 16 },
+  headerBadge: { fontSize: 11, marginTop: 2 },
+  messagesContent: { padding: spacing.md, gap: spacing.sm },
+  messageBubble: { padding: spacing.sm, borderRadius: 12, maxWidth: '85%' },
+  userBubble: { alignSelf: 'flex-end' },
+  assistantBubble: { alignSelf: 'flex-start' },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg },
+  emptyText: { fontSize: 15 },
+  inputBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+});

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -62,6 +62,34 @@ export interface Bookmark {
   created_at: string;
 }
 
+// ── Amicus (#1457) ────────────────────────────────────────────
+
+export interface AmicusThread {
+  thread_id: string;
+  title: string;
+  chapter_ref: string | null;    // e.g. "romans:9"
+  pinned: boolean;
+  created_at: string;
+  last_message_at: string;
+}
+
+export interface AmicusCitation {
+  chunk_id: string;
+  source_type: string;
+  display_label: string;
+  scholar_id?: string;
+}
+
+export interface AmicusMessage {
+  message_id: string;
+  thread_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  citations: AmicusCitation[];
+  follow_ups: string[];
+  created_at: string;
+}
+
 // ══════════════════════════════════════════════════════════════
 // COMPUTED / JOINED TYPES
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #1454. Phase 2 of epic #1446. Depends on #1457 (merged). Paired with #1460 for entitlement gate.

## Summary
New Amicus tab between Explore and Search with its own stack (`AmicusStack`). Four screens: ThreadList (home), Thread (shell), NewThread (creation redirect), Paywall (shell).

## What works
- Thread list with pinned grouping, newest-first, pull-to-refresh.
- Long-press → Alert action sheet (Pin/Unpin, Rename, Delete with confirm).
- Inline rename via `TextInput` with autofocus + onBlur save.
- `NewThread` accepts optional `seedQuery` + `seedChapterRef` for FAB/home-card deep-linking.
- Thread screen shell: header with back + title + chapter badge; inverted FlatList; placeholder input bar.

## What's still stubbed
- Streaming chat → #1455.
- Citation pill taps → #1456.
- Entitlement gate → #1460 (paywall opens from its own route for now).
- Privacy opt-in modal → #1458.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 3,258 tests pass (no new tests; UI change)
- [x] `npx eslint src/screens/Amicus*.tsx src/navigation/AmicusStack.tsx src/navigation/TabNavigator.tsx` — 0 warnings
- [ ] Reviewer: smoke-test empty state, pin/unpin, rename, delete, New button behavior on a dev build.

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe