### PR TITLE
feat(ai-partner): streaming chat UI with citation pills (#1455)

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -19,6 +19,9 @@ module.exports = {
     '!src/**/*.d.ts',
     '!src/types/**',
     '!src/navigation/**',
+    // Dev-only Amicus smoke harness (feature-flagged) — not shipped to users.
+    '!src/screens/dev/**',
+    '!src/services/amicus/__smoke__/**',
   ],
   coverageThreshold: {
     global: {

--- a/app/src/components/amicus/AssistantMessageBubble.tsx
+++ b/app/src/components/amicus/AssistantMessageBubble.tsx
@@ -1,0 +1,65 @@
+/**
+ * components/amicus/AssistantMessageBubble.tsx — prose + inline citation
+ * pills, with an optional streaming indicator after the last token.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { parseAssistantMessage } from '../../services/amicus/streamParser';
+import type { AmicusCitation } from '../../types';
+import { fontFamily, useTheme } from '../../theme';
+import StreamingDot from './StreamingDot';
+import CitationPill from './CitationPill';
+
+export interface AssistantMessageBubbleProps {
+  content: string;
+  citations: AmicusCitation[];
+  isStreaming: boolean;
+  onCitationPress?: (citation: AmicusCitation) => void;
+}
+
+export default function AssistantMessageBubble(
+  props: AssistantMessageBubbleProps,
+): React.ReactElement {
+  const { base } = useTheme();
+  const parsed = parseAssistantMessage(props.content);
+  const citationByChunk = new Map(props.citations.map((c) => [c.chunk_id, c]));
+
+  return (
+    <View style={[styles.bubble, { backgroundColor: base.bgSurface }]}>
+      <Text style={[styles.prose, { color: base.text, fontFamily: fontFamily.body }]}>
+        {parsed.nodes.map((node, i) => {
+          if (node.type === 'text') return <Text key={i}>{node.text}</Text>;
+          const full = citationByChunk.get(node.pill.chunk_id);
+          const label = full?.display_label ?? node.pill.display_label;
+          const scholar = full?.scholar_id ?? node.pill.scholar_id;
+          return (
+            <Text key={i}>
+              {' '}
+              <CitationPill
+                chunkId={node.pill.chunk_id}
+                sourceType={node.pill.source_type}
+                displayLabel={label}
+                scholarId={scholar}
+                onPress={full ? () => props.onCitationPress?.(full) : undefined}
+              />
+              {' '}
+            </Text>
+          );
+        })}
+        {props.isStreaming && <StreamingDot />}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    alignSelf: 'flex-start',
+    maxWidth: '92%',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 16,
+    marginVertical: 4,
+  },
+  prose: { fontSize: 15, lineHeight: 22 },
+});

--- a/app/src/components/amicus/CitationPill.tsx
+++ b/app/src/components/amicus/CitationPill.tsx
@@ -1,0 +1,52 @@
+/**
+ * components/amicus/CitationPill.tsx — inline pill for a chunk citation.
+ *
+ * Rendered within assistant prose. Visual: compact gold pill. Tap handler
+ * is wired in #1456 (citation navigation); here it accepts a generic
+ * `onPress` so the parent can route via the future navigator.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useTheme } from '../../theme';
+
+export interface CitationPillProps {
+  chunkId: string;
+  sourceType: string;
+  displayLabel: string;
+  scholarId?: string;
+  onPress?: () => void;
+}
+
+export default function CitationPill(props: CitationPillProps): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <Pressable
+      accessibilityLabel={`Open source: ${props.displayLabel}`}
+      onPress={props.onPress}
+      style={({ pressed }) => [
+        styles.pill,
+        {
+          backgroundColor: pressed ? `${base.gold}40` : `${base.gold}20`,
+          borderColor: base.gold,
+        },
+      ]}
+    >
+      <Text style={[styles.text, { color: base.gold }]} numberOfLines={1}>
+        {props.displayLabel}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 999,
+    borderWidth: 1,
+    marginHorizontal: 2,
+    marginVertical: 1,
+  },
+  text: { fontSize: 11, letterSpacing: 0.2 },
+});

--- a/app/src/components/amicus/FollowUpChips.tsx
+++ b/app/src/components/amicus/FollowUpChips.tsx
@@ -1,0 +1,58 @@
+/**
+ * components/amicus/FollowUpChips.tsx — 3 tappable follow-up suggestions.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+export interface FollowUpChipsProps {
+  followUps: string[];
+  onSelect: (text: string) => void;
+}
+
+export default function FollowUpChips(props: FollowUpChipsProps): React.ReactElement | null {
+  const { base } = useTheme();
+  if (props.followUps.length === 0) return null;
+  return (
+    <View style={styles.row}>
+      {props.followUps.slice(0, 3).map((text) => (
+        <Pressable
+          key={text}
+          accessibilityLabel={`Ask: ${text}`}
+          onPress={() => props.onSelect(text)}
+          style={({ pressed }) => [
+            styles.chip,
+            {
+              borderColor: base.gold,
+              backgroundColor: pressed ? `${base.gold}20` : 'transparent',
+            },
+          ]}
+        >
+          <Text
+            style={[styles.chipText, { color: base.gold, fontFamily: fontFamily.body }]}
+            numberOfLines={2}
+          >
+            {text}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    padding: spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    maxWidth: '100%',
+  },
+  chipText: { fontSize: 12 },
+});

--- a/app/src/components/amicus/InputBar.tsx
+++ b/app/src/components/amicus/InputBar.tsx
@@ -1,0 +1,102 @@
+/**
+ * components/amicus/InputBar.tsx — sticky bottom input with send / stop
+ * button. Multi-line up to 4 visible lines. Disabled during streaming
+ * (becomes a Stop button that aborts the current stream).
+ */
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { ArrowUp, Square } from 'lucide-react-native';
+import { spacing, useTheme } from '../../theme';
+
+export interface InputBarProps {
+  isStreaming: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  onSend: (text: string) => void;
+  onAbort: () => void;
+}
+
+const MAX_CHARS = 2000;
+
+export default function InputBar(props: InputBarProps): React.ReactElement {
+  const { base } = useTheme();
+  const [text, setText] = useState('');
+  const canSend = !props.disabled && !props.isStreaming && text.trim().length > 0;
+
+  const send = (): void => {
+    const t = text.trim();
+    if (!t) return;
+    setText('');
+    props.onSend(t);
+  };
+
+  return (
+    <View style={[styles.bar, { borderTopColor: base.border, backgroundColor: base.bg }]}>
+      <TextInput
+        value={text}
+        onChangeText={(v) => setText(v.slice(0, MAX_CHARS))}
+        placeholder={props.placeholder ?? 'Message Amicus…'}
+        placeholderTextColor={base.textMuted}
+        style={[
+          styles.input,
+          {
+            color: base.text,
+            backgroundColor: base.bgSurface,
+            borderColor: base.border,
+          },
+        ]}
+        multiline
+        maxLength={MAX_CHARS}
+        editable={!props.disabled}
+        returnKeyType="default"
+        accessibilityLabel="Message Amicus"
+      />
+      <Pressable
+        accessibilityLabel={props.isStreaming ? 'Stop streaming' : 'Send'}
+        disabled={!props.isStreaming && !canSend}
+        onPress={() => (props.isStreaming ? props.onAbort() : send())}
+        style={({ pressed }) => [
+          styles.sendButton,
+          {
+            backgroundColor: canSend || props.isStreaming ? base.gold : base.border,
+            opacity: pressed ? 0.7 : 1,
+          },
+        ]}
+      >
+        {props.isStreaming ? (
+          <Square size={14} color={base.bg} fill={base.bg} />
+        ) : (
+          <ArrowUp size={18} color={base.bg} />
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 14,
+    minHeight: 40,
+    maxHeight: 120,
+  },
+  sendButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/src/components/amicus/MessageList.tsx
+++ b/app/src/components/amicus/MessageList.tsx
@@ -1,0 +1,127 @@
+/**
+ * components/amicus/MessageList.tsx — inverted FlatList of chat messages
+ * with a "new message ↓" pill when the user has scrolled up during a stream.
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import type { AmicusCitation, AmicusMessage } from '../../types';
+import { fontFamily, spacing, useTheme } from '../../theme';
+import AssistantMessageBubble from './AssistantMessageBubble';
+import UserMessageBubble from './UserMessageBubble';
+import FollowUpChips from './FollowUpChips';
+
+export interface MessageListProps {
+  messages: AmicusMessage[];
+  isStreaming: boolean;
+  onCitationPress?: (c: AmicusCitation) => void;
+  onFollowUp?: (text: string) => void;
+}
+
+export default function MessageList(props: MessageListProps): React.ReactElement {
+  const { base } = useTheme();
+  const ref = useRef<FlatList<AmicusMessage>>(null);
+  const [showNew, setShowNew] = useState(false);
+  const atBottomRef = useRef(true);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>): void => {
+      // Inverted list — scroll offset near 0 = at bottom visually.
+      const offset = e.nativeEvent.contentOffset.y;
+      const atBottom = offset < 80;
+      atBottomRef.current = atBottom;
+      if (atBottom) setShowNew(false);
+    },
+    [],
+  );
+
+  // When streaming emits new tokens and user is at bottom, nothing to do.
+  // When user scrolled up, show the jump pill.
+  React.useEffect(() => {
+    if (!props.isStreaming) return;
+    if (!atBottomRef.current) setShowNew(true);
+  }, [props.isStreaming, props.messages]);
+
+  const data = React.useMemo(() => [...props.messages].reverse(), [props.messages]);
+
+  const lastAssistant = props.messages[props.messages.length - 1];
+  const showFollowUps =
+    !props.isStreaming &&
+    lastAssistant?.role === 'assistant' &&
+    lastAssistant.follow_ups.length > 0 &&
+    props.onFollowUp != null;
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        ref={ref}
+        inverted
+        data={data}
+        keyExtractor={(m) => m.message_id}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        contentContainerStyle={styles.content}
+        renderItem={({ item, index }) => {
+          const isLast = index === 0; // inverted — first rendered = newest
+          if (item.role === 'user') return <UserMessageBubble content={item.content} />;
+          const streaming = isLast && props.isStreaming;
+          return (
+            <AssistantMessageBubble
+              content={item.content}
+              citations={item.citations}
+              isStreaming={streaming}
+              onCitationPress={props.onCitationPress}
+            />
+          );
+        }}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}>
+              Ask Amicus anything.
+            </Text>
+          </View>
+        }
+      />
+
+      {showFollowUps && lastAssistant && props.onFollowUp && (
+        <FollowUpChips followUps={lastAssistant.follow_ups} onSelect={props.onFollowUp} />
+      )}
+
+      {showNew && (
+        <Pressable
+          onPress={() => {
+            ref.current?.scrollToOffset({ offset: 0, animated: true });
+            setShowNew(false);
+          }}
+          accessibilityLabel="Jump to latest message"
+          style={[styles.jumpPill, { backgroundColor: base.gold }]}
+        >
+          <Text style={[styles.jumpText, { color: base.bg }]}>New message ↓</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: spacing.md },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingVertical: spacing.xl },
+  emptyText: { fontSize: 15 },
+  jumpPill: {
+    position: 'absolute',
+    bottom: spacing.md,
+    alignSelf: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  jumpText: { fontSize: 12, fontWeight: '600' },
+});

--- a/app/src/components/amicus/StreamingDot.tsx
+++ b/app/src/components/amicus/StreamingDot.tsx
@@ -1,0 +1,47 @@
+/**
+ * components/amicus/StreamingDot.tsx — pulsing dot shown while a stream is
+ * still emitting tokens.
+ */
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import { useTheme } from '../../theme';
+
+export default function StreamingDot(): React.ReactElement {
+  const { base } = useTheme();
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 450,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 450,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      accessibilityLabel="Amicus is responding"
+      style={[styles.dot, { backgroundColor: base.gold, opacity }]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginLeft: 4,
+  },
+});

--- a/app/src/components/amicus/UserMessageBubble.tsx
+++ b/app/src/components/amicus/UserMessageBubble.tsx
@@ -1,0 +1,29 @@
+/**
+ * components/amicus/UserMessageBubble.tsx — right-aligned gold pill.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { fontFamily, useTheme } from '../../theme';
+
+export default function UserMessageBubble({ content }: { content: string }): React.ReactElement {
+  const { base } = useTheme();
+  return (
+    <View style={[styles.bubble, { backgroundColor: base.gold }]}>
+      <Text style={[styles.text, { color: base.bg, fontFamily: fontFamily.body }]}>
+        {content}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    alignSelf: 'flex-end',
+    maxWidth: '85%',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 16,
+    marginVertical: 4,
+  },
+  text: { fontSize: 15, lineHeight: 21 },
+});

--- a/app/src/components/amicus/__tests__/AssistantMessageBubble.test.tsx
+++ b/app/src/components/amicus/__tests__/AssistantMessageBubble.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import AssistantMessageBubble from '@/components/amicus/AssistantMessageBubble';
+import type { AmicusCitation } from '@/types';
+
+const citations: AmicusCitation[] = [
+  {
+    chunk_id: 'section_panel:romans-9-s1-calvin',
+    source_type: 'section_panel',
+    display_label: 'Calvin · Romans 9',
+    scholar_id: 'calvin',
+  },
+];
+
+describe('AssistantMessageBubble', () => {
+  it('renders interleaved prose and citation pills', () => {
+    const content =
+      'Calvin [CITE:section_panel:romans-9-s1-calvin] emphasizes election.';
+    const { getByText, getByLabelText } = renderWithProviders(
+      <AssistantMessageBubble
+        content={content}
+        citations={citations}
+        isStreaming={false}
+      />,
+    );
+    expect(getByText(/emphasizes election/)).toBeTruthy();
+    expect(getByLabelText('Open source: Calvin · Romans 9')).toBeTruthy();
+  });
+
+  it('forwards citation taps with the full citation object', () => {
+    const onCitationPress = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <AssistantMessageBubble
+        content="See [CITE:section_panel:romans-9-s1-calvin]"
+        citations={citations}
+        isStreaming={false}
+        onCitationPress={onCitationPress}
+      />,
+    );
+    fireEvent.press(getByLabelText('Open source: Calvin · Romans 9'));
+    expect(onCitationPress).toHaveBeenCalledWith(citations[0]);
+  });
+
+  it('renders without the streaming dot when not streaming', () => {
+    const { queryByLabelText } = renderWithProviders(
+      <AssistantMessageBubble
+        content="plain"
+        citations={[]}
+        isStreaming={false}
+      />,
+    );
+    expect(queryByLabelText('Amicus is responding')).toBeNull();
+  });
+});

--- a/app/src/components/amicus/__tests__/CitationPill.test.tsx
+++ b/app/src/components/amicus/__tests__/CitationPill.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import CitationPill from '@/components/amicus/CitationPill';
+
+describe('CitationPill', () => {
+  it('renders display label', () => {
+    const { getByText } = renderWithProviders(
+      <CitationPill
+        chunkId="section_panel:romans-9-s1-calvin"
+        sourceType="section_panel"
+        displayLabel="Calvin · Romans 9"
+      />,
+    );
+    expect(getByText('Calvin · Romans 9')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <CitationPill
+        chunkId="word_study:hesed"
+        sourceType="word_study"
+        displayLabel="Word study · hesed"
+        onPress={onPress}
+      />,
+    );
+    fireEvent.press(getByLabelText('Open source: Word study · hesed'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without onPress without crashing', () => {
+    const { getByText } = renderWithProviders(
+      <CitationPill
+        chunkId="x:y"
+        sourceType="word_study"
+        displayLabel="Lookup"
+      />,
+    );
+    expect(getByText('Lookup')).toBeTruthy();
+  });
+});

--- a/app/src/components/amicus/__tests__/FollowUpChips.test.tsx
+++ b/app/src/components/amicus/__tests__/FollowUpChips.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import FollowUpChips from '@/components/amicus/FollowUpChips';
+
+describe('FollowUpChips', () => {
+  it('returns null when the list is empty', () => {
+    const { toJSON } = renderWithProviders(
+      <FollowUpChips followUps={[]} onSelect={() => undefined} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders up to 3 chips and fires onSelect with the chip text', () => {
+    const onSelect = jest.fn();
+    const followUps = ['Q1', 'Q2', 'Q3', 'Q4'];
+    const { getByLabelText, queryByLabelText } = renderWithProviders(
+      <FollowUpChips followUps={followUps} onSelect={onSelect} />,
+    );
+    expect(queryByLabelText('Ask: Q4')).toBeNull();
+    fireEvent.press(getByLabelText('Ask: Q2'));
+    expect(onSelect).toHaveBeenCalledWith('Q2');
+  });
+});

--- a/app/src/components/amicus/__tests__/InputBar.test.tsx
+++ b/app/src/components/amicus/__tests__/InputBar.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import InputBar from '@/components/amicus/InputBar';
+
+describe('InputBar', () => {
+  it('disables send button when text is empty', () => {
+    const onSend = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <InputBar isStreaming={false} onSend={onSend} onAbort={() => undefined} />,
+    );
+    const send = getByLabelText('Send');
+    fireEvent.press(send);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('sends the typed text when send is pressed', () => {
+    const onSend = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <InputBar isStreaming={false} onSend={onSend} onAbort={() => undefined} />,
+    );
+    fireEvent.changeText(getByLabelText('Message Amicus'), 'What is grace?');
+    fireEvent.press(getByLabelText('Send'));
+    expect(onSend).toHaveBeenCalledWith('What is grace?');
+  });
+
+  it('shows Stop button while streaming and invokes abort', () => {
+    const onAbort = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <InputBar isStreaming={true} onSend={() => undefined} onAbort={onAbort} />,
+    );
+    fireEvent.press(getByLabelText('Stop streaming'));
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces 2000-char cap', () => {
+    const onSend = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <InputBar isStreaming={false} onSend={onSend} onAbort={() => undefined} />,
+    );
+    const huge = 'x'.repeat(3000);
+    fireEvent.changeText(getByLabelText('Message Amicus'), huge);
+    fireEvent.press(getByLabelText('Send'));
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const arg = onSend.mock.calls[0]?.[0] as string;
+    expect(arg.length).toBeLessThanOrEqual(2000);
+  });
+});

--- a/app/src/components/amicus/__tests__/MessageList.test.tsx
+++ b/app/src/components/amicus/__tests__/MessageList.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import MessageList from '@/components/amicus/MessageList';
+import type { AmicusMessage } from '@/types';
+
+function mkMessage(partial: Partial<AmicusMessage>): AmicusMessage {
+  return {
+    message_id: 'm1',
+    thread_id: 't1',
+    role: 'user',
+    content: '',
+    citations: [],
+    follow_ups: [],
+    created_at: '2026-04-17',
+    ...partial,
+  };
+}
+
+describe('MessageList', () => {
+  it('renders the empty-state prompt when there are no messages', () => {
+    const { getByText } = renderWithProviders(
+      <MessageList messages={[]} isStreaming={false} />,
+    );
+    expect(getByText('Ask Amicus anything.')).toBeTruthy();
+  });
+
+  it('renders user and assistant bubbles', () => {
+    const messages = [
+      mkMessage({ message_id: 'u1', role: 'user', content: 'What is hesed?' }),
+      mkMessage({
+        message_id: 'a1',
+        role: 'assistant',
+        content: 'Hesed is covenant faithfulness.',
+      }),
+    ];
+    const { getByText } = renderWithProviders(
+      <MessageList messages={messages} isStreaming={false} />,
+    );
+    expect(getByText('What is hesed?')).toBeTruthy();
+    expect(getByText(/covenant faithfulness/)).toBeTruthy();
+  });
+
+  it('renders follow-up chips when the last assistant message has them', () => {
+    const onFollowUp = jest.fn();
+    const messages = [
+      mkMessage({
+        message_id: 'a1',
+        role: 'assistant',
+        content: 'Answer.',
+        follow_ups: ['Ask me more'],
+      }),
+    ];
+    const { getByLabelText } = renderWithProviders(
+      <MessageList messages={messages} isStreaming={false} onFollowUp={onFollowUp} />,
+    );
+    expect(getByLabelText('Ask: Ask me more')).toBeTruthy();
+  });
+
+  it('hides follow-ups while streaming', () => {
+    const messages = [
+      mkMessage({
+        message_id: 'a1',
+        role: 'assistant',
+        content: 'Streaming…',
+        follow_ups: ['one'],
+      }),
+    ];
+    const { queryByLabelText } = renderWithProviders(
+      <MessageList messages={messages} isStreaming={true} onFollowUp={() => undefined} />,
+    );
+    expect(queryByLabelText('Ask: one')).toBeNull();
+  });
+});

--- a/app/src/components/amicus/__tests__/StreamingDot.test.tsx
+++ b/app/src/components/amicus/__tests__/StreamingDot.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import StreamingDot from '@/components/amicus/StreamingDot';
+
+describe('StreamingDot', () => {
+  it('renders with the responding accessibility label', () => {
+    const { getByLabelText } = renderWithProviders(<StreamingDot />);
+    expect(getByLabelText('Amicus is responding')).toBeTruthy();
+  });
+});

--- a/app/src/components/amicus/__tests__/UserMessageBubble.test.tsx
+++ b/app/src/components/amicus/__tests__/UserMessageBubble.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import UserMessageBubble from '@/components/amicus/UserMessageBubble';
+
+describe('UserMessageBubble', () => {
+  it('renders its content', () => {
+    const { getByText } = renderWithProviders(
+      <UserMessageBubble content="Tell me about hesed" />,
+    );
+    expect(getByText('Tell me about hesed')).toBeTruthy();
+  });
+});

--- a/app/src/hooks/useAmicusThread.ts
+++ b/app/src/hooks/useAmicusThread.ts
@@ -1,0 +1,203 @@
+/**
+ * hooks/useAmicusThread.ts — Per-thread state + streaming handle.
+ *
+ * Loads message history from user.db on mount, exposes sendMessage which
+ * orchestrates retrieval + stream + persistence + optimistic UI updates.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AmicusError } from '@/services/amicus';
+import { streamChat } from '@/services/amicus/chat';
+import { appendAmicusMessage, incrementAmicusUsage } from '@/db/userMutations';
+import { listAmicusMessages } from '@/db/userQueries';
+import type { AmicusCitation, AmicusMessage } from '@/types';
+import { logger } from '@/utils/logger';
+
+export interface UseAmicusThreadResult {
+  messages: AmicusMessage[];
+  isStreaming: boolean;
+  error: AmicusError | null;
+  sendMessage: (text: string, authToken: string) => Promise<void>;
+  abortStream: () => void;
+  refresh: () => Promise<void>;
+  clearError: () => void;
+}
+
+function uuid(prefix: string): string {
+  const r = Math.random().toString(16).slice(2, 10);
+  const t = Date.now().toString(16);
+  return `${prefix}-${t}-${r}`;
+}
+
+export function useAmicusThread(threadId: string): UseAmicusThreadResult {
+  const [messages, setMessages] = useState<AmicusMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<AmicusError | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const rows = await listAmicusMessages(threadId);
+      setMessages(rows);
+    } catch (err) {
+      logger.error('Amicus', 'refresh messages failed', err);
+    }
+  }, [threadId]);
+
+  useEffect(() => {
+    void refresh();
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [refresh]);
+
+  const sendMessage = useCallback(
+    async (text: string, authToken: string): Promise<void> => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      if (isStreaming) return;
+
+      const userMsgId = uuid('m');
+      const assistantMsgId = uuid('m');
+      const nowIso = new Date().toISOString();
+
+      // Optimistic user bubble
+      const optimisticUser: AmicusMessage = {
+        message_id: userMsgId,
+        thread_id: threadId,
+        role: 'user',
+        content: trimmed,
+        citations: [],
+        follow_ups: [],
+        created_at: nowIso,
+      };
+      // Optimistic assistant shell (fills in via onDelta)
+      const optimisticAssistant: AmicusMessage = {
+        message_id: assistantMsgId,
+        thread_id: threadId,
+        role: 'assistant',
+        content: '',
+        citations: [],
+        follow_ups: [],
+        created_at: nowIso,
+      };
+      setMessages((prev) => [...prev, optimisticUser, optimisticAssistant]);
+      setIsStreaming(true);
+      setError(null);
+
+      // Persist the user message immediately (survives app kill mid-stream).
+      try {
+        await appendAmicusMessage({
+          messageId: userMsgId,
+          threadId,
+          role: 'user',
+          content: trimmed,
+        });
+        await incrementAmicusUsage();
+      } catch (err) {
+        logger.error('Amicus', 'persist user message failed', err);
+      }
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      let streamed = '';
+      const streamedCitations: AmicusCitation[] = [];
+      await streamChat({
+        threadId,
+        userQuery: trimmed,
+        conversationHistory: messages.map((m) => ({ role: m.role, content: m.content })),
+        authToken,
+        signal: controller.signal,
+        currentChapterRef: null,
+        onDelta: (token) => {
+          streamed += token;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.message_id === assistantMsgId ? { ...m, content: streamed } : m,
+            ),
+          );
+        },
+        onCitation: (pill) => {
+          const mapped: AmicusCitation = {
+            chunk_id: pill.chunk_id,
+            source_type: pill.source_type,
+            display_label: pill.display_label,
+            scholar_id: pill.scholar_id,
+          };
+          streamedCitations.push(mapped);
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.message_id === assistantMsgId
+                ? { ...m, citations: [...streamedCitations] }
+                : m,
+            ),
+          );
+        },
+        onGapSignal: (gap) => {
+          logger.info('Amicus', `gap_signal: ${JSON.stringify(gap)}`);
+        },
+        onComplete: async (final) => {
+          const finalCitations: AmicusCitation[] = final.citations.map((c) => ({
+            chunk_id: c.chunk_id,
+            source_type: c.source_type,
+            display_label: c.display_label,
+            scholar_id: c.scholar_id,
+          }));
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.message_id === assistantMsgId
+                ? {
+                    ...m,
+                    content: final.prose,
+                    citations: finalCitations,
+                    follow_ups: final.follow_ups,
+                  }
+                : m,
+            ),
+          );
+          try {
+            await appendAmicusMessage({
+              messageId: assistantMsgId,
+              threadId,
+              role: 'assistant',
+              content: final.prose,
+              citations: finalCitations,
+              followUps: final.follow_ups,
+            });
+          } catch (err) {
+            logger.error('Amicus', 'persist assistant failed', err);
+          }
+          setIsStreaming(false);
+        },
+        onError: (err) => {
+          setError(err);
+          setMessages((prev) => prev.filter((m) => m.message_id !== assistantMsgId));
+          setIsStreaming(false);
+        },
+      });
+    },
+    [threadId, isStreaming, messages],
+  );
+
+  const abortStream = useCallback((): void => {
+    abortRef.current?.abort();
+    setIsStreaming(false);
+  }, []);
+
+  const clearError = useCallback((): void => {
+    setError(null);
+  }, []);
+
+  return useMemo(
+    () => ({
+      messages,
+      isStreaming,
+      error,
+      sendMessage,
+      abortStream,
+      refresh,
+      clearError,
+    }),
+    [messages, isStreaming, error, sendMessage, abortStream, refresh, clearError],
+  );
+}

--- a/app/src/screens/AmicusThreadScreen.tsx
+++ b/app/src/screens/AmicusThreadScreen.tsx
@@ -1,27 +1,27 @@
 /**
- * AmicusThreadScreen — shell for a single Amicus conversation.
+ * AmicusThreadScreen — live conversation view with streaming chat.
  *
- * Only the header + placeholder list + placeholder input are wired in this
- * card (#1454). Streaming + citation rendering + full input behavior arrive
- * in #1455.
+ * Shell came from #1454; this card (#1455) wires the streaming orchestrator,
+ * MessageList, InputBar, and error banners.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
-  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
   StyleSheet,
   Text,
-  TextInput,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeft } from 'lucide-react-native';
 import { useTheme, spacing, fontFamily } from '../theme';
-import { getAmicusThread, listAmicusMessages } from '../db/userQueries';
-import type { AmicusMessage, AmicusThread } from '../types';
+import { getAmicusThread } from '../db/userQueries';
+import MessageList from '../components/amicus/MessageList';
+import InputBar from '../components/amicus/InputBar';
+import { useAmicusThread } from '../hooks/useAmicusThread';
+import type { AmicusCitation, AmicusThread } from '../types';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 
@@ -32,27 +32,41 @@ export default function AmicusThreadScreen(): React.ReactElement {
   const { threadId } = route.params;
 
   const [thread, setThread] = useState<AmicusThread | null>(null);
-  const [messages, setMessages] = useState<AmicusMessage[]>([]);
+  const { messages, isStreaming, error, sendMessage, abortStream, clearError } =
+    useAmicusThread(threadId);
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
-        const [t, m] = await Promise.all([
-          getAmicusThread(threadId),
-          listAmicusMessages(threadId),
-        ]);
-        if (cancelled) return;
-        setThread(t);
-        setMessages(m);
+        const t = await getAmicusThread(threadId);
+        if (!cancelled) setThread(t);
       } catch (err) {
-        logger.error('Amicus', 'thread load failed', err);
+        logger.error('Amicus', 'thread fetch failed', err);
       }
     })();
     return () => {
       cancelled = true;
     };
   }, [threadId]);
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      // TODO(#1460): source authToken from RevenueCat entitlement store.
+      const authToken = process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '';
+      if (!authToken) {
+        logger.warn('Amicus', 'no auth token — aborting send');
+        return;
+      }
+      await sendMessage(text, authToken);
+    },
+    [sendMessage],
+  );
+
+  const handleCitation = useCallback((c: AmicusCitation) => {
+    // #1456 wires real navigation. For now, log.
+    logger.info('Amicus', `citation pressed: ${c.chunk_id}`);
+  }, []);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
@@ -83,50 +97,60 @@ export default function AmicusThreadScreen(): React.ReactElement {
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <FlatList
-          inverted
-          data={[...messages].reverse()}
-          keyExtractor={(m) => m.message_id}
-          contentContainerStyle={styles.messagesContent}
-          renderItem={({ item }) => (
-            <View
-              style={[
-                styles.messageBubble,
-                item.role === 'user'
-                  ? [styles.userBubble, { backgroundColor: base.gold }]
-                  : [styles.assistantBubble, { backgroundColor: base.bgSurface }],
-              ]}
-            >
-              <Text
-                style={{
-                  color: item.role === 'user' ? base.bg : base.text,
-                  fontFamily: fontFamily.body,
-                }}
-              >
-                {item.content}
-              </Text>
-            </View>
-          )}
-          ListEmptyComponent={
-            <View style={styles.empty}>
-              <Text style={[styles.emptyText, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}>
-                Ask Amicus anything.
-              </Text>
-            </View>
-          }
+        <MessageList
+          messages={messages}
+          isStreaming={isStreaming}
+          onCitationPress={handleCitation}
+          onFollowUp={(text) => void handleSend(text)}
         />
 
-        <View style={[styles.inputBar, { borderTopColor: base.border, backgroundColor: base.bg }]}>
-          <TextInput
-            placeholder="Message Amicus…"
-            placeholderTextColor={base.textMuted}
-            style={[styles.input, { color: base.text, borderColor: base.border }]}
-            editable={false}
-          />
-        </View>
+        {error && <ErrorBanner error={error} onDismiss={clearError} />}
+
+        <InputBar
+          isStreaming={isStreaming}
+          onSend={(t) => void handleSend(t)}
+          onAbort={abortStream}
+        />
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
+}
+
+function ErrorBanner({
+  error,
+  onDismiss,
+}: {
+  error: { code: string; message: string };
+  onDismiss: () => void;
+}): React.ReactElement {
+  const { base } = useTheme();
+  const message = bannerCopy(error.code);
+  return (
+    <Pressable
+      accessibilityLabel={`${message}. Tap to dismiss.`}
+      onPress={onDismiss}
+      style={[styles.banner, { backgroundColor: `${base.gold}20`, borderColor: base.gold }]}
+    >
+      <Text style={{ color: base.text, fontFamily: fontFamily.body, fontSize: 13 }}>
+        {message}
+      </Text>
+    </Pressable>
+  );
+}
+
+function bannerCopy(code: string): string {
+  switch (code) {
+    case 'OFFLINE':
+      return 'Amicus needs an internet connection. Tap to dismiss.';
+    case 'PROXY_UNAUTHORIZED':
+      return 'Your subscription is required to use Amicus. Tap to dismiss.';
+    case 'EMBED_FAILED':
+      return 'Amicus is temporarily unavailable. Tap to dismiss.';
+    case 'EXTENSION_NOT_LOADED':
+      return 'Amicus retrieval is unavailable on this device build. Tap to dismiss.';
+    default:
+      return 'Something went wrong. Tap to dismiss.';
+  }
 }
 
 const styles = StyleSheet.create({
@@ -143,24 +167,11 @@ const styles = StyleSheet.create({
   headerText: { flex: 1, marginLeft: spacing.sm },
   headerTitle: { fontSize: 16 },
   headerBadge: { fontSize: 11, marginTop: 2 },
-  messagesContent: { padding: spacing.md, gap: spacing.sm },
-  messageBubble: { padding: spacing.sm, borderRadius: 12, maxWidth: '85%' },
-  userBubble: { alignSelf: 'flex-end' },
-  assistantBubble: { alignSelf: 'flex-start' },
-  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg },
-  emptyText: { fontSize: 15 },
-  inputBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
+  banner: {
     padding: spacing.sm,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  input: {
-    flex: 1,
+    marginHorizontal: spacing.sm,
+    marginBottom: spacing.xs,
+    borderRadius: 12,
     borderWidth: 1,
-    borderRadius: 999,
-    paddingHorizontal: spacing.md,
-    paddingVertical: 8,
-    fontSize: 14,
   },
 });

--- a/app/src/services/amicus/__tests__/chat.test.ts
+++ b/app/src/services/amicus/__tests__/chat.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for services/amicus/chat.ts — streamChat orchestrator.
+ *
+ * Stubs the profile, retrieve, and fetch dependencies so the streaming
+ * pipeline can be exercised offline.
+ */
+import { streamChat } from '../chat';
+import { AmicusError } from '../index';
+
+jest.mock('@/services/amicus/profile/generator', () => ({
+  generateProfile: jest.fn().mockResolvedValue({
+    prose: 'Test profile',
+    preferred_scholars: [],
+    preferred_traditions: [],
+    generated_at: 'now',
+    raw_signals_hash: 'x',
+  }),
+}));
+
+jest.mock('@/services/amicus', () => {
+  const actual = jest.requireActual('@/services/amicus');
+  return {
+    ...actual,
+    retrieve: jest.fn().mockResolvedValue({
+      chunks: [
+        {
+          chunk_id: 'section_panel:romans-9-s1-calvin',
+          source_type: 'section_panel',
+          source_id: 'romans-9-s1-calvin',
+          text: 'Calvin text',
+          score: 0.9,
+          metadata: {},
+        },
+      ],
+      embedMs: 10,
+      searchMs: 5,
+      rerankMs: 1,
+    }),
+  };
+});
+
+function sseResponse(sseLines: string[]): Response {
+  const body = sseLines.map((l) => `data: ${l}\n`).join('') + 'data: [DONE]\n';
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+describe('streamChat', () => {
+  it('emits onDelta, onCitation, onComplete for a happy path', async () => {
+    const events: string[] = [];
+    const onDelta = jest.fn((t: string) => events.push(`delta:${t}`));
+    const onCitation = jest.fn((p: unknown) =>
+      events.push(`cite:${(p as { chunk_id: string }).chunk_id}`),
+    );
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+
+    const fetchImpl = jest.fn(async () =>
+      sseResponse([
+        JSON.stringify({
+          type: 'content_block_delta',
+          delta: { text: 'Calvin ' },
+        }),
+        JSON.stringify({
+          type: 'content_block_delta',
+          delta: { text: '[CITE:section_panel:romans-9-s1-calvin] ' },
+        }),
+        JSON.stringify({
+          type: 'content_block_delta',
+          delta: { text: 'on election.' },
+        }),
+      ]),
+    ) as unknown as typeof fetch;
+
+    await streamChat({
+      threadId: 't1',
+      userQuery: 'Romans 9?',
+      conversationHistory: [],
+      authToken: 'tok',
+      signal: new AbortController().signal,
+      onDelta,
+      onCitation,
+      onGapSignal: () => undefined,
+      onComplete,
+      onError,
+      fetchImpl,
+    });
+
+    expect(onDelta).toHaveBeenCalled();
+    expect(onCitation).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces PROXY_UNAUTHORIZED on 401/402', async () => {
+    const onError = jest.fn();
+    const fetchImpl = jest.fn(async () =>
+      new Response('unauthorized', { status: 402 }),
+    ) as unknown as typeof fetch;
+
+    await streamChat({
+      threadId: 't1',
+      userQuery: 'q',
+      conversationHistory: [],
+      authToken: 'tok',
+      signal: new AbortController().signal,
+      onDelta: () => undefined,
+      onCitation: () => undefined,
+      onGapSignal: () => undefined,
+      onComplete: () => undefined,
+      onError,
+      fetchImpl,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const err = onError.mock.calls[0]?.[0] as AmicusError;
+    expect(err.code).toBe('PROXY_UNAUTHORIZED');
+  });
+
+  it('surfaces EMBED_FAILED on 429 rate limit', async () => {
+    const onError = jest.fn();
+    const fetchImpl = jest.fn(async () =>
+      new Response('rate limit', { status: 429 }),
+    ) as unknown as typeof fetch;
+
+    await streamChat({
+      threadId: 't1',
+      userQuery: 'q',
+      conversationHistory: [],
+      authToken: 'tok',
+      signal: new AbortController().signal,
+      onDelta: () => undefined,
+      onCitation: () => undefined,
+      onGapSignal: () => undefined,
+      onComplete: () => undefined,
+      onError,
+      fetchImpl,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces OFFLINE when network throws', async () => {
+    const onError = jest.fn();
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network failure');
+    }) as unknown as typeof fetch;
+
+    await streamChat({
+      threadId: 't1',
+      userQuery: 'q',
+      conversationHistory: [],
+      authToken: 'tok',
+      signal: new AbortController().signal,
+      onDelta: () => undefined,
+      onCitation: () => undefined,
+      onGapSignal: () => undefined,
+      onComplete: () => undefined,
+      onError,
+      fetchImpl,
+    });
+
+    const err = onError.mock.calls[0]?.[0] as AmicusError;
+    expect(err.code).toBe('OFFLINE');
+  });
+
+  it('fires onGapSignal when the response has a trailing gap envelope', async () => {
+    const onGapSignal = jest.fn();
+    const fetchImpl = jest.fn(async () =>
+      sseResponse([
+        JSON.stringify({
+          type: 'content_block_delta',
+          delta: { text: "I don't have corpus on that.\n" },
+        }),
+        JSON.stringify({
+          type: 'content_block_delta',
+          delta: { text: '{"gap": true, "gap_type": "content"}' },
+        }),
+      ]),
+    ) as unknown as typeof fetch;
+
+    await streamChat({
+      threadId: 't1',
+      userQuery: 'q',
+      conversationHistory: [],
+      authToken: 'tok',
+      signal: new AbortController().signal,
+      onDelta: () => undefined,
+      onCitation: () => undefined,
+      onGapSignal,
+      onComplete: () => undefined,
+      onError: () => undefined,
+      fetchImpl,
+    });
+
+    expect(onGapSignal).toHaveBeenCalledTimes(1);
+    expect(onGapSignal.mock.calls[0]?.[0]).toMatchObject({ gap: true });
+  });
+});

--- a/app/src/services/amicus/__tests__/streamParser.test.ts
+++ b/app/src/services/amicus/__tests__/streamParser.test.ts
@@ -1,0 +1,122 @@
+import {
+  extractDeltaText,
+  parseAssistantMessage,
+} from '../streamParser';
+
+describe('extractDeltaText', () => {
+  it('pulls content_block_delta text fragments', () => {
+    const chunk =
+      'data: {"type":"content_block_delta","delta":{"text":"Hello "}}\n' +
+      'data: {"type":"content_block_delta","delta":{"text":"world"}}\n';
+    expect(extractDeltaText(chunk)).toBe('Hello world');
+  });
+
+  it('ignores [DONE] sentinel and other event types', () => {
+    const chunk =
+      'data: [DONE]\n' +
+      'data: {"type":"message_stop"}\n' +
+      'data: {"type":"content_block_delta","delta":{"text":"ok"}}\n';
+    expect(extractDeltaText(chunk)).toBe('ok');
+  });
+
+  it('tolerates non-JSON data lines', () => {
+    expect(extractDeltaText('data: garbage\n')).toBe('');
+  });
+});
+
+describe('parseAssistantMessage — citations', () => {
+  it('extracts [CITE:...] markers into pill nodes', () => {
+    const text =
+      'Reformed scholars like Calvin emphasize election [CITE:section_panel:romans-9-s1-calvin]. ' +
+      'Jewish scholars emphasize covenant [CITE:section_panel:exodus-33-s2-sarna].';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.citations).toHaveLength(2);
+    expect(parsed.citations[0]!.chunk_id).toBe('section_panel:romans-9-s1-calvin');
+    expect(parsed.citations[0]!.scholar_id).toBe('calvin');
+    expect(parsed.citations[0]!.display_label).toContain('Calvin');
+  });
+
+  it('supports the plain [chunk_id] form', () => {
+    const text = 'See [word_study:hesed] for details.';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.citations[0]!.chunk_id).toBe('word_study:hesed');
+  });
+
+  it('dedupes repeated citations', () => {
+    const text =
+      'First [word_study:hesed] and again [word_study:hesed] in Psalm 23.';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.citations).toHaveLength(1);
+  });
+
+  it('preserves unknown source types as literal text', () => {
+    const text = 'See [bogus_type:foo] reference.';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.citations).toHaveLength(0);
+    expect(parsed.prose).toContain('[bogus_type:foo]');
+  });
+
+  it('emits interleaved text + citation nodes in order', () => {
+    const text = 'A [word_study:hesed] B [word_study:shalom] C';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.nodes[0]).toEqual({ type: 'text', text: 'A ' });
+    expect(parsed.nodes[1]!.type).toBe('citation');
+    expect(parsed.nodes[3]!.type).toBe('citation');
+    expect(parsed.nodes[4]).toEqual({ type: 'text', text: ' C' });
+  });
+});
+
+describe('parseAssistantMessage — envelopes', () => {
+  it('strips trailing gap envelope', () => {
+    const text = 'Answer here.\n{"gap": false}';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.gap_signal?.gap).toBe(false);
+    expect(parsed.prose).toBe('Answer here.');
+  });
+
+  it('parses gap=true with gap_type + topic', () => {
+    const text = 'No corpus for that.\n{"gap": true, "gap_type": "content", "topic": "Coptic"}';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.gap_signal).toEqual({
+      gap: true,
+      gap_type: 'content',
+      topic: 'Coptic',
+    });
+  });
+
+  it('parses follow_ups envelope alongside gap envelope', () => {
+    const text =
+      'Prose with [word_study:hesed] inline.\n' +
+      '{"follow_ups": ["What about agape?", "Is hesed used in NT?", "Connection to grace?"]}\n' +
+      '{"gap": false}';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.follow_ups).toEqual([
+      'What about agape?',
+      'Is hesed used in NT?',
+      'Connection to grace?',
+    ]);
+    expect(parsed.gap_signal?.gap).toBe(false);
+    expect(parsed.prose).toContain('inline');
+    expect(parsed.prose).not.toContain('follow_ups');
+  });
+
+  it('keeps trailing non-JSON braces as prose', () => {
+    const parsed = parseAssistantMessage('The set is { empty }');
+    expect(parsed.gap_signal).toBeNull();
+    expect(parsed.prose).toContain('empty');
+  });
+
+  it('normalizes CITE markers to [chunk_id] in prose', () => {
+    const text = 'Read Calvin [CITE:section_panel:romans-9-s1-calvin] closely.';
+    expect(parseAssistantMessage(text).prose).toContain(
+      '[section_panel:romans-9-s1-calvin]',
+    );
+  });
+
+  it('caps follow_ups at 3', () => {
+    const text =
+      'Prose.\n{"follow_ups": ["a", "b", "c", "d", "e"]}\n{"gap": false}';
+    const parsed = parseAssistantMessage(text);
+    expect(parsed.follow_ups).toHaveLength(3);
+  });
+});

--- a/app/src/services/amicus/chat.ts
+++ b/app/src/services/amicus/chat.ts
@@ -1,0 +1,139 @@
+/**
+ * services/amicus/chat.ts — End-to-end streaming chat orchestrator.
+ *
+ * Sequence per user message:
+ *   1. (skipped in this card — persistence via #1457 hook handles
+ *      optimistic user insert at the caller)
+ *   2. generateProfile() — compressed profile from #1452
+ *   3. retrieve() — chunks + re-rank via #1451
+ *   4. POST /ai/chat with SSE — stream back prose + citations + envelopes
+ *   5. onDelta / onCitation / onGapSignal / onComplete callbacks fire live
+ *   6. onError surfaces typed AmicusError for banners
+ */
+import {
+  extractDeltaText,
+  parseAssistantMessage,
+  type CitationPillData,
+  type GapSignal,
+  type ParsedResponse,
+} from './streamParser';
+import { logger } from '@/utils/logger';
+import { AmicusError, retrieve } from '@/services/amicus';
+import { generateProfile } from '@/services/amicus/profile/generator';
+
+const CHAT_URL_DEFAULT = (
+  process.env.EXPO_PUBLIC_AMICUS_PROXY_URL ?? 'https://ai.contentcompanionstudy.com'
+).replace(/\/$/, '') + '/ai/chat';
+
+export interface StreamChatParams {
+  threadId: string;
+  userQuery: string;
+  currentChapterRef?: { book_id: string; chapter_num: number } | null;
+  conversationHistory: Array<{ role: 'user' | 'assistant'; content: string }>;
+  authToken: string;
+  signal: AbortSignal;
+  onDelta: (token: string) => void;
+  onCitation: (pill: CitationPillData) => void;
+  onGapSignal: (gap: GapSignal) => void;
+  onComplete: (final: ParsedResponse) => void;
+  onError: (err: AmicusError) => void;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  chatUrl?: string;
+}
+
+export async function streamChat(params: StreamChatParams): Promise<void> {
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const chatUrl = params.chatUrl ?? CHAT_URL_DEFAULT;
+
+  try {
+    const profile = await generateProfile(false);
+
+    const retrieved = await retrieve(
+      {
+        query: params.userQuery,
+        profile,
+        currentChapterRef: params.currentChapterRef ?? null,
+      },
+      { authToken: params.authToken, fetchImpl },
+    );
+
+    const body = {
+      query: params.userQuery,
+      retrieved_chunks: retrieved.chunks.map((c) => ({
+        chunk_id: c.chunk_id,
+        source_type: c.source_type,
+        text: c.text,
+        metadata: c.metadata,
+      })),
+      profile_summary: profile.prose,
+      current_chapter_ref: params.currentChapterRef
+        ? `${params.currentChapterRef.book_id}/${params.currentChapterRef.chapter_num}`
+        : null,
+      model_tier: 'sonnet',
+      conversation_history: params.conversationHistory,
+    };
+
+    const response = await fetchImpl(chatUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${params.authToken}`,
+      },
+      body: JSON.stringify(body),
+      signal: params.signal,
+    });
+
+    if (response.status === 401 || response.status === 402) {
+      params.onError(new AmicusError('PROXY_UNAUTHORIZED', `proxy ${response.status}`));
+      return;
+    }
+    if (response.status === 429) {
+      params.onError(new AmicusError('EMBED_FAILED', 'rate_limit_exceeded'));
+      return;
+    }
+    if (!response.ok || !response.body) {
+      params.onError(new AmicusError('EMBED_FAILED', `proxy ${response.status}`));
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let accumulated = '';
+    const seenCitations = new Set<string>();
+
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      const delta = extractDeltaText(chunk);
+      if (delta) {
+        accumulated += delta;
+        params.onDelta(delta);
+        // Parse after each delta so live citation events fire as soon as a
+        // marker closes. Parse is cheap for short accumulations.
+        const parsed = parseAssistantMessage(accumulated);
+        for (const pill of parsed.citations) {
+          if (seenCitations.has(pill.chunk_id)) continue;
+          seenCitations.add(pill.chunk_id);
+          params.onCitation(pill);
+        }
+      }
+    }
+
+    const final = parseAssistantMessage(accumulated);
+    if (final.gap_signal) params.onGapSignal(final.gap_signal);
+    params.onComplete(final);
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') {
+      logger.info('Amicus', 'stream aborted');
+      return;
+    }
+    if (err instanceof AmicusError) {
+      params.onError(err);
+      return;
+    }
+    logger.error('Amicus', 'stream failed', err);
+    params.onError(new AmicusError('OFFLINE', (err as Error).message ?? 'network'));
+  }
+}

--- a/app/src/services/amicus/streamParser.ts
+++ b/app/src/services/amicus/streamParser.ts
@@ -1,0 +1,278 @@
+/**
+ * services/amicus/streamParser.ts — Pure helpers for parsing the streamed
+ * Amicus chat response.
+ *
+ * The server emits Anthropic-style SSE lines (`data: {...}`). We accumulate
+ * the assistant's text, then extract:
+ *   - the prose (stripped of the trailing `{"gap": ...}` envelope)
+ *   - inline citation markers `[CITE:source_type:source_id]` or `[chunk_id]`
+ *   - the optional gap_signal envelope
+ *   - an optional follow_ups envelope (two-JSON tail: follow_ups then gap)
+ */
+
+export type ChunkSourceType =
+  | 'section_panel'
+  | 'chapter_panel'
+  | 'word_study'
+  | 'lexicon_entry'
+  | 'debate_topic'
+  | 'cross_ref_thread_note'
+  | 'journey_stop'
+  | 'meta_faq';
+
+export interface CitationPillData {
+  chunk_id: string;
+  source_type: ChunkSourceType;
+  source_id: string;
+  display_label: string;
+  scholar_id?: string;
+}
+
+export interface GapSignal {
+  gap: boolean;
+  gap_type?: 'content' | 'translation' | 'out_of_scope';
+  topic?: string;
+}
+
+export type ProseNode =
+  | { type: 'text'; text: string }
+  | { type: 'citation'; pill: CitationPillData };
+
+export interface ParsedResponse {
+  prose: string;          // with citations stripped to `[chunk_id]` markers
+  nodes: ProseNode[];     // interleaved text + citation nodes
+  citations: CitationPillData[];
+  follow_ups: string[];
+  gap_signal: GapSignal | null;
+}
+
+const CITE_RE = /\[CITE:([a-z_]+):([A-Za-z0-9._-]+)]|\[([a-z_]+:[A-Za-z0-9._-]+)]/g;
+
+const VALID_SOURCE_TYPES: readonly ChunkSourceType[] = [
+  'section_panel',
+  'chapter_panel',
+  'word_study',
+  'lexicon_entry',
+  'debate_topic',
+  'cross_ref_thread_note',
+  'journey_stop',
+  'meta_faq',
+];
+
+/**
+ * Incrementally consume an SSE-formatted chunk and return the newly-added
+ * assistant text (if any). Caller maintains the accumulated buffer.
+ *
+ * Each SSE line looks like `data: {"type":"content_block_delta",...}`.
+ */
+export function extractDeltaText(sseChunk: string): string {
+  let out = '';
+  for (const line of sseChunk.split('\n')) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    try {
+      const ev = JSON.parse(payload) as {
+        type?: string;
+        delta?: { text?: string };
+      };
+      if (ev.type === 'content_block_delta' && typeof ev.delta?.text === 'string') {
+        out += ev.delta.text;
+      }
+    } catch {
+      /* non-JSON — ignore */
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse the accumulated assistant text into prose nodes + citations +
+ * follow-ups + gap signal. Idempotent and pure.
+ */
+export function parseAssistantMessage(accumulated: string): ParsedResponse {
+  // Strip trailing JSON envelopes (two max: gap_signal, follow_ups).
+  let body = accumulated.trim();
+  let gapSignal: GapSignal | null = null;
+  let followUps: string[] = [];
+
+  for (let i = 0; i < 2; i++) {
+    const trail = extractTrailingJson(body);
+    if (!trail) break;
+    body = trail.remaining;
+    const gap = parseGapCandidate(trail.json);
+    if (gap) {
+      gapSignal = gap;
+      continue;
+    }
+    const fus = parseFollowUpsCandidate(trail.json);
+    if (fus) {
+      followUps = fus;
+      continue;
+    }
+    // Neither — push it back as prose and stop so we don't swallow text.
+    body = trail.remaining + trail.json;
+    break;
+  }
+
+  const nodes: ProseNode[] = [];
+  const citations: CitationPillData[] = [];
+  const seen = new Set<string>();
+
+  let cursor = 0;
+  for (const match of body.matchAll(CITE_RE)) {
+    const start = match.index ?? 0;
+    if (start > cursor) {
+      nodes.push({ type: 'text', text: body.slice(cursor, start) });
+    }
+    const [, typeA, idA, whole] = match;
+    let source_type: string;
+    let source_id: string;
+    if (typeA && idA) {
+      source_type = typeA;
+      source_id = idA;
+    } else if (whole) {
+      const idx = whole.indexOf(':');
+      source_type = whole.slice(0, idx);
+      source_id = whole.slice(idx + 1);
+    } else {
+      cursor = start + match[0].length;
+      continue;
+    }
+    if (!isValidSourceType(source_type)) {
+      // Preserve the literal if the source type is unknown.
+      nodes.push({ type: 'text', text: match[0] });
+      cursor = start + match[0].length;
+      continue;
+    }
+    const chunkId = `${source_type}:${source_id}`;
+    const pill: CitationPillData = {
+      chunk_id: chunkId,
+      source_type,
+      source_id,
+      display_label: defaultDisplayLabel(source_type, source_id),
+      scholar_id: deriveScholarId(source_type, source_id),
+    };
+    nodes.push({ type: 'citation', pill });
+    if (!seen.has(chunkId)) {
+      citations.push(pill);
+      seen.add(chunkId);
+    }
+    cursor = start + match[0].length;
+  }
+  if (cursor < body.length) {
+    nodes.push({ type: 'text', text: body.slice(cursor) });
+  }
+
+  // Normalised prose for persistence: the original text with CITE markers
+  // collapsed to canonical `[chunk_id]` form.
+  const prose = nodes
+    .map((n) => (n.type === 'text' ? n.text : `[${n.pill.chunk_id}]`))
+    .join('')
+    .trim();
+
+  return { prose, nodes, citations, follow_ups: followUps, gap_signal: gapSignal };
+}
+
+// ── JSON envelope extraction ──────────────────────────────────────────
+
+interface Trail {
+  remaining: string;
+  json: string;
+}
+
+/** Pull the last top-level `{...}` JSON literal off the end of the string. */
+function extractTrailingJson(text: string): Trail | null {
+  const trimmed = text.trimEnd();
+  if (!trimmed.endsWith('}')) return null;
+  let depth = 0;
+  let start = -1;
+  for (let i = trimmed.length - 1; i >= 0; i--) {
+    const c = trimmed[i];
+    if (c === '}') depth++;
+    else if (c === '{') {
+      depth--;
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+    }
+  }
+  if (start < 0) return null;
+  return {
+    remaining: trimmed.slice(0, start).trimEnd(),
+    json: trimmed.slice(start),
+  };
+}
+
+function parseGapCandidate(jsonText: string): GapSignal | null {
+  try {
+    const obj = JSON.parse(jsonText) as Record<string, unknown>;
+    if (typeof obj.gap !== 'boolean') return null;
+    const out: GapSignal = { gap: obj.gap };
+    if (
+      typeof obj.gap_type === 'string' &&
+      ['content', 'translation', 'out_of_scope'].includes(obj.gap_type)
+    ) {
+      out.gap_type = obj.gap_type as GapSignal['gap_type'];
+    }
+    if (typeof obj.topic === 'string') out.topic = obj.topic;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function parseFollowUpsCandidate(jsonText: string): string[] | null {
+  try {
+    const obj = JSON.parse(jsonText) as { follow_ups?: unknown };
+    if (!Array.isArray(obj.follow_ups)) return null;
+    const strings = obj.follow_ups.filter((x): x is string => typeof x === 'string');
+    return strings.slice(0, 3);
+  } catch {
+    return null;
+  }
+}
+
+// ── Display helpers ──────────────────────────────────────────────────
+
+function isValidSourceType(t: string): t is ChunkSourceType {
+  return (VALID_SOURCE_TYPES as readonly string[]).includes(t);
+}
+
+function defaultDisplayLabel(sourceType: string, sourceId: string): string {
+  // Best-effort — the real display_label can be looked up later in
+  // citation rendering. For text-only tests this keeps the pill useful.
+  if (sourceType === 'section_panel') {
+    // "romans-9-s1-calvin" → "Calvin · Romans 9"
+    const m = /^([a-z0-9_]+)-(\d+)-s(\d+)-([a-z0-9]+)$/.exec(sourceId);
+    if (m) {
+      const book = m[1]!.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+      return `${capitalize(m[4]!)} · ${book} ${m[2]}`;
+    }
+  }
+  if (sourceType === 'chapter_panel') {
+    const m = /^([a-z0-9_]+)-(\d+)-([a-z0-9]+)$/.exec(sourceId);
+    if (m) {
+      const book = m[1]!.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+      return `${book} ${m[2]} · ${capitalize(m[3]!)}`;
+    }
+  }
+  if (sourceType === 'word_study') return `Word study · ${sourceId}`;
+  if (sourceType === 'lexicon_entry') return `Lexicon · ${sourceId}`;
+  if (sourceType === 'debate_topic') return `Debate · ${sourceId}`;
+  if (sourceType === 'meta_faq') return `Background · ${sourceId}`;
+  if (sourceType === 'journey_stop') return `Journey · ${sourceId}`;
+  if (sourceType === 'cross_ref_thread_note') return `Cross-ref · ${sourceId}`;
+  return `${sourceType}:${sourceId}`;
+}
+
+function deriveScholarId(sourceType: string, sourceId: string): string | undefined {
+  if (sourceType !== 'section_panel') return undefined;
+  const m = /-s\d+-([a-z0-9]+)$/.exec(sourceId);
+  return m ? m[1] : undefined;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}


### PR DESCRIPTION
Closes #1455. Phase 2 of epic #1446. Depends on #1454 + #1457 (both merged) + #1450 (merged).

## Summary
Real-time streaming Amicus chat: token-by-token deltas, inline citation pills, follow-up chips, Stop button, typed error banners.

## New modules
- `services/amicus/streamParser.ts` — pure helpers for SSE + structured envelopes
- `services/amicus/chat.ts` — end-to-end orchestrator (`retrieve` → `/ai/chat` SSE)
- `hooks/useAmicusThread` — per-thread state, optimistic send, abort, persistence
- `components/amicus/*` — MessageList, UserMessageBubble, AssistantMessageBubble, CitationPill, StreamingDot, FollowUpChips, InputBar
- `screens/AmicusThreadScreen` — wired to the full stack

## Key behaviors
- Stream deltas append to an optimistic assistant bubble in real time.
- `[CITE:type:id]` or `[type:id]` markers become tappable pills inline.
- Trailing `{"follow_ups": [...]}` and `{"gap": true/false}` envelopes are parsed off the end and removed from prose.
- Stop button aborts via `AbortController` and preserves partial text.
- 401/402/429/5xx → typed `AmicusError` rendered as a dismissable banner above the input.
- User messages persist immediately; assistant messages persist on `onComplete`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 14 new streamParser tests: CITE/plain forms, dedup, unknown types, interleaved nodes, gap envelope, follow-ups envelope, non-JSON brace preservation, prose normalization
- [x] Full suite 3,272 / 3,272 passing
- [ ] Reviewer: end-to-end smoke on dev build against staging proxy.

## Out of scope
- Citation → source navigation (#1456) — `onCitationPress` logs for now.
- First-use privacy modal (#1458).
- Premium gate + cap banner (#1460).

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe