### PR TITLE
fix: disable expo-updates to surface the real launch crash

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Companion Study",
     "slug": "companion-study",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "orientation": "default",
     "icon": "./assets/images/icon-512.png",
     "scheme": "scripture",
@@ -59,7 +59,7 @@
     ],
     "updates": {
       "url": "https://u.expo.dev/105f31ba-3cfb-4d35-8509-4abbe6ab132d",
-      "enabled": true,
+      "enabled": false,
       "fallbackToCacheTimeout": 0
     },
     "runtimeVersion": {
@@ -73,4 +73,4 @@
     },
     "owner": "skahz"
   }
-}
+}


### PR DESCRIPTION
## What This Does

Two changes to `app/app.json`:

1. Sets `updates.enabled: false` — disables expo-updates entirely
2. Bumps version `1.0.2` → `1.0.3` for a fresh `runtimeVersion`

## Why

Crash analysis from the symbolicated TestFlight crash log (1.0.2 build 8):

```
Last Exception Backtrace:
0   CoreFoundation       __exceptionPreprocess
3   CompanionStudy       StartupProcedure.throwException(_:)       StartupProcedure.swift:344
4   CompanionStudy       ErrorRecoveryDelegate.throwException      (compiler-generated)
5   CompanionStudy       ErrorRecovery.crash()                     ErrorRecovery.swift:277
6   CompanionStudy       ErrorRecovery.runNextTask()               ErrorRecovery.swift:190
7   CompanionStudy       closure in ErrorRecovery.notify(newRemoteLoadStatus:)  ErrorRecovery.swift:149
```

`expo-updates` is deliberately crashing the app via `ErrorRecovery.crash()`. This is the expo-updates self-preservation mechanism — after N consecutive failed launches, it aborts rather than keep retrying a bad bundle.

The problem: deleting and reinstalling the app doesn't help, which means there's a **real** crash happening on first launch, but ErrorRecovery is masking it behind its own abort.

## Strategy

Disabling `expo-updates` will:
- Stop the ErrorRecovery death spiral
- Surface the actual underlying crash (whatever it is)

Once we see the real crash, we can fix the root cause and re-enable updates.

## Next Steps After Merge

```bash
git checkout master && git pull
cd app
eas build --platform ios --profile production
eas submit --platform ios --latest
```

New build should either:
- **Launch successfully** → original crash was a bogus OTA bundle, not code. Problem solved.
- **Still crash** → we'll get a real crash log that shows our code, not expo-updates internals. Then we fix for real.

## Follow-up

Once the real crash is found and fixed, re-enable `updates.enabled: true` in a follow-up PR.