### PR TITLE
fix: remove react-native-reanimated to resolve SDK 54 native-module crash

### DIFF
--- a/app/__tests__/components/ContentImageGallery.test.tsx
+++ b/app/__tests__/components/ContentImageGallery.test.tsx
@@ -9,18 +9,12 @@ jest.mock('expo-image', () => ({
   },
 }));
 
-jest.mock('react-native-reanimated', () => {
-  const Reanimated = require('react-native-reanimated/mock');
-  Reanimated.default.call = () => {};
-  return Reanimated;
-});
-
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: any) => children,
   Gesture: {
-    Pinch: () => ({ onUpdate: () => ({ onEnd: () => ({}) }), onEnd: () => ({}) }),
-    Pan: () => ({ minPointers: () => ({ onUpdate: () => ({ onEnd: () => ({}) }) }) }),
-    Tap: () => ({ numberOfTaps: () => ({ onEnd: () => ({}) }) }),
+    Pinch: () => ({ onUpdate: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }), onEnd: () => ({ runOnJS: () => ({}) }), runOnJS: () => ({}) }),
+    Pan: () => ({ minPointers: () => ({ onUpdate: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }) }), runOnJS: () => ({}) }),
+    Tap: () => ({ numberOfTaps: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }), runOnJS: () => ({}) }),
     Simultaneous: () => ({}),
     Race: () => ({}),
   },

--- a/app/__tests__/hooks/useTreeCamera.test.ts
+++ b/app/__tests__/hooks/useTreeCamera.test.ts
@@ -1,11 +1,5 @@
 import { renderHook, act } from '@testing-library/react-native';
 
-// react-native-reanimated's runOnJS is a passthrough in tests so the hook
-// logic runs synchronously.
-jest.mock('react-native-reanimated', () => ({
-  runOnJS: (fn: any) => fn,
-}));
-
 // Gesture-handler needs a tiny stand-in for Gesture.Pan / Gesture.Pinch
 // that captures the callbacks so tests can trigger them manually.
 jest.mock('react-native-gesture-handler', () => {
@@ -17,6 +11,7 @@ jest.mock('react-native-gesture-handler', () => {
       onBegin: (cb: any) => { handlers.onBegin = cb; return g; },
       onUpdate: (cb: any) => { handlers.onUpdate = cb; return g; },
       onEnd: (cb: any) => { handlers.onEnd = cb; return g; },
+      runOnJS: () => g,
     };
     return g;
   };

--- a/app/__tests__/screens/GenealogyTreeScreen.test.tsx
+++ b/app/__tests__/screens/GenealogyTreeScreen.test.tsx
@@ -170,16 +170,6 @@ jest.mock('react-native-svg', () => {
   };
 });
 
-jest.mock('react-native-reanimated', () => {
-  const React = require('react');
-  const { View } = require('react-native');
-  return {
-    __esModule: true,
-    default: { View: (props: any) => React.createElement(View, props) },
-    runOnJS: (fn: any) => fn,
-  };
-});
-
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: (props: any) => props.children,
 }));

--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Companion Study",
     "slug": "companion-study",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "default",
     "icon": "./assets/images/icon-512.png",
     "scheme": "scripture",
@@ -59,7 +59,7 @@
     ],
     "updates": {
       "url": "https://u.expo.dev/105f31ba-3cfb-4d35-8509-4abbe6ab132d",
-      "enabled": false,
+      "enabled": true,
       "fallbackToCacheTimeout": 0
     },
     "runtimeVersion": {

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -2,8 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      'react-native-reanimated/plugin',
-    ],
   };
 };

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -158,12 +158,8 @@ jest.mock('expo-web-browser', () => ({
 
 // ── React Native library mocks ────────────────────────────────────
 
-// Mock react-native-reanimated
-jest.mock('react-native-reanimated', () => {
-  const Reanimated = require('react-native-reanimated/mock');
-  Reanimated.default.call = () => {};
-  return Reanimated;
-});
+// react-native-reanimated was removed in favor of RN's built-in Animated API.
+// No mock needed — Animated is part of react-native core.
 
 // Mock react-native-gesture-handler
 jest.mock('react-native-gesture-handler', () => {

--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,6 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-reanimated": "3.19.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",

--- a/app/src/components/ChapterSkeleton.tsx
+++ b/app/src/components/ChapterSkeleton.tsx
@@ -6,14 +6,8 @@
  * animation on reanimated shared values.
  */
 
-import React, { useEffect } from 'react';
-import { View, StyleSheet, type ViewStyle, type DimensionValue } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
+import React, { useEffect, useRef } from 'react';
+import { View, Animated, StyleSheet, type ViewStyle, type DimensionValue } from 'react-native';
 import { useTheme, spacing, radii } from '../theme';
 
 function Bone({ width, height = 14, style, bgColor }: {
@@ -39,22 +33,21 @@ function Bone({ width, height = 14, style, bgColor }: {
 
 export function ChapterSkeleton() {
   const { base } = useTheme();
-  const opacity = useSharedValue(0.3);
+  const opacity = useRef(new Animated.Value(0.3)).current;
 
   useEffect(() => {
-    opacity.value = withRepeat(
-      withTiming(0.7, { duration: 800 }),
-      -1,
-      true
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+      ]),
     );
+    loop.start();
+    return () => loop.stop();
   }, [opacity]);
 
-  const pulse = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-  }));
-
   return (
-    <Animated.View style={[styles.container, { backgroundColor: base.bg }, pulse]}>
+    <Animated.View style={[styles.container, { backgroundColor: base.bg, opacity }]}>
       {/* Title */}
       <View style={styles.header}>
         <Bone width="70%" height={22} bgColor={base.bgSurface} />

--- a/app/src/components/ContentImageGallery.tsx
+++ b/app/src/components/ContentImageGallery.tsx
@@ -19,6 +19,7 @@ import React, { useState, useCallback, useRef } from 'react';
 import {
   View,
   Text,
+  Animated,
   ScrollView,
   Modal,
   TouchableOpacity,
@@ -30,11 +31,6 @@ import {
   type NativeScrollEvent,
 } from 'react-native';
 import { Image } from 'expo-image';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
 import {
   GestureDetector,
   Gesture,
@@ -136,80 +132,110 @@ interface ZoomViewerProps {
 }
 
 function ZoomViewer({ image, visible, onClose }: ZoomViewerProps) {
-  const scale = useSharedValue(1);
-  const savedScale = useSharedValue(1);
-  const translateX = useSharedValue(0);
-  const translateY = useSharedValue(0);
-  const savedTranslateX = useSharedValue(0);
-  const savedTranslateY = useSharedValue(0);
+  // Animated values drive the transform. Paired refs mirror current values so
+  // gesture callbacks (which run on the JS thread via .runOnJS(true)) can
+  // read them synchronously — Animated.Value has no sync getter.
+  const scale = useRef(new Animated.Value(1)).current;
+  const translateX = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(0)).current;
+
+  const scaleRef = useRef(1);
+  const savedScaleRef = useRef(1);
+  const translateXRef = useRef(0);
+  const savedTranslateXRef = useRef(0);
+  const translateYRef = useRef(0);
+  const savedTranslateYRef = useRef(0);
+
+  // Helper: set both the Animated.Value and the shadow ref.
+  const setScale = useCallback((v: number) => {
+    scaleRef.current = v;
+    scale.setValue(v);
+  }, [scale]);
+  const setTx = useCallback((v: number) => {
+    translateXRef.current = v;
+    translateX.setValue(v);
+  }, [translateX]);
+  const setTy = useCallback((v: number) => {
+    translateYRef.current = v;
+    translateY.setValue(v);
+  }, [translateY]);
+
+  // Animate helper: runs Animated.timing and keeps the ref in sync.
+  const animateTo = useCallback((value: Animated.Value, ref: React.MutableRefObject<number>, to: number, duration: number) => {
+    ref.current = to;
+    Animated.timing(value, { toValue: to, duration, useNativeDriver: true }).start();
+  }, []);
 
   const resetTransform = useCallback(() => {
-    scale.value = withTiming(1, { duration: 200 });
-    translateX.value = withTiming(0, { duration: 200 });
-    translateY.value = withTiming(0, { duration: 200 });
-    savedScale.value = 1;
-    savedTranslateX.value = 0;
-    savedTranslateY.value = 0;
-  }, [scale, translateX, translateY, savedScale, savedTranslateX, savedTranslateY]);
+    animateTo(scale, scaleRef, 1, 200);
+    animateTo(translateX, translateXRef, 0, 200);
+    animateTo(translateY, translateYRef, 0, 200);
+    savedScaleRef.current = 1;
+    savedTranslateXRef.current = 0;
+    savedTranslateYRef.current = 0;
+  }, [animateTo, scale, translateX, translateY]);
 
   const pinchGesture = Gesture.Pinch()
     .onUpdate((e) => {
-      scale.value = Math.max(1, Math.min(savedScale.value * e.scale, 5));
+      setScale(Math.max(1, Math.min(savedScaleRef.current * e.scale, 5)));
     })
     .onEnd(() => {
-      if (scale.value < 1.1) {
-        scale.value = withTiming(1, { duration: 200 });
-        translateX.value = withTiming(0, { duration: 200 });
-        translateY.value = withTiming(0, { duration: 200 });
-        savedScale.value = 1;
-        savedTranslateX.value = 0;
-        savedTranslateY.value = 0;
+      if (scaleRef.current < 1.1) {
+        animateTo(scale, scaleRef, 1, 200);
+        animateTo(translateX, translateXRef, 0, 200);
+        animateTo(translateY, translateYRef, 0, 200);
+        savedScaleRef.current = 1;
+        savedTranslateXRef.current = 0;
+        savedTranslateYRef.current = 0;
       } else {
-        savedScale.value = scale.value;
+        savedScaleRef.current = scaleRef.current;
       }
-    });
+    })
+    .runOnJS(true);
 
   const panGesture = Gesture.Pan()
     .minPointers(1)
     .onUpdate((e) => {
-      if (savedScale.value > 1) {
-        translateX.value = savedTranslateX.value + e.translationX;
-        translateY.value = savedTranslateY.value + e.translationY;
+      if (savedScaleRef.current > 1) {
+        setTx(savedTranslateXRef.current + e.translationX);
+        setTy(savedTranslateYRef.current + e.translationY);
       }
     })
     .onEnd(() => {
-      savedTranslateX.value = translateX.value;
-      savedTranslateY.value = translateY.value;
-    });
+      savedTranslateXRef.current = translateXRef.current;
+      savedTranslateYRef.current = translateYRef.current;
+    })
+    .runOnJS(true);
 
   const doubleTapGesture = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(() => {
-      if (scale.value > 1.1) {
-        scale.value = withTiming(1, { duration: 250 });
-        translateX.value = withTiming(0, { duration: 250 });
-        translateY.value = withTiming(0, { duration: 250 });
-        savedScale.value = 1;
-        savedTranslateX.value = 0;
-        savedTranslateY.value = 0;
+      if (scaleRef.current > 1.1) {
+        animateTo(scale, scaleRef, 1, 250);
+        animateTo(translateX, translateXRef, 0, 250);
+        animateTo(translateY, translateYRef, 0, 250);
+        savedScaleRef.current = 1;
+        savedTranslateXRef.current = 0;
+        savedTranslateYRef.current = 0;
       } else {
-        scale.value = withTiming(2.5, { duration: 250 });
-        savedScale.value = 2.5;
+        animateTo(scale, scaleRef, 2.5, 250);
+        savedScaleRef.current = 2.5;
       }
-    });
+    })
+    .runOnJS(true);
 
   const composedGesture = Gesture.Simultaneous(
     pinchGesture,
     Gesture.Race(doubleTapGesture, panGesture),
   );
 
-  const animatedStyle = useAnimatedStyle(() => ({
+  const animatedStyle = {
     transform: [
-      { translateX: translateX.value },
-      { translateY: translateY.value },
-      { scale: scale.value },
+      { translateX },
+      { translateY },
+      { scale },
     ],
-  }));
+  };
 
   const handleClose = useCallback(() => {
     resetTransform();

--- a/app/src/components/LoadingSkeleton.tsx
+++ b/app/src/components/LoadingSkeleton.tsx
@@ -2,14 +2,8 @@
  * LoadingSkeleton — Animated shimmer placeholder for loading states.
  */
 
-import React, { useEffect } from 'react';
-import { View, StyleSheet, type DimensionValue } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
+import React, { useEffect, useRef } from 'react';
+import { View, Animated, StyleSheet, type DimensionValue } from 'react-native';
 import { spacing, radii } from '../theme';
 
 interface Props {
@@ -26,19 +20,18 @@ interface Props {
 const BONE_COLOR = 'rgba(191, 160, 80, 0.08)';
 
 export function LoadingSkeleton({ lines = 3, width = '100%', height = 14 }: Props) {
-  const opacity = useSharedValue(0.3);
+  const opacity = useRef(new Animated.Value(0.3)).current;
 
   useEffect(() => {
-    opacity.value = withRepeat(
-      withTiming(0.7, { duration: 800 }),
-      -1,
-      true
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+      ]),
     );
+    loop.start();
+    return () => loop.stop();
   }, [opacity]);
-
-  const animStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-  }));
 
   return (
     <View style={styles.container}>
@@ -51,8 +44,8 @@ export function LoadingSkeleton({ lines = 3, width = '100%', height = 14 }: Prop
               width: i === lines - 1 ? '60%' : width,
               height,
               backgroundColor: BONE_COLOR,
+              opacity,
             },
-            animStyle,
           ]}
         />
       ))}

--- a/app/src/hooks/useTreeCamera.ts
+++ b/app/src/hooks/useTreeCamera.ts
@@ -22,7 +22,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { Gesture } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
 import { BREAKPOINTS } from '../theme/breakpoints';
 import { TREE_CONSTANTS } from '../utils/treeBuilder';
 
@@ -197,25 +196,27 @@ export function useTreeCamera(): TreeCameraResult {
     () => Gesture.Pan()
       .minDistance(5)
       .onBegin(() => {
-        runOnJS(onPanBegin)();
+        onPanBegin();
       })
       .onUpdate((e) => {
-        runOnJS(onPanUpdate)(e.translationX, e.translationY);
+        onPanUpdate(e.translationX, e.translationY);
       })
       .onEnd((e) => {
-        runOnJS(onPanEnd)(e.velocityX, e.velocityY);
-      }),
+        onPanEnd(e.velocityX, e.velocityY);
+      })
+      .runOnJS(true),
     [onPanBegin, onPanUpdate, onPanEnd],
   );
 
   const pinchGesture = useMemo(
     () => Gesture.Pinch()
       .onBegin((e) => {
-        runOnJS(onPinchBegin)(e.focalX, e.focalY);
+        onPinchBegin(e.focalX, e.focalY);
       })
       .onUpdate((e) => {
-        runOnJS(onPinchUpdate)(e.scale, e.focalX, e.focalY);
-      }),
+        onPinchUpdate(e.scale, e.focalX, e.focalY);
+      })
+      .runOnJS(true),
     [onPinchBegin, onPinchUpdate],
   );
 


### PR DESCRIPTION
## Root Cause

Symbolicated TestFlight crash log (1.0.2 build 8 and 1.0.3 build 9) showed the app aborting on `com.meta.react.turbomodulemanager.queue` during TurboModule registration, 8ms after launch:

```
__cxa_rethrow → objc_exception_rethrow → [anonymous RN bridge frames]
```

Expo SDK 54 requires `react-native-reanimated@~4.1.1`. We're pinned at `3.19.5` (downgraded in #ca89443 to keep MapLibre v10 working on legacy architecture). This mismatch means the native Reanimated module registered by Expo's iOS build doesn't match what our JS code expects, and TurboModuleManager throws an uncaught Obj-C exception at startup.

Confirmation from Expo Go: launching our app via Expo Go also fails with `Exception in HostFunction: <unknown>` — same class of JS↔native version mismatch.

## Why Not "Upgrade to Reanimated 4"

The architectural trilemma:
- **MapLibre v10** → requires legacy architecture
- **Expo SDK 54** → requires Reanimated 4.1.x
- **Reanimated 4** → requires new architecture

Pick any two. Upgrading to Reanimated 4 means enabling new arch, which breaks MapLibre v10 (the crash #ca89443 was fixing in the first place).

MapLibre v11 supports new arch but is still in beta (currently `v11.0.0-beta.30`) with known open bugs (marker positioning, memory leaks on unmount). Not comfortable running that in production.

## The Fix: Remove Reanimated

The app's Reanimated usage was small — 4 files — and all uses stable APIs with direct RN `Animated` equivalents. Removing Reanimated:

- Eliminates the version mismatch → crash resolved
- Keeps MapLibre v10 → map feature preserved
- Keeps legacy architecture → no beta dependencies
- Small, reversible change → can re-adopt Reanimated 4 when we migrate to SDK 55 + new arch + MapLibre v11

## Changes

### Rewrote 4 files to use RN `Animated` API

**`LoadingSkeleton.tsx`** — opacity pulse (`Animated.loop(Animated.sequence([timing, timing]))`)
**`ChapterSkeleton.tsx`** — same pattern, pulse on the root Animated.View
**`useTreeCamera.ts`** — removed `runOnJS` import, added `.runOnJS(true)` to the pan + pinch gestures (gesture-handler 2.x natively supports JS-thread callbacks)
**`ContentImageGallery.tsx`** — rewrote ZoomViewer with `Animated.Value` + shadow refs pattern so gesture callbacks can read current values synchronously. Added `.runOnJS(true)` to pinch/pan/doubleTap. Pinch-zoom, pan, double-tap-to-zoom all preserved.

### Config changes

**`app/package.json`** — removed `react-native-reanimated` dependency
**`app/babel.config.js`** — removed `react-native-reanimated/plugin` from plugins array
**`app/app.json`**:
- Version bumped `1.0.3` → `1.0.4` (required for fresh runtime — prevents stale OTA bundles from being pulled by the new binary)
- `updates.enabled: true` restored (the update system wasn't the bug; disabling it in #1491 was a diagnostic that surfaced the real crash)

## Testing

After merge, test sequence on a dev build (NOT Expo Go — Expo Go will still fail until the dep is actually uninstalled locally):

```bash
git checkout master && git pull
cd app
npm install          # updates lock file
eas build --platform ios --profile production
eas submit --platform ios --latest
```

**Critical things to verify on TestFlight:**
- App launches without crashing
- Genealogy tree: pan, pinch-zoom, center-on-node, era jump
- Content image gallery: tap to open fullscreen, pinch-zoom up to 5x, pan when zoomed, double-tap to zoom, double-tap again to reset
- Chapter loading skeleton still pulses during initial load
- Loading skeleton appears where expected (scholar bio, content detail screens)
- Map works as before (MapLibre v10 unchanged)

## Forward Path

When we migrate to Expo SDK 55 (likely RN 0.82 which removes legacy arch entirely), we'll need:
- MapLibre v11 (hopefully stable by then)
- New Architecture enabled
- Reanimated 4.1.x re-adopted (with the 4 files restored to shared-value patterns)

That migration should be a dedicated PR with time for thorough testing, not a fire drill.
