### PR TITLE
feat(ai-partner): per-chapter chip pool generator (#1461)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ _data/openbible/*.jsonl
 # _tools/build_embeddings.py and merged into scripture.db by #1448.
 embeddings.db
 _tools/embedding_manifest.json
+
+# Amicus chip pool (Card #1461) — never tracked; rebuilt by
+# _tools/build_prompts.py and merged into scripture.db.
+prompts.db
+_tools/prompts_manifest.json

--- a/_tools/build_prompts.py
+++ b/_tools/build_prompts.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""
+build_prompts.py — Amicus chip pool orchestrator (Card #1461).
+
+Pre-generates the FAB-peek chip pool at content build time so runtime cost
+is ~$0. For each live chapter, produces 3 chips per profile variant via
+Claude Haiku; for people/places/debate topics, uses zero-cost templates.
+
+Output writes to a standalone `prompts.db` (like `embeddings.db`); the
+`populate_precached_prompts` loader merges rows into `scripture.db` during
+the main build.
+
+Usage:
+    python _tools/build_prompts.py                  # full rebuild
+    python _tools/build_prompts.py --incremental    # only chapters in manifest
+    python _tools/build_prompts.py --dry-run        # cost estimate
+    python _tools/build_prompts.py --entity-only    # entity chips only
+    python _tools/build_prompts.py --chapter-only   # chapter chips only
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import signal
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / '_tools'))
+
+from content_writer import REGISTRY  # noqa: E402
+from build_prompts_variants import PROFILE_VARIANTS  # noqa: E402
+from build_prompts_entity import all_entity_rows  # noqa: E402
+
+PROMPTS_DB = ROOT / 'prompts.db'
+MANIFEST_PATH = ROOT / '_tools' / 'prompts_manifest.json'
+
+MODEL_NAME = 'claude-haiku-4-5-20251001'
+MAX_TOKENS = 256
+BATCH_CHECKPOINT_EVERY = 10
+# Haiku 4.5: $1/MTok input, $5/MTok output. Per-chip rough estimate below is
+# for dry-run output. Cached-prompt savings are not modeled (~70% savings in
+# practice), so this is a conservative upper bound.
+INPUT_COST_PER_MTOK = 1.0
+OUTPUT_COST_PER_MTOK = 5.0
+AVG_INPUT_TOKENS_PER_CALL = 600
+AVG_OUTPUT_TOKENS_PER_CALL = 80
+
+
+# ── Manifest helpers ──────────────────────────────────────────────────
+
+def load_manifest() -> dict:
+    if MANIFEST_PATH.exists():
+        try:
+            return json.loads(MANIFEST_PATH.read_text(encoding='utf-8'))
+        except json.JSONDecodeError:
+            pass
+    return {'dirty_chapters': [], 'chapter_hashes': {}}
+
+
+def save_manifest(m: dict) -> None:
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_PATH.write_text(json.dumps(m, indent=2, sort_keys=True), encoding='utf-8')
+
+
+# ── DB helpers ────────────────────────────────────────────────────────
+
+def open_prompts_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(PROMPTS_DB))
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS precached_prompts (
+          entity_type TEXT NOT NULL,
+          entity_id TEXT NOT NULL,
+          profile_variant TEXT NOT NULL,
+          chips_json TEXT NOT NULL,
+          generated_at TEXT NOT NULL,
+          PRIMARY KEY (entity_type, entity_id, profile_variant)
+        )
+    ''')
+    conn.execute('''
+        CREATE INDEX IF NOT EXISTS idx_precached_prompts_entity
+          ON precached_prompts(entity_type, entity_id)
+    ''')
+    conn.commit()
+    return conn
+
+
+def upsert_row(
+    conn: sqlite3.Connection,
+    entity_type: str,
+    entity_id: str,
+    profile_variant: str,
+    chips: list[dict[str, Any]],
+) -> None:
+    conn.execute(
+        '''INSERT INTO precached_prompts
+             (entity_type, entity_id, profile_variant, chips_json, generated_at)
+           VALUES (?, ?, ?, ?, datetime('now'))
+           ON CONFLICT(entity_type, entity_id, profile_variant)
+           DO UPDATE SET
+             chips_json = excluded.chips_json,
+             generated_at = excluded.generated_at''',
+        (entity_type, entity_id, profile_variant, json.dumps(chips, ensure_ascii=False)),
+    )
+
+
+# ── Chapter iteration ─────────────────────────────────────────────────
+
+def iter_live_chapters() -> Iterable[tuple[str, int, dict]]:
+    for book_dir, _name, _total, live, _testament, _td in REGISTRY:
+        if live <= 0:
+            continue
+        book_path = ROOT / 'content' / book_dir
+        if not book_path.is_dir():
+            continue
+        for ch_file in sorted(book_path.glob('*.json')):
+            try:
+                data = json.loads(ch_file.read_text(encoding='utf-8'))
+            except json.JSONDecodeError:
+                continue
+            chapter_num = data.get('chapter_num')
+            if not isinstance(chapter_num, int):
+                continue
+            yield book_dir, chapter_num, data
+
+
+def chapter_context_text(data: dict) -> str:
+    """Short blob to send to Haiku — title + a trim of section headers."""
+    parts: list[str] = []
+    title = data.get('title')
+    if title:
+        parts.append(f'Title: {title}')
+    subtitle = data.get('subtitle')
+    if subtitle:
+        parts.append(f'Subtitle: {subtitle}')
+    headers: list[str] = []
+    for sec in data.get('sections', [])[:6]:
+        h = sec.get('header')
+        if h:
+            headers.append(f'- {h}')
+    if headers:
+        parts.append('Sections:\n' + '\n'.join(headers))
+    return '\n'.join(parts)
+
+
+def chapter_content_hash(data: dict) -> str:
+    payload = json.dumps(data, sort_keys=True, ensure_ascii=False).encode('utf-8')
+    return hashlib.sha256(payload).hexdigest()
+
+
+# ── Haiku call ────────────────────────────────────────────────────────
+
+def build_chip_request_body(book_dir: str, ch: int, chapter_ctx: str,
+                            variant: dict) -> dict:
+    system = (
+        "You produce prompt chips for an AI Bible-study companion. Return a "
+        "strict JSON array of EXACTLY 3 chip objects. Each chip is:\n"
+        '  {"label": "<6-10 words>", '
+        '"seed_query": "<full question/prompt>", '
+        '"expected_source_types": ["section_panel" | "chapter_panel" | '
+        '"debate_topic" | "cross_ref_thread_note" | "journey_stop" | '
+        '"word_study" | "lexicon_entry" | "meta_faq"]}\n'
+        "Label MUST be 6 to 10 words. No markdown. No preamble. JSON only."
+    )
+    user = (
+        f"Chapter: {book_dir.replace('_', ' ').title()} {ch}\n"
+        f"{chapter_ctx}\n\n"
+        f"Profile variant: {variant['id']} — {variant['seed_instruction']}\n"
+    )
+    return {
+        'model': MODEL_NAME,
+        'max_tokens': MAX_TOKENS,
+        'system': system,
+        'messages': [{'role': 'user', 'content': user}],
+    }
+
+
+def call_haiku(body: dict, api_key: str) -> list[dict[str, Any]]:
+    import urllib.request
+    import urllib.error
+    req = urllib.request.Request(
+        'https://api.anthropic.com/v1/messages',
+        data=json.dumps(body).encode('utf-8'),
+        headers={
+            'Content-Type': 'application/json',
+            'x-api-key': api_key,
+            'anthropic-version': '2023-06-01',
+            'anthropic-no-retention': 'true',
+        },
+    )
+    delay = 1.0
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read().decode('utf-8'))
+            text = payload.get('content', [{}])[0].get('text', '')
+            parsed = _extract_json_array(text)
+            return _validate_chips(parsed)
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and attempt < 2:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+        except urllib.error.URLError:
+            if attempt < 2:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+    raise RuntimeError('call_haiku exhausted retries')
+
+
+def _extract_json_array(text: str) -> list[dict[str, Any]]:
+    """Best-effort extract the first JSON array from model output."""
+    start = text.find('[')
+    end = text.rfind(']')
+    if start < 0 or end < 0:
+        raise ValueError('no JSON array in model output')
+    raw = text[start:end + 1]
+    data = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError('expected JSON array at top level')
+    return data
+
+
+VALID_SOURCE_TYPES = {
+    'section_panel', 'chapter_panel', 'debate_topic', 'cross_ref_thread_note',
+    'journey_stop', 'word_study', 'lexicon_entry', 'meta_faq',
+}
+
+
+def _validate_chips(chips: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if len(chips) != 3:
+        raise ValueError(f'expected 3 chips, got {len(chips)}')
+    out: list[dict[str, Any]] = []
+    for c in chips:
+        if not isinstance(c, dict):
+            raise ValueError('chip is not an object')
+        label = c.get('label', '').strip()
+        seed_query = c.get('seed_query', '').strip()
+        expected = c.get('expected_source_types', [])
+        word_count = len(label.split())
+        if word_count < 6 or word_count > 10:
+            raise ValueError(f'label word count {word_count} out of range: {label!r}')
+        if not seed_query:
+            raise ValueError('seed_query empty')
+        if not isinstance(expected, list):
+            raise ValueError('expected_source_types must be a list')
+        cleaned = [s for s in expected if isinstance(s, str) and s in VALID_SOURCE_TYPES]
+        out.append({
+            'label': label,
+            'seed_query': seed_query,
+            'expected_source_types': cleaned,
+        })
+    return out
+
+
+# ── Main driver ──────────────────────────────────────────────────────
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--incremental', action='store_true',
+                   help='Re-generate only chapters listed in dirty_chapters')
+    p.add_argument('--dry-run', action='store_true',
+                   help='Print call counts + estimated cost; no writes')
+    p.add_argument('--entity-only', action='store_true',
+                   help='Only (re)generate entity chips (zero LLM cost)')
+    p.add_argument('--chapter-only', action='store_true',
+                   help='Only (re)generate chapter chips')
+    p.add_argument('--yes', action='store_true',
+                   help='Skip the cost confirmation prompt')
+    return p.parse_args(argv)
+
+
+def estimate_cost(num_calls: int) -> float:
+    in_tok = num_calls * AVG_INPUT_TOKENS_PER_CALL
+    out_tok = num_calls * AVG_OUTPUT_TOKENS_PER_CALL
+    return (in_tok / 1_000_000 * INPUT_COST_PER_MTOK
+            + out_tok / 1_000_000 * OUTPUT_COST_PER_MTOK)
+
+
+def build_chapter_rows(incremental: bool, dry_run: bool,
+                       api_key: str | None) -> int:
+    manifest = load_manifest()
+    dirty = set(manifest.get('dirty_chapters', []))
+    chapter_hashes = manifest.get('chapter_hashes', {})
+
+    chapters = list(iter_live_chapters())
+    if incremental:
+        chapters = [
+            (b, c, d) for (b, c, d) in chapters
+            if f'{b}-{c}' in dirty or chapter_content_hash(d) != chapter_hashes.get(f'{b}-{c}')
+        ]
+
+    call_count = len(chapters) * len(PROFILE_VARIANTS)
+    est = estimate_cost(call_count)
+    print(f'  chapters to process: {len(chapters)}')
+    print(f'  variants: {len(PROFILE_VARIANTS)}')
+    print(f'  API calls: {call_count}')
+    print(f'  estimated cost: ~${est:.2f} USD (Haiku {MODEL_NAME})')
+
+    if dry_run:
+        return 0
+
+    if api_key is None:
+        print('  [ERROR] ANTHROPIC_API_KEY is not set')
+        sys.exit(1)
+
+    conn = open_prompts_db()
+    stopped = {'flag': False}
+    prev = signal.signal(signal.SIGINT, lambda s, f: stopped.__setitem__('flag', True))
+
+    written = 0
+    try:
+        for i, (book_dir, ch, data) in enumerate(chapters, start=1):
+            ctx = chapter_context_text(data)
+            entity_id = f'{book_dir}-{ch}'
+            for variant in PROFILE_VARIANTS:
+                body = build_chip_request_body(book_dir, ch, ctx, variant)
+                try:
+                    chips = call_haiku(body, api_key)
+                except Exception as e:  # noqa: BLE001
+                    print(f'  [FAIL] {entity_id} {variant["id"]}: {e}')
+                    continue
+                upsert_row(conn, 'chapter', entity_id, variant['id'], chips)
+                written += 1
+            # Update manifest with latest hash so incremental can skip next run.
+            chapter_hashes[entity_id] = chapter_content_hash(data)
+            if i % BATCH_CHECKPOINT_EVERY == 0:
+                conn.commit()
+                manifest['chapter_hashes'] = chapter_hashes
+                save_manifest(manifest)
+                print(f'  [OK] checkpoint: {i}/{len(chapters)} chapters')
+            if stopped['flag']:
+                print('  [WARN] Ctrl-C — stopping after current chapter.')
+                break
+        conn.commit()
+    finally:
+        signal.signal(signal.SIGINT, prev)
+        conn.close()
+
+    manifest['chapter_hashes'] = chapter_hashes
+    if not stopped['flag']:
+        manifest['dirty_chapters'] = []
+    save_manifest(manifest)
+    print(f'  [DONE] chapter rows written: {written}')
+    return written
+
+
+def build_entity_rows() -> int:
+    rows = all_entity_rows()
+    if not rows:
+        print('  [WARN] no entity rows; is content/meta present?')
+        return 0
+    conn = open_prompts_db()
+    try:
+        for r in rows:
+            upsert_row(
+                conn,
+                r['entity_type'],
+                r['entity_id'],
+                r['profile_variant'],
+                r['chips'],
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    print(f'  [OK] entity rows written: {len(rows)}')
+    return len(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    print('=' * 60)
+    print('Amicus: Building prompt chip pool')
+    print('=' * 60)
+
+    api_key = os.environ.get('ANTHROPIC_API_KEY')
+
+    if args.dry_run:
+        build_chapter_rows(args.incremental, dry_run=True, api_key=api_key)
+        print('  [DRY RUN] no writes performed')
+        return 0
+
+    if args.entity_only:
+        build_entity_rows()
+        return 0
+
+    if args.chapter_only:
+        build_chapter_rows(args.incremental, dry_run=False, api_key=api_key)
+        return 0
+
+    # Full build: entity (cheap) first, then chapter (LLM).
+    est = estimate_cost(len(list(iter_live_chapters())) * len(PROFILE_VARIANTS))
+    if est > 1.0 and not args.yes:
+        try:
+            ans = input(f'Full build will cost ~${est:.2f}. Continue? [y/N] ').strip().lower()
+        except EOFError:
+            ans = 'n'
+        if ans not in ('y', 'yes'):
+            print('  [ABORT] user declined')
+            return 1
+
+    build_entity_rows()
+    build_chapter_rows(args.incremental, dry_run=False, api_key=api_key)
+    size = PROMPTS_DB.stat().st_size if PROMPTS_DB.exists() else 0
+    print(f'\n  prompts.db: {size // 1024}KB')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/_tools/build_prompts_entity.py
+++ b/_tools/build_prompts_entity.py
@@ -1,0 +1,145 @@
+"""
+build_prompts_entity.py — Templated entity chips (zero LLM cost).
+
+Chips for people/places/debate topics are deterministic templates because a
+user's intent on those screens is narrow enough that static phrasing works.
+The chapter chips in `build_prompts.py` are the LLM-generated set; this
+module produces the companion entity rows.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+ROOT = Path(__file__).resolve().parent.parent
+META = ROOT / 'content' / 'meta'
+
+
+def _prettify(name: str) -> str:
+    return name.replace('_', ' ').replace('-', ' ').strip()
+
+
+def person_chips(person_id: str, name: str) -> list[dict[str, Any]]:
+    pretty = _prettify(name or person_id)
+    return [
+        {
+            'label': f'Who was {pretty}?',
+            'seed_query': f'Who was {pretty} — summarize in 3 sentences.',
+            'expected_source_types': ['section_panel', 'chapter_panel'],
+        },
+        {
+            'label': f'Where does {pretty} appear in scripture?',
+            'seed_query': f'List the main scripture references for {pretty}.',
+            'expected_source_types': ['cross_ref_thread_note'],
+        },
+        {
+            'label': f'Scholars on {pretty}',
+            'seed_query': f'How do the scholars read {pretty}?',
+            'expected_source_types': ['section_panel'],
+        },
+    ]
+
+
+def place_chips(place_id: str, name: str) -> list[dict[str, Any]]:
+    pretty = _prettify(name or place_id)
+    return [
+        {
+            'label': f'What happened at {pretty}?',
+            'seed_query': f'What significant events occurred at {pretty}?',
+            'expected_source_types': ['section_panel', 'chapter_panel'],
+        },
+        {
+            'label': f'Scholars on {pretty}',
+            'seed_query': f'What do the scholars say about {pretty}?',
+            'expected_source_types': ['section_panel'],
+        },
+        {
+            'label': 'Related people and events',
+            'seed_query': f'Who and what is connected to {pretty}?',
+            'expected_source_types': ['cross_ref_thread_note', 'journey_stop'],
+        },
+    ]
+
+
+def debate_chips(topic_id: str, title: str) -> list[dict[str, Any]]:
+    pretty = title or _prettify(topic_id)
+    return [
+        {
+            'label': 'Different views on this',
+            'seed_query': f'Summarize the main positions on {pretty}.',
+            'expected_source_types': ['debate_topic'],
+        },
+        {
+            'label': 'Strongest arguments for each side',
+            'seed_query': f'What are the strongest arguments for each view of {pretty}?',
+            'expected_source_types': ['debate_topic'],
+        },
+        {
+            'label': 'Where does this show up in scripture?',
+            'seed_query': f'Which passages most bear on {pretty}?',
+            'expected_source_types': ['debate_topic', 'section_panel'],
+        },
+    ]
+
+
+# ── Iterators over meta files ────────────────────────────────────────
+
+def iter_people() -> Iterator[tuple[str, str]]:
+    path = META / 'people.json'
+    if not path.exists():
+        return
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for p in data.get('people', []) if isinstance(data, dict) else data:
+        pid = p.get('id')
+        if pid:
+            yield pid, p.get('name', pid)
+
+
+def iter_places() -> Iterator[tuple[str, str]]:
+    path = META / 'places.json'
+    if not path.exists():
+        return
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for p in data if isinstance(data, list) else []:
+        pid = p.get('id')
+        if pid:
+            yield pid, p.get('ancient_name') or p.get('modern_name') or pid
+
+
+def iter_debate_topics() -> Iterator[tuple[str, str]]:
+    path = META / 'debate-topics.json'
+    if not path.exists():
+        return
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for t in data if isinstance(data, list) else []:
+        tid = t.get('id')
+        if tid:
+            yield tid, t.get('title', tid)
+
+
+def all_entity_rows() -> list[dict[str, Any]]:
+    """Produce `precached_prompts` rows for every entity."""
+    rows: list[dict[str, Any]] = []
+    for pid, name in iter_people():
+        rows.append({
+            'entity_type': 'person',
+            'entity_id': pid,
+            'profile_variant': 'default',
+            'chips': person_chips(pid, name),
+        })
+    for pid, name in iter_places():
+        rows.append({
+            'entity_type': 'place',
+            'entity_id': pid,
+            'profile_variant': 'default',
+            'chips': place_chips(pid, name),
+        })
+    for tid, title in iter_debate_topics():
+        rows.append({
+            'entity_type': 'debate_topic',
+            'entity_id': tid,
+            'profile_variant': 'default',
+            'chips': debate_chips(tid, title),
+        })
+    return rows

--- a/_tools/build_prompts_variants.py
+++ b/_tools/build_prompts_variants.py
@@ -1,0 +1,100 @@
+"""
+build_prompts_variants.py — Profile variant seeds for the Amicus chip pool.
+
+Each variant biases the LLM prompt toward scholars + themes a user of that
+profile tends to engage with. Matches `PROFILE_VARIANTS` referenced in
+#1461 and consumed by the runtime chip selector (future #1474).
+"""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class ProfileVariant(TypedDict):
+    id: str
+    label: str
+    tradition_bias: list[str]
+    scholar_bias: list[str]
+    genre_bias: list[str]
+    seed_instruction: str
+
+
+PROFILE_VARIANTS: list[ProfileVariant] = [
+    {
+        'id': 'generic_balanced',
+        'label': 'Generic / balanced (default fallback)',
+        'tradition_bias': [],
+        'scholar_bias': [],
+        'genre_bias': [],
+        'seed_instruction': (
+            'Produce chips suitable for a broadly curious reader with no single '
+            'tradition emphasized. Mix exegesis, history, and cross-references.'
+        ),
+    },
+    {
+        'id': 'reformed_narrative',
+        'label': 'Reformed leaning, OT narrative',
+        'tradition_bias': ['Reformed', 'Conservative Evangelical'],
+        'scholar_bias': ['calvin', 'wright', 'macarthur'],
+        'genre_bias': ['narrative', 'law'],
+        'seed_instruction': (
+            'Prefer chips that surface covenant theology, Christocentric '
+            'readings, and Reformed scholarship (Calvin, Wright).'
+        ),
+    },
+    {
+        'id': 'reformed_prophets',
+        'label': 'Reformed leaning, prophets',
+        'tradition_bias': ['Reformed', 'Conservative Evangelical'],
+        'scholar_bias': ['calvin', 'wright', 'oswalt'],
+        'genre_bias': ['prophecy', 'apocalyptic'],
+        'seed_instruction': (
+            'Prefer chips about prophetic structure, messianic typology, and '
+            'Reformed exegesis of Israel vs. Church.'
+        ),
+    },
+    {
+        'id': 'jewish_pentateuch',
+        'label': 'Jewish leaning, Torah',
+        'tradition_bias': ['Jewish', 'Conservative Jewish'],
+        'scholar_bias': ['sarna', 'alter', 'milgrom'],
+        'genre_bias': ['law', 'narrative'],
+        'seed_instruction': (
+            'Prefer chips that foreground Hebrew literary artistry, JPS-style '
+            'commentary, and Ancient Near Eastern context.'
+        ),
+    },
+    {
+        'id': 'jewish_prophets',
+        'label': 'Jewish leaning, prophets',
+        'tradition_bias': ['Jewish', 'Conservative Jewish'],
+        'scholar_bias': ['alter', 'sarna'],
+        'genre_bias': ['prophecy'],
+        'seed_instruction': (
+            'Prefer chips about rhetorical structure in Hebrew prophecy, '
+            'literary echoes within the Tanakh, and prophetic genre.'
+        ),
+    },
+    {
+        'id': 'catholic_gospels',
+        'label': 'Catholic tradition, NT gospels',
+        'tradition_bias': ['Catholic', 'Patristic'],
+        'scholar_bias': ['catena', 'keener'],
+        'genre_bias': ['gospel'],
+        'seed_instruction': (
+            'Prefer chips about patristic readings, sacramental theology, and '
+            'catholic tradition on the Gospels.'
+        ),
+    },
+]
+
+
+def variant_by_id(variant_id: str) -> ProfileVariant | None:
+    for v in PROFILE_VARIANTS:
+        if v['id'] == variant_id:
+            return v
+    return None
+
+
+def variant_ids() -> list[str]:
+    return [v['id'] for v in PROFILE_VARIANTS]

--- a/_tools/build_sqlite.py
+++ b/_tools/build_sqlite.py
@@ -35,7 +35,7 @@ from build_sqlite_loaders import (
     populate_content_library, populate_life_topics, populate_hermeneutic_lenses,
     populate_archaeology, populate_historical_interpretations,
     populate_grammar_articles, populate_content_images,
-    populate_journeys, populate_embeddings,
+    populate_journeys, populate_embeddings, populate_precached_prompts,
     build_fts, compute_difficulty, build_supplemental_translations,
     AVAILABLE_TRANSLATIONS, BUNDLED_TRANSLATIONS,
 )
@@ -159,6 +159,11 @@ def main():
     emb_count = populate_embeddings(conn)
     if emb_count:
         print(f"  [OK] embeddings: {emb_count} chunks populated")
+
+    # Amicus chip pool (Card #1461). Safe no-op when prompts.db is absent.
+    chip_count = populate_precached_prompts(conn)
+    if chip_count:
+        print(f"  [OK] precached_prompts: {chip_count} rows populated")
 
     # Performance indexes for hot-path queries (Card #1175)
     cur.executescript("""

--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -1924,3 +1924,41 @@ def populate_embeddings(conn):
 
     conn.commit()
     return inserted
+# Amicus — Pre-cached FAB chip pool loader (Card #1461)
+# ---------------------------------------------------------------------------
+
+def populate_precached_prompts(conn):
+    """Merge prompts.db (from build_prompts.py) into scripture.db.
+
+    No-op with warning when prompts.db is absent (local dev / CI without
+    the Anthropic key set). Leaves the empty precached_prompts table in
+    place so app code can query safely.
+
+    Returns the number of rows populated (0 on skip).
+    """
+    import sqlite3
+    prompts_db = ROOT / 'prompts.db'
+    if not prompts_db.exists():
+        print('  [WARN] prompts.db not found — skipping precached prompts')
+        print('         Run: python _tools/build_prompts.py')
+        return 0
+
+    src = sqlite3.connect(f'file:{prompts_db}?mode=ro', uri=True)
+    try:
+        rows = src.execute(
+            'SELECT entity_type, entity_id, profile_variant, chips_json, generated_at '
+            'FROM precached_prompts ORDER BY entity_type, entity_id, profile_variant'
+        ).fetchall()
+    finally:
+        src.close()
+
+    cur = conn.cursor()
+    for entity_type, entity_id, variant, chips_json, generated_at in rows:
+        cur.execute(
+            'INSERT INTO precached_prompts'
+            '(entity_type, entity_id, profile_variant, chips_json, generated_at) '
+            'VALUES (?, ?, ?, ?, ?)',
+            (entity_type, entity_id, variant, chips_json, generated_at),
+        )
+    conn.commit()
+    return len(rows)

--- a/_tools/build_sqlite_schema.py
+++ b/_tools/build_sqlite_schema.py
@@ -707,6 +707,22 @@ CREATE INDEX idx_chunk_metadata_chapter
   ON chunk_metadata(book_id, chapter_num);
 
 -- ══════════════════════════════════════════════════════════════
+-- AMICUS — Pre-cached FAB chip pool (Card #1461).
+-- ══════════════════════════════════════════════════════════════
+
+CREATE TABLE precached_prompts (
+  entity_type     TEXT NOT NULL,     -- 'chapter' | 'person' | 'place' | 'debate_topic'
+  entity_id       TEXT NOT NULL,
+  profile_variant TEXT NOT NULL,
+  chips_json      TEXT NOT NULL,
+  generated_at    TEXT NOT NULL,
+  PRIMARY KEY (entity_type, entity_id, profile_variant)
+);
+
+CREATE INDEX idx_precached_prompts_entity
+  ON precached_prompts(entity_type, entity_id);
+
+-- ══════════════════════════════════════════════════════════════
 -- NOTE: User tables (notes, bookmarks, preferences, highlights,
 -- reading progress, plans) live in a separate user.db managed by
 -- the app's userDatabase.ts migration system. They are NOT bundled

--- a/_tools/content_writer.py
+++ b/_tools/content_writer.py
@@ -298,6 +298,7 @@ def save_chapter(book_dir, ch, data):
         json.dump(chapter, f, ensure_ascii=False, indent=2)
 
     _mark_chapter_dirty(book_dir, ch)
+    _mark_chapter_dirty_prompts(book_dir, ch)
 
     sec_panel_count = sum(len(s['panels']) for s in chapter['sections'])
     ch_panel_count = len(chapter['chapter_panels'])
@@ -315,6 +316,30 @@ def _mark_chapter_dirty(book_dir: str, ch: int) -> None:
     chapter_id = f'{book_dir}-{ch}'
     manifest_path = os.path.join(ROOT, '_tools', 'embedding_manifest.json')
     manifest = {'chunks': {}, 'dirty_chapters': []}
+    if os.path.exists(manifest_path):
+        try:
+            with open(manifest_path, 'r', encoding='utf-8') as f:
+                manifest = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    manifest.setdefault('dirty_chapters', [])
+    if chapter_id not in manifest['dirty_chapters']:
+        manifest['dirty_chapters'].append(chapter_id)
+    try:
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+    except OSError:
+        pass
+
+
+def _mark_chapter_dirty_prompts(book_dir: str, ch: int) -> None:
+    """Flag this chapter in _tools/prompts_manifest.json so
+    `build_prompts.py --incremental` knows to re-generate its chip pool
+    on the next run (Card #1461).
+    """
+    chapter_id = f'{book_dir}-{ch}'
+    manifest_path = os.path.join(ROOT, '_tools', 'prompts_manifest.json')
+    manifest = {'dirty_chapters': [], 'chapter_hashes': {}}
     if os.path.exists(manifest_path):
         try:
             with open(manifest_path, 'r', encoding='utf-8') as f:

--- a/_tools/test_build_prompts.py
+++ b/_tools/test_build_prompts.py
@@ -1,0 +1,136 @@
+"""Unit tests for _tools/build_prompts.py helpers (Card #1461).
+
+Run with:
+    python3 _tools/test_build_prompts.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import build_prompts  # noqa: E402
+import build_prompts_entity as entity  # noqa: E402
+from build_prompts_variants import PROFILE_VARIANTS, variant_ids, variant_by_id  # noqa: E402
+
+
+class ProfileVariantTests(unittest.TestCase):
+    def test_six_fixed_variants(self):
+        self.assertEqual(len(PROFILE_VARIANTS), 6)
+
+    def test_every_variant_has_required_fields(self):
+        for v in PROFILE_VARIANTS:
+            self.assertTrue(v['id'])
+            self.assertTrue(v['label'])
+            self.assertTrue(v['seed_instruction'])
+
+    def test_variant_ids_unique_and_findable(self):
+        ids = variant_ids()
+        self.assertEqual(len(ids), len(set(ids)))
+        for vid in ids:
+            self.assertIsNotNone(variant_by_id(vid))
+        self.assertIsNone(variant_by_id('nonexistent'))
+
+    def test_generic_balanced_default_present(self):
+        self.assertIn('generic_balanced', variant_ids())
+
+
+class EntityChipTests(unittest.TestCase):
+    def test_person_chips_shape(self):
+        chips = entity.person_chips('abraham', 'Abraham')
+        self.assertEqual(len(chips), 3)
+        for c in chips:
+            self.assertIn('label', c)
+            self.assertIn('seed_query', c)
+            self.assertIn('expected_source_types', c)
+            self.assertIn('Abraham', c['seed_query'])
+
+    def test_place_chips_reference_the_place(self):
+        chips = entity.place_chips('jerusalem', 'Jerusalem')
+        for c in chips:
+            self.assertIn('Jerusalem', c['seed_query'])
+
+    def test_debate_chips_shape(self):
+        chips = entity.debate_chips('election-vs-predestination', 'Election vs. Predestination')
+        self.assertEqual(len(chips), 3)
+        for c in chips:
+            self.assertTrue(c['label'])
+
+    def test_all_entity_rows_iterates_all_types(self):
+        rows = entity.all_entity_rows()
+        types = {r['entity_type'] for r in rows}
+        self.assertIn('person', types)
+        self.assertIn('place', types)
+        self.assertIn('debate_topic', types)
+
+
+class ChipValidationTests(unittest.TestCase):
+    GOOD = [
+        {
+            'label': 'What does Romans 9 say on election?',
+            'seed_query': 'Explain election in Romans 9 briefly.',
+            'expected_source_types': ['section_panel', 'debate_topic'],
+        },
+        {
+            'label': 'Compare Reformed and Jewish readings of this',
+            'seed_query': 'How do Reformed and Jewish readings differ?',
+            'expected_source_types': ['section_panel'],
+        },
+        {
+            'label': 'Why does Paul use potter and clay imagery',
+            'seed_query': 'Why the potter-and-clay metaphor?',
+            'expected_source_types': ['chapter_panel'],
+        },
+    ]
+
+    def test_accepts_valid_chips(self):
+        out = build_prompts._validate_chips(self.GOOD)
+        self.assertEqual(len(out), 3)
+
+    def test_rejects_wrong_count(self):
+        with self.assertRaises(ValueError):
+            build_prompts._validate_chips(self.GOOD[:2])
+
+    def test_rejects_short_label(self):
+        bad = [dict(self.GOOD[0], label='Too short')] + self.GOOD[1:]
+        with self.assertRaises(ValueError):
+            build_prompts._validate_chips(bad)
+
+    def test_rejects_long_label(self):
+        bad = [dict(self.GOOD[0], label=' '.join(['word'] * 12))] + self.GOOD[1:]
+        with self.assertRaises(ValueError):
+            build_prompts._validate_chips(bad)
+
+    def test_filters_unknown_source_types(self):
+        bad = [dict(self.GOOD[0], expected_source_types=['bogus', 'section_panel'])]
+        out = build_prompts._validate_chips(bad + self.GOOD[1:])
+        self.assertEqual(out[0]['expected_source_types'], ['section_panel'])
+
+    def test_rejects_missing_seed_query(self):
+        bad = [dict(self.GOOD[0], seed_query='')] + self.GOOD[1:]
+        with self.assertRaises(ValueError):
+            build_prompts._validate_chips(bad)
+
+
+class ContextTextTests(unittest.TestCase):
+    def test_context_includes_title_and_headers(self):
+        data = {
+            'title': 'Romans 9',
+            'subtitle': 'Israel and the Sovereignty of God',
+            'sections': [
+                {'header': 'The Election of Israel'},
+                {'header': 'Vessels of Mercy and Wrath'},
+            ],
+        }
+        ctx = build_prompts.chapter_context_text(data)
+        self.assertIn('Romans 9', ctx)
+        self.assertIn('Election of Israel', ctx)
+        self.assertIn('Vessels', ctx)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/_tools/validate_sqlite.py
+++ b/_tools/validate_sqlite.py
@@ -106,6 +106,45 @@ def _has_table(cur, name):
         (name,)))
 
 
+def _validate_precached_prompts(cur):
+    """Section 7 PRECACHED PROMPTS — warn (don't fail) when the table
+    is absent or empty so builds without prompts.db keep passing."""
+    if not _has_table(cur, 'precached_prompts'):
+        warn("precached_prompts table absent — build_prompts.py not run "
+             "or scripture.db pre-dates the schema (non-fatal)")
+        return
+    total = q1(cur, "SELECT COUNT(*) FROM precached_prompts") or 0
+    if total == 0:
+        warn("precached_prompts empty — build_prompts.py not run")
+        return
+    chapter_rows = q1(
+        cur,
+        "SELECT COUNT(*) FROM precached_prompts WHERE entity_type='chapter'",
+    ) or 0
+    entity_rows = total - chapter_rows
+    check(f"precached_prompts populated ({total} rows)", total > 0)
+    if chapter_rows == 0:
+        warn("no chapter chip rows — build_prompts.py was run without an "
+             "ANTHROPIC_API_KEY (or --entity-only). Chapter chips not yet built.")
+    else:
+        check(
+            "precached_prompts chapter rows present",
+            chapter_rows > 0,
+            f"{chapter_rows} chapter rows",
+        )
+    check(
+        "precached_prompts entity rows present",
+        entity_rows > 0,
+        f"{entity_rows} entity rows",
+    )
+    # Spot check: every row has non-empty chips_json array.
+    empty_rows = q1(
+        cur,
+        "SELECT COUNT(*) FROM precached_prompts WHERE chips_json IS NULL OR chips_json = ''",
+    ) or 0
+    check("no empty chips_json rows", empty_rows == 0, f"{empty_rows} empty")
+
+
 def _validate_embeddings(cur):
     """Section 6 EMBEDDINGS — warn (don't fail) when the optional Amicus
     tables are absent so the pre-AI pipeline keeps passing."""
@@ -805,6 +844,12 @@ def main():
     # =========================================================
     print("\n--- 6. EMBEDDINGS ---")
     _validate_embeddings(cur)
+
+    # =========================================================
+    # 7. PRECACHED PROMPTS (Amicus — Card #1461)
+    # =========================================================
+    print("\n--- 7. PRECACHED PROMPTS ---")
+    _validate_precached_prompts(cur)
 
     # DB size cap (raised from the 150MB spec value to accommodate the
     # pre-embedding baseline when embeddings.db hasn't been merged yet).


### PR DESCRIPTION
Closes #1461. Phase 3 of epic #1446.

## Summary
Pre-generates the FAB-peek chip pool at content build time so runtime cost is ~$0.

- 6 fixed profile variants (generic / Reformed×2 / Jewish×2 / Catholic gospels).
- 3 chips per (chapter × variant) via Claude Haiku with bounded 6–10 word labels.
- Templated chips for people/places/debates (zero LLM cost).
- Output → standalone `prompts.db`, merged into `scripture.db` by the existing build orchestrator.

## New files
- `_tools/build_prompts.py` — orchestrator with `--dry-run`, `--incremental`, `--entity-only`, `--chapter-only`, cost prompt >$1, SIGINT checkpoint.
- `_tools/build_prompts_variants.py` — `PROFILE_VARIANTS` list.
- `_tools/build_prompts_entity.py` — people/place/debate chip templates + meta iterators.
- `_tools/test_build_prompts.py` — 15 unit tests.

## Modified files
- `_tools/build_sqlite_schema.py` — `precached_prompts` table.
- `_tools/build_sqlite_loaders.py` — `populate_precached_prompts()` loader with graceful skip.
- `_tools/build_sqlite.py` — wired in.
- `_tools/validate_sqlite.py` — new section 7 PRECACHED PROMPTS.
- `_tools/content_writer.py` — `save_chapter` flags the prompts manifest alongside embeddings.
- `.gitignore` — `prompts.db`, `prompts_manifest.json`.

## Verification
- `python3 _tools/build_prompts.py --entity-only` — writes 993 entity rows in seconds.
- `python3 _tools/build_prompts.py --dry-run` — estimates ~$7 one-time for full chapter build (1,189 × 6 variants).
- `python3 _tools/build_sqlite.py && python3 _tools/validate_sqlite.py` — green with warn-don't-fail when prompts.db is absent.
- `python3 _tools/test_build_prompts.py` — 15/15 pass.

## Out of scope
- Runtime chip selection — #1474.
- FAB UI — #1462.

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe