### PR TITLE
fix: migrate to Expo SDK 54 stack (reanimated 4 + new arch + MapLibre v11)

### DIFF
--- a/app/__tests__/components/ContentImageGallery.test.tsx
+++ b/app/__tests__/components/ContentImageGallery.test.tsx
@@ -9,12 +9,18 @@ jest.mock('expo-image', () => ({
   },
 }));
 
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});
+
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: any) => children,
   Gesture: {
-    Pinch: () => ({ onUpdate: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }), onEnd: () => ({ runOnJS: () => ({}) }), runOnJS: () => ({}) }),
-    Pan: () => ({ minPointers: () => ({ onUpdate: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }) }), runOnJS: () => ({}) }),
-    Tap: () => ({ numberOfTaps: () => ({ onEnd: () => ({ runOnJS: () => ({}) }) }), runOnJS: () => ({}) }),
+    Pinch: () => ({ onUpdate: () => ({ onEnd: () => ({}) }), onEnd: () => ({}) }),
+    Pan: () => ({ minPointers: () => ({ onUpdate: () => ({ onEnd: () => ({}) }) }) }),
+    Tap: () => ({ numberOfTaps: () => ({ onEnd: () => ({}) }) }),
     Simultaneous: () => ({}),
     Race: () => ({}),
   },

--- a/app/__tests__/hooks/useMapTileCache.test.ts
+++ b/app/__tests__/hooks/useMapTileCache.test.ts
@@ -3,7 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react-native';
 jest.mock('@maplibre/maplibre-react-native', () => ({
   OfflineManager: {
     createPack: jest.fn().mockResolvedValue(undefined),
-    getPack: jest.fn().mockResolvedValue(null),
+    getPacks: jest.fn().mockResolvedValue([]),
     setMaximumAmbientCacheSize: jest.fn().mockResolvedValue(undefined),
   },
 }));
@@ -14,7 +14,7 @@ import { useMapTileCache } from '@/hooks/useMapTileCache';
 
 beforeEach(() => {
   (OfflineManager.createPack as jest.Mock).mockClear().mockResolvedValue(undefined);
-  (OfflineManager.getPack as jest.Mock).mockClear().mockResolvedValue(null);
+  (OfflineManager.getPacks as jest.Mock).mockClear().mockResolvedValue([]);
   (OfflineManager.setMaximumAmbientCacheSize as jest.Mock)
     .mockClear()
     .mockResolvedValue(undefined);
@@ -35,20 +35,30 @@ describe('useMapTileCache', () => {
     await waitFor(() => expect(OfflineManager.createPack).toHaveBeenCalled());
     const call = (OfflineManager.createPack as jest.Mock).mock.calls[0][0];
     expect(call).toMatchObject({
-      name: 'biblical-region-base',
-      styleURL: 'https://example/ancient.json',
+      mapStyle: 'https://example/ancient.json',
       minZoom: 0,
       maxZoom: 7,
+      metadata: { name: 'biblical-region-base' },
     });
-    // bounds: [[neLng, neLat], [swLng, swLat]]
-    expect(call.bounds).toEqual([[55, 45], [25, 20]]);
+    // bounds: [west, south, east, north] (flat LngLatBounds in v11)
+    expect(call.bounds).toEqual([25, 20, 55, 45]);
   });
 
-  it('skips pack creation when the pack is already present', async () => {
-    (OfflineManager.getPack as jest.Mock).mockResolvedValueOnce({ name: 'biblical-region-base' });
+  it('skips pack creation when the pack is already present (tagged via metadata.name)', async () => {
+    (OfflineManager.getPacks as jest.Mock).mockResolvedValueOnce([
+      { id: 'uuid-abc', metadata: { name: 'biblical-region-base' } },
+    ]);
     renderHook(() => useMapTileCache('https://example/ancient.json'));
-    await waitFor(() => expect(OfflineManager.getPack).toHaveBeenCalled());
+    await waitFor(() => expect(OfflineManager.getPacks).toHaveBeenCalled());
     expect(OfflineManager.createPack).not.toHaveBeenCalled();
+  });
+
+  it('creates a pack when existing packs are unrelated', async () => {
+    (OfflineManager.getPacks as jest.Mock).mockResolvedValueOnce([
+      { id: 'uuid-xyz', metadata: { name: 'some-other-region' } },
+    ]);
+    renderHook(() => useMapTileCache('https://example/ancient.json'));
+    await waitFor(() => expect(OfflineManager.createPack).toHaveBeenCalled());
   });
 
   it('swallows offline manager errors so the map still renders', async () => {

--- a/app/__tests__/hooks/useMapZoom.test.ts
+++ b/app/__tests__/hooks/useMapZoom.test.ts
@@ -2,14 +2,15 @@ import { renderHook, act } from '@testing-library/react-native';
 
 import { useMapZoom } from '@/hooks/useMapZoom';
 
-/** Build a synthetic MapLibre onRegionDidChange event. */
+/** Build a synthetic MapLibre v11 onRegionDidChange event. */
 function event(zoom: number) {
   return {
-    properties: {
-      zoomLevel: zoom,
-      heading: 0,
+    nativeEvent: {
+      zoom,
+      bearing: 0,
       pitch: 0,
-      isUserInteraction: true,
+      animated: false,
+      userInteraction: true,
     },
   };
 }
@@ -77,5 +78,14 @@ describe('useMapZoom', () => {
       jest.advanceTimersByTime(200);
     });
     expect(result.current.zoomLevel).toBe(22);
+  });
+
+  it('still accepts the v10 feature-shape event during migration', () => {
+    const { result } = renderHook(() => useMapZoom(5));
+    act(() => {
+      result.current.onRegionDidChange({ properties: { zoomLevel: 6.5 } });
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current.zoomLevel).toBeCloseTo(6.5, 1);
   });
 });

--- a/app/__tests__/hooks/useTreeCamera.test.ts
+++ b/app/__tests__/hooks/useTreeCamera.test.ts
@@ -1,5 +1,11 @@
 import { renderHook, act } from '@testing-library/react-native';
 
+// react-native-reanimated's runOnJS is a passthrough in tests so the hook
+// logic runs synchronously.
+jest.mock('react-native-reanimated', () => ({
+  runOnJS: (fn: any) => fn,
+}));
+
 // Gesture-handler needs a tiny stand-in for Gesture.Pan / Gesture.Pinch
 // that captures the callbacks so tests can trigger them manually.
 jest.mock('react-native-gesture-handler', () => {
@@ -11,7 +17,6 @@ jest.mock('react-native-gesture-handler', () => {
       onBegin: (cb: any) => { handlers.onBegin = cb; return g; },
       onUpdate: (cb: any) => { handlers.onUpdate = cb; return g; },
       onEnd: (cb: any) => { handlers.onEnd = cb; return g; },
-      runOnJS: () => g,
     };
     return g;
   };

--- a/app/__tests__/screens/GenealogyTreeScreen.test.tsx
+++ b/app/__tests__/screens/GenealogyTreeScreen.test.tsx
@@ -170,6 +170,16 @@ jest.mock('react-native-svg', () => {
   };
 });
 
+jest.mock('react-native-reanimated', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View: (props: any) => React.createElement(View, props) },
+    runOnJS: (fn: any) => fn,
+  };
+});
+
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: (props: any) => props.children,
 }));

--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Companion Study",
     "slug": "companion-study",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "orientation": "default",
     "icon": "./assets/images/icon-512.png",
     "scheme": "scripture",
@@ -41,8 +41,8 @@
       [
         "expo-build-properties",
         {
-          "ios": { "newArchEnabled": false },
-          "android": { "newArchEnabled": false }
+          "ios": { "newArchEnabled": true },
+          "android": { "newArchEnabled": true }
         }
       ],
       "expo-font",

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -2,5 +2,9 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    // Reanimated 4 routes its worklet transform through react-native-worklets;
+    // the plugin must be last. `react-native-reanimated/plugin` is kept as an
+    // alias by the library but the worklets package is the canonical location.
+    plugins: ['react-native-worklets/plugin'],
   };
 };

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -158,8 +158,16 @@ jest.mock('expo-web-browser', () => ({
 
 // ── React Native library mocks ────────────────────────────────────
 
-// react-native-reanimated was removed in favor of RN's built-in Animated API.
-// No mock needed — Animated is part of react-native core.
+// Mock react-native-reanimated — uses the library's own jest mock, which
+// provides shared-value stubs and a no-op worklet runtime. Reanimated 4
+// requires react-native-worklets; the worklets init path throws in jest
+// without this mock, so every component that imports reanimated needs it.
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  // Silence call() warnings from the mock.
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});
 
 // Mock react-native-gesture-handler
 jest.mock('react-native-gesture-handler', () => {
@@ -182,6 +190,10 @@ jest.mock('react-native-gesture-handler', () => {
 // Mock @maplibre/maplibre-react-native — renders children inline as Views
 // and exposes stub CameraRef methods so components under test can call
 // fitBounds / flyTo without crashing.
+//
+// Matches the v11 API surface: `Map` (not MapView), `GeoJSONSource`
+// (not ShapeSource), a single `Layer` component with a `type` prop
+// instead of `CircleLayer`/`FillLayer`/etc, and the default export removed.
 jest.mock('@maplibre/maplibre-react-native', () => {
   const React = require('react');
   const { View } = require('react-native');
@@ -191,25 +203,26 @@ jest.mock('@maplibre/maplibre-react-native', () => {
       React.createElement(View, { ...props, ref, testID: props.testID ?? name }, props.children),
     );
 
-  const MapView = React.forwardRef((props, ref) =>
+  const Map = React.forwardRef((props, ref) =>
     React.createElement(View, { ...props, ref }, props.children),
   );
 
   const Camera = React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
-      fitBounds: jest.fn(),
+      jumpTo: jest.fn(),
+      easeTo: jest.fn(),
       flyTo: jest.fn(),
-      setCamera: jest.fn(),
-      moveTo: jest.fn(),
+      fitBounds: jest.fn(),
       zoomTo: jest.fn(),
+      setStop: jest.fn().mockResolvedValue(undefined),
     }));
     return React.createElement(View, { testID: 'camera' });
   });
 
-  const ShapeSource = ({ children, onPress }) =>
-    React.createElement(View, { testID: 'shape-source', onPress }, children);
+  const GeoJSONSource = ({ children, onPress }) =>
+    React.createElement(View, { testID: 'geojson-source', onPress }, children);
 
-  const offlineManager = {
+  const OfflineManager = {
     createPack: jest.fn().mockResolvedValue(undefined),
     getPack: jest.fn().mockResolvedValue(null),
     getPacks: jest.fn().mockResolvedValue([]),
@@ -218,28 +231,30 @@ jest.mock('@maplibre/maplibre-react-native', () => {
     clearAmbientCache: jest.fn().mockResolvedValue(undefined),
   };
 
-  const api = {
+  return {
     __esModule: true,
-    MapView,
+    Map,
     Camera,
-    ShapeSource,
-    CircleLayer: pass('CircleLayer'),
-    SymbolLayer: pass('SymbolLayer'),
-    FillLayer: pass('FillLayer'),
-    LineLayer: pass('LineLayer'),
+    GeoJSONSource,
+    Layer: pass('Layer'),
+    LayerAnnotation: pass('LayerAnnotation'),
     Images: pass('Images'),
     RasterSource: pass('RasterSource'),
-    RasterLayer: pass('RasterLayer'),
+    VectorSource: pass('VectorSource'),
+    ImageSource: pass('ImageSource'),
     UserLocation: pass('UserLocation'),
-    Logger: { setLogLevel: jest.fn() },
-    // MapLibre RN exposes both the preferred `OfflineManager` and the
-    // deprecated `offlineManager` alias. Export both so tests can import
-    // either shape.
-    OfflineManager: offlineManager,
-    offlineManager,
+    NativeUserLocation: pass('NativeUserLocation'),
+    Marker: pass('Marker'),
+    ViewAnnotation: pass('ViewAnnotation'),
+    Callout: pass('Callout'),
+    Animated: {},
+    LogManager: { setLogLevel: jest.fn() },
+    NetworkManager: { setConnected: jest.fn() },
+    LocationManager: {},
+    OfflineManager,
+    StaticMapImageManager: {},
+    TransformRequestManager: {},
   };
-
-  return { ...api, default: api };
 });
 
 // `isMapNativeAvailable()` reads NativeModules.MLRNModule to decide

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
         "@expo-google-fonts/eb-garamond": "^0.2.3",
         "@expo-google-fonts/source-sans-3": "^0.2.3",
         "@gorhom/bottom-sheet": "^5.1.1",
-        "@maplibre/maplibre-react-native": "10.2.0",
+        "@maplibre/maplibre-react-native": "^11.0.0-beta.30",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.2.10",
@@ -44,9 +44,11 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
+        "react-native-worklets": "~0.5.1",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -1387,6 +1389,21 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
       "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -3462,28 +3479,58 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@maplibre/maplibre-react-native": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-10.2.0.tgz",
-      "integrity": "sha512-afGseeXy+aoNIS35nQTlD+iZC4gu+WZxB8dnrz+i7chPSpU2RRcEojADlF2apz6X+CvxaLmtxI3JF6r9Hi09Og==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "examples/*"
-      ],
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
       "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-react-native": {
+      "version": "11.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.0.0-beta.31.tgz",
+      "integrity": "sha512-2f51NtePZQlJ3HkNvaCSfCdcJn7RtngP9jAbGvsGkBvEdVKxduSJtbLkYSfgPM8IbRseCg365n3KYIih8pSPcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "24.8.1",
         "@turf/distance": "^7.1.0",
         "@turf/helpers": "^7.1.0",
         "@turf/length": "^7.1.0",
-        "@turf/nearest-point-on-line": "^7.1.0",
-        "debounce": "^2.2.0"
+        "@turf/nearest-point-on-line": "^7.1.0"
       },
       "peerDependencies": {
-        "@expo/config-plugins": ">=7",
+        "@expo/config-plugins": ">=54.0.0",
         "@types/geojson": "^7946.0.0",
-        "@types/react": ">=16.6.1",
-        "react": ">=16.6.1",
-        "react-native": ">=0.59.9"
+        "@types/react": ">=19.1.0",
+        "react": ">=19.1.0",
+        "react-native": ">=0.80.0"
       },
       "peerDependenciesMeta": {
         "@expo/config-plugins": {
@@ -6147,18 +6194,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -10473,6 +10508,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -12586,6 +12627,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -12762,6 +12809,33 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-reanimated": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
+      "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "^7.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "0.78 - 0.82",
+        "react-native-worklets": "0.5 - 0.8"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
@@ -12800,6 +12874,42 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.2.tgz",
+      "integrity": "sha512-lCzmuIPAK/UaOJYEPgYpVqrsxby1I54f7PyyZUMEO04nwc00CDrCvv9lCTY1daLHYTF8lS3f9zlzErfVsIKqkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -13148,6 +13258,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -14245,6 +14361,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "@expo-google-fonts/eb-garamond": "^0.2.3",
     "@expo-google-fonts/source-sans-3": "^0.2.3",
     "@gorhom/bottom-sheet": "^5.1.1",
-    "@maplibre/maplibre-react-native": "10.2.0",
+    "@maplibre/maplibre-react-native": "^11.0.0-beta.30",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.2.10",
@@ -52,9 +52,11 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
+    "react-native-worklets": "~0.5.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/app/src/components/ChapterSkeleton.tsx
+++ b/app/src/components/ChapterSkeleton.tsx
@@ -6,8 +6,14 @@
  * animation on reanimated shared values.
  */
 
-import React, { useEffect, useRef } from 'react';
-import { View, Animated, StyleSheet, type ViewStyle, type DimensionValue } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, StyleSheet, type ViewStyle, type DimensionValue } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
 import { useTheme, spacing, radii } from '../theme';
 
 function Bone({ width, height = 14, style, bgColor }: {
@@ -33,21 +39,22 @@ function Bone({ width, height = 14, style, bgColor }: {
 
 export function ChapterSkeleton() {
   const { base } = useTheme();
-  const opacity = useRef(new Animated.Value(0.3)).current;
+  const opacity = useSharedValue(0.3);
 
   useEffect(() => {
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
-      ]),
+    opacity.value = withRepeat(
+      withTiming(0.7, { duration: 800 }),
+      -1,
+      true
     );
-    loop.start();
-    return () => loop.stop();
   }, [opacity]);
 
+  const pulse = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
   return (
-    <Animated.View style={[styles.container, { backgroundColor: base.bg, opacity }]}>
+    <Animated.View style={[styles.container, { backgroundColor: base.bg }, pulse]}>
       {/* Title */}
       <View style={styles.header}>
         <Bone width="70%" height={22} bgColor={base.bgSurface} />

--- a/app/src/components/ContentImageGallery.tsx
+++ b/app/src/components/ContentImageGallery.tsx
@@ -19,7 +19,6 @@ import React, { useState, useCallback, useRef } from 'react';
 import {
   View,
   Text,
-  Animated,
   ScrollView,
   Modal,
   TouchableOpacity,
@@ -31,6 +30,11 @@ import {
   type NativeScrollEvent,
 } from 'react-native';
 import { Image } from 'expo-image';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import {
   GestureDetector,
   Gesture,
@@ -132,110 +136,80 @@ interface ZoomViewerProps {
 }
 
 function ZoomViewer({ image, visible, onClose }: ZoomViewerProps) {
-  // Animated values drive the transform. Paired refs mirror current values so
-  // gesture callbacks (which run on the JS thread via .runOnJS(true)) can
-  // read them synchronously — Animated.Value has no sync getter.
-  const scale = useRef(new Animated.Value(1)).current;
-  const translateX = useRef(new Animated.Value(0)).current;
-  const translateY = useRef(new Animated.Value(0)).current;
-
-  const scaleRef = useRef(1);
-  const savedScaleRef = useRef(1);
-  const translateXRef = useRef(0);
-  const savedTranslateXRef = useRef(0);
-  const translateYRef = useRef(0);
-  const savedTranslateYRef = useRef(0);
-
-  // Helper: set both the Animated.Value and the shadow ref.
-  const setScale = useCallback((v: number) => {
-    scaleRef.current = v;
-    scale.setValue(v);
-  }, [scale]);
-  const setTx = useCallback((v: number) => {
-    translateXRef.current = v;
-    translateX.setValue(v);
-  }, [translateX]);
-  const setTy = useCallback((v: number) => {
-    translateYRef.current = v;
-    translateY.setValue(v);
-  }, [translateY]);
-
-  // Animate helper: runs Animated.timing and keeps the ref in sync.
-  const animateTo = useCallback((value: Animated.Value, ref: React.MutableRefObject<number>, to: number, duration: number) => {
-    ref.current = to;
-    Animated.timing(value, { toValue: to, duration, useNativeDriver: true }).start();
-  }, []);
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedTranslateX = useSharedValue(0);
+  const savedTranslateY = useSharedValue(0);
 
   const resetTransform = useCallback(() => {
-    animateTo(scale, scaleRef, 1, 200);
-    animateTo(translateX, translateXRef, 0, 200);
-    animateTo(translateY, translateYRef, 0, 200);
-    savedScaleRef.current = 1;
-    savedTranslateXRef.current = 0;
-    savedTranslateYRef.current = 0;
-  }, [animateTo, scale, translateX, translateY]);
+    scale.value = withTiming(1, { duration: 200 });
+    translateX.value = withTiming(0, { duration: 200 });
+    translateY.value = withTiming(0, { duration: 200 });
+    savedScale.value = 1;
+    savedTranslateX.value = 0;
+    savedTranslateY.value = 0;
+  }, [scale, translateX, translateY, savedScale, savedTranslateX, savedTranslateY]);
 
   const pinchGesture = Gesture.Pinch()
     .onUpdate((e) => {
-      setScale(Math.max(1, Math.min(savedScaleRef.current * e.scale, 5)));
+      scale.value = Math.max(1, Math.min(savedScale.value * e.scale, 5));
     })
     .onEnd(() => {
-      if (scaleRef.current < 1.1) {
-        animateTo(scale, scaleRef, 1, 200);
-        animateTo(translateX, translateXRef, 0, 200);
-        animateTo(translateY, translateYRef, 0, 200);
-        savedScaleRef.current = 1;
-        savedTranslateXRef.current = 0;
-        savedTranslateYRef.current = 0;
+      if (scale.value < 1.1) {
+        scale.value = withTiming(1, { duration: 200 });
+        translateX.value = withTiming(0, { duration: 200 });
+        translateY.value = withTiming(0, { duration: 200 });
+        savedScale.value = 1;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
       } else {
-        savedScaleRef.current = scaleRef.current;
+        savedScale.value = scale.value;
       }
-    })
-    .runOnJS(true);
+    });
 
   const panGesture = Gesture.Pan()
     .minPointers(1)
     .onUpdate((e) => {
-      if (savedScaleRef.current > 1) {
-        setTx(savedTranslateXRef.current + e.translationX);
-        setTy(savedTranslateYRef.current + e.translationY);
+      if (savedScale.value > 1) {
+        translateX.value = savedTranslateX.value + e.translationX;
+        translateY.value = savedTranslateY.value + e.translationY;
       }
     })
     .onEnd(() => {
-      savedTranslateXRef.current = translateXRef.current;
-      savedTranslateYRef.current = translateYRef.current;
-    })
-    .runOnJS(true);
+      savedTranslateX.value = translateX.value;
+      savedTranslateY.value = translateY.value;
+    });
 
   const doubleTapGesture = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(() => {
-      if (scaleRef.current > 1.1) {
-        animateTo(scale, scaleRef, 1, 250);
-        animateTo(translateX, translateXRef, 0, 250);
-        animateTo(translateY, translateYRef, 0, 250);
-        savedScaleRef.current = 1;
-        savedTranslateXRef.current = 0;
-        savedTranslateYRef.current = 0;
+      if (scale.value > 1.1) {
+        scale.value = withTiming(1, { duration: 250 });
+        translateX.value = withTiming(0, { duration: 250 });
+        translateY.value = withTiming(0, { duration: 250 });
+        savedScale.value = 1;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
       } else {
-        animateTo(scale, scaleRef, 2.5, 250);
-        savedScaleRef.current = 2.5;
+        scale.value = withTiming(2.5, { duration: 250 });
+        savedScale.value = 2.5;
       }
-    })
-    .runOnJS(true);
+    });
 
   const composedGesture = Gesture.Simultaneous(
     pinchGesture,
     Gesture.Race(doubleTapGesture, panGesture),
   );
 
-  const animatedStyle = {
+  const animatedStyle = useAnimatedStyle(() => ({
     transform: [
-      { translateX },
-      { translateY },
-      { scale },
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
     ],
-  };
+  }));
 
   const handleClose = useCallback(() => {
     resetTransform();

--- a/app/src/components/LoadingSkeleton.tsx
+++ b/app/src/components/LoadingSkeleton.tsx
@@ -2,8 +2,14 @@
  * LoadingSkeleton — Animated shimmer placeholder for loading states.
  */
 
-import React, { useEffect, useRef } from 'react';
-import { View, Animated, StyleSheet, type DimensionValue } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, StyleSheet, type DimensionValue } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
 import { spacing, radii } from '../theme';
 
 interface Props {
@@ -20,18 +26,19 @@ interface Props {
 const BONE_COLOR = 'rgba(191, 160, 80, 0.08)';
 
 export function LoadingSkeleton({ lines = 3, width = '100%', height = 14 }: Props) {
-  const opacity = useRef(new Animated.Value(0.3)).current;
+  const opacity = useSharedValue(0.3);
 
   useEffect(() => {
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
-      ]),
+    opacity.value = withRepeat(
+      withTiming(0.7, { duration: 800 }),
+      -1,
+      true
     );
-    loop.start();
-    return () => loop.stop();
   }, [opacity]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
 
   return (
     <View style={styles.container}>
@@ -44,8 +51,8 @@ export function LoadingSkeleton({ lines = 3, width = '100%', height = 14 }: Prop
               width: i === lines - 1 ? '60%' : width,
               height,
               backgroundColor: BONE_COLOR,
-              opacity,
             },
+            animStyle,
           ]}
         />
       ))}

--- a/app/src/components/map/AncientBorderLayer.tsx
+++ b/app/src/components/map/AncientBorderLayer.tsx
@@ -38,7 +38,7 @@ export const AncientBorderLayer = memo(function AncientBorderLayer({
     <GeoJSONSource
       id="ancient-borders"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      shape={borders as any}
+      data={borders as any}
     >
       <Layer
         id="ancient-borders-fill"

--- a/app/src/components/map/AncientBorderLayer.tsx
+++ b/app/src/components/map/AncientBorderLayer.tsx
@@ -1,19 +1,19 @@
 /**
  * AncientBorderLayer — Renders ancient political borders for the active
  * era (tribal allotments, Roman provinces, Divided Kingdom, etc.) as a
- * single MapLibre ShapeSource with Fill + Line layers.
+ * single MapLibre GeoJSONSource with Fill + Line layers.
  *
  * Hidden in Modern mode — the modern.json style already layers OSM
  * country borders for that variant. Suppressed at the ancient era's
  * default (era === 'all') since no single era's borders apply.
  *
- * Scaffold for epic #1314 / issue #1317. Renders an empty ShapeSource
+ * Scaffold for epic #1314 / issue #1317. Renders an empty GeoJSONSource
  * gracefully until the AWMC/hand-authored polygons land in a follow-up
  * Chat session.
  */
 
 import React, { memo } from 'react';
-import { ShapeSource, FillLayer, LineLayer } from '@maplibre/maplibre-react-native';
+import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
 import { useAncientBorders } from '../../hooks/useAncientBorders';
 import { eras } from '../../theme';
 
@@ -35,20 +35,22 @@ export const AncientBorderLayer = memo(function AncientBorderLayer({
   const eraColor = (era && eras[era]) || '#bfa050'; // data-color: intentional (gold fallback for unknown era — MapLibre GL)
 
   return (
-    <ShapeSource
+    <GeoJSONSource
       id="ancient-borders"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       shape={borders as any}
     >
-      <FillLayer
+      <Layer
         id="ancient-borders-fill"
+        type="fill"
         style={{
           fillColor: eraColor,
           fillOpacity: 0.08,
         }}
       />
-      <LineLayer
+      <Layer
         id="ancient-borders-stroke"
+        type="line"
         style={{
           lineColor: eraColor,
           lineOpacity: 0.55,
@@ -56,6 +58,6 @@ export const AncientBorderLayer = memo(function AncientBorderLayer({
           lineDasharray: [2, 2],
         }}
       />
-    </ShapeSource>
+    </GeoJSONSource>
   );
 });

--- a/app/src/components/map/MapChipNative.tsx
+++ b/app/src/components/map/MapChipNative.tsx
@@ -20,7 +20,7 @@ import {
   StyleSheet,
   Pressable,
 } from 'react-native';
-import { MapView, Camera } from '@maplibre/maplibre-react-native';
+import { Map, Camera } from '@maplibre/maplibre-react-native';
 import { ArrowUpRight } from 'lucide-react-native';
 import { STYLE_ANCIENT } from '../../constants/mapStyles';
 import { useTheme, spacing, radii, fontFamily } from '../../theme';
@@ -34,22 +34,16 @@ import { StoryOverlays } from './StoryOverlays';
 ensureMapLibreInit();
 
 /**
- * Subset of MapLibre's `CameraStop` shape that we actually use. The real
- * type is internal to `@maplibre/maplibre-react-native` (not re-exported
- * from the package root), so we declare our own structural alias and
- * lean on Camera's prop type acceptance at the usage site.
+ * Subset of the v11 Camera `initialViewState` shape that we actually use.
+ * MapLibre RN v11 consolidated the defaultSettings / fitBoundsOptions
+ * surface into a single `initialViewState` prop taking either a center
+ * or bounds. We expose just the fields the chip needs.
  */
-type ChipCameraSettings = {
-  centerCoordinate?: [number, number];
-  zoomLevel?: number;
-  bounds?: {
-    ne: [number, number];
-    sw: [number, number];
-    paddingLeft?: number;
-    paddingRight?: number;
-    paddingTop?: number;
-    paddingBottom?: number;
-  };
+type ChipInitialViewState = {
+  center?: [number, number];
+  zoom?: number;
+  bounds?: [number, number, number, number]; // [west, south, east, north]
+  padding?: { top?: number; right?: number; bottom?: number; left?: number };
 };
 
 interface Props {
@@ -62,13 +56,16 @@ interface Props {
 const CHIP_HEIGHT = 88;
 
 /**
- * Compute a Camera default settings block that frames all of the story's
+ * Compute an `initialViewState` block that frames all of the story's
  * places inside the 88px chip with a little breathing room.
+ *
+ * v11 accepts bounds as `[west, south, east, north]` (LngLatBounds) and
+ * padding as `{top, right, bottom, left}`.
  */
 function defaultCameraForStory(
   story: MapStory,
   places: Place[],
-): ChipCameraSettings {
+): ChipInitialViewState {
   const placeIds = safeParse<string[]>(story.places_json, []);
   const storyPlaces = placeIds
     .map((id) => places.find((p) => p.id === id))
@@ -76,12 +73,12 @@ function defaultCameraForStory(
 
   if (storyPlaces.length === 0) {
     // Fall back to a wide biblical-region view.
-    return { centerCoordinate: [38, 30], zoomLevel: 3 };
+    return { center: [38, 30], zoom: 3 };
   }
 
   if (storyPlaces.length === 1) {
     const p = storyPlaces[0];
-    return { centerCoordinate: [p.longitude, p.latitude], zoomLevel: 6 };
+    return { center: [p.longitude, p.latitude], zoom: 6 };
   }
 
   let minLon = Infinity, maxLon = -Infinity, minLat = Infinity, maxLat = -Infinity;
@@ -92,14 +89,8 @@ function defaultCameraForStory(
     if (p.latitude > maxLat) maxLat = p.latitude;
   }
   return {
-    bounds: {
-      ne: [maxLon, maxLat],
-      sw: [minLon, minLat],
-      paddingLeft: 18,
-      paddingRight: 18,
-      paddingTop: 14,
-      paddingBottom: 14,
-    },
+    bounds: [minLon, minLat, maxLon, maxLat],
+    padding: { top: 14, right: 18, bottom: 14, left: 18 },
   };
 }
 
@@ -145,20 +136,22 @@ function MapChipNative({ story, places, onExpand }: Props) {
 
       {/* Map */}
       <View style={styles.mapFrame} pointerEvents="none">
-        <MapView
+        <Map
           testID="map-chip-view"
           style={StyleSheet.absoluteFill}
           mapStyle={STYLE_ANCIENT}
-          scrollEnabled={false}
-          zoomEnabled={false}
-          pitchEnabled={false}
-          rotateEnabled={false}
-          attributionEnabled={false}
-          logoEnabled={false}
+          dragPan={false}
+          touchZoom={false}
+          doubleTapZoom={false}
+          doubleTapHoldZoom={false}
+          touchRotate={false}
+          touchPitch={false}
+          attribution={false}
+          logo={false}
         >
-          <Camera defaultSettings={cameraSettings} />
+          <Camera initialViewState={cameraSettings} />
           <StoryOverlays story={story} />
-        </MapView>
+        </Map>
       </View>
     </Pressable>
   );

--- a/app/src/components/map/MapChipNative.tsx
+++ b/app/src/components/map/MapChipNative.tsx
@@ -20,7 +20,7 @@ import {
   StyleSheet,
   Pressable,
 } from 'react-native';
-import { Map, Camera } from '@maplibre/maplibre-react-native';
+import { Map, Camera, type InitialViewState } from '@maplibre/maplibre-react-native';
 import { ArrowUpRight } from 'lucide-react-native';
 import { STYLE_ANCIENT } from '../../constants/mapStyles';
 import { useTheme, spacing, radii, fontFamily } from '../../theme';
@@ -34,17 +34,11 @@ import { StoryOverlays } from './StoryOverlays';
 ensureMapLibreInit();
 
 /**
- * Subset of the v11 Camera `initialViewState` shape that we actually use.
- * MapLibre RN v11 consolidated the defaultSettings / fitBoundsOptions
- * surface into a single `initialViewState` prop taking either a center
- * or bounds. We expose just the fields the chip needs.
+ * v11 `InitialViewState` is a discriminated union: either a `center`
+ * variant or a `bounds` variant, never both. We alias the library type
+ * here and build each variant explicitly in `defaultCameraForStory`.
  */
-type ChipInitialViewState = {
-  center?: [number, number];
-  zoom?: number;
-  bounds?: [number, number, number, number]; // [west, south, east, north]
-  padding?: { top?: number; right?: number; bottom?: number; left?: number };
-};
+type ChipInitialViewState = InitialViewState;
 
 interface Props {
   story: MapStory;
@@ -89,7 +83,7 @@ function defaultCameraForStory(
     if (p.latitude > maxLat) maxLat = p.latitude;
   }
   return {
-    bounds: [minLon, minLat, maxLon, maxLat],
+    bounds: [minLon, minLat, maxLon, maxLat] as [number, number, number, number],
     padding: { top: 14, right: 18, bottom: 14, left: 18 },
   };
 }

--- a/app/src/components/map/PersonArcLayer.tsx
+++ b/app/src/components/map/PersonArcLayer.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { ShapeSource, LineLayer, SymbolLayer, CircleLayer } from '@maplibre/maplibre-react-native';
+import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
 import type { PersonArcStop } from '../../hooks/usePersonArc';
 
 interface Props {
@@ -71,9 +71,10 @@ export const PersonArcLayer = memo(function PersonArcLayer({
   return (
     <>
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ShapeSource id="person-arc-line" shape={lineFC as any}>
-        <LineLayer
+      <GeoJSONSource id="person-arc-line" shape={lineFC as any}>
+        <Layer
           id="person-arc-line-layer"
+          type="line"
           style={{
             lineColor: color,
             lineWidth: 2.5,
@@ -83,12 +84,13 @@ export const PersonArcLayer = memo(function PersonArcLayer({
             lineOpacity: 0.85,
           }}
         />
-      </ShapeSource>
+      </GeoJSONSource>
 
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ShapeSource id="person-arc-stops" shape={stopsFC as any}>
-        <CircleLayer
+      <GeoJSONSource id="person-arc-stops" shape={stopsFC as any}>
+        <Layer
           id="person-arc-stops-circle"
+          type="circle"
           style={{
             circleRadius: 10,
             circleColor: color,
@@ -96,8 +98,9 @@ export const PersonArcLayer = memo(function PersonArcLayer({
             circleStrokeWidth: 1.5,
           }}
         />
-        <SymbolLayer
+        <Layer
           id="person-arc-stops-number"
+          type="symbol"
           style={{
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             textField: ['get', 'label'] as any,
@@ -108,9 +111,10 @@ export const PersonArcLayer = memo(function PersonArcLayer({
           }}
         />
         {/* Event label — visible only at closer zooms to avoid clutter */}
-        <SymbolLayer
+        <Layer
           id="person-arc-stops-event"
-          minZoomLevel={8}
+          type="symbol"
+          minzoom={8}
           style={{
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             textField: ['get', 'event'] as any,
@@ -125,7 +129,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
             textMaxWidth: 10,
           }}
         />
-      </ShapeSource>
+      </GeoJSONSource>
     </>
   );
 });

--- a/app/src/components/map/PersonArcLayer.tsx
+++ b/app/src/components/map/PersonArcLayer.tsx
@@ -71,7 +71,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
   return (
     <>
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <GeoJSONSource id="person-arc-line" shape={lineFC as any}>
+      <GeoJSONSource id="person-arc-line" data={lineFC as any}>
         <Layer
           id="person-arc-line-layer"
           type="line"
@@ -87,7 +87,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
       </GeoJSONSource>
 
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <GeoJSONSource id="person-arc-stops" shape={stopsFC as any}>
+      <GeoJSONSource id="person-arc-stops" data={stopsFC as any}>
         <Layer
           id="person-arc-stops-circle"
           type="circle"

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -1,6 +1,6 @@
 /**
  * PlaceMarkerList — Renders all place markers on the map as a single
- * MapLibre ShapeSource + CircleLayer + SymbolLayer.
+ * MapLibre GeoJSONSource + circle Layer + symbol Layer.
  *
  * One GeoJSON FeatureCollection per full `places` list (memoised). Layer
  * expressions drive priority-based visibility, active-place highlighting,
@@ -11,7 +11,7 @@
  */
 
 import React, { memo, useMemo, useCallback } from 'react';
-import { ShapeSource, CircleLayer, SymbolLayer } from '@maplibre/maplibre-react-native';
+import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
 import type { Place, MapStory } from '../../types';
 import { safeParse } from '../../utils/logger';
 
@@ -92,7 +92,7 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
 
   // Radius / color / stroke for the active-place spotlight.
   // Uses a direct id comparison (effectively a poor-man's feature-state —
-  // MapLibre RN v10 doesn't yet expose setFeatureState imperatively, so
+  // MapLibre RN v11 still doesn't expose setFeatureState imperatively, so
   // we drive highlight state through the expression instead).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isActive: any = activePlaceId
@@ -141,15 +141,16 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
   );
 
   return (
-    <ShapeSource
+    <GeoJSONSource
       id="places-source"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       shape={fc as any}
       onPress={onPress}
       hitbox={{ width: 22, height: 22 }}
     >
-      <CircleLayer
+      <Layer
         id="places-dot"
+        type="circle"
         style={{
           circleRadius: circleRadiusExpr,
           circleColor: circleColorExpr,
@@ -159,8 +160,9 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           circleOpacity: ['step', ['zoom'], 0, minZoomExpr, 1] as any,
         }}
       />
-      <SymbolLayer
+      <Layer
         id="places-label"
+        type="symbol"
         style={{
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           textField: ['get', showModern ? 'modern' : 'ancient'] as any,
@@ -186,6 +188,6 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           textIgnorePlacement: false,
         }}
       />
-    </ShapeSource>
+    </GeoJSONSource>
   );
 });

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -144,9 +144,11 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
     <GeoJSONSource
       id="places-source"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      shape={fc as any}
+      data={fc as any}
       onPress={onPress}
-      hitbox={{ width: 22, height: 22 }}
+      // v11: hitbox is a ViewPadding (top/right/bottom/left), not width/height.
+      // 22px in each direction matches the v10 22x22 box.
+      hitbox={{ top: 11, right: 11, bottom: 11, left: 11 }}
     >
       <Layer
         id="places-dot"

--- a/app/src/components/map/StoryOverlays.tsx
+++ b/app/src/components/map/StoryOverlays.tsx
@@ -144,7 +144,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
     <>
       {/* Region polygons — fill + outline */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <GeoJSONSource id="story-regions" shape={regionsFC as any}>
+      <GeoJSONSource id="story-regions" data={regionsFC as any}>
         <Layer
           id="story-regions-fill"
           type="fill"
@@ -171,7 +171,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
           swapping the active story animates the path draw rather than
           snapping. */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <GeoJSONSource id="story-paths" shape={pathsFC as any}>
+      <GeoJSONSource id="story-paths" data={pathsFC as any}>
         <Layer
           id="story-paths-solid"
           type="line"
@@ -203,7 +203,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
           the final segment's bearing. Uses a unicode ► glyph — no image
           asset required — kept legible across zoom levels. */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <GeoJSONSource id="story-path-arrows" shape={arrowsFC as any}>
+      <GeoJSONSource id="story-path-arrows" data={arrowsFC as any}>
         <Layer
           id="story-path-arrows-layer"
           type="symbol"

--- a/app/src/components/map/StoryOverlays.tsx
+++ b/app/src/components/map/StoryOverlays.tsx
@@ -2,7 +2,7 @@
  * StoryOverlays — Renders a story's region polygons and journey paths
  * as MapLibre GeoJSON layers.
  *
- * Uses a single `ShapeSource` per channel (regions / paths / path-arrows)
+ * Uses a single `GeoJSONSource` per channel (regions / paths / path-arrows)
  * so the map interpolates smoothly between stories when `story` changes,
  * rather than flickering as React-rendered primitives unmount and remount.
  *
@@ -14,7 +14,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { ShapeSource, FillLayer, LineLayer, SymbolLayer } from '@maplibre/maplibre-react-native';
+import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
 import { eras } from '../../theme';
 import type { MapStory } from '../../types';
 import { safeParse } from '../../utils/logger';
@@ -95,7 +95,7 @@ export function pathsToFeatureCollection(
 
 /**
  * Path endpoints → Point FeatureCollection with a `bearing` property so
- * a SymbolLayer can render a direction arrow rotated along the final
+ * a symbol Layer can render a direction arrow rotated along the final
  * segment of each journey.
  */
 export function arrowsFromPaths(paths: RawPath[]): GeoJSON.FeatureCollection {
@@ -144,17 +144,19 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
     <>
       {/* Region polygons — fill + outline */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ShapeSource id="story-regions" shape={regionsFC as any}>
-        <FillLayer
+      <GeoJSONSource id="story-regions" shape={regionsFC as any}>
+        <Layer
           id="story-regions-fill"
+          type="fill"
           style={{
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             fillColor: ['get', 'color'] as any,
             fillOpacity: 0.15,
           }}
         />
-        <LineLayer
+        <Layer
           id="story-regions-stroke"
+          type="line"
           style={{
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             lineColor: ['get', 'color'] as any,
@@ -162,16 +164,17 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
             lineWidth: 1.5,
           }}
         />
-      </ShapeSource>
+      </GeoJSONSource>
 
       {/* Journey paths — solid + dashed variants driven by a filter.
           MapLibre interpolates coordinates between source updates so
           swapping the active story animates the path draw rather than
           snapping. */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ShapeSource id="story-paths" shape={pathsFC as any}>
-        <LineLayer
+      <GeoJSONSource id="story-paths" shape={pathsFC as any}>
+        <Layer
           id="story-paths-solid"
+          type="line"
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           filter={['!', ['get', 'dashed']] as any}
           style={{
@@ -181,8 +184,9 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
             lineJoin: 'round',
           }}
         />
-        <LineLayer
+        <Layer
           id="story-paths-dashed"
+          type="line"
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           filter={['get', 'dashed'] as any}
           style={{
@@ -193,15 +197,16 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
             lineDasharray: [3, 2],
           }}
         />
-      </ShapeSource>
+      </GeoJSONSource>
 
       {/* Directional arrowheads at each path's endpoint, rotated along
           the final segment's bearing. Uses a unicode ► glyph — no image
           asset required — kept legible across zoom levels. */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ShapeSource id="story-path-arrows" shape={arrowsFC as any}>
-        <SymbolLayer
+      <GeoJSONSource id="story-path-arrows" shape={arrowsFC as any}>
+        <Layer
           id="story-path-arrows-layer"
+          type="symbol"
           style={{
             textField: '\u25B6',
             textFont: ['Noto Sans Regular'],
@@ -218,7 +223,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
             textOffset: [0.4, 0],
           }}
         />
-      </ShapeSource>
+      </GeoJSONSource>
     </>
   );
 });

--- a/app/src/hooks/useMapTileCache.ts
+++ b/app/src/hooks/useMapTileCache.ts
@@ -14,6 +14,12 @@
  * failure must not block the user from opening the map. At zoom 8+ or
  * outside the biblical region, tiles load online as normal and degrade
  * to blank if the network is unavailable (acceptable per spec).
+ *
+ * v11 note: packs no longer accept a user-provided `name`; each pack
+ * gets an auto-generated UUID. We tag ours via `metadata.name` and
+ * look it up by scanning `getPacks()` rather than `getPack(name)`.
+ * Option names also shifted: `styleURL` → `mapStyle`; bounds are flat
+ * `[west, south, east, north]` instead of `[ne, sw]` nested tuples.
  */
 
 import { useEffect, useRef } from 'react';
@@ -25,20 +31,19 @@ import { logger } from '../utils/logger';
 /** 75 MB ambient tile cache budget — see issue #1321. */
 const AMBIENT_CACHE_BYTES = 75 * 1024 * 1024;
 
-/** Biblical region — bbox covers Israel through Turkey, Egypt, Iraq. */
-const BIBLICAL_BOUNDS = {
-  ne: [55, 45] as [number, number],
-  sw: [25, 20] as [number, number],
-};
+/**
+ * Biblical region as MapLibre RN v11 `LngLatBounds`:
+ * `[west, south, east, north]`. Covers Israel through Turkey, Egypt, Iraq.
+ */
+const BIBLICAL_BOUNDS: [number, number, number, number] = [25, 20, 55, 45];
 
 const PACK_NAME = 'biblical-region-base';
 const PACK_MIN_ZOOM = 0;
 const PACK_MAX_ZOOM = 7;
 
 /**
- * Run once per app lifetime. Idempotent: creating the same pack twice
- * is a no-op (`getPack` short-circuits), and the ambient cache call is
- * cheap.
+ * Run once per app lifetime. Idempotent: an existing pack with the same
+ * metadata.name short-circuits, and the ambient cache call is cheap.
  */
 export function useMapTileCache(styleURL: string) {
   const ranRef = useRef(false);
@@ -65,20 +70,25 @@ export function useMapTileCache(styleURL: string) {
         }
 
         try {
-          const existing = await OfflineManager.getPack(PACK_NAME);
-          if (existing) return;
+          // v11 has no `getPack(name)` — packs are UUID-keyed. Scan the
+          // list and match our tag in `metadata.name`.
+          const existing = await OfflineManager.getPacks();
+          const alreadyCached = existing.some(
+            (p) => p?.metadata?.name === PACK_NAME,
+          );
+          if (alreadyCached) return;
 
           await OfflineManager.createPack(
             {
-              name: PACK_NAME,
-              styleURL,
+              mapStyle: styleURL,
               minZoom: PACK_MIN_ZOOM,
               maxZoom: PACK_MAX_ZOOM,
-              bounds: [BIBLICAL_BOUNDS.ne, BIBLICAL_BOUNDS.sw],
+              bounds: BIBLICAL_BOUNDS,
+              metadata: { name: PACK_NAME },
             },
-            // Progress and error listeners are required by the v10 API but
-            // we don't surface either to the user — the download runs in
-            // the background. Log errors for diagnosis only.
+            // Progress and error listeners are required by the API but we
+            // don't surface either to the user — the download runs in the
+            // background. Log errors for diagnosis only.
             () => undefined,
             (_pack, err) => {
               logger.warn('useMapTileCache', 'Offline pack error', err);

--- a/app/src/hooks/useMapZoom.ts
+++ b/app/src/hooks/useMapZoom.ts
@@ -1,32 +1,32 @@
 /**
- * useMapZoom — Tracks current zoom level from a MapLibre MapView.
+ * useMapZoom — Tracks current zoom level from the MapLibre `Map` component.
  *
- * MapLibre exposes zoom directly on the region-did-change event
- * (no delta arithmetic required). Debounced to avoid re-renders on
- * every drag frame.
+ * MapLibre RN v11 replaced the region-change GeoJSON feature payload with a
+ * structured `ViewStateChangeEvent` carrying `{ center, zoom, bearing, pitch,
+ * bounds }` under `event.nativeEvent`. We debounce updates to avoid
+ * re-rendering on every drag frame.
  *
- * Wire into <MapView onRegionDidChange={onRegionDidChange}> to keep
- * the returned `zoomLevel` in sync with the visible camera.
+ * Wire into <Map onRegionDidChange={onRegionDidChange}> to keep the returned
+ * `zoomLevel` in sync with the visible camera.
  */
 
 import { useState, useCallback, useRef } from 'react';
 
-/** Subset of the MapLibre region-change feature we care about. */
-interface RegionFeature {
-  properties?: {
-    zoomLevel?: number;
-    heading?: number;
-    pitch?: number;
-    isUserInteraction?: boolean;
-  };
+/** Subset of the v11 view-state event we care about. */
+interface ViewStateEventLike {
+  nativeEvent?: { zoom?: number };
+  // Backwards-compat shape from v10 in case any caller still passes the old
+  // GeoJSON feature during the migration. Kept until the map bundle is
+  // validated end-to-end under v11.
+  properties?: { zoomLevel?: number };
 }
 
 export function useMapZoom(initialZoom: number = 5) {
   const [zoomLevel, setZoomLevel] = useState(initialZoom);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const onRegionDidChange = useCallback((feature: RegionFeature) => {
-    const zoom = feature?.properties?.zoomLevel;
+  const onRegionDidChange = useCallback((event: ViewStateEventLike) => {
+    const zoom = event?.nativeEvent?.zoom ?? event?.properties?.zoomLevel;
     if (typeof zoom !== 'number') return;
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {

--- a/app/src/hooks/useTreeCamera.ts
+++ b/app/src/hooks/useTreeCamera.ts
@@ -22,6 +22,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { Gesture } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
 import { BREAKPOINTS } from '../theme/breakpoints';
 import { TREE_CONSTANTS } from '../utils/treeBuilder';
 
@@ -196,27 +197,25 @@ export function useTreeCamera(): TreeCameraResult {
     () => Gesture.Pan()
       .minDistance(5)
       .onBegin(() => {
-        onPanBegin();
+        runOnJS(onPanBegin)();
       })
       .onUpdate((e) => {
-        onPanUpdate(e.translationX, e.translationY);
+        runOnJS(onPanUpdate)(e.translationX, e.translationY);
       })
       .onEnd((e) => {
-        onPanEnd(e.velocityX, e.velocityY);
-      })
-      .runOnJS(true),
+        runOnJS(onPanEnd)(e.velocityX, e.velocityY);
+      }),
     [onPanBegin, onPanUpdate, onPanEnd],
   );
 
   const pinchGesture = useMemo(
     () => Gesture.Pinch()
       .onBegin((e) => {
-        onPinchBegin(e.focalX, e.focalY);
+        runOnJS(onPinchBegin)(e.focalX, e.focalY);
       })
       .onUpdate((e) => {
-        onPinchUpdate(e.scale, e.focalX, e.focalY);
-      })
-      .runOnJS(true),
+        runOnJS(onPinchUpdate)(e.scale, e.focalX, e.focalY);
+      }),
     [onPinchBegin, onPinchUpdate],
   );
 

--- a/app/src/screens/MapScreenNative.tsx
+++ b/app/src/screens/MapScreenNative.tsx
@@ -12,7 +12,7 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { MapView, Camera, type CameraRef } from '@maplibre/maplibre-react-native';
+import { Map, Camera, type CameraRef } from '@maplibre/maplibre-react-native';
 import { usePlaces } from '../hooks/usePlaces';
 import { ensureMapLibreInit } from '../utils/isMapNativeAvailable';
 import { useMapStories } from '../hooks/useMapStories';
@@ -120,10 +120,12 @@ function MapScreen({ route, navigation }: {
           if (p.latitude > maxLat) maxLat = p.latitude;
         }
         cameraRef.current.fitBounds(
-          [maxLon, maxLat],
-          [minLon, minLat],
-          [topPad, 40, panelHeight + 20, 40],
-          700,
+          // v11: LngLatBounds = [west, south, east, north]
+          [minLon, minLat, maxLon, maxLat],
+          {
+            padding: { top: topPad, right: 40, bottom: panelHeight + 20, left: 40 },
+            duration: 700,
+          },
         );
       }
     } catch (err) { logger.warn('MapScreen', 'Operation failed', err); }
@@ -132,16 +134,14 @@ function MapScreen({ route, navigation }: {
   /**
    * Pan (and zoom in) to a specific place.
    *
-   * `setCamera` combines centerCoordinate + zoomLevel in one animation so
-   * we recreate the old `animateToRegion({delta: 2})` behaviour — a close
-   * zoom that clearly frames one place.
+   * v11: `flyTo` takes `{ center, zoom, duration }` and animates the
+   * camera in a single pass — replaces v10's `setCamera({ ..., animationMode })`.
    */
   const panToPlace = useCallback((place: Place) => {
-    cameraRef.current?.setCamera({
-      centerCoordinate: [place.longitude, place.latitude],
-      zoomLevel: 7.5,
-      animationDuration: 500,
-      animationMode: 'flyTo',
+    cameraRef.current?.flyTo({
+      center: [place.longitude, place.latitude],
+      zoom: 7.5,
+      duration: 500,
     });
   }, []);
 
@@ -200,10 +200,11 @@ function MapScreen({ route, navigation }: {
           if (lat > maxLat) maxLat = lat;
         }
         cameraRef.current.fitBounds(
-          [maxLon, maxLat],
-          [minLon, minLat],
-          [insets.top + 80, 40, 120, 40],
-          700,
+          [minLon, minLat, maxLon, maxLat],
+          {
+            padding: { top: insets.top + 80, right: 40, bottom: 120, left: 40 },
+            duration: 700,
+          },
         );
       }
       lastProcessedPerson.current = initialPersonId;
@@ -235,11 +236,10 @@ function MapScreen({ route, navigation }: {
     if (era === 'all') {
       setActiveStory(null);
       setShowPanel(false);
-      cameraRef.current?.setCamera({
-        centerCoordinate: BIBLICAL_REGION.center,
-        zoomLevel: BIBLICAL_REGION.zoom,
-        animationDuration: 500,
-        animationMode: 'flyTo',
+      cameraRef.current?.flyTo({
+        center: BIBLICAL_REGION.center,
+        zoom: BIBLICAL_REGION.zoom,
+        duration: 500,
       });
       return;
     }
@@ -277,18 +277,18 @@ function MapScreen({ route, navigation }: {
         accessibilityLabel="Biblical world map"
         accessibilityHint="Pinch to zoom, drag to pan"
       >
-      <MapView
+      <Map
         style={StyleSheet.absoluteFill}
         mapStyle={showModern ? STYLE_MODERN : STYLE_ANCIENT}
         onRegionDidChange={onRegionDidChange}
-        logoEnabled={false}
-        attributionEnabled={false}
+        logo={false}
+        attribution={false}
       >
         <Camera
           ref={cameraRef}
-          defaultSettings={{
-            centerCoordinate: BIBLICAL_REGION.center,
-            zoomLevel: BIBLICAL_REGION.zoom,
+          initialViewState={{
+            center: BIBLICAL_REGION.center,
+            zoom: BIBLICAL_REGION.zoom,
           }}
         />
         {/* Ancient political borders for the active era (Biblical mode only) */}
@@ -306,7 +306,7 @@ function MapScreen({ route, navigation }: {
         )}
         {/* Person geographic arc (#1324) */}
         {personArc?.stops?.length ? <PersonArcLayer stops={personArc.stops} /> : null}
-      </MapView>
+      </Map>
       </View>
 
       {/* Search bar + era filter — overlaid at top below status bar */}
@@ -322,11 +322,10 @@ function MapScreen({ route, navigation }: {
           onToggleNames={() => setShowModern((v) => !v)}
           onCentre={() => {
             if (activeStory) selectStory(activeStory);
-            else cameraRef.current?.setCamera({
-              centerCoordinate: BIBLICAL_REGION.center,
-              zoomLevel: BIBLICAL_REGION.zoom,
-              animationDuration: 500,
-              animationMode: 'flyTo',
+            else cameraRef.current?.flyTo({
+              center: BIBLICAL_REGION.center,
+              zoom: BIBLICAL_REGION.zoom,
+              duration: 500,
             });
           }}
         />

--- a/app/src/utils/isMapNativeAvailable.ts
+++ b/app/src/utils/isMapNativeAvailable.ts
@@ -38,19 +38,19 @@ function probe(): boolean {
 
   try {
     // Dynamic require so the native module isn't pulled into Expo Go
-    // builds via the static import graph. We exercise the cheapest API
-    // surface MapLibre exposes (setConnected) — if that throws, the
-    // native side is broken in some way we can't render around.
+    // builds via the static import graph. We exercise a cheap no-throw
+    // API — if that throws, the native side is broken in some way we
+    // can't render around.
     //
-    // If `setConnected` is missing entirely (older versions of the
-    // library, or test mocks that don't include it) we treat that as
-    // success: the presence of MLRNModule is sufficient evidence that
-    // the native side is wired up. The probe is here to catch *throws*,
-    // not API-shape drift.
+    // MapLibre RN v11 removed the package's `default` export and moved
+    // the top-level `setConnected` helper under `NetworkManager`. If
+    // either the module or the manager is missing (older versions or
+    // test mocks) we treat that as success: the presence of MLRNModule
+    // is sufficient evidence that the native side is wired up.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const MapLibreGL = require('@maplibre/maplibre-react-native').default;
-    if (typeof MapLibreGL?.setConnected === 'function') {
-      MapLibreGL.setConnected(true);
+    const MapLibreGL = require('@maplibre/maplibre-react-native');
+    if (typeof MapLibreGL?.NetworkManager?.setConnected === 'function') {
+      MapLibreGL.NetworkManager.setConnected(true);
     }
     return true;
   } catch (err) {


### PR DESCRIPTION
## Why

TestFlight 1.0.3/1.0.4 crashed on launch with a TurboModule registration failure. PR #1492 ("remove react-native-reanimated") was a misguided attempt to fix it by ripping reanimated out entirely. The real incompatibility was the **combination** of:

- `react-native-reanimated@3.19.5` under Expo SDK 54 (expects reanimated 4)
- legacy React Native architecture (SDK 54 defaults to New Arch)
- `@maplibre/maplibre-react-native@10.2.0` (v10 doesn't fabric-register under New Arch → classic TurboModule crash)

This PR adopts the supported SDK 54 stack end-to-end and bumps to `1.0.5`.

## What

**Deps (`app/package.json`):**
- `react-native-reanimated` → `~4.1.1` (new)
- `react-native-worklets` → `~0.5.1` (new; reanimated 4 peer dep)
- `@maplibre/maplibre-react-native` → `^11.0.0-beta.30` (from `10.2.0`)

**Build config:**
- `babel.config.js`: add `"react-native-worklets/plugin"` (canonical location for the worklet transform in reanimated 4; the old `react-native-reanimated/plugin` alias still resolves but the worklets plugin is the official path).
- `app.json`: `expo-build-properties.ios.newArchEnabled` and `.android.newArchEnabled` → `true`. Version bumped to `1.0.5`.

**Source files restored to pre-#1492 reanimated patterns:**
- `LoadingSkeleton`, `ChapterSkeleton`: `useSharedValue`/`useAnimatedStyle`/`withRepeat`/`withTiming` pulse (replacing the `Animated.loop` fallback).
- `ContentImageGallery`: `ZoomViewer` pinch/pan/double-tap go back to reanimated shared values + `useAnimatedStyle` — the paired-ref shadow state is gone.
- `useTreeCamera`: gesture callbacks go through `runOnJS(...)` again instead of `.runOnJS(true)` on the gesture builder.

**Test mocks restored + extended:**
- `jest.setup.js`: re-adds `react-native-reanimated/mock`, and rewrites the `@maplibre/maplibre-react-native` mock to the v11 export surface (`Map`, `GeoJSONSource`, `Layer`, `LogManager`, `NetworkManager`, `OfflineManager` — no default export).
- `ContentImageGallery.test.tsx`, `useTreeCamera.test.ts`, `GenealogyTreeScreen.test.tsx`: local reanimated mocks restored.

**MapLibre v11 audit — mechanical rewrite of the map module:**

| v10 | v11 |
|---|---|
| `MapView` | `Map` |
| `ShapeSource` | `GeoJSONSource` |
| `CircleLayer`, `SymbolLayer`, `FillLayer`, `LineLayer` | `<Layer type="..."/>` |
| `scrollEnabled` | `dragPan` |
| `zoomEnabled` | `touchZoom` (+ `doubleTapZoom`, `doubleTapHoldZoom`) |
| `pitchEnabled` | `touchPitch` |
| `rotateEnabled` | `touchRotate` |
| `attributionEnabled` | `attribution` |
| `logoEnabled` | `logo` |
| `Camera defaultSettings={...}` | `Camera initialViewState={...}` |
| `{ centerCoordinate, zoomLevel }` | `{ center, zoom }` |
| `fitBounds(ne, sw, padding[], duration)` | `fitBounds([w,s,e,n], { padding, duration })` |
| `setCamera({ animationMode: 'flyTo', ... })` | `flyTo({ center, zoom, duration })` |
| top-level `setConnected` | `NetworkManager.setConnected` |
| default export | named exports only |

- `useMapZoom`: `onRegionDidChange` now receives a `ViewStateChangeEvent` (`event.nativeEvent.zoom`) instead of a GeoJSON feature (`feature.properties.zoomLevel`). Hook reads either shape so we don't break any callers still using the v10 synthetic during migration; v11 test covers the new path, a backwards-compat test pins the v10 branch.
- `isMapNativeAvailable`: probe drops `.default` (removed in v11) and goes through `NetworkManager.setConnected` when available.
- `OfflineManager` keeps its PascalCase name in v11 — `useMapTileCache` + its test were already aligned.

## Validation

- `npm test` → **3341 passing across 453 suites** ✅
- `npx expo export --platform ios` → bundles **3932 modules** into an 8.47 MB Hermes bytecode bundle ✅
- `<Light>` component is not used in the codebase (no changes needed there); `setAccessToken`/`getAccessToken` never called.

## Test plan

- [ ] Run `eas build --profile preview --platform ios` and confirm the binary launches (no TurboModule crash).
- [ ] Smoke-test the map on a real device: pan/zoom/era filter/story overlay/place detail/chapter deep-link all still work.
- [ ] Smoke-test the genealogy tree: pan, pinch, centre on node, era jump.
- [ ] Confirm ChapterSkeleton + LoadingSkeleton animate smoothly (no stuck opacity).
- [ ] Confirm the fullscreen image viewer in ContentImageGallery still pinch/pans/double-taps cleanly.
- [ ] Promote to TestFlight, verify it no longer crashes on launch.

https://claude.ai/code/session_01CvhqCQ1bXtVXMpF85UENW5