### PR TITLE
feat(ai-partner): FAB + peek sheet component (#1462)

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -29,6 +29,8 @@ import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
 import { ContentUpdateProvider } from './src/providers/ContentUpdateProvider';
 import { AmicusConsentProvider } from './src/services/amicus/consent';
+import { AmicusFabProvider } from './src/contexts/AmicusFabContext';
+import AmicusFab from './src/components/amicus/AmicusFab';
 import { DbDownloadScreen } from './src/screens/DbDownloadScreen';
 import { Sentry, DSN } from './src/lib/sentry';
 
@@ -223,7 +225,10 @@ function App() {
         <ThemeProvider>
           <ContentUpdateProvider>
             <AmicusConsentProvider>
-              <AppShell />
+              <AmicusFabProvider>
+                <AppShell />
+                <AmicusFab />
+              </AmicusFabProvider>
             </AmicusConsentProvider>
           </ContentUpdateProvider>
         </ThemeProvider>

--- a/app/__tests__/screens/AmicusProfileInspectorScreen.test.tsx
+++ b/app/__tests__/screens/AmicusProfileInspectorScreen.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import AmicusProfileInspectorScreen from '@/screens/AmicusProfileInspectorScreen';
+import { ThemeProvider } from '@/theme';
+import { resetMockUserDb } from '../helpers/mockUserDb';
+import { resetMockDb } from '../helpers/mockDb';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+jest.mock('@/db/database', () =>
+  require('../helpers/mockDb').mockDatabaseModule(),
+);
+
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ goBack: mockGoBack }),
+  };
+});
+
+jest.mock('@/services/amicus/profile/generator', () => ({
+  generateProfile: jest.fn().mockResolvedValue({
+    prose: 'Test profile prose',
+    preferred_scholars: ['calvin'],
+    preferred_traditions: ['Reformed'],
+    generated_at: new Date().toISOString(),
+    raw_signals_hash: 'x',
+  }),
+  getProfileForInspection: jest.fn().mockResolvedValue({
+    prose: 'Test profile prose',
+    preferred_scholars: ['calvin'],
+    preferred_traditions: ['Reformed'],
+    generated_at: new Date().toISOString(),
+    raw_signals: {
+      total_chapters_read: 10,
+      last_30_day_chapters: 2,
+      top_scholars_opened: [],
+      tradition_distribution: {},
+      genre_distribution: {},
+      completed_journeys: [],
+      active_journey: null,
+      recent_chapters: [],
+      current_focus: null,
+    },
+  }),
+}));
+
+function renderScreen() {
+  return render(
+    <SafeAreaProvider>
+      <ThemeProvider>
+        <AmicusProfileInspectorScreen />
+      </ThemeProvider>
+    </SafeAreaProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetMockUserDb();
+  resetMockDb();
+});
+
+describe('AmicusProfileInspectorScreen', () => {
+  it('renders the prose after load', async () => {
+    const { findByText } = renderScreen();
+    expect(await findByText('Test profile prose')).toBeTruthy();
+  });
+
+  it('renders the subtitle disclosure', async () => {
+    const { findByText } = renderScreen();
+    expect(
+      await findByText(/summary sent to our AI provider/),
+    ).toBeTruthy();
+  });
+
+  it('shows the header title', async () => {
+    const { findByText } = renderScreen();
+    expect(await findByText('Your Amicus Profile')).toBeTruthy();
+  });
+});

--- a/app/src/components/amicus/AmicusFab.tsx
+++ b/app/src/components/amicus/AmicusFab.tsx
@@ -1,0 +1,126 @@
+/**
+ * components/amicus/AmicusFab.tsx — always-on Amicus surface.
+ *
+ * 56×56 circular FAB, bottom-right, gold. Tap opens the peek sheet.
+ * Composes:
+ *   - `useAmicusFab()` visibility context (for per-screen suppression)
+ *   - `useAmicusAccess()` entitlement/usage gate (from #1460)
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
+import { Lock, MessageSquare } from 'lucide-react-native';
+import { useTheme } from '../../theme';
+import { useAmicusFab } from '../../contexts/AmicusFabContext';
+import { useAmicusAccess } from '../../hooks/useAmicusAccess';
+import AmicusPeekSheet from './AmicusPeekSheet';
+
+const FAB_SIZE = 56;
+const TAB_BAR_HEIGHT = 56; // matches React Navigation bottom-tab default
+const BOTTOM_MARGIN = 16;
+const RIGHT_MARGIN = 16;
+
+export default function AmicusFab(): React.ReactElement | null {
+  const { base } = useTheme();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const { isVisible } = useAmicusFab();
+  const access = useAmicusAccess();
+  const [peekOpen, setPeekOpen] = useState(false);
+
+  // Hide when any screen has requested suppression OR the user turned the
+  // feature off in settings. (Non-premium users still see the FAB but with
+  // a lock overlay — tap opens the paywall.)
+  const shouldRender =
+    isVisible && access.reason !== 'disabled_in_settings';
+
+  const bottomOffset = useMemo<ViewStyle>(
+    () => ({
+      bottom: insets.bottom + TAB_BAR_HEIGHT + BOTTOM_MARGIN,
+      right: RIGHT_MARGIN + insets.right,
+    }),
+    [insets.bottom, insets.right],
+  );
+
+  const handlePress = useCallback(() => {
+    if (access.reason === 'not_premium') {
+      // Non-premium → paywall screen in the Amicus tab.
+      const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+      parent?.navigate('AmicusTab', { screen: 'Paywall' });
+      return;
+    }
+    setPeekOpen(true);
+  }, [access.reason, navigation]);
+
+  if (!shouldRender) return null;
+
+  const isLocked = access.reason === 'not_premium';
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      <Pressable
+        accessibilityLabel={isLocked ? 'Unlock Amicus' : 'Open Amicus'}
+        accessibilityRole="button"
+        onPress={handlePress}
+        style={({ pressed }) => [
+          styles.fab,
+          bottomOffset,
+          {
+            backgroundColor: base.gold,
+            opacity: pressed ? 0.85 : 1,
+          },
+        ]}
+      >
+        <MessageSquare size={24} color={base.bg} />
+        {isLocked && (
+          <View style={[styles.lockBadge, { backgroundColor: base.bg }]}>
+            <Lock size={10} color={base.gold} />
+          </View>
+        )}
+      </Pressable>
+
+      <AmicusPeekSheet isOpen={peekOpen} onClose={() => setPeekOpen(false)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  fab: {
+    position: 'absolute',
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+      },
+      android: { elevation: 4 },
+      default: {},
+    }),
+  },
+  lockBadge: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/src/components/amicus/AmicusPeekSheet.tsx
+++ b/app/src/components/amicus/AmicusPeekSheet.tsx
@@ -1,0 +1,300 @@
+/**
+ * components/amicus/AmicusPeekSheet.tsx — bottom sheet that expands on FAB tap.
+ *
+ * Renders chips + free-text input. Chip activation or send will wire into
+ * the mini-conversation in #1463; for now the peek just surfaces chips and
+ * a non-functional input (to keep #1462 focused on the shell).
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BackHandler,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
+import { ArrowUp } from 'lucide-react-native';
+import { useNavigationState } from '@react-navigation/native';
+import { fontFamily, spacing, useTheme } from '../../theme';
+import { useAmicusChips, type ChipContext } from '../../hooks/useAmicusChips';
+
+export interface AmicusPeekSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Optional override for tests. */
+  contextOverride?: ChipContext;
+  /** Fired when the user taps a chip. #1463 takes this from here. */
+  onChipTap?: (seedQuery: string) => void;
+  /** Fired when the user submits free-text. */
+  onSend?: (text: string) => void;
+}
+
+export default function AmicusPeekSheet(
+  props: AmicusPeekSheetProps,
+): React.ReactElement | null {
+  const { base } = useTheme();
+  const sheetRef = useRef<BottomSheet>(null);
+  const snapPoints = useMemo(() => ['50%', '85%'], []);
+
+  const ctx = useNavigationContext(props.contextOverride);
+  const { chips } = useAmicusChips(ctx);
+  const [text, setText] = useState('');
+
+  // Open / close programmatically.
+  useEffect(() => {
+    if (props.isOpen) sheetRef.current?.snapToIndex(0);
+    else sheetRef.current?.close();
+  }, [props.isOpen]);
+
+  // Android hardware-back closes the sheet (not the app).
+  useEffect(() => {
+    if (!props.isOpen) return undefined;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      props.onClose();
+      return true;
+    });
+    return () => sub.remove();
+  }, [props.isOpen, props]);
+
+  const handleChip = useCallback(
+    (seedQuery: string) => {
+      props.onChipTap?.(seedQuery);
+    },
+    [props],
+  );
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setText('');
+    props.onSend?.(trimmed);
+  }, [text, props]);
+
+  if (!props.isOpen) return null;
+
+  const subtitle = contextSubtitle(ctx);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onClose={props.onClose}
+      backdropComponent={(bdProps) => (
+        <BottomSheetBackdrop
+          {...bdProps}
+          appearsOnIndex={0}
+          disappearsOnIndex={-1}
+          pressBehavior="close"
+        />
+      )}
+      backgroundStyle={[styles.bg, { backgroundColor: base.bg, borderColor: base.border }]}
+      handleIndicatorStyle={[styles.handle, { backgroundColor: base.gold }]}
+    >
+      <BottomSheetView style={styles.content} accessibilityLabel="Amicus peek">
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: base.text, fontFamily: fontFamily.display }]}>
+            Amicus
+          </Text>
+          {subtitle && (
+            <Text
+              numberOfLines={1}
+              style={[styles.subtitle, { color: base.textMuted, fontFamily: fontFamily.bodyItalic }]}
+            >
+              {subtitle}
+            </Text>
+          )}
+        </View>
+
+        <View style={styles.chipArea}>
+          {chips.length === 0 ? (
+            <Text style={[styles.emptyChips, { color: base.textMuted }]}>
+              Ask anything about your current reading.
+            </Text>
+          ) : (
+            chips.map((chip) => (
+              <Pressable
+                key={chip.label}
+                accessibilityLabel={`Ask: ${chip.label}`}
+                onPress={() => handleChip(chip.seed_query)}
+                style={({ pressed }) => [
+                  styles.chip,
+                  {
+                    borderColor: base.gold,
+                    backgroundColor: pressed ? `${base.gold}20` : 'transparent',
+                  },
+                ]}
+              >
+                <Text
+                  style={[styles.chipText, { color: base.gold, fontFamily: fontFamily.body }]}
+                  numberOfLines={2}
+                >
+                  {chip.label}
+                </Text>
+              </Pressable>
+            ))
+          )}
+        </View>
+
+        <View style={[styles.inputBar, { borderTopColor: base.border }]}>
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            placeholder="Message Amicus…"
+            placeholderTextColor={base.textMuted}
+            style={[
+              styles.input,
+              {
+                color: base.text,
+                backgroundColor: base.bgSurface,
+                borderColor: base.border,
+              },
+            ]}
+            accessibilityLabel="Message Amicus from peek"
+            multiline
+          />
+          <Pressable
+            accessibilityLabel="Send"
+            onPress={handleSend}
+            disabled={text.trim().length === 0}
+            style={({ pressed }) => [
+              styles.sendButton,
+              {
+                backgroundColor: text.trim().length > 0 ? base.gold : base.border,
+                opacity: pressed ? 0.7 : 1,
+              },
+            ]}
+          >
+            <ArrowUp size={18} color={base.bg} />
+          </Pressable>
+        </View>
+      </BottomSheetView>
+    </BottomSheet>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Extract chapter/entity context from the active route for chip selection. */
+function useNavigationContext(override?: ChipContext): ChipContext {
+  const state = useNavigationState((s) => s);
+  return useMemo(() => {
+    if (override) return override;
+    if (!state) return { kind: 'none' };
+    const route = findDeepestRoute(state);
+    if (!route) return { kind: 'none' };
+    const params = (route.params ?? {}) as Record<string, unknown>;
+    switch (route.name) {
+      case 'Chapter': {
+        const bookId = typeof params.bookId === 'string' ? params.bookId : undefined;
+        const chapterNum =
+          typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
+        if (bookId && chapterNum) {
+          return { kind: 'chapter', bookId, chapterNum };
+        }
+        return { kind: 'none' };
+      }
+      case 'PersonDetail':
+        if (typeof params.personId === 'string') {
+          return { kind: 'person', personId: params.personId };
+        }
+        return { kind: 'none' };
+      case 'DebateDetail':
+        if (typeof params.topicId === 'string') {
+          return { kind: 'debate_topic', topicId: params.topicId };
+        }
+        return { kind: 'none' };
+      default:
+        return { kind: 'none' };
+    }
+  }, [state, override]);
+}
+
+interface MinimalRoute {
+  name: string;
+  params?: unknown;
+  state?: { routes?: MinimalRoute[]; index?: number };
+}
+
+function findDeepestRoute(state: unknown): MinimalRoute | null {
+  const s = state as {
+    routes?: MinimalRoute[];
+    index?: number;
+  } | null;
+  if (!s || !Array.isArray(s.routes)) return null;
+  const idx = typeof s.index === 'number' ? s.index : s.routes.length - 1;
+  const route = s.routes[idx];
+  if (!route) return null;
+  if (route.state) return findDeepestRoute(route.state) ?? route;
+  return route;
+}
+
+function contextSubtitle(ctx: ChipContext): string {
+  switch (ctx.kind) {
+    case 'chapter':
+      return `Reading ${prettyBook(ctx.bookId)} ${ctx.chapterNum}`;
+    case 'person':
+      return `Person · ${ctx.personId}`;
+    case 'place':
+      return `Place · ${ctx.placeId}`;
+    case 'debate_topic':
+      return 'Browsing a debate';
+    case 'none':
+      return 'Ready to help';
+  }
+}
+
+function prettyBook(bookId: string): string {
+  return bookId.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ── Styles ────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  bg: { borderWidth: StyleSheet.hairlineWidth },
+  handle: { width: 40, height: 4, borderRadius: 2 },
+  content: { flex: 1, padding: spacing.md, gap: spacing.sm },
+  header: { marginBottom: spacing.xs },
+  title: { fontSize: 20 },
+  subtitle: { fontSize: 13, marginTop: 2 },
+  chipArea: { gap: 8 },
+  emptyChips: { fontSize: 13, fontStyle: 'italic' },
+  chip: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    borderRadius: 12,
+  },
+  chipText: { fontSize: 14 },
+  inputBar: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+    marginTop: 'auto',
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 14,
+    minHeight: 40,
+    maxHeight: 120,
+  },
+  sendButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/src/components/amicus/__tests__/AmicusFab.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusFab.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import AmicusFab from '@/components/amicus/AmicusFab';
+import { AmicusFabProvider, useAmicusFab } from '@/contexts/AmicusFabContext';
+
+const mockNavigate = jest.fn();
+const mockGetParent = jest.fn(() => ({ navigate: mockNavigate }));
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      getParent: mockGetParent,
+    }),
+    useNavigationState: () => ({ routes: [{ name: 'HomeMain' }], index: 0 }),
+  };
+});
+
+// BottomSheet pulls in reanimated; stub it to a simple View in tests.
+jest.mock('@gorhom/bottom-sheet', () => {
+  const { View } = require('react-native');
+  const BottomSheet = ({ children }: { children: React.ReactNode }) => (
+    <View>{children}</View>
+  );
+  const BottomSheetView = View;
+  const BottomSheetBackdrop = View;
+  return { __esModule: true, default: BottomSheet, BottomSheetView, BottomSheetBackdrop };
+});
+
+const mockUseAmicusAccess = jest.fn();
+jest.mock('@/hooks/useAmicusAccess', () => ({
+  useAmicusAccess: () => mockUseAmicusAccess(),
+}));
+
+function renderWithFab(node: React.ReactElement) {
+  return renderWithProviders(<AmicusFabProvider>{node}</AmicusFabProvider>);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAmicusAccess.mockReturnValue({
+    canUse: true,
+    reason: 'ok',
+    entitlement: 'premium',
+    usage: { thisMonth: 0, cap: 300, remaining: 300 },
+  });
+});
+
+describe('AmicusFab', () => {
+  it('renders when visible + not suppressed', () => {
+    const { getByLabelText } = renderWithFab(<AmicusFab />);
+    expect(getByLabelText('Open Amicus')).toBeTruthy();
+  });
+
+  it('hides when settings disabled', () => {
+    mockUseAmicusAccess.mockReturnValueOnce({
+      canUse: false,
+      reason: 'disabled_in_settings',
+      entitlement: 'premium',
+      usage: { thisMonth: 0, cap: 300, remaining: 300 },
+    });
+    const { queryByLabelText } = renderWithFab(<AmicusFab />);
+    expect(queryByLabelText('Open Amicus')).toBeNull();
+    expect(queryByLabelText('Unlock Amicus')).toBeNull();
+  });
+
+  it('shows lock icon for non-premium and opens paywall on tap', () => {
+    mockUseAmicusAccess.mockReturnValueOnce({
+      canUse: false,
+      reason: 'not_premium',
+      entitlement: 'none',
+      usage: { thisMonth: 0, cap: 0, remaining: 0 },
+    });
+    const { getByLabelText } = renderWithFab(<AmicusFab />);
+    const fab = getByLabelText('Unlock Amicus');
+    fireEvent.press(fab);
+    expect(mockGetParent).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'AmicusTab',
+      expect.objectContaining({ screen: 'Paywall' }),
+    );
+  });
+
+  it('is hidden when a screen requests suppression', () => {
+    function Consumer() {
+      const { hide } = useAmicusFab();
+      React.useEffect(() => hide(), [hide]);
+      return null;
+    }
+    const { queryByLabelText } = render(
+      <AmicusFabProvider>
+        <Consumer />
+        <AmicusFab />
+      </AmicusFabProvider>,
+    );
+    expect(queryByLabelText('Open Amicus')).toBeNull();
+  });
+});

--- a/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import AmicusPeekSheet from '@/components/amicus/AmicusPeekSheet';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
+
+jest.mock('@/db/database', () =>
+  require('../../../../__tests__/helpers/mockDb').mockDatabaseModule(),
+);
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigationState: () => ({ routes: [{ name: 'HomeMain' }], index: 0 }),
+  };
+});
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const { View } = require('react-native');
+  const BottomSheet = ({ children }: { children: React.ReactNode }) => (
+    <View accessibilityLabel="bottom-sheet">{children}</View>
+  );
+  return {
+    __esModule: true,
+    default: BottomSheet,
+    BottomSheetView: View,
+    BottomSheetBackdrop: View,
+  };
+});
+
+beforeEach(() => resetMockDb());
+
+describe('AmicusPeekSheet', () => {
+  it('renders chips from the precached_prompts table', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'Why does Paul use this metaphor',
+          seed_query: 'Explain the metaphor.',
+          expected_source_types: ['chapter_panel'],
+        },
+      ]),
+    });
+    const { findByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={() => undefined}
+        contextOverride={{ kind: 'chapter', bookId: 'romans', chapterNum: 9 }}
+      />,
+    );
+    expect(
+      await findByLabelText('Ask: Why does Paul use this metaphor'),
+    ).toBeTruthy();
+  });
+
+  it('fires onChipTap with the seed_query when a chip is pressed', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'What does chesed mean in the Psalms',
+          seed_query: 'Explain hesed in the Psalms.',
+          expected_source_types: ['word_study'],
+        },
+      ]),
+    });
+    const onChipTap = jest.fn();
+    const { findByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={() => undefined}
+        contextOverride={{ kind: 'chapter', bookId: 'psalms', chapterNum: 23 }}
+        onChipTap={onChipTap}
+      />,
+    );
+    fireEvent.press(
+      await findByLabelText('Ask: What does chesed mean in the Psalms'),
+    );
+    expect(onChipTap).toHaveBeenCalledWith('Explain hesed in the Psalms.');
+  });
+
+  it('calls onSend with trimmed free text', async () => {
+    getMockDb().getFirstAsync.mockResolvedValue(null);
+    const onSend = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={() => undefined}
+        contextOverride={{ kind: 'none' }}
+        onSend={onSend}
+      />,
+    );
+    fireEvent.changeText(getByLabelText('Message Amicus from peek'), '  what is grace?  ');
+    fireEvent.press(getByLabelText('Send'));
+    expect(onSend).toHaveBeenCalledWith('what is grace?');
+  });
+
+  it('returns nothing when isOpen is false', () => {
+    const { toJSON } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen={false}
+        onClose={() => undefined}
+        contextOverride={{ kind: 'none' }}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/src/contexts/AmicusFabContext.tsx
+++ b/app/src/contexts/AmicusFabContext.tsx
@@ -1,0 +1,84 @@
+/**
+ * contexts/AmicusFabContext.tsx — controls whether the Amicus FAB renders.
+ *
+ * Screens that want to suppress the FAB (modals, auth, onboarding, the
+ * Amicus tab itself) call `hide()` on mount and `show()` on unmount via
+ * the `useSuppressAmicusFab` convenience hook.
+ *
+ * Uses a ref-count so two simultaneous suppressors don't clobber each
+ * other on unmount.
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export interface AmicusFabContextValue {
+  isVisible: boolean;
+  hide: () => void;
+  show: () => void;
+}
+
+const AmicusFabContext = createContext<AmicusFabContextValue | null>(null);
+
+export function AmicusFabProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const suppressorsRef = useRef(0);
+  const [isVisible, setIsVisible] = useState(true);
+
+  const recompute = useCallback(() => {
+    setIsVisible(suppressorsRef.current === 0);
+  }, []);
+
+  const hide = useCallback(() => {
+    suppressorsRef.current += 1;
+    recompute();
+  }, [recompute]);
+
+  const show = useCallback(() => {
+    suppressorsRef.current = Math.max(0, suppressorsRef.current - 1);
+    recompute();
+  }, [recompute]);
+
+  const value = useMemo<AmicusFabContextValue>(
+    () => ({ isVisible, hide, show }),
+    [isVisible, hide, show],
+  );
+
+  return (
+    <AmicusFabContext.Provider value={value}>
+      {children}
+    </AmicusFabContext.Provider>
+  );
+}
+
+export function useAmicusFab(): AmicusFabContextValue {
+  const ctx = useContext(AmicusFabContext);
+  if (!ctx) {
+    // Safe fallback for tests / unmounted callers — no-op suppression.
+    return {
+      isVisible: true,
+      hide: () => undefined,
+      show: () => undefined,
+    };
+  }
+  return ctx;
+}
+
+/** Convenience hook — call in any screen that should suppress the FAB. */
+export function useSuppressAmicusFab(suppress = true): void {
+  const { hide, show } = useAmicusFab();
+  useEffect(() => {
+    if (!suppress) return undefined;
+    hide();
+    return show;
+  }, [hide, show, suppress]);
+}

--- a/app/src/contexts/__tests__/AmicusFabContext.test.tsx
+++ b/app/src/contexts/__tests__/AmicusFabContext.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Text, Pressable } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import {
+  AmicusFabProvider,
+  useAmicusFab,
+  useSuppressAmicusFab,
+} from '@/contexts/AmicusFabContext';
+
+function Status() {
+  const { isVisible } = useAmicusFab();
+  return <Text>{isVisible ? 'visible' : 'hidden'}</Text>;
+}
+
+function Suppressor({ on }: { on: boolean }) {
+  useSuppressAmicusFab(on);
+  return null;
+}
+
+function Toggle({ fn, label }: { fn: () => void; label: string }) {
+  return (
+    <Pressable accessibilityLabel={label} onPress={fn}>
+      <Text>{label}</Text>
+    </Pressable>
+  );
+}
+
+function HideShowControls() {
+  const { hide, show } = useAmicusFab();
+  return (
+    <>
+      <Toggle fn={hide} label="hide" />
+      <Toggle fn={show} label="show" />
+    </>
+  );
+}
+
+describe('AmicusFabProvider', () => {
+  it('starts visible', () => {
+    const { getByText } = render(
+      <AmicusFabProvider>
+        <Status />
+      </AmicusFabProvider>,
+    );
+    expect(getByText('visible')).toBeTruthy();
+  });
+
+  it('hide and show toggle the state', () => {
+    const { getByText, getByLabelText } = render(
+      <AmicusFabProvider>
+        <Status />
+        <HideShowControls />
+      </AmicusFabProvider>,
+    );
+    fireEvent.press(getByLabelText('hide'));
+    expect(getByText('hidden')).toBeTruthy();
+    fireEvent.press(getByLabelText('show'));
+    expect(getByText('visible')).toBeTruthy();
+  });
+
+  it('ref-counts so two suppressors compose', () => {
+    const { getByText, getByLabelText } = render(
+      <AmicusFabProvider>
+        <Status />
+        <HideShowControls />
+      </AmicusFabProvider>,
+    );
+    fireEvent.press(getByLabelText('hide'));
+    fireEvent.press(getByLabelText('hide'));
+    expect(getByText('hidden')).toBeTruthy();
+    fireEvent.press(getByLabelText('show'));
+    // Still one suppressor outstanding — should remain hidden.
+    expect(getByText('hidden')).toBeTruthy();
+    fireEvent.press(getByLabelText('show'));
+    expect(getByText('visible')).toBeTruthy();
+  });
+
+  it('useSuppressAmicusFab hides during mount and restores on unmount', () => {
+    function Harness({ suppress }: { suppress: boolean }) {
+      return (
+        <>
+          <Status />
+          {suppress && <Suppressor on />}
+        </>
+      );
+    }
+    const { getByText, rerender } = render(
+      <AmicusFabProvider>
+        <Harness suppress={false} />
+      </AmicusFabProvider>,
+    );
+    expect(getByText('visible')).toBeTruthy();
+    rerender(
+      <AmicusFabProvider>
+        <Harness suppress={true} />
+      </AmicusFabProvider>,
+    );
+    expect(getByText('hidden')).toBeTruthy();
+    rerender(
+      <AmicusFabProvider>
+        <Harness suppress={false} />
+      </AmicusFabProvider>,
+    );
+    expect(getByText('visible')).toBeTruthy();
+  });
+});

--- a/app/src/hooks/__tests__/useAmicusChips.test.tsx
+++ b/app/src/hooks/__tests__/useAmicusChips.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the pure helpers of useAmicusChips. Hook-level effect
+ * behavior is simpler than the DB plumbing it wraps, so we focus on the
+ * deterministic parts (variant fallback order + context key mapping).
+ */
+import { _internal } from '@/hooks/useAmicusChips';
+
+describe('variantLookupOrder', () => {
+  it('prefers caller-supplied variant, falls back to generic_balanced then default', () => {
+    expect(_internal.variantLookupOrder('reformed_narrative')).toEqual([
+      'reformed_narrative',
+      'generic_balanced',
+      'default',
+    ]);
+  });
+
+  it('omits duplicates when caller passes the default variant', () => {
+    expect(_internal.variantLookupOrder('generic_balanced')).toEqual([
+      'generic_balanced',
+      'default',
+    ]);
+  });
+
+  it('returns just the fallbacks when no variant is provided', () => {
+    expect(_internal.variantLookupOrder()).toEqual(['generic_balanced', 'default']);
+  });
+});
+
+describe('entityKeyFromContext', () => {
+  it('builds chapter keys as `${bookId}-${chapterNum}`', () => {
+    expect(_internal.entityKeyFromContext({
+      kind: 'chapter', bookId: 'romans', chapterNum: 9,
+    })).toEqual({ entityType: 'chapter', entityId: 'romans-9' });
+  });
+
+  it('maps person / place / debate contexts one-to-one', () => {
+    expect(_internal.entityKeyFromContext({ kind: 'person', personId: 'abraham' }))
+      .toEqual({ entityType: 'person', entityId: 'abraham' });
+    expect(_internal.entityKeyFromContext({ kind: 'place', placeId: 'jerusalem' }))
+      .toEqual({ entityType: 'place', entityId: 'jerusalem' });
+    expect(_internal.entityKeyFromContext({ kind: 'debate_topic', topicId: 'yom' }))
+      .toEqual({ entityType: 'debate_topic', entityId: 'yom' });
+  });
+
+  it('returns null for none', () => {
+    expect(_internal.entityKeyFromContext({ kind: 'none' })).toBeNull();
+  });
+});

--- a/app/src/hooks/useAmicusChips.ts
+++ b/app/src/hooks/useAmicusChips.ts
@@ -1,0 +1,130 @@
+/**
+ * hooks/useAmicusChips.ts — Load chip pool rows for the FAB peek.
+ *
+ * Reads from scripture.db's `precached_prompts` table (populated by
+ * `_tools/build_prompts.py`). Picks a profile variant based on the
+ * user's profile lean, falling back to the `generic_balanced` default.
+ *
+ * Returns up to 3 chips; empty if nothing is available for the current
+ * context.
+ */
+import { useEffect, useState } from 'react';
+import { getDb } from '@/db/database';
+import { logger } from '@/utils/logger';
+
+export interface AmicusChip {
+  label: string;
+  seed_query: string;
+  expected_source_types: string[];
+}
+
+export type ChipContext =
+  | { kind: 'chapter'; bookId: string; chapterNum: number }
+  | { kind: 'person'; personId: string }
+  | { kind: 'place'; placeId: string }
+  | { kind: 'debate_topic'; topicId: string }
+  | { kind: 'none' };
+
+export interface UseAmicusChipsResult {
+  chips: AmicusChip[];
+  isLoading: boolean;
+}
+
+export const DEFAULT_VARIANT = 'generic_balanced';
+const CHIP_LIMIT = 3;
+
+/** Variant fallback order — try the user's preferred variant first, then
+ *  the generic default, then `default` (entity rows use 'default'). */
+function variantLookupOrder(preferredVariant?: string): string[] {
+  const out = new Set<string>();
+  if (preferredVariant) out.add(preferredVariant);
+  out.add(DEFAULT_VARIANT);
+  out.add('default');
+  return [...out];
+}
+
+function entityKeyFromContext(
+  ctx: ChipContext,
+): { entityType: string; entityId: string } | null {
+  switch (ctx.kind) {
+    case 'chapter':
+      return { entityType: 'chapter', entityId: `${ctx.bookId}-${ctx.chapterNum}` };
+    case 'person':
+      return { entityType: 'person', entityId: ctx.personId };
+    case 'place':
+      return { entityType: 'place', entityId: ctx.placeId };
+    case 'debate_topic':
+      return { entityType: 'debate_topic', entityId: ctx.topicId };
+    case 'none':
+      return null;
+  }
+}
+
+async function loadChips(
+  ctx: ChipContext,
+  preferredVariant?: string,
+): Promise<AmicusChip[]> {
+  const key = entityKeyFromContext(ctx);
+  if (!key) return [];
+
+  for (const variant of variantLookupOrder(preferredVariant)) {
+    try {
+      const row = await getDb().getFirstAsync<{ chips_json: string }>(
+        `SELECT chips_json FROM precached_prompts
+          WHERE entity_type = ? AND entity_id = ? AND profile_variant = ?`,
+        [key.entityType, key.entityId, variant],
+      );
+      if (!row) continue;
+      try {
+        const parsed = JSON.parse(row.chips_json) as AmicusChip[];
+        return parsed.slice(0, CHIP_LIMIT);
+      } catch (err) {
+        logger.warn('Amicus', `bad chips_json for ${key.entityId}`, err);
+        return [];
+      }
+    } catch (err) {
+      logger.warn('Amicus', 'chip lookup failed', err);
+      return [];
+    }
+  }
+  return [];
+}
+
+function contextCacheKey(ctx: ChipContext): string {
+  switch (ctx.kind) {
+    case 'chapter': return `chapter:${ctx.bookId}-${ctx.chapterNum}`;
+    case 'person': return `person:${ctx.personId}`;
+    case 'place': return `place:${ctx.placeId}`;
+    case 'debate_topic': return `debate_topic:${ctx.topicId}`;
+    case 'none': return 'none';
+  }
+}
+
+export function useAmicusChips(
+  ctx: ChipContext,
+  preferredVariant?: string,
+): UseAmicusChipsResult {
+  const [chips, setChips] = useState<AmicusChip[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const cacheKey = contextCacheKey(ctx);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const out = await loadChips(ctx, preferredVariant);
+      if (cancelled) return;
+      setChips(out);
+      setIsLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // The derived cacheKey captures every ctx field we care about; re-running
+    // when preferredVariant changes is covered below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey, preferredVariant]);
+
+  return { chips, isLoading };
+}
+
+export const _internal = { loadChips, variantLookupOrder, entityKeyFromContext };

--- a/app/src/screens/AmicusThreadListScreen.tsx
+++ b/app/src/screens/AmicusThreadListScreen.tsx
@@ -22,6 +22,7 @@ import { useNavigation } from '@react-navigation/native';
 import { Pin, Plus, MessageSquare } from 'lucide-react-native';
 import { useAmicusThreads } from '../hooks/useAmicusThreads';
 import { useAmicusAccess } from '../hooks/useAmicusAccess';
+import { useSuppressAmicusFab } from '../contexts/AmicusFabContext';
 import { useTheme, spacing, fontFamily } from '../theme';
 import type { ScreenNavProp } from '../navigation/types';
 import type { AmicusThread } from '../types';
@@ -33,6 +34,7 @@ export default function AmicusThreadListScreen(): React.ReactElement {
   const { threads, isLoading, refresh, actions } = useAmicusThreads();
   const access = useAmicusAccess();
   const [renaming, setRenaming] = useState<{ id: string; title: string } | null>(null);
+  useSuppressAmicusFab(); // FAB is redundant on the Amicus tab itself.
 
   // Non-premium users see the paywall in place of the thread list.
   React.useEffect(() => {

--- a/app/src/screens/AmicusThreadScreen.tsx
+++ b/app/src/screens/AmicusThreadScreen.tsx
@@ -29,6 +29,7 @@ import {
   type MetaFaqArticle,
 } from '../services/amicus/citationNav';
 import { useAmicusConsent } from '../services/amicus/consent';
+import { useSuppressAmicusFab } from '../contexts/AmicusFabContext';
 import type { AmicusCitation, AmicusThread } from '../types';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
@@ -45,6 +46,7 @@ export default function AmicusThreadScreen(): React.ReactElement {
   const access = useAmicusAccess();
   const { messages, isStreaming, error, sendMessage, abortStream, clearError } =
     useAmicusThread(threadId);
+  useSuppressAmicusFab();
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
Closes #1462. Phase 3 of epic #1446. Stacked on #1461 (chip pool).

## Summary
Always-on Amicus surface. The FAB sits bottom-right on every primary screen; tap opens a `@gorhom/bottom-sheet` peek that surfaces context-aware chips (from #1461) + a free-text input. Entitlement and settings gates compose via #1460.

## New files
- `contexts/AmicusFabContext.tsx` — ref-counted visibility provider + `useSuppressAmicusFab()` hook for screens that need to hide the FAB.
- `components/amicus/AmicusFab.tsx` — 56×56 circular FAB, lock overlay for non-premium (routes to Paywall).
- `components/amicus/AmicusPeekSheet.tsx` — 50 / 85 snap points, drag handle, backdrop-tap close, Android back close, sticky input.
- `hooks/useAmicusChips.ts` — loads `precached_prompts` rows with variant fallback (preferred → generic_balanced → default) and a typed `ChipContext` union.

## Wired
- `App.tsx` mounts `AmicusFabProvider` + `AmicusFab` at the root.
- `AmicusThreadListScreen` + `AmicusThreadScreen` suppress the FAB so the tab doesn't duplicate it.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all new files
- [x] 15 new tests across FAB context, FAB itself, peek sheet, chips helpers
- [x] Full suite 3,358 / 3,358 passing
- [x] Coverage thresholds green

## Out of scope
- Mini-conversation inside the peek — #1463
- Peek-to-thread promotion — #1464
- Unread-insight badge + haptics — polish pass

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe