### PR TITLE
feat(ai-partner): mini-conversation inside peek sheet (#1463)

### DIFF
--- a/app/src/components/amicus/AmicusPeekSheet.tsx
+++ b/app/src/components/amicus/AmicusPeekSheet.tsx
@@ -1,9 +1,10 @@
 /**
  * components/amicus/AmicusPeekSheet.tsx — bottom sheet that expands on FAB tap.
  *
- * Renders chips + free-text input. Chip activation or send will wire into
- * the mini-conversation in #1463; for now the peek just surfaces chips and
- * a non-functional input (to keep #1462 focused on the shell).
+ * Layers:
+ *   1. Chips + free-text input (collapsed state).
+ *   2. Once a chip or send fires, a mini-conversation (#1463) takes over
+ *      the body of the peek. At turn 3, "Continue in Amicus tab →" shows.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -20,18 +21,27 @@ import BottomSheet, {
 } from '@gorhom/bottom-sheet';
 import { ArrowUp } from 'lucide-react-native';
 import { useNavigationState } from '@react-navigation/native';
-import { fontFamily, spacing, useTheme } from '../../theme';
 import { useAmicusChips, type ChipContext } from '../../hooks/useAmicusChips';
+import { usePeekConversation } from '../../hooks/usePeekConversation';
+import { fontFamily, spacing, useTheme } from '../../theme';
+import type { AmicusCitation } from '../../types';
+import PeekMiniConversation from './PeekMiniConversation';
 
 export interface AmicusPeekSheetProps {
   isOpen: boolean;
   onClose: () => void;
   /** Optional override for tests. */
   contextOverride?: ChipContext;
-  /** Fired when the user taps a chip. #1463 takes this from here. */
+  /** Fired when the user taps a chip before the conversation starts. */
   onChipTap?: (seedQuery: string) => void;
-  /** Fired when the user submits free-text. */
+  /** Fired when the user submits free-text before the conversation starts. */
   onSend?: (text: string) => void;
+  /** Navigate to the citation target and close the peek (wired by parent). */
+  onCitationPress?: (c: AmicusCitation) => void;
+  /** Promote the peek conversation to a persistent thread (#1464). */
+  onContinueInTab?: (snapshot: ReturnType<ReturnType<typeof usePeekConversation>['snapshotForPromotion']>) => void | Promise<void>;
+  /** Expose when handoff is in progress (disables the CTA). */
+  handoffInProgress?: boolean;
 }
 
 export default function AmicusPeekSheet(
@@ -44,11 +54,24 @@ export default function AmicusPeekSheet(
   const ctx = useNavigationContext(props.contextOverride);
   const { chips } = useAmicusChips(ctx);
   const [text, setText] = useState('');
+  const peek = usePeekConversation();
+  const hasConversation = peek.messages.length > 0;
 
-  // Open / close programmatically.
+  // Open / close programmatically. Expand to 85% once a conversation is
+  // underway so users see the bubbles without having to drag.
   useEffect(() => {
-    if (props.isOpen) sheetRef.current?.snapToIndex(0);
-    else sheetRef.current?.close();
+    if (!props.isOpen) {
+      sheetRef.current?.close();
+      return;
+    }
+    sheetRef.current?.snapToIndex(hasConversation ? 1 : 0);
+  }, [props.isOpen, hasConversation]);
+
+  // Reset the ephemeral conversation whenever the peek closes.
+  useEffect(() => {
+    if (!props.isOpen) peek.reset();
+    // `peek.reset` is stable via useCallback, but exhaustive-deps can't see it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.isOpen]);
 
   // Android hardware-back closes the sheet (not the app).
@@ -61,11 +84,20 @@ export default function AmicusPeekSheet(
     return () => sub.remove();
   }, [props.isOpen, props]);
 
+  const chapterRef = useMemo(
+    () =>
+      ctx.kind === 'chapter'
+        ? { book_id: ctx.bookId, chapter_num: ctx.chapterNum }
+        : null,
+    [ctx],
+  );
+
   const handleChip = useCallback(
     (seedQuery: string) => {
       props.onChipTap?.(seedQuery);
+      void peek.send(seedQuery, chapterRef);
     },
-    [props],
+    [props, peek, chapterRef],
   );
 
   const handleSend = useCallback(() => {
@@ -73,7 +105,13 @@ export default function AmicusPeekSheet(
     if (!trimmed) return;
     setText('');
     props.onSend?.(trimmed);
-  }, [text, props]);
+    void peek.send(trimmed, chapterRef);
+  }, [text, props, peek, chapterRef]);
+
+  const handleContinueInTab = useCallback(() => {
+    if (!props.onContinueInTab) return;
+    void props.onContinueInTab(peek.snapshotForPromotion());
+  }, [props, peek]);
 
   if (!props.isOpen) return null;
 
@@ -112,35 +150,49 @@ export default function AmicusPeekSheet(
           )}
         </View>
 
-        <View style={styles.chipArea}>
-          {chips.length === 0 ? (
-            <Text style={[styles.emptyChips, { color: base.textMuted }]}>
-              Ask anything about your current reading.
-            </Text>
-          ) : (
-            chips.map((chip) => (
-              <Pressable
-                key={chip.label}
-                accessibilityLabel={`Ask: ${chip.label}`}
-                onPress={() => handleChip(chip.seed_query)}
-                style={({ pressed }) => [
-                  styles.chip,
-                  {
-                    borderColor: base.gold,
-                    backgroundColor: pressed ? `${base.gold}20` : 'transparent',
-                  },
-                ]}
-              >
-                <Text
-                  style={[styles.chipText, { color: base.gold, fontFamily: fontFamily.body }]}
-                  numberOfLines={2}
+        {hasConversation ? (
+          <PeekMiniConversation
+            messages={peek.messages}
+            isStreaming={peek.isStreaming}
+            turnCount={peek.turnCount}
+            error={peek.error}
+            onDismissError={peek.clearError}
+            onCitationPress={props.onCitationPress}
+            onFollowUp={(t) => void peek.send(t, chapterRef)}
+            onContinueInTab={handleContinueInTab}
+            handoffInProgress={props.handoffInProgress === true}
+          />
+        ) : (
+          <View style={styles.chipArea}>
+            {chips.length === 0 ? (
+              <Text style={[styles.emptyChips, { color: base.textMuted }]}>
+                Ask anything about your current reading.
+              </Text>
+            ) : (
+              chips.map((chip) => (
+                <Pressable
+                  key={chip.label}
+                  accessibilityLabel={`Ask: ${chip.label}`}
+                  onPress={() => handleChip(chip.seed_query)}
+                  style={({ pressed }) => [
+                    styles.chip,
+                    {
+                      borderColor: base.gold,
+                      backgroundColor: pressed ? `${base.gold}20` : 'transparent',
+                    },
+                  ]}
                 >
-                  {chip.label}
-                </Text>
-              </Pressable>
-            ))
-          )}
-        </View>
+                  <Text
+                    style={[styles.chipText, { color: base.gold, fontFamily: fontFamily.body }]}
+                    numberOfLines={2}
+                  >
+                    {chip.label}
+                  </Text>
+                </Pressable>
+              ))
+            )}
+          </View>
+        )}
 
         <View style={[styles.inputBar, { borderTopColor: base.border }]}>
           <TextInput

--- a/app/src/components/amicus/PeekMiniConversation.tsx
+++ b/app/src/components/amicus/PeekMiniConversation.tsx
@@ -1,0 +1,152 @@
+/**
+ * components/amicus/PeekMiniConversation.tsx — conversation rendered
+ * inside the FAB peek sheet (#1463).
+ *
+ * Reuses the bubble + citation pill + follow-up chip components from the
+ * full Amicus tab (#1455) so there is no rendering duplication. Ephemeral
+ * state lives in `usePeekConversation`.
+ */
+import React from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type { PeekMessage } from '../../hooks/usePeekConversation';
+import { AmicusError } from '../../services/amicus';
+import { fontFamily, spacing, useTheme } from '../../theme';
+import type { AmicusCitation } from '../../types';
+import AssistantMessageBubble from './AssistantMessageBubble';
+import FollowUpChips from './FollowUpChips';
+import UserMessageBubble from './UserMessageBubble';
+
+export const PEEK_HANDOFF_THRESHOLD = 3;
+
+export interface PeekMiniConversationProps {
+  messages: PeekMessage[];
+  isStreaming: boolean;
+  turnCount: number;
+  error: AmicusError | null;
+  onDismissError: () => void;
+  onCitationPress?: (c: AmicusCitation) => void;
+  onFollowUp: (text: string) => void;
+  onContinueInTab: () => void;
+  /** Shown when handoff is in progress. */
+  handoffInProgress?: boolean;
+}
+
+export default function PeekMiniConversation(
+  props: PeekMiniConversationProps,
+): React.ReactElement {
+  const { base } = useTheme();
+
+  const lastAssistant = props.messages[props.messages.length - 1];
+  const lastAssistantFollowUps =
+    !props.isStreaming && lastAssistant?.role === 'assistant'
+      ? lastAssistant.follow_ups ?? []
+      : [];
+
+  const showHandoff = props.turnCount >= PEEK_HANDOFF_THRESHOLD;
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        {props.messages.map((m, idx) =>
+          m.role === 'user' ? (
+            <UserMessageBubble key={`u-${idx}`} content={m.content} />
+          ) : (
+            <AssistantMessageBubble
+              key={`a-${idx}`}
+              content={m.content}
+              citations={m.citations ?? []}
+              isStreaming={m.isStreaming === true}
+              onCitationPress={props.onCitationPress}
+            />
+          ),
+        )}
+
+        {lastAssistantFollowUps.length > 0 && (
+          <FollowUpChips
+            followUps={lastAssistantFollowUps}
+            onSelect={props.onFollowUp}
+          />
+        )}
+
+        {showHandoff && (
+          <Pressable
+            accessibilityLabel="Continue in Amicus tab"
+            disabled={props.handoffInProgress}
+            onPress={props.onContinueInTab}
+            style={({ pressed }) => [
+              styles.handoffButton,
+              {
+                backgroundColor: props.handoffInProgress ? base.border : base.gold,
+                opacity: pressed ? 0.7 : 1,
+              },
+            ]}
+          >
+            <Text style={[styles.handoffText, { color: base.bg, fontFamily: fontFamily.displaySemiBold }]}>
+              {props.handoffInProgress ? 'Saving…' : 'Continue in Amicus tab →'}
+            </Text>
+          </Pressable>
+        )}
+      </ScrollView>
+
+      {props.error && (
+        <Pressable
+          accessibilityLabel={`${errorCopy(props.error)}. Tap to dismiss.`}
+          onPress={props.onDismissError}
+          style={[
+            styles.errorBanner,
+            { backgroundColor: `${base.gold}20`, borderColor: base.gold },
+          ]}
+        >
+          <Text
+            style={[styles.errorText, { color: base.text, fontFamily: fontFamily.body }]}
+          >
+            {errorCopy(props.error)}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+function errorCopy(err: AmicusError): string {
+  switch (err.code) {
+    case 'OFFLINE':
+      return 'Amicus needs a connection.';
+    case 'PROXY_UNAUTHORIZED':
+      return 'Your subscription is required to use Amicus.';
+    case 'EMBED_FAILED':
+      return 'Amicus is temporarily unavailable. Try again.';
+    case 'EXTENSION_NOT_LOADED':
+      return 'Amicus retrieval is unavailable on this device build.';
+    default:
+      return 'Something went wrong.';
+  }
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollContent: { padding: spacing.md, gap: spacing.xs },
+  handoffButton: {
+    marginTop: spacing.md,
+    paddingVertical: 12,
+    borderRadius: 999,
+    alignItems: 'center',
+  },
+  handoffText: { fontSize: 14, fontWeight: '600' },
+  errorBanner: {
+    margin: spacing.sm,
+    padding: spacing.sm,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  errorText: { fontSize: 13 },
+});

--- a/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
@@ -1,12 +1,23 @@
+import { act, fireEvent } from '@testing-library/react-native';
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
 import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
 import AmicusPeekSheet from '@/components/amicus/AmicusPeekSheet';
-import { getMockDb, resetMockDb } from '../../../../__tests__/helpers/mockDb';
 
 jest.mock('@/db/database', () =>
   require('../../../../__tests__/helpers/mockDb').mockDatabaseModule(),
 );
+
+type StreamChatParams = Parameters<
+  typeof import('@/services/amicus/chat').streamChat
+>[0];
+let lastStreamParams: StreamChatParams | null = null;
+const mockStreamChat = jest.fn(async (params: StreamChatParams) => {
+  lastStreamParams = params;
+});
+jest.mock('@/services/amicus/chat', () => ({
+  streamChat: (p: StreamChatParams) => mockStreamChat(p),
+}));
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -29,7 +40,12 @@ jest.mock('@gorhom/bottom-sheet', () => {
   };
 });
 
-beforeEach(() => resetMockDb());
+beforeEach(() => {
+  resetMockDb();
+  mockStreamChat.mockClear();
+  lastStreamParams = null;
+  process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'tok';
+});
 
 describe('AmicusPeekSheet', () => {
   it('renders chips from the precached_prompts table', async () => {
@@ -93,6 +109,37 @@ describe('AmicusPeekSheet', () => {
     fireEvent.changeText(getByLabelText('Message Amicus from peek'), '  what is grace?  ');
     fireEvent.press(getByLabelText('Send'));
     expect(onSend).toHaveBeenCalledWith('what is grace?');
+  });
+
+  it('starts a mini-conversation when a chip is tapped and streams the reply', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'Explain hesed',
+          seed_query: 'What is hesed?',
+          expected_source_types: ['word_study'],
+        },
+      ]),
+    });
+    const { findByLabelText, findByText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={() => undefined}
+        contextOverride={{ kind: 'chapter', bookId: 'psalms', chapterNum: 23 }}
+      />,
+    );
+    fireEvent.press(await findByLabelText('Ask: Explain hesed'));
+    expect(mockStreamChat).toHaveBeenCalled();
+    expect(lastStreamParams!.userQuery).toBe('What is hesed?');
+    expect(lastStreamParams!.currentChapterRef).toEqual({
+      book_id: 'psalms',
+      chapter_num: 23,
+    });
+    await act(async () => {
+      lastStreamParams!.onDelta('Hesed is ');
+      lastStreamParams!.onDelta('covenant love.');
+    });
+    expect(await findByText(/covenant love/)).toBeTruthy();
   });
 
   it('returns nothing when isOpen is false', () => {

--- a/app/src/components/amicus/__tests__/PeekMiniConversation.test.tsx
+++ b/app/src/components/amicus/__tests__/PeekMiniConversation.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import PeekMiniConversation, {
+  PEEK_HANDOFF_THRESHOLD,
+} from '@/components/amicus/PeekMiniConversation';
+import { AmicusError } from '@/services/amicus';
+import type { PeekMessage } from '@/hooks/usePeekConversation';
+
+const NOOP = () => undefined;
+
+function makeTurns(n: number): PeekMessage[] {
+  const out: PeekMessage[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({ role: 'user', content: `user ${i}` });
+    out.push({
+      role: 'assistant',
+      content: `answer ${i}`,
+      citations: [],
+      follow_ups: [],
+      isStreaming: false,
+    });
+  }
+  return out;
+}
+
+describe('PeekMiniConversation', () => {
+  it('renders user + assistant bubbles', () => {
+    const { getByText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={makeTurns(1)}
+        isStreaming={false}
+        turnCount={1}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={NOOP}
+        onContinueInTab={NOOP}
+      />,
+    );
+    expect(getByText('user 0')).toBeTruthy();
+    expect(getByText(/answer 0/)).toBeTruthy();
+  });
+
+  it('hides the handoff CTA before the threshold is reached', () => {
+    const { queryByLabelText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={makeTurns(PEEK_HANDOFF_THRESHOLD - 1)}
+        isStreaming={false}
+        turnCount={PEEK_HANDOFF_THRESHOLD - 1}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={NOOP}
+        onContinueInTab={NOOP}
+      />,
+    );
+    expect(queryByLabelText('Continue in Amicus tab')).toBeNull();
+  });
+
+  it('shows the handoff CTA once the turn threshold is met and fires onContinueInTab', () => {
+    const onContinueInTab = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={makeTurns(PEEK_HANDOFF_THRESHOLD)}
+        isStreaming={false}
+        turnCount={PEEK_HANDOFF_THRESHOLD}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={NOOP}
+        onContinueInTab={onContinueInTab}
+      />,
+    );
+    const cta = getByLabelText('Continue in Amicus tab');
+    fireEvent.press(cta);
+    expect(onContinueInTab).toHaveBeenCalled();
+  });
+
+  it('shows "Saving…" and disables the CTA when handoff is in progress', () => {
+    const onContinueInTab = jest.fn();
+    const { getByLabelText, getByText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={makeTurns(PEEK_HANDOFF_THRESHOLD)}
+        isStreaming={false}
+        turnCount={PEEK_HANDOFF_THRESHOLD}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={NOOP}
+        onContinueInTab={onContinueInTab}
+        handoffInProgress
+      />,
+    );
+    expect(getByText(/Saving/)).toBeTruthy();
+    fireEvent.press(getByLabelText('Continue in Amicus tab'));
+    expect(onContinueInTab).not.toHaveBeenCalled();
+  });
+
+  it('renders follow-up chips after the final assistant message and forwards taps', () => {
+    const msgs = makeTurns(1);
+    msgs[1] = { ...msgs[1]!, follow_ups: ['Ask more about Calvin'] };
+    const onFollowUp = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={msgs}
+        isStreaming={false}
+        turnCount={1}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={onFollowUp}
+        onContinueInTab={NOOP}
+      />,
+    );
+    fireEvent.press(getByLabelText('Ask: Ask more about Calvin'));
+    expect(onFollowUp).toHaveBeenCalledWith('Ask more about Calvin');
+  });
+
+  it('does not render follow-up chips while streaming', () => {
+    const msgs = makeTurns(1);
+    msgs[1] = { ...msgs[1]!, follow_ups: ['x'], isStreaming: true };
+    const { queryByLabelText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={msgs}
+        isStreaming={true}
+        turnCount={0}
+        error={null}
+        onDismissError={NOOP}
+        onFollowUp={NOOP}
+        onContinueInTab={NOOP}
+      />,
+    );
+    expect(queryByLabelText('Ask: x')).toBeNull();
+  });
+
+  it('renders an error banner that calls onDismissError on press', () => {
+    const onDismissError = jest.fn();
+    const { getByLabelText } = renderWithProviders(
+      <PeekMiniConversation
+        messages={[]}
+        isStreaming={false}
+        turnCount={0}
+        error={new AmicusError('OFFLINE', 'no net')}
+        onDismissError={onDismissError}
+        onFollowUp={NOOP}
+        onContinueInTab={NOOP}
+      />,
+    );
+    fireEvent.press(getByLabelText(/Amicus needs a connection.*dismiss/));
+    expect(onDismissError).toHaveBeenCalled();
+  });
+});

--- a/app/src/hooks/__tests__/usePeekConversation.test.tsx
+++ b/app/src/hooks/__tests__/usePeekConversation.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for usePeekConversation — ephemeral peek-sheet chat state.
+ *
+ * streamChat is stubbed so the hook is exercised without network I/O.
+ */
+import { act, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+import { AmicusError } from '@/services/amicus';
+import type { streamChat as streamChatFn } from '@/services/amicus/chat';
+
+type StreamChatParams = Parameters<typeof streamChatFn>[0];
+
+let lastStreamParams: StreamChatParams | null = null;
+const mockStreamChat = jest.fn(async (params: StreamChatParams) => {
+  lastStreamParams = params;
+});
+
+jest.mock('@/services/amicus/chat', () => ({
+  streamChat: (p: StreamChatParams) => mockStreamChat(p),
+}));
+
+import { usePeekConversation } from '@/hooks/usePeekConversation';
+
+function Harness({
+  onReady,
+}: {
+  onReady: (api: ReturnType<typeof usePeekConversation>) => void;
+}) {
+  const api = usePeekConversation({ getAuthToken: () => 'tok' });
+  React.useEffect(() => {
+    onReady(api);
+  }, [api, onReady]);
+  return <Text>{api.messages.length}</Text>;
+}
+
+function mount(): Promise<{
+  api: () => ReturnType<typeof usePeekConversation>;
+}> {
+  let latest: ReturnType<typeof usePeekConversation> | null = null;
+  render(<Harness onReady={(a) => (latest = a)} />);
+  return Promise.resolve({ api: () => latest! });
+}
+
+describe('usePeekConversation', () => {
+  beforeEach(() => {
+    mockStreamChat.mockClear();
+    lastStreamParams = null;
+  });
+
+  it('no-ops if text is empty', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('   ');
+    });
+    expect(mockStreamChat).not.toHaveBeenCalled();
+    expect(api().messages).toHaveLength(0);
+  });
+
+  it('appends user + streaming assistant message when send() is called', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('what is grace?', { book_id: 'romans', chapter_num: 5 });
+    });
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+    expect(lastStreamParams?.userQuery).toBe('what is grace?');
+    expect(lastStreamParams?.currentChapterRef).toEqual({
+      book_id: 'romans',
+      chapter_num: 5,
+    });
+    const msgs = api().messages;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe('user');
+    expect(msgs[0]!.content).toBe('what is grace?');
+    expect(msgs[1]!.role).toBe('assistant');
+    expect(msgs[1]!.isStreaming).toBe(true);
+  });
+
+  it('updates assistant content on onDelta and completes on onComplete', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('hi');
+    });
+    await act(async () => {
+      lastStreamParams!.onDelta('Hello');
+      lastStreamParams!.onDelta(' world.');
+    });
+    expect(api().messages[1]!.content).toBe('Hello world.');
+
+    await act(async () => {
+      lastStreamParams!.onComplete({
+        prose: 'Hello world.',
+        nodes: [{ type: 'text', text: 'Hello world.' }],
+        citations: [
+          {
+            chunk_id: 'c1',
+            source_type: 'section_panel',
+            source_id: 'c1',
+            display_label: 'Calvin',
+            scholar_id: 'calvin',
+          },
+        ],
+        follow_ups: ['Tell me more'],
+        gap_signal: null,
+      });
+    });
+
+    const last = api().messages[1]!;
+    expect(last.content).toBe('Hello world.');
+    expect(last.isStreaming).toBe(false);
+    expect(last.citations).toHaveLength(1);
+    expect(last.citations![0]!.chunk_id).toBe('c1');
+    expect(last.follow_ups).toEqual(['Tell me more']);
+    expect(api().isStreaming).toBe(false);
+    expect(api().turnCount).toBe(1);
+  });
+
+  it('drops the streaming placeholder on onError and surfaces the error', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('hi');
+    });
+    await act(async () => {
+      lastStreamParams!.onError(new AmicusError('OFFLINE', 'no net'));
+    });
+    expect(api().messages).toHaveLength(1);
+    expect(api().messages[0]!.role).toBe('user');
+    expect(api().error?.code).toBe('OFFLINE');
+    expect(api().isStreaming).toBe(false);
+  });
+
+  it('clearError resets the error without dropping messages', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('hi');
+    });
+    await act(async () => {
+      lastStreamParams!.onError(new AmicusError('OFFLINE', 'x'));
+    });
+    expect(api().error).not.toBeNull();
+    await act(async () => {
+      api().clearError();
+    });
+    expect(api().error).toBeNull();
+  });
+
+  it('reset clears messages and aborts any in-flight stream', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('hi');
+    });
+    expect(api().messages).toHaveLength(2);
+    await act(async () => {
+      api().reset();
+    });
+    expect(api().messages).toHaveLength(0);
+    expect(api().isStreaming).toBe(false);
+    expect(lastStreamParams!.signal.aborted).toBe(true);
+  });
+
+  it('snapshotForPromotion returns messages with isStreaming flags cleared', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('hi');
+    });
+    const snap = api().snapshotForPromotion();
+    expect(snap).toHaveLength(2);
+    for (const m of snap) {
+      expect(m.isStreaming).toBe(false);
+    }
+  });
+
+  it('sends prior conversation_history on subsequent sends', async () => {
+    const { api } = await mount();
+    await act(async () => {
+      await api().send('first');
+    });
+    await act(async () => {
+      lastStreamParams!.onComplete({
+        prose: 'answer 1',
+        nodes: [{ type: 'text', text: 'answer 1' }],
+        citations: [],
+        follow_ups: [],
+        gap_signal: null,
+      });
+    });
+    await act(async () => {
+      await api().send('second');
+    });
+    expect(lastStreamParams!.conversationHistory).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'answer 1' },
+    ]);
+  });
+});

--- a/app/src/hooks/usePeekConversation.ts
+++ b/app/src/hooks/usePeekConversation.ts
@@ -1,0 +1,197 @@
+/**
+ * hooks/usePeekConversation.ts — Ephemeral conversation state for the
+ * Amicus FAB peek (#1463).
+ *
+ * Messages live in hook memory only — they never touch user.db unless the
+ * user promotes them via the "Continue in Amicus tab →" CTA (#1464). On
+ * peek dismissal the state is discarded.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { AmicusError } from '@/services/amicus';
+import { streamChat } from '@/services/amicus/chat';
+import type { AmicusCitation } from '@/types';
+import { logger } from '@/utils/logger';
+
+export interface PeekMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: AmicusCitation[];
+  follow_ups?: string[];
+  isStreaming?: boolean;
+}
+
+export interface ChapterRef {
+  book_id: string;
+  chapter_num: number;
+}
+
+export interface UsePeekConversationResult {
+  messages: PeekMessage[];
+  isStreaming: boolean;
+  /** A "turn" = one completed user → assistant round. */
+  turnCount: number;
+  error: AmicusError | null;
+  send: (text: string, chapterRef?: ChapterRef | null) => Promise<void>;
+  reset: () => void;
+  abort: () => void;
+  snapshotForPromotion: () => PeekMessage[];
+  clearError: () => void;
+}
+
+export interface UsePeekConversationOptions {
+  getAuthToken?: () => string;
+  fetchImpl?: typeof fetch;
+}
+
+export function usePeekConversation(
+  opts: UsePeekConversationOptions = {},
+): UsePeekConversationResult {
+  const [messages, setMessages] = useState<PeekMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<AmicusError | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const turnCount = useMemo(
+    () => messages.filter((m) => m.role === 'assistant' && !m.isStreaming).length,
+    [messages],
+  );
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    setMessages([]);
+    setError(null);
+    setIsStreaming(false);
+  }, []);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+    setIsStreaming(false);
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const send = useCallback(
+    async (text: string, chapterRef?: ChapterRef | null): Promise<void> => {
+      const trimmed = text.trim();
+      if (!trimmed || isStreaming) return;
+
+      const authToken =
+        opts.getAuthToken?.() ?? process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '';
+      if (!authToken) {
+        logger.warn('AmicusPeek', 'no auth token — peek send aborted');
+        return;
+      }
+
+      // Snapshot history before we append — matches the order the server
+      // expects (oldest → newest).
+      const history = messages.map((m) => ({ role: m.role, content: m.content }));
+
+      const userMsg: PeekMessage = { role: 'user', content: trimmed };
+      const assistantMsg: PeekMessage = {
+        role: 'assistant',
+        content: '',
+        citations: [],
+        follow_ups: [],
+        isStreaming: true,
+      };
+      setMessages((prev) => [...prev, userMsg, assistantMsg]);
+      setIsStreaming(true);
+      setError(null);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      let streamed = '';
+      const citations: AmicusCitation[] = [];
+
+      await streamChat({
+        threadId: 'peek-ephemeral',
+        userQuery: trimmed,
+        conversationHistory: history,
+        currentChapterRef: chapterRef ?? null,
+        authToken,
+        signal: controller.signal,
+        fetchImpl: opts.fetchImpl,
+        onDelta: (token) => {
+          streamed += token;
+          setMessages((prev) => {
+            const next = [...prev];
+            const last = next[next.length - 1];
+            if (last && last.role === 'assistant') {
+              next[next.length - 1] = { ...last, content: streamed };
+            }
+            return next;
+          });
+        },
+        onCitation: (pill) => {
+          citations.push({
+            chunk_id: pill.chunk_id,
+            source_type: pill.source_type,
+            display_label: pill.display_label,
+            scholar_id: pill.scholar_id,
+          });
+          setMessages((prev) => {
+            const next = [...prev];
+            const last = next[next.length - 1];
+            if (last && last.role === 'assistant') {
+              next[next.length - 1] = { ...last, citations: [...citations] };
+            }
+            return next;
+          });
+        },
+        onGapSignal: (gap) => {
+          logger.info('AmicusPeek', `gap_signal: ${JSON.stringify(gap)}`);
+        },
+        onComplete: (final) => {
+          setMessages((prev) => {
+            const next = [...prev];
+            const last = next[next.length - 1];
+            if (last && last.role === 'assistant') {
+              next[next.length - 1] = {
+                ...last,
+                content: final.prose,
+                citations: final.citations.map((c) => ({
+                  chunk_id: c.chunk_id,
+                  source_type: c.source_type,
+                  display_label: c.display_label,
+                  scholar_id: c.scholar_id,
+                })),
+                follow_ups: final.follow_ups,
+                isStreaming: false,
+              };
+            }
+            return next;
+          });
+          setIsStreaming(false);
+        },
+        onError: (err) => {
+          setError(err);
+          setMessages((prev) => prev.filter((m) => !m.isStreaming));
+          setIsStreaming(false);
+        },
+      });
+    },
+    [messages, isStreaming, opts],
+  );
+
+  const snapshotForPromotion = useCallback(
+    (): PeekMessage[] =>
+      messages.map((m) => ({ ...m, isStreaming: false })),
+    [messages],
+  );
+
+  return useMemo(
+    () => ({
+      messages,
+      isStreaming,
+      turnCount,
+      error,
+      send,
+      reset,
+      abort,
+      snapshotForPromotion,
+      clearError,
+    }),
+    [messages, isStreaming, turnCount, error, send, reset, abort, snapshotForPromotion, clearError],
+  );
+}


### PR DESCRIPTION
## Summary

Resolves phase 3, card #1463 of epic #1446. Wires an ephemeral
conversation into the Amicus FAB peek so chip taps and free-text sends
reveal streamed answers in-place.

- `usePeekConversation` hook holds in-memory messages, drives
  `streamChat`, and exposes a `snapshotForPromotion` helper for the
  upcoming "Continue in Amicus tab" handoff (#1464).
- `PeekMiniConversation` renders the reused Assistant/User bubbles,
  follow-up chips, and the handoff CTA that appears once three turns
  have completed. No rendering is duplicated — the existing bubble,
  pill, and chip components from #1455 are reused.
- `AmicusPeekSheet` now expands to the 85% snap when a conversation is
  active, forwards chip/send events through the hook, and resets
  ephemeral state on close.

Messages live in hook memory only — user.db is untouched until the
user promotes the thread via #1464.

## Test plan

- [x] `npx jest src/hooks/__tests__/usePeekConversation.test.tsx` — 8 passing
- [x] `npx jest src/components/amicus/__tests__/PeekMiniConversation.test.tsx` — 7 passing
- [x] `npx jest src/components/amicus/__tests__/AmicusPeekSheet.test.tsx` — 5 passing (including new mini-conversation flow)
- [x] Full suite: 3379 passing
- [x] Coverage thresholds met: 80.39% stmts / 67.34% branch / 72.94% func / 82.18% lines
- [x] `npx tsc --noEmit` clean for all Amicus files
- [x] `npx eslint` clean (0 errors) on modified files

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe