### PR TITLE
fix(eas): development profile targets physical devices instead of simulator

### DIFF
--- a/app/eas.json
+++ b/app/eas.json
@@ -8,7 +8,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "simulator": true
+        "simulator": false
       },
       "channel": "development"
     },


### PR DESCRIPTION
Changes EAS development profile to target physical iOS devices instead of the iOS Simulator.

## Why

Craig works on Windows and cannot run the iOS Simulator locally. The previous `"simulator": true` setting built `.app` bundles that only run in Xcode's iOS Simulator on a Mac — which is useless in this setup. The EAS install URL serves the file as a raw download, not as an installable app, because iOS Safari only recognises ad-hoc-signed IPAs.

## Effect

First build after this change will prompt EAS to register the developer's iPhone UDID with the Apple Developer account (one-time interactive step). Subsequent dev builds are ad-hoc IPAs installable via Safari on any registered device.

## Test

```bash
eas build --platform ios --profile development
# Follow interactive prompts to register device
# Install via Safari link on iPhone
```

No runtime code changed.