### PR TITLE
feat(ai-partner): continue-in-tab handoff from peek (#1464)

### DIFF
--- a/app/src/components/amicus/AmicusPeekSheet.tsx
+++ b/app/src/components/amicus/AmicusPeekSheet.tsx
@@ -20,11 +20,18 @@ import BottomSheet, {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { ArrowUp } from 'lucide-react-native';
-import { useNavigationState } from '@react-navigation/native';
+import {
+  useNavigation,
+  useNavigationState,
+  type NavigationProp,
+  type ParamListBase,
+} from '@react-navigation/native';
 import { useAmicusChips, type ChipContext } from '../../hooks/useAmicusChips';
 import { usePeekConversation } from '../../hooks/usePeekConversation';
+import { promotePeekToThread } from '../../services/amicus/promotePeekToThread';
 import { fontFamily, spacing, useTheme } from '../../theme';
 import type { AmicusCitation } from '../../types';
+import { logger } from '../../utils/logger';
 import PeekMiniConversation from './PeekMiniConversation';
 
 export interface AmicusPeekSheetProps {
@@ -38,10 +45,12 @@ export interface AmicusPeekSheetProps {
   onSend?: (text: string) => void;
   /** Navigate to the citation target and close the peek (wired by parent). */
   onCitationPress?: (c: AmicusCitation) => void;
-  /** Promote the peek conversation to a persistent thread (#1464). */
-  onContinueInTab?: (snapshot: ReturnType<ReturnType<typeof usePeekConversation>['snapshotForPromotion']>) => void | Promise<void>;
-  /** Expose when handoff is in progress (disables the CTA). */
-  handoffInProgress?: boolean;
+  /**
+   * Override the default handoff behavior (#1464). Tests inject this to
+   * avoid touching the real user.db. Production uses the built-in
+   * `promotePeekToThread` service directly.
+   */
+  onContinueInTab?: (snapshot: ReturnType<ReturnType<typeof usePeekConversation>['snapshotForPromotion']>) => Promise<void> | void;
 }
 
 export default function AmicusPeekSheet(
@@ -51,9 +60,12 @@ export default function AmicusPeekSheet(
   const sheetRef = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => ['50%', '85%'], []);
 
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const ctx = useNavigationContext(props.contextOverride);
   const { chips } = useAmicusChips(ctx);
   const [text, setText] = useState('');
+  const [handoffInProgress, setHandoffInProgress] = useState(false);
+  const [handoffError, setHandoffError] = useState<string | null>(null);
   const peek = usePeekConversation();
   const hasConversation = peek.messages.length > 0;
 
@@ -69,7 +81,11 @@ export default function AmicusPeekSheet(
 
   // Reset the ephemeral conversation whenever the peek closes.
   useEffect(() => {
-    if (!props.isOpen) peek.reset();
+    if (!props.isOpen) {
+      peek.reset();
+      setHandoffInProgress(false);
+      setHandoffError(null);
+    }
     // `peek.reset` is stable via useCallback, but exhaustive-deps can't see it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.isOpen]);
@@ -108,10 +124,33 @@ export default function AmicusPeekSheet(
     void peek.send(trimmed, chapterRef);
   }, [text, props, peek, chapterRef]);
 
-  const handleContinueInTab = useCallback(() => {
-    if (!props.onContinueInTab) return;
-    void props.onContinueInTab(peek.snapshotForPromotion());
-  }, [props, peek]);
+  const handleContinueInTab = useCallback(async () => {
+    if (handoffInProgress) return;
+    setHandoffInProgress(true);
+    setHandoffError(null);
+    const snapshot = peek.snapshotForPromotion();
+    try {
+      if (props.onContinueInTab) {
+        await props.onContinueInTab(snapshot);
+      } else {
+        await promotePeekToThread({
+          peekMessages: snapshot,
+          chapterRef,
+          navigation,
+        });
+      }
+      props.onClose();
+    } catch (err) {
+      logger.error('AmicusPeek', `handoff failed: ${String(err)}`);
+      setHandoffError("Couldn't save conversation — try again");
+      setHandoffInProgress(false);
+    }
+  }, [handoffInProgress, peek, props, chapterRef, navigation]);
+
+  const dismissHandoffError = useCallback(
+    () => setHandoffError(null),
+    [],
+  );
 
   if (!props.isOpen) return null;
 
@@ -156,11 +195,12 @@ export default function AmicusPeekSheet(
             isStreaming={peek.isStreaming}
             turnCount={peek.turnCount}
             error={peek.error}
-            onDismissError={peek.clearError}
+            handoffError={handoffError}
+            onDismissError={handoffError ? dismissHandoffError : peek.clearError}
             onCitationPress={props.onCitationPress}
             onFollowUp={(t) => void peek.send(t, chapterRef)}
-            onContinueInTab={handleContinueInTab}
-            handoffInProgress={props.handoffInProgress === true}
+            onContinueInTab={() => void handleContinueInTab()}
+            handoffInProgress={handoffInProgress}
           />
         ) : (
           <View style={styles.chipArea}>

--- a/app/src/components/amicus/PeekMiniConversation.tsx
+++ b/app/src/components/amicus/PeekMiniConversation.tsx
@@ -35,6 +35,8 @@ export interface PeekMiniConversationProps {
   onContinueInTab: () => void;
   /** Shown when handoff is in progress. */
   handoffInProgress?: boolean;
+  /** Custom string error specific to the handoff flow (#1464). */
+  handoffError?: string | null;
 }
 
 export default function PeekMiniConversation(
@@ -97,9 +99,11 @@ export default function PeekMiniConversation(
         )}
       </ScrollView>
 
-      {props.error && (
+      {(props.handoffError || props.error) && (
         <Pressable
-          accessibilityLabel={`${errorCopy(props.error)}. Tap to dismiss.`}
+          accessibilityLabel={`${
+            props.handoffError ?? errorCopy(props.error!)
+          }. Tap to dismiss.`}
           onPress={props.onDismissError}
           style={[
             styles.errorBanner,
@@ -109,7 +113,7 @@ export default function PeekMiniConversation(
           <Text
             style={[styles.errorText, { color: base.text, fontFamily: fontFamily.body }]}
           >
-            {errorCopy(props.error)}
+            {props.handoffError ?? errorCopy(props.error!)}
           </Text>
         </Pressable>
       )}

--- a/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
@@ -47,6 +47,32 @@ beforeEach(() => {
   process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'tok';
 });
 
+async function completeTurn(prose: string): Promise<void> {
+  await act(async () => {
+    lastStreamParams!.onComplete({
+      prose,
+      nodes: [{ type: 'text', text: prose }],
+      citations: [],
+      follow_ups: [],
+      gap_signal: null,
+    });
+  });
+}
+
+type GetByLabelText = ReturnType<typeof renderWithProviders>['getByLabelText'];
+
+async function sendFromInput(
+  getByLabelText: GetByLabelText,
+  text: string,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.changeText(getByLabelText('Message Amicus from peek'), text);
+  });
+  await act(async () => {
+    fireEvent.press(getByLabelText('Send'));
+  });
+}
+
 describe('AmicusPeekSheet', () => {
   it('renders chips from the precached_prompts table', async () => {
     getMockDb().getFirstAsync.mockResolvedValueOnce({
@@ -140,6 +166,120 @@ describe('AmicusPeekSheet', () => {
       lastStreamParams!.onDelta('covenant love.');
     });
     expect(await findByText(/covenant love/)).toBeTruthy();
+  });
+
+  it('invokes onContinueInTab with a snapshot and closes the peek on success', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'Explain hesed',
+          seed_query: 'What is hesed?',
+          expected_source_types: ['word_study'],
+        },
+      ]),
+    });
+    const onContinueInTab = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const { findByLabelText, getByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={onClose}
+        contextOverride={{ kind: 'chapter', bookId: 'psalms', chapterNum: 23 }}
+        onContinueInTab={onContinueInTab}
+      />,
+    );
+    // Ramp up to three completed turns so the CTA appears.
+    fireEvent.press(await findByLabelText('Ask: Explain hesed'));
+    await completeTurn('answer 0');
+    await sendFromInput(getByLabelText, 'follow up 1');
+    await completeTurn('answer 1');
+    await sendFromInput(getByLabelText, 'follow up 2');
+    await completeTurn('answer 2');
+    const cta = await findByLabelText('Continue in Amicus tab');
+    await act(async () => {
+      fireEvent.press(cta);
+    });
+    expect(onContinueInTab).toHaveBeenCalledTimes(1);
+    const snapshot = onContinueInTab.mock.calls[0]![0];
+    expect(Array.isArray(snapshot)).toBe(true);
+    expect(snapshot.every((m: { isStreaming?: boolean }) => !m.isStreaming)).toBe(true);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps the peek open and surfaces an error banner when the handoff fails', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'Explain hesed',
+          seed_query: 'What is hesed?',
+          expected_source_types: ['word_study'],
+        },
+      ]),
+    });
+    const onContinueInTab = jest
+      .fn()
+      .mockRejectedValue(new Error('disk full'));
+    const onClose = jest.fn();
+    const { findByLabelText, findByText, getByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={onClose}
+        contextOverride={{ kind: 'chapter', bookId: 'psalms', chapterNum: 23 }}
+        onContinueInTab={onContinueInTab}
+      />,
+    );
+    fireEvent.press(await findByLabelText('Ask: Explain hesed'));
+    await completeTurn('answer 0');
+    await sendFromInput(getByLabelText, 'follow up 1');
+    await completeTurn('answer 1');
+    await sendFromInput(getByLabelText, 'follow up 2');
+    await completeTurn('answer 2');
+    const cta = await findByLabelText('Continue in Amicus tab');
+    await act(async () => {
+      fireEvent.press(cta);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(await findByText(/Couldn't save conversation/)).toBeTruthy();
+  });
+
+  it('ignores double-taps while handoff is in progress', async () => {
+    getMockDb().getFirstAsync.mockResolvedValueOnce({
+      chips_json: JSON.stringify([
+        {
+          label: 'Explain hesed',
+          seed_query: 'What is hesed?',
+          expected_source_types: ['word_study'],
+        },
+      ]),
+    });
+    let release!: () => void;
+    const pending = new Promise<void>((r) => {
+      release = r;
+    });
+    const onContinueInTab = jest.fn().mockReturnValue(pending);
+    const { findByLabelText, getByLabelText } = renderWithProviders(
+      <AmicusPeekSheet
+        isOpen
+        onClose={() => undefined}
+        contextOverride={{ kind: 'chapter', bookId: 'psalms', chapterNum: 23 }}
+        onContinueInTab={onContinueInTab}
+      />,
+    );
+    fireEvent.press(await findByLabelText('Ask: Explain hesed'));
+    await completeTurn('a0');
+    await sendFromInput(getByLabelText, 'follow up 1');
+    await completeTurn('a1');
+    await sendFromInput(getByLabelText, 'follow up 2');
+    await completeTurn('a2');
+    const cta = await findByLabelText('Continue in Amicus tab');
+    fireEvent.press(cta);
+    fireEvent.press(cta);
+    fireEvent.press(cta);
+    expect(onContinueInTab).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release();
+      await pending;
+    });
   });
 
   it('returns nothing when isOpen is false', () => {

--- a/app/src/services/amicus/__tests__/promotePeekToThread.test.ts
+++ b/app/src/services/amicus/__tests__/promotePeekToThread.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for promotePeekToThread — handoff from peek to persistent thread.
+ */
+import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
+import type { PeekMessage } from '@/hooks/usePeekConversation';
+import {
+  buildThreadTitle,
+  promotePeekToThread,
+  type PromoteNavigation,
+} from '@/services/amicus/promotePeekToThread';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+function makeNav(): { nav: PromoteNavigation; parentNavigate: jest.Mock } {
+  const parentNavigate = jest.fn();
+  const nav: PromoteNavigation = {
+    getParent: () => ({ navigate: parentNavigate }),
+  };
+  return { nav, parentNavigate };
+}
+
+const threeTurnPeek: PeekMessage[] = [
+  { role: 'user', content: 'Explain election in Romans 9' },
+  {
+    role: 'assistant',
+    content: 'Calvin and Barth differ here.',
+    citations: [
+      {
+        chunk_id: 'section_panel:romans-9-s1-calvin',
+        source_type: 'section_panel',
+        display_label: 'Calvin · Romans 9',
+        scholar_id: 'calvin',
+      },
+    ],
+    follow_ups: ['What does Barth say?'],
+    isStreaming: false,
+  },
+  { role: 'user', content: 'What does Barth say?' },
+  {
+    role: 'assistant',
+    content: 'Barth reframes election christologically.',
+    citations: [],
+    follow_ups: [],
+    isStreaming: false,
+  },
+  { role: 'user', content: 'And the Jewish view?' },
+  {
+    role: 'assistant',
+    content: 'Rabbinic tradition reads it corporately.',
+    citations: [],
+    follow_ups: [],
+    isStreaming: false,
+  },
+];
+
+describe('buildThreadTitle', () => {
+  it('returns the fallback for very short first messages', () => {
+    expect(buildThreadTitle('hi')).toBe('New Amicus conversation');
+    expect(buildThreadTitle('')).toBe('New Amicus conversation');
+    expect(buildThreadTitle(undefined)).toBe('New Amicus conversation');
+  });
+
+  it('returns the raw text when under the 50-char limit', () => {
+    expect(buildThreadTitle('What does the Hebrew chesed mean?')).toBe(
+      'What does the Hebrew chesed mean?',
+    );
+  });
+
+  it('truncates at a word boundary and appends an ellipsis when over the limit', () => {
+    const title = buildThreadTitle(
+      'Why do Reformed and Jewish scholars read election differently here?',
+    );
+    expect(title.endsWith('…')).toBe(true);
+    expect(title.length).toBeLessThanOrEqual(51);
+    // No trailing whitespace directly before the ellipsis.
+    expect(title).not.toMatch(/\s…$/);
+    // And the cut happened on a word boundary — the original text should
+    // contain the title's prose prefix followed by a space.
+    expect(
+      'Why do Reformed and Jewish scholars read election differently here?'.startsWith(
+        title.slice(0, -1) + ' ',
+      ),
+    ).toBe(true);
+  });
+
+  it('hard-cuts when there is no usable word boundary', () => {
+    const title = buildThreadTitle('a'.repeat(80));
+    expect(title).toBe('a'.repeat(50) + '…');
+  });
+
+  it('trims whitespace before deciding length', () => {
+    expect(buildThreadTitle('   short   ')).toBe('New Amicus conversation');
+  });
+});
+
+describe('promotePeekToThread', () => {
+  beforeEach(() => resetMockUserDb());
+
+  it('creates a thread + all messages then navigates to AmicusTab/Thread', async () => {
+    const { nav, parentNavigate } = makeNav();
+    const db = getMockUserDb();
+    let idCounter = 0;
+    const makeId = (prefix: string) => `${prefix}-${idCounter++}`;
+
+    const threadId = await promotePeekToThread({
+      peekMessages: threeTurnPeek,
+      chapterRef: { book_id: 'romans', chapter_num: 9 },
+      navigation: nav,
+      makeId,
+    });
+
+    expect(threadId).toBe('t-0');
+
+    const insertCalls = db.runAsync.mock.calls;
+    const threadInsert = insertCalls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO amicus_threads'),
+    );
+    expect(threadInsert).toBeDefined();
+    expect(threadInsert![1]).toEqual([
+      't-0',
+      'Explain election in Romans 9',
+      'romans/9',
+    ]);
+
+    const messageInserts = insertCalls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO amicus_messages'),
+    );
+    expect(messageInserts).toHaveLength(threeTurnPeek.length);
+
+    // First assistant message should have citations + follow_ups serialized.
+    const firstAssistant = messageInserts[1]!;
+    expect(firstAssistant[1]![2]).toBe('assistant');
+    expect(firstAssistant[1]![4]).toContain('section_panel:romans-9-s1-calvin');
+    expect(firstAssistant[1]![5]).toContain('What does Barth say?');
+
+    expect(parentNavigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'Thread',
+      params: { threadId: 't-0' },
+    });
+  });
+
+  it('passes null chapter_ref when the peek has no chapter context', async () => {
+    const { nav } = makeNav();
+    const db = getMockUserDb();
+
+    await promotePeekToThread({
+      peekMessages: [
+        { role: 'user', content: 'what is grace generally?' },
+        { role: 'assistant', content: 'A gift.', isStreaming: false },
+      ],
+      chapterRef: null,
+      navigation: nav,
+    });
+
+    const threadInsert = db.runAsync.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO amicus_threads'),
+    );
+    expect(threadInsert![1]![2]).toBeNull();
+  });
+
+  it('propagates a DB error so the caller can keep the peek open', async () => {
+    const { nav, parentNavigate } = makeNav();
+    const db = getMockUserDb();
+    db.runAsync.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(
+      promotePeekToThread({
+        peekMessages: threeTurnPeek,
+        navigation: nav,
+      }),
+    ).rejects.toThrow('disk full');
+
+    expect(parentNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still completes the write when there is no parent navigator', async () => {
+    const db = getMockUserDb();
+    const navNoParent: PromoteNavigation = { getParent: () => undefined };
+
+    const threadId = await promotePeekToThread({
+      peekMessages: [
+        { role: 'user', content: 'hello there friend' },
+        { role: 'assistant', content: 'hi', isStreaming: false },
+      ],
+      navigation: navNoParent,
+    });
+
+    expect(threadId).toMatch(/^t-/);
+    expect(db.runAsync).toHaveBeenCalled();
+  });
+});

--- a/app/src/services/amicus/promotePeekToThread.ts
+++ b/app/src/services/amicus/promotePeekToThread.ts
@@ -1,0 +1,106 @@
+/**
+ * services/amicus/promotePeekToThread.ts — Handoff (#1464) that turns an
+ * ephemeral peek conversation into a persistent Amicus thread.
+ *
+ * The peek (#1463) lives in hook memory only. When the user taps
+ * "Continue in Amicus tab →" on turn 3+, this module writes the thread
+ * + messages to user.db and navigates into the Amicus tab.
+ */
+import {
+  appendAmicusMessage,
+  createAmicusThread,
+} from '@/db/userMutations';
+import { logger } from '@/utils/logger';
+import type { PeekMessage } from '@/hooks/usePeekConversation';
+
+export interface PromoteChapterRef {
+  book_id: string;
+  chapter_num: number;
+}
+
+/** Minimal nav surface — lets us unit-test without pulling in react-navigation. */
+export interface PromoteNavigation {
+  getParent: () => { navigate: (name: string, params?: unknown) => void } | undefined;
+}
+
+export interface PromotePeekToThreadParams {
+  peekMessages: PeekMessage[];
+  chapterRef?: PromoteChapterRef | null;
+  navigation: PromoteNavigation;
+  /** Injectable for tests. */
+  makeId?: (prefix: string) => string;
+}
+
+const TITLE_MAX_CHARS = 50;
+const TITLE_MIN_CHARS = 10;
+const FALLBACK_TITLE = 'New Amicus conversation';
+
+export function buildThreadTitle(firstUserMessage: string | undefined): string {
+  const trimmed = (firstUserMessage ?? '').trim();
+  if (trimmed.length < TITLE_MIN_CHARS) return FALLBACK_TITLE;
+  if (trimmed.length <= TITLE_MAX_CHARS) return trimmed;
+
+  const slice = trimmed.slice(0, TITLE_MAX_CHARS);
+  const lastSpace = slice.lastIndexOf(' ');
+  // Only break on a word boundary if it gets us past the minimum.
+  const cut = lastSpace >= TITLE_MIN_CHARS ? slice.slice(0, lastSpace) : slice;
+  return `${cut}…`;
+}
+
+function defaultMakeId(prefix: string): string {
+  const r = Math.random().toString(16).slice(2, 10);
+  const t = Date.now().toString(16);
+  return `${prefix}-${t}-${r}`;
+}
+
+function serializeChapterRef(ref: PromoteChapterRef | null | undefined): string | null {
+  if (!ref) return null;
+  return `${ref.book_id}/${ref.chapter_num}`;
+}
+
+/**
+ * Creates a persistent thread from a peek conversation.
+ *
+ * Throws if the DB write fails. Callers are expected to catch and render a
+ * toast/error banner (the peek stays open so the user can retry).
+ */
+export async function promotePeekToThread(
+  params: PromotePeekToThreadParams,
+): Promise<string> {
+  const mkId = params.makeId ?? defaultMakeId;
+  const threadId = mkId('t');
+
+  const firstUser = params.peekMessages.find((m) => m.role === 'user');
+  const title = buildThreadTitle(firstUser?.content);
+  const chapterRef = serializeChapterRef(params.chapterRef);
+
+  await createAmicusThread({ threadId, title, chapterRef });
+
+  for (const msg of params.peekMessages) {
+    await appendAmicusMessage({
+      messageId: mkId('m'),
+      threadId,
+      role: msg.role,
+      content: msg.content,
+      citations: msg.citations?.map((c) => ({
+        chunk_id: c.chunk_id,
+        source_type: c.source_type,
+        display_label: c.display_label,
+        scholar_id: c.scholar_id,
+      })),
+      followUps: msg.follow_ups,
+    });
+  }
+
+  const parent = params.navigation.getParent();
+  if (parent) {
+    parent.navigate('AmicusTab', {
+      screen: 'Thread',
+      params: { threadId },
+    });
+  } else {
+    logger.warn('AmicusPeek', 'handoff: no parent navigator; thread saved but no nav');
+  }
+
+  return threadId;
+}


### PR DESCRIPTION
## Summary

Resolves phase 3, card #1464 of epic #1446. Completes the FAB-peek → Amicus tab story arc.

- New `promotePeekToThread` service generates a word-boundary-truncated title from the first user message, creates the thread row in `amicus_threads`, replays each peek message into `amicus_messages` (citations + follow_ups serialized), and navigates via `parent.navigate('AmicusTab', { screen: 'Thread' })`.
- `AmicusPeekSheet` wires the CTA to the service, tracks `handoffInProgress` to prevent double-taps, and surfaces `"Couldn't save conversation — try again"` on DB failure. On failure the peek stays open so the user can retry — nothing is lost.
- `PeekMiniConversation` accepts an optional `handoffError` string so handoff failures render cleanly without overloading the streaming-error code set.

Title generation cases:
- `< 10` chars → `"New Amicus conversation"` fallback
- `≤ 50` chars → raw text
- `> 50` chars → truncated at a word boundary with trailing `…` (hard-cut if no usable boundary)

## Acceptance criteria

- [x] CTA appears at turn 3 (inherited from #1463)
- [x] Tap creates thread with generated title, writes all messages
- [x] Navigation lands on `AmicusTab/Thread` with the new threadId
- [x] Peek closes after navigation
- [x] Underlying screen state preserved (standard peek-dismissal)
- [x] Double-tap prevented; CTA shows `"Saving…"` during save
- [x] DB failure → banner + peek stays open; messages preserved
- [x] Unit tests: title generation (5 cases), happy path, DB failure, missing parent nav, peek-integration (CTA/error/double-tap)
- [x] No `any` types; lint clean

## Test plan

- [x] `npx jest src/services/amicus/__tests__/promotePeekToThread.test.ts` — 9 passing
- [x] `npx jest src/components/amicus/__tests__/AmicusPeekSheet.test.tsx` — 8 passing (3 new peek-integration tests)
- [x] Full suite: 3391 passing
- [x] Coverage thresholds met: 80.53 / 67.47 / 73.06 / 82.31 (vs required 80 / 65 / 72 / 82)
- [x] `npx tsc --noEmit` clean for all Amicus files
- [x] `npx eslint` clean (0 errors, 0 warnings) on changed files

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe