### PR TITLE
feat(ai-partner): daily proactive prompt generation (#1465)

### DIFF
--- a/ai-proxy/src/dailyPrompt.ts
+++ b/ai-proxy/src/dailyPrompt.ts
@@ -1,0 +1,177 @@
+/**
+ * dailyPrompt.ts — "Amicus noticed..." proactive prompt generator (#1465).
+ *
+ * One non-streaming Haiku call per user per day. The system prompt is
+ * identical for every user, so it benefits from Anthropic prompt caching —
+ * the user-specific signals (profile, recent chapters, client date) stay in
+ * the user message so the system block is a stable cache key.
+ */
+import type { Env } from './types';
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+export const DAILY_PROMPT_MODEL = 'claude-haiku-4-5-20251001';
+const MAX_TOKENS = 180;
+
+export const DAILY_PROMPT_SYSTEM = `You are Amicus, a scholarly study partner for the Companion Study Bible app.
+
+Generate a brief "Amicus noticed..." proactive study prompt for this user based on their recent reading pattern. It should reference something specific they have been studying and suggest a direction they have not explored yet.
+
+Rules:
+- Length: exactly 2 sentences, max ~280 characters of prose.
+- Warm tone, never preachy or moralizing.
+- End the prose with a question the user can tap to explore.
+- Respond ONLY with a single JSON object on a single line (no code fences, no commentary) with the shape:
+  {"prompt_text": "...", "seed_query": "..."}
+- prompt_text is the two-sentence prose shown on the home card.
+- seed_query is the question sent into a fresh Amicus thread when the user taps the card — it should re-state the question in first-person ("What does...", "How do...") so the AI can answer it directly.`;
+
+export interface DailyPromptRequest {
+  profile_summary: string;
+  last_5_chapters: string[];
+  client_date: string; // YYYY-MM-DD
+}
+
+export interface DailyPromptResponse {
+  prompt_text: string;
+  seed_query: string;
+  cached_until: string;
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateDailyPromptRequest(
+  body: unknown,
+): DailyPromptRequest | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b.profile_summary !== 'string') return null;
+  if (!Array.isArray(b.last_5_chapters)) return null;
+  if (!b.last_5_chapters.every((x) => typeof x === 'string')) return null;
+  if (typeof b.client_date !== 'string' || !ISO_DATE_RE.test(b.client_date)) {
+    return null;
+  }
+  return {
+    profile_summary: b.profile_summary,
+    last_5_chapters: b.last_5_chapters as string[],
+    client_date: b.client_date,
+  };
+}
+
+export function buildUserMessage(req: DailyPromptRequest): string {
+  const chapters =
+    req.last_5_chapters.length > 0
+      ? req.last_5_chapters.join(', ')
+      : '(none yet)';
+  const profile = req.profile_summary.trim() || '(no profile yet)';
+  return `Today: ${req.client_date}
+Recent chapters: ${chapters}
+User profile: ${profile}`;
+}
+
+function cachedUntilFor(clientDate: string): string {
+  // 24h past the start of the user's local date → ISO string in UTC.
+  const parsed = new Date(`${clientDate}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + 1);
+  return parsed.toISOString();
+}
+
+interface AnthropicMessagesResponse {
+  content?: Array<{ type: string; text?: string }>;
+}
+
+export interface GenerateArgs {
+  req: DailyPromptRequest;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Calls Anthropic and returns a parsed DailyPromptResponse, or throws for
+ * any upstream failure. Callers map thrown errors to HTTP responses.
+ */
+export async function generateDailyPrompt(
+  args: GenerateArgs,
+): Promise<DailyPromptResponse> {
+  const fetchImpl = args.fetchImpl ?? fetch;
+
+  const body = {
+    model: DAILY_PROMPT_MODEL,
+    max_tokens: MAX_TOKENS,
+    system: [
+      {
+        type: 'text' as const,
+        text: DAILY_PROMPT_SYSTEM,
+        cache_control: { type: 'ephemeral' as const },
+      },
+    ],
+    messages: [
+      { role: 'user' as const, content: buildUserMessage(args.req) },
+    ],
+  };
+
+  const upstream = await fetchImpl(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': args.apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-no-retention': 'true',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!upstream.ok) {
+    throw new Error(`anthropic_error_${upstream.status}`);
+  }
+
+  const payload = (await upstream.json()) as AnthropicMessagesResponse;
+  const text = payload.content
+    ?.filter((c) => c.type === 'text' && typeof c.text === 'string')
+    .map((c) => c.text as string)
+    .join('')
+    .trim();
+  if (!text) throw new Error('anthropic_empty_response');
+
+  const parsed = parseModelPayload(text);
+  if (!parsed) throw new Error('anthropic_bad_shape');
+
+  return {
+    prompt_text: parsed.prompt_text,
+    seed_query: parsed.seed_query,
+    cached_until: cachedUntilFor(args.req.client_date),
+  };
+}
+
+/**
+ * Accepts either a bare JSON object or one wrapped in a ```json ... ``` fence
+ * (models occasionally add fences despite instructions).
+ */
+export function parseModelPayload(
+  raw: string,
+): { prompt_text: string; seed_query: string } | null {
+  const stripped = raw
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```\s*$/i, '')
+    .trim();
+  let obj: unknown;
+  try {
+    obj = JSON.parse(stripped);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.prompt_text !== 'string' || o.prompt_text.length === 0) {
+    return null;
+  }
+  if (typeof o.seed_query !== 'string' || o.seed_query.length === 0) {
+    return null;
+  }
+  return { prompt_text: o.prompt_text, seed_query: o.seed_query };
+}
+
+// Exported for tests that want to assert the cached_until computation.
+export { cachedUntilFor };
+
+// Re-export types for index.ts to avoid `import type` churn.
+export type { Env };

--- a/ai-proxy/src/index.ts
+++ b/ai-proxy/src/index.ts
@@ -13,6 +13,10 @@ import { authenticate, type AuthResult } from './auth';
 import { checkAndIncrement } from './rateLimit';
 import { streamChat } from './anthropic';
 import {
+  generateDailyPrompt,
+  validateDailyPromptRequest,
+} from './dailyPrompt';
+import {
   captureGap,
   isLowRetrievalScore,
   parseGapSignal,
@@ -36,6 +40,9 @@ export default {
       }
       if (url.pathname === '/ai/chat' && request.method === 'POST') {
         return handleChat(request, env, ctx, startedAt);
+      }
+      if (url.pathname === '/ai/daily-prompt' && request.method === 'POST') {
+        return handleDailyPrompt(request, env, startedAt);
       }
       if (url.pathname === '/ai/feedback' && request.method === 'POST') {
         return handleFeedback(request, env, startedAt);
@@ -316,6 +323,66 @@ async function embedQuestion(text: string, env: Env): Promise<number[] | null> {
     return vec && vec.length === 1536 ? vec : null;
   } catch {
     return null;
+  }
+}
+
+// ── /ai/daily-prompt ─────────────────────────────────────────────────
+
+async function handleDailyPrompt(
+  request: Request,
+  env: Env,
+  startedAt: number,
+): Promise<Response> {
+  const auth = await authenticate(request.headers.get('Authorization'), env);
+  const authResponse = authToHttp(auth);
+  if (authResponse) return authResponse;
+  const ctx = (auth as Extract<AuthResult, { ok: true }>).context;
+
+  const rate = await checkAndIncrement(ctx, env);
+  if (!rate.allowed) {
+    return new Response(
+      JSON.stringify({
+        error: 'rate_limit_exceeded',
+        retry_after: rate.retryAfterSec ?? 60,
+      }),
+      {
+        status: 429,
+        headers: { ...JSON_HEADERS, 'Retry-After': String(rate.retryAfterSec ?? 60) },
+      },
+    );
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return jsonError(400, 'invalid_json');
+  }
+  const parsed = validateDailyPromptRequest(rawBody);
+  if (!parsed) return jsonError(400, 'invalid_body');
+  if (!env.ANTHROPIC_API_KEY) {
+    return jsonError(503, 'anthropic_key_missing');
+  }
+
+  try {
+    const result = await generateDailyPrompt({
+      req: parsed,
+      apiKey: env.ANTHROPIC_API_KEY,
+    });
+    logMetadata({
+      endpoint: '/ai/daily-prompt',
+      status: 200,
+      startedAt,
+      entitlement: ctx.entitlement,
+      receiptHash: ctx.receiptHash,
+    });
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: JSON_HEADERS,
+    });
+  } catch (err) {
+    const detail = (err as Error).message;
+    return jsonError(502, 'daily_prompt_failed', detail);
   }
 }
 

--- a/ai-proxy/test/dailyPrompt.test.ts
+++ b/ai-proxy/test/dailyPrompt.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildUserMessage,
+  cachedUntilFor,
+  DAILY_PROMPT_MODEL,
+  DAILY_PROMPT_SYSTEM,
+  generateDailyPrompt,
+  parseModelPayload,
+  validateDailyPromptRequest,
+} from '../src/dailyPrompt';
+
+const baseReq = {
+  profile_summary: 'Reformed-leaning; recent focus on covenant themes.',
+  last_5_chapters: [
+    'jeremiah:29',
+    'jeremiah:30',
+    'jeremiah:31',
+    'romans:9',
+    'romans:10',
+  ],
+  client_date: '2026-04-17',
+};
+
+describe('validateDailyPromptRequest', () => {
+  it('accepts a well-formed body', () => {
+    expect(validateDailyPromptRequest(baseReq)).toEqual(baseReq);
+  });
+
+  it('rejects non-object inputs', () => {
+    expect(validateDailyPromptRequest(null)).toBeNull();
+    expect(validateDailyPromptRequest('x')).toBeNull();
+    expect(validateDailyPromptRequest(42)).toBeNull();
+  });
+
+  it('rejects missing or mistyped fields', () => {
+    expect(
+      validateDailyPromptRequest({ ...baseReq, profile_summary: 7 }),
+    ).toBeNull();
+    expect(
+      validateDailyPromptRequest({ ...baseReq, last_5_chapters: 'jeremiah:29' }),
+    ).toBeNull();
+    expect(
+      validateDailyPromptRequest({ ...baseReq, last_5_chapters: [1, 2, 3] }),
+    ).toBeNull();
+  });
+
+  it('rejects non-ISO client_date values', () => {
+    expect(
+      validateDailyPromptRequest({ ...baseReq, client_date: '04/17/2026' }),
+    ).toBeNull();
+    expect(
+      validateDailyPromptRequest({ ...baseReq, client_date: '2026-4-17' }),
+    ).toBeNull();
+  });
+
+  it('accepts empty chapter history (new users)', () => {
+    const body = { ...baseReq, last_5_chapters: [] };
+    expect(validateDailyPromptRequest(body)).toEqual(body);
+  });
+});
+
+describe('buildUserMessage', () => {
+  it('includes the date, chapters, and profile', () => {
+    const msg = buildUserMessage(baseReq);
+    expect(msg).toContain('2026-04-17');
+    expect(msg).toContain('jeremiah:29');
+    expect(msg).toContain('covenant themes');
+  });
+
+  it('falls back to (none yet) when no chapters are supplied', () => {
+    expect(buildUserMessage({ ...baseReq, last_5_chapters: [] })).toContain(
+      '(none yet)',
+    );
+  });
+
+  it('falls back to (no profile yet) when the profile string is blank', () => {
+    expect(buildUserMessage({ ...baseReq, profile_summary: '   ' })).toContain(
+      '(no profile yet)',
+    );
+  });
+});
+
+describe('cachedUntilFor', () => {
+  it('returns the start of the following UTC day', () => {
+    expect(cachedUntilFor('2026-04-17')).toBe('2026-04-18T00:00:00.000Z');
+  });
+});
+
+describe('parseModelPayload', () => {
+  it('parses a bare JSON object', () => {
+    const parsed = parseModelPayload(
+      '{"prompt_text":"Amicus noticed…","seed_query":"What did Jeremiah say?"}',
+    );
+    expect(parsed).toEqual({
+      prompt_text: 'Amicus noticed…',
+      seed_query: 'What did Jeremiah say?',
+    });
+  });
+
+  it('strips surrounding code fences', () => {
+    const parsed = parseModelPayload(
+      '```json\n{"prompt_text":"x","seed_query":"y"}\n```',
+    );
+    expect(parsed?.prompt_text).toBe('x');
+  });
+
+  it('returns null for non-JSON responses', () => {
+    expect(parseModelPayload('Amicus noticed that...')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(parseModelPayload('{"prompt_text":"x"}')).toBeNull();
+    expect(parseModelPayload('{"seed_query":"x"}')).toBeNull();
+    expect(parseModelPayload('{"prompt_text":"","seed_query":"x"}')).toBeNull();
+  });
+});
+
+describe('generateDailyPrompt', () => {
+  function mockFetch(payload: unknown, opts: { status?: number } = {}) {
+    return (async () =>
+      new Response(JSON.stringify(payload), {
+        status: opts.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch;
+  }
+
+  it('calls Anthropic with the cached system block and returns the parsed payload', async () => {
+    let captured: Request | null = null;
+    const fetchImpl = (async (input: RequestInfo, init?: RequestInit) => {
+      captured = new Request(input as string, init);
+      return new Response(
+        JSON.stringify({
+          content: [
+            {
+              type: 'text',
+              text: '{"prompt_text":"Amicus noticed Jeremiah is weighing on you — want to trace the covenant thread?","seed_query":"What is the covenant arc in Jeremiah 29-31?"}',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await generateDailyPrompt({
+      req: baseReq,
+      apiKey: 'key',
+      fetchImpl,
+    });
+
+    expect(result.prompt_text).toMatch(/covenant thread/);
+    expect(result.seed_query).toMatch(/covenant arc/);
+    expect(result.cached_until).toBe('2026-04-18T00:00:00.000Z');
+
+    expect(captured!.headers.get('x-api-key')).toBe('key');
+    expect(captured!.headers.get('anthropic-no-retention')).toBe('true');
+    const body = JSON.parse(await captured!.text()) as {
+      model: string;
+      system: Array<{ text: string; cache_control?: { type: string } }>;
+    };
+    expect(body.model).toBe(DAILY_PROMPT_MODEL);
+    expect(body.system[0]!.text).toBe(DAILY_PROMPT_SYSTEM);
+    expect(body.system[0]!.cache_control?.type).toBe('ephemeral');
+  });
+
+  it('throws when Anthropic returns a non-2xx', async () => {
+    await expect(
+      generateDailyPrompt({
+        req: baseReq,
+        apiKey: 'key',
+        fetchImpl: mockFetch({}, { status: 500 }),
+      }),
+    ).rejects.toThrow(/anthropic_error_500/);
+  });
+
+  it('throws when the response body is empty', async () => {
+    await expect(
+      generateDailyPrompt({
+        req: baseReq,
+        apiKey: 'key',
+        fetchImpl: mockFetch({ content: [] }),
+      }),
+    ).rejects.toThrow(/anthropic_empty_response/);
+  });
+
+  it('throws when the model returns unparseable JSON', async () => {
+    await expect(
+      generateDailyPrompt({
+        req: baseReq,
+        apiKey: 'key',
+        fetchImpl: mockFetch({ content: [{ type: 'text', text: 'not json' }] }),
+      }),
+    ).rejects.toThrow(/anthropic_bad_shape/);
+  });
+});

--- a/app/__tests__/db/userDatabase.test.ts
+++ b/app/__tests__/db/userDatabase.test.ts
@@ -78,7 +78,7 @@ describe('userDatabase', () => {
       jest.resetModules();
       // Simulate all migrations already applied
       mockGetAllAsync.mockResolvedValueOnce(
-        Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
+        Array.from({ length: 17 }, (_, i) => ({ version: i + 1 })),
       );
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
@@ -94,7 +94,7 @@ describe('userDatabase', () => {
       userDatabaseModule = require('@/db/userDatabase');
       await userDatabaseModule.initUserDatabase();
       // Should run 15 remaining migrations (2 through 16)
-      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(15);
+      expect(mockWithTransactionAsync).toHaveBeenCalledTimes(16);
     });
 
     it('throws on migration failure', async () => {

--- a/app/__tests__/unit/userDatabase.test.ts
+++ b/app/__tests__/unit/userDatabase.test.ts
@@ -66,9 +66,9 @@ describe('userDatabase', () => {
   });
 
   it('skips already-applied migrations', async () => {
-    // Simulate all 16 migrations already applied
+    // Simulate all 17 migrations already applied
     mockGetAllAsync.mockResolvedValue(
-      Array.from({ length: 16 }, (_, i) => ({ version: i + 1 })),
+      Array.from({ length: 17 }, (_, i) => ({ version: i + 1 })),
     );
 
     const { initUserDatabase } = require('@/db/userDatabase');

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -531,6 +531,20 @@ const MIGRATIONS: Migration[] = [
       );
     `,
   },
+  {
+    version: 17,
+    description: 'Amicus — daily prompt cache (#1465)',
+    sql: `
+      CREATE TABLE IF NOT EXISTS amicus_daily_prompt_cache (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        date TEXT NOT NULL,
+        profile_hash TEXT NOT NULL,
+        prompt_text TEXT NOT NULL,
+        seed_query TEXT NOT NULL,
+        generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -471,3 +471,29 @@ export async function incrementAmicusUsage(): Promise<void> {
      ON CONFLICT(day) DO UPDATE SET query_count = query_count + 1`,
   );
 }
+
+// ── Amicus daily prompt cache (#1465) ───────────────────────────────
+
+export interface UpsertDailyPromptArgs {
+  date: string;           // YYYY-MM-DD in user's local tz
+  profileHash: string;
+  promptText: string;
+  seedQuery: string;
+}
+
+export async function upsertDailyPrompt(
+  args: UpsertDailyPromptArgs,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_daily_prompt_cache
+       (id, date, profile_hash, prompt_text, seed_query, generated_at)
+     VALUES (1, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(id) DO UPDATE SET
+       date = excluded.date,
+       profile_hash = excluded.profile_hash,
+       prompt_text = excluded.prompt_text,
+       seed_query = excluded.seed_query,
+       generated_at = excluded.generated_at`,
+    [args.date, args.profileHash, args.promptText, args.seedQuery],
+  );
+}

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -612,3 +612,22 @@ export async function getAmicusUsageThisMonth(): Promise<number> {
   );
   return row?.total ?? 0;
 }
+
+// ── Amicus daily prompt cache (#1465) ───────────────────────────────
+
+export interface CachedDailyPrompt {
+  date: string;
+  profile_hash: string;
+  prompt_text: string;
+  seed_query: string;
+  generated_at: string;
+}
+
+export async function getCachedDailyPrompt(): Promise<CachedDailyPrompt | null> {
+  const row = await getUserDb().getFirstAsync<CachedDailyPrompt>(
+    `SELECT date, profile_hash, prompt_text, seed_query, generated_at
+       FROM amicus_daily_prompt_cache
+      WHERE id = 1`,
+  );
+  return row ?? null;
+}

--- a/app/src/hooks/useDailyPrompt.ts
+++ b/app/src/hooks/useDailyPrompt.ts
@@ -1,0 +1,53 @@
+/**
+ * hooks/useDailyPrompt.ts — React hook wrapper for the daily "Amicus
+ * noticed..." prompt service (#1465).
+ *
+ * Fires on mount and exposes a manual `refresh()` for pull-to-refresh.
+ * Returns null when no cache is available and the proxy is unreachable — the
+ * home card (#1466) hides itself in that case.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getDailyPrompt,
+  type DailyPrompt,
+  type GetDailyPromptOptions,
+} from '@/services/amicus/dailyPrompt';
+
+export interface UseDailyPromptResult {
+  prompt: DailyPrompt | null;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useDailyPrompt(
+  opts: GetDailyPromptOptions = {},
+): UseDailyPromptResult {
+  const [prompt, setPrompt] = useState<DailyPrompt | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    const result = await getDailyPrompt(opts);
+    if (mountedRef.current) {
+      setPrompt(result);
+      setIsLoading(false);
+    }
+    // Options are expected to be stable across renders; exhaustive-deps can't
+    // see into the caller but we don't want spurious reloads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { prompt, isLoading, refresh: load };
+}

--- a/app/src/services/amicus/__tests__/dailyPrompt.test.ts
+++ b/app/src/services/amicus/__tests__/dailyPrompt.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for services/amicus/dailyPrompt.ts — cache + proxy daily prompt.
+ */
+import {
+  getMockUserDb,
+  resetMockUserDb,
+} from '../../../../__tests__/helpers/mockUserDb';
+import {
+  getDailyPrompt,
+  localDate,
+} from '@/services/amicus/dailyPrompt';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+jest.mock('@/db/database', () =>
+  require('../../../../__tests__/helpers/mockDb').mockDatabaseModule(),
+);
+
+const mockGenerateProfile = jest.fn();
+jest.mock('@/services/amicus/profile/generator', () => ({
+  generateProfile: (force?: boolean) => mockGenerateProfile(force),
+}));
+
+const FIXED_DATE = new Date('2026-04-17T12:00:00');
+const now = () => FIXED_DATE;
+
+beforeEach(() => {
+  resetMockUserDb();
+  mockGenerateProfile.mockReset();
+  mockGenerateProfile.mockResolvedValue({
+    prose: 'Reformed-leaning; covenant focus.',
+    preferred_scholars: [],
+    preferred_traditions: [],
+    generated_at: '2026-04-16T00:00:00.000Z',
+    raw_signals_hash: 'hash-1',
+  });
+  process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'tok';
+});
+
+function mockCacheRow(row: Partial<{
+  date: string;
+  profile_hash: string;
+  prompt_text: string;
+  seed_query: string;
+  generated_at: string;
+}> | null): void {
+  const db = getMockUserDb();
+  if (row === null) {
+    db.getFirstAsync.mockImplementation(async () => null);
+  } else {
+    db.getFirstAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes('amicus_daily_prompt_cache')) {
+        return {
+          date: row.date ?? '2026-04-17',
+          profile_hash: row.profile_hash ?? 'hash-1',
+          prompt_text: row.prompt_text ?? 'cached prompt',
+          seed_query: row.seed_query ?? 'cached query',
+          generated_at: row.generated_at ?? '2026-04-17T00:00:00.000Z',
+        };
+      }
+      return null;
+    });
+  }
+}
+
+function mockProxyOk(payload = {
+  prompt_text: 'fresh from proxy',
+  seed_query: 'fresh query',
+  cached_until: '2026-04-18T00:00:00.000Z',
+}): jest.Mock {
+  return jest.fn(async () =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('localDate', () => {
+  it('returns YYYY-MM-DD in local time', () => {
+    expect(localDate(new Date('2026-04-17T12:00:00'))).toBe('2026-04-17');
+  });
+  it('zero-pads single-digit months and days', () => {
+    expect(localDate(new Date('2026-01-05T00:00:00'))).toBe('2026-01-05');
+  });
+});
+
+describe('getDailyPrompt', () => {
+  it('returns the cached prompt when date + profile_hash still match', async () => {
+    mockCacheRow({ date: '2026-04-17', profile_hash: 'hash-1', prompt_text: 'hit' });
+    const fetchImpl = mockProxyOk();
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result).toEqual({ prompt_text: 'hit', seed_query: 'cached query' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('calls the proxy and writes through on cache miss (new day)', async () => {
+    mockCacheRow({ date: '2026-04-16', profile_hash: 'hash-1' });
+    const fetchImpl = mockProxyOk();
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result?.prompt_text).toBe('fresh from proxy');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0]!;
+    const body = JSON.parse(call[1]!.body as string) as {
+      profile_summary: string;
+      client_date: string;
+      last_5_chapters: string[];
+    };
+    expect(body.client_date).toBe('2026-04-17');
+    expect(body.profile_summary).toMatch(/covenant focus/);
+
+    const db = getMockUserDb();
+    const write = db.runAsync.mock.calls.find((c: unknown[]) =>
+      typeof c[0] === 'string' && c[0].includes('amicus_daily_prompt_cache'),
+    );
+    expect(write).toBeDefined();
+    expect(write![1]).toEqual(['2026-04-17', 'hash-1', 'fresh from proxy', 'fresh query']);
+  });
+
+  it('invalidates the cache when profile_hash changes', async () => {
+    mockCacheRow({ date: '2026-04-17', profile_hash: 'old-hash' });
+    const fetchImpl = mockProxyOk();
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result?.prompt_text).toBe('fresh from proxy');
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('falls back to stale cache when the proxy returns a 5xx', async () => {
+    mockCacheRow({ date: '2026-04-10', profile_hash: 'hash-1', prompt_text: 'stale' });
+    const fetchImpl = jest.fn(async () =>
+      new Response('x', { status: 503 }),
+    );
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result).toEqual({ prompt_text: 'stale', seed_query: 'cached query' });
+  });
+
+  it('falls back to stale cache when fetch throws (offline)', async () => {
+    mockCacheRow({ date: '2026-04-10', profile_hash: 'hash-1', prompt_text: 'stale' });
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('Network request failed');
+    });
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result?.prompt_text).toBe('stale');
+  });
+
+  it('returns null when there is no cache AND the proxy is unreachable', async () => {
+    mockCacheRow(null);
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('offline');
+    });
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no profile and no cache', async () => {
+    mockGenerateProfile.mockRejectedValue(new Error('no profile'));
+    mockCacheRow(null);
+    const fetchImpl = mockProxyOk();
+
+    const result = await getDailyPrompt({ now, fetchImpl });
+
+    expect(result).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sends Bearer auth token to the proxy', async () => {
+    mockCacheRow(null);
+    const fetchImpl = mockProxyOk();
+    await getDailyPrompt({ now, fetchImpl, getAuthToken: () => 'my-token' });
+    expect(fetchImpl.mock.calls[0]![1]!.headers).toMatchObject({
+      Authorization: 'Bearer my-token',
+    });
+  });
+
+  it('returns null when the proxy response has the wrong shape', async () => {
+    mockCacheRow(null);
+    const fetchImpl = jest.fn(async () =>
+      new Response(JSON.stringify({ prompt_text: '' }), { status: 200 }),
+    );
+    const result = await getDailyPrompt({ now, fetchImpl });
+    expect(result).toBeNull();
+  });
+});

--- a/app/src/services/amicus/dailyPrompt.ts
+++ b/app/src/services/amicus/dailyPrompt.ts
@@ -1,0 +1,157 @@
+/**
+ * services/amicus/dailyPrompt.ts — Daily proactive "Amicus noticed..." prompt.
+ *
+ * Client-triggered on app open. Cached for 24h in `amicus_daily_prompt_cache`
+ * keyed on (date, profile_hash). Graceful degradation on any failure — the
+ * home card is optional content so we never throw into the UI.
+ */
+import { getCachedDailyPrompt, getRecentChapters } from '@/db/userQueries';
+import { upsertDailyPrompt } from '@/db/userMutations';
+import { generateProfile } from '@/services/amicus/profile/generator';
+import { logger } from '@/utils/logger';
+
+const PROXY_BASE = (
+  process.env.EXPO_PUBLIC_AMICUS_PROXY_URL ?? 'https://ai.contentcompanionstudy.com'
+).replace(/\/$/, '');
+const DAILY_PROMPT_URL = `${PROXY_BASE}/ai/daily-prompt`;
+
+export interface DailyPrompt {
+  prompt_text: string;
+  seed_query: string;
+}
+
+export interface GetDailyPromptOptions {
+  getAuthToken?: () => string;
+  fetchImpl?: typeof fetch;
+  /** Inject a fixed date for deterministic tests. Defaults to now. */
+  now?: () => Date;
+}
+
+/**
+ * Returns today's proactive prompt — from cache, regenerated via the proxy,
+ * or from stale cache if the proxy is unreachable. Returns null if there is
+ * nothing to show (no cache AND proxy failure).
+ */
+export async function getDailyPrompt(
+  opts: GetDailyPromptOptions = {},
+): Promise<DailyPrompt | null> {
+  const today = localDate(opts.now?.() ?? new Date());
+
+  let profileHash = '';
+  try {
+    const profile = await generateProfile(false);
+    profileHash = profile.raw_signals_hash;
+  } catch (err) {
+    logger.warn('AmicusDailyPrompt', `profile_unavailable: ${String(err)}`);
+  }
+
+  const cached = await getCachedDailyPrompt().catch(() => null);
+  if (
+    cached &&
+    cached.date === today &&
+    cached.profile_hash === profileHash
+  ) {
+    return {
+      prompt_text: cached.prompt_text,
+      seed_query: cached.seed_query,
+    };
+  }
+
+  const authToken =
+    opts.getAuthToken?.() ?? process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '';
+  if (!authToken || !profileHash) {
+    // No way to call the proxy — fall back to whatever we have.
+    return cached
+      ? {
+          prompt_text: cached.prompt_text,
+          seed_query: cached.seed_query,
+        }
+      : null;
+  }
+
+  const recentChapters = await getRecentChapters(5).catch(() => []);
+  const last5 = recentChapters
+    .map((c) => `${c.book_id}:${c.chapter_num}`)
+    .slice(0, 5);
+  const profile = await generateProfile(false);
+
+  let fresh: DailyPrompt | null = null;
+  try {
+    fresh = await callProxy({
+      profileSummary: profile.prose,
+      last5Chapters: last5,
+      clientDate: today,
+      authToken,
+      fetchImpl: opts.fetchImpl,
+    });
+  } catch (err) {
+    logger.warn('AmicusDailyPrompt', `proxy_failed: ${String(err)}`);
+  }
+
+  if (!fresh) {
+    // Offline / 5xx / bad shape → keep whatever stale cache we have.
+    return cached
+      ? {
+          prompt_text: cached.prompt_text,
+          seed_query: cached.seed_query,
+        }
+      : null;
+  }
+
+  await upsertDailyPrompt({
+    date: today,
+    profileHash,
+    promptText: fresh.prompt_text,
+    seedQuery: fresh.seed_query,
+  }).catch((err) => {
+    logger.warn('AmicusDailyPrompt', `cache_write_failed: ${String(err)}`);
+  });
+
+  return fresh;
+}
+
+interface CallProxyArgs {
+  profileSummary: string;
+  last5Chapters: string[];
+  clientDate: string;
+  authToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+async function callProxy(args: CallProxyArgs): Promise<DailyPrompt | null> {
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const resp = await fetchImpl(DAILY_PROMPT_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${args.authToken}`,
+    },
+    body: JSON.stringify({
+      profile_summary: args.profileSummary,
+      last_5_chapters: args.last5Chapters,
+      client_date: args.clientDate,
+    }),
+  });
+  if (!resp.ok) return null;
+  const payload = (await resp.json()) as Partial<DailyPrompt>;
+  if (
+    typeof payload.prompt_text !== 'string' ||
+    typeof payload.seed_query !== 'string' ||
+    payload.prompt_text.length === 0 ||
+    payload.seed_query.length === 0
+  ) {
+    return null;
+  }
+  return {
+    prompt_text: payload.prompt_text,
+    seed_query: payload.seed_query,
+  };
+}
+
+/** Format `Date` as YYYY-MM-DD in the user's local timezone. */
+export function localDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary

Resolves phase 4, card #1465 of epic #1446. Generates one "Amicus noticed..." proactive prompt per user per day. Client-triggered, server-generated, client-cached — no background jobs, no battery tax, zero cost when the app isn't opened.

### Server (`ai-proxy`)

- New `POST /ai/daily-prompt` endpoint with the same auth + rate-limit gating as `/ai/chat`.
- Haiku 4.5 call with a prompt-cacheable system block; user-specific signals (profile, recent chapters, date) live in the user message so the system block is a stable cache key.
- Strict response validation — the model must return valid JSON with non-empty `prompt_text` and `seed_query`. Fenced output is tolerated.

### Client (`app`)

- Migration v17 adds the singleton `amicus_daily_prompt_cache` table.
- `getDailyPrompt()` service flow:
  1. Read cache → short-circuit if `(date, profile_hash)` still match.
  2. Otherwise call proxy and write-through.
  3. On offline / 5xx / bad shape → keep whatever stale cache exists; return `null` if none.
- `useDailyPrompt()` hook for the HomeScreen card (#1466 will consume it).

## Acceptance criteria

- [x] Worker endpoint generates valid Haiku response
- [x] Response always includes `prompt_text`, `seed_query`, `cached_until`
- [x] Client cache hit returns same prompt within 24h (same date + hash)
- [x] Cache invalidates when profile_hash changes
- [x] Offline / 5xx gracefully falls back to stale cache or returns null
- [x] Proxy enforces auth + rate limit on this endpoint too
- [x] Unit tests cover: validation, cache hit, cache miss, profile change invalidation, offline fallback, wrong-shape response
- [x] No `any` types; lint clean

## Test plan

- [x] `ai-proxy`: `npm test` — 66 tests passing (17 new in `dailyPrompt.test.ts`)
- [x] `app`: `npx jest src/services/amicus/__tests__/dailyPrompt.test.ts` — 11 passing
- [x] Full `app` suite: 3402 passing
- [x] Coverage thresholds met: 80.41 / 67.49 / 72.85 / 82.20
- [x] `npx tsc --noEmit` clean for both `ai-proxy` and `app`
- [x] `npx eslint` clean for all changed `app/src` files

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe