### PR TITLE
feat(ai-partner): home screen Amicus card (#1466)

### DIFF
--- a/app/__tests__/components/AmicusHomeCard.test.tsx
+++ b/app/__tests__/components/AmicusHomeCard.test.tsx
@@ -1,0 +1,161 @@
+import { act, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import AmicusHomeCard from '@/components/AmicusHomeCard';
+
+const mockGetPreference = jest.fn();
+const mockSetPreference = jest.fn();
+jest.mock('@/db/userQueries', () => ({
+  getPreference: (key: string) => mockGetPreference(key),
+}));
+jest.mock('@/db/userMutations', () => ({
+  setPreference: (key: string, value: string) => mockSetPreference(key, value),
+}));
+
+const mockUseDailyPrompt = jest.fn();
+jest.mock('@/hooks/useDailyPrompt', () => ({
+  useDailyPrompt: () => mockUseDailyPrompt(),
+}));
+
+const mockUseAmicusAccess = jest.fn();
+jest.mock('@/hooks/useAmicusAccess', () => ({
+  useAmicusAccess: () => mockUseAmicusAccess(),
+}));
+
+const mockUseSettingsStore = jest.fn();
+jest.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { amicusEnabled: boolean }) => unknown) =>
+    selector({ amicusEnabled: mockUseSettingsStore() }),
+}));
+
+const mockNavigate = jest.fn();
+const mockParentNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    getParent: () => ({ navigate: mockParentNavigate }),
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPreference.mockResolvedValue(null);
+  mockSetPreference.mockResolvedValue(undefined);
+  mockUseSettingsStore.mockReturnValue(true);
+  mockUseAmicusAccess.mockReturnValue({
+    canUse: true,
+    reason: 'ok',
+    entitlement: 'premium',
+    usage: { thisMonth: 0, cap: 300, remaining: 300 },
+  });
+  mockUseDailyPrompt.mockReturnValue({
+    prompt: null,
+    isLoading: false,
+    refresh: jest.fn(),
+  });
+});
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('AmicusHomeCard', () => {
+  it('returns null when amicus is disabled in settings', async () => {
+    mockUseSettingsStore.mockReturnValue(false);
+    const { toJSON } = renderWithProviders(<AmicusHomeCard />);
+    await flushEffects();
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the fallback copy when the daily prompt is null', async () => {
+    const { findByText } = renderWithProviders(<AmicusHomeCard />);
+    expect(await findByText('Meet Amicus')).toBeTruthy();
+    expect(
+      await findByText(/ready for questions/),
+    ).toBeTruthy();
+  });
+
+  it('renders the daily prompt and navigates with its seed_query on tap', async () => {
+    mockUseDailyPrompt.mockReturnValue({
+      prompt: {
+        prompt_text: 'Amicus noticed you are deep in Jeremiah.',
+        seed_query: 'What is the covenant arc in Jeremiah 29-31?',
+      },
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+    const { findByText, getByLabelText } = renderWithProviders(<AmicusHomeCard />);
+    expect(await findByText('Amicus noticed…')).toBeTruthy();
+    expect(await findByText(/deep in Jeremiah/)).toBeTruthy();
+    fireEvent.press(getByLabelText('Open Amicus'));
+    expect(mockParentNavigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'NewThread',
+      params: { seedQuery: 'What is the covenant arc in Jeremiah 29-31?' },
+    });
+  });
+
+  it('navigates to an empty new thread when the input row is tapped', async () => {
+    mockUseDailyPrompt.mockReturnValue({
+      prompt: {
+        prompt_text: 'something',
+        seed_query: 'query',
+      },
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+    const { getByLabelText } = renderWithProviders(<AmicusHomeCard />);
+    fireEvent.press(getByLabelText('Ask Amicus anything'));
+    expect(mockParentNavigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'NewThread',
+      params: undefined,
+    });
+  });
+
+  it('renders the Unlock variant for non-premium users and navigates to Subscription', async () => {
+    mockUseAmicusAccess.mockReturnValue({
+      canUse: false,
+      reason: 'not_premium',
+      entitlement: 'none',
+      usage: { thisMonth: 0, cap: 0, remaining: 0 },
+    });
+    const { findByText, getByLabelText, queryByLabelText } = renderWithProviders(
+      <AmicusHomeCard />,
+    );
+    expect(await findByText('Unlock Amicus')).toBeTruthy();
+    expect(await findByText(/72 scholars/)).toBeTruthy();
+    expect(queryByLabelText('Ask Amicus anything')).toBeNull();
+    fireEvent.press(getByLabelText('See plans'));
+    expect(mockParentNavigate).toHaveBeenCalledWith('MoreTab', {
+      screen: 'Subscription',
+    });
+  });
+
+  it('hides itself when already dismissed today', async () => {
+    const today = new Date();
+    const y = today.getFullYear();
+    const m = String(today.getMonth() + 1).padStart(2, '0');
+    const d = String(today.getDate()).padStart(2, '0');
+    mockGetPreference.mockResolvedValue(`${y}-${m}-${d}`);
+
+    const { toJSON } = renderWithProviders(<AmicusHomeCard />);
+    await flushEffects();
+    expect(toJSON()).toBeNull();
+  });
+
+  it('dismisses for the day on long-press and persists the date', async () => {
+    const { getByLabelText, toJSON } = renderWithProviders(<AmicusHomeCard />);
+    await flushEffects();
+    const card = getByLabelText('Open Amicus');
+    await act(async () => {
+      fireEvent(card, 'longPress');
+    });
+    expect(mockSetPreference).toHaveBeenCalledWith(
+      'amicus_home_card_dismissed_date',
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    );
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/src/components/AmicusHomeCard.tsx
+++ b/app/src/components/AmicusHomeCard.tsx
@@ -1,0 +1,243 @@
+/**
+ * components/AmicusHomeCard.tsx — "Amicus noticed..." card on HomeScreen (#1466).
+ *
+ * Three modes:
+ *   1. Premium + daily prompt → shows prompt_text, taps deep-link to Amicus.
+ *   2. Premium + no prompt (first launch / offline with no cache) → fallback
+ *      copy with the "Ask Amicus anything…" row.
+ *   3. Non-premium → "Unlock Amicus" variant with a "See plans →" CTA.
+ *
+ * Long-press on any variant dismisses the card for the rest of the day via
+ * a user-preference key. The dismissal resets the next calendar day.
+ */
+import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
+import { MessageSquare } from 'lucide-react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { setPreference } from '../db/userMutations';
+import { getPreference } from '../db/userQueries';
+import { useAmicusAccess } from '../hooks/useAmicusAccess';
+import { useDailyPrompt } from '../hooks/useDailyPrompt';
+import { useSettingsStore } from '../stores/settingsStore';
+import { fontFamily, radii, spacing, useTheme } from '../theme';
+import { logger } from '../utils/logger';
+
+const DISMISS_KEY = 'amicus_home_card_dismissed_date';
+
+function todayStr(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function AmicusHomeCard(): React.ReactElement | null {
+  const { base } = useTheme();
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const amicusEnabled = useSettingsStore((s) => s.amicusEnabled);
+  const access = useAmicusAccess();
+  const { prompt } = useDailyPrompt();
+
+  const [dismissedToday, setDismissedToday] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const stored = await getPreference(DISMISS_KEY).catch(() => null);
+      if (!cancelled && stored === todayStr()) setDismissedToday(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDismiss = useCallback(async () => {
+    setDismissedToday(true);
+    await setPreference(DISMISS_KEY, todayStr()).catch((err) => {
+      logger.warn('AmicusHomeCard', `dismiss_write_failed: ${String(err)}`);
+    });
+    logger.info('AmicusHomeCard', 'dismissed for today');
+  }, []);
+
+  const navigateToNewThread = useCallback(
+    (seedQuery?: string) => {
+      const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+      parent?.navigate('AmicusTab', {
+        screen: 'NewThread',
+        params: seedQuery ? { seedQuery } : undefined,
+      });
+      logger.info(
+        'AmicusHomeCard',
+        seedQuery ? 'tapped prompt' : 'tapped input',
+      );
+    },
+    [navigation],
+  );
+
+  const navigateToPlans = useCallback(() => {
+    const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+    parent?.navigate('MoreTab', { screen: 'Subscription' });
+    logger.info('AmicusHomeCard', 'tapped upgrade');
+  }, [navigation]);
+
+  if (!amicusEnabled) return null;
+  if (dismissedToday) return null;
+
+  const isLocked = access.reason === 'not_premium';
+
+  const header = isLocked
+    ? 'Unlock Amicus'
+    : prompt
+      ? 'Amicus noticed…'
+      : 'Meet Amicus';
+
+  const body = isLocked
+    ? 'Your AI study companion, grounded in 72 scholars. Included with Companion+.'
+    : prompt
+      ? prompt.prompt_text
+      : 'Your scholarly study companion is ready for questions.';
+
+  const onBodyPress = isLocked
+    ? navigateToPlans
+    : () => navigateToNewThread(prompt?.seed_query);
+
+  return (
+    <View
+      style={[
+        styles.outer,
+        { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` },
+      ]}
+    >
+      <View style={[styles.goldStripe, { backgroundColor: base.gold }]} />
+
+      <Pressable
+        onPress={onBodyPress}
+        onLongPress={handleDismiss}
+        accessibilityLabel={isLocked ? 'Unlock Amicus' : 'Open Amicus'}
+        accessibilityHint={
+          isLocked
+            ? 'Opens the subscription screen'
+            : 'Opens a new Amicus thread. Long-press to hide this card for the day.'
+        }
+        android_ripple={{ color: `${base.gold}20` }}
+        style={styles.inner}
+      >
+        <View style={styles.headerRow}>
+          <MessageSquare size={16} color={base.gold} />
+          <Text
+            style={[
+              styles.header,
+              { color: base.gold, fontFamily: fontFamily.displaySemiBold },
+            ]}
+          >
+            {header}
+          </Text>
+        </View>
+
+        <Text
+          style={[
+            styles.body,
+            { color: base.text, fontFamily: fontFamily.body },
+          ]}
+        >
+          {body}
+        </Text>
+
+        {isLocked ? (
+          <TouchableOpacity
+            onPress={navigateToPlans}
+            accessibilityLabel="See plans"
+            style={[
+              styles.ctaButton,
+              { borderColor: base.gold, backgroundColor: `${base.gold}15` },
+            ]}
+          >
+            <Text
+              style={[
+                styles.ctaText,
+                { color: base.gold, fontFamily: fontFamily.uiMedium },
+              ]}
+            >
+              See plans →
+            </Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            onPress={() => navigateToNewThread()}
+            accessibilityLabel="Ask Amicus anything"
+            style={[
+              styles.inputRow,
+              { backgroundColor: base.bg, borderColor: base.border },
+            ]}
+          >
+            <Text
+              numberOfLines={1}
+              style={[
+                styles.inputPlaceholder,
+                { color: base.textMuted, fontFamily: fontFamily.bodyItalic },
+              ]}
+            >
+              Ask Amicus anything…
+            </Text>
+          </TouchableOpacity>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    flexDirection: 'row',
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  goldStripe: {
+    width: 4,
+  },
+  inner: {
+    flex: 1,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  header: {
+    fontSize: 14,
+    letterSpacing: 0.3,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  inputRow: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.sm + 4,
+    paddingVertical: spacing.sm,
+  },
+  inputPlaceholder: {
+    fontSize: 13,
+  },
+  ctaButton: {
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs + 2,
+    marginTop: spacing.xs,
+  },
+  ctaText: {
+    fontSize: 13,
+  },
+});

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -25,6 +25,7 @@ import { useExploreImages } from '../hooks/useExploreImages';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { StreakBadge } from '../components/StreakBadge';
 import { ActivePlanCard } from '../components/ActivePlanCard';
+import AmicusHomeCard from '../components/AmicusHomeCard';
 import { ContinueReadingHero } from '../components/ContinueReadingHero';
 import { ProgressRow } from '../components/ProgressRow';
 import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../components/FeatureCard';
@@ -178,6 +179,11 @@ function HomeScreen() {
         {/* ── 4. Active Reading Plan (compact) ─────────── */}
         <View style={styles.sectionGap}>
           <ActivePlanCard />
+        </View>
+
+        {/* ── 4b. Amicus daily prompt card (#1466) ─────────── */}
+        <View style={styles.sectionGap}>
+          <AmicusHomeCard />
         </View>
 
         {/* Major-zone divider: scripture engagement → exploration + stats */}


### PR DESCRIPTION
## Summary

Resolves phase 4, card #1466 of epic #1446. Adds the "Amicus noticed..." card to HomeScreen — the surface where the #1465 daily prompt meets the user.

Three modes:

- **Premium + daily prompt** → renders `prompt_text`; tap deep-links to the Amicus tab with `seed_query` pre-filled on NewThread.
- **Premium + no prompt** (first launch / offline with no cache / null from #1465) → fallback "Meet Amicus" copy with an "Ask Amicus anything…" row.
- **Non-premium** → "Unlock Amicus" variant with a "See plans →" CTA that jumps to the Subscription screen on the More tab.

Other behavior:

- Long-press dismisses for the day via `amicus_home_card_dismissed_date` in `user_preferences`; card re-appears tomorrow.
- Entire card hides when the `amicusEnabled` setting is off.
- Styling mirrors `ActivePlanCard` (bgElevated + 30%-gold border, `radii.lg`, spacing-based padding) with a 4px gold left stripe accent.

Placement per spec: HomeScreen inserts `<AmicusHomeCard />` between the ActivePlanCard row and the "From your study" carousel.

## Acceptance criteria

- [x] Card renders in correct position in HomeScreen
- [x] Premium + prompt: renders prompt_text; tap navigates to Amicus tab with seed_query
- [x] Premium + no prompt: renders fallback with "ready for questions" copy
- [x] Non-premium: renders "Unlock Amicus" variant with Plans CTA
- [x] Input row navigates to new-thread flow
- [x] Long-press dismiss persists to user.db with today's date; hidden until tomorrow
- [x] Respects `amicus_enabled` preference
- [x] Component tests cover all three variants + dismiss action
- [x] No `any` types; lint clean

## Test plan

- [x] `npx jest __tests__/components/AmicusHomeCard.test.tsx` — 7 passing
- [x] Full suite: 3410 passing
- [x] Coverage thresholds met: 81.00 / 67.70 / 73.65 / 82.79
- [x] `npx tsc --noEmit` clean for all Amicus files
- [x] `npx eslint` clean (0 warnings) on changed files

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe