### PR TITLE
fix: pin react-native-worklets to 0.5.1 per expo-doctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ _tools/embedding_manifest.json
 # _tools/build_prompts.py and merged into scripture.db.
 prompts.db
 _tools/prompts_manifest.json
+
+# Expo export output (from `npx expo export`) 
+app/bundle.log 
+app/dist/ 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -48,7 +48,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
-        "react-native-worklets": "~0.5.1",
+        "react-native-worklets": "0.5.1",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -12877,9 +12877,9 @@
       }
     },
     "node_modules/react-native-worklets": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.2.tgz",
-      "integrity": "sha512-lCzmuIPAK/UaOJYEPgYpVqrsxby1I54f7PyyZUMEO04nwc00CDrCvv9lCTY1daLHYTF8lS3f9zlzErfVsIKqkA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",

--- a/app/package.json
+++ b/app/package.json
@@ -56,7 +56,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
-    "react-native-worklets": "~0.5.1",
+    "react-native-worklets": "0.5.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Expo SDK 54 expects worklets 0.5.1 exactly. Was drifting to 0.5.2 via transitive resolution, caught by the preflight workflow (PR #1505). Also adds app/bundle.log and app/dist/ to .gitignore so expo export artifacts don't accidentally get committed.