### PR TITLE
feat(ai-partner): Apple Foundation Models deferral + routing scaffold (#1473)

### DIFF
--- a/app/src/services/amicus/__tests__/queryRouting.test.ts
+++ b/app/src/services/amicus/__tests__/queryRouting.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for services/amicus/queryRouting.ts — inert scaffold for the
+ * Apple Foundation Models deferral (#1473).
+ */
+import {
+  classifyQuery,
+  pickRoute,
+  resolveRoute,
+  SIMPLE_MAX_CHUNKS,
+  SIMPLE_MAX_QUERY_CHARS,
+} from '@/services/amicus/queryRouting';
+
+describe('classifyQuery', () => {
+  it('returns simple for a short, single-chunk, first-turn query', () => {
+    expect(
+      classifyQuery({
+        query: 'What is hesed?',
+        retrievedChunkCount: 1,
+        conversationHistoryLength: 0,
+      }),
+    ).toBe('simple');
+  });
+
+  it('returns complex when the chunk count exceeds the cap', () => {
+    expect(
+      classifyQuery({
+        query: 'q',
+        retrievedChunkCount: SIMPLE_MAX_CHUNKS + 1,
+        conversationHistoryLength: 0,
+      }),
+    ).toBe('complex');
+  });
+
+  it('accepts chunk count exactly at the cap as simple', () => {
+    expect(
+      classifyQuery({
+        query: 'q',
+        retrievedChunkCount: SIMPLE_MAX_CHUNKS,
+        conversationHistoryLength: 0,
+      }),
+    ).toBe('simple');
+  });
+
+  it('returns complex whenever conversation history is non-empty', () => {
+    expect(
+      classifyQuery({
+        query: 'q',
+        retrievedChunkCount: 1,
+        conversationHistoryLength: 1,
+      }),
+    ).toBe('complex');
+  });
+
+  it('returns complex when the query is long', () => {
+    expect(
+      classifyQuery({
+        query: 'x'.repeat(SIMPLE_MAX_QUERY_CHARS),
+        retrievedChunkCount: 1,
+        conversationHistoryLength: 0,
+      }),
+    ).toBe('complex');
+  });
+
+  it('ignores whitespace when measuring length', () => {
+    expect(
+      classifyQuery({
+        query: '  short query  ',
+        retrievedChunkCount: 1,
+        conversationHistoryLength: 0,
+      }),
+    ).toBe('simple');
+  });
+});
+
+describe('pickRoute', () => {
+  it('returns cloud for complex queries regardless of runtime', () => {
+    expect(
+      pickRoute({ complexity: 'complex', appleFmAvailable: true }),
+    ).toBe('cloud');
+    expect(
+      pickRoute({ complexity: 'complex', appleFmAvailable: false }),
+    ).toBe('cloud');
+  });
+
+  it('returns cloud for simple queries when Apple FM is not available (today\'s default)', () => {
+    expect(pickRoute({ complexity: 'simple' })).toBe('cloud');
+    expect(
+      pickRoute({ complexity: 'simple', appleFmAvailable: false }),
+    ).toBe('cloud');
+  });
+
+  it('returns apple_fm for simple queries only once the capability flips on', () => {
+    // This is the branch the deferred follow-up PR will hit. Today no
+    // production call site passes `appleFmAvailable: true` — the test
+    // exists to freeze the contract.
+    expect(
+      pickRoute({ complexity: 'simple', appleFmAvailable: true }),
+    ).toBe('apple_fm');
+  });
+});
+
+describe('resolveRoute', () => {
+  it('always routes to cloud today', () => {
+    const cases = [
+      { query: 'What is hesed?', retrievedChunkCount: 1, conversationHistoryLength: 0 },
+      { query: 'complex multi turn', retrievedChunkCount: 5, conversationHistoryLength: 3 },
+      { query: 'x'.repeat(500), retrievedChunkCount: 1, conversationHistoryLength: 0 },
+    ];
+    for (const c of cases) {
+      expect(resolveRoute(c)).toBe('cloud');
+    }
+  });
+});

--- a/app/src/services/amicus/queryRouting.ts
+++ b/app/src/services/amicus/queryRouting.ts
@@ -1,0 +1,79 @@
+/**
+ * services/amicus/queryRouting.ts — Query complexity classifier + route
+ * selector (#1473, inert scaffold).
+ *
+ * Today every query routes to `cloud`. The card to evaluate Apple
+ * Foundation Models is deferred until cloud spend crosses the trigger
+ * threshold. This module exists so that when the trigger fires, the
+ * call-site surface can stay unchanged — a future PR wires the
+ * `apple_fm` branch behind a capability check without touching the
+ * streaming chat handler.
+ *
+ * See `docs/decisions/1473-apple-foundation-models-deferral.md`.
+ */
+
+/** Hard cap used by the simple-query classifier. */
+export const SIMPLE_MAX_CHUNKS = 2;
+
+/** Query is considered short below this character count (≈ 100 tokens). */
+export const SIMPLE_MAX_QUERY_CHARS = 400;
+
+export interface QueryClassifierInput {
+  /** Raw user query. */
+  query: string;
+  /** Number of chunks the retriever surfaced. */
+  retrievedChunkCount: number;
+  /** Prior user/assistant turns in the same thread. */
+  conversationHistoryLength: number;
+}
+
+export type QueryComplexity = 'simple' | 'complex';
+
+/**
+ * Per the #1473 spec:
+ *   simple  = retrieved_chunks ≤ 2 AND no multi-turn context AND query < 100 tokens
+ *   complex = everything else
+ *
+ * The 100-token rule is approximated as 400 characters — English averages
+ * ~4 characters per token. The classifier is intentionally generous on
+ * the threshold so a future PR can tighten it without breaking callers.
+ */
+export function classifyQuery(input: QueryClassifierInput): QueryComplexity {
+  if (input.retrievedChunkCount > SIMPLE_MAX_CHUNKS) return 'complex';
+  if (input.conversationHistoryLength > 0) return 'complex';
+  if (input.query.trim().length >= SIMPLE_MAX_QUERY_CHARS) return 'complex';
+  return 'simple';
+}
+
+/** Routes the query dispatcher will eventually pick from. */
+export type QueryRoute = 'cloud' | 'apple_fm';
+
+export interface PickRouteOptions {
+  /** The query's classification. */
+  complexity: QueryComplexity;
+  /**
+   * Whether the runtime exposes Apple Foundation Models. Today this is
+   * always `false` — the eval is deferred.
+   */
+  appleFmAvailable?: boolean;
+}
+
+/**
+ * Select the route for a classified query. Simple queries with an Apple
+ * FM runtime *could* route on-device; today that branch is off.
+ */
+export function pickRoute(opts: PickRouteOptions): QueryRoute {
+  if (opts.complexity === 'simple' && opts.appleFmAvailable === true) {
+    return 'apple_fm';
+  }
+  return 'cloud';
+}
+
+/**
+ * Convenience wrapper so callers don't need to thread complexity through
+ * their own state. `appleFmAvailable` is intentionally not surfaced at
+ * the public call sites until the feasibility audit completes.
+ */
+export function resolveRoute(input: QueryClassifierInput): QueryRoute {
+  return pickRoute({ complexity: classifyQuery(input) });
+}

--- a/docs/decisions/1473-apple-foundation-models-deferral.md
+++ b/docs/decisions/1473-apple-foundation-models-deferral.md
@@ -1,0 +1,52 @@
+# 1473 · Apple Foundation Models evaluation — deferral record
+
+**Status:** Deferred (not in v1)
+**Decision date:** 2026-04-17
+**Trigger to revisit:** Cloud AI spend exceeds **$5K/month** for three consecutive months OR a material Anthropic pricing change.
+
+## Context
+
+Epic #1446 (Amicus — AI Study Partner v1) uses Anthropic Claude — Haiku for short responses, Sonnet for depth and for Partner+ users. The card #1473 asks whether a fraction of queries could be answered on-device by **Apple Foundation Models** (iOS 18+, Apple Silicon) to reduce cloud spend.
+
+We are **deferring** this work. The card's own language makes it clear: *"premature optimization before usage data is real"*. We won't know which queries fit the simple-query profile until the audit-sample pipeline (#1468) and aggregate analytics (#1469) have several months of production traffic to chew on.
+
+## Scope of this record
+
+- Document the trigger condition so it is visible without needing to dig through the issue tracker.
+- Codify a **feasibility checklist** that the engineer picking this up later can run without re-reading the whole epic.
+- Ship a minimal, inert scaffold in the client so when the trigger is hit we are extending existing code, not re-architecting — specifically, a `queryRouting` module whose public API can stay unchanged while an implementation swaps.
+
+## Non-goals
+
+- Shipping any actual Apple Foundation Models routing.
+- Evaluating Gemini Nano. That's a separate card once Android coverage warrants.
+- Training our own fine-tuned model. Sovereignty already lives behind the AI proxy; the proxy pattern gives the portability we'd need.
+
+## Feasibility checklist (for the engineer picking this up later)
+
+Run these in order before writing any code:
+
+1. **iOS 18+ share** — query the analytics (#1469) for User-Agent header distribution. Go/no-go threshold: **≥40%** of Amicus requests come from iOS 18+.
+2. **API surface stability** — confirm the Foundation Models API has not been deprecated or substantially reshaped since iOS 18.
+3. **Quality benchmarks** — pull 200 representative samples from `amicus_response_samples` (spread across gap-signal, user-feedback, and random_1pct pools). Run each through Apple FM and compare to the original Haiku response via the #1468 classifier. Accept only if the Apple FM `needs_review` rate is within **5% absolute** of the Haiku rate.
+4. **Latency** — measure on an iPhone 15 Pro (median of 50 runs). Accept only if median < 500ms; reject if p95 > 1200ms.
+5. **Citation integrity** — Apple FM must not hallucinate chunk_ids. This is the single highest-risk failure mode. Reject the eval if `check_every_citation_has_valid_chunk_id` fails more than 1% of samples.
+
+If all five pass, proceed to the shadow-comparison rollout described in the issue.
+
+## Decision
+
+Stop here until the trigger fires. The inert scaffold below keeps the option open without committing any new complexity to the running app.
+
+## Scaffold shipped with this record
+
+`app/src/services/amicus/queryRouting.ts` — a pure client-side helper that classifies a query as `simple` or `complex` per the rules in card #1473:
+
+- `simple` = ≤2 retrieved chunks AND no multi-turn context AND query < 100 tokens.
+- `complex` = everything else.
+
+Today the router unconditionally returns `'cloud'`. When the trigger fires, a future PR adds an `'apple_fm'` return path behind a capability check — without changing any call site. Tests fix the classification boundaries so future refactors stay inside the documented spec.
+
+## Rollback plan
+
+If the feature ever ships and needs to be pulled back: the router is a single branch. Setting the capability check to `false` reverts 100% of traffic to the cloud path without a code change.


### PR DESCRIPTION
## Summary

Resolves phase 5, card #1473 of epic #1446. The card itself is **explicitly deferred from v1** — its own spec reads *"premature optimization before usage data is real."* This PR captures the deferral decision in-repo and ships an inert routing scaffold so the follow-up PR extends existing code instead of reintroducing architecture.

### Decision record

- `docs/decisions/1473-apple-foundation-models-deferral.md` documents:
  - Status = Deferred.
  - **Trigger to revisit:** cloud AI spend > $5K/mo for three consecutive months OR a material Anthropic pricing change.
  - Five-step feasibility checklist (iOS 18+ share, API stability, quality parity vs Haiku, latency targets, citation integrity) the engineer picking this up later can execute without re-reading the epic.
  - Non-goals (no Gemini Nano, no fine-tuned model).
  - Rollback plan (a single capability flag).

### Inert routing scaffold

- `services/amicus/queryRouting.ts`:
  - `classifyQuery({ query, retrievedChunkCount, conversationHistoryLength })` → `'simple' | 'complex'` per the spec (≤2 chunks, zero prior turns, query < 100 tokens approximated as 400 chars).
  - `pickRoute({ complexity, appleFmAvailable? })` → `'cloud' | 'apple_fm'`. Today every caller lands on `'cloud'`; the `'apple_fm'` branch is gated behind a capability flag that the follow-up PR will flip.
  - `resolveRoute(input)` is the convenience wrapper for chat call sites.

### Why ship anything now

Freezing the classifier boundaries and the routing contract in unit tests means the follow-up PR is an implementation swap — no API design debate — and a reviewer can confirm in one glance that no production code is using Apple FM yet.

## Acceptance criteria

The card's full acceptance criteria (feasibility audit, shadow comparison, quality gate, gradual rollout, cost delta measurement) all require real production traffic and cannot be executed now. This PR delivers what **can** land today:

- [x] Decision documented with trigger condition, feasibility checklist, and rollback plan
- [x] Routing scaffold in place behind a capability flag — follow-up PR ships `'apple_fm'` without changing call sites
- [x] Unit tests freeze the classification boundaries so boundary creep during implementation is caught automatically

The remaining criteria stay checked off in the issue when the trigger fires and the follow-up PR lands.

## Test plan

- [x] `npx jest src/services/amicus/__tests__/queryRouting.test.ts` — 10 passing
- [x] Full suite: 3428 passing
- [x] `npx tsc --noEmit` clean for all Amicus files
- [x] `npx eslint` clean

https://claude.ai/code/session_01Pht3kzgdvkn81DDfL9SnFe