### PR TITLE
fix(ios): patch RCTTurboModule.mm for iOS 26 void-method crash

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -41,7 +41,10 @@
       [
         "expo-build-properties",
         {
-          "ios": { "newArchEnabled": true },
+          "ios": {
+            "newArchEnabled": true,
+            "buildReactNativeFromSource": true
+          },
           "android": { "newArchEnabled": true }
         }
       ],

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "companion-study",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/cinzel": "^0.2.3",
         "@expo-google-fonts/eb-garamond": "^0.2.3",
@@ -67,6 +68,8 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "jest": "^29.7.0",
         "jest-expo": "~54.0.17",
+        "patch-package": "^8.0.1",
+        "postinstall-postinstall": "^2.1.0",
         "prettier": "^3.8.1",
         "typescript": "^5.3.3"
       }
@@ -4672,6 +4675,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -8152,6 +8162,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -8217,6 +8237,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -10501,6 +10536,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -10524,6 +10579,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -10550,6 +10628,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -12247,6 +12335,59 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12404,6 +12545,14 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postinstall-postinstall": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
+      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -14368,6 +14517,16 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14677,6 +14836,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "postinstall": "patch-package",
     "test": "jest",
     "lint": "eslint src/ --max-warnings 0",
     "lint:fix": "eslint src/ --fix",
@@ -75,6 +76,8 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.17",
+    "patch-package": "^8.0.1",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.8.1",
     "typescript": "^5.3.3"
   },

--- a/app/patches/react-native+0.81.5.patch
+++ b/app/patches/react-native+0.81.5.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+index 2a67797..d7e914e 100644
+--- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
++++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+@@ -435,7 +435,12 @@ void ObjCTurboModule::performVoidMethodInvocation(
+     @try {
+       [inv invokeWithTarget:strongModule];
+     } @catch (NSException *exception) {
+-      throw convertNSExceptionToJSError(runtime, exception, std::string{moduleName}, methodNameStr);
++      // Void methods are always async, re-throw instead of converting to
++      // JSError, same as the async branch in performMethodInvocation.
++      // Upstream fix: facebook/react-native#56265 — not yet backported to
++      // 0.81-stable as of Apr 2026. Remove this patch when it lands in a
++      // released RN 0.81.x that Expo SDK 54 picks up.
++      @throw exception;
+     } @finally {
+       [retainedObjectsForInvocation removeAllObjects];
+     }


### PR DESCRIPTION
## Fixes: TestFlight iOS 26 SIGABRT crash

**Root cause:** `facebook/react-native#54859` — on iOS 26 Release builds with New Architecture + RN 0.81.5, void async TurboModule methods that throw an `NSException` cause a `SIGABRT` in `ObjCTurboModule::performVoidMethodInvocation`. The catch block calls `convertNSExceptionToJSError` which touches `jsi::Runtime` from the native-method call invoker thread, and `jsi::Runtime` is not thread-safe. The rethrow has nowhere to go on the GCD queue → `std::__terminate` → abort.

**Fix:** The 3-line upstream fix from `facebook/react-native#56265` (commit `4083a6f`, merged to `main` on Mar 29 2026 by @fabriziocucci). Changes:
- `throw convertNSExceptionToJSError(runtime, exception, ...)` → `@throw exception;`

Same pattern that was already used in the async branch of `performMethodInvocation` — this just mirrors it into `performVoidMethodInvocation`.

**Not backported to `0.81-stable` as of Apr 2026**, so we apply it locally via `patch-package`.

## Why two coupled changes

SDK 54 uses `RCT_USE_PREBUILT_RNCORE=1` by default, fetching a precompiled React-Core XCFramework instead of compiling `node_modules/react-native/ReactCommon/**/*.mm`. A standalone `patch-package` patch wouldn't take effect — the buggy binary would still ship.

So this PR does two things together:
1. **`buildReactNativeFromSource: true`** in `expo-build-properties` — forces source compilation
2. **`patch-package` + `patches/react-native+0.81.5.patch`** — applies the fix during postinstall

Either alone is insufficient. Both ship together.

## Verification against build 14 crash log

All three preconditions from the plan match:
- Frame 9: `ObjCTurboModule::performVoidMethodInvocation + 192 (RCTTurboModule.mm:441)` ✓
- Stack sequence: `objc_exception_rethrow` → `__cxa_rethrow` → `_objc_terminate` → `SIGABRT` ✓
- Thread 1 = dispatch worker thread (`_dispatch_workloop_worker_thread`) ✓

Device: `iPhone17,2` (iPhone 16 Pro Max, A18 Pro) running iOS `26.3.1`. Matches the cohort reported in the upstream issues (iPhone 16 Pro/Pro Max, iPhone 17 Pro, A18 Pro / A19 Pro, iOS 26.x) exactly.

## Trade-offs

- **iOS EAS build time:** +3–8 min for React-Core source compile. Android unaffected.
- **Maintenance:** Patch must be removed when RN backports the fix and Expo picks it up. Triggered by commit `4083a6f` appearing in RN 0.81.x stable + an Expo SDK 54.x patch. Kanban reminder will be added under P2.
- **Blast radius:** 1 file, 3 lines. No app-code changes.

## Post-merge

1. `eas build --platform ios --profile production` (expect 20–30 min)
2. Submit to TestFlight
3. Install on Craig's iPhone — single binary pass/fail: does it reach the home screen?

## Rollback

`git revert <merge-sha>` + rebuild. No user data concerns — purely build-layer. Restores the prebuilt XCFramework path; build time drops back down; app goes back to being crashed.

## References

- Upstream issue: https://github.com/facebook/react-native/issues/54859
- Upstream fix PR: https://github.com/facebook/react-native/pull/56265
- Related Expo issue: https://github.com/expo/expo/issues/44680
- Expo prebuilt React-Core docs: https://docs.expo.dev/versions/latest/sdk/build-properties/