### PR TITLE
diagnostic: disable expo-updates + bump to 1.0.7 to surface real launch error

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Companion Study",
     "slug": "companion-study",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "default",
     "icon": "./assets/images/icon-512.png",
     "scheme": "scripture",
@@ -62,7 +62,7 @@
     ],
     "updates": {
       "url": "https://u.expo.dev/105f31ba-3cfb-4d35-8509-4abbe6ab132d",
-      "enabled": true,
+      "enabled": false,
       "fallbackToCacheTimeout": 0
     },
     "runtimeVersion": {


### PR DESCRIPTION
## Why

TestFlight build 1.0.6(15) — the first build with PR #1514's iOS 26 TurboModule fix merged — launches, then crashes ~0.8s later. Unlike the original crash (which was in `ObjCTurboModule::performVoidMethodInvocation`), this one fires inside expo-updates' deliberate recovery-pipeline abort:

```
StartupProcedure.throwException(_:) (ErrorRecovery.swift:277)
  ← ErrorRecovery.crash()
  ← ErrorRecovery.runNextTask() (ErrorRecovery.swift:190)
  ← closure in ErrorRecovery.notify(newRemoteLoadStatus:) (ErrorRecovery.swift:149)
```

Reading the source: expo-updates runs `waitForRemoteUpdate → launchCached → crash` when it catches an initial error. On a fresh install where the remote server has nothing matching and the cache is empty, the pipeline blows straight through all three steps. **The crash is not the bug — it's the symptom. Something else throws the initial error into expo-updates, and then expo-updates abends the app deliberately because it can't recover.**

## Ruled out

**Stale OTA bundle mismatch.** The EAS Updates dashboard shows all recent published updates tagged runtime `1.0.0`. Our binary is runtime `1.0.6`. A runtime-version mismatch means the server returns "no update" to the device — it never attempts to load a bundle — so a bad bundle can't be the trigger.

## The plan

Temporarily disable expo-updates. This removes the `ErrorRecovery` pipeline from the startup path entirely. Whatever throws the initial error is no longer caught and converted into a deliberate `abort()` — it either propagates into a more informative crash signature or the app launches successfully.

Three possible outcomes on the next TestFlight build:

1. **App reaches the home screen** → expo-updates + its recovery machinery was the proximate cause. Re-enable updates in a follow-up PR after publishing a fresh `production` bundle for the new runtime version.
2. **App crashes with a completely different signature** → the real bug is exposed in that new stack trace. Debug it directly.
3. **Identical `ErrorRecovery.crash()` signature** → would be very surprising since that code path requires `enabled: true` to activate. Would force a close reading of config.

## Changes

Exactly two edits in `app/app.json`:

| Field | Before | After | Why |
|---|---|---|---|
| `version` | `1.0.6` | `1.0.7` | TestFlight build distinctness + invalidates runtime namespace so a stray publish can't land a bundle on the diagnostic binary |
| `updates.enabled` | `true` | `false` | Removes expo-updates from startup path entirely |

Everything else untouched — `updates.url` preserved, project ID preserved, runtime policy unchanged, `runtimeVersion: { policy: "appVersion" }` stays.

## Precedent

Commit `9f33448c` did exactly this ("fix: disable expo-updates to surface real launch crash + bump to 1.0.3") during an earlier crash investigation. Same diagnostic move; clean pattern in the repo.

## Post-merge

1. `eas build --platform ios --profile production` — source compile of React-Core is still in play via the `#1514` patch
2. Submit to TestFlight
3. Crash log or home screen — report back here

## Rollback

`git revert` + rebuild. Harmless; only restores the old config.

## Follow-up (out of scope for this PR)

Once the real bug is fixed and the app launches, a follow-up PR should:
- Re-enable `updates.enabled: true`
- Run `eas update --branch production` to publish a bundle against runtime `1.0.7`
- Verify on TestFlight

I'll open a cleanup reminder issue tracking that.