### PR TITLE
fix(ContentUpdater): chunk full-DB write via FileHandle (iOS 26 NSException)

### DIFF
--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -26,6 +26,9 @@ const mockFileMap = new Map<string, FileRecord>();
 const mockFileOps = {
   create: jest.fn(),
   write: jest.fn(),
+  writeBytes: jest.fn(),
+  handleOpen: jest.fn(),
+  handleClose: jest.fn(),
   copy: jest.fn(),
   move: jest.fn(),
   delete: jest.fn(),
@@ -82,6 +85,24 @@ jest.mock('expo-file-system', () => {
       const rec = getRec(this.uri);
       rec.exists = true;
       rec.size = typeof bytes === 'string' ? bytes.length : bytes.byteLength;
+    }
+    open(): {
+      writeBytes: (chunk: Uint8Array) => void;
+      close: () => void;
+    } {
+      mockFileOps.handleOpen(this.uri);
+      const uri = this.uri;
+      return {
+        writeBytes: (chunk: Uint8Array) => {
+          mockFileOps.writeBytes(uri, chunk);
+          const rec = getRec(uri);
+          rec.exists = true;
+          rec.size += chunk.byteLength;
+        },
+        close: () => {
+          mockFileOps.handleClose(uri);
+        },
+      };
     }
     copy(dest: { uri: string }): void {
       mockFileOps.copy({ from: this.uri, to: dest.uri });
@@ -694,6 +715,68 @@ describe('ContentUpdater service', () => {
       expect(mockFileOps.delete).toHaveBeenCalledWith(
         expect.stringContaining('scripture_backup.db'),
       );
+    });
+
+    // ── chunked-write path (regression for 1.0.6(15)/1.0.6(16)) ─────
+    // `File#write` is a synchronous Expo Modules Function; passing a ~90 MB
+    // buffer through it in one shot caused a process-terminating NSException
+    // on iOS 26. We now route through a FileHandle with 1 MiB chunks and
+    // surface any error as a promise rejection. See PR #1514 + #1516 history.
+
+    it('writes the downloaded payload via FileHandle, not File#write', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
+      resetXhr(200);
+      mockChecksumPass(sampleManifest.full_db_sha256);
+
+      await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(mockFileOps.handleOpen).toHaveBeenCalledWith(
+        expect.stringContaining('scripture_download.db'),
+      );
+      expect(mockFileOps.writeBytes).toHaveBeenCalled();
+      expect(mockFileOps.handleClose).toHaveBeenCalledWith(
+        expect.stringContaining('scripture_download.db'),
+      );
+      // The legacy single-shot write path must be gone.
+      expect(mockFileOps.write).not.toHaveBeenCalled();
+    });
+
+    it('splits a multi-MB payload into 1 MiB chunks', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
+      // 2.5 MiB payload → expect 3 chunks (1 MiB, 1 MiB, 0.5 MiB)
+      const payloadBytes = Math.floor(2.5 * (1 << 20));
+      xhrControls.response = new ArrayBuffer(payloadBytes);
+      xhrControls.status = 200;
+      xhrControls.progressEvents = [];
+      mockChecksumPass(sampleManifest.full_db_sha256);
+
+      await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(mockFileOps.writeBytes).toHaveBeenCalledTimes(3);
+      const chunkSizes = mockFileOps.writeBytes.mock.calls.map(
+        (call) => (call[1] as Uint8Array).byteLength,
+      );
+      expect(chunkSizes).toEqual([1 << 20, 1 << 20, payloadBytes - 2 * (1 << 20)]);
+    });
+
+    it('closes the file handle even when a chunk write throws', async () => {
+      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
+      resetXhr(200);
+      mockFileOps.writeBytes.mockImplementationOnce(() => {
+        throw new Error('simulated native write failure');
+      });
+
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('File write failed');
+      expect(result.error).toContain('simulated native write failure');
+      // Handle must still have been closed despite the throw.
+      expect(mockFileOps.handleClose).toHaveBeenCalled();
     });
   });
 });

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -375,9 +375,29 @@ class ContentUpdaterService {
     }
   }
 
+  /** Size of each chunk (in bytes) when streaming a downloaded payload to disk. */
+  private static readonly WRITE_CHUNK_BYTES = 1 << 20; // 1 MiB
+
   /**
    * XHR-based download with progress reporting. Writes the full response
    * body to `destFile` via the new File API.
+   *
+   * The payload is written in {@link WRITE_CHUNK_BYTES}-sized chunks through a
+   * {@link FileHandle} rather than via a single {@link File#write} call.
+   * `File#write` is a synchronous Expo Modules `Function` — when invoked
+   * with a large (~90 MB) `Uint8Array`, any native error thrown during the
+   * write surfaces as an `NSException` from within
+   * `ObjCTurboModule::performVoidMethodInvocation`. With the iOS 26 patch
+   * from #1514 in place, that exception is re-thrown cleanly rather than
+   * corrupting `jsi::Runtime`, but there is no `@catch` up the GCD queue
+   * so the process aborts. See the 1.0.6(15)/1.0.6(16) TestFlight crash
+   * logs for the terminating `RCTTurboModule.mm:446` frame.
+   *
+   * Chunked writes keep each individual TurboModule invocation in a size
+   * range that file-system natives routinely handle without issue, and —
+   * critically — wrap the write in a try/catch so any failure becomes a
+   * promise rejection surfaced by {@link DbDownloadScreen} instead of a
+   * process-terminating exception.
    */
   private async downloadWithProgress(
     url: string,
@@ -394,30 +414,63 @@ class ContentUpdaterService {
         }
       };
       xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          try {
-            const buffer = xhr.response as ArrayBuffer | null;
-            if (!buffer) {
-              reject(new Error('Download returned empty body'));
-              return;
-            }
-            const bytes = new Uint8Array(buffer);
-            destFile.create({ overwrite: true });
-            destFile.write(bytes);
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
+        if (xhr.status < 200 || xhr.status >= 300) {
+          const httpErr = new Error(`HTTP ${xhr.status}`);
+          (httpErr as Error & { httpStatus?: number }).httpStatus = xhr.status;
+          reject(httpErr);
           return;
         }
-        const httpErr = new Error(`HTTP ${xhr.status}`);
-        (httpErr as Error & { httpStatus?: number }).httpStatus = xhr.status;
-        reject(httpErr);
+
+        const buffer = xhr.response as ArrayBuffer | null;
+        if (!buffer) {
+          reject(new Error('Download returned empty body'));
+          return;
+        }
+
+        const bytes = new Uint8Array(buffer);
+        try {
+          this.writeChunked(destFile, bytes);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          reject(new Error(
+            `File write failed after ${bytes.length} bytes received: ${msg}`,
+          ));
+          return;
+        }
+        resolve();
       };
       xhr.onerror = () => reject(new Error('Download network error'));
       xhr.ontimeout = () => reject(new Error('Download timeout'));
       xhr.send();
     });
+  }
+
+  /**
+   * Write `bytes` to `destFile` in {@link WRITE_CHUNK_BYTES} chunks via a
+   * `FileHandle`. Any error thrown during create/open/write propagates; the
+   * handle is closed via `finally` so a partial write cannot leak a handle.
+   *
+   * Factored out so the full write path is covered by the single try/catch
+   * in {@link downloadWithProgress}.
+   */
+  private writeChunked(destFile: File, bytes: Uint8Array): void {
+    destFile.create({ overwrite: true });
+    const handle = destFile.open();
+    try {
+      const chunk = ContentUpdaterService.WRITE_CHUNK_BYTES;
+      for (let offset = 0; offset < bytes.length; offset += chunk) {
+        const end = Math.min(offset + chunk, bytes.length);
+        handle.writeBytes(bytes.subarray(offset, end));
+      }
+    } finally {
+      try {
+        handle.close();
+      } catch (closeErr) {
+        // Closing a handle on an already-failed write shouldn't mask the
+        // real error; log it and move on so the original exception surfaces.
+        logger.warn(TAG, 'FileHandle close failed after chunked write', closeErr);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Diagnostic + likely fix for the 1.0.6(15) / 1.0.6(16) launch crash

## Root cause hypothesis

Build 15 and 16 crashed on TestFlight ~13s after launch. Crash signature lands inside our own patched `RCTTurboModule.mm:446` — i.e. PR #1514 is doing its job re-throwing the NSException cleanly, but **something is still throwing an NSException from a void sync TurboModule call** that nothing up the GCD queue catches → process aborts.

Traced to `ContentUpdater.downloadWithProgress`:

```ts
destFile.create({ overwrite: true });
destFile.write(bytes);   // ~90 MB Uint8Array, sync Expo Modules Function
```

`expo-file-system`'s `File#write` is exposed as a synchronous `Function` (not `AsyncFunction`) on iOS. When invoked with a ~90 MB buffer, any internal Swift error `Data(bytes:count:).write(to:)` raises — sandbox scoped-access, disk pressure, TypedArray marshalling, etc. — surfaces as an `NSException` via `ObjCTurboModule::performVoidMethodInvocation`. With the #1514 patch in place the exception propagates cleanly, but there is no `@catch` up the dispatch queue → `abort`.

The `ContentUpdater` docstring *already notes* the 1.0.5 build hit the same crash signature against the legacy `expo-file-system` shim. Moving to the new `File` API removed the shim but didn't remove the single-shot sync write pattern — same risk surface, same outcome.

## Fix

Replace the single `destFile.write(bytes)` call with a chunked write through a `FileHandle`:
- `destFile.open()` → loop calling `handle.writeBytes(chunk)` in 1 MiB slices → `handle.close()` in `finally`
- Each TurboModule invocation now writes a size range that file-system natives routinely handle

## Diagnostic value

The full write path is now wrapped in a try/catch. Any failure becomes a promise rejection surfaced by `DbDownloadScreen`'s error UI as `"File write failed after N bytes received: <message>"`.

**This means:**
- If the hypothesis is right → the app boots. ✓
- If the hypothesis is wrong → the app shows a clean error string in the download screen UI, we finally get to see the real exception message, and we iterate from there.

Either way, **no more silent process aborts.** This is the primary win regardless of whether the hypothesis holds.

## Tests

Extended the `MockFile` jest stub with `open()` / `writeBytes` / `handleClose` tracking. Three new regression tests:

- `writes the downloaded payload via FileHandle, not File#write` — proves the legacy path is gone
- `splits a multi-MB payload into 1 MiB chunks` — 2.5 MiB → 3 chunks (1 MiB, 1 MiB, 0.5 MiB)
- `closes the file handle even when a chunk write throws` — error surfaces cleanly, no handle leak

**Full suite**: 465 suites / 3431 tests pass. Zero TS errors. Zero new lint errors.

## Scope

`ContentUpdater.ts` + its test file only. No `app.json` / `eas.json` / native changes. `updates.enabled` stays `false` from #1516. Version stays `1.0.7` per Craig's call — EAS `autoIncrement` handles the build number.

## Post-merge

1. `eas build --platform ios --profile production` from `app/`
2. Submit to TestFlight
3. Install on device (delete previous install first to avoid Springboard caching stale state)

## References

- PR #1514 (iOS 26 TurboModule patch — successfully shipped, proved to work by the crash signature change)
- PR #1516 (diagnostic disable updates — shipped, confirmed updates aren't the issue)
- facebook/react-native#54859 (TurboModule void-method NSException)
- SDK 54 `expo-file-system` `File` vs `FileHandle` — https://docs.expo.dev/versions/v54.0.0/sdk/filesystem/

## Parallel work

Sentry install deferred until Craig provides DSN. Will land as a follow-up commit on this branch or a separate PR.