### PR TITLE
feat(sentry): wire production DSN to activate crash reporting

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -77,7 +77,7 @@
       "policy": "appVersion"
     },
     "extra": {
-      "sentryDsn": "",
+      "sentryDsn": "https://a2bc79d6869d233e51d3e55b1754a72c@o4511235546742784.ingest.us.sentry.io/4511238124994560",
       "eas": {
         "projectId": "105f31ba-3cfb-4d35-8509-4abbe6ab132d"
       }


### PR DESCRIPTION
## Summary
- Fills in `app/app.json` `extra.sentryDsn` with the production DSN from the `companion-study/react-native` Sentry project.
- Until now the Sentry integration (merged in #1518) was code-complete but inert — `lib/sentry.ts` bails out of `init()` whenever the DSN is an empty string. This one-line change flips it on.
- No other code changes; all wiring (`Sentry.wrap` in `App.tsx`, `logger.warn`/`logger.error` forwarding, `setUser` in `authStore`, PII scrubbers) was already in place.

## Follow-up (not in this PR)
- Add a `SENTRY_AUTH_TOKEN` EAS secret (scope `project:releases`) so source maps upload during EAS builds and stack traces symbolicate in the Sentry dashboard.

## Test plan
- [ ] Run a dev build and trigger the `SentrySmokeScreen` "throw" button — confirm event appears in Sentry within ~30s.
- [ ] Confirm the event's `user.id` is the anonymous ID (not an email) and no `ip_address` / `cookie` / `authorization` fields leak through.
- [ ] Confirm release tag matches `com.companionstudy.app@1.0.7+<build>`.
- [ ] Verify app still boots cleanly in dev with the DSN set (no new warnings in Metro).

https://claude.ai/code/session_01QBTmLfnXM15XdfE8jW5cAD