### PR TITLE
diag(sentry): surface init failures instead of swallowing them

### DIFF
--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -91,6 +91,14 @@ function scrubBreadcrumb(crumb: Record<string, unknown>): Record<string, unknown
 
 let _sentry: SentryModule | null = null;
 
+export type SentryInitStatus =
+  | { state: 'disabled-no-dsn' }
+  | { state: 'initialized' }
+  | { state: 'module-shape-mismatch'; initType: string }
+  | { state: 'init-threw'; error: string };
+
+let _initStatus: SentryInitStatus = { state: 'disabled-no-dsn' };
+
 try {
   if (DSN) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -112,11 +120,31 @@ try {
         beforeSend: (event: Record<string, unknown>) => scrubEvent(event),
         beforeBreadcrumb: (crumb: Record<string, unknown>) => scrubBreadcrumb(crumb),
       });
+      _initStatus = { state: 'initialized' };
+    } else {
+      _initStatus = { state: 'module-shape-mismatch', initType: typeof mod?.init };
+      // eslint-disable-next-line no-console
+      console.warn('[sentry] @sentry/react-native loaded but .init is not a function:', typeof mod?.init);
     }
   }
-} catch {
-  // @sentry/react-native failed to load (missing native module, etc.)
-  // Sentry stays disabled — app boots normally.
+} catch (e) {
+  _initStatus = {
+    state: 'init-threw',
+    error: e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+  };
+  // Surfaces in device logs (Xcode console, Console.app, Metro). Previously
+  // this catch was silent, which hid native-module link failures and any
+  // unexpected option rejections in @sentry/react-native init.
+  // eslint-disable-next-line no-console
+  console.warn('[sentry] init failed:', e);
+}
+
+/**
+ * Returns why Sentry is/isn't active. The smoke test screen surfaces this
+ * so we don't have to guess at why events aren't landing in the dashboard.
+ */
+export function getSentryInitStatus(): SentryInitStatus {
+  return _initStatus;
 }
 
 // ── Public helpers ───────────────────────────────────────────────

--- a/app/src/screens/dev/SentrySmokeScreen.tsx
+++ b/app/src/screens/dev/SentrySmokeScreen.tsx
@@ -24,12 +24,14 @@ import {
   addBreadcrumb,
   Sentry,
   DSN,
+  getSentryInitStatus,
 } from '../../lib/sentry';
 import { logger } from '../../utils/logger';
 
 export default function SentrySmokeScreen(): React.ReactElement {
   const dsnConfigured = Boolean(DSN);
   const sentryReady = Boolean(Sentry);
+  const initStatus = getSentryInitStatus();
 
   const throwJsError = useCallback(() => {
     addBreadcrumb('User pressed throw-js-error', 'smoke-test');
@@ -73,6 +75,15 @@ export default function SentrySmokeScreen(): React.ReactElement {
         <Text style={styles.statusLabel}>Sentry module loaded:</Text>
         <Text style={sentryReady ? styles.statusOk : styles.statusBad}>
           {sentryReady ? 'yes' : 'NO — check @sentry/react-native install'}
+        </Text>
+
+        <Text style={styles.statusLabel}>Init status:</Text>
+        <Text style={initStatus.state === 'initialized' ? styles.statusOk : styles.statusBad}>
+          {initStatus.state === 'init-threw'
+            ? `threw: ${initStatus.error}`
+            : initStatus.state === 'module-shape-mismatch'
+              ? `module shape mismatch (init was "${initStatus.initType}")`
+              : initStatus.state}
         </Text>
 
         <Text style={styles.statusLabel}>Release:</Text>


### PR DESCRIPTION
## Summary
Unmutes the silent `catch {}` at `app/src/lib/sentry.ts:117` so we can actually see *why* Sentry isn't capturing events from the app. Previously, any native-module link failure or option rejection during `Sentry.init()` was swallowed with no log and no state export — "no events in dashboard" was indistinguishable from "init crashed silently."

## What's in this PR
- **`lib/sentry.ts`**: the bare `catch {}` becomes a `catch (e)` that `console.warn`s the error (visible in device logs / Metro) and stores the outcome in a new `SentryInitStatus` union (`disabled-no-dsn` | `initialized` | `module-shape-mismatch` | `init-threw`).
- **`SentrySmokeScreen.tsx`**: new "Init status:" row that surfaces the reason text on-screen, so we can diagnose from a dev client without needing Xcode / Console.app.

## What this PR does NOT change
Audit flagged two other items that turned out to be false positives after closer reading:

1. **`ContentUpdater.ts` File.create/open wrap** — they already bubble through `writeChunked()` into the existing try/catch at `ContentUpdater.ts:431`. No unhandled exception risk.
2. **Removing `buildReactNativeFromSource: true`** from `app.json` — this flag is load-bearing. The iOS 26 TurboModule patch at `patches/react-native+0.81.5.patch` modifies React Native's own iOS source (`RCTTurboModule.mm`). Precompiled XCFrameworks ignore patch-package output, so flipping the flag off would silently re-introduce the `SIGABRT` at `performVoidMethodInvocation`.

## Test plan
- [ ] Build a dev client with `EXPO_PUBLIC_SENTRY_SMOKE=true`, open **More → Settings → Sentry smoke test**, confirm the new "Init status" row shows `initialized`
- [ ] Temporarily break something (bad DSN / remove the plugin) and re-open the smoke screen to confirm it shows `init-threw: ...` with the real error
- [ ] Trigger the three smoke buttons and confirm events reach the Sentry dashboard

## Follow-ups (tracked separately)
- `@maplibre/maplibre-react-native@11.0.0-beta.30` is shipping in a critical path — worth considering a pin-to-v10 until v11 GAs
- `setSentryUser(anonId)` runs after `initDatabase()`, so first-launch crashes lose user context — move anon-ID bind earlier in `App.tsx` when we have bandwidth

https://claude.ai/code/session_01QBTmLfnXM15XdfE8jW5cAD