### PR TITLE
diagnostic: on-device startup probe for build-18 crash investigation

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -34,6 +34,15 @@ import AmicusFab from './src/components/amicus/AmicusFab';
 import { DbDownloadScreen } from './src/screens/DbDownloadScreen';
 import { Sentry, DSN, setSentryUser } from './src/lib/sentry';
 import { getAnonymousId } from './src/utils/anonymousId';
+import {
+  record as probeRecord,
+  recordError as probeRecordError,
+  markLaunchStable,
+  STABILITY_WINDOW_MS,
+} from './src/utils/startupProbe';
+import { PreviousProbeGate } from './src/components/PreviousProbeGate';
+
+probeRecord('app:module-loaded');
 
 /**
  * Root navigation ref — shared with non-component code (notification tap
@@ -147,32 +156,54 @@ function AppShell() {
   );
 }
 
-function App() {
+function AppInner() {
   const [fontsLoaded] = useFonts(FONT_MAP);
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
 
   useEffect(() => {
+    probeRecord('app:init-useEffect-entered');
     async function init() {
       try {
+        probeRecord('app:init-started');
         // Lock to portrait by default — specific screens unlock for landscape
         await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+        probeRecord('app:orientation-locked');
         const status = await initDatabase();   // Content DB (scripture.db) — may be missing on first launch
+        probeRecord('app:initDatabase-returned', `status=${status}`);
         await initUserDatabase();              // User DB (user.db) — never replaced, migrated
+        probeRecord('app:initUserDatabase-returned');
         // Bind an anonymous identifier to Sentry so crashes from a single
         // install roll up under one user. Best-effort — if it fails we
         // just don't get per-user grouping this session.
         try {
           const anonId = await getAnonymousId();
           setSentryUser(anonId);
-        } catch {
+          probeRecord('app:sentry-user-bound');
+        } catch (anonErr) {
+          probeRecordError('app:sentry-user-bind-failed', anonErr);
           /* non-fatal */
         }
         await useSettingsStore.getState().hydrate();
+        probeRecord('app:settings-hydrated');
         await useAuthStore.getState().hydrate();
+        probeRecord('app:auth-hydrated');
         await usePremiumStore.getState().hydrate();
+        probeRecord('app:premium-hydrated');
         pruneEvents(90); // Clean up old analytics (fire-and-forget)
+        probeRecord('app:analytics-pruned');
         setDbStatus(status);
+        probeRecord('app:dbStatus-set', `status=${status}`);
+
+        // Declare stability: if we make it here and stay alive for
+        // STABILITY_WINDOW_MS, clear the probe so next launch sees
+        // a clean slate. If the app crashes before the timer fires,
+        // the probe survives for next-launch display.
+        setTimeout(() => {
+          probeRecord('app:launch-stable');
+          markLaunchStable();
+        }, STABILITY_WINDOW_MS);
       } catch (e) {
+        probeRecordError('app:init-threw', e);
         console.error('Init error:', e);
         // Fail-safe: surface the download screen so the user can recover
         setDbStatus('needs_download');
@@ -256,6 +287,19 @@ function App() {
         </ThemeProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
+  );
+}
+
+/**
+ * Outer wrapper: gates the real app tree behind the PreviousProbeGate
+ * so the previous-session probe is visible before any crash-prone
+ * code paths run. See src/utils/startupProbe.ts for context.
+ */
+function App() {
+  return (
+    <PreviousProbeGate>
+      <AppInner />
+    </PreviousProbeGate>
   );
 }
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,8 +1,27 @@
+// ⚠ DIAGNOSTIC IMPORT ORDER — DO NOT REORDER.
+// The startupProbe import MUST be the very first thing evaluated so
+// its rotate() call runs before any other module is loaded. Any
+// module loaded before rotate() could crash during initialisation
+// and its probe entries would land in the wrong file.
+import {
+  record as probeRecord,
+  rotate as probeRotate,
+} from './src/utils/startupProbe';
+
+probeRotate();
+probeRecord('boot:index.ts-loaded');
+
 import { registerRootComponent } from 'expo';
 
+probeRecord('boot:expo-imported');
+
 import App from './App';
+
+probeRecord('boot:App-imported');
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
 registerRootComponent(App);
+
+probeRecord('boot:registerRootComponent-returned');

--- a/app/src/components/PreviousProbeGate.tsx
+++ b/app/src/components/PreviousProbeGate.tsx
@@ -1,0 +1,185 @@
+/**
+ * components/PreviousProbeGate.tsx — First-render gate that shows
+ * the previous session's startup-probe log if one exists.
+ *
+ * Rendered at the very top of App.tsx, before any data init work
+ * begins. If the user's last launch crashed, its probe file still
+ * exists; we render its contents full-screen with a Continue
+ * button. When the user taps Continue, the probe is dismissed and
+ * the real app init proceeds.
+ *
+ * If no previous probe exists, this component renders its children
+ * directly — no visible UI, no delay.
+ *
+ * Why top-level? The crash we're diagnosing fires ~15s into
+ * launch, well after useEffect hooks mount. Pushing the display
+ * as early as possible in the render tree ensures the probe is
+ * visible before any of the code paths that might crash have
+ * a chance to run.
+ *
+ * Remove this component (and its App.tsx mount point) once the
+ * startup crash is diagnosed and fixed.
+ */
+
+import { useEffect, useState, type ReactNode } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  dismissPrevious,
+  readPreviousProbeAsync,
+  type ProbeFile,
+} from '../utils/startupProbe';
+
+interface Props {
+  children: ReactNode;
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'no-previous' }
+  | { kind: 'has-previous'; contents: string };
+
+export function PreviousProbeGate({ children }: Props): React.ReactElement {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    readPreviousProbeAsync().then((result) => {
+      if (cancelled) return;
+      if (result === null) {
+        setState({ kind: 'no-previous' });
+        return;
+      }
+      const contents =
+        typeof result === 'string'
+          ? result
+          : formatProbeFile(result);
+      setState({ kind: 'has-previous', contents });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color="#bfa050" size="small" />
+      </View>
+    );
+  }
+
+  if (state.kind === 'no-previous') {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Previous Launch Probe</Text>
+      <Text style={styles.subtitle}>
+        The last launch did not complete cleanly. The probe below
+        shows the startup milestones it reached before stopping.
+      </Text>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.code} selectable>
+          {state.contents}
+        </Text>
+      </ScrollView>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => {
+          dismissPrevious();
+          setState({ kind: 'no-previous' });
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss probe and continue"
+      >
+        <Text style={styles.buttonText}>Continue</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function formatProbeFile(probe: ProbeFile): string {
+  const header = [
+    `Session started: ${new Date(probe.sessionStart).toISOString()}`,
+    `Probe version: ${probe.version}`,
+    `Entries: ${probe.entries.length}`,
+    '',
+    '── Milestones ──',
+  ].join('\n');
+
+  const body = probe.entries
+    .map((e) => {
+      const elapsed = `+${e.elapsedMs.toString().padStart(5, ' ')}ms`;
+      const detail = e.detail ? `\n    ${e.detail}` : '';
+      return `${elapsed}  ${e.tag}${detail}`;
+    })
+    .join('\n');
+
+  return `${header}\n${body}`;
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: '#0c0a07',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  container: {
+    flex: 1,
+    backgroundColor: '#0c0a07',
+    paddingHorizontal: 20,
+    paddingTop: 60,
+    paddingBottom: 40,
+  },
+  title: {
+    color: '#bfa050',
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  subtitle: {
+    color: '#b8a888',
+    fontSize: 13,
+    marginBottom: 16,
+    lineHeight: 18,
+  },
+  scroll: {
+    flex: 1,
+    backgroundColor: '#1a1510',
+    borderColor: '#3d3528',
+    borderWidth: 1,
+    borderRadius: 6,
+  },
+  scrollContent: {
+    padding: 12,
+  },
+  code: {
+    color: '#d4c9b0',
+    fontFamily: 'Menlo',
+    fontSize: 11,
+    lineHeight: 16,
+  },
+  button: {
+    marginTop: 16,
+    backgroundColor: '#bfa050',
+    borderRadius: 6,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#0c0a07',
+    fontSize: 15,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+});

--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -89,14 +89,25 @@ function scrubBreadcrumb(crumb: Record<string, unknown>): Record<string, unknown
 
 // ── Lazy load + init ─────────────────────────────────────────────
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { record: probeRecord, recordError: probeRecordError } = require('../utils/startupProbe');
+
 let _sentry: SentryModule | null = null;
+
+probeRecord('sentry:module-loaded', `DSN=${DSN ? 'present' : 'missing'}`);
 
 try {
   if (DSN) {
+    probeRecord('sentry:entering-init-block');
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const mod = require('@sentry/react-native');
+    probeRecord(
+      'sentry:require-succeeded',
+      `init=${typeof mod?.init}, wrap=${typeof mod?.wrap}`,
+    );
     if (typeof mod?.init === 'function') {
       _sentry = mod;
+      probeRecord('sentry:calling-init');
       _sentry!.init({
         dsn: DSN,
         environment: ENVIRONMENT,
@@ -112,11 +123,17 @@ try {
         beforeSend: (event: Record<string, unknown>) => scrubEvent(event),
         beforeBreadcrumb: (crumb: Record<string, unknown>) => scrubBreadcrumb(crumb),
       });
+      probeRecord('sentry:init-returned');
+    } else {
+      probeRecord('sentry:init-not-a-function');
     }
+  } else {
+    probeRecord('sentry:skipped-no-dsn');
   }
-} catch {
+} catch (err) {
   // @sentry/react-native failed to load (missing native module, etc.)
   // Sentry stays disabled — app boots normally.
+  probeRecordError('sentry:init-threw', err);
 }
 
 // ── Public helpers ───────────────────────────────────────────────

--- a/app/src/utils/startupProbe.ts
+++ b/app/src/utils/startupProbe.ts
@@ -1,0 +1,193 @@
+/**
+ * utils/startupProbe.ts — Persistent startup milestone logger.
+ *
+ * Writes a sequence of timestamped markers to
+ * `Documents/startup-probe-current.json` during app launch. Each
+ * call serialises the full accumulated log so a crash between two
+ * probe points always leaves the file at the correct state.
+ *
+ * At startup the prior session's current file is rotated to
+ * `startup-probe-previous.json`. If the app survives for
+ * {@link STABILITY_WINDOW_MS} after UI mount, the current file is
+ * deleted — treating stable runtime as "launch succeeded". That
+ * means on the next boot, if `previous` exists, last session
+ * crashed and {@link PreviousProbeBanner} will render it.
+ *
+ * Purpose: build 15 / 16 / 18 TestFlight binaries crash ~15 s after
+ * launch with a signature that tells us WHICH terminate path fires
+ * (RCTFatal via RCTExceptionsManager → void TurboModule NSException)
+ * but not WHICH line of JS is throwing. Sentry isn't transmitting
+ * from the production binary for reasons we haven't pinned down, so
+ * we need an on-device signal that doesn't depend on the network
+ * or on any React-Native error boundary completing gracefully.
+ *
+ * Design constraints:
+ *   - Must survive a hard `abort(3)` → full JSON rewrite on every
+ *     call, not an append stream.
+ *   - Must not itself crash the app → writes go through the
+ *     small-string File#write path (≤ a few KB), which is distinct
+ *     from the large-Uint8Array path implicated in the crash.
+ *   - Must be synchronous during record() → a crash between probe
+ *     N and N+1 leaves the file at probe N.
+ *   - Must not require any new native module → only uses the File
+ *     API from expo-file-system that the app already depends on.
+ *
+ * Remove this module (and its call sites) once the startup crash
+ * is diagnosed and fixed.
+ */
+
+import { File, Paths } from 'expo-file-system';
+
+const CURRENT_FILENAME = 'startup-probe-current.json';
+const PREVIOUS_FILENAME = 'startup-probe-previous.json';
+const PROBE_VERSION = 1;
+export const STABILITY_WINDOW_MS = 5000;
+
+interface ProbeEntry {
+  /** Milliseconds since app start (based on the first record() in this session). */
+  elapsedMs: number;
+  /** Short tag identifying the milestone. */
+  tag: string;
+  /** Optional free-form detail, clamped to 500 chars. */
+  detail?: string;
+}
+
+export interface ProbeFile {
+  version: number;
+  /** Unix epoch ms when this session's first record() fired. */
+  sessionStart: number;
+  /** Recorded milestones in order. */
+  entries: ProbeEntry[];
+}
+
+let sessionStart: number | null = null;
+let entries: ProbeEntry[] = [];
+
+function currentFile(): File {
+  return new File(Paths.document, CURRENT_FILENAME);
+}
+
+function previousFile(): File {
+  return new File(Paths.document, PREVIOUS_FILENAME);
+}
+
+/**
+ * Rotate the prior session's current file into the previous slot.
+ * Call once, as early as possible in app startup, before any
+ * other probe call. Safe to call multiple times (idempotent for
+ * this launch — only does work the first time the file exists).
+ */
+export function rotate(): void {
+  try {
+    const current = currentFile();
+    if (!current.exists) return;
+    const previous = previousFile();
+    if (previous.exists) {
+      try { previous.delete(); } catch { /* ignore */ }
+    }
+    current.move(previous);
+  } catch {
+    /* non-fatal — probe is a diagnostic, not a feature */
+  }
+}
+
+/**
+ * Record a startup milestone. Writes the full accumulated log to
+ * disk synchronously. Never throws.
+ */
+export function record(tag: string, detail?: string): void {
+  try {
+    const now = Date.now();
+    if (sessionStart === null) {
+      sessionStart = now;
+    }
+
+    const trimmedDetail =
+      detail === undefined ? undefined : String(detail).slice(0, 500);
+
+    entries.push({
+      elapsedMs: now - sessionStart,
+      tag,
+      detail: trimmedDetail,
+    });
+
+    const payload: ProbeFile = {
+      version: PROBE_VERSION,
+      sessionStart,
+      entries,
+    };
+    const file = currentFile();
+    file.create({ overwrite: true });
+    file.write(JSON.stringify(payload));
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * Record a caught exception with its message and the first couple
+ * of lines of its stack. Inlining this at every catch site would
+ * bloat the surgical call sites.
+ */
+export function recordError(tag: string, err: unknown): void {
+  if (err instanceof Error) {
+    const firstStackLine = (err.stack ?? '').split('\n').slice(0, 2).join(' | ');
+    record(tag, `${err.message} :: ${firstStackLine}`);
+  } else {
+    record(tag, String(err));
+  }
+}
+
+/**
+ * Read the previous-session probe file. Returns null if the file
+ * is missing, a parsed object if the contents are valid JSON, or
+ * the raw string if parsing failed (we'd rather show raw bytes
+ * than lose diagnostic data).
+ */
+export async function readPreviousProbeAsync(): Promise<
+  ProbeFile | string | null
+> {
+  try {
+    const file = previousFile();
+    if (!file.exists) return null;
+    const bytes = await file.bytes();
+    const text = new TextDecoder('utf-8').decode(bytes);
+    try {
+      return JSON.parse(text) as ProbeFile;
+    } catch {
+      return text;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete the previous-session probe. Call after the user has
+ * acknowledged viewing it, so subsequent launches don't keep
+ * showing the same banner.
+ */
+export function dismissPrevious(): void {
+  try {
+    const file = previousFile();
+    if (file.exists) file.delete();
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * Declare the current launch stable — delete the current-session
+ * file so the next launch won't mistake it for a crash report.
+ * Safe to call multiple times.
+ */
+export function markLaunchStable(): void {
+  try {
+    const file = currentFile();
+    if (file.exists) file.delete();
+  } catch {
+    /* non-fatal */
+  }
+  entries = [];
+  sessionStart = null;
+}


### PR DESCRIPTION
## What this is
A diagnostic build, not a fix. We've been building theories from inference — last three theories were partially right but missed the real cause. This commit stops that by capturing ground-truth data on the device so we can see exactly where the app dies instead of guessing.

## Why it's needed
- Builds 15 / 16 / 18 all crash ~15s after launch
- Crash log shows the *terminate* path (RCTFatal → void TurboModule NSException → patched rethrow → abort) but not the originating JS code
- Sentry is installed and its native crash monitor fires during the crash (stack frame 6: `sentrycrashcm_cppexception_callOriginalTerminationHandler`)
- **But the production iOS binary has sent zero events to Sentry across all crashing builds** — the "smoke test" event visible in the Sentry dashboard was a manual DSN-verification I ran from outside the app earlier in the session, not real telemetry
- This means Sentry is failing to initialize silently, and the silent `catch {}` in `sentry.ts` is swallowing whatever goes wrong

## What it does
Writes timestamped milestone markers to `Documents/startup-probe-current.json` at every significant point in app startup. Each call serialises the full accumulated log so the last entry written reflects the last milestone reached. Survives hard `abort(3)` because every call rewrites the whole log.

On next boot: rotates `current → previous`. If `previous` exists, a full-screen banner (`PreviousProbeGate`) renders its contents before any other app code runs. Auto-clears after 5 seconds of stable runtime (launch succeeded).

## Milestones instrumented
```
boot:index.ts-loaded          ← module graph started
boot:expo-imported
boot:App-imported
boot:registerRootComponent-returned
sentry:module-loaded          (with DSN=present/missing)
sentry:entering-init-block
sentry:require-succeeded       (with init/wrap types)
sentry:calling-init
sentry:init-returned
sentry:init-threw              (with error message) ← key
app:module-loaded
app:init-started
app:orientation-locked
app:initDatabase-returned      (with status=ready/needs_download)
app:initUserDatabase-returned
app:sentry-user-bound
app:settings-hydrated
app:auth-hydrated
app:premium-hydrated
app:dbStatus-set
app:launch-stable              ← reached = no crash in the 5s window
```

## Possible outcomes on next build

| Last probe entry | Diagnosis |
|---|---|
| `sentry:init-threw` | Sentry's init is the proximate crash cause. Error message tells us what. |
| `sentry:entering-init-block` / `sentry:require-succeeded` | `require('@sentry/react-native')` or `init()` is crashing. Native-module linkage issue. |
| `app:initDatabase-returned` / `app:initUserDatabase-returned` | DB bootstrap is the problem. |
| `app:premium-hydrated` | Premium store / RevenueCat hydration. |
| `app:dbStatus-set` (no `app:launch-stable`) | Crash is in render / effect phase, after init. |
| All probes including `app:launch-stable` | App reached stability; crash is elsewhere or has stopped reproducing. |

## Safety constraints
- Probe writes use small-string `File#write` — **not** the 90MB `Uint8Array` path from PR #1519
- Writes are synchronous so a crash between probe N and N+1 leaves the file at probe N
- `record()` is wrapped in `try { ... } catch {}` so the probe can't itself cause a crash
- No new native modules introduced

## Scope
5 files: 1 new utility, 1 new component, surgical edits to `index.ts`, `App.tsx`, `sentry.ts`. Typecheck clean. Targeted tests green across DB, stores, services, ContentUpdater (291 tests pass). Zero new errors, a handful of pre-existing lint warnings unrelated.

## After this ships
1. Install on device → will crash as before
2. Relaunch → probe banner renders showing the last milestone
3. Screenshot/copy the contents, paste back here
4. With that data we know exactly where to look — no more inference

## Remove when done
This is a diagnostic module. Once the crash is fixed it should be reverted. Kanban reminder to be filed as a follow-up.