### PR TITLE
chore(lint): clear 13 warnings blocking --max-warnings 0 CI gate

### DIFF
--- a/app/src/components/amicus/StreamingDot.tsx
+++ b/app/src/components/amicus/StreamingDot.tsx
@@ -2,13 +2,13 @@
  * components/amicus/StreamingDot.tsx — pulsing dot shown while a stream is
  * still emitting tokens.
  */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { useTheme } from '../../theme';
 
 export default function StreamingDot(): React.ReactElement {
   const { base } = useTheme();
-  const opacity = useRef(new Animated.Value(0.3)).current;
+  const [opacity] = useState(() => new Animated.Value(0.3));
 
   useEffect(() => {
     const loop = Animated.loop(

--- a/app/src/components/map/MapErrorBoundary.tsx
+++ b/app/src/components/map/MapErrorBoundary.tsx
@@ -18,8 +18,8 @@
  */
 
 import React, { Component, type ErrorInfo, type ReactNode } from 'react';
-import { MapUnavailableCard } from './MapUnavailableCard';
 import { logger } from '../../utils/logger';
+import { MapUnavailableCard } from './MapUnavailableCard';
 
 interface Props {
   children: ReactNode;

--- a/app/src/hooks/__tests__/useAmicusThreads.test.tsx
+++ b/app/src/hooks/__tests__/useAmicusThreads.test.tsx
@@ -5,12 +5,11 @@ import React from 'react';
 import { Text } from 'react-native';
 import { act, render } from '@testing-library/react-native';
 import { getMockUserDb, resetMockUserDb } from '../../../__tests__/helpers/mockUserDb';
+import { useAmicusThreads } from '@/hooks/useAmicusThreads';
 
 jest.mock('@/db/userDatabase', () =>
   require('../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
 );
-
-import { useAmicusThreads } from '@/hooks/useAmicusThreads';
 
 function Harness({
   onReady,

--- a/app/src/hooks/__tests__/usePeekConversation.test.tsx
+++ b/app/src/hooks/__tests__/usePeekConversation.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Text } from 'react-native';
 import { AmicusError } from '@/services/amicus';
 import type { streamChat as streamChatFn } from '@/services/amicus/chat';
+import { usePeekConversation } from '@/hooks/usePeekConversation';
 
 type StreamChatParams = Parameters<typeof streamChatFn>[0];
 
@@ -19,8 +20,6 @@ const mockStreamChat = jest.fn(async (params: StreamChatParams) => {
 jest.mock('@/services/amicus/chat', () => ({
   streamChat: (p: StreamChatParams) => mockStreamChat(p),
 }));
-
-import { usePeekConversation } from '@/hooks/usePeekConversation';
 
 function Harness({
   onReady,

--- a/app/src/hooks/useAmicusThread.ts
+++ b/app/src/hooks/useAmicusThread.ts
@@ -44,6 +44,7 @@ export function useAmicusThread(threadId: string): UseAmicusThreadResult {
   }, [threadId]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load
     void refresh();
     return () => {
       abortRef.current?.abort();

--- a/app/src/navigation/TabNavigator.tsx
+++ b/app/src/navigation/TabNavigator.tsx
@@ -1,13 +1,13 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Home, Library, Compass, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
-import { useTheme } from '../theme';
-import { HomeStack } from './HomeStack';
-import { ReadStack } from './ReadStack';
-import { ExploreStack } from './ExploreStack';
-import { SearchStack } from './SearchStack';
-import { MoreStack } from './MoreStack';
-import { AmicusStack } from './AmicusStack';
 import { useSettingsStore } from '../stores';
+import { useTheme } from '../theme';
+import { AmicusStack } from './AmicusStack';
+import { ExploreStack } from './ExploreStack';
+import { HomeStack } from './HomeStack';
+import { MoreStack } from './MoreStack';
+import { ReadStack } from './ReadStack';
+import { SearchStack } from './SearchStack';
 
 const Tab = createBottomTabNavigator();
 

--- a/app/src/screens/settings/AmicusSettingsSection.tsx
+++ b/app/src/screens/settings/AmicusSettingsSection.tsx
@@ -17,13 +17,13 @@ import {
   View,
 } from 'react-native';
 import { ChevronRight } from 'lucide-react-native';
-import type { BaseColors } from '../../theme/palettes';
-import { fontFamily, spacing } from '../../theme';
-import { SectionLabel } from './SectionLabel';
 import { clearAllAmicusData } from '../../db/userMutations';
-import { clearProfile } from '../../services/amicus/profile/generator';
 import { resetAmicusOptIn } from '../../services/amicus/consent';
+import { clearProfile } from '../../services/amicus/profile/generator';
+import { fontFamily, spacing } from '../../theme';
+import type { BaseColors } from '../../theme/palettes';
 import { logger } from '../../utils/logger';
+import { SectionLabel } from './SectionLabel';
 
 export interface AmicusSettingsSectionProps {
   base: BaseColors;

--- a/app/src/screens/settings/__tests__/AmicusSettingsSection.test.tsx
+++ b/app/src/screens/settings/__tests__/AmicusSettingsSection.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Alert } from 'react-native';
 import { fireEvent } from '@testing-library/react-native';
+import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
 import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
 import { AmicusSettingsSection } from '@/screens/settings/AmicusSettingsSection';
-import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
 
 jest.mock('@/db/userDatabase', () =>
   require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),

--- a/app/src/services/amicus/__tests__/consent.test.ts
+++ b/app/src/services/amicus/__tests__/consent.test.ts
@@ -2,17 +2,16 @@
  * Tests for services/amicus/consent.ts (pure helpers).
  */
 import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
-
-jest.mock('@/db/userDatabase', () =>
-  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
-);
-
 import {
   AMICUS_OPT_IN_KEY,
   acceptAmicusOptIn,
   hasAcceptedAmicusOptIn,
   resetAmicusOptIn,
 } from '../consent';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
 
 beforeEach(() => {
   resetMockUserDb();


### PR DESCRIPTION
- StreamingDot: replace useRef(new Animated.Value).current with useState lazy-init to satisfy react-hooks/refs
- useAmicusThread: suppress react-hooks/set-state-in-effect on the initial-data-load effect (standard mount-fetch pattern)
- Import-order fixes in MapErrorBoundary, TabNavigator, AmicusSettingsSection (and its test)
- Consolidate imports in consent / useAmicusThreads / usePeekConversation tests so jest.mock sits after the import block (hoisted by babel-jest so behavior is unchanged)

https://claude.ai/code/session_01QBTmLfnXM15XdfE8jW5cAD