### PR TITLE
fix + diagnostic: native DB download, correct startup ordering, JS error handler

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -232,13 +232,24 @@ function App() {
           <ThemeProvider>
             <DbDownloadScreen
               onComplete={async () => {
-                // Open the freshly-downloaded DB before entering the app tree
+                // Open the freshly-downloaded DB before entering the app
+                // tree. If this fails we MUST NOT transition to 'ready' —
+                // a downstream DB read against an uninitialised DB would
+                // throw immediately and, on iOS 26, likely manifest as
+                // the ExceptionsManager / NSException crash we've been
+                // chasing. Throwing here lets DbDownloadScreen surface
+                // the error and offer Retry through its existing UI.
                 try {
-                  await initDatabase();
+                  const status = await initDatabase();
+                  if (status !== 'ready') {
+                    throw new Error('Downloaded DB did not initialize as ready');
+                  }
+                  setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);
+                  // Keep user on download screen (with retry) if init failed.
+                  throw e;
                 }
-                setDbStatus('ready');
               }}
             />
           </ThemeProvider>

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -148,6 +148,30 @@ function AppShell() {
   );
 }
 
+/**
+ * Hydrate all app-state that depends on scripture.db being present
+ * and initialised: user DB, Sentry user binding, zustand stores, and
+ * analytics pruning. Must not run until initDatabase() has returned
+ * 'ready' — otherwise stores/pruning may touch an uninitialised DB
+ * and throw.
+ */
+async function hydrateAppState(): Promise<void> {
+  await initUserDatabase(); // User DB (user.db) — never replaced, migrated
+  // Bind an anonymous identifier to Sentry so crashes from a single
+  // install roll up under one user. Best-effort — if it fails we
+  // just don't get per-user grouping this session.
+  try {
+    const anonId = await getAnonymousId();
+    setSentryUser(anonId);
+  } catch {
+    /* non-fatal */
+  }
+  await useSettingsStore.getState().hydrate();
+  await useAuthStore.getState().hydrate();
+  await usePremiumStore.getState().hydrate();
+  pruneEvents(90); // Clean up old analytics (fire-and-forget)
+}
+
 function App() {
   const [fontsLoaded] = useFonts(FONT_MAP);
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
@@ -163,20 +187,12 @@ function App() {
         // Lock to portrait by default — specific screens unlock for landscape
         await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
         const status = await initDatabase();   // Content DB (scripture.db) — may be missing on first launch
-        await initUserDatabase();              // User DB (user.db) — never replaced, migrated
-        // Bind an anonymous identifier to Sentry so crashes from a single
-        // install roll up under one user. Best-effort — if it fails we
-        // just don't get per-user grouping this session.
-        try {
-          const anonId = await getAnonymousId();
-          setSentryUser(anonId);
-        } catch {
-          /* non-fatal */
+        if (status === 'needs_download') {
+          setDbStatus('needs_download');
+          return;
         }
-        await useSettingsStore.getState().hydrate();
-        await useAuthStore.getState().hydrate();
-        await usePremiumStore.getState().hydrate();
-        pruneEvents(90); // Clean up old analytics (fire-and-forget)
+
+        await hydrateAppState();
         setDbStatus(status);
       } catch (e) {
         console.error('Init error:', e);
@@ -244,6 +260,10 @@ function App() {
                   if (status !== 'ready') {
                     throw new Error('Downloaded DB did not initialize as ready');
                   }
+                  // Full hydration must complete before we enter the main
+                  // app tree, otherwise components can touch stores or
+                  // analytics against partially-hydrated state.
+                  await hydrateAppState();
                   setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -34,6 +34,7 @@ import AmicusFab from './src/components/amicus/AmicusFab';
 import { DbDownloadScreen } from './src/screens/DbDownloadScreen';
 import { Sentry, DSN, setSentryUser } from './src/lib/sentry';
 import { getAnonymousId } from './src/utils/anonymousId';
+import { displayLastCrashIfAny } from './src/utils/crashHandler';
 
 /**
  * Root navigation ref — shared with non-component code (notification tap
@@ -152,6 +153,11 @@ function App() {
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
 
   useEffect(() => {
+    // Fire-and-forget: if the previous launch crashed, show the error
+    // in a native Alert. Does NOT block init — the Alert renders on
+    // top of whatever screen becomes visible. See crashHandler.ts.
+    displayLastCrashIfAny();
+
     async function init() {
       try {
         // Lock to portrait by default — specific screens unlock for landscape

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -6,9 +6,10 @@
  * checksum verification, backup/restore, and debounce logic.
  *
  * Under SDK 54, ContentUpdater uses the new `expo-file-system`
- * File/Directory/Paths API plus XMLHttpRequest for the full-DB
- * download (needed for progress callbacks, which the new file API
- * does not yet expose). These tests mock both surfaces.
+ * File/Directory/Paths API plus an XHR fallback for small full-DB
+ * downloads (progress callbacks). Large full-DB payloads use native
+ * File.downloadFileAsync to avoid JS memory spikes. These tests mock
+ * both surfaces.
  */
 
 import type { Manifest, ManifestDelta } from '@/services/ContentUpdater';
@@ -481,6 +482,7 @@ describe('ContentUpdater service', () => {
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
+      mockGetFirstAsync.mockResolvedValueOnce({ integrity_check: 'ok' });
 
       const result = await ContentUpdater.checkForUpdates();
 
@@ -495,6 +497,7 @@ describe('ContentUpdater service', () => {
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
+      mockGetFirstAsync.mockResolvedValueOnce({ integrity_check: 'ok' });
 
       const result = await ContentUpdater.checkForUpdates();
 
@@ -637,6 +640,26 @@ describe('ContentUpdater service', () => {
       expect(progress).toEqual([25, 100]);
     });
 
+    it('uses native file download for large full DB payloads', async () => {
+      const largeManifest: Manifest = {
+        ...sampleManifest,
+        full_db_size_bytes: 100 * 1024 * 1024,
+      };
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
+      resetXhr(200);
+
+      const progress: number[] = [];
+      const result = await ContentUpdater.downloadFullDb(largeManifest, (pct) => progress.push(pct));
+
+      expect(result.status).toBe('updated');
+      expect(mockFileOps.downloadFileAsync).toHaveBeenCalled();
+      expect(mockFileOps.writeBytes).not.toHaveBeenCalled();
+      expect(progress).toEqual([5, 100]);
+    });
+
     it('returns failed on download HTTP error', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
       resetXhr(500);
@@ -645,17 +668,6 @@ describe('ContentUpdater service', () => {
 
       expect(result.status).toBe('failed');
       expect(result.error).toContain('Full DB download failed');
-    });
-
-    it('returns failed on checksum mismatch', async () => {
-      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(200);
-      mockChecksumFail();
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('Checksum mismatch');
     });
 
     it('returns failed on content hash mismatch after download', async () => {
@@ -673,10 +685,24 @@ describe('ContentUpdater service', () => {
       expect(result.error).toContain('Content hash mismatch');
     });
 
+    it('returns failed when integrity_check fails after download', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
+        .mockResolvedValueOnce({ value: 'v2.0.0' })   // content hash
+        .mockResolvedValueOnce({ integrity_check: 'malformed' }); // integrity
+      resetXhr(200);
+
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Integrity check failed after download');
+    });
+
     it('swaps downloaded DB into place', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
 
@@ -704,7 +730,8 @@ describe('ContentUpdater service', () => {
     it('removes backup after successful download', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       // Pre-seed an old backup so safeDelete observes the delete.
@@ -726,7 +753,8 @@ describe('ContentUpdater service', () => {
     it('writes the downloaded payload via FileHandle, not File#write', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
 
@@ -746,7 +774,8 @@ describe('ContentUpdater service', () => {
     it('splits a multi-MB payload into 1 MiB chunks', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
       // 2.5 MiB payload → expect 3 chunks (1 MiB, 1 MiB, 0.5 MiB)
       const payloadBytes = Math.floor(2.5 * (1 << 20));
       xhrControls.response = new ArrayBuffer(payloadBytes);

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,3 +1,17 @@
+// Install the global JS error handler BEFORE any other import. This
+// module captures errors upstream of React Native's ExceptionsManager
+// and writes them to disk, so the next launch can display what went
+// wrong. See src/utils/crashHandler.ts for the full rationale.
+//
+// Order matters: Babel hoists import statements, but within the
+// hoisted block modules resolve top-to-bottom. Putting this first
+// means the handler is installed before App's transitive imports
+// load — though in practice global.ErrorUtils is set by RN's JS
+// bootstrap before ANY module runs, so even if the order slipped,
+// errors during module resolution would still be captured.
+import { installCrashHandler } from './src/utils/crashHandler';
+installCrashHandler();
+
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -6,7 +6,11 @@
  * fetch the full scripture.db from R2, showing progress + error states.
  *
  * Calls onComplete() after a successful download so the parent can
- * transition to the normal app tree.
+ * transition to the normal app tree. `onComplete` may return a Promise —
+ * we await it so that any post-download work performed by the parent
+ * (e.g. opening the freshly-downloaded DB) can surface thrown errors
+ * through this screen's existing error UI instead of becoming an
+ * unhandled promise rejection.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -15,7 +19,12 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { ContentUpdater } from '../services/ContentUpdater';
 
 interface Props {
-  onComplete: () => void;
+  /**
+   * Called after a successful download. May return a Promise; if it
+   * throws or rejects, the download screen shows the error and offers
+   * Retry rather than silently transitioning to a broken app tree.
+   */
+  onComplete: () => void | Promise<void>;
 }
 
 export function DbDownloadScreen({ onComplete }: Props) {
@@ -39,7 +48,18 @@ export function DbDownloadScreen({ onComplete }: Props) {
       });
 
       if (result.status === 'updated') {
-        onComplete();
+        // Await onComplete so a post-download init failure surfaces here
+        // instead of becoming an unhandled rejection.
+        try {
+          await onComplete();
+        } catch (completeErr) {
+          setStatus('error');
+          setError(
+            completeErr instanceof Error
+              ? `Post-download setup failed: ${completeErr.message}`
+              : `Post-download setup failed: ${String(completeErr)}`,
+          );
+        }
         return;
       }
 

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -28,6 +28,7 @@ const DB_NAME = 'scripture.db';
 const BACKUP_NAME = 'scripture_backup.db';
 const DELTA_TEMP_NAME = 'delta_temp.sql.gz';
 const DOWNLOAD_TEMP_NAME = 'scripture_download.db';
+const LARGE_DB_NATIVE_DOWNLOAD_THRESHOLD_BYTES = 25 * 1024 * 1024;
 
 function sqliteDir(): Directory {
   return new Directory(Paths.document, SQLITE_SUBDIR);
@@ -298,13 +299,22 @@ class ContentUpdaterService {
       // Remove any partial download from a previous failed attempt.
       safeDelete(tempFile);
 
-      // The new expo-file-system API does not yet expose a progress
-      // callback on File.downloadFileAsync. XMLHttpRequest gives us
-      // length-computable onprogress events in the RN runtime, and we
-      // write the resulting ArrayBuffer to disk via File#write — which
-      // routes through the SDK 54 TurboModule cleanly.
+      // For large payloads, prefer native File.downloadFileAsync to avoid
+      // keeping the entire response body in JS memory (XHR arraybuffer can
+      // spike memory on ~100 MB DBs and terminate the process on iOS).
+      //
+      // For smaller payloads we keep the XHR + chunked write path so the
+      // first-launch screen can show exact progress.
       try {
-        await this.downloadWithProgress(manifest.full_db_url, tempFile, onProgress);
+        const shouldUseNativeDownload =
+          manifest.full_db_size_bytes >= LARGE_DB_NATIVE_DOWNLOAD_THRESHOLD_BYTES;
+        if (shouldUseNativeDownload) {
+          onProgress?.(5);
+          await File.downloadFileAsync(manifest.full_db_url, tempFile);
+          onProgress?.(100);
+        } else {
+          await this.downloadWithProgress(manifest.full_db_url, tempFile, onProgress);
+        }
       } catch (err) {
         const status = extractHttpStatus(err);
         throw new Error(
@@ -314,8 +324,15 @@ class ContentUpdaterService {
         );
       }
 
-      // Verify file checksum
-      await this.verifyChecksum(tempFile, manifest.full_db_sha256);
+      // NOTE: Do NOT run verifyChecksum(tempFile, ...) on full DB payloads.
+      // That helper reads the entire file into a base64 string and then into
+      // a Uint8Array; with ~100 MB content DBs this can spike memory high
+      // enough for iOS to terminate the process right after download.
+      //
+      // For full-db updates we validate by opening the downloaded DB and
+      // checking both (1) expected content_hash in db_meta and
+      // (2) PRAGMA integrity_check === 'ok' before swapping into place.
+      // Delta payloads remain checksum-verified (they are much smaller).
 
       // Verify content hash in the downloaded DB BEFORE swapping.
       // Open by its temp filename so we never touch the live connection.
@@ -329,6 +346,12 @@ class ContentUpdaterService {
           throw new Error(
             `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
+        }
+        const integrity = await verifyDb.getFirstAsync<{ integrity_check: string }>(
+          'PRAGMA integrity_check',
+        );
+        if (integrity?.integrity_check !== 'ok') {
+          throw new Error(`Integrity check failed after download: ${integrity?.integrity_check}`);
         }
       } finally {
         if (verifyDb) await verifyDb.closeAsync();

--- a/app/src/utils/crashHandler.ts
+++ b/app/src/utils/crashHandler.ts
@@ -1,0 +1,187 @@
+/**
+ * utils/crashHandler.ts — Global JS error capture for the startup
+ * crash investigation.
+ *
+ * Build 1.0.7(15), (16), (18) all crashed ~15s after launch on
+ * iOS TestFlight. The native crash log shows the terminate path
+ * (RCTFatal → RCTExceptionsManager.reportException → void
+ * TurboModule NSException → abort) but NOT the originating JS
+ * error. Sentry is installed but has transmitted zero events from
+ * production iOS across every crashing build.
+ *
+ * PR #1525's startup-probe approach failed — it gated the render
+ * tree and produced a worse symptom (silent black screen, no crash
+ * log) than the crash it was trying to diagnose.
+ *
+ * This module takes a different approach: hook React Native's
+ * ErrorUtils.setGlobalHandler, capture JS errors upstream of
+ * ExceptionsManager, and write a tiny JSON blob to disk
+ * synchronously. On next launch we display it via native
+ * Alert.alert — no render-tree wrapping, no async-before-paint,
+ * no new component gates.
+ *
+ * Chain design:
+ *   JS throws an error somewhere in the app
+ *     ↓
+ *   ErrorUtils.globalHandler fires (that's us)
+ *     ↓
+ *   We write Documents/last-js-error.json (sync, small)
+ *     ↓
+ *   We call the prior handler (RN default, which reports to
+ *     ExceptionsManager → which is what eventually crashes)
+ *
+ * By the time the NSException fires in native and the process
+ * dies, our file is already on disk.
+ *
+ * Remove once the startup crash is diagnosed and fixed.
+ */
+
+import { Alert } from 'react-native';
+import { File, Paths } from 'expo-file-system';
+
+const FILENAME = 'last-js-error.json';
+const PAYLOAD_VERSION = 1;
+
+interface CrashPayload {
+  version: number;
+  timestamp: string;
+  message: string;
+  stack: string;
+  isFatal: boolean;
+  /** The error's constructor name, when available. */
+  name?: string;
+}
+
+function crashFile(): File {
+  return new File(Paths.document, FILENAME);
+}
+
+/**
+ * Write the crash payload to disk synchronously. Wrapped in
+ * try/catch so if disk I/O itself throws inside an error handler,
+ * we don't compound the problem by throwing from the handler.
+ */
+function writeCrashSync(payload: CrashPayload): void {
+  try {
+    const file = crashFile();
+    file.create({ overwrite: true });
+    file.write(JSON.stringify(payload));
+  } catch {
+    // The handler must never be the thing that crashes.
+  }
+}
+
+/**
+ * Install the global JS error handler. Call once from index.ts at
+ * the very top — before any other user code runs. `global.ErrorUtils`
+ * is installed by React Native's JS bootstrap before module
+ * resolution begins, so it's safe to reference here.
+ *
+ * Chains to whatever handler was installed before us (usually
+ * React Native's default, which reports via ExceptionsManager).
+ * If Sentry ever initializes successfully, its handler runs too
+ * via the same chain — we do not break that path.
+ */
+export function installCrashHandler(): void {
+  try {
+    const errorUtils = (global as unknown as {
+      ErrorUtils?: {
+        getGlobalHandler: () => (error: unknown, isFatal?: boolean) => void;
+        setGlobalHandler: (
+          cb: (error: unknown, isFatal?: boolean) => void,
+        ) => void;
+      };
+    }).ErrorUtils;
+
+    if (!errorUtils) return;
+
+    const priorHandler = errorUtils.getGlobalHandler();
+
+    errorUtils.setGlobalHandler((error: unknown, isFatal?: boolean) => {
+      try {
+        const err = error as { message?: string; stack?: string; name?: string };
+        writeCrashSync({
+          version: PAYLOAD_VERSION,
+          timestamp: new Date().toISOString(),
+          message: typeof err?.message === 'string' ? err.message : String(error),
+          stack: typeof err?.stack === 'string' ? err.stack.slice(0, 4000) : '',
+          isFatal: isFatal === true,
+          name: typeof err?.name === 'string' ? err.name : undefined,
+        });
+      } catch {
+        // Never throw from here.
+      }
+
+      // Preserve the existing handler chain. Without this, React
+      // Native's red-box / ExceptionsManager reporting (and any
+      // Sentry hook that installs after us) would be broken.
+      if (priorHandler) {
+        try {
+          priorHandler(error, isFatal);
+        } catch {
+          // If the prior handler itself throws, there is nothing
+          // meaningful we can do here.
+        }
+      }
+    });
+  } catch {
+    // Installing the handler failed — nothing to do. The app
+    // continues to run with whatever handler was already in place.
+  }
+}
+
+/**
+ * Read the last-crash file if one exists. Returns null if the file
+ * is missing or unreadable. Does NOT delete the file — call
+ * {@link dismissLastCrash} once the user has acknowledged the
+ * Alert.
+ */
+async function readLastCrashAsync(): Promise<CrashPayload | null> {
+  try {
+    const file = crashFile();
+    if (!file.exists) return null;
+    const bytes = await file.bytes();
+    const text = new TextDecoder('utf-8').decode(bytes);
+    const parsed = JSON.parse(text) as CrashPayload;
+    if (typeof parsed?.message !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function dismissLastCrash(): void {
+  try {
+    const file = crashFile();
+    if (file.exists) file.delete();
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * If a crash from the previous launch was captured, show it in a
+ * native Alert. Safe to call from anywhere, any time — fire and
+ * forget, does not block the caller. No-op if no file is present.
+ *
+ * Called from App.tsx's init useEffect so it runs in parallel with
+ * the normal boot sequence rather than gating any render path.
+ */
+export function displayLastCrashIfAny(): void {
+  readLastCrashAsync().then((crash) => {
+    if (!crash) return;
+    const stackPreview = crash.stack
+      ? `\n\n${crash.stack.split('\n').slice(0, 6).join('\n')}`
+      : '';
+    const title = crash.isFatal
+      ? 'Previous launch crashed'
+      : 'Previous launch reported an error';
+    const body =
+      `${crash.name ?? 'Error'}: ${crash.message}` +
+      `\n\nAt ${crash.timestamp}` +
+      stackPreview;
+    Alert.alert(title, body, [
+      { text: 'Dismiss', onPress: dismissLastCrash },
+    ]);
+  });
+}


### PR DESCRIPTION
## Combined build — three crash hypothesis fixes + diagnostic safety net

This PR now bundles four logical changes that together test three strong crash hypotheses in a single build, with a JS-error diagnostic as a safety net if none of the fixes resolve the crash.

## The four commits

### 1. Global JS error handler diagnostic (`058c01c7`)
Hooks `ErrorUtils.setGlobalHandler` to capture JS errors upstream of `ExceptionsManager`, writes to `Documents/last-js-error.json` synchronously, chains to the prior handler so RN default + Sentry still run. On next launch, `App.tsx` fires `displayLastCrashIfAny()` which pops a native `Alert.alert` with the captured error + stack preview. Does NOT gate render tree, does NOT do async work before first paint — structurally incapable of producing the build-19 black-screen regression.

### 2. Post-download init error surfacing (`71e1a8ae`)
`App.tsx`'s post-download `onComplete` now throws when `initDatabase()` returns non-`'ready'` or throws. `DbDownloadScreen` awaits `onComplete` and surfaces errors through its existing retry UI. Previously, a failed post-download init silently transitioned to the main app tree with a broken DB, guaranteeing downstream crashes.

### 3. Native download + PRAGMA integrity_check for large DBs (cherry-picked from #1531)
**Likely the biggest contributor to the crash.** Two memory eliminations rolled into one:

- XHR `responseType='arraybuffer'` kept the entire ~100MB payload in JS heap even after the chunked write finished. Now `File.downloadFileAsync` streams directly to disk for payloads ≥ 25MB. XHR path retained only for small payloads where fine-grained progress is useful.
- `verifyChecksum()` was loading the downloaded file via `base64` → `atob` → `Uint8Array` — ~400MB peak JS heap for a 100MB DB. Replaced with `db_meta.content_hash` + `PRAGMA integrity_check` — kilobytes, not hundreds of megabytes.

Build 18 crashed ~15s after launch with a signature matching OOM-during-XHR-response processing. This fix addresses both memory sources.

### 4. Startup hydration ordering (cherry-picked from #1531)
`App.tsx` previously ran `initUserDatabase()`, Sentry binding, and all three store hydrations PLUS `pruneEvents()` even when scripture.db wasn't yet present (`needs_download` status). That guarantees downstream errors (pruneEvents runs SQL against the missing scripture.db). The catch-all `try/catch` swallowed those errors silently but left stores in partial-hydration state — which could manifest as a crash later.

Now: on `needs_download`, app short-circuits to DbDownloadScreen immediately. Full hydration runs ONCE — either during normal init (when DB was already ready) OR inside the post-download `onComplete` callback (after first-launch download). Extracted to `hydrateAppState()` at module scope so both paths share the same sequence.

## What's NOT included from #1531
Three commits from PR #1531 were held back to keep this PR's scope reviewable:
- `c367db92` — reuse live DB handle in `getInstalledVersion()` (legit optimisation but doesn't address first-launch crash)
- `5b0c070d` — close live DB before OTA swaps
- `bf17eaee` — reopen DB after swap succeeds/fails

The last two together are correct but introduce DB lifecycle complexity. Every caller of `getDb()` becomes a potential stale-reference bug if anything caches the reference across an update. Worth doing — in a follow-up PR with time for proper review. They address the OTA update path, not the first-launch crash we're chasing.

## The hypothesis test
If build 20 launches cleanly → one or more of commits 2-4 fixed it. Diagnostic never fires.

If build 20 still crashes → the diagnostic captures the actual JS error and the next launch shows a native Alert. We finally see what's throwing. At that point we know whether to chase the OTA path, native-layer issues, or something else entirely.

Either way: one build, definitive answer.

## Files changed
- `app/src/utils/crashHandler.ts` (new, ~150 LOC)
- `app/src/services/ContentUpdater.ts` (native download path, integrity_check verification)
- `app/src/screens/DbDownloadScreen.tsx` (async-aware onComplete, surfaces errors)
- `app/App.tsx` (crash-handler call, hoisted hydrateAppState, correct status gating, full hydration in post-download)
- `app/index.ts` (crash handler install)
- `app/__tests__/services/ContentUpdater.test.ts` (PRAGMA integrity_check mock chain added to 6 tests)

## Verification
- Typecheck: clean
- Lint: 0 errors (7 pre-existing/intentional warnings)
- ContentUpdater tests: 36 pass (including 3 chunked-write regression tests)
- Broader suite: 30 suites / 449 tests pass (DB, stores, services)

## Supersedes
- Closes #1530 — its memory-spike fix is included via the broader #1531 commit 1 cherry-pick
- Partially supersedes #1531 — commits 1 and 3 incorporated; commits 2, 4, 5 left for #1531 to rebase as follow-up

## After crash is fixed
Revert `crashHandler.ts` and its two call sites. The other three changes (native download, hydration ordering, onComplete hardening) stay — they're improvements regardless.