### PR TITLE
Verify downloaded DB by opening and running integrity_check; await post-download DB init

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -228,11 +228,16 @@ function App() {
               onComplete={async () => {
                 // Open the freshly-downloaded DB before entering the app tree
                 try {
-                  await initDatabase();
+                  const status = await initDatabase();
+                  if (status !== 'ready') {
+                    throw new Error('Downloaded DB did not initialize as ready');
+                  }
+                  setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);
+                  // Keep user on download screen (with retry) if init failed.
+                  throw e;
                 }
-                setDbStatus('ready');
               }}
             />
           </ThemeProvider>

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -647,17 +647,6 @@ describe('ContentUpdater service', () => {
       expect(result.error).toContain('Full DB download failed');
     });
 
-    it('returns failed on checksum mismatch', async () => {
-      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(200);
-      mockChecksumFail();
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('Checksum mismatch');
-    });
-
     it('returns failed on content hash mismatch after download', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
@@ -671,6 +660,19 @@ describe('ContentUpdater service', () => {
 
       expect(result.status).toBe('failed');
       expect(result.error).toContain('Content hash mismatch');
+    });
+
+    it('returns failed when integrity_check fails after download', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
+        .mockResolvedValueOnce({ value: 'v2.0.0' })   // content hash
+        .mockResolvedValueOnce({ integrity_check: 'malformed' }); // integrity
+      resetXhr(200);
+
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Integrity check failed after download');
     });
 
     it('swaps downloaded DB into place', async () => {

--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -15,7 +15,7 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { ContentUpdater } from '../services/ContentUpdater';
 
 interface Props {
-  onComplete: () => void;
+  onComplete: () => void | Promise<void>;
 }
 
 export function DbDownloadScreen({ onComplete }: Props) {
@@ -39,7 +39,7 @@ export function DbDownloadScreen({ onComplete }: Props) {
       });
 
       if (result.status === 'updated') {
-        onComplete();
+        await onComplete();
         return;
       }
 

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -314,8 +314,15 @@ class ContentUpdaterService {
         );
       }
 
-      // Verify file checksum
-      await this.verifyChecksum(tempFile, manifest.full_db_sha256);
+      // NOTE: Do NOT run verifyChecksum(tempFile, ...) on full DB payloads.
+      // That helper reads the entire file into a base64 string and then into
+      // a Uint8Array; with ~100 MB content DBs this can spike memory high
+      // enough for iOS to terminate the process right after download.
+      //
+      // For full-db updates we validate by opening the downloaded DB and
+      // checking both (1) expected content_hash in db_meta and
+      // (2) PRAGMA integrity_check === 'ok' before swapping into place.
+      // Delta payloads remain checksum-verified (they are much smaller).
 
       // Verify content hash in the downloaded DB BEFORE swapping.
       // Open by its temp filename so we never touch the live connection.
@@ -329,6 +336,12 @@ class ContentUpdaterService {
           throw new Error(
             `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
+        }
+        const integrity = await verifyDb.getFirstAsync<{ integrity_check: string }>(
+          'PRAGMA integrity_check',
+        );
+        if (integrity?.integrity_check !== 'ok') {
+          throw new Error(`Integrity check failed after download: ${integrity?.integrity_check}`);
         }
       } finally {
         if (verifyDb) await verifyDb.closeAsync();


### PR DESCRIPTION
### Motivation

- Avoid reading large full-DB payloads into memory for checksum verification to prevent iOS process termination on large downloads. 
- Ensure the freshly-downloaded DB is valid by checking its `content_hash` and `PRAGMA integrity_check` before swapping it into place. 
- Make the post-download handoff robust by awaiting `initDatabase()` in the download UI and keeping the user on the download screen if initialization fails. 

### Description

- Replace in-memory checksum verification for full DB downloads with opening the downloaded DB and validating `db_meta.value` for `content_hash` and that `PRAGMA integrity_check` returns `ok`. 
- Adjust `ContentUpdater.downloadFullDb` to perform the DB-open validation and throw explicit errors on content-hash mismatch or integrity failures. 
- Update `DbDownloadScreen` to accept an async `onComplete` (type `() => void | Promise<void>`) and `await onComplete()` so parent init can finish before proceeding. 
- Update `App.tsx` download completion handler to call `initDatabase()`, verify it returns `'ready'`, set `dbStatus('ready')` on success, and rethrow on failure so the download screen can show retry/error state. 
- Update unit tests in `app/__tests__/services/ContentUpdater.test.ts` to reflect the new validation paths and error messages. 

### Testing

- Ran the updated unit test suite including `ContentUpdater` tests (modified file `app/__tests__/services/ContentUpdater.test.ts`) with `yarn test` and the tests passed. 
- Exercised the full-DB download code paths in the unit tests that simulate progress, swap, checksum/integrity failures, and cleanup, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55106bc50832484f31e53147ab52e)