### PR TITLE
refactor: DB lifecycle hardening during OTA content updates

### DIFF
--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -256,7 +256,7 @@ const mockFetch = jest.fn();
 
 // ── Mock db/database live-handle helper ───────────────────────────
 const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
-const mockCloseDatabaseConnection = jest.fn().mockResolvedValue(undefined);
+const mockCloseDatabaseConnection = jest.fn().mockResolvedValue(true);
 const mockReloadDatabase = jest.fn().mockResolvedValue(undefined);
 jest.mock('@/db/database', () => ({
   getDbIfInitialized: () => mockGetDbIfInitialized(),
@@ -340,7 +340,7 @@ describe('ContentUpdater service', () => {
     // Re-establish default mock return values after clearAllMocks
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
     mockGetDbIfInitialized.mockReturnValue(null);
-    mockCloseDatabaseConnection.mockResolvedValue(undefined);
+    mockCloseDatabaseConnection.mockResolvedValue(true);
     mockReloadDatabase.mockResolvedValue(mockDbInstance);
   });
 
@@ -557,6 +557,29 @@ describe('ContentUpdater service', () => {
       expect(mockReloadDatabase).toHaveBeenCalled();
     });
 
+    it('safety valve: aborts delta apply when live DB close fails', async () => {
+      // Simulate a live DB that refuses to close cleanly. The updater must
+      // NOT proceed with backup+swap work against a DB that may still be
+      // open on the native side — doing so risks file locks or, on iOS 26,
+      // the FTS5 teardown crash. Expected behavior: log a warning, return
+      // up_to_date, and leave the on-disk DB untouched.
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+      mockCloseDatabaseConnection.mockResolvedValueOnce(false);
+      mockChecksumPass(sampleDelta.sha256);
+
+      const result = await ContentUpdater.applyDelta(sampleDelta);
+
+      expect(result.status).toBe('up_to_date');
+      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
+      // Backup must NOT have fired — that's a file-swap-path operation we
+      // explicitly skipped.
+      expect(mockFileOps.copy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: expect.stringContaining('scripture_backup.db'),
+        }),
+      );
+    });
+
     it('returns failed on download HTTP error', async () => {
       const httpErr = new Error('HTTP 404') as Error & { httpStatus: number };
       httpErr.httpStatus = 404;
@@ -669,6 +692,31 @@ describe('ContentUpdater service', () => {
 
       expect(mockCloseDatabaseConnection).toHaveBeenCalled();
       expect(mockReloadDatabase).toHaveBeenCalled();
+    });
+
+    it('safety valve: aborts full DB swap when live DB close fails', async () => {
+      // Same reasoning as the applyDelta safety valve: a failed close means
+      // the native handle may still be live; moving the temp DB over it
+      // would be unsafe. Expected behavior: log, cleanup the temp file,
+      // return up_to_date, leave scripture.db untouched.
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+      mockCloseDatabaseConnection.mockResolvedValueOnce(false);
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
+      resetXhr(200);
+      getOrCreateRecord('/fake/docs/SQLite/scripture_download.db').exists = true;
+
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('up_to_date');
+      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
+      // Temp file should be cleaned up so the next attempt re-downloads fresh.
+      expect(mockFileOps.delete).toHaveBeenCalledWith(
+        expect.stringContaining('scripture_download.db'),
+      );
+      // The file swap (move) must NOT have fired.
+      expect(mockFileOps.move).not.toHaveBeenCalled();
     });
 
     it('forwards download progress to the onProgress callback', async () => {

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -257,9 +257,11 @@ const mockFetch = jest.fn();
 // ── Mock db/database live-handle helper ───────────────────────────
 const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
 const mockCloseDatabaseConnection = jest.fn().mockResolvedValue(undefined);
+const mockReloadDatabase = jest.fn().mockResolvedValue(undefined);
 jest.mock('@/db/database', () => ({
   getDbIfInitialized: () => mockGetDbIfInitialized(),
   closeDatabaseConnection: () => mockCloseDatabaseConnection(),
+  reloadDatabase: () => mockReloadDatabase(),
 }));
 
 // ── Mock atob (not available in Node test env) ────────────────────
@@ -339,6 +341,7 @@ describe('ContentUpdater service', () => {
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
     mockGetDbIfInitialized.mockReturnValue(null);
     mockCloseDatabaseConnection.mockResolvedValue(undefined);
+    mockReloadDatabase.mockResolvedValue(mockDbInstance);
   });
 
   // ── shouldCheckForUpdates ─────────────────────────────────────
@@ -539,9 +542,19 @@ describe('ContentUpdater service', () => {
       expect(result.status).toBe('updated');
       expect(result.updateType).toBe('delta');
       expect(result.bytesDownloaded).toBe(sampleDelta.size_bytes);
-      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
       expect(mockExecAsync).toHaveBeenCalledWith('BEGIN TRANSACTION');
       expect(mockExecAsync).toHaveBeenCalledWith('COMMIT');
+    });
+
+    it('closes and reloads live DB around delta apply when initialized', async () => {
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+      mockChecksumPass(sampleDelta.sha256);
+      mockGetFirstAsync.mockResolvedValue({ integrity_check: 'ok' });
+
+      await ContentUpdater.applyDelta(sampleDelta);
+
+      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
+      expect(mockReloadDatabase).toHaveBeenCalled();
     });
 
     it('returns failed on download HTTP error', async () => {
@@ -643,7 +656,19 @@ describe('ContentUpdater service', () => {
       expect(result.fromVersion).toBe('v1.0.0');
       expect(result.toVersion).toBe('v2.0.0');
       expect(result.bytesDownloaded).toBe(sampleManifest.full_db_size_bytes);
+    });
+
+    it('closes and reloads live DB around full DB swap when initialized', async () => {
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
+      resetXhr(200);
+
+      await ContentUpdater.downloadFullDb(sampleManifest);
+
       expect(mockCloseDatabaseConnection).toHaveBeenCalled();
+      expect(mockReloadDatabase).toHaveBeenCalled();
     });
 
     it('forwards download progress to the onProgress callback', async () => {

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -256,8 +256,10 @@ const mockFetch = jest.fn();
 
 // ── Mock db/database live-handle helper ───────────────────────────
 const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
+const mockCloseDatabaseConnection = jest.fn().mockResolvedValue(undefined);
 jest.mock('@/db/database', () => ({
   getDbIfInitialized: () => mockGetDbIfInitialized(),
+  closeDatabaseConnection: () => mockCloseDatabaseConnection(),
 }));
 
 // ── Mock atob (not available in Node test env) ────────────────────
@@ -336,6 +338,7 @@ describe('ContentUpdater service', () => {
     // Re-establish default mock return values after clearAllMocks
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
     mockGetDbIfInitialized.mockReturnValue(null);
+    mockCloseDatabaseConnection.mockResolvedValue(undefined);
   });
 
   // ── shouldCheckForUpdates ─────────────────────────────────────
@@ -536,6 +539,7 @@ describe('ContentUpdater service', () => {
       expect(result.status).toBe('updated');
       expect(result.updateType).toBe('delta');
       expect(result.bytesDownloaded).toBe(sampleDelta.size_bytes);
+      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
       expect(mockExecAsync).toHaveBeenCalledWith('BEGIN TRANSACTION');
       expect(mockExecAsync).toHaveBeenCalledWith('COMMIT');
     });
@@ -639,6 +643,7 @@ describe('ContentUpdater service', () => {
       expect(result.fromVersion).toBe('v1.0.0');
       expect(result.toVersion).toBe('v2.0.0');
       expect(result.bytesDownloaded).toBe(sampleManifest.full_db_size_bytes);
+      expect(mockCloseDatabaseConnection).toHaveBeenCalled();
     });
 
     it('forwards download progress to the onProgress callback', async () => {

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -254,6 +254,12 @@ jest.mock('expo-sqlite', () => ({
 const mockFetch = jest.fn();
 (global as any).fetch = mockFetch;
 
+// ── Mock db/database live-handle helper ───────────────────────────
+const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
+jest.mock('@/db/database', () => ({
+  getDbIfInitialized: () => mockGetDbIfInitialized(),
+}));
+
 // ── Mock atob (not available in Node test env) ────────────────────
 (global as any).atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
 
@@ -329,6 +335,7 @@ describe('ContentUpdater service', () => {
 
     // Re-establish default mock return values after clearAllMocks
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
+    mockGetDbIfInitialized.mockReturnValue(null);
   });
 
   // ── shouldCheckForUpdates ─────────────────────────────────────
@@ -402,6 +409,17 @@ describe('ContentUpdater service', () => {
       const version = await ContentUpdater.getInstalledVersion();
 
       expect(version).toBeNull();
+    });
+
+    it('reuses initialized live DB without opening/closing a temp handle', async () => {
+      mockGetFirstAsync.mockResolvedValue({ value: 'v_live' });
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+
+      const version = await ContentUpdater.getInstalledVersion();
+
+      expect(version).toBe('v_live');
+      expect(mockOpenDatabaseAsync).not.toHaveBeenCalled();
+      expect(mockCloseAsync).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -69,6 +69,15 @@ export function getDb(): SQLite.SQLiteDatabase {
 }
 
 /**
+ * Returns the open core DB handle when initialized, otherwise null.
+ * Useful for read-only callers that should avoid opening/closing a
+ * second connection with the same filename.
+ */
+export function getDbIfInitialized(): SQLite.SQLiteDatabase | null {
+  return db;
+}
+
+/**
  * Close the current DB connection and reopen from the (updated) file.
  * Called after ContentUpdater swaps the DB file on disk so all
  * subsequent getDb() calls return a connection to the new content.

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -103,15 +103,31 @@ export async function reloadDatabase(): Promise<SQLite.SQLiteDatabase> {
  * Close the live content DB connection (if open) and clear the in-memory
  * handle. Used before on-disk DB replacement to avoid swapping files while
  * SQLite still has the old file open.
+ *
+ * Returns true if the connection was successfully closed (or was never
+ * open). Returns false if closeAsync threw — in which case the native
+ * SQLite handle may or may not actually be released. Callers should NOT
+ * proceed with a file swap on false, because attempting to move/overwrite
+ * a file that SQLite still has open leads to lock conflicts and, on
+ * iOS 26, the FTS5 teardown crash we saw in TestFlight 1.0.7(20).
+ *
+ * Safety valve: a failed close still sets `db = null` so subsequent
+ * `getDb()` calls force a reopen from disk rather than returning a
+ * possibly-invalid handle. That matches the historical behavior but now
+ * surfaces the error to the caller too.
+ *
+ * @returns true on clean close; false if closeAsync threw
  */
-export async function closeDatabaseConnection(): Promise<void> {
-  if (!db) return;
+export async function closeDatabaseConnection(): Promise<boolean> {
+  if (!db) return true;
   try {
     await db.closeAsync();
-  } catch {
-    // ignore — best-effort close before swap
-  } finally {
     db = null;
+    return true;
+  } catch (err) {
+    logger.warn('DB', 'closeDatabaseConnection: closeAsync threw', err);
+    db = null;
+    return false;
   }
 }
 

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -100,6 +100,22 @@ export async function reloadDatabase(): Promise<SQLite.SQLiteDatabase> {
 }
 
 /**
+ * Close the live content DB connection (if open) and clear the in-memory
+ * handle. Used before on-disk DB replacement to avoid swapping files while
+ * SQLite still has the old file open.
+ */
+export async function closeDatabaseConnection(): Promise<void> {
+  if (!db) return;
+  try {
+    await db.closeAsync();
+  } catch {
+    // ignore — best-effort close before swap
+  } finally {
+    db = null;
+  }
+}
+
+/**
  * Get the database that contains verses for the given translation.
  * - Bundled translations (NIV, KJV) → core scripture.db
  * - Downloaded translations (ESV, ASV, etc.) → separate translation_*.db

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -16,7 +16,7 @@ import * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
 import { inflate } from 'pako';
 import { logger } from '../utils/logger';
-import { getDbIfInitialized } from '../db/database';
+import { closeDatabaseConnection, getDbIfInitialized } from '../db/database';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -221,6 +221,7 @@ class ContentUpdaterService {
       const sql = new TextDecoder().decode(inflate(bytes));
 
       // Backup current DB before modifying
+      await closeDatabaseConnection();
       await this.backupCurrentDb();
 
       // Apply the SQL in a transaction
@@ -365,6 +366,7 @@ class ContentUpdaterService {
       }
 
       // Verification passed — now swap the live DB
+      await closeDatabaseConnection();
       await this.backupCurrentDb();
       const dbFile = sqliteFile(DB_NAME);
       safeDelete(dbFile);

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -16,6 +16,7 @@ import * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
 import { inflate } from 'pako';
 import { logger } from '../utils/logger';
+import { getDbIfInitialized } from '../db/database';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -150,8 +151,14 @@ class ContentUpdaterService {
   async getInstalledVersion(): Promise<string | null> {
     let tempDb: SQLite.SQLiteDatabase | null = null;
     try {
-      tempDb = await SQLite.openDatabaseAsync('scripture.db');
-      const row = await tempDb.getFirstAsync<{ value: string }>(
+      // If the app already has scripture.db open, reuse that live handle.
+      // Opening/closing another handle to the same file can close the active
+      // connection on some SQLite wrappers, causing downstream query crashes.
+      const liveDb = getDbIfInitialized();
+      const queryDb = liveDb ?? await SQLite.openDatabaseAsync('scripture.db');
+      if (!liveDb) tempDb = queryDb;
+
+      const row = await queryDb.getFirstAsync<{ value: string }>(
         "SELECT value FROM db_meta WHERE key = 'content_hash'",
       );
       return row?.value ?? null;

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -79,6 +79,38 @@ export interface UpdateResult {
 }
 
 // ── Service ──────────────────────────────────────────────────
+//
+// TODO (future architecture): migrate OTA apply from close-and-reopen
+// to defer-to-cold-start.
+//
+// Current approach: when an update is ready, we close the live DB
+// handle, apply the swap on disk, then reopen. This works but is
+// fragile — any code holding a `getDb()` reference across an `await`
+// that spans an update will have a stale handle, and any in-flight
+// query at close time surfaces as a cryptic SQLite error.
+//
+// The safer architecture is to never close a running DB for an update
+// at all. Instead:
+//   1. Download the new DB to a pending-update temp path.
+//   2. Write a tiny marker file indicating an update is pending.
+//   3. Do NOT swap during the running session.
+//   4. On next app cold-start, BEFORE initDatabase() opens scripture.db,
+//      check for the pending marker. If present, swap the files while
+//      no SQLite connection exists, then delete the marker and proceed
+//      with normal startup.
+//
+// This trades "users see updates within seconds" for "users see updates
+// on next launch." For a Bible study app with scholarly content updates
+// (rather than safety-critical data), that's an acceptable tradeoff and
+// eliminates an entire class of concurrency bugs by design.
+//
+// The tri-commit close/reopen logic below is phase-1. Phase-2 replaces
+// it with the cold-start-swap architecture. See PR #1532 / #1533
+// discussion for context.
+//
+// In the interim, the `if (!closedCleanly) return up_to_date` safety
+// valve below (ContentUpdaterService.applyDelta + downloadFullDb) ensures
+// a failed close aborts the update rather than corrupting the DB file.
 
 class ContentUpdaterService {
   private lastCheckTime = 0;
@@ -223,7 +255,18 @@ class ContentUpdaterService {
 
       // Backup current DB before modifying
       closedLiveDb = getDbIfInitialized() != null;
-      if (closedLiveDb) await closeDatabaseConnection();
+      if (closedLiveDb) {
+        const closedCleanly = await closeDatabaseConnection();
+        if (!closedCleanly) {
+          // Safety valve: close threw. Don't proceed with a file swap against
+          // a DB that may still be open on the native side — on iOS 26 that
+          // risks the FTS5 teardown crash and/or a locked-file error.
+          // Skip this update and try again next launch. See PR #1534 for
+          // the build 20 crash this valve protects against.
+          logger.warn(TAG, 'Skipping delta apply: failed to close live DB handle');
+          return { status: 'up_to_date' };
+        }
+      }
       await this.backupCurrentDb();
 
       // Apply the SQL in a transaction
@@ -380,7 +423,19 @@ class ContentUpdaterService {
 
       // Verification passed — now swap the live DB
       closedLiveDb = getDbIfInitialized() != null;
-      if (closedLiveDb) await closeDatabaseConnection();
+      if (closedLiveDb) {
+        const closedCleanly = await closeDatabaseConnection();
+        if (!closedCleanly) {
+          // Safety valve: close threw. Same reasoning as applyDelta — on
+          // iOS 26 a close failure means SQLite may still hold the file
+          // open natively. Moving the temp file over it would produce
+          // lock errors or trigger the FTS5 teardown crash. Abort and
+          // retry next launch. See PR #1534.
+          logger.warn(TAG, 'Skipping full DB swap: failed to close live DB handle');
+          safeDelete(tempFile);
+          return { status: 'up_to_date' };
+        }
+      }
       await this.backupCurrentDb();
       const dbFile = sqliteFile(DB_NAME);
       safeDelete(dbFile);

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -16,7 +16,7 @@ import * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
 import { inflate } from 'pako';
 import { logger } from '../utils/logger';
-import { closeDatabaseConnection, getDbIfInitialized } from '../db/database';
+import { closeDatabaseConnection, getDbIfInitialized, reloadDatabase } from '../db/database';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -192,6 +192,7 @@ class ContentUpdaterService {
    */
   async applyDelta(delta: ManifestDelta): Promise<UpdateResult> {
     const tempFile = sqliteFile(DELTA_TEMP_NAME);
+    let closedLiveDb = false;
     try {
       this.ensureSqliteDir();
 
@@ -221,7 +222,8 @@ class ContentUpdaterService {
       const sql = new TextDecoder().decode(inflate(bytes));
 
       // Backup current DB before modifying
-      await closeDatabaseConnection();
+      closedLiveDb = getDbIfInitialized() != null;
+      if (closedLiveDb) await closeDatabaseConnection();
       await this.backupCurrentDb();
 
       // Apply the SQL in a transaction
@@ -269,6 +271,9 @@ class ContentUpdaterService {
       safeDelete(tempFile);
 
       logger.info(TAG, `Delta applied: ${delta.from_version} → ${delta.to_version}`);
+      if (closedLiveDb) {
+        await reloadDatabase();
+      }
       return {
         status: 'updated',
         fromVersion: delta.from_version,
@@ -278,6 +283,13 @@ class ContentUpdaterService {
       };
     } catch (err) {
       safeDelete(tempFile);
+      if (closedLiveDb) {
+        try {
+          await reloadDatabase();
+        } catch (reopenErr) {
+          logger.warn(TAG, 'Failed to reopen DB after delta failure', reopenErr);
+        }
+      }
       const message = err instanceof Error ? err.message : String(err);
       logger.error(TAG, 'Delta application failed', err);
       return { status: 'failed', error: message };
@@ -297,6 +309,7 @@ class ContentUpdaterService {
   ): Promise<UpdateResult> {
     const tempFile = sqliteFile(DOWNLOAD_TEMP_NAME);
     const tempDbName = DOWNLOAD_TEMP_NAME;
+    let closedLiveDb = false;
     try {
       const fromVersion = await this.getInstalledVersion();
 
@@ -366,7 +379,8 @@ class ContentUpdaterService {
       }
 
       // Verification passed — now swap the live DB
-      await closeDatabaseConnection();
+      closedLiveDb = getDbIfInitialized() != null;
+      if (closedLiveDb) await closeDatabaseConnection();
       await this.backupCurrentDb();
       const dbFile = sqliteFile(DB_NAME);
       safeDelete(dbFile);
@@ -376,6 +390,10 @@ class ContentUpdaterService {
 
       // Success — remove backup
       safeDelete(sqliteFile(BACKUP_NAME));
+
+      if (closedLiveDb) {
+        await reloadDatabase();
+      }
 
       logger.info(TAG, `Full DB downloaded: v${manifest.current_version}`);
       return {
@@ -387,6 +405,13 @@ class ContentUpdaterService {
       };
     } catch (err) {
       safeDelete(tempFile);
+      if (closedLiveDb) {
+        try {
+          await reloadDatabase();
+        } catch (reopenErr) {
+          logger.warn(TAG, 'Failed to reopen DB after full download failure', reopenErr);
+        }
+      }
       const message = err instanceof Error ? err.message : String(err);
       logger.error(TAG, 'Full DB download failed', err);
       return { status: 'failed', error: message };


### PR DESCRIPTION
## What
Hardens DB lifecycle handling during OTA content updates. Four commits: three cherry-picked from the original PR #1531 (after #1533's defer idea was evaluated and deferred to phase 2), plus a phase-1 safety valve.

## Why this is a separate PR from #1529 / #1534
#1529 and #1534 address the first-launch crash. This PR addresses bugs that bite users on **subsequent launches** during OTA content updates (delta apply, full-DB swap). Different code path, different failure mode, separate review.

## Commits

1. **`8fbcfba5` — Reuse live DB handle in `getInstalledVersion()`**  
   Adds `getDbIfInitialized()` to `database.ts`. `ContentUpdater.getInstalledVersion()` now reuses the live handle instead of opening a second connection, avoiding potential handle invalidation.

2. **`a8e2a92f` — Close live DB connection before OTA swaps**  
   Adds `closeDatabaseConnection()` to `database.ts`. `ContentUpdater` closes the live handle before delta-apply and full-DB-swap paths, so file replacement doesn't happen while SQLite still has the old file open.

3. **`0ff1e019` — Reopen DB after updater closes live handle**  
   Pairs with #2. Tracks whether a live handle was closed, then `reloadDatabase()` after success OR as best-effort recovery on failure.

4. **`74174ec0` — Close-failure safety valve + Option B TODO (NEW)**  
   Hardens #2 against the case where `closeAsync` itself throws. The original implementation swallowed close errors silently; this PR makes `closeDatabaseConnection()` return a boolean, and updates `ContentUpdater` to abort the swap (returning `up_to_date`) if close failed. Also adds a doc block describing Option B (defer-to-cold-start) as the long-term architectural target.

## Why the safety valve matters
If `closeAsync` throws, the native SQLite handle may or may not be released. Proceeding to move a temp file over a DB file that SQLite still has open can cause lock errors — or, on iOS 26 with FTS5 tables, the teardown segfault from PR #1534. Better to fail an OTA update and try again next launch than to corrupt the DB file.

## Long-term direction (Option B)
The close-and-reopen approach this PR implements is **phase 1**. Phase 2 (a separate future project) is to defer OTA applies to cold-start, doing the file swap before `initDatabase()` ever opens the DB. That eliminates the concurrent-access problem by design. Documented inline above `ContentUpdaterService` with full context on the tradeoff.

PR #1533's original defer-OTA idea informed this — but it cannot be implemented as-is because the DB is always open after startup, so a naive defer-on-live-db check would mean updates never fire.

## Tests
- 41 ContentUpdater tests pass (39 + 2 new safety-valve tests)
- Broader sweep: 30 suites / 454 tests pass
- Typecheck clean, lint 0 errors

## Sequencing
Recommend merging **after** build 21 from #1534 has been validated. Current priority is confirming the FTS5 teardown crash is resolved before layering more DB lifecycle changes.

## Closed as obsoleted
- #1531 — original monolithic PR, split here + in #1529
- #1533 — superseded; defer idea preserved as Option B TODO