### PR TITLE
Defer OTA when live DB open, use native download for large DBs, and reorder app init/hydration

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -152,25 +152,34 @@ function App() {
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
 
   useEffect(() => {
+    async function hydrateAppState() {
+      await initUserDatabase(); // User DB (user.db) — never replaced, migrated
+      // Bind an anonymous identifier to Sentry so crashes from a single
+      // install roll up under one user. Best-effort — if it fails we
+      // just don't get per-user grouping this session.
+      try {
+        const anonId = await getAnonymousId();
+        setSentryUser(anonId);
+      } catch {
+        /* non-fatal */
+      }
+      await useSettingsStore.getState().hydrate();
+      await useAuthStore.getState().hydrate();
+      await usePremiumStore.getState().hydrate();
+      pruneEvents(90); // Clean up old analytics (fire-and-forget)
+    }
+
     async function init() {
       try {
         // Lock to portrait by default — specific screens unlock for landscape
         await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
         const status = await initDatabase();   // Content DB (scripture.db) — may be missing on first launch
-        await initUserDatabase();              // User DB (user.db) — never replaced, migrated
-        // Bind an anonymous identifier to Sentry so crashes from a single
-        // install roll up under one user. Best-effort — if it fails we
-        // just don't get per-user grouping this session.
-        try {
-          const anonId = await getAnonymousId();
-          setSentryUser(anonId);
-        } catch {
-          /* non-fatal */
+        if (status === 'needs_download') {
+          setDbStatus('needs_download');
+          return;
         }
-        await useSettingsStore.getState().hydrate();
-        await useAuthStore.getState().hydrate();
-        await usePremiumStore.getState().hydrate();
-        pruneEvents(90); // Clean up old analytics (fire-and-forget)
+
+        await hydrateAppState();
         setDbStatus(status);
       } catch (e) {
         console.error('Init error:', e);
@@ -228,11 +237,27 @@ function App() {
               onComplete={async () => {
                 // Open the freshly-downloaded DB before entering the app tree
                 try {
-                  await initDatabase();
+                  const status = await initDatabase();
+                  if (status !== 'ready') {
+                    throw new Error('Downloaded DB did not initialize as ready');
+                  }
+                  await initUserDatabase();
+                  try {
+                    const anonId = await getAnonymousId();
+                    setSentryUser(anonId);
+                  } catch {
+                    /* non-fatal */
+                  }
+                  await useSettingsStore.getState().hydrate();
+                  await useAuthStore.getState().hydrate();
+                  await usePremiumStore.getState().hydrate();
+                  pruneEvents(90);
+                  setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);
+                  // Keep user on download screen (with retry) if init failed.
+                  throw e;
                 }
-                setDbStatus('ready');
               }}
             />
           </ThemeProvider>

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -6,9 +6,10 @@
  * checksum verification, backup/restore, and debounce logic.
  *
  * Under SDK 54, ContentUpdater uses the new `expo-file-system`
- * File/Directory/Paths API plus XMLHttpRequest for the full-DB
- * download (needed for progress callbacks, which the new file API
- * does not yet expose). These tests mock both surfaces.
+ * File/Directory/Paths API plus an XHR fallback for small full-DB
+ * downloads (progress callbacks). Large full-DB payloads use native
+ * File.downloadFileAsync to avoid JS memory spikes. These tests mock
+ * both surfaces.
  */
 
 import type { Manifest, ManifestDelta } from '@/services/ContentUpdater';
@@ -253,6 +254,12 @@ jest.mock('expo-sqlite', () => ({
 const mockFetch = jest.fn();
 (global as any).fetch = mockFetch;
 
+// ── Mock db/database live-handle helper ───────────────────────────
+const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
+jest.mock('@/db/database', () => ({
+  getDbIfInitialized: () => mockGetDbIfInitialized(),
+}));
+
 // ── Mock atob (not available in Node test env) ────────────────────
 (global as any).atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
 
@@ -328,6 +335,7 @@ describe('ContentUpdater service', () => {
 
     // Re-establish default mock return values after clearAllMocks
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
+    mockGetDbIfInitialized.mockReturnValue(null);
   });
 
   // ── shouldCheckForUpdates ─────────────────────────────────────
@@ -402,6 +410,17 @@ describe('ContentUpdater service', () => {
 
       expect(version).toBeNull();
     });
+
+    it('reuses initialized live DB without opening/closing a temp handle', async () => {
+      mockGetFirstAsync.mockResolvedValue({ value: 'v_live' });
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+
+      const version = await ContentUpdater.getInstalledVersion();
+
+      expect(version).toBe('v_live');
+      expect(mockOpenDatabaseAsync).not.toHaveBeenCalled();
+      expect(mockCloseAsync).not.toHaveBeenCalled();
+    });
   });
 
   // ── findDelta ─────────────────────────────────────────────────
@@ -474,6 +493,16 @@ describe('ContentUpdater service', () => {
       expect(result.toVersion).toBe('v2.0.0');
     });
 
+    it('defers OTA apply when live DB handle is open', async () => {
+      mockFetchManifest();
+      mockGetFirstAsync.mockResolvedValueOnce({ value: 'v1.0.0' });
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+
+      const result = await ContentUpdater.checkForUpdates();
+
+      expect(result.status).toBe('up_to_date');
+    });
+
     it('falls back to full download when no delta matches', async () => {
       mockFetchManifest();
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v0.5.0' });
@@ -518,6 +547,7 @@ describe('ContentUpdater service', () => {
       expect(mockExecAsync).toHaveBeenCalledWith('BEGIN TRANSACTION');
       expect(mockExecAsync).toHaveBeenCalledWith('COMMIT');
     });
+
 
     it('returns failed on download HTTP error', async () => {
       const httpErr = new Error('HTTP 404') as Error & { httpStatus: number };
@@ -620,6 +650,7 @@ describe('ContentUpdater service', () => {
       expect(result.bytesDownloaded).toBe(sampleManifest.full_db_size_bytes);
     });
 
+
     it('forwards download progress to the onProgress callback', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
@@ -637,6 +668,26 @@ describe('ContentUpdater service', () => {
       expect(progress).toEqual([25, 100]);
     });
 
+    it('uses native file download for large full DB payloads', async () => {
+      const largeManifest: Manifest = {
+        ...sampleManifest,
+        full_db_size_bytes: 100 * 1024 * 1024,
+      };
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
+      resetXhr(200);
+
+      const progress: number[] = [];
+      const result = await ContentUpdater.downloadFullDb(largeManifest, (pct) => progress.push(pct));
+
+      expect(result.status).toBe('updated');
+      expect(mockFileOps.downloadFileAsync).toHaveBeenCalled();
+      expect(mockFileOps.writeBytes).not.toHaveBeenCalled();
+      expect(progress).toEqual([5, 100]);
+    });
+
     it('returns failed on download HTTP error', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
       resetXhr(500);
@@ -645,17 +696,6 @@ describe('ContentUpdater service', () => {
 
       expect(result.status).toBe('failed');
       expect(result.error).toContain('Full DB download failed');
-    });
-
-    it('returns failed on checksum mismatch', async () => {
-      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(200);
-      mockChecksumFail();
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('Checksum mismatch');
     });
 
     it('returns failed on content hash mismatch after download', async () => {
@@ -671,6 +711,19 @@ describe('ContentUpdater service', () => {
 
       expect(result.status).toBe('failed');
       expect(result.error).toContain('Content hash mismatch');
+    });
+
+    it('returns failed when integrity_check fails after download', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
+        .mockResolvedValueOnce({ value: 'v2.0.0' })   // content hash
+        .mockResolvedValueOnce({ integrity_check: 'malformed' }); // integrity
+      resetXhr(200);
+
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Integrity check failed after download');
     });
 
     it('swaps downloaded DB into place', async () => {

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -69,6 +69,15 @@ export function getDb(): SQLite.SQLiteDatabase {
 }
 
 /**
+ * Returns the open core DB handle when initialized, otherwise null.
+ * Useful for read-only callers that should avoid opening/closing a
+ * second connection with the same filename.
+ */
+export function getDbIfInitialized(): SQLite.SQLiteDatabase | null {
+  return db;
+}
+
+/**
  * Close the current DB connection and reopen from the (updated) file.
  * Called after ContentUpdater swaps the DB file on disk so all
  * subsequent getDb() calls return a connection to the new content.
@@ -88,6 +97,22 @@ export async function reloadDatabase(): Promise<SQLite.SQLiteDatabase> {
   }
   logger.info('DB', 'Database connection reloaded after content update');
   return db;
+}
+
+/**
+ * Close the live content DB connection (if open) and clear the in-memory
+ * handle. Used before on-disk DB replacement to avoid swapping files while
+ * SQLite still has the old file open.
+ */
+export async function closeDatabaseConnection(): Promise<void> {
+  if (!db) return;
+  try {
+    await db.closeAsync();
+  } catch {
+    // ignore — best-effort close before swap
+  } finally {
+    db = null;
+  }
 }
 
 /**

--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -15,7 +15,7 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { ContentUpdater } from '../services/ContentUpdater';
 
 interface Props {
-  onComplete: () => void;
+  onComplete: () => void | Promise<void>;
 }
 
 export function DbDownloadScreen({ onComplete }: Props) {
@@ -39,7 +39,7 @@ export function DbDownloadScreen({ onComplete }: Props) {
       });
 
       if (result.status === 'updated') {
-        onComplete();
+        await onComplete();
         return;
       }
 

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -16,6 +16,7 @@ import * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
 import { inflate } from 'pako';
 import { logger } from '../utils/logger';
+import { getDbIfInitialized } from '../db/database';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -28,6 +29,7 @@ const DB_NAME = 'scripture.db';
 const BACKUP_NAME = 'scripture_backup.db';
 const DELTA_TEMP_NAME = 'delta_temp.sql.gz';
 const DOWNLOAD_TEMP_NAME = 'scripture_download.db';
+const LARGE_DB_NATIVE_DOWNLOAD_THRESHOLD_BYTES = 25 * 1024 * 1024;
 
 function sqliteDir(): Directory {
   return new Directory(Paths.document, SQLITE_SUBDIR);
@@ -100,6 +102,15 @@ class ContentUpdaterService {
         `Update available: ${installedVersion ?? 'none'} → ${manifest.current_version}`,
       );
 
+      // Avoid applying live updates while the app holds an open DB handle.
+      // Closing the handle during active reads can crash in sqlite finalizers
+      // (seen in TestFlight 1.0.7(20) at SQLiteModule.closeDatabase).
+      // Defer OTA apply to a future launch flow where no live handle exists.
+      if (getDbIfInitialized()) {
+        logger.warn(TAG, 'Deferring OTA apply while live DB is open');
+        return { status: 'up_to_date' };
+      }
+
       // Try delta first if we have an installed version
       if (installedVersion) {
         const delta = this.findDelta(manifest, installedVersion);
@@ -149,8 +160,14 @@ class ContentUpdaterService {
   async getInstalledVersion(): Promise<string | null> {
     let tempDb: SQLite.SQLiteDatabase | null = null;
     try {
-      tempDb = await SQLite.openDatabaseAsync('scripture.db');
-      const row = await tempDb.getFirstAsync<{ value: string }>(
+      // If the app already has scripture.db open, reuse that live handle.
+      // Opening/closing another handle to the same file can close the active
+      // connection on some SQLite wrappers, causing downstream query crashes.
+      const liveDb = getDbIfInitialized();
+      const queryDb = liveDb ?? await SQLite.openDatabaseAsync('scripture.db');
+      if (!liveDb) tempDb = queryDb;
+
+      const row = await queryDb.getFirstAsync<{ value: string }>(
         "SELECT value FROM db_meta WHERE key = 'content_hash'",
       );
       return row?.value ?? null;
@@ -298,13 +315,22 @@ class ContentUpdaterService {
       // Remove any partial download from a previous failed attempt.
       safeDelete(tempFile);
 
-      // The new expo-file-system API does not yet expose a progress
-      // callback on File.downloadFileAsync. XMLHttpRequest gives us
-      // length-computable onprogress events in the RN runtime, and we
-      // write the resulting ArrayBuffer to disk via File#write — which
-      // routes through the SDK 54 TurboModule cleanly.
+      // For large payloads, prefer native File.downloadFileAsync to avoid
+      // keeping the entire response body in JS memory (XHR arraybuffer can
+      // spike memory on ~100 MB DBs and terminate the process on iOS).
+      //
+      // For smaller payloads we keep the XHR + chunked write path so the
+      // first-launch screen can show exact progress.
       try {
-        await this.downloadWithProgress(manifest.full_db_url, tempFile, onProgress);
+        const shouldUseNativeDownload =
+          manifest.full_db_size_bytes >= LARGE_DB_NATIVE_DOWNLOAD_THRESHOLD_BYTES;
+        if (shouldUseNativeDownload) {
+          onProgress?.(5);
+          await File.downloadFileAsync(manifest.full_db_url, tempFile);
+          onProgress?.(100);
+        } else {
+          await this.downloadWithProgress(manifest.full_db_url, tempFile, onProgress);
+        }
       } catch (err) {
         const status = extractHttpStatus(err);
         throw new Error(
@@ -314,8 +340,15 @@ class ContentUpdaterService {
         );
       }
 
-      // Verify file checksum
-      await this.verifyChecksum(tempFile, manifest.full_db_sha256);
+      // NOTE: Do NOT run verifyChecksum(tempFile, ...) on full DB payloads.
+      // That helper reads the entire file into a base64 string and then into
+      // a Uint8Array; with ~100 MB content DBs this can spike memory high
+      // enough for iOS to terminate the process right after download.
+      //
+      // For full-db updates we validate by opening the downloaded DB and
+      // checking both (1) expected content_hash in db_meta and
+      // (2) PRAGMA integrity_check === 'ok' before swapping into place.
+      // Delta payloads remain checksum-verified (they are much smaller).
 
       // Verify content hash in the downloaded DB BEFORE swapping.
       // Open by its temp filename so we never touch the live connection.
@@ -329,6 +362,12 @@ class ContentUpdaterService {
           throw new Error(
             `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
+        }
+        const integrity = await verifyDb.getFirstAsync<{ integrity_check: string }>(
+          'PRAGMA integrity_check',
+        );
+        if (integrity?.integrity_check !== 'ok') {
+          throw new Error(`Integrity check failed after download: ${integrity?.integrity_check}`);
         }
       } finally {
         if (verifyDb) await verifyDb.closeAsync();


### PR DESCRIPTION
### Motivation

- Prevent crashes and corruption from swapping the on-disk content DB while an app-held SQLite handle is open.  
- Avoid JS memory spikes when downloading large full DB payloads by using a native download path instead of buffering via XHR.  
- Ensure app-level stores and user DB are hydrated only after the content DB is available, and make the first-launch download flow await post-download initialization.

### Description

- Added `getDbIfInitialized()` and `closeDatabaseConnection()` in `src/db/database.ts` to expose the live DB handle and allow safe close-before-swap.  
- In `services/ContentUpdater.ts` added a guard to defer OTA apply when a live DB handle exists, introduced `LARGE_DB_NATIVE_DOWNLOAD_THRESHOLD_BYTES`, and selected a native `File.downloadFileAsync` path for large full-DB downloads while keeping XHR-based progress for small downloads.  
- Replaced memory-heavy checksum-for-full-db flow by opening the downloaded DB and verifying the `db_meta` `content_hash` and `PRAGMA integrity_check` before swapping the file.  
- Reworked app startup in `App.tsx` to introduce `hydrateAppState()` and to early-return to the download screen when `initDatabase()` reports `'needs_download'`, and to run the full hydration sequence after a successful post-download init.  
- Updated `DbDownloadScreen.tsx` so `onComplete` may be async and is `await`ed in the download flow.  
- Updated `__tests__/services/ContentUpdater.test.ts` to mock the live DB helper, add tests for reusing live DB handles, deferring OTA when DB is open, native-download behavior for large payloads, and integrity-check failure scenarios, and to adjust progress/error expectations accordingly.

### Testing

- Ran the unit test suite for the updater with `jest` (the `ContentUpdater service` suite and related mocks); all tests in the updated `__tests__/services/ContentUpdater.test.ts` passed.  
- Verified the modified startup and download flow in unit tests that exercise `getInstalledVersion`, `checkForUpdates`, `downloadFullDb`, and `applyDelta` behaviors; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55106bc50832484f31e53147ab52e)