### PR TITLE
fix(ContentUpdater): remove full-DB PRAGMA integrity_check (iOS 26 FTS5 teardown crash)

### DIFF
--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -482,7 +482,6 @@ describe('ContentUpdater service', () => {
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
-      mockGetFirstAsync.mockResolvedValueOnce({ integrity_check: 'ok' });
 
       const result = await ContentUpdater.checkForUpdates();
 
@@ -497,7 +496,6 @@ describe('ContentUpdater service', () => {
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v2.0.0' });
-      mockGetFirstAsync.mockResolvedValueOnce({ integrity_check: 'ok' });
 
       const result = await ContentUpdater.checkForUpdates();
 
@@ -647,8 +645,7 @@ describe('ContentUpdater service', () => {
       };
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' })
-        .mockResolvedValueOnce({ integrity_check: 'ok' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
       resetXhr(200);
 
       const progress: number[] = [];
@@ -685,24 +682,10 @@ describe('ContentUpdater service', () => {
       expect(result.error).toContain('Content hash mismatch');
     });
 
-    it('returns failed when integrity_check fails after download', async () => {
-      mockGetFirstAsync
-        .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
-        .mockResolvedValueOnce({ value: 'v2.0.0' })   // content hash
-        .mockResolvedValueOnce({ integrity_check: 'malformed' }); // integrity
-      resetXhr(200);
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('Integrity check failed after download');
-    });
-
     it('swaps downloaded DB into place', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' })
-        .mockResolvedValueOnce({ integrity_check: 'ok' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
 
@@ -730,8 +713,7 @@ describe('ContentUpdater service', () => {
     it('removes backup after successful download', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' })
-        .mockResolvedValueOnce({ integrity_check: 'ok' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       // Pre-seed an old backup so safeDelete observes the delete.
@@ -753,8 +735,7 @@ describe('ContentUpdater service', () => {
     it('writes the downloaded payload via FileHandle, not File#write', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' })
-        .mockResolvedValueOnce({ integrity_check: 'ok' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
       resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
 
@@ -774,8 +755,7 @@ describe('ContentUpdater service', () => {
     it('splits a multi-MB payload into 1 MiB chunks', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' })
-        .mockResolvedValueOnce({ integrity_check: 'ok' });
+        .mockResolvedValueOnce({ value: 'v2.0.0' });
       // 2.5 MiB payload → expect 3 chunks (1 MiB, 1 MiB, 0.5 MiB)
       const payloadBytes = Math.floor(2.5 * (1 << 20));
       xhrControls.response = new ArrayBuffer(payloadBytes);

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -329,9 +329,23 @@ class ContentUpdaterService {
       // a Uint8Array; with ~100 MB content DBs this can spike memory high
       // enough for iOS to terminate the process right after download.
       //
-      // For full-db updates we validate by opening the downloaded DB and
-      // checking both (1) expected content_hash in db_meta and
-      // (2) PRAGMA integrity_check === 'ok' before swapping into place.
+      // We also deliberately do NOT run `PRAGMA integrity_check` here. On
+      // iOS 26 with expo-sqlite, running integrity_check loads all FTS5
+      // virtual-table indexes, and the subsequent `closeAsync` then
+      // segfaults inside `sqlite3Fts5IndexClose` during FTS5 vtab
+      // teardown. See TestFlight 1.0.7(20) crash — Thread 7 EXC_BAD_ACCESS
+      // at exsqlite3_finalize, called from SQLiteModule.closeDatabase.
+      //
+      // Validation for full-db updates is now: open the downloaded DB and
+      // check that `db_meta.content_hash` matches the manifest's
+      // `current_version`. The content_hash was computed at build time
+      // over the full contents of scripture.db — a corrupt/truncated
+      // download is overwhelmingly likely to fail at SQLite open
+      // (throwing before we reach the content_hash read) or to miss the
+      // db_meta row entirely. This is less rigorous than integrity_check
+      // but avoids the teardown crash. TODO: re-add integrity verification
+      // once expo-sqlite's FTS5 teardown bug is resolved upstream, or
+      // migrate to a streaming SHA-256 during chunked write.
       // Delta payloads remain checksum-verified (they are much smaller).
 
       // Verify content hash in the downloaded DB BEFORE swapping.
@@ -346,12 +360,6 @@ class ContentUpdaterService {
           throw new Error(
             `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
-        }
-        const integrity = await verifyDb.getFirstAsync<{ integrity_check: string }>(
-          'PRAGMA integrity_check',
-        );
-        if (integrity?.integrity_check !== 'ok') {
-          throw new Error(`Integrity check failed after download: ${integrity?.integrity_check}`);
         }
       } finally {
         if (verifyDb) await verifyDb.closeAsync();


### PR DESCRIPTION
## Why
TestFlight 1.0.7(20) segfaulted at launch. The crash is in SQLite's FTS5 teardown path during `closeAsync`, triggered by the `PRAGMA integrity_check` call we added in #1529.

## Crash signature
`EXC_BAD_ACCESS (SIGSEGV)`, 3.5s after launch, Thread 7:
```
exsqlite3_finalize              ← garbage pointer deref
sqlite3Fts5IndexClose
fts5DisconnectMethod
fts5FreeVtab
sqlite3VtabUnlock
disconnectAllVtab
sqlite3Close
SQLiteModule.closeDatabase      ← expo-sqlite iOS closeAsync
```

## What's happening
1. Download completes → native `File.downloadFileAsync` writes temp file (fine, no memory spike — that fix from #1529 is still working)
2. We open the temp DB with `openDatabaseAsync(tempDbName)`
3. We run `SELECT content_hash FROM db_meta` — passes
4. We run `PRAGMA integrity_check` — passes
5. `verifyDb.closeAsync()` → SQLite tears down FTS5 vtabs → finalize on stale pointer → segfault

`integrity_check` forces SQLite to load and validate every FTS5 index. scripture.db has FTS5 tables for verse search and people search. The combination of "FTS5 indexes loaded by integrity_check" + "expo-sqlite's closeAsync path on iOS 26" produces a use-after-free during teardown.

## The fix
Remove the `PRAGMA integrity_check` block from `downloadFullDb`. Keep the `content_hash` check — that hash is baked into `db_meta` at build time over the full file contents, so a corrupt/truncated download fails at open or misses the row. Less rigorous than integrity_check, but avoids the teardown crash.

Documented as a TODO to revisit once expo-sqlite's FTS5 teardown is fixed upstream, or to migrate to streaming SHA-256 during the chunked write.

## Intentionally NOT fixed here
The `applyDelta` path has the same `PRAGMA integrity_check` → `closeAsync` pattern at ContentUpdater.ts:234. Left as-is because:
- First-launch users (the ones currently crashing) never hit the delta path
- Delta integrity_check runs after transactional SQL mutation — more valuable there as a corruption check
- If it ever crashes for a delta user, same fix applies; deferring avoids scope creep

A separate follow-up PR can address the delta-path integrity_check if it becomes a problem.

## Tests
- Removed `returns failed when integrity_check fails after download` (the tested code path no longer exists)
- Removed dead integrity_check mocks from 5 full-DB tests where they'd never be consumed now
- Delta-path tests untouched
- 35 ContentUpdater tests pass
- Typecheck clean, lint 0 errors

## Changes against PR #1529 that stay intact
- Native download for large payloads (the real memory fix) ✓
- content_hash verification ✓
- Hydration ordering fix ✓
- onComplete error surfacing ✓
- Global JS error handler diagnostic ✓

## Expected build 21 behavior
Three outcomes possible:
- **App reaches home screen cleanly** — all the #1529 fixes work, this was the last blocker. We revert the diagnostic in a small follow-up.
- **App crashes, Alert on relaunch** — a different JS error fires; the diagnostic captures it.
- **App crashes silently** — a different native-layer bug; crash log tells us where.

## Supersedes
- Closes #1533 (which kept the integrity_check call; that's the root cause, not a solution)

## Budget
~$4-6 EAS credits remain. This will be the final build of the month likely. If it works, great. If not, we have the diagnostic and crash logs to plan next month's work carefully.