### PR TITLE
Safely apply OTA DB updates: reuse live DB handle, use native download, and reorganize app init

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -152,25 +152,34 @@ function App() {
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
 
   useEffect(() => {
+    async function hydrateAppState() {
+      await initUserDatabase(); // User DB (user.db) — never replaced, migrated
+      // Bind an anonymous identifier to Sentry so crashes from a single
+      // install roll up under one user. Best-effort — if it fails we
+      // just don't get per-user grouping this session.
+      try {
+        const anonId = await getAnonymousId();
+        setSentryUser(anonId);
+      } catch {
+        /* non-fatal */
+      }
+      await useSettingsStore.getState().hydrate();
+      await useAuthStore.getState().hydrate();
+      await usePremiumStore.getState().hydrate();
+      pruneEvents(90); // Clean up old analytics (fire-and-forget)
+    }
+
     async function init() {
       try {
         // Lock to portrait by default — specific screens unlock for landscape
         await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
         const status = await initDatabase();   // Content DB (scripture.db) — may be missing on first launch
-        await initUserDatabase();              // User DB (user.db) — never replaced, migrated
-        // Bind an anonymous identifier to Sentry so crashes from a single
-        // install roll up under one user. Best-effort — if it fails we
-        // just don't get per-user grouping this session.
-        try {
-          const anonId = await getAnonymousId();
-          setSentryUser(anonId);
-        } catch {
-          /* non-fatal */
+        if (status === 'needs_download') {
+          setDbStatus('needs_download');
+          return;
         }
-        await useSettingsStore.getState().hydrate();
-        await useAuthStore.getState().hydrate();
-        await usePremiumStore.getState().hydrate();
-        pruneEvents(90); // Clean up old analytics (fire-and-forget)
+
+        await hydrateAppState();
         setDbStatus(status);
       } catch (e) {
         console.error('Init error:', e);
@@ -228,11 +237,27 @@ function App() {
               onComplete={async () => {
                 // Open the freshly-downloaded DB before entering the app tree
                 try {
-                  await initDatabase();
+                  const status = await initDatabase();
+                  if (status !== 'ready') {
+                    throw new Error('Downloaded DB did not initialize as ready');
+                  }
+                  await initUserDatabase();
+                  try {
+                    const anonId = await getAnonymousId();
+                    setSentryUser(anonId);
+                  } catch {
+                    /* non-fatal */
+                  }
+                  await useSettingsStore.getState().hydrate();
+                  await useAuthStore.getState().hydrate();
+                  await usePremiumStore.getState().hydrate();
+                  pruneEvents(90);
+                  setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);
+                  // Keep user on download screen (with retry) if init failed.
+                  throw e;
                 }
-                setDbStatus('ready');
               }}
             />
           </ThemeProvider>

--- a/app/__tests__/services/ContentUpdater.test.ts
+++ b/app/__tests__/services/ContentUpdater.test.ts
@@ -6,9 +6,8 @@
  * checksum verification, backup/restore, and debounce logic.
  *
  * Under SDK 54, ContentUpdater uses the new `expo-file-system`
- * File/Directory/Paths API plus XMLHttpRequest for the full-DB
- * download (needed for progress callbacks, which the new file API
- * does not yet expose). These tests mock both surfaces.
+ * File/Directory/Paths API with native File.downloadFileAsync for full-DB
+ * downloads. XHR remains mocked for legacy/internal helper coverage.
  */
 
 import type { Manifest, ManifestDelta } from '@/services/ContentUpdater';
@@ -253,6 +252,12 @@ jest.mock('expo-sqlite', () => ({
 const mockFetch = jest.fn();
 (global as any).fetch = mockFetch;
 
+// ── Mock db/database live-handle helper ───────────────────────────
+const mockGetDbIfInitialized = jest.fn().mockReturnValue(null);
+jest.mock('@/db/database', () => ({
+  getDbIfInitialized: () => mockGetDbIfInitialized(),
+}));
+
 // ── Mock atob (not available in Node test env) ────────────────────
 (global as any).atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
 
@@ -328,6 +333,7 @@ describe('ContentUpdater service', () => {
 
     // Re-establish default mock return values after clearAllMocks
     mockOpenDatabaseAsync.mockResolvedValue(mockDbInstance);
+    mockGetDbIfInitialized.mockReturnValue(null);
   });
 
   // ── shouldCheckForUpdates ─────────────────────────────────────
@@ -402,6 +408,17 @@ describe('ContentUpdater service', () => {
 
       expect(version).toBeNull();
     });
+
+    it('reuses initialized live DB without opening/closing a temp handle', async () => {
+      mockGetFirstAsync.mockResolvedValue({ value: 'v_live' });
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+
+      const version = await ContentUpdater.getInstalledVersion();
+
+      expect(version).toBe('v_live');
+      expect(mockOpenDatabaseAsync).not.toHaveBeenCalled();
+      expect(mockCloseAsync).not.toHaveBeenCalled();
+    });
   });
 
   // ── findDelta ─────────────────────────────────────────────────
@@ -474,6 +491,16 @@ describe('ContentUpdater service', () => {
       expect(result.toVersion).toBe('v2.0.0');
     });
 
+    it('defers OTA apply when live DB handle is open', async () => {
+      mockFetchManifest();
+      mockGetFirstAsync.mockResolvedValueOnce({ value: 'v1.0.0' });
+      mockGetDbIfInitialized.mockReturnValue(mockDbInstance);
+
+      const result = await ContentUpdater.checkForUpdates();
+
+      expect(result.status).toBe('up_to_date');
+    });
+
     it('falls back to full download when no delta matches', async () => {
       mockFetchManifest();
       mockGetFirstAsync.mockResolvedValueOnce({ value: 'v0.5.0' });
@@ -518,6 +545,7 @@ describe('ContentUpdater service', () => {
       expect(mockExecAsync).toHaveBeenCalledWith('BEGIN TRANSACTION');
       expect(mockExecAsync).toHaveBeenCalledWith('COMMIT');
     });
+
 
     it('returns failed on download HTTP error', async () => {
       const httpErr = new Error('HTTP 404') as Error & { httpStatus: number };
@@ -620,26 +648,39 @@ describe('ContentUpdater service', () => {
       expect(result.bytesDownloaded).toBe(sampleManifest.full_db_size_bytes);
     });
 
-    it('forwards download progress to the onProgress callback', async () => {
+
+    it('forwards coarse progress to the onProgress callback', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
       mockChecksumPass(sampleManifest.full_db_sha256);
-      xhrControls.progressEvents = [
-        { loaded: 50, total: 200, lengthComputable: true },
-        { loaded: 200, total: 200, lengthComputable: true },
-      ];
-      xhrControls.status = 200;
 
       const progress: number[] = [];
       await ContentUpdater.downloadFullDb(sampleManifest, (pct) => progress.push(pct));
 
-      expect(progress).toEqual([25, 100]);
+      expect(progress).toEqual([5, 100]);
+    });
+
+    it('uses native file download for full DB payloads', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })
+        .mockResolvedValueOnce({ value: 'v2.0.0' })
+        .mockResolvedValueOnce({ integrity_check: 'ok' });
+
+      const progress: number[] = [];
+      const result = await ContentUpdater.downloadFullDb(sampleManifest, (pct) => progress.push(pct));
+
+      expect(result.status).toBe('updated');
+      expect(mockFileOps.downloadFileAsync).toHaveBeenCalled();
+      expect(mockFileOps.writeBytes).not.toHaveBeenCalled();
+      expect(progress).toEqual([5, 100]);
     });
 
     it('returns failed on download HTTP error', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(500);
+      const httpErr = new Error('HTTP 500') as Error & { httpStatus: number };
+      httpErr.httpStatus = 500;
+      mockDownloadState.nextError = httpErr;
 
       const result = await ContentUpdater.downloadFullDb(sampleManifest);
 
@@ -647,22 +688,10 @@ describe('ContentUpdater service', () => {
       expect(result.error).toContain('Full DB download failed');
     });
 
-    it('returns failed on checksum mismatch', async () => {
-      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(200);
-      mockChecksumFail();
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('Checksum mismatch');
-    });
-
     it('returns failed on content hash mismatch after download', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
         .mockResolvedValueOnce({ value: 'wrong_hash' }); // verify after swap
-      resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       // Live DB must exist to exercise the path.
       getOrCreateRecord('/fake/docs/SQLite/scripture.db').exists = true;
@@ -673,11 +702,21 @@ describe('ContentUpdater service', () => {
       expect(result.error).toContain('Content hash mismatch');
     });
 
+    it('returns failed when integrity_check fails after download', async () => {
+      mockGetFirstAsync
+        .mockResolvedValueOnce({ value: 'v1.0.0' })   // getInstalledVersion
+        .mockResolvedValueOnce({ value: 'v2.0.0' })   // content hash
+        .mockResolvedValueOnce({ integrity_check: 'malformed' }); // integrity
+      const result = await ContentUpdater.downloadFullDb(sampleManifest);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Integrity check failed after download');
+    });
+
     it('swaps downloaded DB into place', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
 
       await ContentUpdater.downloadFullDb(sampleManifest);
@@ -690,7 +729,9 @@ describe('ContentUpdater service', () => {
 
     it('cleans up temp file on failure', async () => {
       mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(500);
+      const httpErr = new Error('HTTP 500') as Error & { httpStatus: number };
+      httpErr.httpStatus = 500;
+      mockDownloadState.nextError = httpErr;
       // Temp must "exist" so the cleanup path actually calls delete.
       getOrCreateRecord('/fake/docs/SQLite/scripture_download.db').exists = true;
 
@@ -705,7 +746,6 @@ describe('ContentUpdater service', () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      resetXhr(200);
       mockChecksumPass(sampleManifest.full_db_sha256);
       // Pre-seed an old backup so safeDelete observes the delete.
       getOrCreateRecord('/fake/docs/SQLite/scripture_backup.db').exists = true;
@@ -717,66 +757,16 @@ describe('ContentUpdater service', () => {
       );
     });
 
-    // ── chunked-write path (regression for 1.0.6(15)/1.0.6(16)) ─────
-    // `File#write` is a synchronous Expo Modules Function; passing a ~90 MB
-    // buffer through it in one shot caused a process-terminating NSException
-    // on iOS 26. We now route through a FileHandle with 1 MiB chunks and
-    // surface any error as a promise rejection. See PR #1514 + #1516 history.
-
-    it('writes the downloaded payload via FileHandle, not File#write', async () => {
+    it('does not invoke XHR/file-handle write path for full DB', async () => {
       mockGetFirstAsync
         .mockResolvedValueOnce({ value: 'v1.0.0' })
         .mockResolvedValueOnce({ value: 'v2.0.0' });
-      resetXhr(200);
-      mockChecksumPass(sampleManifest.full_db_sha256);
 
       await ContentUpdater.downloadFullDb(sampleManifest);
 
-      expect(mockFileOps.handleOpen).toHaveBeenCalledWith(
-        expect.stringContaining('scripture_download.db'),
-      );
-      expect(mockFileOps.writeBytes).toHaveBeenCalled();
-      expect(mockFileOps.handleClose).toHaveBeenCalledWith(
-        expect.stringContaining('scripture_download.db'),
-      );
-      // The legacy single-shot write path must be gone.
+      expect(mockFileOps.writeBytes).not.toHaveBeenCalled();
+      expect(mockFileOps.handleOpen).not.toHaveBeenCalled();
       expect(mockFileOps.write).not.toHaveBeenCalled();
-    });
-
-    it('splits a multi-MB payload into 1 MiB chunks', async () => {
-      mockGetFirstAsync
-        .mockResolvedValueOnce({ value: 'v1.0.0' })
-        .mockResolvedValueOnce({ value: 'v2.0.0' });
-      // 2.5 MiB payload → expect 3 chunks (1 MiB, 1 MiB, 0.5 MiB)
-      const payloadBytes = Math.floor(2.5 * (1 << 20));
-      xhrControls.response = new ArrayBuffer(payloadBytes);
-      xhrControls.status = 200;
-      xhrControls.progressEvents = [];
-      mockChecksumPass(sampleManifest.full_db_sha256);
-
-      await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(mockFileOps.writeBytes).toHaveBeenCalledTimes(3);
-      const chunkSizes = mockFileOps.writeBytes.mock.calls.map(
-        (call) => (call[1] as Uint8Array).byteLength,
-      );
-      expect(chunkSizes).toEqual([1 << 20, 1 << 20, payloadBytes - 2 * (1 << 20)]);
-    });
-
-    it('closes the file handle even when a chunk write throws', async () => {
-      mockGetFirstAsync.mockResolvedValue({ value: 'v1.0.0' });
-      resetXhr(200);
-      mockFileOps.writeBytes.mockImplementationOnce(() => {
-        throw new Error('simulated native write failure');
-      });
-
-      const result = await ContentUpdater.downloadFullDb(sampleManifest);
-
-      expect(result.status).toBe('failed');
-      expect(result.error).toContain('File write failed');
-      expect(result.error).toContain('simulated native write failure');
-      // Handle must still have been closed despite the throw.
-      expect(mockFileOps.handleClose).toHaveBeenCalled();
     });
   });
 });

--- a/app/src/db/database.ts
+++ b/app/src/db/database.ts
@@ -69,6 +69,15 @@ export function getDb(): SQLite.SQLiteDatabase {
 }
 
 /**
+ * Returns the open core DB handle when initialized, otherwise null.
+ * Useful for read-only callers that should avoid opening/closing a
+ * second connection with the same filename.
+ */
+export function getDbIfInitialized(): SQLite.SQLiteDatabase | null {
+  return db;
+}
+
+/**
  * Close the current DB connection and reopen from the (updated) file.
  * Called after ContentUpdater swaps the DB file on disk so all
  * subsequent getDb() calls return a connection to the new content.
@@ -88,6 +97,22 @@ export async function reloadDatabase(): Promise<SQLite.SQLiteDatabase> {
   }
   logger.info('DB', 'Database connection reloaded after content update');
   return db;
+}
+
+/**
+ * Close the live content DB connection (if open) and clear the in-memory
+ * handle. Used before on-disk DB replacement to avoid swapping files while
+ * SQLite still has the old file open.
+ */
+export async function closeDatabaseConnection(): Promise<void> {
+  if (!db) return;
+  try {
+    await db.closeAsync();
+  } catch {
+    // ignore — best-effort close before swap
+  } finally {
+    db = null;
+  }
 }
 
 /**

--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -15,7 +15,7 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { ContentUpdater } from '../services/ContentUpdater';
 
 interface Props {
-  onComplete: () => void;
+  onComplete: () => void | Promise<void>;
 }
 
 export function DbDownloadScreen({ onComplete }: Props) {
@@ -39,7 +39,7 @@ export function DbDownloadScreen({ onComplete }: Props) {
       });
 
       if (result.status === 'updated') {
-        onComplete();
+        await onComplete();
         return;
       }
 

--- a/app/src/services/ContentUpdater.ts
+++ b/app/src/services/ContentUpdater.ts
@@ -16,6 +16,7 @@ import * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
 import { inflate } from 'pako';
 import { logger } from '../utils/logger';
+import { getDbIfInitialized } from '../db/database';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -100,6 +101,15 @@ class ContentUpdaterService {
         `Update available: ${installedVersion ?? 'none'} → ${manifest.current_version}`,
       );
 
+      // Avoid applying live updates while the app holds an open DB handle.
+      // Closing the handle during active reads can crash in sqlite finalizers
+      // (seen in TestFlight 1.0.7(20) at SQLiteModule.closeDatabase).
+      // Defer OTA apply to a future launch flow where no live handle exists.
+      if (getDbIfInitialized()) {
+        logger.warn(TAG, 'Deferring OTA apply while live DB is open');
+        return { status: 'up_to_date' };
+      }
+
       // Try delta first if we have an installed version
       if (installedVersion) {
         const delta = this.findDelta(manifest, installedVersion);
@@ -149,8 +159,14 @@ class ContentUpdaterService {
   async getInstalledVersion(): Promise<string | null> {
     let tempDb: SQLite.SQLiteDatabase | null = null;
     try {
-      tempDb = await SQLite.openDatabaseAsync('scripture.db');
-      const row = await tempDb.getFirstAsync<{ value: string }>(
+      // If the app already has scripture.db open, reuse that live handle.
+      // Opening/closing another handle to the same file can close the active
+      // connection on some SQLite wrappers, causing downstream query crashes.
+      const liveDb = getDbIfInitialized();
+      const queryDb = liveDb ?? await SQLite.openDatabaseAsync('scripture.db');
+      if (!liveDb) tempDb = queryDb;
+
+      const row = await queryDb.getFirstAsync<{ value: string }>(
         "SELECT value FROM db_meta WHERE key = 'content_hash'",
       );
       return row?.value ?? null;
@@ -298,13 +314,13 @@ class ContentUpdaterService {
       // Remove any partial download from a previous failed attempt.
       safeDelete(tempFile);
 
-      // The new expo-file-system API does not yet expose a progress
-      // callback on File.downloadFileAsync. XMLHttpRequest gives us
-      // length-computable onprogress events in the RN runtime, and we
-      // write the resulting ArrayBuffer to disk via File#write — which
-      // routes through the SDK 54 TurboModule cleanly.
+      // Use native file download for all full DB payloads. The XHR+ArrayBuffer
+      // path has repeatedly surfaced process-terminating Obj-C exceptions
+      // under the new architecture (see TestFlight 1.0.7(21) and earlier).
       try {
-        await this.downloadWithProgress(manifest.full_db_url, tempFile, onProgress);
+        onProgress?.(5);
+        await File.downloadFileAsync(manifest.full_db_url, tempFile);
+        onProgress?.(100);
       } catch (err) {
         const status = extractHttpStatus(err);
         throw new Error(
@@ -314,8 +330,15 @@ class ContentUpdaterService {
         );
       }
 
-      // Verify file checksum
-      await this.verifyChecksum(tempFile, manifest.full_db_sha256);
+      // NOTE: Do NOT run verifyChecksum(tempFile, ...) on full DB payloads.
+      // That helper reads the entire file into a base64 string and then into
+      // a Uint8Array; with ~100 MB content DBs this can spike memory high
+      // enough for iOS to terminate the process right after download.
+      //
+      // For full-db updates we validate by opening the downloaded DB and
+      // checking both (1) expected content_hash in db_meta and
+      // (2) PRAGMA integrity_check === 'ok' before swapping into place.
+      // Delta payloads remain checksum-verified (they are much smaller).
 
       // Verify content hash in the downloaded DB BEFORE swapping.
       // Open by its temp filename so we never touch the live connection.
@@ -329,6 +352,12 @@ class ContentUpdaterService {
           throw new Error(
             `Content hash mismatch after download: expected ${manifest.current_version}, got ${row?.value}`,
           );
+        }
+        const integrity = await verifyDb.getFirstAsync<{ integrity_check: string }>(
+          'PRAGMA integrity_check',
+        );
+        if (integrity?.integrity_check !== 'ok') {
+          throw new Error(`Integrity check failed after download: ${integrity?.integrity_check}`);
         }
       } finally {
         if (verifyDb) await verifyDb.closeAsync();


### PR DESCRIPTION
### Motivation
- Avoid crashes and memory issues when applying OTA content DB updates while the app holds an open SQLite handle.
- Use the native file download path to prevent large ArrayBuffer/base64 memory spikes and Obj-C exceptions observed with the legacy XHR+write path.
- Ensure user-scoped initialization (user DB, stores, Sentry anon id) is performed consistently both on cold init and after a first-launch DB download.

### Description
- Reorganized app startup in `App.tsx` by extracting `hydrateAppState()` and calling it only after content DB initialization, and set `dbStatus` early when `initDatabase()` returns `needs_download`.
- Updated `DbDownloadScreen` `onComplete` to be `async`-capable and await post-download initialization steps (`initDatabase`, `initUserDatabase`, Sentry anon id set, store hydrations, and `pruneEvents`) before setting `dbStatus` to `ready`.
- Added `getDbIfInitialized()` and `closeDatabaseConnection()` helpers in `src/db/database.ts` to expose/close the live content DB handle without forcing open/close churn.
- In `services/ContentUpdater.ts` added an early check using `getDbIfInitialized()` to defer OTA applies when a live DB handle is open, reused the live handle inside `getInstalledVersion()` to avoid opening a second connection, switched full-DB downloads to `File.downloadFileAsync`, and replaced the memory-heavy file checksum step with validation that opens the downloaded DB and checks `db_meta.content_hash` plus `PRAGMA integrity_check` before swapping files.
- Updated `__tests__/services/ContentUpdater.test.ts` to mock native `downloadFileAsync`, introduce `mockGetDbIfInitialized`, and add tests covering live-handle reuse/deferral, native download usage, integrity-check failure, and adjusted download progress expectations while removing the legacy chunked-write assertions.

### Testing
- Ran the `jest` unit test suite for the ContentUpdater service (`__tests__/services/ContentUpdater.test.ts`) which exercises manifest fetching, delta/full update flows, and the new live-DB and native-download paths, and the tests passed.
- Verified that `ContentUpdater` tests asserting the native download, deferral when live DB is open, and integrity-check behavior all succeed under the updated mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55106bc50832484f31e53147ab52e)