### PR TITLE
fix(amicus): prevent AmicusFab crash when mounted outside NavigationContainer

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -142,6 +142,9 @@ function AppShell() {
         <ErrorBoundary>
           <RootNavigator />
         </ErrorBoundary>
+        <ErrorBoundary fallbackMessage="The Amicus button is temporarily unavailable.">
+          <AmicusFab />
+        </ErrorBoundary>
       </NavigationContainer>
       <StatusBar style={statusBarStyle === 'light-content' ? 'light' : 'dark'} />
     </>
@@ -286,7 +289,6 @@ function App() {
             <AmicusConsentProvider>
               <AmicusFabProvider>
                 <AppShell />
-                <AmicusFab />
               </AmicusFabProvider>
             </AmicusConsentProvider>
           </ContentUpdateProvider>

--- a/app/src/components/amicus/AmicusFab.tsx
+++ b/app/src/components/amicus/AmicusFab.tsx
@@ -20,6 +20,7 @@ import { Lock, MessageSquare } from 'lucide-react-native';
 import { useTheme } from '../../theme';
 import { useAmicusFab } from '../../contexts/AmicusFabContext';
 import { useAmicusAccess } from '../../hooks/useAmicusAccess';
+import { logger } from '../../utils/logger';
 import AmicusPeekSheet from './AmicusPeekSheet';
 
 const FAB_SIZE = 56;
@@ -30,7 +31,18 @@ const RIGHT_MARGIN = 16;
 export default function AmicusFab(): React.ReactElement | null {
   const { base } = useTheme();
   const insets = useSafeAreaInsets();
-  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  // Defensive: useNavigation throws synchronously if no NavigationContainer
+  // ancestor exists. In Release mode that throw becomes a fatal NSException
+  // via RCTFatal and aborts the app on first launch. The hook is still called
+  // on every render (its internal useContext runs before the throw), so hook
+  // order is stable — the try/catch only suppresses the error.
+  let navigation: NavigationProp<ParamListBase> | null = null;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    navigation = useNavigation<NavigationProp<ParamListBase>>();
+  } catch (e) {
+    logger.warn('AmicusFab', 'mounted outside NavigationContainer; rendering null', e);
+  }
   const { isVisible } = useAmicusFab();
   const access = useAmicusAccess();
   const [peekOpen, setPeekOpen] = useState(false);
@@ -52,13 +64,14 @@ export default function AmicusFab(): React.ReactElement | null {
   const handlePress = useCallback(() => {
     if (access.reason === 'not_premium') {
       // Non-premium → paywall screen in the Amicus tab.
-      const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+      const parent = navigation?.getParent<NavigationProp<ParamListBase>>();
       parent?.navigate('AmicusTab', { screen: 'Paywall' });
       return;
     }
     setPeekOpen(true);
   }, [access.reason, navigation]);
 
+  if (!navigation) return null;
   if (!shouldRender) return null;
 
   const isLocked = access.reason === 'not_premium';

--- a/app/src/components/amicus/__tests__/AmicusFab.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusFab.test.tsx
@@ -6,18 +6,34 @@ import { AmicusFabProvider, useAmicusFab } from '@/contexts/AmicusFabContext';
 
 const mockNavigate = jest.fn();
 const mockGetParent = jest.fn(() => ({ navigate: mockNavigate }));
+let mockUseNavigationShouldThrow = false;
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
     ...actual,
-    useNavigation: () => ({
-      navigate: jest.fn(),
-      getParent: mockGetParent,
-    }),
+    useNavigation: () => {
+      if (mockUseNavigationShouldThrow) {
+        throw new Error(
+          "Couldn't find a navigation object. Is your component inside NavigationContainer?",
+        );
+      }
+      return {
+        navigate: jest.fn(),
+        getParent: mockGetParent,
+      };
+    },
     useNavigationState: () => ({ routes: [{ name: 'HomeMain' }], index: 0 }),
   };
 });
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 // BottomSheet pulls in reanimated; stub it to a simple View in tests.
 jest.mock('@gorhom/bottom-sheet', () => {
@@ -41,6 +57,7 @@ function renderWithFab(node: React.ReactElement) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseNavigationShouldThrow = false;
   mockUseAmicusAccess.mockReturnValue({
     canUse: true,
     reason: 'ok',
@@ -97,5 +114,25 @@ describe('AmicusFab', () => {
       </AmicusFabProvider>,
     );
     expect(queryByLabelText('Open Amicus')).toBeNull();
+  });
+
+  it('renders null and logs a warning when mounted outside NavigationContainer', () => {
+    // Regression: iOS 26 first-launch crash on TestFlight builds 18 and 21.
+    // useNavigation throws synchronously when no NavigationContainer is an
+    // ancestor; in Release mode that becomes a fatal NSException via RCTFatal.
+    // The component must return null instead of throwing.
+    mockUseNavigationShouldThrow = true;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { logger } = require('@/utils/logger');
+
+    const { queryByLabelText } = renderWithFab(<AmicusFab />);
+
+    expect(queryByLabelText('Open Amicus')).toBeNull();
+    expect(queryByLabelText('Unlock Amicus')).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'AmicusFab',
+      expect.stringContaining('outside NavigationContainer'),
+      expect.any(Error),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes the iOS first-launch crash on TestFlight builds 18 and 21. Root cause: `<AmicusFab />` was mounted as a sibling of `<AppShell />`, which placed it outside the `<NavigationContainer>` that lives inside AppShell. The component calls `useNavigation()` unconditionally at `AmicusFab.tsx:33`, which throws synchronously when no navigation context exists. In Release mode, that throw becomes a fatal `NSException` via `RCTFatal()` and aborts the app ~4 seconds into first launch.

## Diagnosis

- Xcode's Objective-C exception breakpoint on a Release build caught the throw at `RCTFatal` (`RCTAssert.m:147`). Exception reason: `"Unhandled JS Exception: Error: Couldn't find a navigation object. Is your component inside NavigationContainer?"`.
- JS stack trace originated from the `RootApp → View → AppContainer` mount path — exactly when the AmicusFab provider tree initializes.
- Same error had been visible during dev-mode testing as a dismissable RedBox, but its significance wasn't recognized because:
  - Dev mode allows dismiss-and-continue, masking the underlying tree-state corruption.
  - Release mode converts unhandled JS errors to fatal native exceptions via RCTFatal — a code path that doesn't exist in dev.
  - The existing JS global error handler (added in #1529) doesn't see this error because it's caught by React's reconciler and re-thrown into native code, bypassing JS-level error handling.

## Changes

**`app/App.tsx`**
- Move `<AmicusFab />` from outside `<NavigationContainer>` (sibling of AppShell) into AppShell, as a sibling of `<RootNavigator>` inside `<NavigationContainer>`.
- Wrap it in its own `<ErrorBoundary>` so a future render error degrades gracefully rather than blanking the entire app.

**`app/src/components/amicus/AmicusFab.tsx`**
- Defensive: wrap `useNavigation()` in a try/catch. On throw, log via `logger.warn` and render `null`. Prevents this crash mode from ever reaching RCTFatal again — even if the tree is restructured in future.
- Hook order is preserved: the hook's internal `useContext` still runs on every render before any throw, so React's hook registry remains stable.

**`app/src/components/amicus/__tests__/AmicusFab.test.tsx`**
- New regression test: `renders null and logs a warning when mounted outside NavigationContainer`.
- Mocks `useNavigation` to throw the exact error message from `@react-navigation/native`; asserts the component returns `null` and calls `logger.warn` with the expected tag/message.
- Existing tests remain green.

## Validation

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (one targeted `react-hooks/rules-of-hooks` disable is justified in an adjacent comment — the hook IS called every render, the try/catch only suppresses its error)
- [x] `npm test` — 3432 tests pass, including the new regression test
- [ ] EAS preview build: TestFlight install succeeds, no crash on first launch
- [ ] Manually validated FAB tap behavior (peek sheet opens, paywall navigation works)

## What this PR does NOT do

- Does not refactor any other provider hierarchy.
- Does not change Sentry, OTA, or DB initialization paths.
- Does not invalidate #1514 (iOS 26 TurboModule patch) or #1534 (FTS5 integrity_check removal) — both remain necessary.
- Does not close #1532 (DB lifecycle hardening during OTA) — separate latent issue, worth merging after this is verified.

## Follow-ups (separate PRs)

1. Audit other components for unguarded `useNavigation()` calls.
2. Add a smoke test that mounts the full provider tree — would have caught this.
3. Document the `useNavigation()`-inside-`NavigationContainer` rule in `DEV_GUIDE.md` with a code-review checklist item.