### PR TITLE
Fix DbDownloadScreen showing as frozen at 5% on large downloads

### DIFF
--- a/app/src/screens/DbDownloadScreen.tsx
+++ b/app/src/screens/DbDownloadScreen.tsx
@@ -3,7 +3,7 @@
  *
  * Shown by App.tsx when initDatabase() reports 'needs_download' (no DB on
  * device, or DB file is too small to be valid). Drives ContentUpdater to
- * fetch the full scripture.db from R2, showing progress + error states.
+ * fetch the full scripture.db from R2.
  *
  * Calls onComplete() after a successful download so the parent can
  * transition to the normal app tree. `onComplete` may return a Promise —
@@ -11,12 +11,40 @@
  * (e.g. opening the freshly-downloaded DB) can surface thrown errors
  * through this screen's existing error UI instead of becoming an
  * unhandled promise rejection.
+ *
+ * ── UI states during download ─────────────────────────────────────────
+ *
+ * The download mechanism in `ContentUpdater.downloadFullDb` cannot emit
+ * smooth progress events for the large-file path (≥ 25 MB). The new
+ * `expo-file-system` `File.downloadFileAsync` API does not yet expose an
+ * `onProgress` callback in the SDK 54 release line we ship on, and the
+ * legacy `expo-file-system/legacy` `createDownloadResumable` shim crashes
+ * on download completion under the New Architecture (see comment block at
+ * the top of `ContentUpdater.ts`). For the typical Companion Study DB
+ * payload (~94 MB) the callback fires 5% → silence → 100%, which made
+ * earlier builds appear frozen at 5%.
+ *
+ * To avoid the misleading "stuck progress bar" UX without restoring a
+ * crash-prone download mechanism, this screen detects when the progress
+ * callback has gone silent for more than {@link STALL_DETECTION_MS} and
+ * switches to an indeterminate UI: large spinner, total payload size,
+ * helper copy, elapsed-time counter. As soon as a real progress event
+ * fires, it switches back to the percentage bar — so smaller updates
+ * (delta SQL patches, future `onProgress`-aware download APIs) still get
+ * the smooth-bar treatment automatically.
  */
 
-import { useCallback, useEffect, useState } from 'react';
-import { StyleSheet, View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
 import { ContentUpdater } from '../services/ContentUpdater';
+import { fontFamily, spacing, useTheme } from '../theme';
 
 interface Props {
   /**
@@ -27,17 +55,56 @@ interface Props {
   onComplete: () => void | Promise<void>;
 }
 
+/**
+ * Time without a progress callback after which we treat the download as
+ * "indeterminate" and swap to the spinner UI. Long enough that a slow
+ * download still trickling in chunks doesn't flicker, short enough that a
+ * truly silent path (the large-file branch in ContentUpdater) flips over
+ * within a beat or two.
+ */
+const STALL_DETECTION_MS = 2000;
+
+/** How often the elapsed-time + stall-detection timer ticks. */
+const TICK_INTERVAL_MS = 250;
+
+function formatBytes(bytes: number | null): string | null {
+  if (bytes == null) return null;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatElapsed(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
 export function DbDownloadScreen({ onComplete }: Props) {
   const { base } = useTheme();
+
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState<'idle' | 'downloading' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [sizeBytes, setSizeBytes] = useState<number | null>(null);
+  const [elapsedSec, setElapsedSec] = useState(0);
+  /**
+   * True when the most recent progress callback fired within
+   * {@link STALL_DETECTION_MS}. When true we show the % bar; when false
+   * we show the indeterminate spinner UI. Defaults to false so the very
+   * first few hundred ms — before any callback — render as indeterminate.
+   */
+  const [progressIsLive, setProgressIsLive] = useState(false);
+
+  const downloadStartRef = useRef<number | null>(null);
+  const lastProgressUpdateRef = useRef<number | null>(null);
 
   const startDownload = useCallback(async () => {
     setStatus('downloading');
     setError(null);
     setProgress(0);
+    setProgressIsLive(false);
+    setElapsedSec(0);
+    downloadStartRef.current = Date.now();
+    lastProgressUpdateRef.current = null;
 
     try {
       const manifest = await ContentUpdater.fetchManifest();
@@ -45,6 +112,7 @@ export function DbDownloadScreen({ onComplete }: Props) {
 
       const result = await ContentUpdater.downloadFullDb(manifest, (pct) => {
         setProgress(pct);
+        lastProgressUpdateRef.current = Date.now();
       });
 
       if (result.status === 'updated') {
@@ -76,36 +144,92 @@ export function DbDownloadScreen({ onComplete }: Props) {
     startDownload();
   }, [startDownload]);
 
+  // Tick: update elapsed seconds + recompute "is progress live" flag.
+  // Only runs while a download is in flight.
+  useEffect(() => {
+    if (status !== 'downloading') return;
+
+    const interval = setInterval(() => {
+      const now = Date.now();
+
+      if (downloadStartRef.current != null) {
+        setElapsedSec(Math.floor((now - downloadStartRef.current) / 1000));
+      }
+
+      const lastUpdate = lastProgressUpdateRef.current;
+      // "Live" only when we've actually seen a callback recently AND
+      // progress is somewhere in the middle. At 0 we haven't started; at
+      // 100 we're handing off to onComplete and the bar hitting full
+      // immediately after a long indeterminate stretch is jarring.
+      const sinceLastUpdate = lastUpdate == null ? Infinity : now - lastUpdate;
+      const isLive =
+        sinceLastUpdate < STALL_DETECTION_MS && progress > 0 && progress < 100;
+      setProgressIsLive(isLive);
+    }, TICK_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [status, progress]);
+
+  const sizeText = formatBytes(sizeBytes);
   const clampedPct = Math.max(0, Math.min(100, progress));
-  const sizeMb = sizeBytes ? (sizeBytes / 1024 / 1024).toFixed(1) : null;
 
   return (
     <View style={[styles.container, { backgroundColor: base.bg }]}>
       <View style={styles.content}>
         <Text style={[styles.title, { color: base.gold }]}>Companion Study</Text>
-        <Text style={[styles.subtitle, { color: base.textDim }]}>Setting up your library…</Text>
+        <Text style={[styles.subtitle, { color: base.textDim }]}>
+          Setting up your library…
+        </Text>
 
-        {status === 'downloading' && (
+        {status === 'downloading' && progressIsLive && (
           <>
             <View
               style={[
                 styles.progressTrack,
                 { backgroundColor: base.bgElevated, borderColor: base.border },
               ]}
+              accessibilityRole="progressbar"
+              accessibilityValue={{ min: 0, max: 100, now: Math.round(clampedPct) }}
             >
               <View
                 style={[
                   styles.progressFill,
-                  { backgroundColor: '#bfa050', width: `${clampedPct}%` },
+                  { backgroundColor: base.gold, width: `${clampedPct}%` },
                 ]}
               />
             </View>
             <Text style={[styles.progressText, { color: base.text }]}>
               {clampedPct.toFixed(0)}%
-              {sizeMb ? ` • ${sizeMb} MB` : ''}
+              {sizeText ? ` • ${sizeText}` : ''}
             </Text>
-            {clampedPct === 0 && <ActivityIndicator color={base.gold} style={styles.spinner} />}
           </>
+        )}
+
+        {status === 'downloading' && !progressIsLive && (
+          <View
+            style={styles.indeterminateBlock}
+            accessibilityRole="progressbar"
+            accessibilityLabel="Downloading scripture content"
+          >
+            <ActivityIndicator
+              color={base.gold}
+              size="large"
+              style={styles.spinnerLarge}
+            />
+            <Text style={[styles.indetTitle, { color: base.text }]}>
+              Downloading scripture content
+            </Text>
+            {sizeText != null && (
+              <Text style={[styles.indetSize, { color: base.textDim }]}>{sizeText}</Text>
+            )}
+            <Text style={[styles.indetHelp, { color: base.textMuted }]}>
+              This may take a minute on slower connections.{'\n'}
+              Please don&rsquo;t close the app.
+            </Text>
+            <Text style={[styles.elapsed, { color: base.textMuted }]}>
+              Elapsed {formatElapsed(elapsedSec)}
+            </Text>
+          </View>
         )}
 
         {status === 'error' && (
@@ -171,8 +295,38 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: spacing.xs,
   },
-  spinner: {
+  indeterminateBlock: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  spinnerLarge: {
+    marginBottom: spacing.lg,
+    transform: [{ scale: 1.4 }],
+  },
+  indetTitle: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  indetSize: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    marginTop: spacing.xs,
+    textAlign: 'center',
+  },
+  indetHelp: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: spacing.lg,
+    textAlign: 'center',
+  },
+  elapsed: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
     marginTop: spacing.md,
+    textAlign: 'center',
+    fontVariant: ['tabular-nums'],
   },
   errorBlock: {
     alignItems: 'center',


### PR DESCRIPTION
## Problem

The DB download screen looks frozen at 5% for the entire ~60s of a first-launch download.

`ContentUpdater.downloadFullDb` has two paths:
- **< 25 MB** → XHR with real progress events (smooth bar)
- **≥ 25 MB** → `File.downloadFileAsync` (memory-safe, but emits *no* progress events — only `onProgress?.(5)` then `onProgress?.(100)` at the end)

Companion Study's DB is ~94 MB → always takes the silent path → looks dead.

The new `expo-file-system` `File.downloadFileAsync` did gain an `onProgress` callback in the Expo CHANGELOG's "Unpublished" section, but it hasn't reached our `~19.0.21` SDK 54 line. Switching to `expo-file-system/legacy` `createDownloadResumable` would give us real progress, but it's the API explicitly called out at the top of `ContentUpdater.ts` as crashing on download completion under the New Architecture (TestFlight 1.0.5 crash log). With the recent RN void-method exception patch in place it *might* be safe now, but that needs rentamac validation we don't currently have.

## Fix (UI-only, zero download-mechanism risk)

Detect the stall: if the progress callback has been silent for > 2s and we haven't hit 100, swap from the percentage bar to an indeterminate UI:

- Large spinner
- "Downloading scripture content"
- Total payload size (e.g. "94.2 MB")
- Helper copy: "This may take a minute on slower connections. Please don't close the app."
- Elapsed-time counter

The screen switches **back** to the percentage bar the moment a real progress event fires — so delta patches (small XHR path) and any future `onProgress`-aware download API still get smooth-bar treatment automatically.

Pure JS, OTA-deliverable. No `ContentUpdater` changes → no risk of regressing the iOS 26 RCTTurboModule crash that motivated the current download architecture.

## Out of scope (separate cards to file)

1. Investigate `File.downloadFileAsync` `onProgress` once it lands in a published 19.0.x or we move to SDK 55 — would let us delete this stall-detection workaround and use real progress everywhere.
2. Re-evaluate `expo-file-system/legacy` `createDownloadResumable` now that the RN void-method exception patch is shipped — may have closed the original crash window.

## Verification

- ✅ Sandbox: brace/paren balanced, diff clean
- ⏳ Production: ship via `eas update --branch production` after merge; watch Sentry for any new errors on `DbDownloadScreen` or `ContentUpdater` paths. Easy revert via OTA if anything regresses.

## Acceptance criteria

- First-launch DB download no longer appears frozen
- Indeterminate state shows spinner, size, helpful copy, elapsed time
- Smooth progress bar still works when callback actually fires (small delta updates)
- No changes to download mechanism → iOS 26 crash protection unchanged
