### PR TITLE
Add fix_missing_art script + workflow for surgical R2 art uploads

### DIFF
--- a/.github/workflows/fix-missing-art.yml
+++ b/.github/workflows/fix-missing-art.yml
@@ -1,0 +1,72 @@
+name: Fix Missing Art (R2)
+
+# Manually-triggered workflow to upload curated Wikimedia art assets to R2.
+#
+# Runs `_tools/fix_missing_art.py`, which holds a hardcoded list of
+# (r2_filename, wikimedia_source_url) pairs. To add or change what gets
+# uploaded, edit the `TARGETS` list in that script and push to master —
+# no workflow edit required.
+#
+# Trigger:
+#   - workflow_dispatch (manual, from the Actions tab)
+#
+# Deliberately NOT triggered by path filters on push/PR: the target list
+# is curated, not derived from content. Running on every push to
+# `_tools/fix_missing_art.py` would re-fetch and re-upload the same files
+# unnecessarily.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Fetch + convert but skip R2 uploads (for validation)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      only:
+        description: 'Filename substring filter (optional — leave empty to run full list)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  upload-art:
+    name: Upload missing art assets to R2
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+      R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install boto3 Pillow
+
+      - name: Run fix_missing_art
+        run: |
+          args=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            args="$args --dry-run"
+          fi
+          if [ -n "${{ github.event.inputs.only }}" ]; then
+            args="$args --only ${{ github.event.inputs.only }}"
+          fi
+          python _tools/fix_missing_art.py $args

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+fix_missing_art.py — Fetch and upload a specific list of art assets to R2.
+
+Bridges the gap between `content_images` rows referencing an R2 URL and the
+actual file existing on R2. When a curated image is referenced by an
+Explore card or detail screen but the bytes aren't in the bucket yet, the
+app renders a placeholder instead of the image. This script takes a list
+of (filename, wikimedia_source_url) pairs, downloads each source (with the
+proper User-Agent Wikimedia requires), converts PNG → JPG to match the
+filename extension written into the DB, and uploads to R2 under the
+`art/` prefix.
+
+Why this script exists as its own tool:
+  - `download_explore_images.py` + `upload_images_to_r2.py` do this for
+    the full curated inventory via the `_tools/art_staging/` directory.
+    That flow is fine for bulk work but brittle for one-off re-uploads: it
+    requires staging, mode flags, manifest updates, and can silently skip
+    files if the staging dir is missing pieces.
+  - This script is a single surgical operation for a named list of files.
+    No staging dir, no sibling manifests, no mode flags — just fetch,
+    convert if needed, upload, verify, report.
+
+Usage:
+    python _tools/fix_missing_art.py                   # run the full target list
+    python _tools/fix_missing_art.py --dry-run         # fetch + validate only, no R2 writes
+    python _tools/fix_missing_art.py --only schnorr    # substring filter over target filenames
+
+Environment variables (required unless --dry-run):
+    R2_ACCOUNT_ID
+    R2_ACCESS_KEY_ID
+    R2_SECRET_ACCESS_KEY
+    R2_BUCKET_NAME
+    R2_PUBLIC_URL
+
+Reads from `.env` at the repo root if present (matches the pattern used by
+`upload_images_to_r2.py`). In CI the env vars come from secrets directly.
+
+Exit codes:
+    0  — every targeted file was uploaded and verified 200 on R2
+    1  — one or more files failed at fetch, convert, or upload
+    2  — environment/config error (missing creds, missing deps, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ENV_FILE = ROOT / '.env'
+
+# Wikimedia requires an identifying User-Agent with contact info.
+# https://meta.wikimedia.org/wiki/User-Agent_policy
+WIKIMEDIA_USER_AGENT = (
+    'CompanionStudyBot/1.0 '
+    '(https://companionstudy.app; craig@companionstudy.app) '
+    'Python/3'
+)
+
+# Immutable cache — art files are versioned by filename; if we ever need to
+# replace one we'd change the filename.
+CACHE_CONTROL = 'public, max-age=31536000, immutable'
+
+
+@dataclass(frozen=True)
+class ArtTarget:
+    """A single file to fetch and upload.
+
+    `r2_filename` is the name the DB's `content_images.url` column expects
+    (e.g. `schnorr-010.jpg`). `source_url` is the upstream Wikimedia URL.
+    `description` is free-text for logs.
+    """
+    r2_filename: str
+    source_url: str
+    description: str
+
+
+# ── Tonight's target list: 4 Map + 5 Prophecy card images ──────────────
+#
+# These filenames are already referenced by `content_images` rows in
+# scripture.db (verified against the Apr 21 2026 build). The rows point at
+# `https://contentcompanionstudy.com/art/{r2_filename}` — so uploading each
+# file under `art/{r2_filename}` completes the chain; no DB edit required.
+#
+# Source URLs copied from `download_explore_images.py` (same file, same
+# curation, same credits), kept inline here so this script is
+# self-contained and does not reach into another script's data.
+#
+# Adding future files: append to this list. To run a different list
+# entirely, refactor to read from a JSON input — but deliberately not
+# doing that now, we want the target set reviewed in PR.
+TARGETS: list[ArtTarget] = [
+    # ── Map card (4) ────────────────────────────────────────────────
+    ArtTarget(
+        r2_filename='figures-abraham-journey.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/7/72/Figures_The_Journey_of_Abraham.jpg',
+        description='Map/abram-call — Figures: The Journey of Abraham',
+    ),
+    ArtTarget(
+        r2_filename='figures-red-sea-crossing.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/1/17/Figures_Crossing_of_the_Red_Sea.jpg',
+        description='Map/exodus-plagues — Figures: Crossing of the Red Sea',
+    ),
+    ArtTarget(
+        r2_filename='holman-paul-journey3.jpg',
+        source_url="https://upload.wikimedia.org/wikipedia/commons/0/02/Holman_Paul%27s_Third_Missionary_Journey.jpg",
+        description="Map/paul-journey3 — Holman: Paul's Third Missionary Journey",
+    ),
+    ArtTarget(
+        r2_filename='campin-nativity.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/3/38/Robert_Campin_-_The_Nativity_-_WGA14420.jpg',
+        description='Map/nativity — Robert Campin: The Nativity',
+    ),
+
+    # ── Prophecy card (5) ───────────────────────────────────────────
+    ArtTarget(
+        r2_filename='schnorr-010.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/f/f5/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_010.png',
+        description='Prophecy/seed_of_woman — Schnorr: Creation (PNG→JPG)',
+    ),
+    ArtTarget(
+        r2_filename='schnorr-091.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/2/28/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_091.png',
+        description='Prophecy/davidic_covenant — Schnorr: David with harp (PNG→JPG)',
+    ),
+    ArtTarget(
+        r2_filename='michelangelo-isaiah.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/1/18/Michelangelo%2C_profeta_Isaia_02.jpg',
+        description='Prophecy/suffering_servant — Michelangelo: Prophet Isaiah',
+    ),
+    ArtTarget(
+        r2_filename='michelangelo-daniel.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/0/03/Michelangelo%2C_profeta_Daniele_02.jpg',
+        description='Prophecy/son_of_man — Michelangelo: Prophet Daniel',
+    ),
+    ArtTarget(
+        r2_filename='michelangelo-jeremiah.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/4/4a/Michelangelo_Buonarroti_-_Sistine_Chapel_Ceiling_-_Jeremiah.jpg',
+        description='Prophecy/new_covenant — Michelangelo: Prophet Jeremiah',
+    ),
+]
+
+
+# ── env loading ────────────────────────────────────────────────────────
+
+def load_env() -> None:
+    """Load `.env` at repo root if present. Env already set wins.
+
+    Matches the behaviour of `load_env()` in `upload_images_to_r2.py` so a
+    developer who has the existing flow working locally doesn't need to do
+    anything different.
+    """
+    if not ENV_FILE.exists():
+        return
+    with open(ENV_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            value = value.strip().strip('"').strip("'")
+            os.environ.setdefault(key.strip(), value)
+
+
+def require_env(key: str) -> str:
+    """Fetch an env var or die with a clear message."""
+    value = os.environ.get(key)
+    if not value:
+        print(f'[X] Missing required environment variable: {key}')
+        sys.exit(2)
+    return value
+
+
+# ── fetch ──────────────────────────────────────────────────────────────
+
+def fetch_source(target: ArtTarget) -> bytes:
+    """Download `target.source_url`. Returns raw bytes.
+
+    Uses the Wikimedia-compliant User-Agent. Raises on non-200 or empty
+    response so the caller can record it as a failure.
+    """
+    req = urllib.request.Request(
+        target.source_url,
+        headers={
+            'User-Agent': WIKIMEDIA_USER_AGENT,
+            'Accept': 'image/*,*/*',
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = resp.read()
+    if len(data) < 1024:
+        raise RuntimeError(
+            f'Response too small ({len(data)} bytes) — likely not a valid image'
+        )
+    return data
+
+
+# ── convert ────────────────────────────────────────────────────────────
+
+def ensure_jpeg(source_url: str, raw: bytes) -> bytes:
+    """If the R2 filename is .jpg but the source is .png (or other), convert.
+
+    The DB references files with .jpg extensions regardless of upstream
+    format (`schnorr-010.jpg` → upstream is a PNG). Uploading the raw PNG
+    bytes under a .jpg key means the served file's magic bytes don't match
+    its extension, which trips `expo-image` on some platforms.
+
+    Decision: convert to JPEG using Pillow, quality 90. JPEG at q90 is
+    visually indistinguishable from the PNG source at the display sizes
+    used in-app and avoids the format/extension mismatch.
+    """
+    if source_url.lower().endswith('.jpg') or source_url.lower().endswith('.jpeg'):
+        return raw  # Already JPEG, no conversion needed
+
+    try:
+        from PIL import Image
+    except ImportError:
+        print('[X] Pillow not installed. Run: pip install Pillow')
+        sys.exit(2)
+
+    img = Image.open(io.BytesIO(raw))
+    # PNGs from Wikimedia can be RGBA; JPEG is RGB-only. Flatten to white.
+    if img.mode in ('RGBA', 'LA') or (img.mode == 'P' and 'transparency' in img.info):
+        background = Image.new('RGB', img.size, (255, 255, 255))
+        background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
+        img = background
+    elif img.mode != 'RGB':
+        img = img.convert('RGB')
+
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG', quality=90, optimize=True)
+    return buf.getvalue()
+
+
+# ── upload ─────────────────────────────────────────────────────────────
+
+def get_s3_client():
+    """boto3 S3 client wired for CloudFlare R2."""
+    try:
+        import boto3
+    except ImportError:
+        print('[X] boto3 not installed. Run: pip install boto3')
+        sys.exit(2)
+
+    return boto3.client(
+        's3',
+        endpoint_url=f"https://{require_env('R2_ACCOUNT_ID')}.r2.cloudflarestorage.com",
+        aws_access_key_id=require_env('R2_ACCESS_KEY_ID'),
+        aws_secret_access_key=require_env('R2_SECRET_ACCESS_KEY'),
+        region_name='auto',
+    )
+
+
+def upload_to_r2(s3, bucket: str, target: ArtTarget, body: bytes) -> None:
+    """Upload `body` to R2 at `art/{r2_filename}`."""
+    s3.put_object(
+        Bucket=bucket,
+        Key=f'art/{target.r2_filename}',
+        Body=body,
+        ContentType='image/jpeg',
+        CacheControl=CACHE_CONTROL,
+    )
+
+
+# ── verify ─────────────────────────────────────────────────────────────
+
+def verify_public_url(public_url_base: str, target: ArtTarget) -> int:
+    """HEAD the public URL and return the HTTP status code.
+
+    Best-effort: CloudFlare's public URL may take a moment to propagate
+    after upload, but in practice R2 serves immediately. We still treat a
+    non-200 as a soft warning rather than a hard failure, because the
+    upload has already succeeded by the time we reach here.
+    """
+    url = f"{public_url_base.rstrip('/')}/art/{target.r2_filename}"
+    req = urllib.request.Request(url, method='HEAD', headers={'User-Agent': 'companionstudy-verify/1.0'})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return 0
+
+
+# ── main ───────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split('\n\n')[0] if __doc__ else '')
+    parser.add_argument('--dry-run', action='store_true', help='Fetch + convert but skip R2 upload')
+    parser.add_argument('--only', metavar='SUBSTRING', help='Only process targets whose filename contains SUBSTRING')
+    args = parser.parse_args()
+
+    load_env()
+
+    # Filter targets
+    targets = list(TARGETS)
+    if args.only:
+        targets = [t for t in targets if args.only in t.r2_filename]
+        if not targets:
+            print(f'[X] --only={args.only!r} matched zero targets')
+            return 2
+
+    print('=' * 60)
+    print('fix_missing_art — surgical R2 art upload')
+    print('=' * 60)
+    print(f'Targets: {len(targets)}')
+    if args.dry_run:
+        print('Mode:    DRY RUN (no R2 writes)')
+    print()
+
+    s3 = None
+    bucket = ''
+    public_url_base = ''
+    if not args.dry_run:
+        s3 = get_s3_client()
+        bucket = require_env('R2_BUCKET_NAME')
+        public_url_base = require_env('R2_PUBLIC_URL')
+
+    succeeded: list[str] = []
+    failed: list[tuple[str, str]] = []  # (filename, reason)
+
+    for i, target in enumerate(targets, 1):
+        print(f'[{i}/{len(targets)}] {target.r2_filename}')
+        print(f'         {target.description}')
+
+        # Fetch
+        try:
+            raw = fetch_source(target)
+            print(f'         [OK] fetched {len(raw):,} bytes')
+        except Exception as e:
+            print(f'         [X] fetch failed: {e}')
+            failed.append((target.r2_filename, f'fetch: {e}'))
+            continue
+
+        # Convert if needed
+        try:
+            body = ensure_jpeg(target.source_url, raw)
+            if body is not raw:
+                print(f'         [OK] converted to JPEG ({len(body):,} bytes)')
+        except Exception as e:
+            print(f'         [X] convert failed: {e}')
+            failed.append((target.r2_filename, f'convert: {e}'))
+            continue
+
+        # Upload
+        if args.dry_run:
+            print('         [--] skipped upload (dry run)')
+            succeeded.append(target.r2_filename)
+            continue
+
+        try:
+            upload_to_r2(s3, bucket, target, body)
+            print(f'         [OK] uploaded to art/{target.r2_filename}')
+        except Exception as e:
+            print(f'         [X] upload failed: {e}')
+            failed.append((target.r2_filename, f'upload: {e}'))
+            continue
+
+        # Verify (best-effort)
+        status = verify_public_url(public_url_base, target)
+        if status == 200:
+            print(f'         [OK] verified 200 at public URL')
+        else:
+            print(f'         [!] public URL returned {status} (may just be CDN lag)')
+
+        succeeded.append(target.r2_filename)
+
+    # Summary
+    print()
+    print('=' * 60)
+    print('SUMMARY')
+    print('=' * 60)
+    print(f'  Succeeded: {len(succeeded)}')
+    print(f'  Failed:    {len(failed)}')
+    if failed:
+        print()
+        print('  Failures:')
+        for filename, reason in failed:
+            print(f'    - {filename}: {reason}')
+
+    return 0 if not failed else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The Map and Prophecy cards on the Explore screen render placeholder/empty boxes because the images they reference in `content_images` aren't actually on R2.

9 files total:
- **Map (4):** `figures-abraham-journey.jpg`, `figures-red-sea-crossing.jpg`, `holman-paul-journey3.jpg`, `campin-nativity.jpg`
- **Prophecy (5):** `schnorr-010.jpg`, `schnorr-091.jpg`, `michelangelo-isaiah.jpg`, `michelangelo-daniel.jpg`, `michelangelo-jeremiah.jpg`

All 9 URLs in the DB are correctly-formed (`https://contentcompanionstudy.com/art/{filename}`), and all 9 return 404. The DB content is fine; the bucket is just missing the bytes.

## Why a new tool instead of the existing ones

The existing flow — `download_explore_images.py` → stage in `_tools/art_staging/` → `upload_images_to_r2.py` — is built for bulk curation work against a staging directory and manifest files. It's fine for that, but brittle for surgical "push these N specific files" operations:

- A missing file in the staging dir silently skips (no failure signal).
- Filenames can drift between the download script's target names and the uploader's glob.
- Requires two scripts run in order.

`fix_missing_art.py` is purpose-built: a hardcoded `TARGETS` list of `(r2_filename, wikimedia_source_url, description)` tuples, fetch → convert if needed → upload → verify → report. Non-zero exit on any failure.

## What's in this PR

**`_tools/fix_missing_art.py`**

- Tonight's 9 targets baked in. Easy to extend — just add to the `TARGETS` list in a future PR.
- Uses the Wikimedia-compliant User-Agent that upstream requires.
- Converts PNG → JPG when the R2 filename demands it (the Schnorr sources are PNG but referenced as `.jpg` in the DB). JPEG at quality 90, RGBA flattened to white.
- Reuses the same `load_env()` pattern + `boto3` S3 client pattern as `upload_images_to_r2.py`. Reads `.env` locally if present; in CI the env comes from secrets.
- Flags: `--dry-run` (fetch + convert but skip R2 writes), `--only SUBSTRING` (filename filter).
- Exit codes: 0 = all succeeded, 1 = one or more failed, 2 = config/env error.

**`.github/workflows/fix-missing-art.yml`**

- Manually triggered via `workflow_dispatch` from the Actions tab.
- Inputs: `dry_run` (choice), `only` (string).
- R2 credentials from existing `secrets.R2_*` (same set used by `content-pipeline.yml` and `content.yml`).
- Installs `boto3` + `Pillow`, runs the script, exits on failure.

## How to run after merge

Go to the Actions tab → "Fix Missing Art (R2)" → "Run workflow" → leave inputs blank → click green button. ~60 seconds. Images are live on R2 the moment the job succeeds.

For a safer first run: set `dry_run` to `true`. The workflow will fetch and convert all 9 but skip the actual R2 writes, so you can see what it would do without committing.

## Why no app/DB change is needed

The `content_images` table already references the correct URLs. The app's image components haven't changed behavior — they just couldn't render what wasn't there. Once the bytes are on R2, the next image load (`expo-image` doesn't cache 404s) pulls the file and renders it.

No OTA, no rebuild, no rentamac.

## Verification

- ✅ Sandbox: `python3 -c 'import ast; ast.parse(...)'` clean, YAML parses, `--help` works, `--dry-run --only` exercises the full code path
- ❌ Sandbox cannot fetch from Wikimedia (egress proxy 403). The GitHub Actions runner has no such restriction.
- ⏳ Post-merge: run the workflow, confirm 9/9 succeed, open app → tap Map and Prophecy → see images

## Out of scope (follow-up cards to file)

- **[P1/M] Audit + re-upload the other ~40 broken art URLs** in `content_images`. Same workflow, bigger TARGETS list.
- **[P1/M] Topical Index image coverage** — `content_type='topic'` has zero rows in `content_images`. Needs content work before a script like this can help.
- **[P2/L] Guided Journeys explore card** — new feature, no manifest entry, no content. Full epic.
- **[P2/S] Replace Wikimedia hotlink URLs** — 6 URLs in `content_images` still hotlink Wikimedia thumbs directly. Should be R2-hosted.
- **[P3/XS] CI check** — fail `content-pipeline.yml` if any `content_images.url` returns non-200. Catches the next "forgot to upload" before ship.

## Not bundled with PR #1560

PR #1560 (DB download progress UI) is an app-side JS-only change going out via `eas update`. This PR is a CI tooling + R2 asset push with no app code changes. Clean separation, clean revert paths for both.
