### PR TITLE
Fix iOS map and Amicus crash paths

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -11,6 +11,7 @@ import {
   DarkTheme,
   DefaultTheme,
   createNavigationContainerRef,
+  type NavigationState,
 } from '@react-navigation/native';
 
 import { FONT_MAP, ThemeProvider, useTheme } from './src/theme';
@@ -118,6 +119,7 @@ const linking: any = {
 /** Inner app shell — consumes theme context for nav theme + status bar. */
 function AppShell() {
   const { base: themeBase, mode, statusBarStyle } = useTheme();
+  const [navigationState, setNavigationState] = useState<NavigationState | undefined>();
 
   // Install notification tap router (handles both cold-start and warm taps).
   useNotificationRouter(navigationRef);
@@ -139,12 +141,26 @@ function AppShell() {
 
   return (
     <>
-      <NavigationContainer ref={navigationRef} theme={navTheme} linking={linking}>
+      <NavigationContainer
+        ref={navigationRef}
+        theme={navTheme}
+        linking={linking}
+        onReady={() => setNavigationState(navigationRef.getRootState())}
+        onStateChange={() => setNavigationState(navigationRef.getRootState())}
+      >
         <ErrorBoundary>
           <RootNavigator />
         </ErrorBoundary>
         <ErrorBoundary renderFallback={AmicusFabErrorFallback}>
-          <AmicusFab />
+          <AmicusFab
+            navigationState={navigationState}
+            onOpenPaywall={() =>
+              (navigationRef.navigate as unknown as (
+                name: 'AmicusTab',
+                params: { screen: 'Paywall' },
+              ) => void)('AmicusTab', { screen: 'Paywall' })
+            }
+          />
         </ErrorBoundary>
       </NavigationContainer>
       <StatusBar style={statusBarStyle === 'light-content' ? 'light' : 'dark'} />

--- a/app/patches/@maplibre+maplibre-react-native+11.0.0-beta.31.patch
+++ b/app/patches/@maplibre+maplibre-react-native+11.0.0-beta.31.patch
@@ -1,36 +1,16 @@
 diff --git a/node_modules/@maplibre/maplibre-react-native/ios/components/ViewManager.h b/node_modules/@maplibre/maplibre-react-native/ios/components/ViewManager.h
+index a692e25..8d60d71 100644
 --- a/node_modules/@maplibre/maplibre-react-native/ios/components/ViewManager.h
 +++ b/node_modules/@maplibre/maplibre-react-native/ios/components/ViewManager.h
-@@ -1,7 +1,37 @@
+@@ -1,7 +1,16 @@
  #import <React/RCTViewManager.h>
  #import "MLRNEvent.h"
  
-+// =============================================================================
-+// Companion Study local patch — applied via patch-package
-+// -----------------------------------------------------------------------------
-+// Fix: "Invariant Violation: Tried to register two views with the same name
-+// MLRNCamera" crash on MapScreen mount under RN New Architecture.
-+//
-+// Root cause: maplibre-react-native v11-beta still ships old-architecture
-+// ViewManager subclasses (MLRNCameraManager, MLRNMapViewManager) alongside
-+// the new-arch Fabric ComponentViews. Because this base class unconditionally
-+// inherits from RCTViewManager, RN's legacy-interop scanner auto-registers
-+// those subclasses under view names "MLRNCamera" / "MLRNMapView", which
-+// Codegen has ALREADY registered via the Fabric component views. Collision.
-+//
-+// On new arch, the only remaining use of these "Manager" classes is as a
-+// namespace for class-level helper methods invoked by the TurboModules
-+// (e.g. [MLRNCameraManager handleImperativeStop:...]). They are never
-+// instantiated and their -view hook is never called (Fabric uses
-+// ComponentViews instead). Subclassing NSObject on new arch removes them
-+// from RN's registration scanner while preserving every symbol the
-+// TurboModule code references.
-+//
-+// Remove this patch when maplibre-react-native ships arch-guarded managers
-+// upstream. Track: file issue on maplibre/maplibre-react-native referencing
-+// v11.0.0-beta.31.
-+// =============================================================================
-+
++// MapLibre v11 beta ships legacy RCTViewManager subclasses next to Fabric
++// ComponentViews. Under the New Architecture, RN registers the Fabric views
++// first, then legacy interop scans these managers and collides on names like
++// MLRNCamera. The managers are only used as static helper namespaces on New
++// Architecture, so keep them out of the legacy view-manager scanner.
 +#ifdef RCT_NEW_ARCH_ENABLED
 +@interface ViewManager : NSObject
 +#else

--- a/app/src/components/amicus/AmicusFab.tsx
+++ b/app/src/components/amicus/AmicusFab.tsx
@@ -1,7 +1,7 @@
 /**
- * components/amicus/AmicusFab.tsx — always-on Amicus surface.
+ * components/amicus/AmicusFab.tsx - always-on Amicus surface.
  *
- * 56×56 circular FAB, bottom-right, gold. Tap opens the peek sheet.
+ * 56x56 circular FAB, bottom-right, gold. Tap opens the peek sheet.
  * Composes:
  *   - `useAmicusFab()` visibility context (for per-screen suppression)
  *   - `useAmicusAccess()` entitlement/usage gate (from #1460)
@@ -15,12 +15,10 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
 import { Lock, MessageSquare } from 'lucide-react-native';
 import { useTheme } from '../../theme';
 import { useAmicusFab } from '../../contexts/AmicusFabContext';
 import { useAmicusAccess } from '../../hooks/useAmicusAccess';
-import { logger } from '../../utils/logger';
 import AmicusPeekSheet from './AmicusPeekSheet';
 
 const FAB_SIZE = 56;
@@ -28,30 +26,25 @@ const TAB_BAR_HEIGHT = 56; // matches React Navigation bottom-tab default
 const BOTTOM_MARGIN = 16;
 const RIGHT_MARGIN = 16;
 
-export default function AmicusFab(): React.ReactElement | null {
+interface Props {
+  navigationState?: unknown;
+  onOpenPaywall?: () => void;
+}
+
+export default function AmicusFab({
+  navigationState,
+  onOpenPaywall,
+}: Props): React.ReactElement | null {
   const { base } = useTheme();
   const insets = useSafeAreaInsets();
-  // Defensive: useNavigation throws synchronously if no NavigationContainer
-  // ancestor exists. In Release mode that throw becomes a fatal NSException
-  // via RCTFatal and aborts the app on first launch. The hook is still called
-  // on every render (its internal useContext runs before the throw), so hook
-  // order is stable — the try/catch only suppresses the error.
-  let navigation: NavigationProp<ParamListBase> | null = null;
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    navigation = useNavigation<NavigationProp<ParamListBase>>();
-  } catch (e) {
-    logger.warn('AmicusFab', 'mounted outside NavigationContainer; rendering null', e);
-  }
   const { isVisible } = useAmicusFab();
   const access = useAmicusAccess();
   const [peekOpen, setPeekOpen] = useState(false);
 
   // Hide when any screen has requested suppression OR the user turned the
-  // feature off in settings. (Non-premium users still see the FAB but with
-  // a lock overlay — tap opens the paywall.)
-  const shouldRender =
-    isVisible && access.reason !== 'disabled_in_settings';
+  // feature off in settings. Non-premium users still see the FAB but with
+  // a lock overlay; tap opens the paywall.
+  const shouldRender = isVisible && access.reason !== 'disabled_in_settings';
 
   const bottomOffset = useMemo<ViewStyle>(
     () => ({
@@ -63,15 +56,12 @@ export default function AmicusFab(): React.ReactElement | null {
 
   const handlePress = useCallback(() => {
     if (access.reason === 'not_premium') {
-      // Non-premium → paywall screen in the Amicus tab.
-      const parent = navigation?.getParent<NavigationProp<ParamListBase>>();
-      parent?.navigate('AmicusTab', { screen: 'Paywall' });
+      onOpenPaywall?.();
       return;
     }
     setPeekOpen(true);
-  }, [access.reason, navigation]);
+  }, [access.reason, onOpenPaywall]);
 
-  if (!navigation) return null;
   if (!shouldRender) return null;
 
   const isLocked = access.reason === 'not_premium';
@@ -99,7 +89,11 @@ export default function AmicusFab(): React.ReactElement | null {
         )}
       </Pressable>
 
-      <AmicusPeekSheet isOpen={peekOpen} onClose={() => setPeekOpen(false)} />
+      <AmicusPeekSheet
+        isOpen={peekOpen}
+        onClose={() => setPeekOpen(false)}
+        navigationState={navigationState}
+      />
     </View>
   );
 }

--- a/app/src/components/amicus/AmicusPeekSheet.tsx
+++ b/app/src/components/amicus/AmicusPeekSheet.tsx
@@ -20,7 +20,6 @@ import BottomSheet, {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { ArrowUp } from 'lucide-react-native';
-import { useNavigationState } from '@react-navigation/native';
 import { useAmicusChips, type ChipContext } from '../../hooks/useAmicusChips';
 import { usePeekConversation } from '../../hooks/usePeekConversation';
 import { fontFamily, spacing, useTheme } from '../../theme';
@@ -42,6 +41,8 @@ export interface AmicusPeekSheetProps {
   onContinueInTab?: (snapshot: ReturnType<ReturnType<typeof usePeekConversation>['snapshotForPromotion']>) => void | Promise<void>;
   /** Expose when handoff is in progress (disables the CTA). */
   handoffInProgress?: boolean;
+  /** Root nav state supplied by AppShell; this sheet is not a navigator child. */
+  navigationState?: unknown;
 }
 
 export default function AmicusPeekSheet(
@@ -51,7 +52,7 @@ export default function AmicusPeekSheet(
   const sheetRef = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => ['50%', '85%'], []);
 
-  const ctx = useNavigationContext(props.contextOverride);
+  const ctx = useNavigationContext(props.contextOverride, props.navigationState);
   const { chips } = useAmicusChips(ctx);
   const [text, setText] = useState('');
   const peek = usePeekConversation();
@@ -234,12 +235,14 @@ export default function AmicusPeekSheet(
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /** Extract chapter/entity context from the active route for chip selection. */
-function useNavigationContext(override?: ChipContext): ChipContext {
-  const state = useNavigationState((s) => s);
+function useNavigationContext(
+  override?: ChipContext,
+  navigationState?: unknown,
+): ChipContext {
   return useMemo(() => {
     if (override) return override;
-    if (!state) return { kind: 'none' };
-    const route = findDeepestRoute(state);
+    if (!navigationState) return { kind: 'none' };
+    const route = findDeepestRoute(navigationState);
     if (!route) return { kind: 'none' };
     const params = (route.params ?? {}) as Record<string, unknown>;
     switch (route.name) {
@@ -265,7 +268,7 @@ function useNavigationContext(override?: ChipContext): ChipContext {
       default:
         return { kind: 'none' };
     }
-  }, [state, override]);
+  }, [navigationState, override]);
 }
 
 interface MinimalRoute {

--- a/app/src/components/amicus/__tests__/AmicusFab.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusFab.test.tsx
@@ -5,24 +5,11 @@ import AmicusFab from '@/components/amicus/AmicusFab';
 import { AmicusFabProvider, useAmicusFab } from '@/contexts/AmicusFabContext';
 
 const mockNavigate = jest.fn();
-const mockGetParent = jest.fn(() => ({ navigate: mockNavigate }));
-let mockUseNavigationShouldThrow = false;
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
     ...actual,
-    useNavigation: () => {
-      if (mockUseNavigationShouldThrow) {
-        throw new Error(
-          "Couldn't find a navigation object. Is your component inside NavigationContainer?",
-        );
-      }
-      return {
-        navigate: jest.fn(),
-        getParent: mockGetParent,
-      };
-    },
     useNavigationState: () => ({ routes: [{ name: 'HomeMain' }], index: 0 }),
   };
 });
@@ -57,7 +44,6 @@ function renderWithFab(node: React.ReactElement) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockUseNavigationShouldThrow = false;
   mockUseAmicusAccess.mockReturnValue({
     canUse: true,
     reason: 'ok',
@@ -91,10 +77,11 @@ describe('AmicusFab', () => {
       entitlement: 'none',
       usage: { thisMonth: 0, cap: 0, remaining: 0 },
     });
-    const { getByLabelText } = renderWithFab(<AmicusFab />);
+    const { getByLabelText } = renderWithFab(
+      <AmicusFab onOpenPaywall={() => mockNavigate('AmicusTab', { screen: 'Paywall' })} />,
+    );
     const fab = getByLabelText('Unlock Amicus');
     fireEvent.press(fab);
-    expect(mockGetParent).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(
       'AmicusTab',
       expect.objectContaining({ screen: 'Paywall' }),
@@ -116,23 +103,8 @@ describe('AmicusFab', () => {
     expect(queryByLabelText('Open Amicus')).toBeNull();
   });
 
-  it('renders null and logs a warning when mounted outside NavigationContainer', () => {
-    // Regression: iOS 26 first-launch crash on TestFlight builds 18 and 21.
-    // useNavigation throws synchronously when no NavigationContainer is an
-    // ancestor; in Release mode that becomes a fatal NSException via RCTFatal.
-    // The component must return null instead of throwing.
-    mockUseNavigationShouldThrow = true;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { logger } = require('@/utils/logger');
-
-    const { queryByLabelText } = renderWithFab(<AmicusFab />);
-
-    expect(queryByLabelText('Open Amicus')).toBeNull();
-    expect(queryByLabelText('Unlock Amicus')).toBeNull();
-    expect(logger.warn).toHaveBeenCalledWith(
-      'AmicusFab',
-      expect.stringContaining('outside NavigationContainer'),
-      expect.any(Error),
-    );
+  it('renders outside NavigationContainer because navigation is supplied by AppShell', () => {
+    const { getByLabelText } = renderWithFab(<AmicusFab />);
+    expect(getByLabelText('Open Amicus')).toBeTruthy();
   });
 });

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -26,34 +26,16 @@ import { MapErrorBoundary } from '../components/map/MapErrorBoundary';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import { useTheme } from '../theme';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
-import type { MapStory } from '../types';
-import { safeParse } from '../utils/logger';
 
 // Re-export the R2 style URLs so any existing `import { STYLE_ANCIENT }
 // from '../screens/MapScreen'` call sites keep working without pulling
 // MapLibre into scope.
 export { STYLE_ANCIENT, STYLE_MODERN } from '../constants/mapStyles';
+export { buildPlaceToStoriesMap } from './mapScreenUtils';
 
 interface Props {
   route: ScreenRouteProp<'Explore', 'Map'>;
   navigation: ScreenNavProp<'Explore', 'Map'>;
-}
-
-/**
- * Build a place-id → stories[] index. Pure helper kept at the dispatcher
- * level so unit tests don't need MapLibre (even transitively).
- */
-export function buildPlaceToStoriesMap(stories: MapStory[]): Map<string, MapStory[]> {
-  const map = new Map<string, MapStory[]>();
-  for (const story of stories) {
-    const ids = safeParse<string[]>(story.places_json, []);
-    for (const id of ids) {
-      const list = map.get(id);
-      if (list) list.push(story);
-      else map.set(id, [story]);
-    }
-  }
-  return map;
 }
 
 // Lazy so MapScreenNative.tsx (and therefore `@maplibre/...`) never

--- a/app/src/screens/MapScreenNative.tsx
+++ b/app/src/screens/MapScreenNative.tsx
@@ -37,7 +37,7 @@ import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 import { lightImpact } from '../utils/haptics';
 import { STYLE_ANCIENT, STYLE_MODERN } from '../constants/mapStyles';
-import { buildPlaceToStoriesMap } from './MapScreen';
+import { buildPlaceToStoriesMap } from './mapScreenUtils';
 
 // The dispatcher (MapScreen.tsx) gates on isMapNativeAvailable() before
 // this module loads. Run module-level init so tiles can be fetched.

--- a/app/src/screens/mapScreenUtils.ts
+++ b/app/src/screens/mapScreenUtils.ts
@@ -1,0 +1,19 @@
+import type { MapStory } from '../types';
+import { safeParse } from '../utils/logger';
+
+/**
+ * Build a place-id -> stories[] index. Kept outside MapScreen/MapScreenNative
+ * so the lazy native map screen does not import its dispatcher during load.
+ */
+export function buildPlaceToStoriesMap(stories: MapStory[]): Map<string, MapStory[]> {
+  const map = new Map<string, MapStory[]>();
+  for (const story of stories) {
+    const ids = safeParse<string[]>(story.places_json, []);
+    for (const id of ids) {
+      const list = map.get(id);
+      if (list) list.push(story);
+      else map.set(id, [story]);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary
- patch MapLibre iOS New Architecture view-manager registration to avoid duplicate MLRNCamera registration
- remove Amicus FAB/peek direct navigator hook usage by passing root navigation state from AppShell
- break the MapScreen dispatcher/native circular import by moving pure helpers to a separate module

## Verification
- npm exec -- tsc --noEmit
- npm run lint
- npm exec -- patch-package --check
- npm test -- --runInBand