### PR TITLE
fix(ios): patch fmt Pod to disable consteval on Xcode 26

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -48,6 +48,7 @@
           "android": { "newArchEnabled": true }
         }
       ],
+      "./plugins/withFmtConsteval",
       "expo-font",
       "expo-screen-orientation",
       [

--- a/app/plugins/withFmtConsteval.js
+++ b/app/plugins/withFmtConsteval.js
@@ -1,0 +1,117 @@
+/**
+ * plugins/withFmtConsteval.js — Expo config plugin.
+ *
+ * Injects a post_install hook into the generated iOS Podfile that sets
+ * `FMT_USE_CONSTEVAL=0` on the `fmt` Pod target, working around a
+ * Clang/Xcode 26.x incompatibility with fmt 8.x's consteval-annotated
+ * FMT_STRING macros.
+ *
+ * ── Why this plugin exists ─────────────────────────────────────────
+ *
+ * `app.json` sets `expo-build-properties.ios.buildReactNativeFromSource: true`
+ * so that `patches/react-native+0.81.5.patch` (iOS 26 void-method crash
+ * fix from facebook/react-native#56265) actually gets applied at build
+ * time. With the precompiled React-Core XCFramework the patch would
+ * have no effect.
+ *
+ * Building RN from source compiles its transitive C++ dependencies from
+ * source too — including `fmt` via the `glog` and `React-cxxreact` Pods.
+ * fmt 8.x's header `fmt/format-inl.h` uses `consteval` on FMT_STRING(...)
+ * template instantiations. Under Xcode 26's stricter Apple Clang, those
+ * instantiations fail with "call to consteval function ... is not a
+ * constant expression" errors:
+ *
+ *     fmt/format-inl.h:59:24: call to consteval function is not a
+ *       constant expression
+ *
+ * The fix: set `FMT_USE_CONSTEVAL=0` as a preprocessor definition for the
+ * fmt Pod. fmt's own compatibility macro downgrades all consteval
+ * functions to constexpr, which both older and newer Clang versions
+ * handle without complaint. Compile-time format-string validation is
+ * disabled — meaning invalid format strings would surface at runtime
+ * instead of build time — but RN uses fmt only in logging internals with
+ * fixed format strings; no user-controlled input reaches it.
+ *
+ * ── Lifecycle ──────────────────────────────────────────────────────
+ *
+ * This plugin is a temporary workaround paired with the iOS 26 void-method
+ * patch and `buildReactNativeFromSource: true`. Remove ALL THREE together
+ * when a released RN 0.81.x or SDK 54.x includes the upstream fix, at
+ * which point RN can be consumed as a precompiled XCFramework again.
+ *
+ * Idempotent: a marker check ensures repeated prebuilds don't stack
+ * duplicate patches in the Podfile.
+ */
+
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const MARKER = '# BEGIN withFmtConsteval';
+const END_MARKER = '# END withFmtConsteval';
+
+const PATCH_BLOCK = `
+  ${MARKER} — applied by plugins/withFmtConsteval.js
+  # Works around Xcode 26 Clang strictness with fmt 8.x consteval usage.
+  # Removed when we no longer build React Native from source.
+  installer.pods_project.targets.each do |target|
+    if target.name == 'fmt'
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+        unless config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'].include?('FMT_USE_CONSTEVAL=0')
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'
+        end
+      end
+    end
+  end
+  ${END_MARKER}
+`;
+
+/**
+ * Expo config plugin entry point.
+ * @param {import('@expo/config-plugins').ConfigPlugin} config
+ */
+const withFmtConsteval = (config) => {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const podfilePath = path.join(
+        config.modRequest.platformProjectRoot,
+        'Podfile',
+      );
+      if (!fs.existsSync(podfilePath)) {
+        throw new Error(
+          `[withFmtConsteval] Podfile not found at ${podfilePath}. ` +
+            'The Expo template may have moved or prebuild is running ' +
+            'in an unexpected order.',
+        );
+      }
+
+      let contents = fs.readFileSync(podfilePath, 'utf8');
+
+      // Idempotency — skip if already patched.
+      if (contents.includes(MARKER)) {
+        return config;
+      }
+
+      // The Expo template's post_install block opens with this exact line.
+      // Matching on the line with the installer binding is specific enough
+      // to avoid accidentally matching a different post_install block.
+      const postInstallOpen = /(post_install do \|installer\|\n)/;
+      if (!postInstallOpen.test(contents)) {
+        throw new Error(
+          '[withFmtConsteval] Could not find `post_install do |installer|` ' +
+            'block in Podfile. The Expo template structure may have changed; ' +
+            'update this plugin to match.',
+        );
+      }
+
+      contents = contents.replace(postInstallOpen, `$1${PATCH_BLOCK}`);
+      fs.writeFileSync(podfilePath, contents);
+
+      return config;
+    },
+  ]);
+};
+
+module.exports = withFmtConsteval;


### PR DESCRIPTION
## Problem

The iOS build on Xcode 26.x fails during `npx expo run:ios` with five compile errors in `Pods/fmt/include/fmt/format-inl.h`:

```
call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char [3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
```

The errors all center on fmt's `FMT_STRING(...)` macro, which uses `consteval`-annotated function templates. Newer Apple Clang (Xcode 26) is stricter about evaluating consteval functions in template instantiation contexts than the Clang the fmt 8.x shipped in RN 0.81.5 was validated against.

This blocks local iOS validation on rentamac and would also block EAS iOS builds once their image updates to Xcode 26.

## Why we can't just use the prebuilt React-Core XCFramework

`app.json` intentionally sets `expo-build-properties.ios.buildReactNativeFromSource: true` (see commit `db0d2777`). That setting exists so `app/patches/react-native+0.81.5.patch` — the iOS 26 void-method SIGABRT fix from facebook/react-native#56265 — actually applies at build time. With the precompiled React-Core XCFramework the patch has no effect and the production iOS 26 crash from build 14 returns.

Building RN from source pulls `fmt` into the per-project compile path, which is where we hit the consteval errors.

## Fix

New Expo config plugin: `app/plugins/withFmtConsteval.js`. Uses `withDangerousMod` to inject a hook into the generated Podfile's `post_install` block that sets `FMT_USE_CONSTEVAL=0` on the `fmt` Pod target.

`FMT_USE_CONSTEVAL` is fmt's own compatibility knob. Setting it to `0` downgrades all `consteval` functions in fmt to `constexpr`, which both the RN-validated Clang AND Xcode 26's newer Clang handle cleanly. No fmt or RN source is modified.

**Trade-off:** Compile-time format-string validation in fmt is disabled — invalid format strings would surface at runtime instead of build time. RN uses fmt only in logging internals with fixed format strings; no user-controlled input reaches fmt. Acceptable.

**Plugin properties:**
- Idempotent — marker check (`# BEGIN withFmtConsteval`) prevents duplicate injection on repeat prebuilds
- Non-invasive — injects AFTER the opener of the existing `post_install do |installer|` block, leaves `react_native_post_install(...)` and everything else intact
- Fail-loud — if the Expo template's `post_install` block shape changes and the regex doesn't match, the plugin throws with a clear message rather than silently skipping

Validated against a mock SDK 54-shaped Podfile: correct block insertion, idempotency on repeat application, existing `post_install` content preserved.

## Lifecycle

This plugin, `buildReactNativeFromSource: true`, and `patches/react-native+0.81.5.patch` form a coupled set of temporary workarounds for RN 0.81.5 on Xcode 26. **Remove ALL THREE together** when a released RN 0.81.x or SDK 54.x includes the upstream iOS 26 void-method fix, at which point RN can be consumed as a precompiled XCFramework again and fmt is no longer compiled in the project build.

Tracked in the comment at the top of `withFmtConsteval.js`.

## Files changed

- `app/plugins/withFmtConsteval.js` — new
- `app/app.json` — one-line addition: `"./plugins/withFmtConsteval"` in the plugins array, positioned right after `expo-build-properties` since it's tightly coupled to that plugin's `buildReactNativeFromSource` flag

## Validation plan

On rentamac:

1. `git fetch && git checkout fix/fmt-consteval-compile`
2. `cd app && rm -rf ios`
3. `npx expo prebuild --platform ios --clean`
4. `grep -A 2 'BEGIN withFmtConsteval' ios/Podfile` — confirm the injection landed
5. `npx expo run:ios --no-build-cache`
6. iOS build succeeds (no fmt compile errors)
7. App installs and launches in the simulator

## Relationship to PR #1564

This PR is a prerequisite for actually validating [PR #1564](https://github.com/CraigBuckmaster/ScriptureDeepDive/pull/1564) (the MapLibre dual-bundle fix) on a fresh rentamac build. PR #1564's fix was already confirmed at the bundle level (`MLRNCamera` occurrences: 6 → 5, with only 1 real registration call remaining), but end-to-end device validation was blocked by this fmt error.

Suggested merge order: this PR first (unblocks builds on Xcode 26), then validate PR #1564 on a fresh build, then merge #1564.
