### PR TITLE
fix(ios): downgrade fmt Pod to C++17 — PR #1565's preprocessor approach didn't work

### DIFF
--- a/app/plugins/withFmtConsteval.js
+++ b/app/plugins/withFmtConsteval.js
@@ -54,6 +54,17 @@
  * React Native's own code (Fabric, Hermes, TurboModule JSI glue)
  * genuinely needs C++20 and will not compile as C++17.
  *
+ * ── Injection point matters ───────────────────────────────────────
+ *
+ * The block MUST be injected AFTER the `react_native_post_install(...)`
+ * call, NOT at the opening of `post_install do |installer|`. RN 0.81.5's
+ * `react_native_post_install` ends by calling
+ * `NewArchitectureHelper.set_clang_cxx_language_standard_if_needed`,
+ * which iterates every pod target (including `fmt`) and sets
+ * `CLANG_CXX_LANGUAGE_STANDARD = "c++20"`. A block injected before that
+ * call would run first and then be silently overwritten, fmt would
+ * still build as C++20, and the consteval error would reappear.
+ *
  * ── Lifecycle ──────────────────────────────────────────────────────
  *
  * This plugin is a temporary workaround paired with the iOS 26
@@ -63,8 +74,8 @@
  * rules, at which point RN can be consumed as a precompiled XCFramework
  * again and fmt is no longer compiled in the project build.
  *
- * Idempotent: a marker check ensures repeated prebuilds don't stack
- * duplicate patches in the Podfile.
+ * Idempotent: repeated prebuilds strip-and-reinject the current block,
+ * so stale content from prior plugin versions is replaced cleanly.
  */
 
 const { withDangerousMod } = require('@expo/config-plugins');
@@ -141,19 +152,55 @@ const withFmtConsteval = (config) => {
       // always inject current content. Idempotent when no block is present.
       contents = stripExistingBlock(contents);
 
-      // The Expo template's post_install block opens with this exact line.
-      // Matching on the line with the installer binding is specific enough
-      // to avoid accidentally matching a different post_install block.
-      const postInstallOpen = /(post_install do \|installer\|\n)/;
-      if (!postInstallOpen.test(contents)) {
+      // CRITICAL: inject AFTER the `react_native_post_install(...)` call,
+      // not at the opening of `post_install do |installer|`. React Native
+      // 0.81.5's `react_native_post_install` ends with a call to
+      // `NewArchitectureHelper.set_clang_cxx_language_standard_if_needed`,
+      // which iterates every pod target (including fmt) and sets
+      // `CLANG_CXX_LANGUAGE_STANDARD` to c++20. If our block ran first,
+      // RN would overwrite our c++17 setting and fmt would still build
+      // as C++20, reproducing the consteval error we came here to fix.
+      // See: facebook/react-native commit 71da21243 (scripts/cocoapods/
+      // new_architecture.rb) for the overwrite logic.
+      const callStart = contents.indexOf('react_native_post_install(');
+      if (callStart === -1) {
         throw new Error(
-          '[withFmtConsteval] Could not find `post_install do |installer|` ' +
-            'block in Podfile. The Expo template structure may have changed; ' +
+          '[withFmtConsteval] Could not find `react_native_post_install(` ' +
+            'call in Podfile. The Expo template structure may have changed; ' +
             'update this plugin to match.',
         );
       }
 
-      contents = contents.replace(postInstallOpen, `$1${PATCH_BLOCK}`);
+      // Scan forward tracking paren depth to find the matching closing `)`.
+      // RN's post-install call uses simple args (no parens inside strings),
+      // so naive counting is safe for the Expo Podfile template.
+      let depth = 1;
+      let i = callStart + 'react_native_post_install('.length;
+      while (i < contents.length && depth > 0) {
+        const ch = contents[i];
+        if (ch === '(') depth += 1;
+        else if (ch === ')') depth -= 1;
+        i += 1;
+      }
+      if (depth !== 0) {
+        throw new Error(
+          '[withFmtConsteval] Could not find matching `)` for ' +
+            'react_native_post_install call. Podfile may be malformed.',
+        );
+      }
+
+      // `i` now points one past the closing `)`. Find the newline that
+      // terminates the call statement and inject immediately after it so
+      // the block starts on a fresh line.
+      const nlIdx = contents.indexOf('\n', i);
+      if (nlIdx === -1) {
+        throw new Error(
+          '[withFmtConsteval] No newline found after react_native_post_install() call.',
+        );
+      }
+
+      contents =
+        contents.slice(0, nlIdx + 1) + PATCH_BLOCK + contents.slice(nlIdx + 1);
       fs.writeFileSync(podfilePath, contents);
 
       return config;

--- a/app/plugins/withFmtConsteval.js
+++ b/app/plugins/withFmtConsteval.js
@@ -1,10 +1,10 @@
 /**
  * plugins/withFmtConsteval.js — Expo config plugin.
  *
- * Injects a post_install hook into the generated iOS Podfile that sets
- * `FMT_USE_CONSTEVAL=0` on the `fmt` Pod target, working around a
- * Clang/Xcode 26.x incompatibility with fmt 8.x's consteval-annotated
- * FMT_STRING macros.
+ * Injects a post_install hook into the generated iOS Podfile that
+ * downgrades the `fmt` Pod target (and only that target) to C++17,
+ * working around a Clang/Xcode 26.x incompatibility with fmt's
+ * consteval-annotated FMT_STRING macros.
  *
  * ── Why this plugin exists ─────────────────────────────────────────
  *
@@ -16,28 +16,52 @@
  *
  * Building RN from source compiles its transitive C++ dependencies from
  * source too — including `fmt` via the `glog` and `React-cxxreact` Pods.
- * fmt 8.x's header `fmt/format-inl.h` uses `consteval` on FMT_STRING(...)
- * template instantiations. Under Xcode 26's stricter Apple Clang, those
- * instantiations fail with "call to consteval function ... is not a
- * constant expression" errors:
+ * fmt's header `fmt/format-inl.h` uses `consteval` on FMT_STRING(...)
+ * template instantiations. Under Xcode 26's stricter Apple Clang (21.x),
+ * those instantiations fail with "call to consteval function ... is not
+ * a constant expression" errors at five sites in format-inl.h (lines
+ * 59, 60, 1387, 1391, 1394).
  *
- *     fmt/format-inl.h:59:24: call to consteval function is not a
- *       constant expression
+ * See:
+ *   - facebook/react-native#55601
+ *   - fmtlib/fmt#4740
+ *   - expo/expo#44229
  *
- * The fix: set `FMT_USE_CONSTEVAL=0` as a preprocessor definition for the
- * fmt Pod. fmt's own compatibility macro downgrades all consteval
- * functions to constexpr, which both older and newer Clang versions
- * handle without complaint. Compile-time format-string validation is
- * disabled — meaning invalid format strings would surface at runtime
- * instead of build time — but RN uses fmt only in logging internals with
- * fixed format strings; no user-controlled input reaches it.
+ * ── Why we downgrade to C++17, NOT define FMT_USE_CONSTEVAL=0 ──────
+ *
+ * The obvious first fix — set `FMT_USE_CONSTEVAL=0` via
+ * `GCC_PREPROCESSOR_DEFINITIONS` — does NOT work for the fmt version
+ * vendored into RN 0.81.5. fmt's `base.h` does not gate its
+ * `FMT_USE_CONSTEVAL` setter with `#ifndef`; the detection block
+ * unconditionally `#define`s it based on `__apple_build_version__`, so
+ * an external `-D` flag gets clobbered by the internal define.
+ * Empirically verified on rentamac (Xcode 26.4.1): the build fails
+ * identically with the preprocessor define in place.
+ *
+ * Downgrading the language standard is the documented-working approach
+ * (see bleepingswift.com article on the same error, and the top-voted
+ * answer in fmtlib/fmt#4740). The mechanism: consteval is a C++20
+ * feature. When fmt compiles as C++17, `__cpp_consteval` is not
+ * defined, fmt's detection logic falls through, and `FMT_USE_CONSTEVAL`
+ * ends up 0. The problematic consteval constructors never get
+ * instantiated. fmt has long been C++11-compatible, so C++17 is safely
+ * within its supported range. Compile-time format-string validation is
+ * disabled — invalid format strings would surface at runtime instead
+ * of build time — but RN uses fmt only in logging internals with fixed
+ * format strings; no user-controlled input reaches fmt.
+ *
+ * Scope matters: we downgrade ONLY the `fmt` target, not project-wide.
+ * React Native's own code (Fabric, Hermes, TurboModule JSI glue)
+ * genuinely needs C++20 and will not compile as C++17.
  *
  * ── Lifecycle ──────────────────────────────────────────────────────
  *
- * This plugin is a temporary workaround paired with the iOS 26 void-method
- * patch and `buildReactNativeFromSource: true`. Remove ALL THREE together
- * when a released RN 0.81.x or SDK 54.x includes the upstream fix, at
- * which point RN can be consumed as a precompiled XCFramework again.
+ * This plugin is a temporary workaround paired with the iOS 26
+ * void-method patch and `buildReactNativeFromSource: true`. Remove ALL
+ * THREE together when a released RN 0.81.x or SDK 54.x ships with a
+ * newer fmt (12.1+) that handles Apple Clang 21's stricter consteval
+ * rules, at which point RN can be consumed as a precompiled XCFramework
+ * again and fmt is no longer compiled in the project build.
  *
  * Idempotent: a marker check ensures repeated prebuilds don't stack
  * duplicate patches in the Podfile.
@@ -52,20 +76,44 @@ const END_MARKER = '# END withFmtConsteval';
 
 const PATCH_BLOCK = `
   ${MARKER} — applied by plugins/withFmtConsteval.js
-  # Works around Xcode 26 Clang strictness with fmt 8.x consteval usage.
+  # Downgrade ONLY the fmt Pod to C++17 so its consteval-annotated
+  # FMT_STRING macros compile under Xcode 26.x Apple Clang 21+.
+  # See the long comment at the top of plugins/withFmtConsteval.js.
   # Removed when we no longer build React Native from source.
   installer.pods_project.targets.each do |target|
     if target.name == 'fmt'
       target.build_configurations.each do |config|
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
-        unless config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'].include?('FMT_USE_CONSTEVAL=0')
-          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'
-        end
+        config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
       end
     end
   end
   ${END_MARKER}
 `;
+
+/**
+ * Strip any existing plugin block so a rerun replaces with current content
+ * rather than appending or silently keeping a stale block.
+ * @param {string} contents
+ * @returns {string}
+ */
+function stripExistingBlock(contents) {
+  const startIdx = contents.indexOf(MARKER);
+  if (startIdx === -1) return contents;
+  const endIdx = contents.indexOf(END_MARKER, startIdx);
+  if (endIdx === -1) return contents; // malformed; leave alone
+  // Walk back to the start of the line containing MARKER.
+  let lineStart = contents.lastIndexOf('\n', startIdx) + 1;
+  // The injected PATCH_BLOCK starts with a leading newline, so after a
+  // first run the block is preceded by a blank line. Consume that blank
+  // line too, otherwise successive re-applies accumulate blank lines
+  // and break idempotency.
+  if (lineStart >= 2 && contents[lineStart - 2] === '\n') {
+    lineStart -= 1;
+  }
+  const lineEnd = contents.indexOf('\n', endIdx);
+  const afterBlock = lineEnd === -1 ? '' : contents.slice(lineEnd + 1);
+  return contents.slice(0, lineStart) + afterBlock;
+}
 
 /**
  * Expo config plugin entry point.
@@ -89,10 +137,9 @@ const withFmtConsteval = (config) => {
 
       let contents = fs.readFileSync(podfilePath, 'utf8');
 
-      // Idempotency — skip if already patched.
-      if (contents.includes(MARKER)) {
-        return config;
-      }
+      // Strip any stale block from a prior version of this plugin so we
+      // always inject current content. Idempotent when no block is present.
+      contents = stripExistingBlock(contents);
 
       // The Expo template's post_install block opens with this exact line.
       // Matching on the line with the installer binding is specific enough


### PR DESCRIPTION
## Problem

PR #1565 (already merged) attempted to fix the Xcode 26 fmt consteval build error by injecting `FMT_USE_CONSTEVAL=0` into the fmt Pod's `GCC_PREPROCESSOR_DEFINITIONS` via `plugins/withFmtConsteval.js`. **Validated on rentamac (Xcode 26.4.1): the build fails identically, with or without that preprocessor define.** The fix didn't work.

Reproduction after `git pull` to current master + `npx expo prebuild --platform ios --clean` + `npx expo run:ios`:

```
❌  fmt/format-inl.h:59:24
  > 59 |     fmt::format_to(it, FMT_STRING("{}{}"), message, SEP);
       |                        ^ call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char [3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
```

(plus 4 identical errors at format-inl.h:60, 1387, 1391, 1394)

The Podfile contains the expected block from PR #1565:
```
# BEGIN withFmtConsteval — applied by plugins/withFmtConsteval.js
  installer.pods_project.targets.each do |target|
    if target.name == 'fmt'
      ...
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'
```

So the plugin is firing. The preprocessor define just doesn't take effect.

## Why the preprocessor approach doesn't work

The fmt version vendored into RN 0.81.5's `base.h` does NOT gate `FMT_USE_CONSTEVAL` with `#ifndef`. Its detection block unconditionally `#define`s the macro based on `__apple_build_version__ >= 14000029L`, which clobbers any external `-D` flag. Per [fmtlib/fmt#4740](https://github.com/fmtlib/fmt/issues/4740) — the only proposed fix that would respect `-DFMT_USE_CONSTEVAL=0` is a source-level patch to `base.h` directly.

## Fix

Replace the ineffective `GCC_PREPROCESSOR_DEFINITIONS` approach with `CLANG_CXX_LANGUAGE_STANDARD = 'c++17'` on the `fmt` target only. This is the documented-working approach per:

- [bleepingswift's Xcode 26.4 React Native writeup](https://bleepingswift.com/blog/fmt-consteval-error-xcode-26-4-react-native)
- [fmtlib/fmt#4740](https://github.com/fmtlib/fmt/issues/4740) (top-voted workaround)
- [facebook/react-native#55601](https://github.com/facebook/react-native/issues/55601) comments

Mechanism: `consteval` is a C++20 feature. When fmt compiles as C++17 the feature-test macro `__cpp_consteval` is undefined, fmt's detection logic in `base.h` falls through, and `FMT_USE_CONSTEVAL` ends up 0. The problematic consteval constructors never instantiate. fmt has been C++11-compatible for years, so C++17 is safely within its supported range.

**Scope matters:** we downgrade ONLY the `fmt` target. React Native core (Fabric, Hermes, TurboModule JSI glue) genuinely needs C++20 and will not compile as C++17. The `target.name == 'fmt'` check is the whole safety net.

## Plugin improvements

Added `stripExistingBlock` to make the plugin replace its own previously-injected block on re-run rather than marker-check-and-skip. Without this, anyone who already ran `prebuild` under PR #1565's plugin keeps the stale ineffective block after upgrading — plugin rerun would see the marker and no-op. Now the rerun strips and replaces.

Verified idempotency: three successive applies produce identical output; old ineffective block from PR #1565 gets cleanly replaced (1 marker, `react_native_post_install` preserved).

## Trade-off

Compile-time format-string validation in fmt is disabled — invalid format strings would surface at runtime instead of build time. RN uses fmt only in logging internals with fixed format strings; no user-controlled input reaches fmt. Acceptable.

## Lifecycle

Same as PR #1565's plugin: temporary workaround paired with `buildReactNativeFromSource: true` and `patches/react-native+0.81.5.patch`. Remove all three together when a released RN 0.81.x or SDK 54.x bundles fmt 12.1+ (the version that handles Apple Clang 21's stricter consteval rules). Track facebook/react-native#55601 for that release.

## Validation plan on rentamac

```
git pull
cd app
rm -rf ios node_modules/.cache
npx expo prebuild --platform ios --clean
grep -A 3 'BEGIN withFmtConsteval' ios/Podfile   # verify C++17 is in the block
npx expo run:ios --no-build-cache
```

Expected: iOS build succeeds past the fmt compile step, app launches on sim.

Once validated, this unblocks Map tab validation for PR #1564's MapLibre fix (already merged but not yet validated end-to-end on Xcode 26).