### PR TITLE
fix(map): avoid invalid MapLibre opacity step expression

### DIFF
--- a/app/__tests__/components/PlaceMarkerList.test.tsx
+++ b/app/__tests__/components/PlaceMarkerList.test.tsx
@@ -90,7 +90,9 @@ describe('buildPlaceVisibilityExpr (MapLibre step-spec regression guard)', () =>
     //   index 2:           base_output (any expression — OK)
     //   index 3, 5, 7, ...: stop_input_N (MUST be literal number)
     //   index 4, 6, 8, ...: stop_output_N (any expression — OK)
-    const stopInputs = expr.slice(3).filter((_, i) => i % 2 === 0);
+    const stopInputs = (expr.slice(3) as unknown[]).filter(
+      (_: unknown, i: number) => i % 2 === 0,
+    );
     expect(stopInputs.length).toBeGreaterThan(0);
     for (const input of stopInputs) {
       expect(typeof input).toBe('number');
@@ -100,7 +102,9 @@ describe('buildPlaceVisibilityExpr (MapLibre step-spec regression guard)', () =>
 
   it('produces stop inputs in strictly ascending order (also a step-spec requirement)', () => {
     const expr = buildPlaceVisibilityExpr([]);
-    const stopInputs = expr.slice(3).filter((_, i) => i % 2 === 0) as number[];
+    const stopInputs = (expr.slice(3) as unknown[]).filter(
+      (_: unknown, i: number) => i % 2 === 0,
+    ) as number[];
     for (let i = 1; i < stopInputs.length; i += 1) {
       expect(stopInputs[i]).toBeGreaterThan(stopInputs[i - 1]);
     }

--- a/app/__tests__/components/PlaceMarkerList.test.tsx
+++ b/app/__tests__/components/PlaceMarkerList.test.tsx
@@ -1,4 +1,7 @@
-import { placesToFeatureCollection } from '@/components/map/PlaceMarkerList';
+import {
+  buildPlaceVisibilityExpr,
+  placesToFeatureCollection,
+} from '@/components/map/PlaceMarkerList';
 import type { Place } from '@/types';
 
 const makePlace = (id: string, priority: number, extra: Partial<Place> = {}): Place => ({
@@ -56,5 +59,65 @@ describe('placesToFeatureCollection', () => {
       ancient: 'Bethel',
       modern: 'Bethel',
     });
+  });
+});
+
+/**
+ * Regression guard for the iOS MapLibre crash described in PR #1567.
+ *
+ * The original bug was a `step` expression with a non-literal `case` sub-
+ * expression as a stop input. MapLibre's iOS SDK threw an uncaught
+ * NSException at -[MLRNStyle setCircleOpacity:withReactStyleValue:] which
+ * Sentry's terminate handler turned into a SIGABRT crash. The TypeScript
+ * type system permits the broken shape — only runtime native validation
+ * catches it — so a test that locks in the structural invariant is the
+ * cheapest insurance against re-regression.
+ *
+ * The MapLibre style spec invariant being tested: in `["step", input,
+ * base_output, stop_input_1, stop_output_1, ...]`, every stop_input_N
+ * MUST be a literal number. Outputs may be expressions; inputs may not.
+ */
+describe('buildPlaceVisibilityExpr (MapLibre step-spec regression guard)', () => {
+  it('returns a step expression', () => {
+    const expr = buildPlaceVisibilityExpr([]);
+    expect(expr[0]).toBe('step');
+    expect(expr[1]).toEqual(['zoom']);
+  });
+
+  it('uses literal numeric stop inputs (the spec violation that caused the crash)', () => {
+    const expr = buildPlaceVisibilityExpr([]);
+    // Step expression layout after `["step", ["zoom"]]`:
+    //   index 2:           base_output (any expression — OK)
+    //   index 3, 5, 7, ...: stop_input_N (MUST be literal number)
+    //   index 4, 6, 8, ...: stop_output_N (any expression — OK)
+    const stopInputs = expr.slice(3).filter((_, i) => i % 2 === 0);
+    expect(stopInputs.length).toBeGreaterThan(0);
+    for (const input of stopInputs) {
+      expect(typeof input).toBe('number');
+      expect(Number.isFinite(input)).toBe(true);
+    }
+  });
+
+  it('produces stop inputs in strictly ascending order (also a step-spec requirement)', () => {
+    const expr = buildPlaceVisibilityExpr([]);
+    const stopInputs = expr.slice(3).filter((_, i) => i % 2 === 0) as number[];
+    for (let i = 1; i < stopInputs.length; i += 1) {
+      expect(stopInputs[i]).toBeGreaterThan(stopInputs[i - 1]);
+    }
+  });
+
+  it('threads storyPlaceIds through every per-zoom output so story places are always visible', () => {
+    const ids = ['jerusalem', 'bethlehem'];
+    const expr = buildPlaceVisibilityExpr(ids);
+    const serialised = JSON.stringify(expr);
+    // Every output that gates visibility must reference the story-place
+    // literal so story features are unaffected by zoom thresholds.
+    const literalRefs = serialised.match(/"literal"/g) ?? [];
+    // One per output band (base + 4 stops = 5), minus the final `1` band
+    // which has no `case` and therefore no literal reference. So we expect
+    // at least 4 references.
+    expect(literalRefs.length).toBeGreaterThanOrEqual(4);
+    expect(serialised).toContain('"jerusalem"');
+    expect(serialised).toContain('"bethlehem"');
   });
 });

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -47,21 +47,6 @@ export function placesToFeatureCollection(places: Place[]): GeoJSON.FeatureColle
   };
 }
 
-/**
- * Min-zoom per priority — mirrors the old `maxPriorityForZoom` thresholds
- * from geoMath.ts but expressed as a MapLibre `match` expression so the
- * GPU renders/hides per-feature without JS involvement.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const PRIORITY_MIN_ZOOM: any = ['match',
-  ['get', 'priority'],
-  1, 3,
-  2, 5,
-  3, 7,
-  4, 8,
-  8, // fallback
-];
-
 export const PlaceMarkerList = memo(function PlaceMarkerList({
   places,
   showModern,
@@ -77,18 +62,33 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
     return safeParse<string[]>(activeStory.places_json, []);
   }, [activeStory]);
 
-  // Full visibility expression: story places are always visible (min-zoom 0),
-  // other places hidden below their priority's min-zoom threshold.
+  // Full visibility expression: story places are always visible, other places
+  // appear at fixed zoom stops according to priority. Keep the zoom stops as
+  // literal numbers; MapLibre rejects dynamic stop thresholds in `step`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const minZoomExpr: any = useMemo(
-    () => [
+  const visibilityOpacityExpr: any = useMemo(() => {
+    const isStoryPlace = ['in', ['get', 'id'], ['literal', storyPlaceIds]];
+    const visibleThroughPriority = (maxPriority: number) => [
       'case',
-      ['in', ['get', 'id'], ['literal', storyPlaceIds]],
+      ['any', isStoryPlace, ['<=', ['get', 'priority'], maxPriority]],
+      1,
       0,
-      PRIORITY_MIN_ZOOM,
-    ],
-    [storyPlaceIds],
-  );
+    ];
+
+    return [
+      'step',
+      ['zoom'],
+      ['case', isStoryPlace, 1, 0],
+      3,
+      visibleThroughPriority(1),
+      5,
+      visibleThroughPriority(2),
+      7,
+      visibleThroughPriority(3),
+      8,
+      1,
+    ];
+  }, [storyPlaceIds]);
 
   // Radius / color / stroke for the active-place spotlight.
   // Uses a direct id comparison (effectively a poor-man's feature-state —
@@ -158,8 +158,7 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           circleColor: circleColorExpr,
           circleStrokeColor: circleStrokeColorExpr,
           circleStrokeWidth: circleStrokeWidthExpr,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          circleOpacity: ['step', ['zoom'], 0, minZoomExpr, 1] as any,
+          circleOpacity: visibilityOpacityExpr,
         }}
       />
       <Layer
@@ -184,8 +183,7 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           textOffset: [0, 1.1],
           textAnchor: 'top',
           textOptional: true,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          textOpacity: ['step', ['zoom'], 0, minZoomExpr, 1] as any,
+          textOpacity: visibilityOpacityExpr,
           textAllowOverlap: false,
           textIgnorePlacement: false,
         }}

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -47,6 +47,62 @@ export function placesToFeatureCollection(places: Place[]): GeoJSON.FeatureColle
   };
 }
 
+/**
+ * Build the per-feature, zoom-gated opacity expression for the places layer.
+ *
+ * ⚠️ DO NOT REFACTOR INTO THE OBVIOUS-LOOKING SHAPE.
+ *
+ * The natural-feeling form crashes the iOS MapLibre SDK at runtime:
+ *
+ *     ['step', ['zoom'], 0, perFeatureMinZoomExpr, 1]
+ *
+ * MapLibre's style spec requires the stop INPUTS of a `step` expression to
+ * be literal numeric constants. A `case`/`match` sub-expression as a stop
+ * input is a spec violation; the iOS SDK throws an uncaught NSException
+ * from -[MLRNStyle setCircleOpacity:withReactStyleValue:]
+ * (MLRNStyle.m:1216), Sentry's CPP terminate handler converts it to
+ * SIGABRT, and the app hard-crashes the moment a place layer is added to
+ * the map. There is no JS error boundary that catches this. See PR #1567
+ * / the crash report at commit 1b9183bb for the full stack.
+ *
+ * The valid structure is the inverse: `step` on `["zoom"]` with literal
+ * breakpoints, and `case` expressions as the OUTPUTS at each zoom band.
+ * Yes it's verbose. Leave it that way.
+ *
+ * Visibility ladder (matches the old PRIORITY_MIN_ZOOM table):
+ *   zoom < 3  — story places only
+ *   zoom 3+   — story + priority 1
+ *   zoom 5+   — story + priority 1-2
+ *   zoom 7+   — story + priority 1-3
+ *   zoom 8+   — everything (also handles unknown priority values,
+ *               which previously got the fallback min-zoom 8)
+ *
+ * Exported for unit testing — the regression test in
+ * `__tests__/components/PlaceMarkerList.test.tsx` asserts that all stop-
+ * input positions in the returned `step` expression are numeric literals,
+ * which is the spec invariant whose violation caused the crash.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildPlaceVisibilityExpr(storyPlaceIds: string[]): any[] {
+  const isStoryPlace = ['in', ['get', 'id'], ['literal', storyPlaceIds]];
+  const visibleThroughPriority = (maxPriority: number) => [
+    'case',
+    ['any', isStoryPlace, ['<=', ['get', 'priority'], maxPriority]],
+    1,
+    0,
+  ];
+
+  return [
+    'step',
+    ['zoom'],
+    ['case', isStoryPlace, 1, 0],
+    3, visibleThroughPriority(1),
+    5, visibleThroughPriority(2),
+    7, visibleThroughPriority(3),
+    8, 1,
+  ];
+}
+
 export const PlaceMarkerList = memo(function PlaceMarkerList({
   places,
   showModern,
@@ -62,33 +118,14 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
     return safeParse<string[]>(activeStory.places_json, []);
   }, [activeStory]);
 
-  // Full visibility expression: story places are always visible, other places
-  // appear at fixed zoom stops according to priority. Keep the zoom stops as
-  // literal numbers; MapLibre rejects dynamic stop thresholds in `step`.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const visibilityOpacityExpr: any = useMemo(() => {
-    const isStoryPlace = ['in', ['get', 'id'], ['literal', storyPlaceIds]];
-    const visibleThroughPriority = (maxPriority: number) => [
-      'case',
-      ['any', isStoryPlace, ['<=', ['get', 'priority'], maxPriority]],
-      1,
-      0,
-    ];
-
-    return [
-      'step',
-      ['zoom'],
-      ['case', isStoryPlace, 1, 0],
-      3,
-      visibleThroughPriority(1),
-      5,
-      visibleThroughPriority(2),
-      7,
-      visibleThroughPriority(3),
-      8,
-      1,
-    ];
-  }, [storyPlaceIds]);
+  // Per-feature, zoom-gated visibility expression. The expression is built
+  // by `buildPlaceVisibilityExpr` above — see its doc comment for the
+  // (substantial) constraints. Memoised so identity is stable when
+  // `storyPlaceIds` doesn't change, avoiding native style re-applies.
+  const visibilityOpacityExpr = useMemo(
+    () => buildPlaceVisibilityExpr(storyPlaceIds),
+    [storyPlaceIds],
+  );
 
   // Radius / color / stroke for the active-place spotlight.
   // Uses a direct id comparison (effectively a poor-man's feature-state —

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -83,7 +83,7 @@ export function placesToFeatureCollection(places: Place[]): GeoJSON.FeatureColle
  * which is the spec invariant whose violation caused the crash.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildPlaceVisibilityExpr(storyPlaceIds: string[]): any[] {
+export function buildPlaceVisibilityExpr(storyPlaceIds: string[]): any {
   const isStoryPlace = ['in', ['get', 'id'], ['literal', storyPlaceIds]];
   const visibleThroughPriority = (maxPriority: number) => [
     'case',


### PR DESCRIPTION
## Summary

- replaces the invalid dynamic `step` threshold used for place marker opacity
- keeps story places always visible while preserving priority-based zoom visibility
- applies the same safe expression to dot and label opacity

## Why

The iOS crash report showed MapLibre aborting while setting `circleOpacity` in `MLRNStyle.m`. The previous expression passed another expression as a `step` stop threshold (`minZoomExpr`), but MapLibre expects literal numeric stop thresholds and throws during native style conversion.

## Validation

- `npm test -- --runTestsByPath __tests__/components/PlaceMarkerList.test.tsx --runInBand`
- `npx eslint src/components/map/PlaceMarkerList.tsx`