### PR TITLE
fix(amicus): silence expected noise from unbuilt future-table queries

### DIFF
--- a/app/__tests__/services/amicus/profile/signals.test.ts
+++ b/app/__tests__/services/amicus/profile/signals.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Focused tests for the "future table" silencing in
+ * `services/amicus/profile/signals.ts`.
+ *
+ * The getTopScholarsOpened / getJourneyState catch blocks used to
+ * unconditionally call `logger.info` when the underlying table didn't
+ * exist yet. Those tables are expected to be absent until their
+ * migrations land, so the log fired on every `collectSignals()` call —
+ * drowning real errors in expected noise on dev terminals and in
+ * Sentry breadcrumbs. This test locks in the current behaviour:
+ *
+ *   - "no such table" errors: silent, return empty/default
+ *   - any other SQL error: still surfaces via logger.info
+ */
+
+import { logger } from '@/utils/logger';
+import { getTopScholarsOpened, getJourneyState } from '@/services/amicus/profile/signals';
+
+// Mock the user-db accessor so we can throw from the getAllAsync/getFirstAsync
+// calls that signals.ts makes — no real SQLite involved.
+const mockGetAllAsync = jest.fn();
+const mockGetFirstAsync = jest.fn();
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({
+    getAllAsync: mockGetAllAsync,
+    getFirstAsync: mockGetFirstAsync,
+  }),
+}));
+
+describe('signals.ts — future-table silencing', () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockGetAllAsync.mockReset();
+    mockGetFirstAsync.mockReset();
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  describe('getTopScholarsOpened (scholar_opens table)', () => {
+    it('returns [] without logging when table does not exist', async () => {
+      mockGetAllAsync.mockRejectedValueOnce(
+        new Error("no such table: scholar_opens"),
+      );
+      const result = await getTopScholarsOpened(5);
+      expect(result).toEqual([]);
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it('still logs (and returns []) for unexpected errors', async () => {
+      mockGetAllAsync.mockRejectedValueOnce(
+        new Error('disk I/O error'),
+      );
+      const result = await getTopScholarsOpened(5);
+      expect(result).toEqual([]);
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const [tag, msg] = infoSpy.mock.calls[0] as [string, string];
+      expect(tag).toBe('AmicusProfile');
+      expect(msg).toMatch(/scholar_opens unavailable/);
+      expect(msg).toMatch(/disk I\/O error/);
+    });
+
+    it('returns the real rows when the query succeeds', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        { scholar_id: 'wright', open_count: 7 },
+        { scholar_id: 'sarna', open_count: 4 },
+      ]);
+      const result = await getTopScholarsOpened(5);
+      expect(result).toEqual([
+        { scholar_id: 'wright', open_count: 7 },
+        { scholar_id: 'sarna', open_count: 4 },
+      ]);
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getJourneyState (journey_progress table)', () => {
+    it('returns empty state without logging when table does not exist', async () => {
+      // Failure mode in practice: getAllAsync throws; getFirstAsync
+      // never gets a chance to run. Match that.
+      mockGetAllAsync.mockRejectedValueOnce(
+        new Error("no such table: journey_progress"),
+      );
+      const result = await getJourneyState();
+      expect(result).toEqual({ completed: [], active: null });
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it('still logs (and returns empty state) for unexpected errors', async () => {
+      mockGetAllAsync.mockRejectedValueOnce(new Error('database is locked'));
+      const result = await getJourneyState();
+      expect(result).toEqual({ completed: [], active: null });
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const [tag, msg] = infoSpy.mock.calls[0] as [string, string];
+      expect(tag).toBe('AmicusProfile');
+      expect(msg).toMatch(/journey_progress unavailable/);
+      expect(msg).toMatch(/database is locked/);
+    });
+
+    it('returns the real state when both queries succeed', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        { journey_id: 'exodus-story' },
+        { journey_id: 'psalms-week' },
+      ]);
+      mockGetFirstAsync.mockResolvedValueOnce({ journey_id: 'kings-arc' });
+      const result = await getJourneyState();
+      expect(result).toEqual({
+        completed: ['exodus-story', 'psalms-week'],
+        active: 'kings-arc',
+      });
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('matches the case-insensitive SQLite error message variant', async () => {
+    // SQLite's exact message is lowercase ("no such table: X") but some
+    // wrappers capitalise it. Sanity-check the regex is case-insensitive.
+    mockGetAllAsync.mockRejectedValueOnce(
+      new Error('No Such Table: scholar_opens'),
+    );
+    const result = await getTopScholarsOpened(5);
+    expect(result).toEqual([]);
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/services/amicus/profile/signals.ts
+++ b/app/src/services/amicus/profile/signals.ts
@@ -21,6 +21,25 @@ const CURRENT_FOCUS_MIN_CHAPTERS = 3;
 const TOP_SCHOLARS_LIMIT = 5;
 const SCHOLAR_ENGAGEMENT_FLOOR = 10;
 
+/**
+ * True iff `err` is the "no such table" SQLite error — i.e. the table
+ * a query targets has not been created yet. This is the *expected*
+ * failure mode for tables that exist in signals.ts in advance of the
+ * migrations that create them (e.g. `scholar_opens`, `journey_progress`
+ * as of 2026-04). Those queries deliberately run and fail-fast rather
+ * than gate behind table-existence checks; this helper lets us skip
+ * the logger breadcrumb so dev terminals and Sentry aren't filled
+ * with confirmed-harmless noise on every call to `collectSignals`.
+ *
+ * Any other SQL failure (syntax error, corrupted DB, type mismatch)
+ * still surfaces through `logger.info` so we don't accidentally hide
+ * real bugs behind this predicate.
+ */
+function isNoSuchTableError(err: unknown): boolean {
+  const msg = (err as Error | undefined)?.message ?? '';
+  return /no such table/i.test(msg);
+}
+
 export async function collectSignals(): Promise<RawSignals> {
   const [totals, recent30, scholars, traditions, genres, journeys, recentChapters, focus] =
     await Promise.all([
@@ -76,8 +95,13 @@ export async function getTopScholarsOpened(limit: number): Promise<ScholarEngage
     );
     return rows;
   } catch (err) {
-    // scholar_opens is a future engagement table — return empty until it exists.
-    logger.info('AmicusProfile', `scholar_opens unavailable: ${(err as Error).message}`);
+    // `scholar_opens` is a future engagement table; return empty until
+    // the migration that creates it lands. Skip the logger breadcrumb
+    // for the expected "no such table" case so dev terminals and
+    // Sentry don't get spammed on every signal collection.
+    if (!isNoSuchTableError(err)) {
+      logger.info('AmicusProfile', `scholar_opens unavailable: ${(err as Error).message}`);
+    }
     return [];
   }
 }
@@ -148,8 +172,12 @@ export async function getJourneyState(): Promise<{
       active: activeRow?.journey_id ?? null,
     };
   } catch (err) {
-    // journey_progress not yet populated for this user — safe to skip.
-    logger.info('AmicusProfile', `journey_progress unavailable: ${(err as Error).message}`);
+    // `journey_progress` is a future engagement table; return an empty
+    // journey state until the migration that creates it lands. Same
+    // rationale as `scholar_opens` above.
+    if (!isNoSuchTableError(err)) {
+      logger.info('AmicusProfile', `journey_progress unavailable: ${(err as Error).message}`);
+    }
     return { completed: [], active: null };
   }
 }


### PR DESCRIPTION
signals.ts runs SELECT queries against `scholar_opens` and `journey_progress` — engagement tables whose migrations haven't landed yet. The existing catch blocks unconditionally called `logger.info` for the "no such table" error, which fired every time `collectSignals()` ran (which is: every Amicus Profile generation, so every daily-prompt rehydrate). This drowned real SQL errors on dev terminals and produced useless breadcrumbs in Sentry.

Add a narrow `isNoSuchTableError` predicate and gate the logger.info call on it. The expected "table not yet created" failure mode becomes silent; any OTHER SQL failure (disk I/O, locked db, syntax error, etc.) still surfaces through the existing log line so we don't hide real bugs. When the migrations for these tables finally land, the predicate stops matching and the code path becomes dead — no cleanup needed.

Tests cover:
- "no such table" errors: silent return of the empty/default value
- unexpected SQL errors: still logged with the original tag + message
- successful queries: real rows / state returned, no log
- case-insensitive regex match (SQLite emits lowercase; some wrappers capitalise)

No behaviour change for consumers — both functions still return the same empty/default when the tables are absent, just without the noisy log.