### PR TITLE
fix(map): decouple story selection from era filter chip

### DIFF
--- a/app/__tests__/unit/mapScreenHelpers.test.ts
+++ b/app/__tests__/unit/mapScreenHelpers.test.ts
@@ -27,7 +27,7 @@ jest.mock('@/hooks/useAncientBorders', () => ({
   }),
 }));
 
-import { buildPlaceToStoriesMap, STYLE_ANCIENT, STYLE_MODERN } from '@/screens/MapScreen';
+import { buildPlaceToStoriesMap, resolveBorderEra, STYLE_ANCIENT, STYLE_MODERN } from '@/screens/MapScreen';
 import type { MapStory } from '@/types';
 
 function story(id: string, places: string[]): MapStory {
@@ -81,5 +81,55 @@ describe('MapLibre style URLs', () => {
 
   it('points modern.json at the R2-hosted map-styles path', () => {
     expect(STYLE_MODERN).toMatch(/map-styles\/modern\.json$/);
+  });
+});
+
+/**
+ * Regression guard for the story-select / era-filter decoupling
+ * introduced in the PR that ships this file alongside.
+ *
+ * Before: selecting a story called `setActiveEra(story.era)` as a
+ * side effect so the AncientBorderLayer would repaint — but that
+ * ALSO narrowed the EraFilterBar to the story's era, trapping the
+ * user there after the story closed.
+ *
+ * After: border era is derived from `activeStory?.era ?? filterEra`
+ * so the map repaints correctly while the filter chip stays
+ * untouched. This test pins the derivation so a future refactor
+ * can't regress to the side-effect pattern without a red CI.
+ */
+describe('resolveBorderEra', () => {
+  it('returns the active story’s era when a story is selected, regardless of the filter', () => {
+    // The user is browsing "All" stories but has tapped one in the
+    // Kingdom era — borders should match the story, not the filter.
+    expect(resolveBorderEra({ era: 'kingdom' }, 'all')).toBe('kingdom');
+  });
+
+  it('returns the active story’s era even when the filter already matches', () => {
+    // Belt-and-suspenders: if both agree, no ambiguity.
+    expect(resolveBorderEra({ era: 'exodus' }, 'exodus')).toBe('exodus');
+  });
+
+  it('returns the filter era when no story is active', () => {
+    // User has the Patriarchs chip selected, no story open — borders
+    // follow the chip.
+    expect(resolveBorderEra(null, 'patriarchs')).toBe('patriarchs');
+  });
+
+  it("returns 'all' when no story is active and the filter is 'all'", () => {
+    // Default/idle state — whatever 'all' means downstream (typically
+    // no borders or a neutral backdrop) is correctly propagated.
+    expect(resolveBorderEra(null, 'all')).toBe('all');
+  });
+
+  it('prefers the story era over the filter even when they disagree', () => {
+    // The exact bug scenario from Craig's screenshot: user's filter
+    // chip is on "All", user taps a Kingdom story. Borders MUST
+    // follow the story (kingdom); the filter MUST remain untouched.
+    // resolveBorderEra only handles the first half; the parent
+    // component is responsible for not calling setFilterEra —
+    // but this test pins the resolver's contract.
+    expect(resolveBorderEra({ era: 'kingdom' }, 'all')).toBe('kingdom');
+    expect(resolveBorderEra({ era: 'nt' }, 'exile')).toBe('nt');
   });
 });

--- a/app/src/screens/MapScreen.tsx
+++ b/app/src/screens/MapScreen.tsx
@@ -56,6 +56,33 @@ export function buildPlaceToStoriesMap(stories: MapStory[]): Map<string, MapStor
   return map;
 }
 
+/**
+ * Resolve which era the AncientBorderLayer should render for.
+ *
+ * When a story is selected, borders match the story's era so the
+ * map's political backdrop reflects the story's historical moment
+ * (David's kingdom borders for "David's Rise", Babylonian-era
+ * borders for "Babylonian Exile", etc.). When no story is active,
+ * borders follow the user's filter-chip selection.
+ *
+ * This used to be handled via a side effect inside `selectStory`
+ * that called `setActiveEra(story.era)` — which also hijacked the
+ * EraFilterBar chip selection and narrowed the visible story strip
+ * to just that era, stranding the user after they closed the story.
+ * Deriving the border era here instead keeps the two concerns
+ * (visual context vs. story filter) cleanly separated.
+ *
+ * Kept at the dispatcher level (not MapScreenNative) for the same
+ * reason as `buildPlaceToStoriesMap` — unit tests don't have to pull
+ * in MapLibre just to exercise this one-line decision.
+ */
+export function resolveBorderEra(
+  activeStory: Pick<MapStory, 'era'> | null,
+  filterEra: string,
+): string {
+  return activeStory?.era ?? filterEra;
+}
+
 // Lazy so MapScreenNative.tsx (and therefore `@maplibre/...`) never
 // evaluates in Expo Go. Marked as a module-level constant so React can
 // memoise the lazy wrapper across renders.

--- a/app/src/screens/MapScreenNative.tsx
+++ b/app/src/screens/MapScreenNative.tsx
@@ -37,7 +37,7 @@ import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 import { lightImpact } from '../utils/haptics';
 import { STYLE_ANCIENT, STYLE_MODERN } from '../constants/mapStyles';
-import { buildPlaceToStoriesMap } from './MapScreen';
+import { buildPlaceToStoriesMap, resolveBorderEra } from './MapScreen';
 
 // The dispatcher (MapScreen.tsx) gates on isMapNativeAvailable() before
 // this module loads. Run module-level init so tiles can be fetched.
@@ -90,15 +90,19 @@ function MapScreen({ route, navigation }: {
   // Map of placeId → stories that include it
   const placeToStories = useMemo(() => buildPlaceToStoriesMap(stories), [stories]);
 
-  /** Select a story → overlays, camera fit, panel open, era auto-switch. */
+  /** Select a story → overlays, camera fit, panel open. */
   const selectStory = useCallback((story: MapStory) => {
     setActiveStory(story);
     setShowPanel(true);
     setSelectedPlace(null);
-    // Auto-switch the ancient-border layer to match the story's era
-    // (scaffold for #1317). Preserves the user's 'all' selection only
-    // when no era info is present on the story.
-    if (story.era) setActiveEra(story.era);
+    // Historical note: previously this also did `setActiveEra(story.era)`
+    // so the AncientBorderLayer would repaint to the story's era. That
+    // also silently hijacked the EraFilterBar filter — selecting "David's
+    // Rise" while browsing "All" eras would narrow the story strip to
+    // just Kingdom-era stories, and closing the story left the filter
+    // stuck. The border-layer's era prop is now derived from
+    // `activeStory?.era ?? activeEra` below, so the visual effect on
+    // the map persists without touching the filter state.
 
     try {
       const placeIds: string[] = JSON.parse(story.places_json ?? '[]');
@@ -168,8 +172,12 @@ function MapScreen({ route, navigation }: {
       const story = stories.find((s) => s.id === initialStoryId);
       if (story) {
         selectStory(story);
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        if (story.era) setActiveEra(story.era);
+        // `setActiveEra(story.era)` used to live here for the same
+        // reason the former `selectStory` auto-switched — so the
+        // border layer would repaint. The border layer's prop now
+        // derives the era from `activeStory?.era ?? activeEra`, so
+        // setting it explicitly would revive the filter-hijack bug
+        // in the deep-link path.
         lastProcessedStory.current = initialStoryId;
       }
     } else if (initialPlaceId && places.length) {
@@ -291,8 +299,13 @@ function MapScreen({ route, navigation }: {
             zoom: BIBLICAL_REGION.zoom,
           }}
         />
-        {/* Ancient political borders for the active era (Biblical mode only) */}
-        <AncientBorderLayer era={activeEra} showModern={showModern} />
+        {/* Ancient political borders for the active era (Biblical mode only).
+            See `resolveBorderEra` for the derivation rationale and the
+            filter-hijack bug this avoids. */}
+        <AncientBorderLayer
+          era={resolveBorderEra(activeStory, activeEra)}
+          showModern={showModern}
+        />
         <PlaceMarkerList
           places={places}
           showModern={showModern}


### PR DESCRIPTION
User-reported bug: tapping a story on the bottom strip silently changed the EraFilterBar chip to that story's era. After closing the story, the user was stranded on a filter showing only 2-3 stories with no obvious way back to "All". The filter appeared broken when really it had been hijacked.

Root cause: `selectStory` and the deep-link handler both called `setActiveEra(story.era)` as a side effect. The goal was to repaint the AncientBorderLayer to match the story's historical moment — a legitimate visual requirement — but `activeEra` was doing double duty as (a) the border layer's input AND (b) the story-list filter. Any change to (a) clobbered (b).

Fix: separate the two concerns. The border layer's era is now derived from `activeStory?.era ?? activeEra` via a new pure helper `resolveBorderEra(activeStory, filterEra)`. Removing the two `setActiveEra(story.era)` side-effects leaves the filter chip untouched when the user selects a story. The border layer still repaints correctly — while a story is active, its era wins; when no story is active (including after closing one), the chip selection takes over.

The helper lives in `MapScreen.tsx` alongside
`buildPlaceToStoriesMap` — same rationale (unit tests don't need MapLibre to exercise a one-line decision) — and MapScreenNative imports it. Existing tests in
`__tests__/unit/mapScreenHelpers.test.ts` are extended with a `describe('resolveBorderEra')` block covering the four matrix cases (story ±, filter ±) plus the exact bug scenario from Craig's screenshot (filter='all', story in 'kingdom' → border era MUST be 'kingdom').

No state-shape changes, no store migrations. The behaviour change is visible only in the specific "tap story while on a broader filter" path, which is where the bug lived.