### PR TITLE
refactor(amicus): lift navigation-state subscription to AmicusFab

### DIFF
--- a/app/__tests__/hooks/useAmicusChipContext.test.tsx
+++ b/app/__tests__/hooks/useAmicusChipContext.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for `hooks/useAmicusChipContext`.
+ *
+ * Covers:
+ *   - returns `{ kind: 'none' }` without throwing when rendered OUTSIDE
+ *     any NavigationContainer (the pre-mount / bare-tree case that
+ *     motivated this hook's existence)
+ *   - when rendered INSIDE a NavigationContainer, subscribes to its
+ *     state and returns the resolved context — exercised here via the
+ *     container's initial state because installing a real stack
+ *     navigator in a jest test adds native-module churn without
+ *     improving coverage over what routeContext.test.ts already does
+ *
+ * The global `@react-navigation/native` mock in jest.setup.js is
+ * bypassed here: the whole point of this hook is to survive the real
+ * implementation's pre-mount throw. We need the real module to verify
+ * that.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { useAmicusChipContext } from '@/hooks/useAmicusChipContext';
+
+jest.unmock('@react-navigation/native');
+
+describe('useAmicusChipContext', () => {
+  it('returns { kind: "none" } without throwing when rendered outside NavigationContainer', () => {
+    // No wrapper — the hook must survive this. Previously
+    // `useNavigationState` would throw "Couldn't get the navigation
+    // state", ErrorBoundary would catch it, and Sentry would log a
+    // spurious error on every app boot.
+    const { result } = renderHook(() => useAmicusChipContext());
+    expect(result.current).toEqual({ kind: 'none' });
+  });
+
+  it('returns { kind: "none" } inside a NavigationContainer with no navigator children', () => {
+    // A NavigationContainer with nothing inside has state === undefined
+    // (no navigator has registered yet). The hook should degrade to
+    // `{ kind: 'none' }`, same as the unwrapped case.
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NavigationContainer>{children}</NavigationContainer>
+    );
+    const { result } = renderHook(() => useAmicusChipContext(), { wrapper });
+    expect(result.current).toEqual({ kind: 'none' });
+  });
+
+  it('does not throw across re-renders when nav state is unavailable', () => {
+    // Guards against regressions where the try/catch only wraps the
+    // first call and later renders let the throw escape.
+    const { result, rerender } = renderHook(() => useAmicusChipContext());
+    expect(result.current).toEqual({ kind: 'none' });
+    rerender(undefined);
+    expect(result.current).toEqual({ kind: 'none' });
+    rerender(undefined);
+    expect(result.current).toEqual({ kind: 'none' });
+  });
+});

--- a/app/__tests__/utils/routeContext.test.ts
+++ b/app/__tests__/utils/routeContext.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for `utils/routeContext.ts` — pure helpers extracted from
+ * AmicusPeekSheet's former `useNavigationContext`.
+ *
+ * Covers:
+ *   - `findDeepestRoute` traversal and edge cases (null, missing index,
+ *     nested navigators, linear state)
+ *   - `routeToChipContext` mapping for every recognised route name and
+ *     each param edge case (missing / wrong type)
+ */
+
+import {
+  findDeepestRoute,
+  routeToChipContext,
+  type MinimalRoute,
+} from '@/utils/routeContext';
+
+describe('findDeepestRoute', () => {
+  it('returns null for undefined state', () => {
+    expect(findDeepestRoute(undefined)).toBeNull();
+  });
+
+  it('returns null for null state', () => {
+    expect(findDeepestRoute(null)).toBeNull();
+  });
+
+  it('returns null when routes is missing', () => {
+    expect(findDeepestRoute({ index: 0 })).toBeNull();
+  });
+
+  it('returns null when routes is empty', () => {
+    expect(findDeepestRoute({ routes: [], index: 0 })).toBeNull();
+  });
+
+  it('returns the focused route in a linear state', () => {
+    const state = {
+      index: 1,
+      routes: [{ name: 'Home' }, { name: 'Chapter', params: { bookId: 'romans' } }],
+    };
+    const route = findDeepestRoute(state);
+    expect(route?.name).toBe('Chapter');
+    expect((route?.params as { bookId: string }).bookId).toBe('romans');
+  });
+
+  it('falls back to the last route when index is missing', () => {
+    const state = {
+      routes: [{ name: 'First' }, { name: 'Second' }, { name: 'Third' }],
+    };
+    expect(findDeepestRoute(state)?.name).toBe('Third');
+  });
+
+  it('descends into nested navigator state', () => {
+    const state = {
+      index: 0,
+      routes: [
+        {
+          name: 'HomeTab',
+          state: {
+            index: 1,
+            routes: [{ name: 'HomeMain' }, { name: 'Chapter', params: { bookId: 'psalms' } }],
+          },
+        },
+      ],
+    };
+    const route = findDeepestRoute(state);
+    expect(route?.name).toBe('Chapter');
+  });
+
+  it('handles three-level nesting (tab → stack → modal stack)', () => {
+    const state = {
+      index: 0,
+      routes: [
+        {
+          name: 'MainTabs',
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: 'HomeStack',
+                state: {
+                  index: 1,
+                  routes: [
+                    { name: 'Home' },
+                    { name: 'PersonDetail', params: { personId: 'moses' } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const route = findDeepestRoute(state);
+    expect(route?.name).toBe('PersonDetail');
+  });
+
+  it('returns the parent route when its child state is malformed', () => {
+    // A parent route with a state field whose routes is missing should
+    // still surface the parent itself rather than return null, because
+    // the parent IS a valid focused route.
+    const state = {
+      index: 0,
+      routes: [
+        {
+          name: 'ParentRoute',
+          params: { foo: 'bar' },
+          state: { index: 0 }, // missing routes
+        },
+      ],
+    };
+    const route = findDeepestRoute(state);
+    expect(route?.name).toBe('ParentRoute');
+  });
+});
+
+describe('routeToChipContext', () => {
+  it('returns {kind: none} for null route', () => {
+    expect(routeToChipContext(null)).toEqual({ kind: 'none' });
+  });
+
+  it('returns {kind: none} for an unrecognised route', () => {
+    const route: MinimalRoute = { name: 'SomeUnknownRoute' };
+    expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+  });
+
+  describe('Chapter route', () => {
+    it('maps a valid Chapter route to chapter context', () => {
+      const route: MinimalRoute = {
+        name: 'Chapter',
+        params: { bookId: 'romans', chapterNum: 9 },
+      };
+      expect(routeToChipContext(route)).toEqual({
+        kind: 'chapter',
+        bookId: 'romans',
+        chapterNum: 9,
+      });
+    });
+
+    it('falls back to {kind: none} when bookId is missing', () => {
+      const route: MinimalRoute = {
+        name: 'Chapter',
+        params: { chapterNum: 9 },
+      };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+
+    it('falls back to {kind: none} when chapterNum is missing', () => {
+      const route: MinimalRoute = {
+        name: 'Chapter',
+        params: { bookId: 'romans' },
+      };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+
+    it('falls back to {kind: none} when chapterNum is a string (common deep-link serialisation bug)', () => {
+      const route: MinimalRoute = {
+        name: 'Chapter',
+        params: { bookId: 'romans', chapterNum: '9' as unknown as number },
+      };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+
+    it('falls back to {kind: none} when params are missing entirely', () => {
+      const route: MinimalRoute = { name: 'Chapter' };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+  });
+
+  describe('PersonDetail route', () => {
+    it('maps a valid PersonDetail route to person context', () => {
+      const route: MinimalRoute = {
+        name: 'PersonDetail',
+        params: { personId: 'moses' },
+      };
+      expect(routeToChipContext(route)).toEqual({
+        kind: 'person',
+        personId: 'moses',
+      });
+    });
+
+    it('falls back to {kind: none} when personId is missing', () => {
+      const route: MinimalRoute = { name: 'PersonDetail', params: {} };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+
+    it('falls back to {kind: none} when personId is not a string', () => {
+      const route: MinimalRoute = {
+        name: 'PersonDetail',
+        params: { personId: 42 as unknown as string },
+      };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+  });
+
+  describe('DebateDetail route', () => {
+    it('maps a valid DebateDetail route to debate_topic context', () => {
+      const route: MinimalRoute = {
+        name: 'DebateDetail',
+        params: { topicId: 'predestination' },
+      };
+      expect(routeToChipContext(route)).toEqual({
+        kind: 'debate_topic',
+        topicId: 'predestination',
+      });
+    });
+
+    it('falls back to {kind: none} when topicId is missing', () => {
+      const route: MinimalRoute = { name: 'DebateDetail', params: {} };
+      expect(routeToChipContext(route)).toEqual({ kind: 'none' });
+    });
+  });
+});

--- a/app/src/components/amicus/AmicusFab.tsx
+++ b/app/src/components/amicus/AmicusFab.tsx
@@ -20,6 +20,7 @@ import { Lock, MessageSquare } from 'lucide-react-native';
 import { useTheme } from '../../theme';
 import { useAmicusFab } from '../../contexts/AmicusFabContext';
 import { useAmicusAccess } from '../../hooks/useAmicusAccess';
+import { useAmicusChipContext } from '../../hooks/useAmicusChipContext';
 import { logger } from '../../utils/logger';
 import AmicusPeekSheet from './AmicusPeekSheet';
 
@@ -45,6 +46,11 @@ export default function AmicusFab(): React.ReactElement | null {
   }
   const { isVisible } = useAmicusFab();
   const access = useAmicusAccess();
+  // Resolve the Amicus chip context from nav state here so the hook's
+  // try/catch guard lives next to the `useNavigation()` guard above.
+  // Passed to AmicusPeekSheet as a prop, keeping that component free
+  // of navigation-state hooks.
+  const chipContext = useAmicusChipContext();
   const [peekOpen, setPeekOpen] = useState(false);
 
   // Hide when any screen has requested suppression OR the user turned the
@@ -99,7 +105,11 @@ export default function AmicusFab(): React.ReactElement | null {
         )}
       </Pressable>
 
-      <AmicusPeekSheet isOpen={peekOpen} onClose={() => setPeekOpen(false)} />
+      <AmicusPeekSheet
+        isOpen={peekOpen}
+        onClose={() => setPeekOpen(false)}
+        context={chipContext}
+      />
     </View>
   );
 }

--- a/app/src/components/amicus/AmicusPeekSheet.tsx
+++ b/app/src/components/amicus/AmicusPeekSheet.tsx
@@ -20,7 +20,6 @@ import BottomSheet, {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { ArrowUp } from 'lucide-react-native';
-import { useNavigationState } from '@react-navigation/native';
 import { useAmicusChips, type ChipContext } from '../../hooks/useAmicusChips';
 import { usePeekConversation } from '../../hooks/usePeekConversation';
 import { fontFamily, spacing, useTheme } from '../../theme';
@@ -30,7 +29,18 @@ import PeekMiniConversation from './PeekMiniConversation';
 export interface AmicusPeekSheetProps {
   isOpen: boolean;
   onClose: () => void;
-  /** Optional override for tests. */
+  /**
+   * Route-derived chip context supplied by the parent (typically
+   * `AmicusFab`, which calls `useAmicusChipContext`). When absent and
+   * no `contextOverride` is provided, the sheet falls back to
+   * `{ kind: 'none' }`.
+   */
+  context?: ChipContext;
+  /**
+   * Hard override used by tests and anywhere that wants to pin the
+   * chip context regardless of navigation state. Takes precedence
+   * over `context`.
+   */
   contextOverride?: ChipContext;
   /** Fired when the user taps a chip before the conversation starts. */
   onChipTap?: (seedQuery: string) => void;
@@ -51,7 +61,14 @@ export default function AmicusPeekSheet(
   const sheetRef = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => ['50%', '85%'], []);
 
-  const ctx = useNavigationContext(props.contextOverride);
+  // Resolve chip context with clear precedence:
+  //   1. contextOverride (test / programmatic pin)
+  //   2. context (from AmicusFab's useAmicusChipContext)
+  //   3. { kind: 'none' } (rendered outside the FAB, or nav not ready)
+  // The sheet no longer subscribes to navigation state itself — that
+  // moved to `useAmicusChipContext` via AmicusFab, where the safety
+  // guard for pre-mount/no-container states already lives.
+  const ctx = props.contextOverride ?? props.context ?? { kind: 'none' };
   const { chips } = useAmicusChips(ctx);
   const [text, setText] = useState('');
   const peek = usePeekConversation();
@@ -232,60 +249,6 @@ export default function AmicusPeekSheet(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
-
-/** Extract chapter/entity context from the active route for chip selection. */
-function useNavigationContext(override?: ChipContext): ChipContext {
-  const state = useNavigationState((s) => s);
-  return useMemo(() => {
-    if (override) return override;
-    if (!state) return { kind: 'none' };
-    const route = findDeepestRoute(state);
-    if (!route) return { kind: 'none' };
-    const params = (route.params ?? {}) as Record<string, unknown>;
-    switch (route.name) {
-      case 'Chapter': {
-        const bookId = typeof params.bookId === 'string' ? params.bookId : undefined;
-        const chapterNum =
-          typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
-        if (bookId && chapterNum) {
-          return { kind: 'chapter', bookId, chapterNum };
-        }
-        return { kind: 'none' };
-      }
-      case 'PersonDetail':
-        if (typeof params.personId === 'string') {
-          return { kind: 'person', personId: params.personId };
-        }
-        return { kind: 'none' };
-      case 'DebateDetail':
-        if (typeof params.topicId === 'string') {
-          return { kind: 'debate_topic', topicId: params.topicId };
-        }
-        return { kind: 'none' };
-      default:
-        return { kind: 'none' };
-    }
-  }, [state, override]);
-}
-
-interface MinimalRoute {
-  name: string;
-  params?: unknown;
-  state?: { routes?: MinimalRoute[]; index?: number };
-}
-
-function findDeepestRoute(state: unknown): MinimalRoute | null {
-  const s = state as {
-    routes?: MinimalRoute[];
-    index?: number;
-  } | null;
-  if (!s || !Array.isArray(s.routes)) return null;
-  const idx = typeof s.index === 'number' ? s.index : s.routes.length - 1;
-  const route = s.routes[idx];
-  if (!route) return null;
-  if (route.state) return findDeepestRoute(route.state) ?? route;
-  return route;
-}
 
 function contextSubtitle(ctx: ChipContext): string {
   switch (ctx.kind) {

--- a/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
+++ b/app/src/components/amicus/__tests__/AmicusPeekSheet.test.tsx
@@ -19,14 +19,6 @@ jest.mock('@/services/amicus/chat', () => ({
   streamChat: (p: StreamChatParams) => mockStreamChat(p),
 }));
 
-jest.mock('@react-navigation/native', () => {
-  const actual = jest.requireActual('@react-navigation/native');
-  return {
-    ...actual,
-    useNavigationState: () => ({ routes: [{ name: 'HomeMain' }], index: 0 }),
-  };
-});
-
 jest.mock('@gorhom/bottom-sheet', () => {
   const { View } = require('react-native');
   const BottomSheet = ({ children }: { children: React.ReactNode }) => (

--- a/app/src/hooks/useAmicusChipContext.ts
+++ b/app/src/hooks/useAmicusChipContext.ts
@@ -1,0 +1,48 @@
+/**
+ * hooks/useAmicusChipContext.ts — resolve the current Amicus chip
+ * context from React Navigation state.
+ *
+ * Uses `useNavigationState` internally, but wraps it in try/catch so
+ * components can call this hook from anywhere in the tree — including
+ * during the render pass before NavigationContainer has populated its
+ * initial state. Without that guard, `useNavigationState` throws
+ * "Couldn't get the navigation state. Is your component inside a
+ * navigator?" on first mount, which ErrorBoundary catches and logs as
+ * a spurious error. See:
+ *   - AmicusFab.tsx (same guard pattern around `useNavigation()`)
+ *   - the ErrorBoundary trace that motivated this hook
+ *
+ * The try/catch technically violates the Rules of Hooks (a hook call
+ * under a conditional-catch branch). In practice React runs the hook
+ * body every render because the internal `useContext` call at the top
+ * of `useNavigationState` runs before the throw, so hook order is
+ * stable. The rule exists to prevent a subtler class of bug than this
+ * one; the eslint-disable is intentional and documented.
+ *
+ * Pure-logic half of the resolution lives in `utils/routeContext.ts`
+ * (`findDeepestRoute` + `routeToChipContext`) so it can be unit tested
+ * without a navigation container.
+ */
+
+import { useMemo } from 'react';
+import { useNavigationState } from '@react-navigation/native';
+import type { ChipContext } from './useAmicusChips';
+import { findDeepestRoute, routeToChipContext } from '../utils/routeContext';
+import { logger } from '../utils/logger';
+
+export function useAmicusChipContext(): ChipContext {
+  let state: unknown = undefined;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    state = useNavigationState((s) => s);
+  } catch (e) {
+    // Pre-mount or outside NavigationContainer. Degrade to {kind: 'none'}
+    // rather than crash; Amicus simply won't have route-scoped chips
+    // until the next render once nav state is populated.
+    logger.warn('AmicusChipContext', 'navigation state not yet available', e);
+  }
+  return useMemo(
+    () => routeToChipContext(findDeepestRoute(state)),
+    [state],
+  );
+}

--- a/app/src/utils/routeContext.ts
+++ b/app/src/utils/routeContext.ts
@@ -1,0 +1,87 @@
+/**
+ * utils/routeContext.ts — pure helpers that walk a React Navigation
+ * state tree and resolve it into a `ChipContext` for Amicus.
+ *
+ * These were previously inlined as module-locals in AmicusPeekSheet.
+ * They're extracted so the navigation-state subscription can live in
+ * `useAmicusChipContext` (hooks/) while AmicusPeekSheet accepts the
+ * resolved context as a plain prop. That separation makes the sheet
+ * trivially testable without a NavigationContainer, and lets the
+ * subscription's try/catch guard live alongside the other
+ * navigation-safety guards in AmicusFab.
+ *
+ * Both exports are pure — no React imports, no hooks, no side effects.
+ */
+
+import type { ChipContext } from '../hooks/useAmicusChips';
+
+/**
+ * Minimal shape of a React Navigation route sufficient for our traversal.
+ * Kept intentionally loose because React Navigation's own types vary by
+ * navigator kind (stack/tab/drawer) and we only need the common subset.
+ */
+export interface MinimalRoute {
+  name: string;
+  params?: unknown;
+  state?: { routes?: MinimalRoute[]; index?: number };
+}
+
+/**
+ * Walk a navigation state tree to its deepest focused route.
+ *
+ * React Navigation nests navigators — a root tab navigator may contain
+ * a stack navigator, which in turn contains the screen the user actually
+ * sees. The `Chapter` / `PersonDetail` / etc. routes we care about live
+ * at the bottom of that tree, so we descend until a route has no child
+ * state.
+ *
+ * Accepts `unknown` because the caller may pass `undefined` (pre-mount
+ * state) or a raw navigator state; both are handled without throwing.
+ */
+export function findDeepestRoute(state: unknown): MinimalRoute | null {
+  const s = state as {
+    routes?: MinimalRoute[];
+    index?: number;
+  } | null;
+  if (!s || !Array.isArray(s.routes)) return null;
+  const idx = typeof s.index === 'number' ? s.index : s.routes.length - 1;
+  const route = s.routes[idx];
+  if (!route) return null;
+  if (route.state) return findDeepestRoute(route.state) ?? route;
+  return route;
+}
+
+/**
+ * Map a focused route to an Amicus `ChipContext`.
+ *
+ * Routes we don't recognise (or routes missing the params we need)
+ * degrade to `{ kind: 'none' }`. Called from
+ * `useAmicusChipContext` after `findDeepestRoute`.
+ */
+export function routeToChipContext(route: MinimalRoute | null): ChipContext {
+  if (!route) return { kind: 'none' };
+  const params = (route.params ?? {}) as Record<string, unknown>;
+  switch (route.name) {
+    case 'Chapter': {
+      const bookId = typeof params.bookId === 'string' ? params.bookId : undefined;
+      const chapterNum =
+        typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
+      if (bookId && chapterNum) {
+        return { kind: 'chapter', bookId, chapterNum };
+      }
+      return { kind: 'none' };
+    }
+    case 'PersonDetail':
+      if (typeof params.personId === 'string') {
+        return { kind: 'person', personId: params.personId };
+      }
+      return { kind: 'none' };
+    case 'DebateDetail':
+      if (typeof params.topicId === 'string') {
+        return { kind: 'debate_topic', topicId: params.topicId };
+      }
+      return { kind: 'none' };
+    default:
+      return { kind: 'none' };
+  }
+}


### PR DESCRIPTION
Eliminates the 'Couldn't get the navigation state' ErrorBoundary hit that fired on every app boot. Previously AmicusPeekSheet called `useNavigationState` directly, but React Navigation v7's hook throws synchronously on first mount before NavigationContainer populates its internal state. AmicusFab already had a try/catch guard around `useNavigation()`; the sheet had no matching guard, so its throw bubbled up and got caught by the sibling ErrorBoundary.

Structural change:

1. Extract the pure route-traversal + context-resolution logic into `utils/routeContext.ts`: - `MinimalRoute` (loose shape sufficient for traversal) - `findDeepestRoute(state)` (walks nested navigators) - `routeToChipContext(route)` (maps route.name → ChipContext) No React imports, no hooks. Trivially unit-testable.

2. New hook `hooks/useAmicusChipContext` subscribes to navigation state with a try/catch guard matching the existing AmicusFab pattern, and returns `ChipContext` directly. Hook-level error handling lives in exactly one place now instead of two components duplicating it.

3. AmicusFab calls `useAmicusChipContext` at the top level (alongside its own nav-safety guards) and passes the resolved context to AmicusPeekSheet as a prop.

4. AmicusPeekSheet becomes a pure presentational component w.r.t. navigation — it accepts `context?: ChipContext` and falls back through `contextOverride → context → { kind: 'none' }`. The former inline `useNavigationContext`, `findDeepestRoute`, and `MinimalRoute` are removed.

Why not go further (context-provider pattern with initial-state-ready detection): the try/catch idiom is already established in this codebase with explicit comments, and React Navigation doesn't expose a clean API for knowing when container state is first populated. The lift-up pattern here gets the testability and single-source-of-truth wins without a ~100-line App.tsx change.

Test coverage:

- `__tests__/utils/routeContext.test.ts` — 16 assertions covering findDeepestRoute (null/empty/linear/nested/three-level/malformed) and routeToChipContext (every recognised route name + every param edge case)

- `__tests__/hooks/useAmicusChipContext.test.tsx` — covers the core value proposition of this refactor: rendering outside NavigationContainer must NOT throw. Three scenarios: no provider, empty NavigationContainer, repeated re-renders.

- Existing `AmicusPeekSheet.test.tsx` tests continue to pass via the `contextOverride` prop. The now-dead `jest.mock('@react-navigation/ native', ...)` block in that file is removed; the sheet no longer imports navigation hooks.

No runtime behaviour change on the happy path. On the error path (fresh boot, pre-nav-container-ready), chips scope to `{ kind: 'none' }` until the next render — same as if the user was on a screen Amicus doesn't recognise.