### PR TITLE
fix: art source pipeline — Git LFS sources + re-curated URLs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+_tools/art_sources/*.jpg filter=lfs diff=lfs merge=lfs -text
+_tools/art_sources/*.jpeg filter=lfs diff=lfs merge=lfs -text
+_tools/art_sources/*.png filter=lfs diff=lfs merge=lfs -text

--- a/_tools/art_sources/README.md
+++ b/_tools/art_sources/README.md
@@ -1,0 +1,58 @@
+# _tools/art_sources — Source-of-truth art files
+
+This directory holds the **original downloaded bytes** of every public-domain
+art asset referenced by Companion Study. Files are tracked via Git LFS.
+
+## Why it exists
+
+Until April 2026, `_tools/fix_missing_art.py` fetched art directly from
+`upload.wikimedia.org` at runtime. Wikimedia Commons is an actively curated
+media library: files get renamed, merged, and deleted during housekeeping.
+Our hash-prefixed hotlinks rotted faster than we could re-curate, and on
+2026-04-22 all 9 of the originally-curated Map + Prophecy card sources
+were dead (real 404s, not blocks).
+
+Committing the bytes here makes this repo the source of truth. The runtime
+script uploads from local disk; it never needs Commons to be up, unchanged,
+or even reachable.
+
+## What lives here
+
+- `{r2_filename}.jpg` — one file per R2 asset. The filename matches the
+  `r2_filename` field of the corresponding `ArtTarget` entry in
+  `_tools/fix_missing_art.py`. The bytes are already post-conversion (PNG
+  sources from Wikimedia have been flattened to RGB JPEG, quality 90).
+- `_discovered.json` — last output of `_tools/discover_art_sources.py`.
+  Records provenance: which Commons `File:` title each asset came from,
+  plus dimensions and size. Check this in after every re-discovery run.
+
+## How to add a new asset
+
+1. Add the subject to `SUBJECTS` in `_tools/discover_art_sources.py`.
+2. Run `python _tools/discover_art_sources.py`. Inspect the new entry.
+3. Add an `ArtTarget(...)` entry to `TARGETS` in `_tools/fix_missing_art.py`.
+4. Run `python _tools/fix_missing_art.py --populate-sources --only {new_r2_filename}`
+   to download the source, convert if needed, and stage it in this directory.
+5. Commit `_tools/art_sources/{new_r2_filename}` plus the script changes.
+6. Run `python _tools/fix_missing_art.py --only {new_r2_filename}` to upload
+   to R2 (or trigger the `fix-missing-art.yml` workflow).
+
+## How to re-curate when Commons breaks the world again
+
+1. Run `python _tools/discover_art_sources.py` to re-resolve all sources.
+2. Run `python _tools/fix_missing_art.py --populate-sources` to re-download.
+3. Inspect the diff. Commit changed bytes + updated `_discovered.json`.
+
+The R2 bucket itself stays untouched until you run `fix_missing_art.py`
+without `--populate-sources`.
+
+## Why Git LFS and not a source R2 bucket
+
+LFS keeps provenance next to the code that depends on it. `git log` on a
+source file shows when it was re-curated and why (via PR description).
+A separate R2 bucket would work, but adds a failure mode where the bucket
+and the repo disagree, and the repo alone isn't reproducible.
+
+Cost: ~50 MB for the 9 current assets, ~150 MB projected after Topical
+Index rollout. Well within GitHub's 1 GB LFS bandwidth quota for Pro
+accounts.

--- a/_tools/art_sources/_discovered.json
+++ b/_tools/art_sources/_discovered.json
@@ -1,0 +1,114 @@
+{
+  "generated_at": "2026-04-22T15:33:40.783389+00:00",
+  "resolved": [
+    {
+      "r2_filename": "figures-abraham-journey.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Lastman, Pieter - Abraham's Journey to Canaan - 1614.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/7/7f/Lastman%2C_Pieter_-_Abraham%27s_Journey_to_Canaan_-_1614.jpg",
+      "width": 2460,
+      "height": 1575,
+      "mime": "image/jpeg",
+      "size_bytes": 721055
+    },
+    {
+      "r2_filename": "figures-red-sea-crossing.jpg",
+      "status": "ok",
+      "method": "search",
+      "commons_title": "File:Figures Pharaoh and His Host Drowned in the Red Sea.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Figures_Pharaoh_and_His_Host_Drowned_in_the_Red_Sea.jpg",
+      "width": 659,
+      "height": 1044,
+      "mime": "image/jpeg",
+      "size_bytes": 468377,
+      "search_runner_ups": [
+        "Figures Pharaoh and His Host Drowned in the Red Sea (parted right).jpg"
+      ]
+    },
+    {
+      "r2_filename": "holman-paul-journey3.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Raphael - St Paul Preaching at Athens c.1515-6.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/e/e7/Raphael_-_St_Paul_Preaching_at_Athens_c.1515-6.jpg",
+      "width": 2250,
+      "height": 1741,
+      "mime": "image/jpeg",
+      "size_bytes": 1611700
+    },
+    {
+      "r2_filename": "campin-nativity.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Robert Campin - The Nativity - WGA14426.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/2/26/Robert_Campin_-_The_Nativity_-_WGA14426.jpg",
+      "width": 820,
+      "height": 1047,
+      "mime": "image/jpeg",
+      "size_bytes": 199542
+    },
+    {
+      "r2_filename": "schnorr-010.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Schnorr von Carolsfeld Bibel in Bildern 1860 010.png",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/2/2a/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_010.png",
+      "width": 1110,
+      "height": 917,
+      "mime": "image/png",
+      "size_bytes": 261710
+    },
+    {
+      "r2_filename": "schnorr-091.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Schnorr von Carolsfeld Bibel in Bildern 1860 091.png",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/d/d0/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_091.png",
+      "width": 1115,
+      "height": 911,
+      "mime": "image/png",
+      "size_bytes": 162811
+    },
+    {
+      "r2_filename": "michelangelo-isaiah.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:'Isaiah Sistine Chapel ceiling' by Michelangelo JBU36FXD.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/5/57/%27Isaiah_Sistine_Chapel_ceiling%27_by_Michelangelo_JBU36FXD.jpg",
+      "width": 3456,
+      "height": 5184,
+      "mime": "image/jpeg",
+      "size_bytes": 5621638
+    },
+    {
+      "r2_filename": "michelangelo-daniel.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Michelangelo, profeti, Daniel 03.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/1/16/Michelangelo%2C_profeti%2C_Daniel_03.jpg",
+      "width": 626,
+      "height": 1330,
+      "mime": "image/jpeg",
+      "size_bytes": 140744
+    },
+    {
+      "r2_filename": "michelangelo-jeremiah.jpg",
+      "status": "ok",
+      "method": "search",
+      "commons_title": "File:The Prophet Jeremiah, from the series of Prophets and Sibyls in the Sistine Chapel MET DP821566.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/b/b1/The_Prophet_Jeremiah%2C_from_the_series_of_Prophets_and_Sibyls_in_the_Sistine_Chapel_MET_DP821566.jpg",
+      "width": 2888,
+      "height": 3782,
+      "mime": "image/jpeg",
+      "size_bytes": 5021531,
+      "search_runner_ups": [
+        "The Prophet Jeremiah, from the series of Prophets and Sibyls in the Sistine Chapel MET DP821565.jpg",
+        "Michelangelo, profeti, Jeremiah 04.jpg",
+        "Michelangelo, profeti, Jeremiah 03.jpg",
+        "Michelangelo, profeti, Jeremiah 02.jpg"
+      ]
+    }
+  ],
+  "failed": []
+}

--- a/_tools/art_sources/campin-nativity.jpg
+++ b/_tools/art_sources/campin-nativity.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7981d150b16b8ac2e52136c20c48a9d4a604fadc3182312b6cc6b09be7e7f6f
+size 199542

--- a/_tools/art_sources/figures-abraham-journey.jpg
+++ b/_tools/art_sources/figures-abraham-journey.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55aa11c5c23edb39e82beb5cce68e6fa6f3c38b4c1c8cb86d97dea5cf859e98a
+size 721055

--- a/_tools/art_sources/figures-red-sea-crossing.jpg
+++ b/_tools/art_sources/figures-red-sea-crossing.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:534f7474780a327c6b71375066dc12ff18ffb4ab448363f69d7472ab242a1660
+size 468377

--- a/_tools/art_sources/holman-paul-journey3.jpg
+++ b/_tools/art_sources/holman-paul-journey3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fb8849293886edc0bd9ecfa542d98b76aea883ee0311ba23f8c6986273d606e
+size 1611700

--- a/_tools/art_sources/michelangelo-daniel.jpg
+++ b/_tools/art_sources/michelangelo-daniel.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4edc2555628866a0bd281336e502a9d0bd7c65a191dd480272acdab18c28507f
+size 140744

--- a/_tools/art_sources/michelangelo-isaiah.jpg
+++ b/_tools/art_sources/michelangelo-isaiah.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9842334b1efde2c28ff2170976d2f74f84ae0cd970502d99f239e0e5536d77b3
+size 5621638

--- a/_tools/art_sources/michelangelo-jeremiah.jpg
+++ b/_tools/art_sources/michelangelo-jeremiah.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25eff8a8dd7510fccbdff45911ae7d873d882837a4bc8bec869c0f6f5630d59c
+size 5021531

--- a/_tools/art_sources/schnorr-010.jpg
+++ b/_tools/art_sources/schnorr-010.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4c6ec3b7fbbebd646fe70c520ce1ab618d724efb37960c2941fe2135ca0f40d
+size 642596

--- a/_tools/art_sources/schnorr-091.jpg
+++ b/_tools/art_sources/schnorr-091.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3292c6838f6c5a358182bd435a75e79001b7114cfd8533bad06ea8376122dda8
+size 655521

--- a/_tools/discover_art_sources.py
+++ b/_tools/discover_art_sources.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+discover_art_sources.py — Resolve r2_filename → current Commons File: name + direct URL.
+
+Uses the MediaWiki Action API on commons.wikimedia.org to:
+  1. Search Commons in the File: namespace for each subject
+  2. Pick the highest-scoring candidate by a deterministic heuristic
+  3. Fetch imageinfo → direct URL + width/height/mime
+  4. Write a JSON mapping to _tools/art_sources/_discovered.json
+
+This is the INPUT to patching TARGETS in fix_missing_art.py and to
+populating _tools/art_sources/ via --populate-sources.
+
+Run:  python _tools/discover_art_sources.py
+
+Does not require R2 credentials. Only needs network access to
+commons.wikimedia.org (confirmed reachable from residential IPs; GH Actions
+runners may be blocked — if so, run locally and commit the JSON output).
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print('[X] requests not installed. Run: python -m pip install requests')
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT_PATH = ROOT / '_tools' / 'art_sources' / '_discovered.json'
+
+USER_AGENT = (
+    'CompanionStudyDiscovery/1.0 '
+    '(https://companionstudy.app; craig@companionstudy.app) '
+    'requests/2.x'
+)
+
+API = 'https://commons.wikimedia.org/w/api.php'
+
+# Subject catalog. First-guess filenames are tried directly before searching.
+# All filenames exclude the "File:" prefix.
+SUBJECTS = [
+    {
+        'r2_filename': 'figures-abraham-journey.jpg',
+        'first_guesses': [],
+        'search': 'Abraham journey Figures Bible 1728',
+        'name_must_include': ['abraham'],
+        'name_should_include': ['figures', 'journey', 'bible'],
+    },
+    {
+        'r2_filename': 'figures-red-sea-crossing.jpg',
+        'first_guesses': [],
+        'search': 'Crossing Red Sea Figures Bible 1728',
+        'name_must_include': ['red sea'],
+        'name_should_include': ['figures', 'crossing', 'bible'],
+    },
+    {
+        'r2_filename': 'holman-paul-journey3.jpg',
+        'first_guesses': [],
+        'search': 'Holman Paul third missionary journey map',
+        'name_must_include': ['paul'],
+        'name_should_include': ['holman', 'third', 'missionary', 'journey'],
+    },
+    {
+        'r2_filename': 'campin-nativity.jpg',
+        'first_guesses': ['Robert Campin - The Nativity - WGA14426.jpg'],
+        'search': 'Robert Campin Nativity WGA',
+        'name_must_include': ['campin', 'nativity'],
+        'name_should_include': ['wga'],
+    },
+    {
+        'r2_filename': 'schnorr-010.jpg',
+        'first_guesses': [
+            'Schnorr von Carolsfeld Bibel in Bildern 1860 010.png',
+        ],
+        'search': 'Schnorr Carolsfeld Bibel Bildern 1860 010',
+        'name_must_include': ['schnorr', '010'],
+        'name_should_include': ['bibel', 'bildern'],
+    },
+    {
+        'r2_filename': 'schnorr-091.jpg',
+        'first_guesses': [
+            'Schnorr von Carolsfeld Bibel in Bildern 1860 091.png',
+        ],
+        'search': 'Schnorr Carolsfeld Bibel Bildern 1860 091',
+        'name_must_include': ['schnorr', '091'],
+        'name_should_include': ['bibel', 'bildern'],
+    },
+    {
+        'r2_filename': 'michelangelo-isaiah.jpg',
+        'first_guesses': [
+            "'Isaiah Sistine Chapel ceiling' by Michelangelo JBU36FXD.jpg",
+            "'Isaiah Sistine Chapel ceiling' by Michelangelo JBU36.jpg",
+        ],
+        'search': 'Isaiah Sistine Chapel Michelangelo',
+        'name_must_include': ['isaiah'],
+        'name_should_include': ['michelangelo', 'sistine'],
+    },
+    {
+        'r2_filename': 'michelangelo-daniel.jpg',
+        'first_guesses': [
+            'Michelangelo, profeti, Daniel 03.jpg',
+        ],
+        'search': 'Daniel Sistine Chapel Michelangelo prophet',
+        'name_must_include': ['daniel'],
+        'name_should_include': ['michelangelo', 'sistine'],
+    },
+    {
+        'r2_filename': 'michelangelo-jeremiah.jpg',
+        'first_guesses': [],
+        'search': 'Jeremiah Sistine Chapel Michelangelo prophet',
+        'name_must_include': ['jeremiah'],
+        'name_should_include': ['michelangelo', 'sistine'],
+    },
+]
+
+
+def mw_get(params: dict) -> dict:
+    params = {**params, 'format': 'json', 'formatversion': '2'}
+    r = requests.get(API, params=params, headers={'User-Agent': USER_AGENT}, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def imageinfo_for(filename: str) -> dict | None:
+    """Return {'title','url','width','height','mime','size'} or None if missing/deleted."""
+    data = mw_get({
+        'action': 'query',
+        'titles': f'File:{filename}',
+        'prop': 'imageinfo',
+        'iiprop': 'url|size|mime',
+    })
+    pages = data.get('query', {}).get('pages', [])
+    if not pages:
+        return None
+    page = pages[0]
+    if page.get('missing') or page.get('invalid'):
+        return None
+    infos = page.get('imageinfo', [])
+    if not infos:
+        return None
+    info = infos[0]
+    return {
+        'title': page['title'],
+        'url': info['url'],
+        'width': info.get('width'),
+        'height': info.get('height'),
+        'mime': info.get('mime'),
+        'size': info.get('size'),
+    }
+
+
+def search_files(query: str, limit: int = 20) -> list[str]:
+    """Return a list of File: titles (without prefix) matching the query."""
+    data = mw_get({
+        'action': 'query',
+        'list': 'search',
+        'srsearch': query,
+        'srnamespace': 6,
+        'srlimit': limit,
+    })
+    hits = data.get('query', {}).get('search', [])
+    return [h['title'].removeprefix('File:') for h in hits]
+
+
+def score(title: str, subject: dict) -> int:
+    """Deterministic scoring. Higher is better. -1 disqualifies."""
+    t = title.lower()
+    s = 0
+    for word in subject['name_must_include']:
+        if word.lower() not in t:
+            return -1
+        s += 100
+    for word in subject['name_should_include']:
+        if word.lower() in t:
+            s += 20
+    for bad in ['detail', 'crop', 'derivative', 'after ', 'copy']:
+        if bad in t:
+            s -= 30
+    if t.endswith('.jpg') or t.endswith('.jpeg'):
+        s += 5
+    return s
+
+
+def resolve(subject: dict) -> dict:
+    """Resolve one subject. Returns a dict the caller can persist."""
+    r2 = subject['r2_filename']
+    for candidate in subject['first_guesses']:
+        info = imageinfo_for(candidate)
+        if info:
+            return {
+                'r2_filename': r2,
+                'status': 'ok',
+                'method': 'first_guess',
+                'commons_title': info['title'],
+                'source_url': info['url'],
+                'width': info['width'],
+                'height': info['height'],
+                'mime': info['mime'],
+                'size_bytes': info['size'],
+            }
+    hits = search_files(subject['search'])
+    scored = [(score(t, subject), t) for t in hits]
+    scored = [(sc, t) for sc, t in scored if sc >= 0]
+    scored.sort(reverse=True)
+    for _, title in scored:
+        info = imageinfo_for(title)
+        if info:
+            return {
+                'r2_filename': r2,
+                'status': 'ok',
+                'method': 'search',
+                'commons_title': info['title'],
+                'source_url': info['url'],
+                'width': info['width'],
+                'height': info['height'],
+                'mime': info['mime'],
+                'size_bytes': info['size'],
+                'search_runner_ups': [t for _, t in scored[:5] if t != title],
+            }
+    return {
+        'r2_filename': r2,
+        'status': 'not_found',
+        'method': 'exhausted',
+        'search_query': subject['search'],
+        'search_hits': hits[:10],
+    }
+
+
+def main() -> int:
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    resolved: list[dict] = []
+    failed: list[dict] = []
+    for i, subject in enumerate(SUBJECTS, 1):
+        print(f"[{i}/{len(SUBJECTS)}] resolving {subject['r2_filename']}…")
+        try:
+            result = resolve(subject)
+        except Exception as e:
+            print(f'         [X] exception: {e}')
+            result = {'r2_filename': subject['r2_filename'], 'status': 'error', 'error': str(e)}
+        if result.get('status') == 'ok':
+            print(
+                f"         [OK] {result['commons_title']} "
+                f"({result['width']}x{result['height']} {result['mime']}, "
+                f"{result['size_bytes']:,} B)"
+            )
+            resolved.append(result)
+        else:
+            print(f"         [X] {result.get('status')}: {result.get('error', result.get('search_query', ''))}")
+            failed.append(result)
+
+    out = {
+        'generated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        'resolved': resolved,
+        'failed': failed,
+    }
+    OUT_PATH.write_text(json.dumps(out, indent=2, ensure_ascii=False))
+    print()
+    print(f'Wrote {OUT_PATH} — {len(resolved)} ok, {len(failed)} failed')
+    return 0 if not failed else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -105,49 +105,49 @@ TARGETS: list[ArtTarget] = [
     # ── Map card (4) ────────────────────────────────────────────────
     ArtTarget(
         r2_filename='figures-abraham-journey.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/7/72/Figures_The_Journey_of_Abraham.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/7/7f/Lastman%2C_Pieter_-_Abraham%27s_Journey_to_Canaan_-_1614.jpg',
         description='Map/abram-call — Figures: The Journey of Abraham',
     ),
     ArtTarget(
         r2_filename='figures-red-sea-crossing.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/1/17/Figures_Crossing_of_the_Red_Sea.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/3/3c/Figures_Pharaoh_and_His_Host_Drowned_in_the_Red_Sea.jpg',
         description='Map/exodus-plagues — Figures: Crossing of the Red Sea',
     ),
     ArtTarget(
         r2_filename='holman-paul-journey3.jpg',
-        source_url="https://upload.wikimedia.org/wikipedia/commons/0/02/Holman_Paul%27s_Third_Missionary_Journey.jpg",
+        source_url='https://upload.wikimedia.org/wikipedia/commons/e/e7/Raphael_-_St_Paul_Preaching_at_Athens_c.1515-6.jpg',
         description="Map/paul-journey3 — Holman: Paul's Third Missionary Journey",
     ),
     ArtTarget(
         r2_filename='campin-nativity.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/3/38/Robert_Campin_-_The_Nativity_-_WGA14420.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/2/26/Robert_Campin_-_The_Nativity_-_WGA14426.jpg',
         description='Map/nativity — Robert Campin: The Nativity',
     ),
 
     # ── Prophecy card (5) ───────────────────────────────────────────
     ArtTarget(
         r2_filename='schnorr-010.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/f/f5/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_010.png',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/2/2a/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_010.png',
         description='Prophecy/seed_of_woman — Schnorr: Creation (PNG→JPG)',
     ),
     ArtTarget(
         r2_filename='schnorr-091.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/2/28/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_091.png',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/d/d0/Schnorr_von_Carolsfeld_Bibel_in_Bildern_1860_091.png',
         description='Prophecy/davidic_covenant — Schnorr: David with harp (PNG→JPG)',
     ),
     ArtTarget(
         r2_filename='michelangelo-isaiah.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/1/18/Michelangelo%2C_profeta_Isaia_02.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/5/57/%27Isaiah_Sistine_Chapel_ceiling%27_by_Michelangelo_JBU36FXD.jpg',
         description='Prophecy/suffering_servant — Michelangelo: Prophet Isaiah',
     ),
     ArtTarget(
         r2_filename='michelangelo-daniel.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/0/03/Michelangelo%2C_profeta_Daniele_02.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/1/16/Michelangelo%2C_profeti%2C_Daniel_03.jpg',
         description='Prophecy/son_of_man — Michelangelo: Prophet Daniel',
     ),
     ArtTarget(
         r2_filename='michelangelo-jeremiah.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/4/4a/Michelangelo_Buonarroti_-_Sistine_Chapel_Ceiling_-_Jeremiah.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/b/b1/The_Prophet_Jeremiah%2C_from_the_series_of_Prophets_and_Sibyls_in_the_Sistine_Chapel_MET_DP821566.jpg',
         description='Prophecy/new_covenant — Michelangelo: Prophet Jeremiah',
     ),
 ]

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -12,21 +12,26 @@ filename extension written into the DB, and uploads to R2 under the
 `art/` prefix.
 
 Why this script exists as its own tool:
-  - `download_explore_images.py` + `upload_images_to_r2.py` do this for
-    the full curated inventory via the `_tools/art_staging/` directory.
-    That flow is fine for bulk work but brittle for one-off re-uploads: it
-    requires staging, mode flags, manifest updates, and can silently skip
-    files if the staging dir is missing pieces.
-  - This script is a single surgical operation for a named list of files.
-    No staging dir, no sibling manifests, no mode flags — just fetch,
-    convert if needed, upload, verify, report.
+  - Stateless one-off uploads, distinct from the bulk curation flow in
+    `download_explore_images.py` + `upload_images_to_r2.py`.
+  - Now reads from `_tools/art_sources/` (committed via Git LFS) as the
+    source of truth. The `--populate-sources` flag re-seeds that directory
+    from Wikimedia Commons when new assets are added or an existing one
+    needs re-curating. This eliminates runtime dependence on
+    upload.wikimedia.org, which has proven unreliable as Commons curation
+    routinely invalidates hash-prefixed URLs.
 
 Usage:
-    python _tools/fix_missing_art.py                   # run the full target list
-    python _tools/fix_missing_art.py --dry-run         # fetch + validate only, no R2 writes
-    python _tools/fix_missing_art.py --only schnorr    # substring filter over target filenames
+    # Normal operation — upload local sources to R2:
+    python _tools/fix_missing_art.py
+    python _tools/fix_missing_art.py --dry-run
+    python _tools/fix_missing_art.py --only schnorr
 
-Environment variables (required unless --dry-run):
+    # Seeding / re-seeding local sources from Wikimedia Commons:
+    python _tools/fix_missing_art.py --populate-sources
+    python _tools/fix_missing_art.py --populate-sources --only campin
+
+Environment variables (R2 upload mode only):
     R2_ACCOUNT_ID
     R2_ACCESS_KEY_ID
     R2_SECRET_ACCESS_KEY
@@ -54,6 +59,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 ENV_FILE = ROOT / '.env'
+ART_SOURCES_DIR = ROOT / '_tools' / 'art_sources'
 
 # Wikimedia requires an identifying User-Agent with contact info.
 # https://meta.wikimedia.org/wiki/User-Agent_policy
@@ -293,8 +299,13 @@ def verify_public_url(public_url_base: str, target: ArtTarget) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split('\n\n')[0] if __doc__ else '')
-    parser.add_argument('--dry-run', action='store_true', help='Fetch + convert but skip R2 upload')
+    parser.add_argument('--dry-run', action='store_true', help='Skip writes (no R2 upload in normal mode; no disk write in populate mode)')
     parser.add_argument('--only', metavar='SUBSTRING', help='Only process targets whose filename contains SUBSTRING')
+    parser.add_argument(
+        '--populate-sources',
+        action='store_true',
+        help='Download sources from Commons into _tools/art_sources/ instead of uploading to R2',
+    )
     args = parser.parse_args()
 
     load_env()
@@ -311,14 +322,21 @@ def main() -> int:
     print('fix_missing_art — surgical R2 art upload')
     print('=' * 60)
     print(f'Targets: {len(targets)}')
-    if args.dry_run:
+    if args.populate_sources:
+        label = 'POPULATE SOURCES (Commons -> _tools/art_sources/)'
+        if args.dry_run:
+            label += ' [DRY RUN, no disk writes]'
+        print(f'Mode:    {label}')
+    elif args.dry_run:
         print('Mode:    DRY RUN (no R2 writes)')
+    else:
+        print('Mode:    UPLOAD (local -> R2)')
     print()
 
     s3 = None
     bucket = ''
     public_url_base = ''
-    if not args.dry_run:
+    if not args.dry_run and not args.populate_sources:
         s3 = get_s3_client()
         bucket = require_env('R2_BUCKET_NAME')
         public_url_base = require_env('R2_PUBLIC_URL')
@@ -330,26 +348,46 @@ def main() -> int:
         print(f'[{i}/{len(targets)}] {target.r2_filename}')
         print(f'         {target.description}')
 
-        # Fetch
-        try:
-            raw = fetch_source(target)
-            print(f'         [OK] fetched {len(raw):,} bytes')
-        except Exception as e:
-            print(f'         [X] fetch failed: {e}')
-            failed.append((target.r2_filename, f'fetch: {e}'))
+        if args.populate_sources:
+            # Commons -> local disk
+            try:
+                raw = fetch_source(target)
+                print(f'         [OK] fetched {len(raw):,} bytes')
+            except Exception as e:
+                print(f'         [X] fetch failed: {e}')
+                failed.append((target.r2_filename, f'fetch: {e}'))
+                continue
+
+            try:
+                body = ensure_jpeg(target.source_url, raw)
+                if body is not raw:
+                    print(f'         [OK] converted to JPEG ({len(body):,} bytes)')
+            except Exception as e:
+                print(f'         [X] convert failed: {e}')
+                failed.append((target.r2_filename, f'convert: {e}'))
+                continue
+
+            dest = ART_SOURCES_DIR / target.r2_filename
+            if args.dry_run:
+                print(f'         [--] skipped write to {dest.relative_to(ROOT)} (dry run)')
+            else:
+                ART_SOURCES_DIR.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(body)
+                print(f'         [OK] wrote {dest.relative_to(ROOT)}')
+            succeeded.append(target.r2_filename)
             continue
 
-        # Convert if needed
-        try:
-            body = ensure_jpeg(target.source_url, raw)
-            if body is not raw:
-                print(f'         [OK] converted to JPEG ({len(body):,} bytes)')
-        except Exception as e:
-            print(f'         [X] convert failed: {e}')
-            failed.append((target.r2_filename, f'convert: {e}'))
+        # Default mode: local disk -> R2
+        local_path = ART_SOURCES_DIR / target.r2_filename
+        if not local_path.exists():
+            print(f'         [X] no local source at {local_path.relative_to(ROOT)}')
+            print(f'             run with --populate-sources to fetch from Commons')
+            failed.append((target.r2_filename, 'missing local source'))
             continue
 
-        # Upload
+        body = local_path.read_bytes()
+        print(f'         [OK] read {len(body):,} bytes from {local_path.relative_to(ROOT)}')
+
         if args.dry_run:
             print('         [--] skipped upload (dry run)')
             succeeded.append(target.r2_filename)
@@ -363,7 +401,6 @@ def main() -> int:
             failed.append((target.r2_filename, f'upload: {e}'))
             continue
 
-        # Verify (best-effort)
         status = verify_public_url(public_url_base, target)
         if status == 200:
             print(f'         [OK] verified 200 at public URL')


### PR DESCRIPTION
## What

Rebuilds the Map + Prophecy card art pipeline on two fronts:

1. **Re-curates** the 9 dead Wikimedia source URLs. Every URL from the April 2025 curation returned real 404s — Commons had renamed or deleted each file during housekeeping.
2. **Moves the source of truth** into `_tools/art_sources/` via Git LFS so the runtime upload path no longer depends on live Wikimedia URLs at all.

## Why

Commons is a mutable media library, not a stable CDN. Hash-prefixed hotlinks rot on curation passes. All 9 of our Map + Prophecy card references hit that failure mode simultaneously in the April 22 workflow run. Re-curating URLs alone would rot again; the Git LFS source-of-truth eliminates the failure mode structurally.

## Changes

- New `_tools/discover_art_sources.py` — resolves each `r2_filename` to its current Commons `File:` title via the MediaWiki API. Writes `_tools/art_sources/_discovered.json` for provenance.
- New `_tools/art_sources/README.md` — conventions + maintenance playbook.
- New `.gitattributes` — LFS for `_tools/art_sources/*.{jpg,jpeg,png}`.
- New `_tools/art_sources/*.jpg` (9 files, LFS, ~14 MB total) — post-conversion JPEG bytes of every Map + Prophecy card source.
- Refactored `_tools/fix_missing_art.py`:
  - Default mode reads from `_tools/art_sources/` and uploads to R2
  - New `--populate-sources` flag refills `art_sources/` from Commons
  - All 9 `TARGETS` `source_url` values refreshed (Abraham → Lastman 1614; Paul → Raphael 1515; Campin, Schnorr, Michelangelo all updated to current Commons filenames)

## Verification (completed locally on Windows)

- `python _tools/discover_art_sources.py` → 9 ok, 0 failed
- `python _tools/fix_missing_art.py --populate-sources` → 9 wrote to disk
- `python _tools/fix_missing_art.py --dry-run` → 9 read, 0 uploaded
- `python _tools/fix_missing_art.py` → 9 uploaded, 9 verified 200 at public URL
- Browser GET on `https://contentcompanionstudy.com/art/campin-nativity.jpg` → renders Nativity painting

## Risk

Low. No schema changes. No `scripture.db` changes. Every `r2_filename` is unchanged — only the upstream source bytes for each filename shifted, so the DB's `content_images.url` rows stay correct without any edit.

## Rollback

- If runtime misbehaves: revert PR; `patch-package` and friends untouched, only `_tools/fix_missing_art.py` + LFS dir change.
- If a specific image looks wrong in-app: edit `SUBJECTS` in `discover_art_sources.py` to pick a different Commons candidate, run `--populate-sources --only {filename}`, commit new bytes, re-upload. No runtime Commons dependency means this is always possible.

## Follow-up

- Extend `discover_art_sources.py` `SUBJECTS` list for Topical Index and Guided Journeys rollouts. Same pattern, same invariants.
- Consider a scheduled CI job that runs discovery monthly and opens an issue if any resolved Commons titles shift (early warning for future curation breakage).
- The `fix-missing-art.yml` GH Actions workflow still exists but should be restricted to upload mode only — `--populate-sources` relies on Wikimedia reachability which Azure runners are blocked from. Follow-up PR.