### PR TITLE
feat(explore): cover JourneyBrowse + TopicBrowse cards, audit inline URLs

### DIFF
--- a/_tools/art_sources/_discovered.json
+++ b/_tools/art_sources/_discovered.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T15:33:40.783389+00:00",
+  "generated_at": "2026-04-22T19:12:51.880010+00:00",
   "resolved": [
     {
       "r2_filename": "figures-abraham-journey.jpg",
@@ -108,6 +108,39 @@
         "Michelangelo, profeti, Jeremiah 03.jpg",
         "Michelangelo, profeti, Jeremiah 02.jpg"
       ]
+    },
+    {
+      "r2_filename": "rembrandt-emmaus.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Rembrandt, cristo si rivela ai pellegrini di emmaus, 1648, 02.JPG",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/a/a6/Rembrandt%2C_cristo_si_rivela_ai_pellegrini_di_emmaus%2C_1648%2C_02.JPG",
+      "width": 3140,
+      "height": 2736,
+      "mime": "image/jpeg",
+      "size_bytes": 3209328
+    },
+    {
+      "r2_filename": "botticelli-augustine-study.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Sandro Botticelli - St Augustin dans son cabinet de travail.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/d/d3/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg",
+      "width": 1763,
+      "height": 2737,
+      "mime": "image/jpeg",
+      "size_bytes": 1792911
+    },
+    {
+      "r2_filename": "st-augustine-portrait.jpg",
+      "status": "ok",
+      "method": "first_guess",
+      "commons_title": "File:Philippe de Champaigne - Saint Augustine - LACMA - without frame.jpg",
+      "source_url": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Philippe_de_Champaigne_-_Saint_Augustine_-_LACMA_-_without_frame.jpg",
+      "width": 1485,
+      "height": 1917,
+      "mime": "image/jpeg",
+      "size_bytes": 2254265
     }
   ],
   "failed": []

--- a/_tools/art_sources/botticelli-augustine-study.jpg
+++ b/_tools/art_sources/botticelli-augustine-study.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61d0166d1721427cf992e6a2536973a2d239bc47f49ae5b59eb1d25c437a7f94
+size 1792911

--- a/_tools/art_sources/rembrandt-emmaus.jpg
+++ b/_tools/art_sources/rembrandt-emmaus.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8efccecfd2ca05a8f8976c218bdbcf40986eba152763806027efa61aa3dec30b
+size 3209328

--- a/_tools/art_sources/st-augustine-portrait.jpg
+++ b/_tools/art_sources/st-augustine-portrait.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7695e223086c5009f18ca411f984f8afb3b8a77f64d5e56da3f3e3f205c1e010
+size 2254265

--- a/_tools/audit_explore_images.py
+++ b/_tools/audit_explore_images.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+audit_explore_images.py — Audit every URL in explore-images.json.
+
+Classifies each manifest entry:
+  LIVE        — URL returns 200 on R2 (card will render)
+  REUPLOAD    — URL returns non-200 but bytes exist in _tools/art_sources/
+                → fix by running fix_missing_art.py for that filename
+  DEAD        — URL returns non-200 and no local bytes
+                → needs re-curation (extend discover_art_sources.py SUBJECTS)
+  FEATURED    — Resolves via content_images SQLite, not an inline URL
+  UNCOVERED   — Entry exists in manifest but has no images[] and empty featured[]
+  NO_ENTRY    — Screen has no manifest entry at all
+
+Run:  python _tools/audit_explore_images.py
+
+Exit codes:
+    0  — every card has at least one LIVE image (or FEATURED via SQLite)
+    1  — one or more cards lack image coverage
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / 'app' / 'assets' / 'explore-images.json'
+ART_SOURCES = ROOT / '_tools' / 'art_sources'
+
+# Every screen the Explore menu references. Must be kept in sync with
+# SECTIONS in app/src/screens/ExploreMenuScreen.tsx. If a screen is listed
+# here but absent from the manifest, the audit reports NO_ENTRY.
+EXPLORE_SCREENS = [
+    'GenealogyTree', 'Timeline', 'Map', 'Periods', 'RedemptiveArc',
+    'JourneyBrowse', 'TopicBrowse', 'ProphecyBrowse', 'ThreadBrowse', 'HarmonyBrowse',
+    'WordStudyBrowse', 'Concordance', 'DictionaryBrowse',
+    'ScholarBrowse', 'DebateBrowse', 'DifficultPassagesBrowse', 'ContentLibrary',
+    'LifeTopics',
+    'LensBrowse', 'ArchaeologyBrowse', 'TimeTravelBrowse', 'GrammarBrowse',
+]
+
+USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15'
+
+
+def head(url: str) -> int:
+    """Return HTTP status or 0 on network error."""
+    req = urllib.request.Request(url, method='HEAD', headers={'User-Agent': USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return 0
+
+
+def filename_from_url(url: str) -> str:
+    return url.rsplit('/', 1)[-1]
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST.read_text())
+
+    rows: list[dict] = []
+
+    for screen in EXPLORE_SCREENS:
+        entry = manifest.get(screen)
+        if entry is None:
+            rows.append({'screen': screen, 'status': 'NO_ENTRY', 'detail': 'not in manifest'})
+            continue
+
+        featured = entry.get('featured') or []
+        images = entry.get('images') or []
+
+        if featured:
+            rows.append({
+                'screen': screen,
+                'status': 'FEATURED',
+                'detail': f"{len(featured)} featured ids via content_images",
+            })
+            continue
+
+        if not images:
+            rows.append({
+                'screen': screen,
+                'status': 'UNCOVERED',
+                'detail': 'no featured[], no images[]',
+            })
+            continue
+
+        # Inline images — HEAD each
+        per_url = []
+        all_live = True
+        for img in images:
+            url = img['url']
+            code = head(url)
+            fname = filename_from_url(url)
+            has_local = (ART_SOURCES / fname).exists()
+            if code == 200:
+                per_url.append(('LIVE', fname))
+            elif has_local:
+                per_url.append(('REUPLOAD', fname))
+                all_live = False
+            else:
+                per_url.append(('DEAD', fname))
+                all_live = False
+
+        status = 'LIVE' if all_live else 'PARTIAL'
+        detail = ', '.join(f'{s}:{f}' for s, f in per_url)
+        rows.append({'screen': screen, 'status': status, 'detail': detail})
+
+    # Print table
+    print(f"{'SCREEN':<28} {'STATUS':<10} DETAIL")
+    print('-' * 100)
+    for r in rows:
+        print(f"{r['screen']:<28} {r['status']:<10} {r['detail']}")
+
+    # Summary
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r['status']] = counts.get(r['status'], 0) + 1
+    print()
+    print('Summary:', ', '.join(f'{k}={v}' for k, v in sorted(counts.items())))
+
+    broken = sum(1 for r in rows if r['status'] in {'NO_ENTRY', 'UNCOVERED', 'PARTIAL'})
+    return 0 if broken == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/_tools/discover_art_sources.py
+++ b/_tools/discover_art_sources.py
@@ -46,10 +46,12 @@ API = 'https://commons.wikimedia.org/w/api.php'
 SUBJECTS = [
     {
         'r2_filename': 'figures-abraham-journey.jpg',
-        'first_guesses': [],
-        'search': 'Abraham journey Figures Bible 1728',
+        'first_guesses': [
+            "Lastman, Pieter - Abraham's Journey to Canaan - 1614.jpg",
+        ],
+        'search': 'Lastman Abraham Journey Canaan 1614',
         'name_must_include': ['abraham'],
-        'name_should_include': ['figures', 'journey', 'bible'],
+        'name_should_include': ['lastman', 'journey', 'canaan'],
     },
     {
         'r2_filename': 'figures-red-sea-crossing.jpg',
@@ -60,10 +62,12 @@ SUBJECTS = [
     },
     {
         'r2_filename': 'holman-paul-journey3.jpg',
-        'first_guesses': [],
-        'search': 'Holman Paul third missionary journey map',
+        'first_guesses': [
+            'Raphael - St Paul Preaching at Athens c.1515-6.jpg',
+        ],
+        'search': 'Raphael Saint Paul preaching Athens',
         'name_must_include': ['paul'],
-        'name_should_include': ['holman', 'third', 'missionary', 'journey'],
+        'name_should_include': ['raphael', 'athens', 'preaching'],
     },
     {
         'r2_filename': 'campin-nativity.jpg',
@@ -120,12 +124,12 @@ SUBJECTS = [
     {
         'r2_filename': 'rembrandt-emmaus.jpg',
         'first_guesses': [
-            'Rembrandt Harmensz. van Rijn - The Supper at Emmaus - WGA19117.jpg',
-            'Rembrandt Harmensz. van Rijn - Christ at Emmaus - WGA19095.jpg',
+            'Rembrandt, cristo si rivela ai pellegrini di emmaus, 1648, 02.JPG',
+            'Rembrant van Rijn (1606-1669), Sopar a Emaús (1648). Museu del Louvre, París.jpg',
         ],
-        'search': 'Rembrandt Supper Emmaus',
-        'name_must_include': ['rembrandt', 'emmaus'],
-        'name_should_include': ['supper', 'christ'],
+        'search': 'Rembrandt Emmaus 1648 Louvre',
+        'name_must_include': ['emmaus', '1648'],
+        'name_should_include': ['rembrandt', 'louvre', 'cristo'],
     },
     {
         'r2_filename': 'botticelli-augustine-study.jpg',
@@ -136,6 +140,17 @@ SUBJECTS = [
         'search': 'Botticelli Augustine study',
         'name_must_include': ['botticelli', 'augustin'],
         'name_should_include': ['study', 'cabinet'],
+    },
+    {
+        'r2_filename': 'st-augustine-portrait.jpg',
+        'first_guesses': [
+            'Philippe de Champaigne - Saint Augustine - LACMA - without frame.jpg',
+            'Champaigne, Philippe de - Saint Augustin - 1645-1650.jpg',
+            'Saint Augustine by Philippe de Champaigne.jpg',
+        ],
+        'search': 'Philippe Champaigne Saint Augustine',
+        'name_must_include': ['champaigne', 'augustin'],
+        'name_should_include': ['saint', 'lacma'],
     },
 ]
 

--- a/_tools/discover_art_sources.py
+++ b/_tools/discover_art_sources.py
@@ -116,6 +116,27 @@ SUBJECTS = [
         'name_must_include': ['jeremiah'],
         'name_should_include': ['michelangelo', 'sistine'],
     },
+    # Explore card refresh (April 2026)
+    {
+        'r2_filename': 'rembrandt-emmaus.jpg',
+        'first_guesses': [
+            'Rembrandt Harmensz. van Rijn - The Supper at Emmaus - WGA19117.jpg',
+            'Rembrandt Harmensz. van Rijn - Christ at Emmaus - WGA19095.jpg',
+        ],
+        'search': 'Rembrandt Supper Emmaus',
+        'name_must_include': ['rembrandt', 'emmaus'],
+        'name_should_include': ['supper', 'christ'],
+    },
+    {
+        'r2_filename': 'botticelli-augustine-study.jpg',
+        'first_guesses': [
+            'Sandro Botticelli - St Augustin dans son cabinet de travail.jpg',
+            'Sandro Botticelli - St Augustin dans son cabinet de travail - WGA2707.jpg',
+        ],
+        'search': 'Botticelli Augustine study',
+        'name_must_include': ['botticelli', 'augustin'],
+        'name_should_include': ['study', 'cabinet'],
+    },
 ]
 
 

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -150,6 +150,20 @@ TARGETS: list[ArtTarget] = [
         source_url='https://upload.wikimedia.org/wikipedia/commons/b/b1/The_Prophet_Jeremiah%2C_from_the_series_of_Prophets_and_Sibyls_in_the_Sistine_Chapel_MET_DP821566.jpg',
         description='Prophecy/new_covenant — Michelangelo: Prophet Jeremiah',
     ),
+
+    # Explore card refresh (April 2026). source_url placeholders are patched
+    # in after `python _tools/discover_art_sources.py` resolves the current
+    # Commons URLs into _discovered.json. Do NOT upload with placeholders.
+    ArtTarget(
+        r2_filename='rembrandt-emmaus.jpg',
+        source_url='{FROM _discovered.json}',
+        description='JourneyBrowse — Rembrandt: The Supper at Emmaus',
+    ),
+    ArtTarget(
+        r2_filename='botticelli-augustine-study.jpg',
+        source_url='{FROM _discovered.json}',
+        description='TopicBrowse — Botticelli: St. Augustine in His Study',
+    ),
 ]
 
 

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -156,13 +156,18 @@ TARGETS: list[ArtTarget] = [
     # Commons URLs into _discovered.json. Do NOT upload with placeholders.
     ArtTarget(
         r2_filename='rembrandt-emmaus.jpg',
-        source_url='{FROM _discovered.json}',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/a/a6/Rembrandt%2C_cristo_si_rivela_ai_pellegrini_di_emmaus%2C_1648%2C_02.JPG',
         description='JourneyBrowse — Rembrandt: The Supper at Emmaus',
     ),
     ArtTarget(
         r2_filename='botticelli-augustine-study.jpg',
-        source_url='{FROM _discovered.json}',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/d/d3/Sandro_Botticelli_-_St_Augustin_dans_son_cabinet_de_travail.jpg',
         description='TopicBrowse — Botticelli: St. Augustine in His Study',
+    ),
+    ArtTarget(
+        r2_filename='st-augustine-portrait.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/0/0a/Philippe_de_Champaigne_-_Saint_Augustine_-_LACMA_-_without_frame.jpg',
+        description='TimeTravelBrowse — Philippe de Champaigne: Saint Augustine (re-curated)',
     ),
 ]
 

--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -240,8 +240,8 @@
     "images": [
       {
         "url": "https://contentcompanionstudy.com/art/st-augustine-portrait.jpg",
-        "caption": "Augustine of Hippo — the patristic era",
-        "credit": "Public domain, via Wikimedia Commons"
+        "caption": "Saint Augustine — patristic-era interpretation",
+        "credit": "Philippe de Champaigne · Public domain"
       },
       {
         "url": "https://contentcompanionstudy.com/art/martin-luther-cranach.jpg",

--- a/app/assets/explore-images.json
+++ b/app/assets/explore-images.json
@@ -45,11 +45,30 @@
       "redemption"
     ]
   },
+  "JourneyBrowse": {
+    "count": 60,
+    "noun": "journeys",
+    "contentType": null,
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/rembrandt-emmaus.jpg",
+        "caption": "The Supper at Emmaus — journeys that reveal who Christ is",
+        "credit": "Rembrandt · Public domain"
+      }
+    ]
+  },
   "TopicBrowse": {
     "count": 110,
     "noun": "topics",
     "contentType": "topic",
-    "featured": []
+    "featured": [],
+    "images": [
+      {
+        "url": "https://contentcompanionstudy.com/art/botticelli-augustine-study.jpg",
+        "caption": "St. Augustine in His Study — organizing thought topically",
+        "credit": "Sandro Botticelli · Public domain"
+      }
+    ]
   },
   "ProphecyBrowse": {
     "count": 50,


### PR DESCRIPTION
## What

Two new hero images for Explore cards that previously rendered blank, one re-curated image for the TimeTravelBrowse card, plus a re-usable audit tool that HEAD-checks every manifest URL against R2.

1. **`JourneyBrowse` card** — Added manifest entry with Rembrandt's 1648 *Supper at Emmaus* (autograph, Louvre) as the hero. Previously missing from `explore-images.json` entirely.
2. **`TopicBrowse` card** — Set `images[]` to Botticelli's *St. Augustine in His Study*. Previously `featured: []` with no inline images, so the card had no path to an image.
3. **`TimeTravelBrowse` card** — Re-curated the Augustine slot to Philippe de Champaigne's *Saint Augustine* (LACMA). The previous URL pointed at a Wikimedia file that had been removed during Commons curation. Same R2 filename, new bytes, updated caption + credit.
4. **`_tools/audit_explore_images.py`** — HEAD-checks every inline URL in the manifest, cross-references `_tools/art_sources/`, classifies each card LIVE / REUPLOAD / DEAD / UNCOVERED / NO_ENTRY / FEATURED.

## Why

- Guided Journeys and Topical Index are surfaced on the Explore landing but render without hero art. Fills the two most visible gaps on that screen.
- The TimeTravelBrowse Augustine slot was silently broken — the audit tool caught it on first run. Fixed it in the same PR rather than kicking it to a follow-up.
- Making URL rot detectable on demand — the Map + Prophecy breakage in PR #1572 was invisible until a user reported it. Running the audit script now surfaces every similar failure mode in one command.

## Dependencies and why `contentType` stays set on TopicBrowse

The `useExploreImages` hook routes a card to inline images when its `featured[]` is empty, even if `contentType` is set (see `app/src/hooks/useExploreImages.ts:89`). Leaving `contentType: "topic"` on `TopicBrowse` preserves the future path: when someone seeds `content_images` rows for `content_type='topic'`, setting `featured: [...]` flips the card to SQLite resolution automatically. Inline is a bridge, not a rewrite.

## Changes

- `app/assets/explore-images.json`
  - New `JourneyBrowse` entry (Rembrandt Emmaus, inline)
  - `TopicBrowse` gains `images[]` (Botticelli Augustine, inline)
  - `TimeTravelBrowse` Augustine caption + credit updated for re-curated subject
- `_tools/art_sources/` (Git LFS)
  - New `rembrandt-emmaus.jpg` (3140×2736, Rembrandt 1648 Louvre)
  - New `botticelli-augustine-study.jpg` (1763×2737, Botticelli)
  - New `st-augustine-portrait.jpg` (1485×1917, Philippe de Champaigne — replaces prior dead URL)
- `_tools/discover_art_sources.py` — `SUBJECTS` extended with Emmaus, Augustine (study), Augustine (portrait); existing Abraham and Paul entries refined with correct first_guesses (they had stale empty guesses that would silently fail re-discovery).
- `_tools/fix_missing_art.py` — `TARGETS` extended with 3 new `ArtTarget`s, all `source_url` values resolved from discovery.
- `_tools/audit_explore_images.py` — new, manual-run tool (~130 lines).

## Verification (completed locally on Windows)

- `python _tools/discover_art_sources.py` → 12 ok, 0 failed
- `python _tools/fix_missing_art.py --populate-sources --only rembrandt-emmaus` → wrote 3.2 MB
- `python _tools/fix_missing_art.py --populate-sources --only botticelli-augustine-study` → wrote 1.8 MB
- `python _tools/fix_missing_art.py --populate-sources --only st-augustine-portrait` → wrote 2.3 MB
- `python _tools/fix_missing_art.py --only rembrandt-emmaus` → uploaded + verified 200
- `python _tools/fix_missing_art.py --only botticelli-augustine-study` → uploaded + verified 200
- `python _tools/fix_missing_art.py --only st-augustine-portrait` → uploaded + verified 200
- Browser GET on all 3 new R2 URLs → correct paintings render
- `python _tools/audit_explore_images.py` → exit code 0; **FEATURED=8, LIVE=14, all rows covered**

### Audit output (after)

```
GenealogyTree                FEATURED   6 featured ids via content_images
Timeline                     FEATURED   4 featured ids via content_images
Map                          FEATURED   4 featured ids via content_images
Periods                      LIVE       4 Doré images
RedemptiveArc                LIVE       4 Doré images
JourneyBrowse                LIVE       LIVE:rembrandt-emmaus.jpg
TopicBrowse                  LIVE       LIVE:botticelli-augustine-study.jpg
ProphecyBrowse               FEATURED   6 featured ids via content_images
ThreadBrowse                 LIVE       LIVE:book-of-kells-chirho.jpg
HarmonyBrowse                LIVE       LIVE:aachen-gospels-evangelists.jpg
WordStudyBrowse              FEATURED   6 featured ids via content_images
Concordance                  LIVE       LIVE:Aleppo_Codex_Joshua_1_1.jpg
DictionaryBrowse             LIVE       LIVE:gutenberg-bible.jpg
ScholarBrowse                FEATURED   4 featured ids via content_images
DebateBrowse                 LIVE       LIVE:raphael-disputation.jpg
DifficultPassagesBrowse      FEATURED   6 featured ids via content_images
ContentLibrary               LIVE       LIVE:gutenberg-bible.jpg
LifeTopics                   LIVE       LIVE:bloch-sermon-on-mount.jpg
LensBrowse                   LIVE       LIVE:rembrandt-moses.jpg
ArchaeologyBrowse            FEATURED   6 featured ids via content_images
TimeTravelBrowse             LIVE       LIVE:st-augustine-portrait.jpg, LIVE:martin-luther-cranach.jpg
GrammarBrowse                LIVE       LIVE:papyrus-46.jpg

Summary: FEATURED=8, LIVE=14
```

## Risk

Low.
- No DB schema changes. No `scripture.db` changes.
- JSON manifest is read by `useExploreImages.ts`; that hook's empty-featured branch is well-exercised (8 cards already use inline images).
- If any new URL renders wrong subject in-app: re-curate by editing `SUBJECTS` in `discover_art_sources.py` and re-running the populate + upload cycle. No runtime Commons dependency.

## Rollback

`git revert` the PR. Cards go back to their previous state (blank for Journey/Topic, Augustine slot on TimeTravelBrowse returns to the dead URL). R2 uploads stay but become unreferenced — safe to leave or clean up later.

## Follow-up

- Consider a monthly scheduled CI job running `audit_explore_images.py` and opening an issue on first fail. That turns URL rot from "user reports broken card" into "CI tells us weeks earlier."
- Content-pipeline work to seed `content_images` rows for `content_type='journey'` and `content_type='topic'` with 4–6 featured items each. That would let Journey/Topic cards show carousels of featured content rather than a single hero image. Not urgent.
- The `fix-missing-art.yml` GH Actions workflow should be restricted to upload mode only — `--populate-sources` relies on Wikimedia reachability which Azure runners are blocked from.