### PR TITLE
fix: sticky headers + 2-line title wrap on detail screens

### DIFF
--- a/app/src/components/ScreenHeader.tsx
+++ b/app/src/components/ScreenHeader.tsx
@@ -48,7 +48,7 @@ export function ScreenHeader({ title, subtitle, onBack, style, titleColor, backL
       <View style={styles.textWrap}>
         <View style={[styles.goldBar, { backgroundColor: resolvedTitleColor }]} />
         <View style={styles.titleTextWrap}>
-          <Text style={[styles.title, { color: resolvedTitleColor }]} numberOfLines={1} accessibilityRole="header">{title}</Text>
+          <Text style={[styles.title, { color: resolvedTitleColor }]} numberOfLines={2} accessibilityRole="header">{title}</Text>
           {subtitle ? (
             <Text style={[styles.subtitle, { color: base.textMuted }]}>{subtitle}</Text>
           ) : null}

--- a/app/src/screens/ArchaeologyDetailScreen.tsx
+++ b/app/src/screens/ArchaeologyDetailScreen.tsx
@@ -74,13 +74,13 @@ function ArchaeologyDetailScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]} edges={['top']}>
+      <DetailHeroHeader
+        title={discovery.name}
+        subtitle={discovery.location ?? undefined}
+        imageUrl={heroImage}
+        onBack={() => navigation.goBack()}
+      />
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
-        <DetailHeroHeader
-          title={discovery.name}
-          subtitle={discovery.location ?? undefined}
-          imageUrl={heroImage}
-          onBack={() => navigation.goBack()}
-        />
 
         <View style={styles.body}>
           {/* Metadata pill row */}

--- a/app/src/screens/JourneyDetailScreen.tsx
+++ b/app/src/screens/JourneyDetailScreen.tsx
@@ -78,13 +78,14 @@ function JourneyDetailScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title={journey.title}
           subtitle={journey.subtitle ?? undefined}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
 
         {/* Metadata row */}
         <View style={styles.metaRow}>
@@ -176,9 +177,10 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: spacing.xl * 2,
   },
-  header: {
+  stickyHeader: {
     paddingHorizontal: spacing.md,
     paddingTop: spacing.sm,
+    paddingBottom: spacing.sm,
   },
   metaRow: {
     flexDirection: 'row',

--- a/app/src/screens/PeriodsScreen.tsx
+++ b/app/src/screens/PeriodsScreen.tsx
@@ -54,13 +54,14 @@ function PeriodsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="The Periods of the Bible"
           subtitle={`${eras.length} eras from creation to the apostolic age`}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
 
         {visibleEras.map((era, index) => (
           <EraCard
@@ -226,11 +227,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   scrollContent: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
     paddingBottom: spacing.xxl,
   },
-  header: {
-    marginBottom: spacing.lg,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
   },
   /* Era card wrapper with timeline track */
   eraCardWrapper: {

--- a/app/src/screens/ProphecyDetailScreen.tsx
+++ b/app/src/screens/ProphecyDetailScreen.tsx
@@ -117,13 +117,14 @@ function ProphecyDetailScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="Prophecy Chain"
           titleColor={categoryColor}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {contentImages.length > 0 && <ContentImageGallery images={contentImages} />}
 
@@ -210,11 +211,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
     paddingBottom: spacing.xxl,
   },
-  header: {
-    marginBottom: spacing.sm,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
   },
   chainTitle: {
     fontFamily: fontFamily.displaySemiBold,

--- a/app/src/screens/RedemptiveArcScreen.tsx
+++ b/app/src/screens/RedemptiveArcScreen.tsx
@@ -48,13 +48,14 @@ function RedemptiveArcScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="The Story of the Bible"
           subtitle={`${acts.length} acts in God's redemptive narrative`}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
 
         {visibleActs.map((act, index) => (
           <TouchableOpacity
@@ -171,8 +172,12 @@ function RedemptiveArcScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   loadingPad: { padding: spacing.lg },
-  scrollContent: { padding: spacing.md, paddingBottom: spacing.xxl },
-  header: { marginBottom: spacing.lg },
+  scrollContent: { paddingHorizontal: spacing.md, paddingBottom: spacing.xxl },
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
   actCard: {
     borderRadius: radii.md,
     borderWidth: 1,

--- a/app/src/screens/ScholarBioScreen.tsx
+++ b/app/src/screens/ScholarBioScreen.tsx
@@ -52,13 +52,15 @@ function ScholarBioScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title={scholar.name}
           subtitle={scholar.tradition ?? undefined}
           titleColor={color}
           onBack={() => navigation.goBack()}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
         {bio?.eyebrow && (
           <Text style={[styles.eyebrow, { color: base.textMuted }]}>{bio.eyebrow}</Text>
         )}
@@ -112,7 +114,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+  },
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
   },
   eyebrow: {
     fontFamily: fontFamily.bodyItalic,

--- a/app/src/screens/WordStudyDetailScreen.tsx
+++ b/app/src/screens/WordStudyDetailScreen.tsx
@@ -54,13 +54,14 @@ function WordStudyDetailScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="Word Study"
           titleColor={accentColor}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {contentImages.length > 0 && <ContentImageGallery images={contentImages} />}
 
@@ -147,10 +148,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  header: {
-    marginBottom: spacing.md,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
   },
   original: {
     fontFamily: fontFamily.bodyMedium,


### PR DESCRIPTION
## What

Lifts the header band (back button + title + optional subtitle) out of the `ScrollView` on seven detail screens so it stays pinned while the body scrolls. Also raises `numberOfLines` on the global `ScreenHeader` title from 1 to 2 so long titles wrap to a second line instead of truncating with an ellipsis.

## Why

User reported three symptoms that collapsed to the same root cause:

1. Back button scrolls off screen on long content → no affordance to go back without scrolling all the way up.
2. On narrow/long titles (e.g. *"Why Does God Allow Suffering?"* in the Concepts/Journey flow), the title shows as `WHY DOES GOD ALLOW SUFFE…` — the `numberOfLines={1}` clamp on `ScreenHeader` cuts it off.
3. Applied consistently across all similar detail screens so the UX doesn't feel patchy.

## Screens touched

| Screen | Notes |
|---|---|
| `PeriodsScreen` | |
| `RedemptiveArcScreen` | "Story of the Bible" |
| `ProphecyDetailScreen` | |
| `JourneyDetailScreen` | **Concepts route here too** — one fix covers both |
| `WordStudyDetailScreen` | |
| `ScholarBioScreen` | |
| `ArchaeologyDetailScreen` | Uses `DetailHeroHeader`; the 140px hero (image + overlaid back) stays pinned — same visual contract, just sticky |

## How

Pattern, applied identically:

```diff
-<SafeAreaView>
-  <ScrollView>
-    <ScreenHeader title={…} onBack={…} style={styles.header} />
-    {…body…}
-  </ScrollView>
-</SafeAreaView>
+<SafeAreaView>
+  <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
+    <ScreenHeader title={…} onBack={…} />
+  </View>
+  <ScrollView>
+    {…body…}
+  </ScrollView>
+</SafeAreaView>
```

Styles: removed per-screen `header: { marginBottom }` declarations, replaced with `stickyHeader: { paddingHorizontal, paddingTop, paddingBottom }` so the pinned band owns its own spacing. Scroll containers had their top padding dropped (the sticky band supplies it now) and kept their `paddingBottom: spacing.xxl`.

Global title change in `ScreenHeader.tsx`: `numberOfLines={1}` → `numberOfLines={2}`. The `textWrap`/`titleTextWrap` styles already use `flex: 1`, so wrapping works with no layout changes — longer titles just take a second line.

## What this does NOT change

- No navigation changes.
- No prop signature changes on `ScreenHeader` or `DetailHeroHeader`.
- No theme token changes.
- No database, content, or CI pipeline changes.
- No test updates needed — existing `ScreenHeader.test.tsx` assertions (title text, back button press, subtitle rendering) are behavior-preserving.

## Testing

- `npx tsc --noEmit`: clean (0 errors).
- Jest: not run locally (sandbox npm install issues); CI will cover on the PR. Changes are pure JSX restructuring so test risk is nil.
- Manual verification recommended on device/simulator for all seven screens: confirm back button stays pinned when scrolling, confirm long titles wrap.

## Rollback

`git revert c6f2f38` — no schema, no data, no config.

## Follow-ups (out of scope)

- A handful of other detail screens (`PersonDetail`, `TopicDetail`, etc.) use the same pattern and would benefit from the same sticky treatment. Deliberately scoped to the reported seven — will follow up as a separate PR if the pattern lands well here.
