### PR TITLE
fix: sticky headers on 7 more scrolling screens (follow-up to #1581)

### DIFF
--- a/app/src/screens/BookIntroScreen.tsx
+++ b/app/src/screens/BookIntroScreen.tsx
@@ -41,13 +41,14 @@ function BookIntroScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title={intro.title ?? 'About This Book'}
           subtitle={intro.subtitle ?? undefined}
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {/* ── At-a-Glance Card (#1112) ── */}
         {intro.at_a_glance && (
@@ -249,10 +250,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  header: {
-    marginBottom: spacing.md,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
   },
   /* ── Enrichment styles (#1112) ── */
   enrichLabel: {

--- a/app/src/screens/ChapterListScreen.tsx
+++ b/app/src/screens/ChapterListScreen.tsx
@@ -61,15 +61,16 @@ function ChapterListScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         {/* Header with back button */}
         <ScreenHeader
           title={book.name}
           subtitle={`${book.total_chapters} chapters`}
           onBack={() => navigation.goBack()}
           backLabel="Back to library"
-          style={styles.headerSpacing}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {/* Progress summary — only shown when user has started the book */}
         {visited.size > 0 && (
@@ -165,10 +166,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  headerSpacing: {
-    marginBottom: spacing.md,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
   },
   progressRow: {
     marginBottom: spacing.md,

--- a/app/src/screens/NotificationPrefsScreen.tsx
+++ b/app/src/screens/NotificationPrefsScreen.tsx
@@ -88,12 +88,13 @@ function NotificationPrefsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="Notification Preferences"
           onBack={() => navigation.goBack()}
-          style={styles.headerSpacing}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {/* Global toggle */}
         <SectionLabel text="GENERAL" base={base} />
@@ -198,8 +199,12 @@ function ToggleRow({
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  content: { padding: spacing.md },
-  headerSpacing: { marginBottom: spacing.lg },
+  content: { paddingHorizontal: spacing.md, paddingBottom: spacing.md },
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
   sectionLabel: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 11,

--- a/app/src/screens/SettingsScreen.tsx
+++ b/app/src/screens/SettingsScreen.tsx
@@ -72,12 +72,13 @@ function SettingsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="Settings"
           onBack={() => navigation.goBack()}
-          style={styles.headerSpacing}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         <PremiumBanner
           base={base}
@@ -155,10 +156,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  headerSpacing: {
-    marginBottom: spacing.lg,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
   },
   navArrow: {
     fontSize: 24,

--- a/app/src/screens/SubscriptionScreen.tsx
+++ b/app/src/screens/SubscriptionScreen.tsx
@@ -76,12 +76,13 @@ function SubscriptionScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.scroll}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title=""
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.scroll}>
 
         {/* Hero */}
         <View style={styles.hero}>
@@ -280,10 +281,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scroll: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  header: {
-    marginBottom: spacing.sm,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
   },
   hero: {
     alignItems: 'center',

--- a/app/src/screens/ThreadDetailScreen.tsx
+++ b/app/src/screens/ThreadDetailScreen.tsx
@@ -106,12 +106,13 @@ export default function ThreadDetailScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      <ScrollView contentContainerStyle={styles.content}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
         <ScreenHeader
           title="Thread"
           onBack={() => navigation.goBack()}
-          style={styles.header}
         />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
 
         {/* Theme title */}
         <Text style={[styles.themeTitle, { color: base.text }]}>{thread.theme}</Text>
@@ -224,11 +225,13 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
     paddingBottom: spacing.xxl,
   },
-  header: {
-    marginBottom: spacing.sm,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
   },
   themeTitle: {
     fontFamily: fontFamily.displaySemiBold,

--- a/app/src/screens/UserProfileScreen.tsx
+++ b/app/src/screens/UserProfileScreen.tsx
@@ -122,7 +122,9 @@ function UserProfileScreen() {
   if (!user) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-        <ScreenHeader title="Profile" onBack={() => navigation.goBack()} style={styles.headerSpacing} />
+        <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
+          <ScreenHeader title="Profile" onBack={() => navigation.goBack()} />
+        </View>
         <View style={styles.emptyState}>
           <Text style={[styles.emptyText, { color: base.textDim }]}>
             Sign in to view your profile.
@@ -142,8 +144,10 @@ function UserProfileScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
+        <ScreenHeader title="Profile" onBack={() => navigation.goBack()} />
+      </View>
       <ScrollView contentContainerStyle={styles.content}>
-        <ScreenHeader title="Profile" onBack={() => navigation.goBack()} style={styles.headerSpacing} />
 
         {/* Avatar */}
         <View style={styles.avatarSection}>
@@ -321,10 +325,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    padding: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
-  headerSpacing: {
-    marginBottom: spacing.lg,
+  stickyHeader: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
   },
 
   /* Avatar */


### PR DESCRIPTION
## What

Follow-up to #1581. Applies the same sticky-header pattern to seven more scrolling screens surfaced in a full audit of the codebase.

## Why

After #1581 landed sticky headers on 7 detail screens, I ran a proper audit (`grep` for `ScreenHeader` appearing inside a `ScrollView` block) across all 65+ screen files. That turned up additional screens with the same bug that weren't in the original list.

## Screens fixed

| Screen | Category |
|---|---|
| `ThreadDetailScreen` | Content detail |
| `BookIntroScreen` | Content detail (428 lines, scrolls a lot) |
| `ChapterListScreen` | Content detail |
| `UserProfileScreen` | Long-scroll profile (492 lines) — both loaded and empty states |
| `SettingsScreen` | Settings |
| `SubscriptionScreen` | Long-scroll paywall (476 lines) |
| `NotificationPrefsScreen` | Settings |

## Audit findings — worth knowing

**Already architected correctly (no change):** `PersonDetailScreen` (modal pattern, explicit `// Sticky header` comment), `TopicDetailScreen`, `LifeTopicDetailScreen`, `HarmonyDetailScreen`, `TimeTravelDetailScreen`. Someone already got this right on half the app — the bug is inconsistent application of the pattern, not a universal regression.

**Deliberately out of scope:** `LoginScreen`, `SignUpScreen`, `ForgotPasswordScreen`. Auth forms have keyboard-avoidance concerns (`KeyboardAvoidingView` layout, field focus scroll behavior) that warrant a separate UX review. Mechanical lift-and-stick could cause visible jank when the keyboard opens.

## How

Same pattern as #1581:

```diff
-<SafeAreaView>
-  <ScrollView>
-    <ScreenHeader … style={styles.header} />
-    {…body…}
-  </ScrollView>
-</SafeAreaView>
+<SafeAreaView>
+  <View style={[styles.stickyHeader, { backgroundColor: base.bg }]}>
+    <ScreenHeader … />
+  </View>
+  <ScrollView>
+    {…body…}
+  </ScrollView>
+</SafeAreaView>
```

Per-screen `header: { marginBottom }` / `headerSpacing: { marginBottom }` style entries replaced with `stickyHeader: { paddingHorizontal, paddingTop, paddingBottom }`. ScrollView `padding` split into `paddingHorizontal` + `paddingBottom` since the sticky band now owns the top gap.

`UserProfileScreen` has two render paths (loaded and sign-in-prompt empty state) — both got the sticky wrapper for consistency.

## What this does NOT change

- No navigation, prop signatures, or theme token changes.
- No tests needed — all screen tests assert on `ScreenHeader` presence/title/back-press, which is behavior-preserving.
- No schema, content pipeline, or CI changes.

## Testing

- `npx tsc --noEmit`: clean (0 errors in changed files).
- Jest: CI will run on the PR. Pure JSX restructuring, test risk nil.
- Manual verification on device/simulator: confirm back button stays pinned while scrolling on all 7 screens.

## Rollback

`git revert <hash>` — no schema, no data, no config.

## Follow-up worth doing

Codify this pattern in a shared `<DetailScreenLayout>` component so new screens can't regress. Separate issue — not blocking this PR.
