### PR TITLE
content: add 8 patristic + canon-formation scholars (#1537)

### DIFF
--- a/_tools/config.py
+++ b/_tools/config.py
@@ -1279,3 +1279,29 @@ BOOK_META['revelation'] = {
     'vhl_key': ['revelation', 'apocalypse', 'Alpha and Omega', 'Lamb', 'throne', 'seal', 'trumpet', 'bowl', 'dragon', 'beast', 'false prophet', 'Babylon', 'New Jerusalem', 'bride', 'witness', 'testimony', 'conquer', 'overcome', 'worthy', 'Holy Holy Holy', 'wrath', 'blood', 'white', 'mark', 'number', '666', 'thousand years', 'millennium', 'first resurrection', 'second death', 'lake of fire', 'tree of life', 'river of life', 'morning star', 'key of David', 'book of life', 'new heaven', 'new earth', 'Maranatha', 'Come Lord Jesus', 'seven spirits', 'seven churches', 'seven seals', 'seven trumpets', 'seven bowls', 'twenty-four elders', 'four living creatures', '144000', 'great multitude', 'two witnesses', 'woman clothed with the sun', 'rider on the white horse', 'King of kings', 'Lord of lords'],
     'vhl_time': ['the time is near', 'what must soon take place', 'I am coming soon', 'a thousand years', 'the first resurrection', 'the second death', 'forever and ever', 'no more death', 'no more night', 'the beginning and the end', 'who is and who was and who is to come'],
 }
+
+# ── "How We Got The Bible" epic: patristic + canon-formation voices (#1537) ──
+# These scholars are cited in extrabiblical / canon-formation content rather than
+# as per-book chapter panels. Their COMMENTATOR_SCOPE entries are left as empty
+# lists so that if a scholar panel were ever added inside a canonical book it
+# would fail schema-validator scope enforcement until deliberately widened.
+
+# Patristic (canon formation, early NT usage)
+SCHOLAR_REGISTRY.append(('athanasius', 'athanasius', 'Athanasius', 'athanasius'))
+SCHOLAR_REGISTRY.append(('jerome', 'jerome', 'Jerome', 'jerome'))
+SCHOLAR_REGISTRY.append(('augustine', 'augustine', 'Augustine', 'augustine'))
+SCHOLAR_REGISTRY.append(('tertullian', 'tertullian', 'Tertullian', 'tertullian'))
+COMMENTATOR_SCOPE['athanasius'] = []
+COMMENTATOR_SCOPE['jerome'] = []
+COMMENTATOR_SCOPE['augustine'] = []
+COMMENTATOR_SCOPE['tertullian'] = []
+
+# Modern canon studies & Second Temple Judaism
+SCHOLAR_REGISTRY.append(('kruger', 'kruger', 'Kruger', 'kruger'))
+SCHOLAR_REGISTRY.append(('metzger', 'metzger', 'Metzger', 'metzger'))
+SCHOLAR_REGISTRY.append(('nickelsburg', 'nickelsburg', 'Nickelsburg', 'nickelsburg'))
+SCHOLAR_REGISTRY.append(('vanderkam', 'vanderkam', 'VanderKam', 'vanderkam'))
+COMMENTATOR_SCOPE['kruger'] = []
+COMMENTATOR_SCOPE['metzger'] = []
+COMMENTATOR_SCOPE['nickelsburg'] = []
+COMMENTATOR_SCOPE['vanderkam'] = []

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "1c7094321bde1fce",
-  "build_time": "2026-04-16T21:00:55.853051Z"
+  "content_hash": "d0d10d73481c6b56",
+  "build_time": "2026-04-23T11:19:15.316813Z"
 }

--- a/content/meta/scholar-bios.json
+++ b/content/meta/scholar-bios.json
@@ -1142,5 +1142,197 @@
         "body": "Lundbom notes appear throughout Jeremiah in this tool.\n\nJer 1  Jer 2  Jer 3  Jer 4  Jer 5  Jer 6  Jer 7  Jer 8  Jer 9  Jer 10  Jer 11  Jer 12  Jer 13  Jer 14  Jer 15  Jer 16  Jer 17  Jer 18  Jer 19  Jer 20  Jer 21  Jer 22  Jer 23  Jer 24  Jer 25  Jer 26  Jer 27  Jer 28  Jer 29  Jer 30  Jer 31  Jer 32  Jer 33  Jer 34  Jer 35  Jer 36  Jer 37  Jer 38  Jer 39  Jer 40  Jer 41  Jer 42  Jer 43  Jer 44  Jer 45  Jer 46  Jer 47  Jer 48  Jer 49  Jer 50  Jer 51  Jer 52"
       }
     ]
+  },
+  "athanasius": {
+    "key": "athanasius",
+    "name": "Athanasius of Alexandria",
+    "eyebrow": "Patristic · 4th Century",
+    "tradition": "c. 296–373 · Bishop of Alexandria · Festal Letter 39 (367) gives the earliest surviving list of the 27 NT books as canonical",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Athanasius (c. 296–373) was bishop of Alexandria from 328 until his death, a forty-five-year tenure interrupted by five exiles under successive emperors hostile to his Nicene Christology. A young attendant at the Council of Nicaea in 325, he became the most forceful defender of the homoousios formula through the middle decades of the fourth century."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Athanasius reads Scripture with a pervasive Christological lens, defending the Son's full divinity through close exegesis of disputed texts (Prov 8:22, Phil 2, Heb 1). His Festal Letter 39 (367) is the earliest surviving document to list the twenty-seven New Testament books as the exclusive canonical collection, distinguishing them from 'ecclesiastical' works (e.g., Didache, Shepherd) and from books deemed apocryphal."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Athanasius is the paradigmatic figure of Nicene Orthodoxy. Revered as a father and doctor in both Eastern and Western traditions, his opposition to Arianism at enormous personal cost kept the Egyptian church loyal to the Nicene confession through decades of imperial pressure."
+      },
+      {
+        "title": "Appears In",
+        "body": "Athanasius appears in materials on New Testament canon formation and Christological controversy."
+      }
+    ]
+  },
+  "jerome": {
+    "key": "jerome",
+    "name": "Jerome",
+    "eyebrow": "Patristic · 4th–5th Century",
+    "tradition": "c. 347–420 · Translator of the Latin Vulgate · distinguished the Hebrew canon from the wider Septuagint collection in his Prologus Galeatus",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Jerome (c. 347–420) was educated at Rome, lived as an ascetic in Syria, served as secretary to Pope Damasus, and spent his last three decades in Bethlehem translating the Bible from Hebrew into Latin. The Vulgate became the dominant Bible of the Latin West for more than a millennium."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Jerome's signature commitment was to hebraica veritas — translating the Old Testament from Hebrew rather than the Greek Septuagint. In the Prologus Galeatus to Samuel and Kings, he distinguished the books of the Hebrew Bible as 'canonical' from additional books (Tobit, Judith, Wisdom, Sirach, 1–2 Maccabees, additions to Daniel/Esther) that could be read 'for the edification of the people, but not to establish the authority of ecclesiastical doctrines.' In practice, however, he translated and transmitted these books alongside the canonical ones."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Jerome stands within Latin patristic Christianity as its greatest biblical scholar. His canonical distinctions would resurface in sharper form at the Protestant Reformation, while his Vulgate was defined as the authoritative Latin Bible at Trent (1546)."
+      },
+      {
+        "title": "Appears In",
+        "body": "Jerome appears in materials on canon formation, the Old Testament apocrypha, and the history of biblical translation."
+      }
+    ]
+  },
+  "augustine": {
+    "key": "augustine",
+    "name": "Augustine of Hippo",
+    "eyebrow": "Patristic · 4th–5th Century",
+    "tradition": "354–430 · Bishop of Hippo Regius · decisive influence at the Councils of Hippo (393) and Carthage (397) on the wider Old Testament canon",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Augustine (354–430) was born in Thagaste in Roman North Africa, converted in Milan in 386, and served as bishop of Hippo Regius from 395 until his death. His more than a hundred books, hundreds of letters, and thousands of sermons made him the theological centre of gravity for the Latin West for more than a millennium."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Augustine articulated the 'rule of charity' as a hermeneutical principle in De Doctrina Christiana. On the sons of God in Genesis 6:1–4, he argued in City of God XV.22–23 against the earlier angelic reading (found in Tertullian and the Greek fathers), identifying the sons of God as descendants of Seth and the daughters of men as descendants of Cain — a reading that shaped Western Christian interpretation of the passage for centuries. On canon, he defended the wider Greek/Latin collection against Jerome's narrower hebraica veritas."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Augustine is the foundational figure of Latin Christian theology. His inclusive Old Testament canon prevailed at Hippo (393) and Carthage (397 and 419) and passed through the medieval West to the Council of Trent."
+      },
+      {
+        "title": "Appears In",
+        "body": "Augustine appears in materials on canon formation, hermeneutics, and the history of Genesis 6 interpretation."
+      }
+    ]
+  },
+  "tertullian": {
+    "key": "tertullian",
+    "name": "Tertullian of Carthage",
+    "eyebrow": "Patristic · 2nd–3rd Century",
+    "tradition": "c. 155–c. 220 · Latin apologist and theologian · early defender of 1 Enoch as Scripture in De Cultu Feminarum",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Tertullian (c. 155–c. 220) was the first major Christian author to write theology in Latin, producing apologetic, polemical, and ascetical treatises at Carthage in Roman North Africa. He coined or stabilised key Latin theological terms — trinitas, persona, substantia. In later life he associated with the charismatic-ascetical Montanist movement, later judged schismatic."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "In De Cultu Feminarum 1.3, Tertullian defends 1 Enoch against its detractors, arguing that its rejection 'by some' (likely its exclusion from the rabbinic canon) does not bind Christians, and that its usage in the Epistle of Jude (vv. 14–15) is itself evidence of authoritative reception. The passage is an important data point for reconstructing how 1 Enoch was read in late-second- and early-third-century Christian communities."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Tertullian belongs to the Latin apologetic and anti-heretical tradition. His theology is strongly incarnational and morally rigorous. Despite never being formally canonised as a saint in the Latin church (owing to his later Montanist associations), his vocabulary and arguments remained foundational for Latin theology."
+      },
+      {
+        "title": "Appears In",
+        "body": "Tertullian appears in materials on early patristic reception of Second Temple literature and on pre-canonical New Testament usage."
+      }
+    ]
+  },
+  "kruger": {
+    "key": "kruger",
+    "name": "Michael J. Kruger",
+    "eyebrow": "Evangelical · Canon Studies",
+    "tradition": "b. 1971 · President, Reformed Theological Seminary (Charlotte) · Ph.D. Edinburgh · canon self-authentication model",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Michael J. Kruger is president and Samuel C. Patterson Professor of New Testament and Early Christianity at Reformed Theological Seminary in Charlotte. He earned his Ph.D. under Larry W. Hurtado at the University of Edinburgh."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Kruger's canon work is organised around the 'self-authenticating' model — arguing that the early church recognised canonical books through their own divine attributes (apostolic origin, corporate ecclesial reception, internal qualities) rather than by later imposed church decisions. He contends historically that the New Testament's boundaries were substantially clear earlier than many critical historians allow, while granting uneven regional reception of certain books (Hebrews, James, 2 Peter, 2–3 John, Jude, Revelation) through the third and fourth centuries."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Kruger writes from within confessional Reformed evangelicalism. His canon scholarship engages mainline and critical interlocutors (Metzger, Sundberg, McDonald, Ehrman) while drawing on the Westminster Confession's doctrine of the self-attesting Scriptures."
+      },
+      {
+        "title": "Appears In",
+        "body": "Kruger appears in materials on New Testament canon formation and the criteria for canonical recognition."
+      }
+    ]
+  },
+  "metzger": {
+    "key": "metzger",
+    "name": "Bruce M. Metzger",
+    "eyebrow": "Mainline · Textual Criticism",
+    "tradition": "1914–2007 · Princeton Theological Seminary · chair of the UBS Greek New Testament committee · general editor of the NRSV",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "Bruce M. Metzger (1914–2007) taught New Testament at Princeton Theological Seminary for nearly fifty years. He chaired the committee producing the United Bible Societies' Greek New Testament (1966 and later editions) and served as general editor of the New Revised Standard Version (1989)."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Metzger's canon scholarship is historical and descriptive, tracing the gradual and uneven reception of particular books across regions and centuries. His textual criticism follows the reasoned eclecticism of the UBS/Nestle-Aland tradition, weighing external and internal evidence together. His Textual Commentary on the Greek New Testament documents the committee's reasoning on every significant variant adopted by the UBS text."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Metzger was an ordained Presbyterian minister and wrote from within mainline Protestant scholarship. He is the standard dialogue partner for evangelical canon scholars like Kruger, who often accept his historical reconstruction while differing in theological interpretation."
+      },
+      {
+        "title": "Appears In",
+        "body": "Metzger appears in materials on New Testament canon formation and the manuscript history of the New Testament."
+      }
+    ]
+  },
+  "nickelsburg": {
+    "key": "nickelsburg",
+    "name": "George W. E. Nickelsburg",
+    "eyebrow": "Critical · Second Temple Judaism",
+    "tradition": "b. 1934 · Professor emeritus, University of Iowa · co-author of Hermeneia commentary on 1 Enoch",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "George W. E. Nickelsburg is professor emeritus of religion at the University of Iowa (Ph.D. Harvard). His scholarly focus has been the Jewish literature of the Second Temple period, especially apocalyptic, wisdom, and narrative texts outside the Hebrew Bible."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Nickelsburg's two-volume Hermeneia commentary on 1 Enoch (2001, 2012, with VanderKam) is the standard English-language critical commentary on the book. His Resurrection, Immortality, and Eternal Life in Intertestamental Judaism traces the development of post-mortem vindication and judgment categories across the Second Temple corpus — essential background for New Testament resurrection language."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Nickelsburg writes from within the mainstream historical-critical academy. His work is descriptive and reconstructive rather than confessional, treating ancient texts as historical witnesses to particular Jewish communities."
+      },
+      {
+        "title": "Appears In",
+        "body": "Nickelsburg appears in materials on 1 Enoch and other Second Temple apocalyptic and wisdom literature."
+      }
+    ]
+  },
+  "vanderkam": {
+    "key": "vanderkam",
+    "name": "James C. VanderKam",
+    "eyebrow": "Critical · Second Temple Judaism",
+    "tradition": "b. 1946 · John A. O'Brien Professor emeritus, University of Notre Dame · leading scholar of Jubilees and the Dead Sea Scrolls",
+    "sections": [
+      {
+        "title": "Biography",
+        "body": "James C. VanderKam is the John A. O'Brien Professor emeritus of theology at the University of Notre Dame (Ph.D. Harvard, under Frank Moore Cross). He served on the international editorial team for the Discoveries in the Judaean Desert series and has been a leading voice in Second Temple scholarship for decades."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "VanderKam's work on Jubilees — including the CSCO critical edition (1989) and the Hermeneia commentary (2018) — is the standard English-language scholarship on that book. His Calendars in the Dead Sea Scrolls traces the 364-day solar calendar attested in Jubilees, some Enochic texts, and several Qumran scrolls, showing how calendar was a marker of sectarian identity."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Like Nickelsburg, VanderKam writes from within the mainstream critical academy. His work is descriptive and historically reconstructive, providing essential background for reading the canonical biblical texts in their first-century Jewish matrix."
+      },
+      {
+        "title": "Appears In",
+        "body": "VanderKam appears in materials on Jubilees, the Dead Sea Scrolls, and Enochic literature."
+      }
+    ]
   }
 }

--- a/content/meta/scholar-scopes.json
+++ b/content/meta/scholar-scopes.json
@@ -18,6 +18,8 @@
   "ashley": [
     "numbers"
   ],
+  "athanasius": [],
+  "augustine": [],
   "beale": [
     "revelation"
   ],
@@ -108,6 +110,7 @@
   "hubbard": [
     "ruth"
   ],
+  "jerome": [],
   "jobes": [
     "esther",
     "1_peter"
@@ -120,6 +123,7 @@
     "nehemiah",
     "psalms"
   ],
+  "kruger": [],
   "kruse": [
     "1_john",
     "2_john",
@@ -216,6 +220,7 @@
   "mccartney": [
     "james"
   ],
+  "metzger": [],
   "milgrom": [
     "leviticus",
     "numbers"
@@ -303,6 +308,7 @@
     "jude",
     "revelation"
   ],
+  "nickelsburg": [],
   "obrien": [
     "ephesians",
     "colossians",
@@ -353,6 +359,7 @@
     "jonah",
     "micah"
   ],
+  "tertullian": [],
   "thiselton": [
     "1_corinthians"
   ],
@@ -367,6 +374,7 @@
   "tsumura": [
     "1_samuel"
   ],
+  "vanderkam": [],
   "vangemeren": [
     "psalms"
   ],

--- a/content/meta/scholars.json
+++ b/content/meta/scholars.json
@@ -2527,5 +2527,277 @@
         "body": "Green notes appear in Jude."
       }
     ]
+  },
+  {
+    "id": "athanasius",
+    "panel_key": "athanasius",
+    "label": "Athanasius",
+    "name": "Athanasius of Alexandria",
+    "color": "#a87820",
+    "tradition": "Patristic · 4th Century",
+    "scope": [],
+    "scope_text": "New Testament canon, Christology, Trinity",
+    "description": "Alexandrian bishop whose Festal Letter 39 (367 AD) gives the earliest surviving list of the twenty-seven New Testament books as the canonical collection.",
+    "eyebrow": "Patristic · 4th Century",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Athanasius (c. 296–373) was born in or near Alexandria and was ordained a deacon by Bishop Alexander, whom he accompanied to the Council of Nicaea in 325 as a young attendant. He succeeded Alexander as bishop of Alexandria in 328 and served in that office for forty-five years, during which he was exiled five times by successive emperors for his uncompromising opposition to Arian Christology. His writings span the full range of fourth-century Christian concerns — dogmatic, polemical, exegetical, ascetical, and pastoral.\n\nAmong his many works, his thirty-ninth Festal Letter, written in 367, is the earliest surviving document to list the twenty-seven books of the New Testament as the exclusive canonical collection. It also distinguishes these from books 'appointed to be read' by catechumens (including the Didache and Shepherd of Hermas) and from books deemed apocryphal. The Festal Letter did not create the NT canon — much of its contents was already received across the churches — but it is a key witness to the shape of canonical consensus in the eastern Mediterranean by the late fourth century."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Athanasius reads Scripture with a pervasive Christological and Trinitarian lens. His great defense of the Son's full divinity against Arianism in the Orations Against the Arians proceeds by close exegesis of disputed texts — Proverbs 8:22 ('The Lord created me'), Philippians 2, Hebrews 1 — arguing that the biblical idiom of Christ's subordination reflects the economy of the incarnation, not an ontological inferiority. He treats the Old and New Testaments as a unified witness to Christ, employing typological and prosopological readings that identify the pre-incarnate Son as the speaker and actor in many Old Testament theophanies.\n\nHis canon-forming instincts were pastoral and liturgical as much as intellectual: he argues that the canonical books are the 'fountains of salvation' from which the church drinks, and that reading them rightly forms believers in the Christian mystery."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Athanasius is the paradigmatic representative of Nicene Orthodoxy — the conviction, crystallised at the Council of Nicaea and defended through decades of controversy, that the Son is of the same essence (homoousios) as the Father. His theology is inseparable from his pastoral and political labours: he resisted imperial Arianism at enormous personal cost and kept the Egyptian church loyal to the Nicene confession when much of the rest of the empire had drifted into Homoian or Anomoian positions. He is revered as a father and doctor in both Eastern and Western traditions."
+      },
+      {
+        "title": "Key Works",
+        "body": "Festal Letter 39 (367)\nThe earliest surviving list of the twenty-seven New Testament books as the exclusive canonical collection, distinguishing canonical, ecclesiastical, and apocryphal writings.\n\nOn the Incarnation (De Incarnatione, c. 318)\nA youthful but theologically mature account of why the Word became flesh.\n\nOrations Against the Arians (c. 340–345)\nFour discourses providing the definitive patristic defense of the Son's consubstantiality with the Father through close exegesis of disputed biblical texts.\n\nLife of Anthony (c. 360)\nThe foundational hagiography of Christian monasticism, widely influential on both Eastern and Western spiritual traditions."
+      },
+      {
+        "title": "Appears In",
+        "body": "Athanasius notes appear in materials on New Testament canon formation and early Christological controversy."
+      }
+    ]
+  },
+  {
+    "id": "jerome",
+    "panel_key": "jerome",
+    "label": "Jerome",
+    "name": "Jerome",
+    "color": "#c27030",
+    "tradition": "Patristic · Late 4th–Early 5th Century",
+    "scope": [],
+    "scope_text": "Canon formation, Old Testament apocrypha, translation history",
+    "description": "Translator of the Latin Vulgate and decisive Western voice for distinguishing the Hebrew canon from the wider Greek Septuagint collection.",
+    "eyebrow": "Patristic · 4th–5th Century",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Eusebius Sophronius Hieronymus — Jerome (c. 347–420) — was born in Stridon, on the border of Dalmatia and Pannonia, educated at Rome under the grammarian Donatus, and baptised there in his twenties. After periods of ascetic retreat in the Syrian desert, ordination at Antioch, and study with Gregory Nazianzen at Constantinople, he served as secretary to Pope Damasus in Rome (382–385). At Damasus's request he began the revision of the Latin Bible that became his life's work. From 386 until his death he lived in Bethlehem, where he learned Hebrew from Jewish teachers and produced the bulk of what later tradition called the Vulgate.\n\nAlongside translation he wrote voluminous commentaries (on most of the prophets, several of the minor epistles, Matthew, and Ecclesiastes among others), biographies of monastic figures, vehement polemical treatises, and more than 150 surviving letters that form one of the great epistolary corpora of late antiquity."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Jerome's signature commitment was to hebraica veritas — 'the Hebrew truth' — the principle that the Old Testament should be translated from the Hebrew original rather than from the Greek Septuagint. This placed him in public disagreement with Augustine, who defended the Septuagint's inspired authority on the grounds of its use by the apostles and the wider Greek-speaking church.\n\nIn the prefaces to his translations, especially the so-called Prologus Galeatus ('helmeted prologue') to the Books of Samuel and Kings, he articulates a canonical distinction that would have long afterlives in the West. The books present in the Hebrew Bible are 'canonical'; the books found only in the Greek (Tobit, Judith, Wisdom, Sirach, 1–2 Maccabees, additions to Daniel and Esther, and others) are to be read 'for the edification of the people, but not to establish the authority of ecclesiastical doctrines.' In practice, however, he translated and circulated these books alongside the canonical ones, and they continued to be copied in Vulgate manuscripts."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Jerome stands within Latin patristic Christianity as its greatest biblical scholar. His personal theology is generally Nicene and ascetic, with a strong emphasis on virginity and monastic withdrawal. His enduring significance lies less in systematic theology than in his fusion of philological rigour, Hebrew competence, and literary Latinity, which gave the Latin West a Bible it would read for more than a millennium and a canonical vocabulary that would resurface in sharper form at the Reformation."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Vulgate (c. 382–405)\nJerome's revision of the Latin Gospels and fresh translation of the Hebrew Old Testament; the dominant Latin Bible of the Western church for over a millennium.\n\nPrologue to the Books of Samuel and Kings (the 'Helmeted Prologue')\nHis most important canonical statement, distinguishing Hebrew-canon books from additional books to be read for edification rather than doctrine.\n\nCommentaries on the Prophets\nExtensive commentaries on Isaiah, Jeremiah, Ezekiel, Daniel, and the Minor Prophets, drawing heavily on Hebrew text and Jewish exegetical traditions.\n\nDe Viris Illustribus (On Illustrious Men, 392)\nA catalogue of Christian authors from the apostles to his own day, significant for the history of early Christian literature."
+      },
+      {
+        "title": "Appears In",
+        "body": "Jerome notes appear in materials on canon formation, the Old Testament apocrypha, and the history of biblical translation."
+      }
+    ]
+  },
+  {
+    "id": "augustine",
+    "panel_key": "augustine",
+    "label": "Augustine",
+    "name": "Augustine of Hippo",
+    "color": "#8b4513",
+    "tradition": "Patristic · Late 4th–Early 5th Century",
+    "scope": [],
+    "scope_text": "Canon formation, hermeneutics, Genesis interpretation",
+    "description": "North African bishop whose regional councils at Hippo (393) and Carthage (397) ratified the broader Septuagint-based canon that shaped Catholic and Orthodox Old Testaments.",
+    "eyebrow": "Patristic · 4th–5th Century",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Aurelius Augustinus — Augustine (354–430) — was born in Thagaste in Roman North Africa to a Christian mother, Monica, and a pagan father, Patricius. After education at Madauros and Carthage he taught rhetoric in Carthage, Rome, and Milan, passing through Manichaeism and Neoplatonism before his conversion to Christianity in 386, described at length in the Confessions. Baptised by Ambrose in 387, he returned to North Africa, was ordained a priest in 391 and consecrated bishop of Hippo Regius in 395. He served in that office until his death in 430, while the Vandals besieged the city.\n\nAugustine's output is vast: more than a hundred books, hundreds of letters, and thousands of sermons, making him the most quoted Christian author of the first millennium and the theological centre of gravity for the Latin West."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Augustine approaches Scripture as a unified divine utterance in which obscurities and difficulties are intended to stretch the reader into love of God and neighbour — the 'rule of charity' he sets out in De Doctrina Christiana. Where a literal reading would conflict with sound doctrine or with the love commandment, he is willing to read figuratively.\n\nHis interpretation of the 'sons of God' in Genesis 6:1–4 illustrates the point. Earlier Christian writers such as Justin, Tertullian, and several of the Greek fathers had identified the sons of God as fallen angels, following the reading also attested in 1 Enoch and Jubilees. In City of God XV.22–23, Augustine argues instead that the sons of God are the descendants of Seth and the daughters of men the descendants of Cain, and that the Nephilim are their offspring. This reading — whose influence in the Latin West was enormous — shifted the majority Christian interpretation of Genesis 6 decisively, though the angelic reading remains in some Eastern and modern scholarly discussion.\n\nOn the canon, Augustine defended the wider collection received in the Greek and Latin churches against Jerome's narrower hebraica veritas, and his position prevailed at the regional Councils of Hippo (393) and Carthage (397 and 419), whose canonical lists are among the earliest conciliar decisions on the Old and New Testament canons."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Augustine is the foundational figure of Latin Christian theology. His teachings on grace, original sin, predestination, the two cities, and the church's relation to the world shaped medieval scholasticism, the Reformation (which read him selectively in its debates on justification), and much of modern Catholic and Protestant thought. On canon, his inclusive Septuagint-based position passed through the medieval West to the Council of Trent, which formally defined the Catholic canon in 1546."
+      },
+      {
+        "title": "Key Works",
+        "body": "Confessions (c. 397–400)\nThirteen books of autobiographical and theological reflection, one of the foundational texts of Western introspective literature.\n\nCity of God (De Civitate Dei, 413–426)\nAugustine's great work of theological history, contrasting the earthly and heavenly cities; Books XI–XXII include his mature Genesis interpretation and canonical judgments.\n\nOn Christian Doctrine (De Doctrina Christiana, 396–427)\nHis hermeneutical handbook, articulating the 'rule of charity' and the principles for reading obscure passages.\n\nCanonical Lists at Hippo (393) and Carthage (397)\nRegional African councils over which he exercised decisive influence, ratifying the wider Old Testament canon including the deuterocanonical books."
+      },
+      {
+        "title": "Appears In",
+        "body": "Augustine notes appear in materials on canon formation, hermeneutics, and the history of Genesis 6 interpretation."
+      }
+    ]
+  },
+  {
+    "id": "tertullian",
+    "panel_key": "tertullian",
+    "label": "Tertullian",
+    "name": "Tertullian of Carthage",
+    "color": "#a0522d",
+    "tradition": "Patristic · Late 2nd–Early 3rd Century",
+    "scope": [],
+    "scope_text": "Early patristics, Enochic literature reception, New Testament usage",
+    "description": "North African Latin apologist and theologian; one of the earliest Christian writers to quote 1 Enoch as Scripture and an important witness to New Testament usage before the formal canon.",
+    "eyebrow": "Patristic · 2nd–3rd Century",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Quintus Septimius Florens Tertullianus — Tertullian (c. 155–c. 220) — was born in Carthage in Roman North Africa and wrote in Latin and Greek during the reigns of Septimius Severus and his successors. Later traditions that he was trained as a lawyer and ordained a priest cannot be firmly verified from his own writings, but his rhetorical legal style and command of doctrinal controversy suggest substantial formal education.\n\nHe is the first major Christian author to write theology in Latin, and his surviving works — about thirty treatises — address apologetics, anti-heresy polemic, ascetical practice, and Christian living. In later life he associated with the New Prophecy movement (Montanism), a charismatic-ascetical stream later judged schismatic; scholars debate the extent and significance of this shift."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Tertullian brought the precision of Latin legal and rhetorical language to Christian doctrine, coining or stabilising terms — trinitas, persona, substantia — that would shape the Latin theological vocabulary for centuries. He read Scripture as self-evidently authoritative, marshalled it in rapid-fire quotation against opponents (Against Marcion, Against Praxeas), and drew on its narratives for ascetical and moral teaching.\n\nHis most striking contribution to canon history is his treatment of 1 Enoch. In De Cultu Feminarum ('On the Apparel of Women') 1.3, he defends the book against its detractors, arguing that its rejection 'by some' (likely referring to its exclusion from the rabbinic canon) does not bind Christians, since Enoch's narrative was preserved through Noah and since the Epistle of Jude quotes the book (Jude 14–15). This positive reception is evidence that in some late-second- and early-third-century Christian communities 1 Enoch was read as authoritative, even as the wider church was moving toward its exclusion. Nickelsburg, VanderKam, and others have used Tertullian's testimony as an important data point in reconstructing the book's reception history."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Tertullian belongs to the Latin apologetic and anti-heretical tradition alongside figures such as Irenaeus and, later, Cyprian. His theology is strongly incarnational, Trinitarian in vocabulary (though before the full Nicene settlement), and morally rigorous. His later Montanist associations meant he was never formally canonised as a saint in the Latin church, but his vocabulary and his arguments remained foundational for Latin theology for centuries."
+      },
+      {
+        "title": "Key Works",
+        "body": "Apology (Apologeticus, c. 197)\nA defense of Christianity addressed to Roman magistrates, combining legal argument with scathing attack on pagan religion.\n\nAgainst Marcion (c. 207–208)\nFive books defending the unity of the Old and New Testaments against Marcion's excision of the OT and much of the NT.\n\nAgainst Praxeas\nA key pre-Nicene treatise defending the distinction of Father, Son, and Spirit while maintaining the unity of God; the treatise coins the Latin term trinitas.\n\nDe Cultu Feminarum (On the Apparel of Women)\nThe treatise containing Tertullian's defense of 1 Enoch and one of the earliest extended Christian discussions of the book."
+      },
+      {
+        "title": "Appears In",
+        "body": "Tertullian notes appear in materials on early patristic reception of Second Temple literature, especially 1 Enoch, and in discussions of pre-canonical New Testament usage."
+      }
+    ]
+  },
+  {
+    "id": "kruger",
+    "panel_key": "kruger",
+    "label": "Kruger",
+    "name": "Michael J. Kruger",
+    "color": "#507890",
+    "tradition": "Evangelical · Reformed · Contemporary",
+    "scope": [],
+    "scope_text": "New Testament canon, canonical criteria, self-authentication model",
+    "description": "President of Reformed Theological Seminary (Charlotte). Evangelical NT canon scholar whose work defends an organic, self-authenticating model of canonical recognition.",
+    "eyebrow": "Evangelical · Canon Studies",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Michael J. Kruger (b. 1971) is the president and the Samuel C. Patterson Professor of New Testament and Early Christianity at Reformed Theological Seminary in Charlotte. He earned his Ph.D. under the New Testament scholar Larry W. Hurtado at the University of Edinburgh, where his doctoral work on early Christian attitudes toward Scripture became the starting point for his subsequent canon research. He has served in faculty leadership roles at RTS since the early 2000s and has become one of the most prolific contemporary evangelical voices on the formation and authority of the New Testament canon."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Kruger's canon scholarship is organised around what he calls the 'self-authenticating' model of canonicity. Against external-criteria models that locate canonical authority in later church decisions, and against purely historical-critical models that treat canonisation as a contingent political process, he argues that the early church recognised the canonical books through their own divine attributes — apostolic origin, corporate ecclesial reception, and the internal qualities the Holy Spirit produces in their readers.\n\nThis model is explicitly theological and self-consciously Reformed, drawing on the confessional category of the self-attesting Scriptures. Kruger argues historically that the boundaries of the New Testament collection were substantially clear much earlier than many critical historians allow, though he readily grants that certain books (notably Hebrews, James, 2 Peter, 2–3 John, Jude, Revelation) were received unevenly in different regions through the third and fourth centuries."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Kruger writes from within confessional Reformed evangelicalism. His canon scholarship is in conversation with mainline and critical interlocutors (especially Metzger, McDonald, Sundberg, and Ehrman), but his constructive proposals are shaped by Westminster and Reformed Christology and by the doctrine of Scripture articulated in the Westminster Confession of Faith. This makes him a valuable dialogue partner for readers who want to hear how contemporary evangelical scholarship engages mainstream canon research without adopting its sometimes skeptical conclusions."
+      },
+      {
+        "title": "Key Works",
+        "body": "Canon Revisited: Establishing the Origins and Authority of the New Testament Books (Crossway, 2012)\nKruger's most systematic statement of the self-authenticating model, surveying extrinsic, community-determined, and intrinsic approaches to canon and arguing for an integrated account.\n\nThe Question of Canon: Challenging the Status Quo in the New Testament Debate (IVP Academic, 2013)\nA shorter, more polemical work contesting the 'extrinsic' model associated with Sundberg and McDonald and arguing that the canonical impulse is native to early Christianity, not imposed later.\n\nThe Heresy of Orthodoxy (with Andreas Köstenberger, Crossway, 2010)\nA response to Bauer-Ehrman reconstructions of early Christian diversity, arguing that orthodoxy and canon are more primitive than revisionist accounts allow."
+      },
+      {
+        "title": "Appears In",
+        "body": "Kruger notes appear in materials on New Testament canon formation and the criteria by which the early church recognised canonical writings."
+      }
+    ]
+  },
+  {
+    "id": "metzger",
+    "panel_key": "metzger",
+    "label": "Metzger",
+    "name": "Bruce M. Metzger",
+    "color": "#708090",
+    "tradition": "Mainline · Textual Criticism · 20th Century",
+    "scope": [],
+    "scope_text": "New Testament canon formation, textual criticism",
+    "description": "Princeton Theological Seminary professor and the leading 20th-century English-language scholar of New Testament textual criticism and canon formation.",
+    "eyebrow": "Mainline · Textual Criticism",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "Bruce Manning Metzger (1914–2007) was one of the most influential New Testament scholars of the twentieth century. He taught at Princeton Theological Seminary for nearly fifty years (1938–1984) and remained actively engaged in research and translation committees until shortly before his death. Educated at Lebanon Valley College and Princeton Seminary, with a Ph.D. from Princeton University in classics, he combined philological depth with ecclesial and ecumenical engagement.\n\nHe served as chair of the committee producing the United Bible Societies' Greek New Testament (1966 and subsequent editions) — the standard critical text underlying most modern translations — and as general editor of the New Revised Standard Version (1989). He was also a member of the translation committee for the NIV in its early stages. His combined output in textual criticism, canon studies, and translation shaped the landscape of English-language New Testament scholarship for a generation."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Metzger's approach to the New Testament canon is fundamentally historical: he reconstructs the gradual and uneven process by which particular books came to be received as Scripture across the regions and centuries of early Christianity. He is attentive to the differing criteria applied in different contexts — apostolic origin, orthodoxy, widespread and continuous ecclesial usage — and to the persistence of 'disputed' books (antilegomena) well into the fourth and fifth centuries.\n\nHis textual criticism follows the reasoned eclecticism articulated in the UBS/Nestle-Aland tradition: external evidence (manuscript age, geographical distribution, textual family) and internal evidence (scribal habits, intrinsic probability) are weighed together, and no single principle dominates. His Textual Commentary on the Greek New Testament (1971, rev. 1994) gives the reasoning behind every significant variant adopted by the UBS committee, making it an indispensable companion to the critical text."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Metzger was an ordained Presbyterian minister and wrote from within mainline Protestant scholarship. His work is irenic, historically grounded, and characterised by a steady refusal either to overstate the coherence of the early canon or to collapse it into a late ecclesiastical imposition. He is the standard dialogue partner for Kruger and other evangelical canon scholars, who often accept his historical reconstruction while differing in their theological interpretation of it."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Canon of the New Testament: Its Origin, Development, and Significance (Oxford, 1987)\nThe most widely used English-language study of New Testament canon formation, tracing the process from the first century through late antiquity.\n\nThe Text of the New Testament: Its Transmission, Corruption, and Restoration (with Bart D. Ehrman, 4th ed., Oxford, 2005)\nThe standard introduction to New Testament textual criticism, revised across decades.\n\nA Textual Commentary on the Greek New Testament (UBS, 1971; rev. 1994)\nThe committee's reasoning for textual decisions in the UBS/Nestle-Aland critical text.\n\nThe Bible in Translation (Baker, 2001)\nA historical survey of ancient and English Bible translations from an insider's perspective."
+      },
+      {
+        "title": "Appears In",
+        "body": "Metzger notes appear in materials on New Testament canon formation and the manuscript history of the New Testament."
+      }
+    ]
+  },
+  {
+    "id": "nickelsburg",
+    "panel_key": "nickelsburg",
+    "label": "Nickelsburg",
+    "name": "George W. E. Nickelsburg",
+    "color": "#483d8b",
+    "tradition": "Critical · Second Temple Judaism · Contemporary",
+    "scope": [],
+    "scope_text": "1 Enoch, Second Temple apocalyptic, Jewish literature between the Testaments",
+    "description": "Professor emeritus at the University of Iowa; co-author with VanderKam of the two-volume Hermeneia commentary on 1 Enoch and a leading scholar of Second Temple apocalyptic.",
+    "eyebrow": "Critical · Second Temple Judaism",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "George W. E. Nickelsburg (b. 1934) is professor emeritus of religion at the University of Iowa. He earned his Th.D. from Harvard Divinity School and taught at Iowa from 1969 until his retirement in 2000. His scholarly focus has been the Jewish literature of the Second Temple period — the so-called intertestamental literature — with particular attention to apocalyptic, wisdom, and narrative texts that stand outside the Hebrew Bible but illuminate the religious matrix of early Judaism and nascent Christianity.\n\nHis collaboration with James C. VanderKam on the Hermeneia commentary on 1 Enoch (two volumes, 2001 and 2012) is regarded as the standard critical commentary in English on the most important Jewish apocalypse outside the biblical canon."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "Nickelsburg reads Second Temple Jewish texts as evidence of the diverse theological imagination from which both rabbinic Judaism and early Christianity emerged. His work on 1 Enoch is attentive to its composite literary history (the Book of the Watchers, the Astronomical Book, the Book of Dreams, the Epistle of Enoch, and the later Similitudes), to its transmission in Aramaic at Qumran and subsequently in Greek and Ethiopic, and to its shaping of later apocalyptic and eschatological language.\n\nIn Resurrection, Immortality, and Eternal Life in Intertestamental Judaism, he traces how the categories of post-mortem vindication and judgment developed across the Second Temple corpus, providing essential background for New Testament conceptions of resurrection and eternal life."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Nickelsburg writes from within the mainstream historical-critical academy. He is not working from within a confessional framework; his work is descriptive and reconstructive, treating ancient texts as historical witnesses to particular Jewish communities rather than as Scripture to be theologically interpreted. That methodological stance makes his work especially valuable for understanding how Jewish literature outside the biblical canon functioned in its original contexts."
+      },
+      {
+        "title": "Key Works",
+        "body": "1 Enoch 1: A Commentary on the Book of 1 Enoch Chapters 1–36; 81–108 (Hermeneia, Fortress, 2001)\nThe definitive English-language critical commentary on the earlier portions of 1 Enoch.\n\n1 Enoch 2: A Commentary on the Book of 1 Enoch Chapters 37–82 (with James C. VanderKam, Hermeneia, Fortress, 2012)\nThe companion volume covering the Similitudes and the Astronomical Book.\n\nJewish Literature Between the Bible and the Mishnah (Fortress, 1981; rev. 2005)\nThe standard student-level introduction to the literature of the Second Temple period.\n\nResurrection, Immortality, and Eternal Life in Intertestamental Judaism (Harvard, 1972; rev. 2006)\nA foundational study of the development of resurrection and post-mortem vindication in Second Temple thought."
+      },
+      {
+        "title": "Appears In",
+        "body": "Nickelsburg notes appear in materials on 1 Enoch and other Second Temple apocalyptic and wisdom literature."
+      }
+    ]
+  },
+  {
+    "id": "vanderkam",
+    "panel_key": "vanderkam",
+    "label": "VanderKam",
+    "name": "James C. VanderKam",
+    "color": "#6b8e23",
+    "tradition": "Critical · Second Temple Judaism · Contemporary",
+    "scope": [],
+    "scope_text": "Jubilees, Dead Sea Scrolls, Enochic literature, Second Temple calendar",
+    "description": "John A. O'Brien Professor emeritus at the University of Notre Dame; leading scholar of Jubilees, the Dead Sea Scrolls, and Enochic literature.",
+    "eyebrow": "Critical · Second Temple Judaism",
+    "bio_sections": [
+      {
+        "title": "Biography",
+        "body": "James C. VanderKam (b. 1946) is the John A. O'Brien Professor emeritus of theology at the University of Notre Dame, where he taught from 1991 until his retirement in 2016. Earlier he taught at North Carolina State University. He earned his Ph.D. in Near Eastern languages and civilisations from Harvard University under Frank Moore Cross, whose influence on a generation of Dead Sea Scrolls and Second Temple scholarship VanderKam's career extends.\n\nHe served as a member of the international editorial team for the Discoveries in the Judaean Desert series, responsible for the publication of the non-biblical Qumran manuscripts, and has been associate editor of major reference works including the Encyclopedia of the Dead Sea Scrolls. His work on the Book of Jubilees — both text-critical edition and commentary — established him as the foremost Western authority on that text."
+      },
+      {
+        "title": "Interpretive Approach",
+        "body": "VanderKam's scholarship is philologically grounded, historically situated, and attentive to the religious and calendrical concerns that animated particular Second Temple Jewish communities. His two-volume critical edition of Jubilees in the CSCO series (1989) established the Ge'ez text alongside Greek, Latin, and Syriac witnesses, and his commentary and introduction (Jubilees, 2018) remains the most thorough English-language treatment of the book.\n\nHis Calendars in the Dead Sea Scrolls traces the 364-day solar calendar attested in Jubilees, some Enochic texts, and several Qumran scrolls, showing how calendrical commitments functioned as a marker of sectarian identity. His broader work on the Scrolls — in particular The Dead Sea Scrolls Today — has been widely used as an accessible introduction for students and general readers."
+      },
+      {
+        "title": "Theological Tradition",
+        "body": "Like Nickelsburg, VanderKam writes from within the mainstream critical academy. His work is descriptive and reconstructive, treating Jubilees, 1 Enoch, and the Qumran scrolls as historical witnesses to particular Jewish communities rather than as theological claims to be adjudicated. His scholarship provides essential background for reading how the canonical biblical texts would have been heard by first-century Jews formed by this literary and calendrical environment."
+      },
+      {
+        "title": "Key Works",
+        "body": "The Book of Jubilees: A Critical Text (CSCO, 2 vols., 1989)\nVanderKam's critical edition of Jubilees based on the Ge'ez manuscripts and the Greek, Latin, and Syriac fragments.\n\nJubilees 1 and Jubilees 2 (Hermeneia, 2018)\nTwo-volume critical commentary on Jubilees; the standard English-language reference.\n\n1 Enoch 2 (with George W. E. Nickelsburg, Hermeneia, 2012)\nCommentary on the Similitudes and Astronomical Book of 1 Enoch.\n\nThe Dead Sea Scrolls Today (Eerdmans, 1994; rev. 2010)\nThe most widely used introductory survey of the Scrolls for students and general readers.\n\nCalendars in the Dead Sea Scrolls: Measuring Time (Routledge, 1998)\nA focused study of the 364-day solar calendar in Jubilees, some Enochic texts, and the Qumran scrolls."
+      },
+      {
+        "title": "Appears In",
+        "body": "VanderKam notes appear in materials on Jubilees, the Dead Sea Scrolls, and Enochic literature."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## What this does
Adds 8 scholars to the registry — 4 patristic (Athanasius, Jerome, Augustine, Tertullian) and 4 modern canon / Second Temple scholars (Kruger, Metzger, Nickelsburg, VanderKam). These voices are foundational for the "How We Got The Bible" epic (#1536) and are cited in canon-formation and extrabiblical content rather than per-book chapter panels.

## Closes
Closes #1537

## Changes
- `content/meta/scholars.json` — 8 new entries, full 11-key shape matching `bruce`, 5 `bio_sections` each (Biography, Interpretive Approach, Theological Tradition, Key Works, Appears In). Total: 72 → 80.
- `content/meta/scholar-bios.json` — 8 short bio blurbs matching the existing shape (4 sections each).
- `content/meta/scholar-scopes.json` — 8 scope entries, all empty lists. Patristic / canon scholars won't appear as chapter panels inside canonical books; empty lists mean the schema_validator's scope enforcement will catch an accidental leak.
- `_tools/config.py` — 8 new `SCHOLAR_REGISTRY.append` + 8 new `COMMENTATOR_SCOPE[id] = []` entries at end of file.
- `app/assets/db-manifest.json` — content hash bump from DB rebuild.

Colors picked to be distinct from the 72 existing hexes: `#a87820`, `#c27030`, `#8b4513`, `#a0522d` (patristic, warm tones suggesting antiquity); `#507890`, `#708090`, `#483d8b`, `#6b8e23` (modern, cooler tones).

## How I verified
- `python _tools/schema_validator.py` — 136482 passed, 77 failed, 0 new failures vs. master (all 77 pre-existing, unrelated to scholars). ✅
- `python _tools/build_sqlite.py` — scripture.db rebuilt cleanly, `scholars` table row count **80**. ✅
- `python _tools/validate_sqlite.py` — 93 passed, 0 failed, 2 warnings (both pre-existing: embeddings.db / prompts.db not built). ✅
- Verified all 8 new scholars present in `scholars` table with expected names.

## Out of scope
- Did not touch `app/src/theme/colors.ts` or `app/src/utils/panelLabels.ts`. The issue's "Files to touch" list does not include them, and since these 8 scholars aren't wired as chapter panels (empty scopes), the existing hex color stored on the `scholars` row is sufficient. Follow-up issues that wire them as panels can add those entries then.
- `app/assets/explore-images.json` also showed drift vs. `content/meta/explore-images.json` on master. Reverted — unrelated to this issue.

## Rollback
Revert this PR. No schema migrations on user.db. No R2 state changes. The `scripture.db` rebuilt from content after revert would have 72 rows again.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHELDhvq1dxY36oL5Gguad)_