### PR TITLE
feat: add st2 (Second Temple Context) section-panel type (#1540)

### DIFF
--- a/_tools/content_writer.py
+++ b/_tools/content_writer.py
@@ -423,6 +423,12 @@ def _normalise_section_panel(key, value):
     if key in ('poi', 'tl'):
         return value
 
+    # Second Temple Context (st2) — already structured by the generator
+    # (HWGTB #1540). Expected payload: {header, body, extrabiblical_ids,
+    # citation_refs, scholar_voices?, takeaway?}.
+    if key == 'st2' and isinstance(value, dict):
+        return value
+
     # Scholar commentary panels (mac, calvin, net, sarna, oswalt, etc.)
     if isinstance(value, list) and value:
         first = value[0]
@@ -588,6 +594,8 @@ def validate_chapter_json(json_path):
 
     known_section_types = {
         'heb', 'ctx', 'hist', 'cross', 'poi', 'tl', 'places',
+        # st2 — Second Temple Context panel (HWGTB #1540)
+        'st2',
     }
     # Add all scholar keys from COMMENTATOR_SCOPE
     try:

--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -1204,6 +1204,8 @@ def main():
             'heb', 'hist', 'ctx', 'cross', 'greek', 'hebtext', 'interlinear',
             'tl', 'places', 'poi', 'themes', 'lit', 'trans', 'src', 'rec',
             'thread', 'tx', 'textual', 'debate', 'discourse', 'ppl', 'com',
+            # st2 — Second Temple Context panel (HWGTB #1540)
+            'st2',
         }
         unregistered = []
         for book_dir in sorted(CONTENT.iterdir()):
@@ -1223,6 +1225,80 @@ def main():
         print(f"  Unregistered scholars: {len(unregistered)}")
     else:
         print("  [SKIP] scholars.json not found")
+
+    # ── 13b. st2 panel payload integrity (HWGTB #1540) ──
+    print("\n--- 13b. ST2 PANEL INTEGRITY ---")
+
+    st2_extrabiblical_ids = set()
+    eb_path_st2 = META / 'extrabiblical.json'
+    if eb_path_st2.exists():
+        try:
+            ebd = json.loads(eb_path_st2.read_text(encoding='utf-8'))
+            st2_extrabiblical_ids = {e['id'] for e in (ebd if isinstance(ebd, list) else []) if 'id' in e}
+        except Exception:
+            pass
+
+    st2_ref_re = re.compile(
+        r'^[a-z0-9_]+(\s[a-z0-9_]+)*\s\d+(-\d+)?(:\d+(-\d+)?)?$'
+    )
+    st2_valid_citation_types = {'direct_quotation', 'allusion', 'echo'}
+    st2_required_keys = {'header', 'body', 'extrabiblical_ids', 'citation_refs'}
+    st2_panel_count = 0
+
+    for book_dir in sorted(CONTENT.iterdir()):
+        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+            continue
+        for json_file in sorted(book_dir.glob('*.json')):
+            try:
+                data = json.loads(json_file.read_text(encoding='utf-8'))
+            except Exception:
+                continue
+            for i, sec in enumerate(data.get('sections', [])):
+                st2 = sec.get('panels', {}).get('st2')
+                if st2 is None:
+                    continue
+                loc = f"{book_dir.name}/{json_file.stem} S{i+1}"
+                st2_panel_count += 1
+                check(f"st2 {loc} is object", isinstance(st2, dict),
+                      f"got {type(st2).__name__}")
+                if not isinstance(st2, dict):
+                    continue
+                missing = st2_required_keys - set(st2.keys())
+                check(f"st2 {loc} has required keys",
+                      len(missing) == 0,
+                      f"missing {sorted(missing)}")
+
+                # extrabiblical_ids[] resolve
+                for j, eid in enumerate(st2.get('extrabiblical_ids', []) or []):
+                    check(f"st2 {loc} extrabiblical_ids[{j}] valid",
+                          eid in st2_extrabiblical_ids,
+                          f"'{eid}' not in extrabiblical.json")
+
+                # citation_refs[].nt parses + .type enum
+                for j, cit in enumerate(st2.get('citation_refs', []) or []):
+                    if not isinstance(cit, dict):
+                        check(f"st2 {loc} citation_refs[{j}] is object", False,
+                              f"got {type(cit).__name__}")
+                        continue
+                    nt = str(cit.get('nt', '')).strip().lower()
+                    check(f"st2 {loc} citation_refs[{j}].nt parses",
+                          bool(st2_ref_re.match(nt)),
+                          f"ref '{cit.get('nt')}' does not match verse pattern")
+                    if 'type' in cit:
+                        check(f"st2 {loc} citation_refs[{j}].type valid",
+                              cit['type'] in st2_valid_citation_types,
+                              f"'{cit['type']}' not in {sorted(st2_valid_citation_types)}")
+
+                # scholar_voices[].scholar_id resolve (if present)
+                for j, sv in enumerate(st2.get('scholar_voices', []) or []):
+                    if not isinstance(sv, dict):
+                        continue
+                    sid = sv.get('scholar_id')
+                    check(f"st2 {loc} scholar_voices[{j}].scholar_id valid",
+                          sid in scholar_ids,
+                          f"'{sid}' not in scholars.json")
+
+    print(f"  st2 panels scanned: {st2_panel_count}")
 
     # ── 14. Verse overlap check (#560) ──
     print("\n--- 14. VERSE OVERLAPS ---")

--- a/_tools/validate_sqlite.py
+++ b/_tools/validate_sqlite.py
@@ -728,6 +728,28 @@ def main():
         "SELECT COUNT(*) FROM chapter_panels WHERE json_valid(content_json) = 0")
     check("All chapter_panel JSON valid", invalid_cp == 0, f"{invalid_cp} invalid")
 
+    # st2 panels (HWGTB #1540): extrabiblical_ids[] entries resolve to
+    # extrabiblical.id. Defensive: only runs if the extrabiblical table
+    # exists (merged via #1538) and there are st2 panels to check.
+    if _has_table(cur, 'extrabiblical'):
+        import json as _json
+        eb_ids = {row[0] for row in q(cur, "SELECT id FROM extrabiblical")}
+        st2_rows = q(cur,
+            "SELECT section_id, content_json FROM section_panels "
+            "WHERE panel_type = 'st2'")
+        bad_refs = []
+        for sid, cj in st2_rows:
+            try:
+                payload = _json.loads(cj) if cj else {}
+                for eid in payload.get('extrabiblical_ids', []) or []:
+                    if eid not in eb_ids:
+                        bad_refs.append(f"{sid} -> {eid}")
+            except Exception as err:
+                bad_refs.append(f"{sid}: JSON parse error — {err}")
+        check("st2 panel extrabiblical_ids resolve",
+              len(bad_refs) == 0, f"{bad_refs[:5]}")
+        print(f"  st2 panels: {len(st2_rows)}")
+
     # People: father/mother references point to existing people
     bad_fathers = q(cur,
         "SELECT p.id, p.father FROM people p "

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "e23e12864fe9945d",
-  "build_time": "2026-04-23T11:54:42.572073Z"
+  "content_hash": "1be3a0aebc28ba0e",
+  "build_time": "2026-04-23T12:07:41.110289Z"
 }


### PR DESCRIPTION
## What this does
Registers `st2` (Second Temple Context) as a valid section-panel type in the pipeline and adds full integrity validation. Pipeline-only; app-side rendering lands in HWGTB-P2-01 (#1546).

## Closes
Closes #1540

## Changes
- `_tools/content_writer.py` — `'st2'` added to `known_section_types`; explicit passthrough case in `_normalise_section_panel` for documentation/intent.
- `_tools/schema_validator.py`:
  - `'st2'` added to `non_scholar_panels` so the UNREGISTERED SCHOLARS check doesn't flag it.
  - New section **13b. ST2 PANEL INTEGRITY** that sweeps every `content/{book}/*.json` chapter, validates the required-keys shape (`header`, `body`, `extrabiblical_ids`, `citation_refs`), cross-links `extrabiblical_ids[]` against `extrabiblical.json`, parses `citation_refs[].nt` as a verse ref, enforces `citation_refs[].type ∈ {direct_quotation, allusion, echo}`, and cross-links `scholar_voices[].scholar_id` against `scholars.json`.
- `_tools/validate_sqlite.py` — DB-side check that every `extrabiblical_ids[]` entry in st2 `section_panels` rows resolves to an `extrabiblical.id`. Guarded behind `_has_table(cur, 'extrabiblical')` so the check only runs once #1538 ships the table.
- `build_sqlite_loaders.py` — **no code change**: the section_panels loader is panel-type-agnostic, so st2 is routed automatically with `panel_type='st2'`.
- `app/assets/db-manifest.json` — content hash bump.

## How I verified
Smoke-tested end-to-end:
1. Temporarily created `content/meta/extrabiblical.json` with one stub entry (simulating #1538 merged).
2. Added an `st2` panel to Jude 1 section 2 (covers Jude 14–15 which quotes 1 Enoch 1:9).
3. **Positive path**: schema_validator clean for st2, build succeeded, st2 panel landed in `section_panels` with full payload (`SELECT COUNT(*)=1 WHERE panel_type='st2'`).
4. **Negative paths**: mutated the panel to use an unknown `extrabiblical_id`, `citation_refs[].type='bogus_type'`, and `citation_refs[].nt='Not A Ref'`. All three failures fired:
   - `[FAIL] st2 jude/1 S2 extrabiblical_ids[0] valid`
   - `[FAIL] st2 jude/1 S2 citation_refs[0].nt parses`
   - `[FAIL] st2 jude/1 S2 citation_refs[0].type valid`
5. Reverted both test mutations (Jude 1 back to master; deleted test extrabiblical.json).

Final (clean) state:
- `python _tools/schema_validator.py` — 136482 passed, 77 failed (all pre-existing on master), 0 new failures ✅
- `python _tools/build_sqlite.py` ✅
- `python _tools/validate_sqlite.py` — 93 passed, 0 failed, 2 warnings ✅

## Out of scope
- Depends on #1538 (extrabiblical table). The `validate_sqlite` check is guarded with `_has_table` so a checkout without #1538 merged still passes clean (the check is a no-op). Once #1538 lands, the guard flips to active. No content currently uses st2; first use lands in #1543.
- App-side rendering (PanelRenderer dispatcher, component, theme color) — HWGTB-P2-01 (#1546).
- `app/assets/explore-images.json` drift reverted.

## Rollback
Revert this PR. Next `build_sqlite.py` rebuilds without the schema validator's st2 section; any st2 section_panels rows (none in Phase 1) would drop on rebuild since scripture.db is replaced each build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHELDhvq1dxY36oL5Gguad)_