### PR TITLE
content: 12 extrabiblical entries (brief summaries) (#1541)

### DIFF
--- a/content/meta/extrabiblical.json
+++ b/content/meta/extrabiblical.json
@@ -1,1 +1,405 @@
-[]
+[
+  {
+    "id": "1_enoch",
+    "title": "1 Enoch (Ethiopic Enoch)",
+    "also_known_as": ["Book of Enoch", "Ethiopic Enoch"],
+    "category": "pseudepigrapha",
+    "estimated_date": "3rd c. BC – 1st c. AD (composite)",
+    "original_language": "Aramaic (portions in Hebrew); preserved in full only in Ge'ez (Classical Ethiopic), with substantial Greek fragments and Aramaic copies of every section except the Similitudes at Qumran",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "canonical (part of the Broader Canon)"
+    },
+    "brief_summary": "1 Enoch is a composite Jewish apocalyptic work attributed to the antediluvian patriarch Enoch (Gen 5:18–24). Its five major sections — the Book of the Watchers (chs 1–36), the Similitudes or Book of Parables (chs 37–71), the Astronomical Book (chs 72–82), the Book of Dreams (chs 83–90), and the Epistle of Enoch (chs 91–105) — were composed over roughly four centuries, from the third century BC into the first century AD.\n\nThe Book of the Watchers expands the cryptic narrative of Genesis 6:1–4, recounting the rebellion of the angelic 'Watchers' who took human wives, fathered the giants (Nephilim), and taught humanity forbidden arts, bringing cosmic disorder that the Flood is meant to reverse. The Astronomical Book presents a 364-day solar calendar; the Dreams section contains the Animal Apocalypse, an allegorical vision of Jewish history from Adam to the Maccabean revolt; the Epistle warns the wicked rich and consoles the righteous poor; and the Similitudes develops the figure of a heavenly 'Son of Man' who will judge the nations.\n\nOriginally written in Aramaic — fragments of every section except the Similitudes have been recovered at Qumran — the book circulated in Greek in late antiquity but survives in full only in Ge'ez (Classical Ethiopic). The Epistle of Jude quotes 1 Enoch 1:9 directly (Jude 14–15), making it the only explicit quotation of an extra-biblical book in the New Testament.\n\nEarly Christian writers received 1 Enoch variously. Tertullian defended it as Scripture on the basis of Jude's citation; Origen cited it with respect; Augustine and Jerome argued against canonical status while acknowledging its antiquity. By the fourth century the Greek-speaking and Latin churches had effectively excluded it. The Ethiopian Tewahedo Church, however, preserved the full Ge'ez text and includes 1 Enoch in its biblical canon — the only Christian tradition to do so.",
+    "full_summary": null,
+    "nt_citations": [
+      { "ref": "Jude 14-15", "cites": "1 Enoch 1:9", "type": "direct_quotation" }
+    ],
+    "ot_allusions": [
+      { "ref": "Genesis 6:1-4", "connection": "The Book of the Watchers (chs 1–36) greatly expands the cryptic narrative of the sons of God and daughters of men, identifying the sons of God as fallen angels and the Nephilim as their offspring." },
+      { "ref": "Genesis 5:18-24", "connection": "Pseudepigraphically attributed to Enoch, who 'walked with God, and he was not, for God took him.'" }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "nickelsburg", "position": "Traces the composite literary history across four centuries in the standard English-language Hermeneia commentary (1 Enoch 1 [2001]; 1 Enoch 2 [2012], with VanderKam). Notes that every section except the Similitudes is attested at Qumran in Aramaic, placing the core tradition firmly in Second Temple Judaism." },
+      { "scholar_id": "vanderkam", "position": "In his work on Jubilees and the Dead Sea Scrolls, treats 1 Enoch as part of a broader Enochic literary tradition whose 364-day solar calendar linked the book to the Qumran sectarians and distinguished them from the temple establishment in Jerusalem." },
+      { "scholar_id": "tertullian", "position": "In De Cultu Feminarum 1.3 defends the book against detractors, arguing that its rejection 'by some' (probably the rabbinic canon) does not bind Christians and that Jude's citation (Jude 14–15) is itself evidence of authoritative apostolic reception." },
+      { "scholar_id": "bruce", "position": "Evangelical NT perspective: Jude's citation shows the book was widely known and respected in some first-century Jewish-Christian circles, but citation does not entail canonisation — Paul likewise cites Greek poets in Acts 17 and Titus 1 without implying their inspiration." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["apocalyptic", "watchers", "enochic-literature", "second-temple", "ethiopian-tewahedo-canon", "jude"],
+    "further_reading": [
+      { "title": "1 Enoch 1: A Commentary on the Book of 1 Enoch Chapters 1–36; 81–108", "author": "George W. E. Nickelsburg", "note": "Hermeneia (Fortress, 2001)." },
+      { "title": "1 Enoch 2: A Commentary on the Book of 1 Enoch Chapters 37–82", "author": "George W. E. Nickelsburg and James C. VanderKam", "note": "Hermeneia (Fortress, 2012)." }
+    ]
+  },
+  {
+    "id": "2_enoch",
+    "title": "2 Enoch (Slavonic Enoch)",
+    "also_known_as": ["Slavonic Enoch", "Book of the Secrets of Enoch"],
+    "category": "pseudepigrapha",
+    "estimated_date": "Probably 1st c. AD; later redaction in the Slavonic tradition",
+    "original_language": "Most likely Greek (from a Hebrew or Aramaic Vorlage); preserved only in Old Church Slavonic in two recensions (longer and shorter)",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "not canonical"
+    },
+    "brief_summary": "2 Enoch — distinct from 1 Enoch despite the shared attribution — narrates Enoch's ascent through seven (or, in the longer recension, ten) heavens, his observation of cosmic order and the dwellings of the righteous and the wicked, his conversations with God, and his commissioning to instruct his sons before his final translation. Chapters 68–73 add a genealogy and priestly lineage that connects Enoch's line to Melchizedek, whose miraculous birth and priestly ministry the book develops at length.\n\nThe date of composition is debated. The dominant scholarly view places the original text in the first century AD, before the destruction of the Second Temple in 70 — the sacrificial descriptions in chs 59, 68–69 presuppose a functioning temple, and the astronomical material (chs 11–17) draws on pre-70 Jewish apocalyptic conventions. Other scholars argue for a slightly later date or for a more complex compositional history extending into later Jewish or Christian circles.\n\nThe most striking feature of 2 Enoch is the Melchizedek narrative in chs 68–73 (often printed as 2 Enoch 68–73 or as a separate text known as 2 Enoch/Melchizedek). It recounts the birth of Melchizedek from Noah's sister-in-law Sopanima after her death, his rescue by the archangel Michael, and his preservation through the Flood — material with no parallel in 1 Enoch or in Genesis 14.\n\nUnlike 1 Enoch, 2 Enoch has no attestation at Qumran and no quotation in the New Testament. It was effectively unknown to Western Christendom until Slavonic manuscripts were published in the nineteenth century. No Christian tradition has ever received it as canonical, though it is occasionally drawn on in Eastern Orthodox devotional and iconographic contexts. The book is nonetheless significant for mapping the variety of Second Temple speculation on cosmology, angelology, and priesthood.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Genesis 5:18-24", "connection": "Like 1 Enoch, pseudepigraphically attributed to the antediluvian patriarch Enoch." },
+      { "ref": "Genesis 14:18-20", "connection": "The Melchizedek narrative (chs 68–73) expands the Genesis 14 figure into a detailed pre-Flood origin story with no biblical parallel." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "nickelsburg", "position": "Treats 2 Enoch as part of the broader Second Temple literary tradition that includes 1 Enoch and Jubilees, though noting that it stands at considerable distance from those texts in language and content. In Jewish Literature Between the Bible and the Mishnah, surveys the book's cosmology and its unparalleled Melchizedek material." },
+      { "scholar_id": "collins", "position": "Places 2 Enoch among the Second Temple apocalypses in his wider studies of apocalyptic literature, while cautioning that its composition history and textual transmission are considerably more obscure than those of 1 Enoch or 4 Ezra." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["apocalyptic", "enochic-literature", "second-temple", "melchizedek", "slavonic"],
+    "further_reading": [
+      { "title": "Old Testament Pseudepigrapha, vol. 1: Apocalyptic Literature and Testaments", "author": "James H. Charlesworth, ed.", "note": "Doubleday, 1983. Contains Francis I. Andersen's standard English translation of 2 Enoch with introduction." }
+    ]
+  },
+  {
+    "id": "jubilees",
+    "title": "Book of Jubilees",
+    "also_known_as": ["Lesser Genesis", "Leptogenesis"],
+    "category": "pseudepigrapha",
+    "estimated_date": "c. 160–150 BC, in the early Maccabean period",
+    "original_language": "Hebrew (fragments of roughly a dozen manuscripts at Qumran); preserved in full only in Ge'ez (Classical Ethiopic), partially in Latin and Syriac",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "canonical (part of the Broader Canon)"
+    },
+    "brief_summary": "Jubilees retells the narrative of Genesis and the first half of Exodus (through the Sinai theophany) as a revelation given to Moses on Mount Sinai by the angel of the presence. The book's name reflects its distinctive chronological framework: all of history is ordered into seven-year 'weeks' and forty-nine-year 'jubilees,' producing a symbolic calendar in which events from creation to Sinai occupy exactly fifty jubilees.\n\nThe retelling serves several aims. First, it harmonises perceived difficulties in Genesis — explaining where Cain's wife came from, clarifying the ages of the patriarchs, supplying missing details about Enoch and the Flood. Second, it projects Second Temple legal and liturgical practice back into the patriarchal period: Abraham keeps the Passover, Jacob observes Shavuot, and the feasts follow Jubilees' 364-day solar calendar rather than the lunar calendar of the Jerusalem temple. Third, it draws sharp ethnic and religious boundaries — intermarriage, Sabbath violation, and idolatry are repeatedly denounced — which many scholars read as a response to Hellenising pressures in the early Maccabean era.\n\nJubilees was highly authoritative at Qumran: roughly a dozen manuscripts have been recovered, and the Damascus Document (CD 16:3–4) cites it as 'the book of the divisions of the times by their jubilees and their weeks.' The Ethiopian Tewahedo Church preserved the full Ge'ez text and includes Jubilees in its biblical canon, making it — alongside 1 Enoch — one of the two Old Testament pseudepigrapha considered Scripture in any major Christian tradition.\n\nNew Testament writers do not quote Jubilees, but its angelology, its strict Sabbath observance, its emphasis on predestined historical eras, and its sectarian calendar illuminate the Second Temple Jewish matrix within which early Christianity took shape.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Genesis 1-50", "connection": "Rewrites the entire book of Genesis with expansions, harmonisations, and halakhic interpolations." },
+      { "ref": "Exodus 1-24", "connection": "Continues through the Sinai theophany; the narrative frame presents the whole as revelation to Moses on the mountain." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "vanderkam", "position": "The leading Western authority on Jubilees. His two-volume Hermeneia commentary (2018) and earlier CSCO critical edition (1989) remain the standard references. Dates the book to c. 160–150 BC and identifies its calendrical and legal concerns with a pre-Qumranic priestly group from which the Qumran community later emerged." },
+      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, treats Jubilees as a key witness to pre-rabbinic Jewish halakha and to the calendrical and ethnic tensions that produced the Qumran sectarians. Views the retelling of Genesis as an early example of what modern scholars call 'rewritten Bible.'" },
+      { "scholar_id": "collins", "position": "Places Jubilees within the broader wisdom and apocalyptic streams of Second Temple Judaism, noting how its angelology and eschatology draw on and develop material shared with 1 Enoch." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["rewritten-bible", "second-temple", "qumran", "dead-sea-scrolls", "ethiopian-tewahedo-canon", "calendar", "jubilees"],
+    "further_reading": [
+      { "title": "Jubilees 1 and Jubilees 2", "author": "James C. VanderKam", "note": "Hermeneia (Fortress, 2018). The standard English-language critical commentary." },
+      { "title": "The Book of Jubilees", "author": "James C. VanderKam", "note": "CSCO 510–511 (Peeters, 1989). Two-volume critical edition and translation of the Ge'ez with Hebrew, Greek, Latin, and Syriac witnesses." }
+    ]
+  },
+  {
+    "id": "jasher",
+    "title": "Book of Jasher (Sefer haYashar)",
+    "also_known_as": ["Book of Jashar", "Sefer haYashar", "Book of the Upright"],
+    "category": "pseudepigrapha",
+    "estimated_date": "The lost OT source cannot be dated; the extant medieval Sefer haYashar is c. 11th–13th c. AD; a separate 18th c. English forgery circulates under the same title",
+    "original_language": "The OT source is unknown; the medieval Sefer haYashar is Hebrew; the 18th c. forgery is English",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "not canonical"
+    },
+    "brief_summary": "The Hebrew Bible twice refers to a 'Book of Jashar' (sefer ha-yashar, literally 'Book of the Upright'): Joshua 10:13 cites it as the source of the account of the sun standing still over Gibeon, and 2 Samuel 1:18 notes that David's lament over Saul and Jonathan was recorded in it. A third probable reference is 1 Kings 8:53 in the Septuagint tradition. Whatever these references point to, the original work is lost. No manuscripts or independent citations have survived from antiquity, and its contents are known only through the brief quotations preserved in the biblical text.\n\nSeveral later works have circulated under the title 'Book of Jasher' and are often confused with the lost biblical source. The most important is the medieval Sefer haYashar (often dated to somewhere between the eleventh and thirteenth centuries), a Hebrew retelling of biblical history from Adam through the Judges. It draws on Jewish midrashic traditions and postdates the biblical references by well over a millennium. The medieval work is a genuine Jewish text but has no historical connection to the lost source cited by the biblical writers.\n\nA separate eighteenth-century English publication (1751) also styled 'The Book of Jasher' is a modern forgery, unrelated to the medieval Hebrew work or to the biblical reference. Neither the medieval Sefer haYashar nor the eighteenth-century work has been received as canonical by any Christian tradition. The lost biblical source is significant historically because it shows the biblical writers knew and used older Hebrew literary sources — a fact attested elsewhere by references to the 'Book of the Wars of the Lord' (Num 21:14) and the 'Book of the Annals of the Kings of Israel' — but it cannot itself be read.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Joshua 10:13", "connection": "The Joshua narrator cites the Book of Jashar as the source of the account of the sun and moon standing still over Gibeon and the Valley of Aijalon." },
+      { "ref": "2 Samuel 1:18", "connection": "David's Lament of the Bow, mourning Saul and Jonathan, is said to have been recorded in the Book of Jashar and commanded to be taught to Judah." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "longman", "position": "Treats the biblical references as pointing to a lost Hebrew source-collection of poetry and national memory, analogous to the 'Book of the Wars of the Lord' in Numbers 21:14 and the various royal annals cited in Kings and Chronicles. Cautions that the extant Sefer haYashar is a medieval midrashic work, not the biblical source." },
+      { "scholar_id": "provan", "position": "Notes the reference in 2 Samuel 1:18 among several instances where the biblical narrators openly cite earlier Israelite literature, suggesting that the canonical books are the crystallised distillation of a larger national archive now lost." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["lost-source", "ot-references", "medieval-midrash", "sefer-hayashar", "forgery"],
+    "further_reading": [
+      { "title": "The Lost Books of the Old Testament", "author": "Various", "note": "General scholarly surveys of the Book of the Wars of the Lord, the Book of Jashar, and other biblical source citations — see standard OT introductions (e.g., Childs; Dillard and Longman)." }
+    ]
+  },
+  {
+    "id": "assumption_of_moses",
+    "title": "Assumption of Moses",
+    "also_known_as": ["Testament of Moses", "Assumptio Mosis"],
+    "category": "pseudepigrapha",
+    "estimated_date": "Early 1st c. AD (most scholars); possibly a rework of a Maccabean-era Testament of Moses",
+    "original_language": "Hebrew or Aramaic original; preserved only in a single incomplete 6th c. Latin palimpsest discovered in Milan in the 19th century",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "not canonical"
+    },
+    "brief_summary": "The Assumption of Moses is a Jewish pseudepigraphon cast as Moses' farewell address to Joshua on the plains of Moab before his death (cf. Deut 31–33). In the extant text, Moses foretells the history of Israel from the conquest through the Hasmonean period and into a final eschatological crisis, culminating in the intervention of a mysterious figure called 'Taxo' and the inauguration of God's kingdom.\n\nThe extant Latin palimpsest — the only surviving copy — breaks off before the end. Early Christian writers, including Origen, Clement of Alexandria, and the compiler of the Apostolic Constitutions, refer to a Jewish work about Moses' death that contained a dispute between the archangel Michael and the devil over Moses' body. No such scene appears in the extant Latin text, leading most scholars since R. H. Charles to conclude that the Assumption of Moses originally included this material in its now-lost conclusion.\n\nThis matters directly for the interpretation of Jude 9: 'But even the archangel Michael, when he was disputing with the devil about the body of Moses, did not himself dare to condemn him for slander but said, \"The Lord rebuke you!\"' Patristic writers from Origen onward explicitly connected Jude 9 with the Assumption of Moses. If the identification is correct, Jude alludes to the same Jewish tradition attested in that book.\n\nNeither the work itself nor the patristic testimonies establish it as Scripture. The Assumption of Moses has never been received as canonical in any Christian tradition. It is significant, however, for illuminating the Second Temple Jewish imagination from which Jude's brief letter drew its imagery of the righteous dead, angelic mediation, and eschatological vindication.",
+    "full_summary": null,
+    "nt_citations": [
+      { "ref": "Jude 9", "cites": "Assumption of Moses (lost ending)", "type": "allusion" }
+    ],
+    "ot_allusions": [
+      { "ref": "Deuteronomy 31-34", "connection": "Cast as Moses' final words to Joshua before his death, expanding the framework of Deuteronomy's farewell speeches." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "nickelsburg", "position": "Surveys the Assumption of Moses among the Second Temple testamentary works in Jewish Literature Between the Bible and the Mishnah, endorses the scholarly consensus that the lost ending contained the Michael-versus-devil dispute, and reads the surviving text as an apocalyptic protest composed in the early first century AD." },
+      { "scholar_id": "bruce", "position": "In his commentary and survey work on the General Epistles, follows the patristic and modern consensus that Jude 9 alludes to the lost ending of the Assumption of Moses. Treats Jude's use of the tradition as a rhetorical illustration (similar to the Enoch citation in Jude 14–15), arguing that allusion to a Jewish pseudepigraphon does not entail canonical endorsement of the source text." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["second-temple", "testamentary-literature", "apocalyptic", "jude", "michael", "moses"],
+    "further_reading": [
+      { "title": "Old Testament Pseudepigrapha, vol. 1", "author": "James H. Charlesworth, ed.", "note": "Doubleday, 1983. Contains J. Priest's translation and introduction to the Testament/Assumption of Moses." }
+    ]
+  },
+  {
+    "id": "tobit",
+    "title": "Tobit",
+    "also_known_as": ["Book of Tobit", "Tobias"],
+    "category": "deuterocanon",
+    "estimated_date": "c. 3rd–2nd c. BC",
+    "original_language": "Aramaic (with at least one Hebrew witness); fragments of four Aramaic and one Hebrew manuscript at Qumran (4Q196–200). Standard text preserved in Greek (two recensions) and Latin (Vulgate)",
+    "tradition_status": {
+      "protestant": "not canonical (grouped with the Apocrypha in Reformation Bibles)",
+      "catholic": "canonical (deuterocanonical)",
+      "eastern_orthodox": "canonical (Anagignoskomena)",
+      "ethiopian_tewahedo": "canonical (Broader Canon)"
+    },
+    "brief_summary": "Tobit is a Jewish diaspora novella set in the Assyrian exile. The protagonist, Tobit of the tribe of Naphtali, is a pious Israelite deported to Nineveh who continues to observe Jewish piety — burying the unclaimed dead, giving alms, keeping the festivals — at risk to himself. Blinded in an accident and reduced to poverty, Tobit prays for death. At the same moment, far away in Ecbatana, a young woman named Sarah — whose seven successive bridegrooms have all been killed on the wedding night by the demon Asmodeus — likewise prays for death.\n\nGod hears both prayers and sends the archangel Raphael in disguise to travel with Tobit's son Tobias on a journey to recover a family deposit in Media. Along the way Raphael instructs Tobias in how to drive off Asmodeus, marry Sarah, and heal his father's blindness. The book concludes with Tobit's hymn of praise (ch 13) and a farewell address to Tobias (ch 14) prophesying the destruction of Nineveh and the restoration of Israel.\n\nComposed probably in the third or second century BC — well before the events it describes — Tobit is a work of pious fiction shaped by biblical wisdom and narrative conventions. It teaches the practical outworking of Torah piety in a diaspora setting, emphasises filial devotion, burial of the dead, and almsgiving, and develops Jewish angelology (Raphael is one of the 'seven holy angels') and demonology.\n\nAttestation of Aramaic and Hebrew copies at Qumran confirms the book's Jewish Second Temple provenance. Jerome included Tobit in the Vulgate but distinguished it from the Hebrew-canon books in his prologues. Augustine defended its broader canonical status, and the regional Councils of Hippo (393) and Carthage (397 and 419) confirmed that position for the Latin West. The Council of Trent (1546) formally defined Tobit as deuterocanonical in response to the Reformation's return to the shorter Hebrew canon. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive it as Scripture.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Deuteronomy 14:22-29", "connection": "Tobit's tithing and almsgiving practices (Tob 1:6-8) expand the Deuteronomic tithe legislation into a fuller diaspora piety." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "jerome", "position": "Included Tobit in the Vulgate — translating from an Aramaic exemplar — but distinguished it in his prologues from the books 'of the Hebrew truth,' stating it belonged among books 'to be read for the edification of the people, but not to establish the authority of ecclesiastical doctrines.'" },
+      { "scholar_id": "augustine", "position": "Defended the wider Greek and Latin canon against Jerome's narrower Hebraica veritas. The regional Councils of Hippo (393) and Carthage (397 and 419), over which he exercised decisive influence, affirmed Tobit alongside the other deuterocanonical books." },
+      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, treats Tobit as a representative example of Second Temple diaspora narrative — a pious novella combining wisdom teaching, angelology, and family drama, meant to sustain Jewish identity and practice under foreign rule." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["deuterocanon", "apocrypha", "diaspora", "second-temple", "angelology", "raphael", "qumran"],
+    "further_reading": [
+      { "title": "Tobit", "author": "Joseph A. Fitzmyer", "note": "Commentaries on Early Jewish Literature (de Gruyter, 2003). Standard critical commentary." },
+      { "title": "The Book of Tobit: Text, Tradition, Theology", "author": "Géza G. Xeravits and József Zsengellér, eds.", "note": "Brill, 2005. Essays on the book's textual history and theological themes." }
+    ]
+  },
+  {
+    "id": "judith",
+    "title": "Judith",
+    "also_known_as": ["Book of Judith"],
+    "category": "deuterocanon",
+    "estimated_date": "Late 2nd or early 1st c. BC",
+    "original_language": "Hebrew original (not extant; lost); preserved in Greek (Septuagint) and Latin (Vulgate, Jerome's free revision)",
+    "tradition_status": {
+      "protestant": "not canonical (grouped with the Apocrypha in Reformation Bibles)",
+      "catholic": "canonical (deuterocanonical)",
+      "eastern_orthodox": "canonical (Anagignoskomena)",
+      "ethiopian_tewahedo": "canonical (Broader Canon)"
+    },
+    "brief_summary": "Judith is a Jewish novella of deliverance set in a deliberately confused historical frame: 'Nebuchadnezzar, king of the Assyrians' (the title itself conflates the Neo-Babylonian king with the Assyrian empire he actually dissolved) sends his general Holofernes to punish the peoples of the west. When Holofernes besieges the Jewish hill-town of Bethulia, Judith — a beautiful, pious, wealthy widow — offers to save the town. Dressed in finery and carrying her own kosher food, she enters the enemy camp, charms Holofernes, waits until he is drunk and alone in his tent, and beheads him with his own sword. She returns to Bethulia with the head; the Israelites rout the leaderless Assyrian army, and the book ends with Judith's hymn of praise and a long, peaceful widowhood.\n\nThe book's deliberate historical dislocation — Nebuchadnezzar is called king of Assyria, and the setting cannot be harmonised with any known Persian or Hellenistic campaign — has long been recognised as a literary rather than historical feature. Most scholars read Judith as pious fiction composed in the late Hasmonean period (late second or early first century BC), perhaps to encourage Jewish resistance under Hellenistic or Roman pressure. It portrays Torah observance, prayer, and decisive courage as the true means of national deliverance.\n\nThe Hebrew original has not survived; the book is known through the Greek of the Septuagint (two recensions) and Jerome's free Latin rendering, which he produced reluctantly for the Vulgate from an Aramaic exemplar. Jerome's prologue to Judith classes it among the books read 'for the edification of the people, but not to establish the authority of ecclesiastical doctrines.' Augustine defended its broader canonicity at Hippo and Carthage, and that position was formally reaffirmed at Trent. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive Judith as Scripture; the Protestant Reformers followed Jerome's narrower judgment, placing it among the Apocrypha.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Exodus 15", "connection": "Judith's hymn of praise (ch 16) echoes the Song of the Sea and other Old Testament victory songs." },
+      { "ref": "Judges 4-5", "connection": "Judith's deliverance of Israel by assassinating a foreign general consciously mirrors Jael's killing of Sisera — both are celebrated in victory songs immediately afterward." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "jerome", "position": "Translated Judith reluctantly from an Aramaic exemplar for the Vulgate, producing a free rendering rather than a close translation. His prologue classed Judith with the books read for edification rather than for establishing doctrine — the distinction that would later be taken up by the Reformers." },
+      { "scholar_id": "augustine", "position": "Defended Judith among the books of the wider Greek and Latin canon. Under his influence the regional Councils of Hippo (393) and Carthage (397 and 419) affirmed its canonical status for the Latin West." },
+      { "scholar_id": "nickelsburg", "position": "Reads Judith as a late Hasmonean Jewish novella composed to encourage Torah-observant resistance under foreign domination. Places it alongside Tobit, Susanna, and 2 Maccabees as examples of edifying Second Temple narrative fiction." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["deuterocanon", "apocrypha", "second-temple", "novella", "hasmonean", "holofernes"],
+    "further_reading": [
+      { "title": "Judith", "author": "Carey A. Moore", "note": "Anchor Bible 40 (Doubleday, 1985). Standard critical commentary." },
+      { "title": "A Commentary on the Book of Judith", "author": "Deborah Levine Gera", "note": "Commentaries on Early Jewish Literature (de Gruyter, 2014)." }
+    ]
+  },
+  {
+    "id": "wisdom_of_solomon",
+    "title": "Wisdom of Solomon",
+    "also_known_as": ["Book of Wisdom", "Sapientia Salomonis"],
+    "category": "deuterocanon",
+    "estimated_date": "Mid to late 1st c. BC, probably Alexandrian",
+    "original_language": "Greek (composed directly in Greek; no Hebrew or Aramaic Vorlage is attested)",
+    "tradition_status": {
+      "protestant": "not canonical (grouped with the Apocrypha in Reformation Bibles)",
+      "catholic": "canonical (deuterocanonical)",
+      "eastern_orthodox": "canonical (Anagignoskomena)",
+      "ethiopian_tewahedo": "canonical (Broader Canon)"
+    },
+    "brief_summary": "Wisdom of Solomon is a philosophical wisdom text pseudepigraphically attributed to Solomon but composed in elegant Alexandrian Greek, probably in the mid to late first century BC. The book falls into three main parts. Chapters 1–5 contrast the destinies of the righteous and the wicked, developing a strong doctrine of post-mortem vindication: though the righteous seem to die, their souls are 'in the hand of God' (Wis 3:1), and they will stand to judge their oppressors. Chapters 6–9 present Wisdom herself as a cosmic figure — an 'emanation of the glory of the Almighty' (Wis 7:25), a 'reflection of eternal light,' 'the fashioner of all things' — personified in terms drawn from Greek philosophical vocabulary and Hebrew wisdom traditions alike. Chapters 10–19 retell the Exodus as a demonstration of Wisdom's guidance of Israel and judgment on Egypt, with extended polemic against the idolatry of Gentile religion.\n\nThe book's engagement with Greek philosophical categories — the immortal soul, virtue, the cosmic Logos — makes it a bridge between Second Temple Judaism and the intellectual world of the New Testament. Several New Testament passages contain material that echoes Wisdom of Solomon closely: the argument against Gentile idolatry in Romans 1:18–32 tracks the polemic in Wisdom 13–14; Romans 9:21 ('the potter has power over the clay') resembles Wisdom 15:7; and Hebrews 1:3, describing the Son as 'the radiance of God's glory and the exact representation of his being,' reuses language strikingly close to Wisdom 7:25–26. Most New Testament scholars read these as allusions to or shared dependence on the same Hellenistic Jewish vocabulary, not necessarily direct quotation.\n\nBecause Wisdom existed only in Greek, it was excluded from the rabbinic canon. Jerome grouped it with the apocrypha; Augustine and the African councils received it as canonical. The Council of Trent affirmed its deuterocanonical status for Catholicism; the Eastern Orthodox and Ethiopian Tewahedo churches likewise received it as Scripture; the Protestant Reformers, following Jerome, placed it among the Apocrypha.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Proverbs 8", "connection": "Wisdom's self-description as the fashioner of creation (Wis 7:22–8:1) extends the personified Wisdom figure of Proverbs 8 into explicitly philosophical vocabulary." },
+      { "ref": "Exodus 7-14", "connection": "Chapters 10–19 retell the Exodus as a demonstration of Wisdom's guidance of Israel and judgment on Egypt." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "augustine", "position": "Received Wisdom among the canonical books of the Greek and Latin churches and defended its place at Hippo and Carthage. Frequently cites it in his theological works as a genuine witness to wisdom theology, particularly on the immortality of the soul and the divine Wisdom active in creation." },
+      { "scholar_id": "jerome", "position": "Grouped Wisdom among the apocrypha in the Prologus Galeatus on the grounds that it was not extant in Hebrew and was not received in the rabbinic canon. Nonetheless translated and transmitted it in the Vulgate alongside the canonical books." },
+      { "scholar_id": "collins", "position": "In his work on Jewish wisdom literature, reads Wisdom of Solomon as the high point of Hellenistic Jewish appropriation of Greek philosophical vocabulary within a firmly biblical theological framework. Notes the striking verbal overlaps with Romans 1 and Hebrews 1 as evidence of a shared Hellenistic Jewish idiom in which the New Testament writers also stood." },
+      { "scholar_id": "keener", "position": "In his work on the New Testament background, identifies Wisdom of Solomon as the most important single Jewish extra-canonical text for understanding Paul's argument in Romans 1:18–32 and the Christological language of Hebrews 1 and Colossians 1." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["deuterocanon", "apocrypha", "wisdom", "hellenistic-judaism", "alexandria", "pauline-background", "hebrews"],
+    "further_reading": [
+      { "title": "The Wisdom of Solomon", "author": "David Winston", "note": "Anchor Bible 43 (Doubleday, 1979). The standard English-language critical commentary." }
+    ]
+  },
+  {
+    "id": "sirach",
+    "title": "Sirach (Ecclesiasticus)",
+    "also_known_as": ["Ben Sira", "Ecclesiasticus", "The Wisdom of Jesus ben Sira"],
+    "category": "deuterocanon",
+    "estimated_date": "c. 180 BC (Hebrew original); Greek translation c. 132 BC per the grandson's prologue",
+    "original_language": "Hebrew original (extensive fragments preserved in the Cairo Geniza and at Qumran and Masada); standard text preserved in the Greek translation by the author's grandson",
+    "tradition_status": {
+      "protestant": "not canonical (grouped with the Apocrypha in Reformation Bibles)",
+      "catholic": "canonical (deuterocanonical)",
+      "eastern_orthodox": "canonical (Anagignoskomena)",
+      "ethiopian_tewahedo": "canonical (Broader Canon)"
+    },
+    "brief_summary": "Sirach — also titled Ecclesiasticus in the Latin tradition and Ben Sira in Jewish sources — is the longest Jewish wisdom book outside the Hebrew Bible. The Hebrew original was composed in Jerusalem around 180 BC by Jeshua ben Eleazar ben Sira, a Jerusalem teacher of wisdom. The author's grandson translated the book into Greek in Alexandria around 132 BC and prefaced his translation with a prologue — the prologue itself is the earliest explicit reference to a tripartite Hebrew canonical collection ('the Law, the Prophets, and the other books of our fathers').\n\nSirach is structured as a long anthology of wisdom instruction along the lines of Proverbs, with extended poems on themes including the fear of the Lord, practical ethics, family life, friendship, business, speech, mercy, prayer, and the avoidance of folly. Its distinctive contributions include an extended personification of Wisdom as the self-revelation of God (ch 24), a great 'Praise of the Fathers' hymn surveying Israel's history through its notable figures (chs 44–50), and a concluding prayer of the grandfather (ch 51).\n\nThe Hebrew text was lost in the rabbinic tradition but rediscovered piecemeal in the Cairo Geniza (from 1896 onward) and at Qumran and Masada, confirming the Greek grandson's translation as essentially faithful. Sirach was widely cited in early Christianity — Athanasius's Festal Letter 39 (367) explicitly lists it among the books 'appointed to be read' by catechumens, and the book was constantly quoted by the Latin fathers (hence the title Ecclesiasticus, 'the church book,' reflecting its widespread liturgical use).\n\nJerome's Prologus Galeatus classed Sirach among the apocrypha on the grounds that it was not in the rabbinic canon. Augustine defended it as canonical; the African councils and later Trent affirmed that position for the Latin West. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive Sirach as Scripture. The Reformers placed it among the Apocrypha, though early Protestant Bibles (including Luther's) printed it in a separate apocryphal section for edification.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Proverbs 8", "connection": "Sirach 24 extends the personified Wisdom of Proverbs 8, presenting her as having taken up residence in Jerusalem and identifying her with the Torah." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "athanasius", "position": "In Festal Letter 39 (367), lists the books 'appointed to be read' by catechumens. Sirach appears there — not as canonical Scripture but as a book useful for instruction in piety. This is a key fourth-century witness to the book's ecclesiastical standing in the Eastern churches." },
+      { "scholar_id": "jerome", "position": "Grouped Sirach among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic canon. Translated and transmitted it in the Vulgate nonetheless; his judgment was followed by the Reformers a millennium later." },
+      { "scholar_id": "augustine", "position": "Received Sirach as canonical, citing it frequently in his theological and pastoral works. Under his influence the regional Councils of Hippo and Carthage affirmed Sirach alongside the other deuterocanonical books." },
+      { "scholar_id": "collins", "position": "In his studies of Second Temple wisdom literature, traces Sirach's synthesis of Proverbs-style wisdom with identification of Wisdom and Torah (ch 24), and surveys the book's enormous influence on later Jewish and Christian ethical instruction." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["deuterocanon", "apocrypha", "wisdom", "ben-sira", "cairo-geniza", "second-temple", "praise-of-the-fathers"],
+    "further_reading": [
+      { "title": "The Wisdom of Ben Sira", "author": "Patrick W. Skehan and Alexander A. Di Lella", "note": "Anchor Bible 39 (Doubleday, 1987). Standard English-language critical commentary." }
+    ]
+  },
+  {
+    "id": "1_maccabees",
+    "title": "1 Maccabees",
+    "also_known_as": ["First Maccabees"],
+    "category": "deuterocanon",
+    "estimated_date": "Late 2nd c. BC, probably c. 100 BC",
+    "original_language": "Hebrew original (not extant; Jerome reports having seen it); preserved in Greek (Septuagint) and Latin (Vulgate)",
+    "tradition_status": {
+      "protestant": "not canonical (grouped with the Apocrypha in Reformation Bibles)",
+      "catholic": "canonical (deuterocanonical)",
+      "eastern_orthodox": "canonical (Anagignoskomena)",
+      "ethiopian_tewahedo": "canonical (Broader Canon; includes 1–3 Maccabees)"
+    },
+    "brief_summary": "1 Maccabees is the primary historical narrative of the Jewish revolt against the Seleucid king Antiochus IV Epiphanes and of the rise of the Hasmonean dynasty that followed. Composed in Hebrew in the late second century BC by a writer sympathetic to the Hasmoneans, the book covers roughly 175–134 BC in sixteen chapters of straightforward historical prose.\n\nThe narrative opens with Alexander the Great and the emergence of the Seleucid kingdom, then focuses on Antiochus IV's persecution of Jewish practice — the prohibition of the Sabbath and circumcision, the desecration of the Jerusalem Temple with 'the abomination that causes desolation' (1 Macc 1:54; cf. Dan 9:27, 11:31, 12:11) in December 167 BC, and the forced imposition of pagan worship. It recounts the resistance led by the priest Mattathias and his sons Judah, Jonathan, and Simon (the 'Maccabees'), Judah's military victories, and the rededication of the Temple in December 164 BC — the event commemorated thereafter by the eight-day Feast of Dedication (Hanukkah).\n\nThis matters directly for the New Testament. John 10:22 — 'Then came the Feast of Dedication at Jerusalem. It was winter, and Jesus was in the temple courts walking in Solomon's Colonnade' — refers to Hanukkah, the annual commemoration of the rededication described in 1 Maccabees 4:36–59 (paralleled in 2 Macc 10:1–8). The historical events behind the festival are known only from 1 and 2 Maccabees; the Jewish Bible is silent on them.\n\n1 Maccabees was excluded from the rabbinic canon and grouped by Jerome among the apocrypha. Augustine and the African councils received it as canonical; the Council of Trent formally defined it as deuterocanonical. Eastern Orthodox and Ethiopian Tewahedo churches likewise receive it. The Protestant Reformers followed Jerome's narrower canon, placing 1 Maccabees in the Apocrypha.",
+    "full_summary": null,
+    "nt_citations": [
+      { "ref": "John 10:22", "cites": "1 Maccabees 4:36-59", "type": "allusion" }
+    ],
+    "ot_allusions": [
+      { "ref": "Daniel 11:31", "connection": "The 'abomination that causes desolation' (1 Macc 1:54) echoes Daniel's prophecy; Antiochus IV's desecration of the Temple is the event most Second Temple and NT interpreters identified with the Danielic text." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "jerome", "position": "Grouped 1 Maccabees among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic Hebrew canon, noting that he had seen the Hebrew original. Transmitted the book in the Vulgate nonetheless." },
+      { "scholar_id": "augustine", "position": "Defended 1 Maccabees as canonical in the Greek and Latin churches, citing it in City of God and his other works. The African councils of Hippo and Carthage affirmed its canonical status under his influence." },
+      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, reads 1 Maccabees as the most important surviving historical source for the Hasmonean period and as a work of dynastic apologetic written to justify Hasmonean rule. Notes its essentially 'biblical' historiographical style in deliberate imitation of Kings and Chronicles." },
+      { "scholar_id": "collins", "position": "In his survey work on Second Temple Judaism, places 1 Maccabees alongside 2 Maccabees, Josephus, and the Qumran scrolls as the foundational sources for reconstructing the political and religious matrix from which both rabbinic Judaism and early Christianity emerged." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["deuterocanon", "apocrypha", "hasmonean", "hanukkah", "antiochus-iv", "historical-narrative", "john-10"],
+    "further_reading": [
+      { "title": "1 Maccabees", "author": "Jonathan A. Goldstein", "note": "Anchor Bible 41 (Doubleday, 1976). Standard English-language critical commentary." }
+    ]
+  },
+  {
+    "id": "4_ezra",
+    "title": "4 Ezra (2 Esdras)",
+    "also_known_as": ["2 Esdras", "Fourth Ezra", "Apocalypse of Ezra"],
+    "category": "pseudepigrapha",
+    "estimated_date": "Late 1st c. AD, after the destruction of the Second Temple in AD 70",
+    "original_language": "Hebrew or Aramaic original (not extant); early Greek translation (largely lost); preserved in full in Latin and in Syriac, Ethiopic, Arabic, Georgian, and Armenian translations",
+    "tradition_status": {
+      "protestant": "not canonical (included in the Apocrypha in some early Protestant Bibles as 2 Esdras)",
+      "catholic": "not canonical (printed in an appendix to the Vulgate after the Council of Trent)",
+      "eastern_orthodox": "varied — received as canonical in Slavonic tradition; printed in Greek Bibles as an appendix",
+      "ethiopian_tewahedo": "canonical (Broader Canon)"
+    },
+    "brief_summary": "4 Ezra — printed in the Latin tradition as 2 Esdras chs 3–14 — is one of the most theologically serious Jewish apocalypses of the late first century AD. Composed in the generation after the destruction of the Second Temple in AD 70, it is cast as the experience of 'Ezra' (the biblical scribe) in Babylon thirty years after the Babylonian exile, but its real subject is the theodicy crisis provoked by the Roman destruction of Jerusalem.\n\nThe book unfolds in seven visions. In the first three (chs 3–9), Ezra presses the angel Uriel with hard questions: Why has God given Israel to a heathen power? Why has he not vindicated the righteous? How can divine justice be defended when so few will be saved? Ezra's questions receive answers, but the answers sharpen rather than resolve the grief. In the last four visions (chs 9–13), the mood shifts: Ezra sees a mourning woman transformed into the heavenly Jerusalem; an eagle with three heads representing the Roman empire, which will fall before the Messiah; and a man rising from the sea to judge the nations (ch 13). In the final vision (ch 14) Ezra is instructed to dictate ninety-four books — the twenty-four canonical Hebrew Scriptures plus seventy books 'for the wise' — a remarkable reflection on canon formation from within the tradition.\n\nThe original Hebrew or Aramaic text is lost; the standard Latin text (used in the Vulgate as 2 Esdras) includes two Christian supplements (chs 1–2 = '5 Ezra' and chs 15–16 = '6 Ezra') that are separate later compositions. Parallels with the Apocalypse of John are striking — the figure of the man from the sea, the eagle-as-empire imagery, the four beasts of Daniel 7 reinterpreted, the seven-fold structure — and most scholars read them as independent but near-contemporary Jewish and Christian apocalypses responding to similar Roman pressures.\n\nNo Christian tradition has received chs 3–14 as part of the primary biblical canon, but the Ethiopian Tewahedo Church includes it in its Broader Canon, and the Slavonic Orthodox tradition historically received it as canonical. The Council of Trent printed 2 Esdras in an appendix to the Vulgate rather than defining it as deuterocanonical.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Daniel 7", "connection": "The eagle vision (4 Ezra 11–12) and the man-from-the-sea vision (ch 13) reinterpret Daniel's four-beasts and Son of Man imagery for the Roman imperial situation." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "nickelsburg", "position": "Treats 4 Ezra as the most theologically profound Jewish apocalyptic response to the destruction of the Second Temple, reading its seven visions as a dialectical working-through of the theodicy crisis that 70 AD forced upon thoughtful Jews and early Christians alike." },
+      { "scholar_id": "collins", "position": "In his studies of Jewish apocalyptic, highlights the remarkable structural and thematic parallels between 4 Ezra and the Apocalypse of John, arguing that both are best read as independent but near-contemporary Jewish and Christian apocalypses responding to the same Roman context." },
+      { "scholar_id": "vanderkam", "position": "In his work on the Dead Sea Scrolls and Second Temple literature, draws attention to 4 Ezra 14's canon-formation narrative — ninety-four books, of which twenty-four are for all and seventy are esoteric — as a significant witness to how first-century Jews imagined the boundaries of their scriptural tradition." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["apocalyptic", "pseudepigrapha", "second-temple", "post-70", "theodicy", "revelation-parallels", "canon-formation"],
+    "further_reading": [
+      { "title": "A Commentary on the Book of 4 Ezra", "author": "Michael E. Stone", "note": "Hermeneia (Fortress, 1990). Standard English-language critical commentary." }
+    ]
+  },
+  {
+    "id": "damascus_document",
+    "title": "Damascus Document (CD)",
+    "also_known_as": ["CD", "Cairo Damascus Document", "Zadokite Document"],
+    "category": "dss",
+    "estimated_date": "Original composition probably late 2nd or early 1st c. BC; Qumran manuscripts range from 1st c. BC to 1st c. AD; the Cairo Geniza manuscripts are medieval copies (10th–12th c. AD)",
+    "original_language": "Hebrew. First discovered as two medieval Hebrew manuscripts in the Cairo Geniza (Solomon Schechter, 1896); later confirmed by fragments of at least ten ancient Hebrew manuscripts from Qumran Caves 4, 5, and 6 (4Q265–273, 5Q12, 6Q15)",
+    "tradition_status": {
+      "protestant": "not canonical",
+      "catholic": "not canonical",
+      "eastern_orthodox": "not canonical",
+      "ethiopian_tewahedo": "not canonical"
+    },
+    "brief_summary": "The Damascus Document is one of the most important sectarian texts of the Qumran community. Although fragmentary copies had been known since Solomon Schechter's 1896 discovery of two medieval manuscripts in the Cairo Geniza — then classified as a 'Zadokite Document' — the later recovery of ancient Hebrew fragments from Qumran Caves 4, 5, and 6 confirmed it as a foundational document of the same movement that produced the other Dead Sea Scrolls.\n\nThe work falls into two main parts. The 'Admonition' (CD I–VIII, XIX–XX) is a theological-historical narrative reviewing God's dealings with the 'remnant' — the faithful community called out of apostate Israel — and denouncing opponents. It introduces the figures of the Teacher of Righteousness, the Wicked Priest, and the Man of the Lie, and it speaks of the community's 'new covenant' in the land of Damascus (whether the place-name is literal or symbolic is debated). The 'Laws' section (CD IX–XVI and the 4Q parallels) contains distinctive halakhic rulings — on Sabbath observance stricter than in other Jewish traditions, on sexual purity, on oaths, on marriage law, on priestly purity, and on organisation of the community. CD 16:3–4 explicitly cites the Book of Jubilees as 'the book of the divisions of the times by their jubilees and their weeks' — a rare surviving ancient citation of that book by name and strong evidence of Jubilees' authoritative status at Qumran.\n\nThe New Testament does not cite the Damascus Document, but the document illuminates the Second Temple Jewish context in multiple directions. Its strict Sabbath legislation contrasts with Jesus' Sabbath disputes (Mark 2:23–3:6; Matt 12:1–14; Luke 6:1–11); its 'new covenant in Damascus' vocabulary shows that the phrase was in Jewish circulation before Paul used it in 2 Cor 3:6 and Heb 8:8 quoted Jeremiah 31; and its communal structure, messianic expectation (two messiahs, priestly and royal), and eschatological orientation populate the backdrop against which the Gospels and Acts narrate early Christian origins. No tradition has ever received the Damascus Document as Scripture; it is a sectarian document whose significance is historical and comparative, not canonical.",
+    "full_summary": null,
+    "nt_citations": [],
+    "ot_allusions": [
+      { "ref": "Amos 5:26-27", "connection": "CD VII:14–21 interprets Amos's 'exile beyond Damascus' as a reference to the community's own self-understanding as a righteous remnant in exile from apostate Jerusalem." },
+      { "ref": "Jeremiah 31:31-34", "connection": "The community's self-description as 'the new covenant in the land of Damascus' draws on Jeremiah's new-covenant oracle, demonstrating that the phrase was already in Jewish circulation before the New Testament writers applied it to Christ." }
+    ],
+    "scholar_voices": [
+      { "scholar_id": "vanderkam", "position": "Treats the Damascus Document as a foundational sectarian text whose ancient Qumran copies (4Q265–273, 5Q12, 6Q15) confirm the medieval Geniza manuscripts' substantial faithfulness to the original. In The Dead Sea Scrolls Today, surveys its place alongside the Community Rule (1QS) as the two central documents of the Qumran movement." },
+      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, reads the Damascus Document as a key witness to the sectarian Second Temple environment and specifically to the calendrical, halakhic, and eschatological concerns that distinguished groups like the Qumran community from the Jerusalem temple establishment." },
+      { "scholar_id": "collins", "position": "In his work on Second Temple apocalypticism, places the Damascus Document within the broader stream of sectarian Jewish self-definition, highlighting its distinctive halakhic rulings and its explicit citation of Jubilees (CD 16:3–4) as evidence of a shared calendrical tradition tying it to Jubilees and to Enochic literature." }
+    ],
+    "related_debate_ids": [],
+    "related_journey_ids": [],
+    "related_difficult_passage_ids": [],
+    "tags": ["dead-sea-scrolls", "dss", "qumran", "sectarian", "cairo-geniza", "second-temple", "new-covenant", "halakha"],
+    "further_reading": [
+      { "title": "The Damascus Document Reconsidered", "author": "Magen Broshi, ed.", "note": "Israel Exploration Society, 1992. Standard English-language edition of the Cairo manuscripts with introduction." },
+      { "title": "The Complete Dead Sea Scrolls in English", "author": "Géza Vermes", "note": "Penguin, 7th ed. 2011. Accessible translation of CD alongside the other Qumran sectarian texts." }
+    ]
+  }
+]


### PR DESCRIPTION
## What this does
Seeds `content/meta/extrabiblical.json` with the 12 foundational entries for the "How We Got The Bible" epic:

| Category | Entries |
|---|---|
| Pseudepigrapha | 1 Enoch, 2 Enoch, Jubilees, Jasher, Assumption of Moses, 4 Ezra |
| Deuterocanon | Tobit, Judith, Wisdom of Solomon, Sirach, 1 Maccabees |
| DSS | Damascus Document (CD) |

## Closes
Closes #1541

## Per-entry check

| id | words | scholars | NT cits |
|---|---:|---:|---:|
| 1_enoch | 301 | 4 | 1 (Jude 14-15) |
| 2_enoch | 291 | 2 | 0 |
| jubilees | 278 | 3 | 0 |
| jasher | 284 | 2 | 0 |
| assumption_of_moses | 273 | 2 | 1 (Jude 9) |
| tobit | 324 | 3 | 0 |
| judith | 309 | 3 | 0 |
| wisdom_of_solomon | 324 | 4 | 0 |
| sirach | 325 | 4 | 0 |
| 1_maccabees | 290 | 4 | 1 (John 10:22) |
| 4_ezra | 364 | 3 | 0 |
| damascus_document | 345 | 3 | 0 |

All `brief_summary` values are 273–364 words (spec: 200–400). Every entry has at least 2 `scholar_voices` drawn from evangelical, critical, and patristic voices where possible.

## Editorial commitments

- **Tradition status is descriptive, not prescriptive.** "The Ethiopian Tewahedo Church includes 1 Enoch in its canon" is stated as fact; no "1 Enoch is Scripture" claims.
- **NT citation ≠ canonicity** is stated explicitly in the 1 Enoch and Assumption of Moses entries.
- **No conspiracy framing.** Canon formation described as slow, regional, and contested.
- **Scholar positions substantiated.** Each scholar_voice reflects what that scholar actually argues in their published work (Nickelsburg: Hermeneia commentaries; VanderKam: Jubilees/DSS; Jerome: Prologus Galeatus; Augustine: Hippo/Carthage; Tertullian: De Cultu Feminarum; Bruce: NT perspective on Jude; Collins, Keener, Longman, Provan: cited only in areas within their published scope).
- **The Jasher entry carefully distinguishes three separate works** that circulate under the name: the lost OT source (Josh 10:13, 2 Sam 1:18), the medieval Sefer haYashar (c. 11th–13th c.), and the 18th-century English forgery. The entry names the forgery as such.

## Cross-link arrays are empty

`related_debate_ids`, `related_journey_ids`, `related_difficult_passage_ids` are all `[]` on every entry per the issue's "single coordinated pass" instruction. They will be wired in HWGTB-P1-09 (#1576) after the sibling content issues land.

## How I verified
Because this branch is off master and does not contain #1537's scholar additions or #1538's schema/validator, I merged both locally for validation, then hard-reset to master + restored only the content file before committing.

With #1537 and #1538 applied locally:
- `python _tools/schema_validator.py` — **136634 passed** (adds 152 new passes over master's baseline of 136482), 77 pre-existing failures, 0 new failures ✅
- `python _tools/build_sqlite.py` — `extrabiblical: 12 rows` ✅
- `python _tools/validate_sqlite.py` — **99 passed**, 0 failed, 2 warnings (embeddings/prompts pre-existing) ✅
- All DB-side checks green: tradition_status non-empty; brief_summary non-empty; scholar_voices[].scholar_id resolve; related_debate_ids / related_difficult_passage_ids resolve.

On the final committed state (branched from master, without #1537/#1538):
- `python _tools/schema_validator.py` — 136482 passed (identical to master baseline). The file is present but ignored by the pre-#1538 validator code.

## Merge order

This PR depends on **#1537** (scholars — Nickelsburg, VanderKam, Augustine, Jerome, Tertullian, Kruger, Metzger, Athanasius) and **#1538** (extrabiblical schema + validator). Merge those first; otherwise the file lives as content-only without a loader. Once #1538 lands the table will be populated automatically on the next build.

## Out of scope
- `full_summary` for every entry is `null` — Phase 4 (HWGTB-P4-02A/B/C/D).
- Cross-link arrays empty — HWGTB-P1-09 (#1576).
- App-side rendering (ExtraBiblicalIndexScreen, ExtraBiblicalDetailScreen) — HWGTB-P2-02/P2-03.

## Rollback
Revert this PR. Content file is removed; no schema changes, no user.db impact. Next `build_sqlite.py` run yields `extrabiblical: 0 rows`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHELDhvq1dxY36oL5Gguad)_