### PR TITLE
Add guided study V2 evidence trail

### DIFF
--- a/app/__tests__/components/guidedStudyV2.test.tsx
+++ b/app/__tests__/components/guidedStudyV2.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { EvidenceTrailRow, StudyModeSelector } from '@/components/guidedStudy';
+
+const trailItem = {
+  key: 'context:genesis_1_1:ctx',
+  title: 'Start with context',
+  subtitle: 'Ancient audience, genre, and setting',
+  panelType: 'ctx',
+  sectionNum: 1,
+  badge: 'Required' as const,
+};
+
+describe('guided study V2 components', () => {
+  it('renders study modes and emits selection changes', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(<StudyModeSelector value="deep" onChange={onChange} />);
+
+    fireEvent.press(getByLabelText('Teaching prep, 25 min'));
+
+    expect(onChange).toHaveBeenCalledWith('teaching');
+  });
+
+  it('renders an evidence trail row with its badge and opens the panel', () => {
+    const onPress = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <EvidenceTrailRow item={trailItem} index={0} onPress={onPress} />,
+    );
+
+    expect(getByText('Start with context')).toBeTruthy();
+    expect(getByText('Required')).toBeTruthy();
+    fireEvent.press(getByLabelText('Open Start with context'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/__tests__/services/guidedStudy.test.ts
+++ b/app/__tests__/services/guidedStudy.test.ts
@@ -80,7 +80,21 @@ const sections: Array<Section & { panels: SectionPanel[] }> = [
 
 const chapterPanels: ChapterPanel[] = [
   { id: 1, chapter_id: 'genesis_1', panel_type: 'cross', content_json: '{"refs":["John 1:1"]}' },
+  { id: 2, chapter_id: 'genesis_1', panel_type: 'debate', content_json: '{"topic":"days"}' },
 ];
+
+const bookIntro: ParsedBookIntro = {
+  era: 'Primeval',
+  purpose: 'Explain beginnings and covenant hope.',
+  at_a_glance: {
+    author: 'Moses (traditional)',
+    date: '~1446–1406 BC',
+    chapters: 50,
+    genre: 'Theological Narrative',
+    key_theme: 'Creation, fall, and covenant promise',
+    key_word: 'beginning',
+  },
+};
 
 describe('guided study services', () => {
   it('calculates stable study depth estimates from verse and panel word counts', () => {
@@ -94,18 +108,6 @@ describe('guided study services', () => {
   });
 
   it('builds scene rows, observe prompts, recommendations, and concept chips', () => {
-    const bookIntro: ParsedBookIntro = {
-      era: 'Primeval',
-      purpose: 'Explain beginnings and covenant hope.',
-      at_a_glance: {
-        author: 'Moses (traditional)',
-        date: '~1446–1406 BC',
-        chapters: 50,
-        genre: 'Theological Narrative',
-        key_theme: 'Creation, fall, and covenant promise',
-        key_word: 'beginning',
-      },
-    };
     const plan = buildGuidedStudyPlan({
       book,
       chapter,
@@ -116,6 +118,7 @@ describe('guided study services', () => {
     });
 
     expect(plan.title).toBe('The Creation of the Heaven and the Earth');
+    expect(plan.mode).toBe('deep');
     expect(plan.sceneRows.map((row) => row.label)).toEqual([
       'Genre',
       'Moment',
@@ -123,8 +126,56 @@ describe('guided study services', () => {
       'Purpose',
     ]);
     expect(plan.prompts).toHaveLength(2);
-    expect(plan.recommendations.map((rec) => rec.panelType)).toEqual(['ctx', 'heb', 'cross']);
+    expect(plan.recommendations.map((rec) => rec.panelType)).toEqual([
+      'ctx',
+      'heb',
+      'cross',
+      'debate',
+    ]);
+    expect(plan.evidenceTrail.map((item) => item.title)).toEqual([
+      'Start with context',
+      'Check the language',
+      'Compare Scripture',
+      'If unclear, weigh debate',
+    ]);
     expect(plan.conceptChips.map((chip) => chip.label)).toContain('Theological Narrative');
+  });
+
+  it('adapts recommendation depth and better questions by study mode', () => {
+    const quick = buildGuidedStudyPlan({
+      book,
+      chapter,
+      sections,
+      chapterPanels,
+      verses,
+      bookIntro,
+      mode: 'quick',
+    });
+    const teaching = buildGuidedStudyPlan({
+      book,
+      chapter,
+      sections,
+      chapterPanels,
+      verses,
+      bookIntro,
+      mode: 'teaching',
+    });
+    const devotional = buildGuidedStudyPlan({
+      book,
+      chapter,
+      sections,
+      chapterPanels,
+      verses,
+      bookIntro,
+      mode: 'devotional',
+    });
+
+    expect(quick.recommendations).toHaveLength(3);
+    expect(quick.betterQuestionPrompt).toContain('one question');
+    expect(teaching.betterQuestionPrompt).toContain('teach this passage');
+    expect(devotional.betterQuestionPrompt).toBe(
+      'What does the chapter emphasize before you ask how it applies to me?',
+    );
   });
 
   it('schedules one row per populated synthesis field at the first interval', () => {

--- a/app/src/components/guidedStudy/EvidenceTrailRow.tsx
+++ b/app/src/components/guidedStudy/EvidenceTrailRow.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ChevronRight } from 'lucide-react-native';
+import { ConfidenceBadge } from './ConfidenceBadge';
+import { fontFamily, MIN_TOUCH_TARGET, radii, spacing, useTheme } from '../../theme';
+import type { GuidedEvidenceTrailItem } from '../../services/guidedStudy';
+
+interface Props {
+  item: GuidedEvidenceTrailItem;
+  index: number;
+  onPress: () => void;
+}
+
+export function EvidenceTrailRow({ item, index, onPress }: Props) {
+  const { base } = useTheme();
+  const isFirst = index === 0;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.72}
+      style={[
+        styles.row,
+        {
+          backgroundColor: isFirst ? `${base.gold}10` : base.bgElevated,
+          borderColor: isFirst ? `${base.gold}35` : `${base.border}99`,
+        },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${item.title}`}
+    >
+      <View style={[styles.stripe, { backgroundColor: base.gold }]} />
+      <View style={[styles.indexPill, { borderColor: `${base.gold}45` }]}>
+        <Text style={[styles.indexText, { color: base.gold }]}>{index + 1}</Text>
+      </View>
+      <View style={styles.textWrap}>
+        <View style={styles.titleRow}>
+          <Text style={[styles.title, { color: base.text }]}>{item.title}</Text>
+          <View style={[styles.badge, { borderColor: `${base.gold}30` }]}>
+            <Text style={[styles.badgeText, { color: base.gold }]}>{item.badge}</Text>
+          </View>
+          <ConfidenceBadge level={item.confidence} />
+        </View>
+        <Text style={[styles.subtitle, { color: base.textMuted }]}>{item.subtitle}</Text>
+      </View>
+      <ChevronRight size={15} color={base.textMuted} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: MIN_TOUCH_TARGET,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    overflow: 'hidden',
+    paddingRight: spacing.sm,
+  },
+  stripe: {
+    width: 3,
+    alignSelf: 'stretch',
+  },
+  indexPill: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  indexText: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 11,
+  },
+  textWrap: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    flexWrap: 'wrap',
+  },
+  title: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  badge: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 2,
+  },
+  badgeText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+  },
+});

--- a/app/src/components/guidedStudy/StudyModeSelector.tsx
+++ b/app/src/components/guidedStudy/StudyModeSelector.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { fontFamily, radii, spacing, useTheme } from '../../theme';
 import {
   GUIDED_STUDY_MODE_OPTIONS,
   type GuidedStudyMode,
 } from '../../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
 
 interface Props {
   value: GuidedStudyMode;
@@ -15,7 +15,7 @@ export function StudyModeSelector({ value, onChange }: Props) {
   const { base } = useTheme();
 
   return (
-    <View style={styles.wrap} accessibilityRole="tablist">
+    <View style={styles.wrap}>
       {GUIDED_STUDY_MODE_OPTIONS.map((mode) => {
         const active = mode.key === value;
         return (
@@ -34,7 +34,7 @@ export function StudyModeSelector({ value, onChange }: Props) {
             accessibilityState={{ selected: active }}
             accessibilityLabel={`${mode.label}, ${mode.estimate}`}
           >
-            <Text style={[styles.label, { color: active ? base.gold : base.text }]}>
+            <Text style={[styles.label, { color: active ? base.gold : base.text }]}> 
               {mode.label}
             </Text>
             <Text style={[styles.estimate, { color: base.textMuted }]}>{mode.estimate}</Text>

--- a/app/src/components/guidedStudy/StudyModeSelector.tsx
+++ b/app/src/components/guidedStudy/StudyModeSelector.tsx
@@ -34,9 +34,7 @@ export function StudyModeSelector({ value, onChange }: Props) {
             accessibilityState={{ selected: active }}
             accessibilityLabel={`${mode.label}, ${mode.estimate}`}
           >
-            <Text style={[styles.label, { color: active ? base.gold : base.text }]}> 
-              {mode.label}
-            </Text>
+            <Text style={[styles.label, { color: active ? base.gold : base.text }]}>{mode.label}</Text>
             <Text style={[styles.estimate, { color: base.textMuted }]}>{mode.estimate}</Text>
           </TouchableOpacity>
         );

--- a/app/src/components/guidedStudy/StudyModeSelector.tsx
+++ b/app/src/components/guidedStudy/StudyModeSelector.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import {
+  GUIDED_STUDY_MODE_OPTIONS,
+  type GuidedStudyMode,
+} from '../../services/guidedStudy';
+
+interface Props {
+  value: GuidedStudyMode;
+  onChange: (mode: GuidedStudyMode) => void;
+}
+
+export function StudyModeSelector({ value, onChange }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View style={styles.wrap} accessibilityRole="tablist">
+      {GUIDED_STUDY_MODE_OPTIONS.map((mode) => {
+        const active = mode.key === value;
+        return (
+          <TouchableOpacity
+            key={mode.key}
+            onPress={() => onChange(mode.key)}
+            activeOpacity={0.72}
+            style={[
+              styles.option,
+              {
+                borderColor: active ? base.gold : `${base.border}AA`,
+                backgroundColor: active ? `${base.gold}16` : base.bgSurface,
+              },
+            ]}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={`${mode.label}, ${mode.estimate}`}
+          >
+            <Text style={[styles.label, { color: active ? base.gold : base.text }]}>
+              {mode.label}
+            </Text>
+            <Text style={[styles.estimate, { color: base.textMuted }]}>{mode.estimate}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.md,
+  },
+  option: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    minWidth: '47%',
+    flexGrow: 1,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+  estimate: {
+    fontFamily: fontFamily.ui,
+    fontSize: 10,
+    marginTop: 2,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -1,6 +1,8 @@
 export { ConfidenceBadge } from './ConfidenceBadge';
 export { ContextGuardBanner } from './ContextGuardBanner';
+export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { PanelRecommendationRow } from './PanelRecommendationRow';
+export { StudyModeSelector } from './StudyModeSelector';
 export { StudySessionCTA } from './StudySessionCTA';
 export { StudySessionStepper } from './StudySessionStepper';

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -18,6 +18,14 @@ import {
 } from '@react-navigation/native';
 import { ArrowLeft, MessageSquare } from 'lucide-react-native';
 import {
+  EvidenceTrailRow,
+  PanelRecommendationRow,
+  StudyModeSelector,
+  StudySessionStepper,
+} from '../components/guidedStudy';
+import { UpgradePrompt } from '../components/UpgradePrompt';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import {
   getBook,
   getBookIntro,
   getChapter,
@@ -27,21 +35,11 @@ import {
   getVerses,
 } from '../db/content';
 import { useGuidedStudySession, usePremium } from '../hooks';
+import { buildGuidedStudyPlan, type GuidedStudyMode, type GuidedStudyStep } from '../services/guidedStudy';
 import { useSettingsStore } from '../stores';
-import type { Book, Chapter, ChapterPanel, Section, SectionPanel, Verse } from '../types';
-import type { ParsedBookIntro } from '../types';
-import type { GuidedStudyMode, GuidedStudyStep } from '../services/guidedStudy';
-import { buildGuidedStudyPlan } from '../services/guidedStudy';
-import {
-  EvidenceTrailRow,
-  PanelRecommendationRow,
-  StudyModeSelector,
-  StudySessionStepper,
-} from '../components/guidedStudy';
-import { UpgradePrompt } from '../components/UpgradePrompt';
-import { safeParse } from '../utils/logger';
 import { fontFamily, radii, spacing, useTheme } from '../theme';
-import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import type { Book, Chapter, ChapterPanel, ParsedBookIntro, Section, SectionPanel, Verse } from '../types';
+import { safeParse } from '../utils/logger';
 
 interface RouteParams {
   bookId: string;
@@ -178,10 +176,7 @@ function StudySessionScreen() {
     }
     await session.saveSynthesis(synthesisDraft);
     const ref = `${book?.name ?? bookId} ${chapterNum}`;
-    // Cap each field so the seed query doesn't blow past Amicus's length
-    // limit on long syntheses and renders reasonably in the peek sheet.
-    const clip = (s: string, n = 200) =>
-      s.length > n ? `${s.slice(0, n - 1).trimEnd()}\u2026` : s;
+    const clip = (s: string, n = 200) => (s.length > n ? `${s.slice(0, n - 3).trimEnd()}...` : s);
     const seedQuery =
       `Help me refine my study synthesis for ${ref}. ` +
       `Takeaway: ${clip(synthesisDraft.takeaway)}. ` +
@@ -223,9 +218,7 @@ function StudySessionScreen() {
         <TouchableOpacity onPress={() => navigation.goBack()} accessibilityLabel="Back">
           <ArrowLeft size={20} color={base.gold} />
         </TouchableOpacity>
-        <Text style={[styles.navTitle, { color: base.text }]}> 
-          Study {book?.name ?? bookId} {chapterNum}
-        </Text>
+        <Text style={[styles.navTitle, { color: base.text }]}>Study {book?.name ?? bookId} {chapterNum}</Text>
       </View>
 
       <ScrollView contentContainerStyle={styles.content}>
@@ -276,9 +269,7 @@ function StudySessionScreen() {
         {session.currentStep === 'explore' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Evidence Trail</Text>
-            <Text style={[styles.sectionIntro, { color: base.textDim }]}> 
-              Open the panels in this order to build context before conclusions.
-            </Text>
+            <Text style={[styles.sectionIntro, { color: base.textDim }]}>Open the panels in this order to build context before conclusions.</Text>
             {plan.evidenceTrail.length > 0 ? (
               <View style={styles.trailList}>
                 {plan.evidenceTrail.map((item, index) => (
@@ -310,9 +301,7 @@ function StudySessionScreen() {
               ]}
             >
               <Text style={[styles.questionLabel, { color: base.gold }]}>Better question</Text>
-              <Text style={[styles.questionText, { color: base.text }]}> 
-                {plan.betterQuestionPrompt}
-              </Text>
+              <Text style={[styles.questionText, { color: base.text }]}>{plan.betterQuestionPrompt}</Text>
             </View>
             <PrimaryButton label="Synthesize what you saw" onPress={() => goStep('synthesize')} />
           </View>
@@ -358,7 +347,7 @@ function StudySessionScreen() {
         {session.currentStep === 'review' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Review</Text>
-            <Text style={[styles.body, { color: base.textDim }]}> 
+            <Text style={[styles.body, { color: base.textDim }]}>
               {reviewSaved
                 ? 'Saved. Your review prompts and concept vocabulary are ready in My Study.'
                 : isPremium
@@ -367,7 +356,7 @@ function StudySessionScreen() {
             </Text>
             <View style={styles.chipRow}>
               {plan.conceptChips.map((chip) => (
-                <View key={chip.id} style={[styles.chip, { borderColor: `${base.gold}35` }]}> 
+                <View key={chip.id} style={[styles.chip, { borderColor: `${base.gold}35` }]}>
                   <Text style={[styles.chipText, { color: base.gold }]}>{chip.label}</Text>
                 </View>
               ))}

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -30,9 +30,14 @@ import { useGuidedStudySession, usePremium } from '../hooks';
 import { useSettingsStore } from '../stores';
 import type { Book, Chapter, ChapterPanel, Section, SectionPanel, Verse } from '../types';
 import type { ParsedBookIntro } from '../types';
-import type { GuidedStudyStep } from '../services/guidedStudy';
+import type { GuidedStudyMode, GuidedStudyStep } from '../services/guidedStudy';
 import { buildGuidedStudyPlan } from '../services/guidedStudy';
-import { PanelRecommendationRow, StudySessionStepper } from '../components/guidedStudy';
+import {
+  EvidenceTrailRow,
+  PanelRecommendationRow,
+  StudyModeSelector,
+  StudySessionStepper,
+} from '../components/guidedStudy';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { safeParse } from '../utils/logger';
 import { fontFamily, radii, spacing, useTheme } from '../theme';
@@ -68,6 +73,7 @@ function StudySessionScreen() {
   const [responseDrafts, setResponseDrafts] = useState<Record<string, string>>({});
   const [synthesisDraft, setSynthesisDraft] = useState(session.synthesis);
   const [reviewSaved, setReviewSaved] = useState(false);
+  const [studyMode, setStudyMode] = useState<GuidedStudyMode>('deep');
 
   useEffect(() => {
     let cancelled = false;
@@ -125,8 +131,16 @@ function StudySessionScreen() {
 
   const plan = useMemo(() => {
     if (!chapter) return null;
-    return buildGuidedStudyPlan({ book, chapter, sections, chapterPanels, verses, bookIntro });
-  }, [book, chapter, sections, chapterPanels, verses, bookIntro]);
+    return buildGuidedStudyPlan({
+      book,
+      chapter,
+      sections,
+      chapterPanels,
+      verses,
+      bookIntro,
+      mode: studyMode,
+    });
+  }, [book, chapter, sections, chapterPanels, verses, bookIntro, studyMode]);
 
   const savePromptDrafts = useCallback(async () => {
     if (!plan) return;
@@ -209,13 +223,14 @@ function StudySessionScreen() {
         <TouchableOpacity onPress={() => navigation.goBack()} accessibilityLabel="Back">
           <ArrowLeft size={20} color={base.gold} />
         </TouchableOpacity>
-        <Text style={[styles.navTitle, { color: base.text }]}>
+        <Text style={[styles.navTitle, { color: base.text }]}> 
           Study {book?.name ?? bookId} {chapterNum}
         </Text>
       </View>
 
       <ScrollView contentContainerStyle={styles.content}>
         <StudySessionStepper activeStep={session.currentStep} onSelect={goStep} />
+        <StudyModeSelector value={studyMode} onChange={setStudyMode} />
 
         {session.currentStep === 'scene' && (
           <View style={styles.section}>
@@ -260,17 +275,44 @@ function StudySessionScreen() {
 
         {session.currentStep === 'explore' && (
           <View style={styles.section}>
-            <Text style={[styles.heading, { color: base.text }]}>Recommended next</Text>
+            <Text style={[styles.heading, { color: base.text }]}>Evidence Trail</Text>
+            <Text style={[styles.sectionIntro, { color: base.textDim }]}> 
+              Open the panels in this order to build context before conclusions.
+            </Text>
+            {plan.evidenceTrail.length > 0 ? (
+              <View style={styles.trailList}>
+                {plan.evidenceTrail.map((item, index) => (
+                  <EvidenceTrailRow
+                    key={item.key}
+                    item={item}
+                    index={index}
+                    onPress={() => openRecommendation(item.panelType, item.sectionNum)}
+                  />
+                ))}
+              </View>
+            ) : (
+              <View
+                style={[styles.list, { borderColor: base.border, backgroundColor: base.bgElevated }]}
+              >
+                {plan.recommendations.map((rec) => (
+                  <PanelRecommendationRow
+                    key={rec.key}
+                    recommendation={rec}
+                    onPress={() => openRecommendation(rec.panelType, rec.sectionNum)}
+                  />
+                ))}
+              </View>
+            )}
             <View
-              style={[styles.list, { borderColor: base.border, backgroundColor: base.bgElevated }]}
+              style={[
+                styles.questionCard,
+                { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` },
+              ]}
             >
-              {plan.recommendations.map((rec) => (
-                <PanelRecommendationRow
-                  key={rec.key}
-                  recommendation={rec}
-                  onPress={() => openRecommendation(rec.panelType, rec.sectionNum)}
-                />
-              ))}
+              <Text style={[styles.questionLabel, { color: base.gold }]}>Better question</Text>
+              <Text style={[styles.questionText, { color: base.text }]}>
+                {plan.betterQuestionPrompt}
+              </Text>
             </View>
             <PrimaryButton label="Synthesize what you saw" onPress={() => goStep('synthesize')} />
           </View>
@@ -316,7 +358,7 @@ function StudySessionScreen() {
         {session.currentStep === 'review' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Review</Text>
-            <Text style={[styles.body, { color: base.textDim }]}>
+            <Text style={[styles.body, { color: base.textDim }]}> 
               {reviewSaved
                 ? 'Saved. Your review prompts and concept vocabulary are ready in My Study.'
                 : isPremium
@@ -325,7 +367,7 @@ function StudySessionScreen() {
             </Text>
             <View style={styles.chipRow}>
               {plan.conceptChips.map((chip) => (
-                <View key={chip.id} style={[styles.chip, { borderColor: `${base.gold}35` }]}>
+                <View key={chip.id} style={[styles.chip, { borderColor: `${base.gold}35` }]}> 
                   <Text style={[styles.chipText, { color: base.gold }]}>{chip.label}</Text>
                 </View>
               ))}
@@ -420,6 +462,13 @@ const styles = StyleSheet.create({
     fontSize: 22,
     marginBottom: spacing.md,
   },
+  sectionIntro: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: -spacing.xs,
+    marginBottom: spacing.md,
+  },
   sceneRow: {
     borderBottomWidth: 1,
     paddingVertical: spacing.sm,
@@ -459,6 +508,28 @@ const styles = StyleSheet.create({
     borderRadius: radii.md,
     paddingHorizontal: spacing.md,
     marginBottom: spacing.md,
+  },
+  trailList: {
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  questionCard: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  questionLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  questionText: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 20,
   },
   primaryButton: {
     borderRadius: radii.md,

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -310,7 +310,7 @@ function StudySessionScreen() {
               ]}
             >
               <Text style={[styles.questionLabel, { color: base.gold }]}>Better question</Text>
-              <Text style={[styles.questionText, { color: base.text }]}>
+              <Text style={[styles.questionText, { color: base.text }]}> 
                 {plan.betterQuestionPrompt}
               </Text>
             </View>

--- a/app/src/services/guidedStudy/index.ts
+++ b/app/src/services/guidedStudy/index.ts
@@ -1,12 +1,20 @@
 export { getStudyDepthEstimate } from './estimate';
 export { buildGuidedStudyPlan } from './plan';
 export { buildReviewItemsFromSynthesis, nextIntervalAfter, REVIEW_INTERVAL_DAYS } from './review';
+export {
+  GUIDED_STUDY_MODE_OPTIONS,
+  GUIDED_STUDY_MODES,
+  GUIDED_STUDY_STEP_LABELS,
+} from './types';
 export type {
   ConfidenceLevel,
   GuidedConceptChip,
+  GuidedEvidenceTrailItem,
   GuidedPanelRecommendation,
   GuidedPrompt,
   GuidedSceneRow,
+  GuidedStudyMode,
+  GuidedStudyModeOption,
   GuidedStudyPlan,
   GuidedStudyPlanInput,
   GuidedStudyStep,

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,11 +1,17 @@
 import type { SectionPanel } from '../../types';
 import type {
+  ConfidenceLevel,
   GuidedConceptChip,
+  GuidedEvidenceTrailItem,
   GuidedPanelRecommendation,
   GuidedPrompt,
+  GuidedStudyMode,
   GuidedStudyPlan,
   GuidedStudyPlanInput,
 } from './types';
+import { GUIDED_STUDY_MODE_OPTIONS } from './types';
+
+const DEFAULT_MODE: GuidedStudyMode = 'deep';
 
 const RECOMMENDATION_ORDER = [
   'hist',
@@ -31,6 +37,16 @@ const PANEL_LABELS: Record<string, string> = {
   src: 'Cross-Testament Echoes',
   com: 'Scholar Commentary',
   debate: 'Scholar Debate',
+  lit: 'Literary Structure',
+  thread: 'Intertextual Threading',
+  discourse: 'Argument Flow',
+};
+
+const MODE_RECOMMENDATION_LIMIT: Record<GuidedStudyMode, number> = {
+  quick: 3,
+  deep: 5,
+  teaching: 5,
+  devotional: 3,
 };
 
 // TODO(#1584): Replace with labels from content/meta/concepts.json via
@@ -55,24 +71,6 @@ const CONCEPT_WORDS = [
   'suffering',
 ];
 
-function compact(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const cleaned = value.replace(/\s+/g, ' ').trim();
-  return cleaned.length > 0 ? cleaned : null;
-}
-
-function firstSentence(value: string | null | undefined): string | null {
-  const text = compact(value);
-  if (!text) return null;
-  const match = text.match(/^(.+?[.!?])\s/);
-  return match?.[1] ?? text;
-}
-
-function displayChapter(input: GuidedStudyPlanInput): string {
-  const bookName = input.book?.name ?? input.chapter.book_id;
-  return `${bookName} ${input.chapter.chapter_num}`;
-}
-
 // Canonical genre → opening-prompt map. Keys must exactly match the
 // `genre_label` values produced by the content pipeline (see books.json).
 // If a new genre is added to content, extend this table; `genrePrompt`
@@ -92,6 +90,91 @@ const GENRE_PROMPTS: Record<string, string> = {
   Wisdom: 'What pattern of wise or foolish living is being exposed?',
 };
 
+type EvidenceTrailKind = 'context' | 'structure' | 'language' | 'scripture' | 'debate';
+
+interface EvidenceTrailDefinition {
+  kind: EvidenceTrailKind;
+  title: string;
+  subtitle: string;
+  badge: GuidedEvidenceTrailItem['badge'];
+  candidatePanelTypes: string[];
+  confidence?: ConfidenceLevel;
+}
+
+const EVIDENCE_TRAIL_DEFINITIONS: Record<EvidenceTrailKind, EvidenceTrailDefinition> = {
+  context: {
+    kind: 'context',
+    title: 'Start with context',
+    subtitle: 'Ancient audience, genre, and setting',
+    badge: 'Required',
+    candidatePanelTypes: ['hist', 'ctx'],
+  },
+  structure: {
+    kind: 'structure',
+    title: 'Trace the structure',
+    subtitle: 'How the chapter is arranged and argued',
+    badge: 'Helpful',
+    candidatePanelTypes: ['lit', 'discourse'],
+  },
+  language: {
+    kind: 'language',
+    title: 'Check the language',
+    subtitle: 'Key words, translation choices, and repeated phrases',
+    badge: 'Helpful',
+    candidatePanelTypes: ['heb', 'greek', 'trans', 'tx'],
+  },
+  scripture: {
+    kind: 'scripture',
+    title: 'Compare Scripture',
+    subtitle: 'Echoes, cross-references, and canonical connections',
+    badge: 'Helpful',
+    candidatePanelTypes: ['cross', 'src', 'thread'],
+  },
+  debate: {
+    kind: 'debate',
+    title: 'If unclear, weigh debate',
+    subtitle: 'Where careful interpreters differ',
+    badge: 'Debated',
+    candidatePanelTypes: ['debate', 'com'],
+    confidence: 'debated',
+  },
+};
+
+const MODE_TRAIL_ORDER: Record<GuidedStudyMode, EvidenceTrailKind[]> = {
+  quick: ['context', 'language', 'scripture'],
+  deep: ['context', 'language', 'scripture', 'debate'],
+  teaching: ['context', 'structure', 'scripture', 'debate'],
+  devotional: ['context', 'scripture', 'language'],
+};
+
+function compact(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const cleaned = value.replace(/\s+/g, ' ').trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function firstSentence(value: string | null | undefined): string | null {
+  const text = compact(value);
+  if (!text) return null;
+  const match = text.match(/^(.+?[.!?])\s/);
+  return match?.[1] ?? text;
+}
+
+function displayChapter(input: GuidedStudyPlanInput): string {
+  const bookName = input.book?.name ?? input.chapter.book_id;
+  return `${bookName} ${input.chapter.chapter_num}`;
+}
+
+function normalizeMode(mode?: GuidedStudyMode): GuidedStudyMode {
+  return GUIDED_STUDY_MODE_OPTIONS.some((option) => option.key === mode)
+    ? mode ?? DEFAULT_MODE
+    : DEFAULT_MODE;
+}
+
+function modeLabel(mode: GuidedStudyMode): string {
+  return GUIDED_STUDY_MODE_OPTIONS.find((option) => option.key === mode)?.label ?? 'Deep study';
+}
+
 function genrePrompt(genreLabel?: string): string {
   if (!genreLabel) {
     return 'What does the passage emphasize before you open any study panels?';
@@ -102,8 +185,17 @@ function genrePrompt(genreLabel?: string): string {
   );
 }
 
-function sectionPrompt(input: GuidedStudyPlanInput): string {
+function betterQuestionPrompt(input: GuidedStudyPlanInput, mode: GuidedStudyMode): string {
   const first = input.sections[0];
+  if (mode === 'quick') {
+    return 'What is the one question you should answer before moving on?';
+  }
+  if (mode === 'teaching') {
+    return 'What would someone need clarified before they could teach this passage responsibly?';
+  }
+  if (mode === 'devotional') {
+    return 'What does the chapter emphasize before you ask how it applies to me?';
+  }
   if (!first) return 'What question would help you understand this chapter on its own terms?';
   return `What do verses ${first.verse_start}-${first.verse_end} ask you to notice about the original audience, not just yourself?`;
 }
@@ -137,7 +229,7 @@ function buildRecommendations(input: GuidedStudyPlanInput): GuidedPanelRecommend
   }
 
   for (const chapterPanel of input.chapterPanels) {
-    if (recs.length >= 5) break;
+    if (recs.length >= 7) break;
     const label = PANEL_LABELS[chapterPanel.panel_type];
     if (!label || used.has(`chapter:${chapterPanel.panel_type}`)) continue;
     recs.push({
@@ -150,7 +242,31 @@ function buildRecommendations(input: GuidedStudyPlanInput): GuidedPanelRecommend
     used.add(`chapter:${chapterPanel.panel_type}`);
   }
 
-  return recs.slice(0, 5);
+  return recs;
+}
+
+function buildEvidenceTrail(
+  mode: GuidedStudyMode,
+  recommendations: GuidedPanelRecommendation[],
+): GuidedEvidenceTrailItem[] {
+  return MODE_TRAIL_ORDER[mode]
+    .map((kind) => {
+      const definition = EVIDENCE_TRAIL_DEFINITIONS[kind];
+      const recommendation = recommendations.find((rec) =>
+        definition.candidatePanelTypes.includes(rec.panelType),
+      );
+      if (!recommendation) return null;
+      return {
+        key: `${kind}:${recommendation.key}`,
+        title: definition.title,
+        subtitle: definition.subtitle,
+        panelType: recommendation.panelType,
+        sectionNum: recommendation.sectionNum,
+        badge: definition.badge,
+        confidence: definition.confidence ?? recommendation.confidence,
+      } satisfies GuidedEvidenceTrailItem;
+    })
+    .filter((item): item is GuidedEvidenceTrailItem => item != null);
 }
 
 function buildConceptChips(input: GuidedStudyPlanInput): GuidedConceptChip[] {
@@ -182,6 +298,7 @@ function buildConceptChips(input: GuidedStudyPlanInput): GuidedConceptChip[] {
 }
 
 export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPlan {
+  const mode = normalizeMode(input.mode);
   const chapterTitle = input.chapter.title || displayChapter(input);
   const purpose = firstSentence(input.bookIntro?.purpose);
   const moment =
@@ -193,18 +310,22 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
   const guidance = compact(input.book?.genre_guidance);
   const audienceContext =
     compact(input.bookIntro?.era) ?? compact(input.bookIntro?.at_a_glance?.chapters?.toString());
+  const allRecommendations = buildRecommendations(input);
+  const betterQuestion = betterQuestionPrompt(input, mode);
 
   const prompts: GuidedPrompt[] = [
     {
       key: 'genre-observation',
       text: genrePrompt(input.book?.genre_label ?? input.bookIntro?.at_a_glance?.genre),
     },
-    { key: 'better-question', text: sectionPrompt(input) },
+    { key: 'better-question', text: betterQuestion },
   ];
 
   return {
     chapterId: input.chapter.id,
     title: chapterTitle,
+    mode,
+    modeLabel: modeLabel(mode),
     sceneRows: [
       { label: 'Genre', value: guidance ? `${genre}: ${guidance}` : genre },
       { label: 'Moment', value: moment },
@@ -220,7 +341,9 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
       },
     ],
     prompts,
-    recommendations: buildRecommendations(input),
+    recommendations: allRecommendations.slice(0, MODE_RECOMMENDATION_LIMIT[mode]),
+    evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
+    betterQuestionPrompt: betterQuestion,
     conceptChips: buildConceptChips(input),
   };
 }

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -249,24 +249,28 @@ function buildEvidenceTrail(
   mode: GuidedStudyMode,
   recommendations: GuidedPanelRecommendation[],
 ): GuidedEvidenceTrailItem[] {
-  return MODE_TRAIL_ORDER[mode]
-    .map((kind) => {
-      const definition = EVIDENCE_TRAIL_DEFINITIONS[kind];
-      const recommendation = recommendations.find((rec) =>
-        definition.candidatePanelTypes.includes(rec.panelType),
-      );
-      if (!recommendation) return null;
-      return {
-        key: `${kind}:${recommendation.key}`,
-        title: definition.title,
-        subtitle: definition.subtitle,
-        panelType: recommendation.panelType,
-        sectionNum: recommendation.sectionNum,
-        badge: definition.badge,
-        confidence: definition.confidence ?? recommendation.confidence,
-      } satisfies GuidedEvidenceTrailItem;
-    })
-    .filter((item): item is GuidedEvidenceTrailItem => item != null);
+  const items: GuidedEvidenceTrailItem[] = [];
+
+  for (const kind of MODE_TRAIL_ORDER[mode]) {
+    const definition = EVIDENCE_TRAIL_DEFINITIONS[kind];
+    const recommendation = recommendations.find((rec) =>
+      definition.candidatePanelTypes.includes(rec.panelType),
+    );
+    if (!recommendation) continue;
+
+    const confidence = definition.confidence ?? recommendation.confidence;
+    items.push({
+      key: `${kind}:${recommendation.key}`,
+      title: definition.title,
+      subtitle: definition.subtitle,
+      panelType: recommendation.panelType,
+      badge: definition.badge,
+      ...(recommendation.sectionNum != null ? { sectionNum: recommendation.sectionNum } : {}),
+      ...(confidence ? { confidence } : {}),
+    });
+  }
+
+  return items;
 }
 
 function buildConceptChips(input: GuidedStudyPlanInput): GuidedConceptChip[] {

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,15 +1,15 @@
 import type { SectionPanel } from '../../types';
-import type {
-  ConfidenceLevel,
-  GuidedConceptChip,
-  GuidedEvidenceTrailItem,
-  GuidedPanelRecommendation,
-  GuidedPrompt,
-  GuidedStudyMode,
-  GuidedStudyPlan,
-  GuidedStudyPlanInput,
+import {
+  GUIDED_STUDY_MODE_OPTIONS,
+  type ConfidenceLevel,
+  type GuidedConceptChip,
+  type GuidedEvidenceTrailItem,
+  type GuidedPanelRecommendation,
+  type GuidedPrompt,
+  type GuidedStudyMode,
+  type GuidedStudyPlan,
+  type GuidedStudyPlanInput,
 } from './types';
-import { GUIDED_STUDY_MODE_OPTIONS } from './types';
 
 const DEFAULT_MODE: GuidedStudyMode = 'deep';
 
@@ -50,7 +50,7 @@ const MODE_RECOMMENDATION_LIMIT: Record<GuidedStudyMode, number> = {
 };
 
 // TODO(#1584): Replace with labels from content/meta/concepts.json via
-// getAllConcepts(). Hardcoding 15 concepts is a v1 stopgap — this list
+// getAllConcepts(). Hardcoding 15 concepts is a v1 stopgap. This list
 // doesn't scale with content and silently excludes concepts the content
 // team adds (justification, atonement, incarnation, sanctification, etc.).
 const CONCEPT_WORDS = [
@@ -71,11 +71,11 @@ const CONCEPT_WORDS = [
   'suffering',
 ];
 
-// Canonical genre → opening-prompt map. Keys must exactly match the
+// Canonical genre to opening-prompt map. Keys must exactly match the
 // `genre_label` values produced by the content pipeline (see books.json).
 // If a new genre is added to content, extend this table; `genrePrompt`
 // falls back to a generic prompt for unknown genres.
-// TODO(#1584): Pair this with the concept-list refactor — both should
+// TODO(#1584): Pair this with the concept-list refactor. Both should
 // derive from a single source of canonical labels.
 const GENRE_PROMPTS: Record<string, string> = {
   'Theological Narrative':

--- a/app/src/services/guidedStudy/types.ts
+++ b/app/src/services/guidedStudy/types.ts
@@ -14,6 +14,44 @@ export const GUIDED_STUDY_STEP_LABELS: Record<GuidedStudyStep, string> = {
   review: 'Review',
 };
 
+export const GUIDED_STUDY_MODES = ['quick', 'deep', 'teaching', 'devotional'] as const;
+
+export type GuidedStudyMode = (typeof GUIDED_STUDY_MODES)[number];
+
+export interface GuidedStudyModeOption {
+  key: GuidedStudyMode;
+  label: string;
+  estimate: string;
+  description: string;
+}
+
+export const GUIDED_STUDY_MODE_OPTIONS: GuidedStudyModeOption[] = [
+  {
+    key: 'quick',
+    label: 'Quick pass',
+    estimate: '8-10 min',
+    description: 'Context, one key observation, and a short takeaway.',
+  },
+  {
+    key: 'deep',
+    label: 'Deep study',
+    estimate: '20-30 min',
+    description: 'A fuller trail through context, language, Scripture, and debate.',
+  },
+  {
+    key: 'teaching',
+    label: 'Teaching prep',
+    estimate: '25 min',
+    description: 'Structure, claims, and what someone else will need clarified.',
+  },
+  {
+    key: 'devotional',
+    label: 'Devotional',
+    estimate: '12 min',
+    description: 'Observe the text carefully before moving toward prayerful response.',
+  },
+];
+
 export interface StudyDepthEstimate {
   readMin: number;
   guidedMin: number;
@@ -41,6 +79,16 @@ export interface GuidedPanelRecommendation {
   confidence?: ConfidenceLevel;
 }
 
+export interface GuidedEvidenceTrailItem {
+  key: string;
+  title: string;
+  subtitle: string;
+  panelType: string;
+  sectionNum?: number;
+  badge: 'Required' | 'Helpful' | 'Optional' | 'Debated';
+  confidence?: ConfidenceLevel;
+}
+
 export interface GuidedConceptChip {
   id: string;
   label: string;
@@ -49,9 +97,13 @@ export interface GuidedConceptChip {
 export interface GuidedStudyPlan {
   chapterId: string;
   title: string;
+  mode: GuidedStudyMode;
+  modeLabel: string;
   sceneRows: GuidedSceneRow[];
   prompts: GuidedPrompt[];
   recommendations: GuidedPanelRecommendation[];
+  evidenceTrail: GuidedEvidenceTrailItem[];
+  betterQuestionPrompt: string;
   conceptChips: GuidedConceptChip[];
 }
 
@@ -62,4 +114,5 @@ export interface GuidedStudyPlanInput {
   chapterPanels: ChapterPanel[];
   verses: Verse[];
   bookIntro?: ParsedBookIntro | null;
+  mode?: GuidedStudyMode;
 }


### PR DESCRIPTION
## Summary

Adds the first Guided Study V2 slice on top of PR #1580. This keeps the chapter reader unchanged and makes the guided session itself smarter.

## Changes

- Adds study modes: Quick pass, Deep study, Teaching prep, and Devotional.
- Makes `buildGuidedStudyPlan` mode-aware.
- Adds an Evidence Trail for the Explore step: context, language, Scripture comparison, and interpretive debate when available.
- Adds a Better Question card in the Explore step.
- Adds `StudyModeSelector` and `EvidenceTrailRow` components in the existing dark/gold guided-study aesthetic.
- Adds service and component tests for the new V2 behavior.

## Notes

- This is intentionally stacked on `codex/guided-study-recovery` so PR #1580 can land first.
- No new chapter reader UI is added in this iteration.
- Local checkout had unrelated dirty PR #1580 repair work, so this PR was created via the GitHub connector. CI should be treated as the verification source for this draft.