### PR TITLE
content: 6 difficult passages on canon-adjacent questions (#1545)

### DIFF
--- a/content/meta/difficult-passages.json
+++ b/content/meta/difficult-passages.json
@@ -6685,5 +6685,681 @@
         "year": 2008
       }
     ]
+  },
+  {
+    "id": "jude-quotes-enoch",
+    "title": "Jude Quotes 1 Enoch as Prophecy",
+    "category": "theological",
+    "severity": "major",
+    "passage": "Jude 14-15",
+    "question": "If 1 Enoch is not in the Protestant canon, why does Jude quote it with the formula 'Enoch prophesied'?",
+    "responses": [
+      {
+        "tradition": "Citation affirms content, not canonicity",
+        "tradition_family": "evangelical",
+        "scholar_id": "bruce",
+        "summary": "Jude treats the quoted words of 1 Enoch 1:9 as a genuine prophetic utterance — the Lord genuinely is coming with his holy ones to execute judgment — without thereby canonizing the whole book. The distinction mirrors Paul's citations of Greek poets (Acts 17:28, Titus 1:12, 1 Corinthians 15:33): the specific quoted content is affirmed as true without extending inspiration to Aratus, Epimenides, or Menander. Canonicity in the later technical sense — a closed list of inspired books used normatively by the church — is a question Jude's citation does not purport to settle. The quotation affirms what Enoch actually prophesied; it does not ratify every sentence of the book that preserves that prophecy.",
+        "key_verses": [
+          "Jude 14-15",
+          "Acts 17:28",
+          "Titus 1:12",
+          "1 Corinthians 15:33"
+        ],
+        "strengths": [
+          "Explains the Jude/Paul parallel cleanly",
+          "Preserves the distinction between prophetic content and canonical status",
+          "Aligns with Jerome's position and the subsequent Latin West consensus",
+          "Defended by major evangelical NT scholars (Bruce, Bauckham, Schreiner, Davids)"
+        ],
+        "weaknesses": [
+          "Requires a technical definition of 'canon' that may not fit Jude's 1st-century framework",
+          "Jude's 'prophesied' formula is stronger than Paul's 'as certain of your own poets have said'",
+          "Does not fully explain why Jude uses the formula appropriate to Scripture if the source is not Scripture"
+        ]
+      },
+      {
+        "tradition": "Tertullian: citation implies scriptural authority",
+        "tradition_family": "patristic",
+        "scholar_id": "tertullian",
+        "summary": "Tertullian (De Cultu Feminarum 1.3) argued on this passage that 1 Enoch should be received as Scripture. His reasoning is direct: the apostolic writer quotes the book as prophecy; that quotation is itself Scripture (Jude); therefore the quoted text shares in scriptural authority. The Ethiopian Orthodox Tewahedo Church inherited this logic through its pre-Chalcedonian Alexandrian connection and retains 1 Enoch in its 81-book canon as continuous living tradition. Jude's prophetic formula, on this reading, is exactly what a NT author would say of any Scripture, and we should take it at face value.",
+        "key_verses": [
+          "Jude 14-15"
+        ],
+        "strengths": [
+          "Takes Jude's prophetic formula at face value",
+          "Has the strongest continuous-tradition case (Ethiopian canon preserves 1 Enoch unbroken)",
+          "Aligns with how Jude's Jewish-Christian audience would have heard 'prophesied'"
+        ],
+        "weaknesses": [
+          "Did not prevail in the patristic West (Jerome and Augustine both reject)",
+          "Most early Christian canon lists explicitly exclude 1 Enoch while affirming Jude",
+          "Makes canon depend on a single NT citation"
+        ]
+      },
+      {
+        "tradition": "Authoritative Jewish tradition, not canonical in later technical sense",
+        "tradition_family": "critical",
+        "scholar_id": "nickelsburg",
+        "summary": "The 1st-century Jewish category system had more gradations than later Christian canon-theology recognizes. 1 Enoch was broadly honored as inspired and prophetic at Qumran (where extensive Aramaic fragments survive) and in diaspora Judaism, without requiring a formal 'canon' decision to establish its authority. Jude participates in this authoritative-but-permeable reading culture. The later question 'is it in the canon?' presupposes a hermeneutical framework Jude himself did not operate within. 1 Enoch 1:9 was a recognized theophanic oracle; Jude appeals to its recognized authority for his audience.",
+        "key_verses": [
+          "Jude 14-15"
+        ],
+        "strengths": [
+          "Historically accurate about 1st-century Jewish reading culture",
+          "Aligns with the Qumran evidence (1 Enoch alongside biblical texts)",
+          "Explains Jude's prophetic language without anachronistic canon framing"
+        ],
+        "weaknesses": [
+          "Relativizes the canon question in ways many find theologically problematic",
+          "Does not tell modern readers how to handle 1 Enoch",
+          "Leaves Protestant/Catholic/Orthodox canon disputes under-adjudicated"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "jude",
+        "chapter_num": 1
+      }
+    ],
+    "tags": [
+      "canon-formation",
+      "pseudepigrapha",
+      "jude",
+      "1-enoch",
+      "inspiration",
+      "hwgtb"
+    ],
+    "context": "Jude 14-15 is the NT's most explicit quotation of a work outside the Hebrew OT canon. The introduction formula 'Enoch, the seventh from Adam, prophesied saying' uses the exact language Jude would apply to an OT prophet. The quoted text matches 1 Enoch 1:9 — a work preserved complete only in Ethiopic Geʽez, with Aramaic fragments at Qumran confirming the text's pre-Christian origin. Patristic responses diverged sharply (Tertullian defended canonical status; Jerome rejected it), and the canonical verdict in the Latin West eventually followed Jerome. For modern Protestant readers the question is sharp: does Jude's usage compel us to receive 1 Enoch as Scripture?",
+    "key_verses": [
+      "Jude 14-15",
+      "1 Enoch 1:9"
+    ],
+    "consensus": "Evangelical consensus: Jude's citation affirms the specific prophetic content of 1 Enoch 1:9 as true without canonizing the book. This parallels Paul's quotations of Greek poets and matches the Jerome-to-Reformation Western tradition. Ethiopian Orthodox tradition preserves 1 Enoch as canonical, and patristic voice (Tertullian) defended that view; both deserve respectful engagement even from a Protestant position.",
+    "further_reading": [
+      "F.F. Bruce, The Canon of Scripture (IVP, 1988), ch. 3",
+      "Richard Bauckham, Jude, 2 Peter (WBC, 1983), pp. 96-98",
+      "George Nickelsburg, 1 Enoch 1: Hermeneia (Fortress, 2001), pp. 142-146",
+      "Michael Kruger, Canon Revisited (Crossway, 2012)"
+    ],
+    "images": []
+  },
+  {
+    "id": "michael-moses-body",
+    "title": "Michael Disputing Over the Body of Moses",
+    "category": "theological",
+    "severity": "moderate",
+    "passage": "Jude 9",
+    "question": "Where does Jude get the story of Michael the archangel disputing with Satan over Moses' body, and does it imply the Assumption of Moses is Scripture?",
+    "responses": [
+      {
+        "tradition": "Allusion to Assumption of Moses — not canonization",
+        "tradition_family": "evangelical",
+        "scholar_id": "bruce",
+        "summary": "Origen (De Principiis 3.2.1) and Clement of Alexandria both identify Jude's source as the Assumption of Moses (also called the Testament of Moses), a 1st-century BC/AD Jewish work that narrated Moses' death and heavenly ascent. The relevant ending of the book is lost, but the patristic attestation is strong and thematically coherent. Jude uses the Michael-vs-Satan episode as a rhetorical a fortiori argument: if even Michael, confronting the devil himself, deferred judgment to God ('The Lord rebuke you'), the opponents' casual blaspheming of 'glorious ones' (likely angelic powers, v. 8) is grotesque presumption. The allusion does not canonize the Assumption of Moses; it appeals to a shared tradition Jude's readers recognize.",
+        "key_verses": [
+          "Jude 9",
+          "Zechariah 3:2"
+        ],
+        "strengths": [
+          "Has strong patristic source-identification (Origen, Clement)",
+          "Explains Jude's rhetorical strategy (a fortiori from Michael to opponents)",
+          "Coheres with Jude's other Second Temple references (1 Enoch at vv. 14-15)",
+          "Preserves distinction between 'shared tradition' and 'canonical source'"
+        ],
+        "weaknesses": [
+          "Assumption of Moses ending is lost, so direct comparison is impossible",
+          "Relies on patristic source attribution that could be wrong",
+          "Does not resolve why Jude would draw on extra-biblical narrative for rhetorical weight"
+        ]
+      },
+      {
+        "tradition": "Oral tradition, not specifically the Assumption of Moses",
+        "tradition_family": "evangelical",
+        "scholar_id": "schreiner",
+        "summary": "Schreiner and others note that the source attribution to the Assumption of Moses rests entirely on patristic tradition (Origen, Clement) — the surviving portion of the Assumption does not contain the episode. Jude may be drawing on a broader oral-literary Jewish tradition about Moses' burial by Michael that was reflected in but not exclusive to the Assumption of Moses. The Deuteronomy 34:5-6 note that 'no one knows the place of Moses' burial' invited speculative expansion in Second Temple Judaism, and Michael's role as Israel's guardian (Daniel 10:13, 21; 12:1) made him the natural figure in such expansions.",
+        "key_verses": [
+          "Deuteronomy 34:5-6",
+          "Daniel 12:1",
+          "Jude 9"
+        ],
+        "strengths": [
+          "Does not require commitment to a specific text whose ending is lost",
+          "Accounts for why Michael is the figure (his guardian role for Israel)",
+          "Aligns with broader Second Temple speculative tradition about Moses' death"
+        ],
+        "weaknesses": [
+          "Weakens the force of Jude's appeal — 'shared tradition' is vaguer than a specific text",
+          "Does not explain why Origen and Clement confidently identified the Assumption of Moses",
+          "Diffuses the source-question rather than answering it"
+        ]
+      },
+      {
+        "tradition": "Canonical tradition of inspired Jewish Scripture",
+        "tradition_family": "orthodox",
+        "scholar_id": "tertullian",
+        "summary": "Early patristic writers (Origen, Clement) treat Jude's source as a real book they knew, and treated it with respect as inspired Jewish literature. The Ethiopian and some Orthodox traditions are more hospitable to this broader corpus than the Western canon; on this reading, Jude is citing a Jewish work that was genuinely authoritative in its community. The Assumption of Moses was never received as canonical in any Christian communion, but its authority within 1st-century Jewish-Christian reading culture was substantial enough that an apostle could cite it without apology. This position does not require us to receive the Assumption as Scripture today; it acknowledges its genuine standing at the time Jude wrote.",
+        "key_verses": [
+          "Jude 9"
+        ],
+        "strengths": [
+          "Honors the patristic record (Origen, Clement did treat it as a real inspired text)",
+          "Explains Jude's confident citation without hesitation",
+          "Coheres with broader Second Temple reading culture"
+        ],
+        "weaknesses": [
+          "No Christian communion actually received the Assumption of Moses as Scripture",
+          "Moves the canonical question without resolving it",
+          "Some strengths claims rely on patristic attestation that is itself contested"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "jude",
+        "chapter_num": 1
+      },
+      {
+        "book_id": "deuteronomy",
+        "chapter_num": 34
+      },
+      {
+        "book_id": "daniel",
+        "chapter_num": 10
+      },
+      {
+        "book_id": "zechariah",
+        "chapter_num": 3
+      }
+    ],
+    "tags": [
+      "canon-formation",
+      "pseudepigrapha",
+      "jude",
+      "assumption-of-moses",
+      "michael",
+      "hwgtb"
+    ],
+    "context": "Jude 9 narrates a scene absent from the Hebrew OT: the archangel Michael, in dispute with Satan over Moses' body, does not pronounce a blasphemous judgment but says 'The Lord rebuke you' — the exact wording of Zechariah 3:2 (Yahweh to Satan in Joshua-the-priest's vision). The source is debated, but the dominant patristic identification (Origen, Clement) points to the Assumption of Moses, a 1st-century Jewish pseudepigraphon whose ending is now lost. Jude uses the story as an a fortiori argument: if Michael himself deferred judgment to God, the opponents' casual blasphemy of 'glorious ones' (v. 8) is audacious folly.",
+    "key_verses": [
+      "Jude 9",
+      "Zechariah 3:2",
+      "Deuteronomy 34:5-6",
+      "Daniel 12:1"
+    ],
+    "consensus": "Broad scholarly consensus that Jude alludes to a Jewish tradition about Moses' death preserved in (or related to) the Assumption of Moses. The evangelical consensus is that the allusion does not canonize the source — the parallel with Paul's pagan-poet citations holds here as it does for Jude 14-15.",
+    "further_reading": [
+      "Richard Bauckham, Jude, 2 Peter (WBC, 1983), pp. 65-76",
+      "Peter Davids, The Letters of 2 Peter and Jude (Pillar, 2006), pp. 59-65",
+      "F.F. Bruce, The Canon of Scripture (IVP, 1988), ch. 3"
+    ],
+    "images": []
+  },
+  {
+    "id": "jesus-preaching-to-spirits",
+    "title": "Jesus Preaching to the Spirits in Prison",
+    "category": "theological",
+    "severity": "major",
+    "passage": "1 Peter 3:18-20",
+    "question": "To whom did Christ 'preach' or 'proclaim' after his death, and why does the passage invoke Noah's Flood and disobedient spirits?",
+    "responses": [
+      {
+        "tradition": "Proclamation to the bound Watchers of 1 Enoch",
+        "tradition_family": "second-temple",
+        "scholar_id": "nickelsburg",
+        "summary": "Peter's reference to 'spirits in prison' who 'formerly did not obey when God's patience waited in the days of Noah' aligns tightly with the Book of the Watchers (1 Enoch 6-16): rebel angels bound in a dark prison awaiting judgment after they transgressed in pre-Flood times. On this reading (Dalton, Selwyn, Bauckham, Achtemeier, Nickelsburg) Christ's 'proclamation' (ekēruxen — the verb for heralding) is a triumphal announcement of victory to the bound watchers, not an offer of salvation. The context — right after 'put to death in the flesh, made alive in the spirit' — is Christ's post-resurrection announcement of cosmic victory. The Watcher framework explains why Peter mentions Noah's Flood specifically (not any other OT event) and why the spirits are 'in prison' rather than simply dead.",
+        "key_verses": [
+          "1 Peter 3:18-20",
+          "2 Peter 2:4-5",
+          "Jude 6",
+          "Genesis 6:1-4"
+        ],
+        "strengths": [
+          "Explains the specifically pre-Flood context",
+          "Makes sense of 'spirits in prison' (Watcher imprisonment, not general dead)",
+          "Coheres with 2 Peter 2:4 and Jude 6 on bound angels",
+          "Reads 'proclamation' as triumphal announcement — fits the resurrection context"
+        ],
+        "weaknesses": [
+          "Requires acceptance of Watcher-tradition background",
+          "Some readers find angelic rebellion difficult theologically",
+          "Has been misused historically to support 'harrowing of hell' and 'second chance after death' readings the text does not support"
+        ]
+      },
+      {
+        "tradition": "Christ preaching through Noah to antediluvian humans",
+        "tradition_family": "evangelical",
+        "scholar_id": "schreiner",
+        "summary": "Grudem and a minority of evangelical commentators argue that 'Christ' preached through Noah (by the Spirit of Christ at work in Noah — cf. 1 Peter 1:11) to the antediluvian humans who ultimately perished in the Flood. On this reading the 'spirits' are human souls of the disobedient pre-Flood generation, and the 'prison' is a metaphor for their post-mortem state. The verb kēryssō (preach) fits an evangelistic rather than triumphal context. This preserves a more strictly Christocentric reading without relying on 1 Enoch's Watcher mythology.",
+        "key_verses": [
+          "1 Peter 1:10-11",
+          "1 Peter 3:18-20",
+          "Genesis 6:3"
+        ],
+        "strengths": [
+          "Avoids commitment to Watcher-tradition background",
+          "Fits 1 Peter 1:11 ('the Spirit of Christ in the prophets')",
+          "Reads 'preach' as evangelistic (kēryssō's usual sense)"
+        ],
+        "weaknesses": [
+          "Makes 'spirits' mean human souls — unusual NT usage",
+          "Does not explain why Noah's Flood specifically is mentioned",
+          "Strains the Greek syntax; most commentators reject this reading",
+          "Doesn't clarify why Christ preaches in prison rather than when the humans were alive"
+        ]
+      },
+      {
+        "tradition": "Harrowing of hell (Christ descends to release OT saints)",
+        "tradition_family": "patristic",
+        "scholar_id": "augustine",
+        "summary": "Early patristic tradition (Gospel of Nicodemus, Odes of Solomon 42, Irenaeus, later Apostles' Creed 'he descended into hell') developed a reading in which Christ, between death and resurrection, descended to Hades to preach to and release the righteous dead of the OT. Augustine tentatively associated 1 Peter 3:18-20 with this descent while noting the exegetical difficulties. The Apostles' Creed phrase 'descended into hell' (descendit ad inferos) became formalized in the 4th century and has remained in Catholic, Orthodox, and mainstream Protestant creeds, though its exact meaning is debated.",
+        "key_verses": [
+          "1 Peter 3:18-20",
+          "Ephesians 4:9-10",
+          "Matthew 27:52-53"
+        ],
+        "strengths": [
+          "Has deep patristic tradition and creedal anchoring",
+          "Explains 'descended into hell' creedal phrase",
+          "Integrates with broader theology of Christ's victory over death"
+        ],
+        "weaknesses": [
+          "The 'OT saints released' reading is difficult to sustain exegetically from 1 Peter 3",
+          "Conflates spirits 'in prison' with 'righteous dead' — the text contrasts them",
+          "Does not explain the specifically Noah-era reference",
+          "Most modern commentators (both evangelical and critical) reject this as the passage's primary meaning"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "1_peter",
+        "chapter_num": 3
+      },
+      {
+        "book_id": "2_peter",
+        "chapter_num": 2
+      },
+      {
+        "book_id": "jude",
+        "chapter_num": 1
+      },
+      {
+        "book_id": "genesis",
+        "chapter_num": 6
+      }
+    ],
+    "tags": [
+      "1-peter",
+      "second-temple",
+      "1-enoch",
+      "watchers",
+      "harrowing-of-hell",
+      "hwgtb"
+    ],
+    "context": "1 Peter 3:18-20 is one of the most interpretively contested passages in the NT. Christ 'was put to death in the flesh but made alive in the spirit, in which he went and proclaimed to the spirits in prison, because they formerly did not obey when God's patience waited in the days of Noah.' The passage concentrates three interpretive puzzles: who are the spirits, where is the prison, and what does 'proclaim' mean? The emergence of the Book of the Watchers tradition as context (via 1 Enoch 10-16 on the binding of rebel angels under the pre-Flood generation) has shifted scholarly consensus over the past century toward the Watcher-proclamation reading, though the 'harrowing of hell' tradition remains embedded in the Apostles' Creed and historic Christian imagination.",
+    "key_verses": [
+      "1 Peter 3:18-20",
+      "2 Peter 2:4-5",
+      "Jude 6",
+      "Genesis 6:1-4",
+      "Ephesians 4:8-10"
+    ],
+    "consensus": "Modern scholarly consensus (majority of evangelical and critical commentators) favors the Watcher-proclamation reading: Christ announces triumphal victory to the bound watchers of 1 Enoch tradition. The traditional Creedal 'harrowing of hell' reading has deep patristic and liturgical roots but is exegetically harder to sustain. The Grudem 'Christ preached through Noah' view is a minority evangelical position.",
+    "further_reading": [
+      "William Dalton, Christ's Proclamation to the Spirits (Pontifical Biblical Institute, 1965)",
+      "Richard Bauckham, 'The Spirits in Prison' (Themelios, 1981)",
+      "Peter Davids, First Peter (NICNT, 1990), pp. 136-142",
+      "Paul Achtemeier, 1 Peter (Hermeneia, 1996)",
+      "Wayne Grudem, 1 Peter (TNTC, 1988) [for the minority view]"
+    ],
+    "images": []
+  },
+  {
+    "id": "angels-that-sinned",
+    "title": "The Angels That Sinned (Cast Into Tartarus)",
+    "category": "theological",
+    "severity": "moderate",
+    "passage": "2 Peter 2:4",
+    "question": "Where does the NT's language about bound angels awaiting judgment come from, given that the OT does not narrate it?",
+    "responses": [
+      {
+        "tradition": "Direct dependence on the Book of the Watchers (1 Enoch)",
+        "tradition_family": "second-temple",
+        "scholar_id": "nickelsburg",
+        "summary": "Peter's vocabulary — 'cast them into Tartarus' (tartarōsas), 'chains of gloomy darkness' (seirais zophou paradōken), 'kept until the judgment' (eis krisin tēroumenous) — tracks the Watcher tradition of 1 Enoch 1-36 point for point. 1 Enoch narrates the watchers' descent before the Flood (a reading of Genesis 6:1-4), their transgression, and their binding 'in a dark place' awaiting 'the day of their great judgment' (1 Enoch 10:12-14). The word 'Tartarus' itself is used in the Greek form of 1 Enoch (Codex Panopolitanus fragments) for the watchers' prison, and appears nowhere in the OT. Davids and Bauckham argue for direct literary dependence on 1 Enoch; the vocabulary is too close to be coincidence.",
+        "key_verses": [
+          "2 Peter 2:4-5",
+          "Jude 6",
+          "Genesis 6:1-4"
+        ],
+        "strengths": [
+          "Vocabulary alignment is exceptionally close",
+          "Explains 'Tartarus' specifically (OT lacks this term)",
+          "Coheres with Jude 6 on the same tradition",
+          "Matches the broader Second Temple Jewish reading of Genesis 6"
+        ],
+        "weaknesses": [
+          "Requires the interpreter to accept 1 Enoch's narrative framework as Peter's background",
+          "Some readers find direct NT dependence on non-canonical books theologically uncomfortable",
+          "1 Enoch's ending about final judgment adds details Peter does not"
+        ]
+      },
+      {
+        "tradition": "Broad Second Temple tradition, not necessarily direct literary dependence",
+        "tradition_family": "evangelical",
+        "scholar_id": "schreiner",
+        "summary": "Peter's audience would have been shaped by Second Temple Jewish traditions whether or not Peter himself read 1 Enoch directly. The Watcher tradition was broadly diffused across Jewish literature: 1 Enoch, Jubilees 5, the Damascus Document, Genesis Apocryphon, Book of Giants. Peter draws on a theological category-vocabulary his readers share, using it to make a theological point (God judges rebellion, even angelic) without committing to the specific narrative details of any one source. This preserves the doctrinal point while avoiding over-commitment to 1 Enoch's canonicity.",
+        "key_verses": [
+          "2 Peter 2:4-5",
+          "Jude 6",
+          "Genesis 6:1-4",
+          "Deuteronomy 32:8 (LXX)"
+        ],
+        "strengths": [
+          "Avoids over-commitment to 1 Enoch as Peter's specific source",
+          "Acknowledges the genuine broad Second Temple diffusion of Watcher tradition",
+          "Preserves the doctrinal point without canonical implications"
+        ],
+        "weaknesses": [
+          "The vocabulary match with 1 Enoch is very close (Tartarus, chains, gloomy darkness, judgment-day custody)",
+          "The 'broad tradition' framing may underplay what Peter actually seems to assume",
+          "Doesn't fully explain why the specifically Greek term Tartarus appears"
+        ]
+      },
+      {
+        "tradition": "Angels of Genesis 6 read through OT alone",
+        "tradition_family": "evangelical",
+        "scholar_id": "moo",
+        "summary": "A minority evangelical reading holds that Peter's reference is to the angelic beings of Genesis 6:1-4 (the 'sons of God' on the angelic interpretation), but that he is reading Genesis itself, not 1 Enoch. The bound-angels language may be Peter's own theological amplification of the OT tradition: God's judgment on the angels of Genesis 6 is implicitly asserted by the theological logic of the Flood narrative, even if not explicitly narrated. This preserves scriptural sufficiency: the NT's theology of fallen angels draws from the OT without requiring extra-biblical sources.",
+        "key_verses": [
+          "Genesis 6:1-4",
+          "2 Peter 2:4",
+          "Jude 6"
+        ],
+        "strengths": [
+          "Preserves OT sufficiency for the underlying theology",
+          "Does not require 1 Enoch as source",
+          "Coheres with the angelic reading of Genesis 6"
+        ],
+        "weaknesses": [
+          "Does not explain the specific 'Tartarus' / chains / judgment-day-custody vocabulary (not in Genesis 6)",
+          "Strains credibility given how tightly Peter's language tracks 1 Enoch",
+          "Makes Peter's language unaccountably similar to a book he does not read"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "2_peter",
+        "chapter_num": 2
+      },
+      {
+        "book_id": "jude",
+        "chapter_num": 1
+      },
+      {
+        "book_id": "genesis",
+        "chapter_num": 6
+      },
+      {
+        "book_id": "1_peter",
+        "chapter_num": 3
+      }
+    ],
+    "tags": [
+      "2-peter",
+      "second-temple",
+      "1-enoch",
+      "watchers",
+      "tartarus",
+      "hwgtb"
+    ],
+    "context": "2 Peter 2:4 opens a triad of OT judgment examples (fallen angels, the Flood, Sodom & Gomorrah) meant to reassure readers that God will judge the false teachers. But the opening example has no OT analogue: Genesis does not say God bound angels in Tartarus. The theological vocabulary — Tartarus, chains of gloom, custody until judgment — is the vocabulary of the Book of the Watchers tradition preserved in 1 Enoch 1-36 and assumed across Second Temple Jewish literature. The passage raises the canon-adjacent question of how deeply NT authors are formed by Jewish literature outside the Hebrew canon.",
+    "key_verses": [
+      "2 Peter 2:4-5",
+      "Jude 6",
+      "Genesis 6:1-4",
+      "1 Enoch 10:12-14"
+    ],
+    "consensus": "Scholarly consensus (evangelical and critical) that 2 Peter 2:4 reflects the Watcher tradition crystallized in 1 Enoch. Disagreement is about whether this is direct literary dependence or broader tradition-dependence. Very few modern scholars defend a 'Genesis 6 alone' reading.",
+    "further_reading": [
+      "Peter Davids, The Letters of 2 Peter and Jude (Pillar, 2006), pp. 222-230",
+      "Richard Bauckham, Jude, 2 Peter (WBC, 1983), pp. 248-251",
+      "George Nickelsburg, 1 Enoch 1: Hermeneia (Fortress, 2001)",
+      "Douglas Moo, 2 Peter, Jude (NIVAC, 1996)"
+    ],
+    "images": []
+  },
+  {
+    "id": "jannes-and-jambres",
+    "title": "Jannes and Jambres: Names Not in the Old Testament",
+    "category": "historical",
+    "severity": "minor",
+    "passage": "2 Timothy 3:8",
+    "question": "Paul names Pharaoh's magicians as 'Jannes and Jambres' — but the OT never names them. Where does Paul get the names?",
+    "responses": [
+      {
+        "tradition": "Jewish interpretive tradition (Damascus Document, Targums)",
+        "tradition_family": "evangelical",
+        "scholar_id": "mounce",
+        "summary": "By Paul's day the names Jannes and Jambres for Pharaoh's magicians (Exod 7:11-12) had been established in Jewish interpretive tradition for over two centuries. The Damascus Document (CD 5:17-19) from Qumran — late 2nd or early 1st century BC — mentions 'Jannes and his brother' whom Belial raised up against Moses and Aaron. Targum Pseudo-Jonathan on Exodus 1:15 and 7:11 gives the Aramaic forms (Yohané and Mamré). By the 1st century AD, Pliny the Elder (Natural History 30.11) and Apuleius (Apology 90) both reference 'Iannes' among famous magicians, showing the tradition had diffused beyond Jewish circles. Paul draws on shared tradition as cultural shorthand — exactly parallel to his quotations of Greek poets (Aratus, Epimenides, Menander).",
+        "key_verses": [
+          "2 Timothy 3:8",
+          "Exodus 7:11-12",
+          "Exodus 8:18-19"
+        ],
+        "strengths": [
+          "Names specific documented sources (Damascus Document, Targums, Pliny)",
+          "Parallels Paul's other pagan-source citations",
+          "Does not require any extra-biblical canonization",
+          "Strong manuscript and textual evidence for the tradition's antiquity"
+        ],
+        "weaknesses": [
+          "Paul names the figures without explanation — assumes Timothy knows them — which shows how widely received the tradition was",
+          "Does not tell us whether the names are historically accurate or purely traditional",
+          "Requires the reader to accept Paul drawing authoritatively on extra-biblical tradition"
+        ]
+      },
+      {
+        "tradition": "Apostolic revelation of otherwise-lost names",
+        "tradition_family": "evangelical",
+        "scholar_id": "towner",
+        "summary": "A minority conservative reading holds that Paul as an apostle received the specific names by divine revelation, supplementing the OT narrative with historically accurate detail. On this view the names are true-as-history and Paul's knowledge comes through apostolic inspiration rather than through inherited Jewish tradition. This reading preserves a maximally conservative view of scriptural authority and avoids any implication of dependence on extra-biblical sources. Mounce and Towner do not hold this view; it is represented by some older Pastoral commentary tradition.",
+        "key_verses": [
+          "2 Timothy 3:8",
+          "2 Timothy 3:16"
+        ],
+        "strengths": [
+          "Preserves a strict view of apostolic revelation",
+          "Treats the names as historically accurate data",
+          "Avoids any implication of extra-biblical source-dependence"
+        ],
+        "weaknesses": [
+          "Ignores the well-documented Damascus Document and Targum tradition predating Paul by centuries",
+          "Requires implausible apostolic special revelation for names already in common Jewish use",
+          "Most evangelical commentators (Mounce, Towner, Knight) reject this view",
+          "Contradicts the simpler and better-documented explanation"
+        ]
+      },
+      {
+        "tradition": "Jewish midrashic tradition filling biblical narrative gaps",
+        "tradition_family": "critical",
+        "scholar_id": "vanderkam",
+        "summary": "The Jannes and Jambres tradition is one instance of a broader Second Temple practice: Jewish interpreters filled gaps in biblical narrative with named figures and elaborated back-stories. Targum Pseudo-Jonathan names them as sons of Balaam; the fragmentary Book of Jannes and Jambres (attested by Origen, Decretum Gelasianum) gave them a dedicated narrative; the Talmud (b. Menahot 85a) preserves the tradition. Paul participates in this midrashic culture fluently — he names the magicians, treats them as well-known, and assumes Timothy shares the cultural literacy. The theological weight Paul places on the Jannes/Jambres typology (opposition to Moses = opposition to truth) presupposes their full narrative existence in the shared tradition.",
+        "key_verses": [
+          "2 Timothy 3:8",
+          "Damascus Document (CD) 5:17-19",
+          "Targum Pseudo-Jonathan Exodus 1:15, 7:11"
+        ],
+        "strengths": [
+          "Places the tradition in its full Second Temple context",
+          "Explains both Paul's confidence and Timothy's presumed familiarity",
+          "Aligns with mainstream modern scholarship on Paul's Jewish background",
+          "Accounts for the broad diffusion of the names across Jewish, Christian, and pagan sources"
+        ],
+        "weaknesses": [
+          "May understate Paul's theological use of the tradition (Paul is doing more than casual allusion)",
+          "Leaves open whether the names are historically accurate or traditional invention",
+          "Some readers find 'midrashic tradition' language insufficiently respectful of the NT text"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "2_timothy",
+        "chapter_num": 3
+      },
+      {
+        "book_id": "exodus",
+        "chapter_num": 7
+      },
+      {
+        "book_id": "exodus",
+        "chapter_num": 8
+      }
+    ],
+    "tags": [
+      "2-timothy",
+      "pseudepigrapha",
+      "jannes-jambres",
+      "dead-sea-scrolls",
+      "damascus-document",
+      "hwgtb"
+    ],
+    "context": "Paul names Exodus's anonymous Egyptian magicians — Jannes and Jambres — without explanation, using them as types of the false teachers opposing Timothy. The names are absent from the Hebrew OT but are documented in Jewish interpretive tradition from at least the 2nd century BC (Damascus Document CD 5:17-19). By the 1st century AD the names had diffused into Jewish, Christian, and pagan literature. Paul draws on this shared cultural knowledge as rhetorical resource; his Ephesian audience would have recognized the names without difficulty. The passage illustrates the permeability of Scripture's boundary with respected extra-biblical Jewish tradition at the moment the NT was being written.",
+    "key_verses": [
+      "2 Timothy 3:8",
+      "Exodus 7:11-12",
+      "Damascus Document (CD) 5:17-19"
+    ],
+    "consensus": "Broad scholarly consensus (evangelical and critical) that Paul draws on well-established Jewish interpretive tradition. The names are not original with Paul; they reflect a tradition documented centuries earlier. The apostolic-revelation reading is a minority conservative view rejected by most modern Pastoral commentators.",
+    "further_reading": [
+      "William Mounce, Pastoral Epistles (WBC, 2000)",
+      "Philip Towner, 1-2 Timothy, Titus (NICNT, 2006)",
+      "James VanderKam, The Dead Sea Scrolls Today (Eerdmans, 1994)"
+    ],
+    "images": []
+  },
+  {
+    "id": "book-of-jasher-in-ot",
+    "title": "The Book of Jasher and Other Lost Books Cited in the Old Testament",
+    "category": "historical",
+    "severity": "moderate",
+    "passage": "Joshua 10:13; 2 Samuel 1:18",
+    "question": "The OT itself cites books that are not in any canon — the Book of Jasher, the Book of the Wars of the LORD, the chronicles of various prophets. What are these, and why are they not Scripture?",
+    "responses": [
+      {
+        "tradition": "Lost ancient Israelite sources consulted as historical sources",
+        "tradition_family": "evangelical",
+        "scholar_id": "bruce",
+        "summary": "The Book of Jasher (sefer hayashar, 'Book of the Upright') is cited in Joshua 10:13 for the sun standing still and in 2 Samuel 1:18 for David's lament over Saul and Jonathan. The Book of the Wars of the LORD is cited in Numbers 21:14. Various chronicles of Samuel the seer, Nathan the prophet, Gad the seer, Iddo, and others are referenced in 1-2 Chronicles. These were genuine ancient Israelite source-works that the inspired authors of the OT historical books consulted — similar to how Luke 'investigated carefully' (Luke 1:3) before writing. They were not canonical themselves; they served as sources from which the canonical books drew. Their loss does not impoverish Scripture because God preserved the specific material he intended us to have.",
+        "key_verses": [
+          "Joshua 10:13",
+          "2 Samuel 1:18",
+          "Numbers 21:14",
+          "1 Chronicles 29:29",
+          "2 Chronicles 9:29",
+          "Luke 1:3"
+        ],
+        "strengths": [
+          "Takes the OT's source-citations at face value as historical",
+          "Parallels Luke's explicit research methodology",
+          "Preserves inspired-author / source distinction",
+          "Does not require the lost books themselves to be canonical"
+        ],
+        "weaknesses": [
+          "Some of these works may have been more poetry/liturgy than sober history",
+          "Cannot reconstruct the original works to verify what the OT authors used",
+          "Leaves open whether the lost material would have changed OT understanding"
+        ]
+      },
+      {
+        "tradition": "The medieval Sefer haYashar and 18th-century English Jasher are NOT the biblical Jasher",
+        "tradition_family": "evangelical",
+        "scholar_id": "bruce",
+        "summary": "Two later works circulate under the name 'Book of Jasher' and are often confused with the OT's Jasher. First: Sefer haYashar, a medieval Hebrew midrash composed c. 11th-13th century in Spain or Italy, drawing on Talmudic and midrashic tradition to retell biblical history. This is a legitimate Jewish devotional text but is centuries younger than the OT Jasher. Second: 'The Book of Jasher' published in English by Jacob Ilive in London (1751, reprinted by Joseph Hamil), presented as a translation of an ancient Alexandrian manuscript found by 'Alcuin of Britain' — this is a documented English forgery. Neither of these is the Jasher cited by Joshua 10 or 2 Samuel 1; the OT Jasher remains lost. The distinction matters because contemporary popular literature sometimes presents the modern works as 'the lost book of Jasher finally rediscovered,' which is historically false.",
+        "key_verses": [
+          "Joshua 10:13",
+          "2 Samuel 1:18"
+        ],
+        "strengths": [
+          "Historically accurate about the three distinct 'Jashers'",
+          "Names the 1751 work as the documented forgery it is",
+          "Protects against contemporary conspiratorial readings ('rediscovered lost Scripture')"
+        ],
+        "weaknesses": [
+          "Purely negative in clarifying what Jasher is NOT",
+          "Does not tell us what the OT Jasher actually contained",
+          "May feel deflationary to readers interested in 'ancient rediscovered Scripture'"
+        ]
+      },
+      {
+        "tradition": "Inspired selection under providential preservation",
+        "tradition_family": "orthodox",
+        "scholar_id": "athanasius",
+        "summary": "The Christian doctrine of canon assumes that God, providentially preserving his Word, preserved what he meant for the church to have as Scripture. The OT's own citation of non-extant sources shows that the inspired books did not contain the totality of Israelite religious literature — but they contain what God intended the church to receive. The patristic tradition read the OT's source-citations as evidence of scrupulous historical composition under divine oversight: the canonical book consulted non-canonical sources, just as any careful historian would. The lost books are not 'missing Scripture' but Israel's broader cultural production, from which the inspired authors drew as appropriate.",
+        "key_verses": [
+          "Joshua 10:13",
+          "2 Samuel 1:18",
+          "Numbers 21:14",
+          "Isaiah 34:16"
+        ],
+        "strengths": [
+          "Grounds the canon in divine providence rather than chance preservation",
+          "Coheres with Christian theology of Scripture's sufficiency",
+          "Addresses the pastoral concern ('did we lose Scripture?') directly"
+        ],
+        "weaknesses": [
+          "Somewhat theological rather than historical-critical",
+          "Does not engage what the lost books actually contained",
+          "Can feel circular ('God preserved what he meant us to have, therefore what we have is what he meant')"
+        ]
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_id": "joshua",
+        "chapter_num": 10
+      },
+      {
+        "book_id": "2_samuel",
+        "chapter_num": 1
+      },
+      {
+        "book_id": "numbers",
+        "chapter_num": 21
+      },
+      {
+        "book_id": "1_chronicles",
+        "chapter_num": 29
+      },
+      {
+        "book_id": "2_chronicles",
+        "chapter_num": 9
+      }
+    ],
+    "tags": [
+      "canon-formation",
+      "jasher",
+      "lost-books",
+      "ot-sources",
+      "apocrypha",
+      "hwgtb"
+    ],
+    "context": "The Hebrew Bible itself cites several books that are not in any Christian canon: the Book of Jasher (Joshua 10:13; 2 Samuel 1:18), the Book of the Wars of the LORD (Numbers 21:14), the chronicles of Samuel, Nathan, Gad, Iddo, and others (1-2 Chronicles), and the 'book of the acts of Solomon' (1 Kings 11:41). These were apparently ancient Israelite sources consulted by the inspired authors of the OT historical books but are themselves no longer extant. The situation is complicated by the existence of two later works that circulate under the name 'Book of Jasher' — a medieval Sefer haYashar (c. 11th-13th century) and a documented 18th-century English forgery — neither of which is the OT's Jasher. The passage raises the pastoral question of 'lost Scripture' and the more precise historical question of how inspired OT books relate to their non-canonical sources.",
+    "key_verses": [
+      "Joshua 10:13",
+      "2 Samuel 1:18",
+      "Numbers 21:14",
+      "1 Chronicles 29:29"
+    ],
+    "consensus": "Broad evangelical consensus that the OT's source-citations demonstrate careful historical composition by inspired authors who consulted non-canonical sources — similar to Luke's methodology. No serious scholar identifies the medieval Sefer haYashar or the 18th-century English 'Book of Jasher' with the OT's Jasher; these confusions persist only in popular literature. The OT Jasher itself is lost and cannot be reconstructed.",
+    "further_reading": [
+      "F.F. Bruce, The Canon of Scripture (IVP, 1988)",
+      "David Stec, The Text of Joshua 10:13 (Vetus Testamentum, 1988)",
+      "Edward Mack, 'Book of Jasher' in ISBE (1915)"
+    ],
+    "images": []
   }
 ]


### PR DESCRIPTION
## What this does
Appends **6 new entries** to `content/meta/difficult-passages.json` covering canon-formation and extra-biblical literature difficulties readers encounter in Scripture. Total `difficult_passages` rows: **53 → 59**.

| id | passage |
|---|---|
| `jude-quotes-enoch` | Jude 14–15 |
| `michael-moses-body` | Jude 9 |
| `jesus-preaching-to-spirits` | 1 Peter 3:18–20 |
| `angels-that-sinned` | 2 Peter 2:4 |
| `jannes-and-jambres` | 2 Timothy 3:8 |
| `book-of-jasher-in-ot` | Joshua 10:13; 2 Samuel 1:18 |

## Closes
Closes #1545

## Note on passage selection
The issue listed 6 target passages. `nephilim-sons-of-god` for Genesis 6:1–4 **was already present on master with 5 responses**, so this PR substitutes `book-of-jasher-in-ot` — an equally canon-adjacent difficult passage covering the OT's own citation of the lost Book of Jasher (Joshua 10:13, 2 Samuel 1:18), the medieval *Sefer haYashar*, and the documented 1751 English forgery. This keeps the PR at **6 new entries** while avoiding duplication with the existing nephilim entry. If the reviewer prefers, I can revert `book-of-jasher-in-ot` and instead augment the existing `nephilim-sons-of-god` entry with additional responses.

## Per-passage shape

Each entry has the full existing `difficult-passages.json` schema:
- `id`, `title`, `category`, `severity`, `passage`, `question`, `context`, `key_verses`, `consensus`, `responses[]`, `related_chapters[]`, `tags`, `further_reading`, `images`
- `responses[]` with **all required keys**: `tradition`, `tradition_family`, `scholar_id`, `summary`, `key_verses`, `strengths`, `weaknesses`
- **3 responses per passage** spanning distinct `tradition_family` values (evangelical + critical + patristic / second-temple / orthodox)
- `related_chapters` populated with `{book_id, chapter_num}` objects
- `consensus` — honest assessment of where agreement exists

## Scholar coverage

Mix of existing master scholars (`bruce`, `schreiner`, `moo`, `mounce`, `towner`) and HWGTB-P0-01 additions (`tertullian`, `athanasius`, `augustine`, `nickelsburg`, `vanderkam`).

Tradition families used: `evangelical` (primary), `critical`, `patristic`, `second-temple`, `orthodox`.

## Editorial commitments per epic guardrails

- **Descriptive, not prescriptive** on tradition status of source texts (1 Enoch, Assumption of Moses, Damascus Document, Jubilees). Ethiopian Orthodox canonicity of 1 Enoch stated as fact.
- **Scholar diversity on every contested question.** Where evangelical and critical scholars genuinely disagree (Watcher-tradition vs Genesis-6-alone reading of 2 Peter 2:4; Jude's Enoch citation implications; Watcher-proclamation vs harrowing-of-hell vs "Christ preached through Noah" reading of 1 Peter 3:18-20), all positions argued on their own terms.
- **Explicit rejection of conspiracy framings.** `book-of-jasher-in-ot` entry specifically names the 1751 English forgery as a forgery and distinguishes it from the lost OT Jasher and the medieval *Sefer haYashar* — protecting readers from popular "rediscovered lost Scripture" claims.
- **NT citation ≠ canonicity** stated explicitly in the Jude/Enoch and Assumption-of-Moses entries; consistent across the set.
- **Named primary sources throughout**: Origen's *De Principiis* 3.2.1 (Assumption of Moses), Tertullian's *De Cultu Feminarum* 1.3 (1 Enoch), Damascus Document CD 5:17–19 (Jannes and Jambres), Targum Pseudo-Jonathan Exodus 1:15 and 7:11, Pliny *Natural History* 30.11, 1 Enoch 10:12–14, Gospel of Nicodemus, Apostles' Creed.

## Note on extrabiblical cross-link acceptance criterion

The issue's last acceptance line:
> Cross-links from extrabiblical entries (`related_difficult_passage_ids`) are added in HWGTB-P1-09 (not in this PR)

This PR ships the 6 passages with stable IDs that **#1576** (HWGTB-P1-09) can reference. Aligns with the epic's architectural decision to wire all cross-links in a single coordinated pass after sibling content lands.

## How I verified

Full pipeline with prerequisites applied locally (#1537 scholars):
- `python _tools/build_sqlite.py` — `difficult_passages: 59 rows` ✅
- `python _tools/schema_validator.py` — **136560 passed**, 77 failed (same 77 pre-existing master-baseline failures, 0 new failures from my 6 entries) ✅
- `python _tools/validate_sqlite.py` — **93 passed**, 0 failed ✅

Smoke on master without prereqs:
- `build_sqlite.py` succeeds: `difficult_passages: 59 rows`
- `schema_validator`: 136560 passed, 77 failed (same — the validator does not cross-check `difficult-passages.responses[].scholar_id`, so scholar-id resolution is deferred to runtime consumption)
- `validate_sqlite`: 93 passed, 0 failed

## Note on line endings
Matched master's CRLF line endings (the existing `difficult-passages.json` uses `\r\n`). The diff shows the actual content changes (677 insertions, 1 deletion) rather than a full-file reformat.

## Merge order

Depends on **#1537** (PR #1583) for the 5 patristic/modern scholars referenced (`tertullian`, `athanasius`, `augustine`, `nickelsburg`, `vanderkam`). Safe to merge after #1537; no hard failures in any validator even without #1537 applied (scholar-id resolution is not enforced on difficult-passages in the current validator).

Pairs with **#1576** (HWGTB-P1-09) which wires extrabiblical cross-links after this and sibling content lands.

## Rollback
Revert this PR. `difficult-passages.json` returns to 53 entries; the `difficult_passages` table row count returns to 53 on next build. No schema changes, no user.db impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa)_