### PR TITLE
feat(app): ExtraBiblicalDetailScreen (#1548)

### DIFF
--- a/app/__tests__/screens/ExtraBiblicalDetailScreen.test.tsx
+++ b/app/__tests__/screens/ExtraBiblicalDetailScreen.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * ExtraBiblicalDetailScreen.test.tsx — Detail view for one extrabiblical
+ * entry (HWGTB-P2-03 / #1548).
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import ExtraBiblicalDetailScreen from '@/screens/ExtraBiblicalDetailScreen';
+import type { ExtrabiblicalEntry } from '@/types';
+
+// ── Navigation mock ─────────────────────────────────────────────
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+      push: jest.fn(),
+      setOptions: jest.fn(),
+    }),
+    useRoute: () => ({ params: { id: '1_enoch' } }),
+    useScrollToTop: jest.fn(),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+jest.mock('lucide-react-native', () => ({
+  ChevronLeft: () => null,
+  ArrowLeft: () => null,
+  Search: () => null,
+  X: () => null,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 44, bottom: 34, left: 0, right: 0 }),
+}));
+
+// ── Premium mock — mutable for per-test flip ─────────────────────
+let mockIsPremium = true;
+const mockShowUpgrade = jest.fn();
+const mockDismissUpgrade = jest.fn();
+let mockUpgradeRequest: { variant: string; featureName: string } | null = null;
+jest.mock('@/hooks/usePremium', () => ({
+  usePremium: () => ({
+    isPremium: mockIsPremium,
+    upgradeRequest: mockUpgradeRequest,
+    showUpgrade: mockShowUpgrade,
+    dismissUpgrade: mockDismissUpgrade,
+  }),
+}));
+
+// ── Entry fixture ───────────────────────────────────────────────
+const FIXTURE: ExtrabiblicalEntry = {
+  id: '1_enoch',
+  title: '1 Enoch (Ethiopic Enoch)',
+  also_known_as: ['Book of Enoch', 'Ethiopic Enoch'],
+  category: 'pseudepigrapha',
+  estimated_date: '3rd c. BC – 1st c. AD',
+  original_language: 'Aramaic / Hebrew, preserved in Ethiopic Geʽez',
+  tradition_status: {
+    protestant: 'not canonical',
+    catholic: 'not canonical',
+    eastern_orthodox: 'not canonical',
+    ethiopian_tewahedo: 'canonical (81-book canon)',
+  },
+  brief_summary:
+    '1 Enoch is a composite work of five distinct books.\n\nIt is preserved complete only in Ethiopic Geʽez.',
+  full_summary: null,
+  nt_citations: [
+    { ref: 'Jude 14-15', cites: '1 Enoch 1:9', type: 'direct_quotation' },
+  ],
+  ot_allusions: [
+    { ref: 'Genesis 6:1-4', connection: 'The Watchers expand Gen 6:1-4.' },
+  ],
+  scholar_voices: [
+    {
+      scholar_id: 'nickelsburg',
+      position: "Hermeneia commentary on 1 Enoch.",
+    },
+  ],
+  related_debate_ids: ['did-jude-affirm-enoch-as-scripture'],
+  related_journey_ids: ['canon-formation'],
+  related_difficult_passage_ids: ['jude-quotes-enoch'],
+  tags: ['pseudepigrapha', 'hwgtb'],
+  further_reading: [
+    {
+      title: '1 Enoch 1',
+      author: 'Nickelsburg',
+      note: 'Hermeneia (2001)',
+    },
+    {
+      title: 'Online Aramaic fragments archive',
+      url: 'https://example.org/1enoch-aramaic',
+    },
+  ],
+};
+
+let mockEntry: ExtrabiblicalEntry | null = FIXTURE;
+let mockLoading = false;
+jest.mock('@/hooks/useExtraBiblicalEntry', () => ({
+  useExtraBiblicalEntry: () => ({ entry: mockEntry, loading: mockLoading }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsPremium = true;
+  mockUpgradeRequest = null;
+  mockEntry = FIXTURE;
+  mockLoading = false;
+});
+
+describe('ExtraBiblicalDetailScreen', () => {
+  describe('render — premium tier', () => {
+    it('renders hero title + aliases', () => {
+      const { getAllByText, getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      // Title appears twice: screen header + hero card
+      expect(getAllByText('1 Enoch (Ethiopic Enoch)').length).toBeGreaterThanOrEqual(1);
+      expect(getByText(/Also known as:.*Book of Enoch.*Ethiopic Enoch/)).toBeTruthy();
+    });
+
+    it('renders tradition badges', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByLabelText(/^Protestant:/)).toBeTruthy();
+      expect(getByLabelText(/^Ethiopian Tewahedo:/)).toBeTruthy();
+    });
+
+    it('renders full brief_summary (both paragraphs)', () => {
+      const { getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(
+        getByText(/1 Enoch is a composite work of five distinct books\./),
+      ).toBeTruthy();
+      expect(getByText(/It is preserved complete only in Ethiopic Geʽez\./)).toBeTruthy();
+    });
+
+    it('renders NT citations with ref + source + type', () => {
+      const { getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText('Jude 14-15')).toBeTruthy();
+      expect(getByText(/→ 1 Enoch 1:9/)).toBeTruthy();
+      expect(getByText('Direct quotation')).toBeTruthy();
+    });
+
+    it('renders OT allusions', () => {
+      const { getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText('Genesis 6:1-4')).toBeTruthy();
+      expect(getByText(/The Watchers expand Gen 6:1-4/)).toBeTruthy();
+    });
+
+    it('renders scholar voices', () => {
+      const { getAllByText, getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      // 'Nickelsburg' appears twice: scholar-voice name AND further-reading author
+      expect(getAllByText('Nickelsburg').length).toBeGreaterThanOrEqual(1);
+      expect(getByText(/Hermeneia commentary on 1 Enoch/)).toBeTruthy();
+    });
+
+    it('renders related-debate chip and section header', () => {
+      const { getByLabelText, getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText('RELATED DEBATES')).toBeTruthy();
+      expect(
+        getByLabelText('Open debate did-jude-affirm-enoch-as-scripture'),
+      ).toBeTruthy();
+    });
+
+    it('renders related-difficult-passage and related-journey chips', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByLabelText('Open difficult jude-quotes-enoch')).toBeTruthy();
+      expect(getByLabelText('Open journey canon-formation')).toBeTruthy();
+    });
+
+    it('renders further-reading items', () => {
+      const { getAllByText, getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText('1 Enoch 1')).toBeTruthy();
+      expect(getAllByText('Nickelsburg').length).toBeGreaterThanOrEqual(1);
+      expect(getByText('Online Aramaic fragments archive')).toBeTruthy();
+    });
+
+    it('renders "Coming soon" placeholder when full_summary is null', () => {
+      const { getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText(/Coming soon — expanded scholarly summary/)).toBeTruthy();
+    });
+
+    it('renders full_summary when it is present instead of placeholder', () => {
+      mockEntry = { ...FIXTURE, full_summary: 'Expanded analysis goes here.' };
+      const { getByText, queryByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText('Expanded analysis goes here.')).toBeTruthy();
+      expect(queryByText(/Coming soon/)).toBeNull();
+    });
+  });
+
+  describe('deep-link navigation — premium tier', () => {
+    it('tapping NT citation navigates to Chapter with parsed book/chapter/verse', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Open Jude 14-15'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'Chapter',
+        expect.objectContaining({ bookId: 'jude', chapterNum: 1 }),
+      );
+    });
+
+    it('tapping OT allusion navigates to Chapter with bookId', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Open Genesis 6:1-4'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'Chapter',
+        expect.objectContaining({ bookId: 'genesis', chapterNum: 6 }),
+      );
+    });
+
+    it('tapping scholar navigates to ScholarBio', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Scholar: nickelsburg'));
+      expect(mockNavigate).toHaveBeenCalledWith('ScholarBio', {
+        scholarId: 'nickelsburg',
+      });
+    });
+
+    it('tapping debate chip navigates to DebateDetail', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(
+        getByLabelText('Open debate did-jude-affirm-enoch-as-scripture'),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('DebateDetail', {
+        topicId: 'did-jude-affirm-enoch-as-scripture',
+      });
+    });
+
+    it('tapping difficult-passage chip navigates to DifficultPassageDetail', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Open difficult jude-quotes-enoch'));
+      expect(mockNavigate).toHaveBeenCalledWith('DifficultPassageDetail', {
+        passageId: 'jude-quotes-enoch',
+      });
+    });
+
+    it('tapping journey chip navigates to JourneyDetail', () => {
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Open journey canon-formation'));
+      expect(mockNavigate).toHaveBeenCalledWith('JourneyDetail', {
+        journeyId: 'canon-formation',
+      });
+    });
+
+    it('tapping further-reading with url calls Linking.openURL', () => {
+      const openUrlSpy = jest
+        .spyOn(Linking, 'openURL')
+        .mockResolvedValue(undefined);
+      const { getByLabelText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      fireEvent.press(getByLabelText('Open Online Aramaic fragments archive'));
+      expect(openUrlSpy).toHaveBeenCalledWith('https://example.org/1enoch-aramaic');
+      openUrlSpy.mockRestore();
+    });
+  });
+
+  describe('free tier (premium gating)', () => {
+    it('renders only first paragraph of brief_summary', () => {
+      mockIsPremium = false;
+      const { getByText, queryByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(
+        getByText(/1 Enoch is a composite work of five distinct books\./),
+      ).toBeTruthy();
+      // Second paragraph is hidden
+      expect(
+        queryByText(/It is preserved complete only in Ethiopic Geʽez\./),
+      ).toBeNull();
+    });
+
+    it('hides all gated sections (NT citations, scholars, debates, etc.)', () => {
+      mockIsPremium = false;
+      const { queryByText, queryByLabelText } = renderWithProviders(
+        <ExtraBiblicalDetailScreen />,
+      );
+      expect(queryByText('NEW TESTAMENT CITATIONS')).toBeNull();
+      expect(queryByText('SCHOLAR VOICES')).toBeNull();
+      expect(queryByText('RELATED DEBATES')).toBeNull();
+      expect(queryByText('FULL SUMMARY')).toBeNull();
+      expect(queryByLabelText('Open Jude 14-15')).toBeNull();
+      expect(queryByLabelText('Scholar: nickelsburg')).toBeNull();
+    });
+
+    it('shows unlock CTA and fires showUpgrade on tap', () => {
+      mockIsPremium = false;
+      const { getByLabelText, getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText(/Unlock the full entry/)).toBeTruthy();
+      fireEvent.press(getByLabelText('Unlock full entry'));
+      expect(mockShowUpgrade).toHaveBeenCalledWith(
+        'explore',
+        'Extra-Biblical Literature',
+      );
+    });
+  });
+
+  describe('loading + not-found states', () => {
+    it('shows loading indicator when loading=true', () => {
+      mockLoading = true;
+      mockEntry = null;
+      const { toJSON } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(toJSON()).not.toBeNull();
+    });
+
+    it('shows "Entry not found" when entry=null after load', () => {
+      mockLoading = false;
+      mockEntry = null;
+      const { getByText } = renderWithProviders(<ExtraBiblicalDetailScreen />);
+      expect(getByText(/Entry not found\./)).toBeTruthy();
+    });
+  });
+});

--- a/app/src/components/ExtraBiblicalHero.tsx
+++ b/app/src/components/ExtraBiblicalHero.tsx
@@ -1,0 +1,170 @@
+/**
+ * ExtraBiblicalHero — Header block for ExtraBiblicalDetailScreen
+ * (HWGTB-P2-03 / #1548). Shows title, also-known-as aliases, dates /
+ * language, and the 4-tradition status row.
+ *
+ * Kept as a standalone component per the issue's file layout so the
+ * screen stays thin and the hero can be reused if a card-style preview
+ * is ever needed elsewhere (e.g. CanonComparisonScreen).
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import type {
+  ExtrabiblicalEntry,
+  ExtrabiblicalTraditionStatus,
+} from '../types';
+
+interface Props {
+  entry: ExtrabiblicalEntry;
+}
+
+const TRADITION_ROW: Array<{
+  key: keyof ExtrabiblicalTraditionStatus;
+  short: string;
+  full: string;
+}> = [
+  { key: 'protestant', short: 'Prot', full: 'Protestant' },
+  { key: 'catholic', short: 'Cath', full: 'Catholic' },
+  { key: 'eastern_orthodox', short: 'EO', full: 'Eastern Orthodox' },
+  { key: 'ethiopian_tewahedo', short: 'Eth', full: 'Ethiopian Tewahedo' },
+];
+
+type TraditionClass = 'in' | 'out' | 'partial';
+
+function classifyStatus(value: string): TraditionClass {
+  const v = value.toLowerCase();
+  if (
+    /canonical|included|accepted|scripture|deuterocanon/.test(v) &&
+    !/not\s/.test(v)
+  ) {
+    return 'in';
+  }
+  if (/not\s|excluded|reject|apocryph|outside|noncanonical|non-canonical/.test(v)) {
+    return 'out';
+  }
+  return 'partial';
+}
+
+function statusSymbol(cls: TraditionClass): string {
+  switch (cls) {
+    case 'in':
+      return '✓';
+    case 'out':
+      return '✗';
+    case 'partial':
+      return '~';
+  }
+}
+
+export function ExtraBiblicalHero({ entry }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: base.bgElevated }]}>
+      <Text style={[styles.title, { color: base.text }]}>{entry.title}</Text>
+      {entry.also_known_as.length > 0 ? (
+        <Text style={[styles.aliases, { color: base.textDim }]} numberOfLines={2}>
+          {'Also known as: ' + entry.also_known_as.join(' · ')}
+        </Text>
+      ) : null}
+
+      {(entry.estimated_date || entry.original_language) ? (
+        <View style={styles.metaRow}>
+          {entry.estimated_date ? (
+            <View style={[styles.metaChip, { borderColor: base.gold + '40' }]}>
+              <Text style={[styles.metaLabel, { color: base.textMuted }]}>DATE</Text>
+              <Text style={[styles.metaValue, { color: base.text }]}>
+                {entry.estimated_date}
+              </Text>
+            </View>
+          ) : null}
+          {entry.original_language ? (
+            <View style={[styles.metaChip, { borderColor: base.gold + '40' }]}>
+              <Text style={[styles.metaLabel, { color: base.textMuted }]}>LANGUAGE</Text>
+              <Text style={[styles.metaValue, { color: base.text }]}>
+                {entry.original_language}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+
+      <View style={styles.traditionRow}>
+        {TRADITION_ROW.map((t) => {
+          const raw = entry.tradition_status[t.key] ?? '';
+          const cls = classifyStatus(raw);
+          const color =
+            cls === 'in' ? base.gold : cls === 'out' ? base.textMuted : base.textDim;
+          return (
+            <View
+              key={t.key}
+              accessibilityLabel={`${t.full}: ${raw || 'unspecified'}`}
+              style={[styles.traditionBadge, { borderColor: color + '55' }]}
+            >
+              <Text style={[styles.traditionLabel, { color }]}>
+                {t.short} {statusSymbol(cls)}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 22,
+    lineHeight: 28,
+  },
+  aliases: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  metaChip: {
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+  },
+  metaLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 9,
+    letterSpacing: 0.8,
+  },
+  metaValue: {
+    fontFamily: fontFamily.body,
+    fontSize: 12,
+    marginTop: 1,
+  },
+  traditionRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: spacing.xs,
+  },
+  traditionBadge: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  traditionLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 11,
+  },
+});

--- a/app/src/db/content/extrabiblical.ts
+++ b/app/src/db/content/extrabiblical.ts
@@ -14,7 +14,12 @@ import { getDb } from '../database';
 import { escapeLike } from '../../utils/escapeLike';
 import type {
   ExtrabiblicalCategory,
+  ExtrabiblicalEntry,
+  ExtrabiblicalFurtherReading,
+  ExtrabiblicalNTCitation,
+  ExtrabiblicalOTAllusion,
   ExtrabiblicalRow,
+  ExtrabiblicalScholarVoice,
   ExtrabiblicalSummary,
   ExtrabiblicalTraditionStatus,
 } from '../../types';
@@ -90,6 +95,43 @@ function rowToSummary(row: ExtrabiblicalRow): ExtrabiblicalSummary {
   };
 }
 
+function safeParseObjectArray<T>(raw: string | null): T[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Parse a raw row into a fully-typed entry for the Detail screen. */
+function rowToEntry(row: ExtrabiblicalRow): ExtrabiblicalEntry {
+  return {
+    id: row.id,
+    title: row.title,
+    also_known_as: safeParseStringArray(row.also_known_as_json),
+    category: row.category,
+    estimated_date: row.estimated_date,
+    original_language: row.original_language,
+    tradition_status: parseTraditionStatus(row.tradition_status_json),
+    brief_summary: row.brief_summary,
+    full_summary: row.full_summary,
+    nt_citations: safeParseObjectArray<ExtrabiblicalNTCitation>(row.nt_citations_json),
+    ot_allusions: safeParseObjectArray<ExtrabiblicalOTAllusion>(row.ot_allusions_json),
+    scholar_voices: safeParseObjectArray<ExtrabiblicalScholarVoice>(row.scholar_voices_json),
+    related_debate_ids: safeParseStringArray(row.related_debate_ids_json),
+    related_journey_ids: safeParseStringArray(row.related_journey_ids_json),
+    related_difficult_passage_ids: safeParseStringArray(
+      row.related_difficult_passage_ids_json,
+    ),
+    tags: safeParseStringArray(row.tags_json),
+    further_reading: safeParseObjectArray<ExtrabiblicalFurtherReading>(
+      row.further_reading_json,
+    ),
+  };
+}
+
 // ── Queries ───────────────────────────────────────────────────
 
 const SUMMARY_COLUMNS =
@@ -132,6 +174,18 @@ export async function getExtraBiblicalById(
     logger.error('db/extrabiblical', 'getExtraBiblicalById failed', err);
     return null;
   }
+}
+
+/**
+ * Parsed entry for the Detail screen (HWGTB-P2-03 / #1548). Wraps
+ * getExtraBiblicalById with JSON parsing of every serialized column
+ * so screen code never has to JSON.parse defensively.
+ */
+export async function getExtraBiblicalEntry(
+  id: string,
+): Promise<ExtrabiblicalEntry | null> {
+  const row = await getExtraBiblicalById(id);
+  return row ? rowToEntry(row) : null;
 }
 
 /**

--- a/app/src/db/content/index.ts
+++ b/app/src/db/content/index.ts
@@ -69,6 +69,7 @@ export {
   getContentLibraryCounts, getContentLibrary, searchContentLibrary,
 } from './contentLibrary';
 export {
-  getAllExtraBiblical, getExtraBiblicalById, searchExtraBiblical,
-  getExtraBiblicalByCategory, _resetExtrabiblicalTableCache,
+  getAllExtraBiblical, getExtraBiblicalById, getExtraBiblicalEntry,
+  searchExtraBiblical, getExtraBiblicalByCategory,
+  _resetExtrabiblicalTableCache,
 } from './extrabiblical';

--- a/app/src/hooks/useExtraBiblicalEntry.ts
+++ b/app/src/hooks/useExtraBiblicalEntry.ts
@@ -1,0 +1,51 @@
+/**
+ * useExtraBiblicalEntry — loads one parsed ExtrabiblicalEntry by id.
+ * Used by ExtraBiblicalDetailScreen (HWGTB-P2-03 / #1548).
+ */
+
+import { useEffect, useState } from 'react';
+import { getExtraBiblicalEntry } from '../db/content';
+import type { ExtrabiblicalEntry } from '../types';
+import { logger } from '../utils/logger';
+
+export interface UseExtraBiblicalEntryResult {
+  entry: ExtrabiblicalEntry | null;
+  loading: boolean;
+}
+
+export function useExtraBiblicalEntry(id: string | undefined): UseExtraBiblicalEntryResult {
+  const [entry, setEntry] = useState<ExtrabiblicalEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEntry(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    getExtraBiblicalEntry(id)
+      .then((e) => {
+        if (!cancelled) {
+          setEntry(e);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        logger.error('useExtraBiblicalEntry', 'load failed', err);
+        if (!cancelled) {
+          setEntry(null);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return { entry, loading };
+}

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -30,6 +30,7 @@ const DifficultPassagesBrowseScreen = lazySuspense(() => import('../screens/Diff
 const DifficultPassageDetailScreen = lazySuspense(() => import('../screens/DifficultPassageDetailScreen'));
 const HowWeGotTheBibleLandingScreen = lazySuspense(() => import('../screens/HowWeGotTheBibleLandingScreen'));
 const ExtraBiblicalIndexScreen = lazySuspense(() => import('../screens/ExtraBiblicalIndexScreen'));
+const ExtraBiblicalDetailScreen = lazySuspense(() => import('../screens/ExtraBiblicalDetailScreen'));
 const ConcordanceScreen = lazySuspense(() => import('../screens/ConcordanceScreen'));
 const ContentLibraryScreen = lazySuspense(() => import('../screens/ContentLibraryScreen'));
 const DictionaryBrowseScreen = lazySuspense(() => import('../screens/DictionaryBrowseScreen'));
@@ -90,6 +91,7 @@ export function ExploreStack() {
       <Stack.Screen name="DifficultPassageDetail" component={DifficultPassageDetailScreen} />
       <Stack.Screen name="HowWeGotTheBibleLanding" component={HowWeGotTheBibleLandingScreen} />
       <Stack.Screen name="ExtraBiblicalIndex" component={ExtraBiblicalIndexScreen} />
+      <Stack.Screen name="ExtraBiblicalDetail" component={ExtraBiblicalDetailScreen} />
       <Stack.Screen name="Concordance" component={ConcordanceScreen} />
       <Stack.Screen name="ContentLibrary" component={ContentLibraryScreen} />
       <Stack.Screen name="DictionaryBrowse" component={DictionaryBrowseScreen} />

--- a/app/src/screens/ExtraBiblicalDetailScreen.tsx
+++ b/app/src/screens/ExtraBiblicalDetailScreen.tsx
@@ -1,0 +1,703 @@
+/**
+ * ExtraBiblicalDetailScreen — Detail view for one extrabiblical entry
+ * (HWGTB-P2-03 / #1548). Sections (in order):
+ *   1. Hero (title + aliases + dates + tradition status)
+ *   2. Brief summary
+ *   3. NT citations
+ *   4. OT allusions
+ *   5. Scholar voices
+ *   6. Related debates
+ *   7. Related difficult passages
+ *   8. Related journeys
+ *   9. Further reading
+ *  10. Full summary (or "Coming soon" placeholder)
+ *
+ * Premium gating matches DebatePanel.tsx:
+ *  - Free tier: Hero + first paragraph of brief_summary only
+ *  - Premium tier: all sections
+ * Tapping anywhere in the gated region fires showUpgrade('explore',
+ * 'Extra-Biblical Literature').
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  Linking,
+  SafeAreaView,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { ChevronLeft } from 'lucide-react-native';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { usePremium } from '../hooks/usePremium';
+import { useExtraBiblicalEntry } from '../hooks/useExtraBiblicalEntry';
+import { UpgradePrompt } from '../components/UpgradePrompt';
+import { ExtraBiblicalHero } from '../components/ExtraBiblicalHero';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { parseReference, getBookByName } from '../utils/verseResolver';
+import { logger } from '../utils/logger';
+import type {
+  ExtrabiblicalEntry,
+  ExtrabiblicalNTCitation,
+  ExtrabiblicalOTAllusion,
+  ExtrabiblicalScholarVoice,
+  ExtrabiblicalFurtherReading,
+} from '../types';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+
+type Nav = ScreenNavProp<'Explore', 'ExtraBiblicalDetail'>;
+type Route = ScreenRouteProp<'Explore', 'ExtraBiblicalDetail'>;
+
+function ExtraBiblicalDetailScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<Route>();
+  const { id } = route.params;
+  const { entry, loading } = useExtraBiblicalEntry(id);
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
+
+  const handleVersePress = useCallback(
+    (ref: string) => {
+      const parsed = parseReferenceExtended(ref);
+      if (parsed) {
+        navigation.navigate('Chapter', {
+          bookId: parsed.bookId,
+          chapterNum: parsed.chapter,
+          ...(parsed.verseStart !== undefined
+            ? { verseNum: parsed.verseStart }
+            : {}),
+        });
+      }
+    },
+    [navigation],
+  );
+
+  const handleScholarPress = useCallback(
+    (scholarId: string) => {
+      navigation.navigate('ScholarBio', { scholarId });
+    },
+    [navigation],
+  );
+
+  const handleDebatePress = useCallback(
+    (topicId: string) => navigation.navigate('DebateDetail', { topicId }),
+    [navigation],
+  );
+
+  const handleDifficultPassagePress = useCallback(
+    (passageId: string) =>
+      navigation.navigate('DifficultPassageDetail', { passageId }),
+    [navigation],
+  );
+
+  const handleJourneyPress = useCallback(
+    (journeyId: string) => navigation.navigate('JourneyDetail', { journeyId }),
+    [navigation],
+  );
+
+  const handleExternalLink = useCallback((url: string) => {
+    Linking.openURL(url).catch((err) =>
+      logger.warn('ExtraBiblicalDetail', `Failed to open ${url}`, err),
+    );
+  }, []);
+
+  const handleUpgrade = useCallback(() => {
+    showUpgrade('explore', 'Extra-Biblical Literature');
+  }, [showUpgrade]);
+
+  const firstParagraph = useMemo(
+    () => (entry ? firstParagraphOf(entry.brief_summary) : ''),
+    [entry],
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <ScreenHeader onBack={() => navigation.goBack()} title="" />
+        <View style={styles.center}>
+          <ActivityIndicator color={base.gold} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!entry) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <ScreenHeader onBack={() => navigation.goBack()} title="Not Found" />
+        <View style={styles.center}>
+          <Text style={[styles.bodyText, { color: base.textDim }]}>
+            Entry not found.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScreenHeader
+        onBack={() => navigation.goBack()}
+        title={entry.title}
+      />
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <ExtraBiblicalHero entry={entry} />
+
+        {/* Section 2: Brief summary — free users get first paragraph only */}
+        <View style={styles.section}>
+          <Text style={[styles.sectionLabel, { color: base.textMuted }]}>SUMMARY</Text>
+          <Text style={[styles.bodyText, { color: base.text }]}>
+            {isPremium ? entry.brief_summary : firstParagraph}
+          </Text>
+        </View>
+
+        {isPremium ? (
+          <PremiumSections
+            entry={entry}
+            onVersePress={handleVersePress}
+            onScholarPress={handleScholarPress}
+            onDebatePress={handleDebatePress}
+            onDifficultPassagePress={handleDifficultPassagePress}
+            onJourneyPress={handleJourneyPress}
+            onExternalLink={handleExternalLink}
+          />
+        ) : (
+          <LockedFooter onUpgrade={handleUpgrade} />
+        )}
+      </ScrollView>
+
+      {upgradeRequest && (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────
+
+function ScreenHeader({ onBack, title }: { onBack: () => void; title: string }) {
+  const { base } = useTheme();
+  return (
+    <View style={styles.headerRow}>
+      <TouchableOpacity
+        onPress={onBack}
+        style={styles.backBtn}
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <ChevronLeft size={22} color={base.gold} />
+      </TouchableOpacity>
+      <Text style={[styles.headerTitle, { color: base.gold }]} numberOfLines={1}>
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+function PremiumSections({
+  entry,
+  onVersePress,
+  onScholarPress,
+  onDebatePress,
+  onDifficultPassagePress,
+  onJourneyPress,
+  onExternalLink,
+}: {
+  entry: ExtrabiblicalEntry;
+  onVersePress: (ref: string) => void;
+  onScholarPress: (id: string) => void;
+  onDebatePress: (id: string) => void;
+  onDifficultPassagePress: (id: string) => void;
+  onJourneyPress: (id: string) => void;
+  onExternalLink: (url: string) => void;
+}) {
+  const { base } = useTheme();
+  return (
+    <>
+      {entry.nt_citations.length > 0 ? (
+        <Section label="NEW TESTAMENT CITATIONS">
+          {entry.nt_citations.map((c, i) => (
+            <NTCitationRow key={`${c.ref}-${i}`} cit={c} onPress={onVersePress} />
+          ))}
+        </Section>
+      ) : null}
+
+      {entry.ot_allusions.length > 0 ? (
+        <Section label="OLD TESTAMENT ALLUSIONS">
+          {entry.ot_allusions.map((a, i) => (
+            <OTAllusionRow key={`${a.ref}-${i}`} allusion={a} onPress={onVersePress} />
+          ))}
+        </Section>
+      ) : null}
+
+      {entry.scholar_voices.length > 0 ? (
+        <Section label="SCHOLAR VOICES">
+          {entry.scholar_voices.map((v, i) => (
+            <ScholarVoiceRow
+              key={`${v.scholar_id}-${i}`}
+              voice={v}
+              onPress={onScholarPress}
+            />
+          ))}
+        </Section>
+      ) : null}
+
+      {entry.related_debate_ids.length > 0 ? (
+        <Section label="RELATED DEBATES">
+          <ChipRow ids={entry.related_debate_ids} onPress={onDebatePress} testIdPrefix="debate" />
+        </Section>
+      ) : null}
+
+      {entry.related_difficult_passage_ids.length > 0 ? (
+        <Section label="RELATED DIFFICULT PASSAGES">
+          <ChipRow
+            ids={entry.related_difficult_passage_ids}
+            onPress={onDifficultPassagePress}
+            testIdPrefix="difficult"
+          />
+        </Section>
+      ) : null}
+
+      {entry.related_journey_ids.length > 0 ? (
+        <Section label="RELATED JOURNEYS">
+          <ChipRow ids={entry.related_journey_ids} onPress={onJourneyPress} testIdPrefix="journey" />
+        </Section>
+      ) : null}
+
+      {entry.further_reading.length > 0 ? (
+        <Section label="FURTHER READING">
+          {entry.further_reading.map((f, i) => (
+            <FurtherReadingRow
+              key={`${f.title}-${i}`}
+              item={f}
+              onPress={onExternalLink}
+            />
+          ))}
+        </Section>
+      ) : null}
+
+      <Section label="FULL SUMMARY">
+        {entry.full_summary ? (
+          <Text style={[styles.bodyText, { color: base.text }]}>
+            {entry.full_summary}
+          </Text>
+        ) : (
+          <View
+            style={[
+              styles.comingSoonCard,
+              { backgroundColor: base.bgElevated, borderColor: base.gold + '30' },
+            ]}
+          >
+            <Text style={[styles.comingSoonText, { color: base.textDim }]}>
+              Coming soon — expanded scholarly summary
+            </Text>
+          </View>
+        )}
+      </Section>
+    </>
+  );
+}
+
+function LockedFooter({ onUpgrade }: { onUpgrade: () => void }) {
+  const { base } = useTheme();
+  return (
+    <TouchableOpacity
+      onPress={onUpgrade}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel="Unlock full entry"
+      style={[
+        styles.lockedCard,
+        { backgroundColor: base.bgElevated, borderColor: base.gold + '30' },
+      ]}
+    >
+      <Text style={[styles.lockedTitle, { color: base.gold }]}>
+        {'✨ Unlock the full entry'}
+      </Text>
+      <Text style={[styles.lockedDesc, { color: base.textDim }]}>
+        NT citations, OT allusions, scholar voices, related debates,
+        difficult passages, journeys, and further reading.
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  const { base } = useTheme();
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionLabel, { color: base.textMuted }]}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+function NTCitationRow({
+  cit,
+  onPress,
+}: {
+  cit: ExtrabiblicalNTCitation;
+  onPress: (ref: string) => void;
+}) {
+  const { base } = useTheme();
+  return (
+    <TouchableOpacity
+      onPress={() => onPress(cit.ref)}
+      activeOpacity={0.7}
+      accessibilityRole="link"
+      accessibilityLabel={`Open ${cit.ref}`}
+      style={[styles.citationRow, { borderColor: base.gold + '30' }]}
+    >
+      <Text style={[styles.citationRef, { color: base.gold }]}>{cit.ref}</Text>
+      <Text style={[styles.citationCites, { color: base.textDim }]}>
+        {'→ '}
+        {cit.cites}
+      </Text>
+      {cit.type ? (
+        <Text style={[styles.citationType, { color: base.textMuted }]}>
+          {formatCitationType(cit.type)}
+        </Text>
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+function OTAllusionRow({
+  allusion,
+  onPress,
+}: {
+  allusion: ExtrabiblicalOTAllusion;
+  onPress: (ref: string) => void;
+}) {
+  const { base } = useTheme();
+  return (
+    <TouchableOpacity
+      onPress={() => onPress(allusion.ref)}
+      activeOpacity={0.7}
+      accessibilityRole="link"
+      accessibilityLabel={`Open ${allusion.ref}`}
+      style={[styles.citationRow, { borderColor: base.gold + '30' }]}
+    >
+      <Text style={[styles.citationRef, { color: base.gold }]}>
+        {allusion.ref}
+      </Text>
+      <Text style={[styles.bodyText, { color: base.textDim }]}>
+        {allusion.connection}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function ScholarVoiceRow({
+  voice,
+  onPress,
+}: {
+  voice: ExtrabiblicalScholarVoice;
+  onPress: (scholarId: string) => void;
+}) {
+  const { base } = useTheme();
+  return (
+    <View style={styles.voiceBlock}>
+      <TouchableOpacity
+        onPress={() => onPress(voice.scholar_id)}
+        accessibilityRole="button"
+        accessibilityLabel={`Scholar: ${voice.scholar_id}`}
+      >
+        <Text style={[styles.voiceName, { color: base.gold }]}>
+          {formatScholarLabel(voice.scholar_id)}
+        </Text>
+      </TouchableOpacity>
+      <Text style={[styles.bodyText, { color: base.textDim }]}>
+        {voice.position}
+      </Text>
+    </View>
+  );
+}
+
+function ChipRow({
+  ids,
+  onPress,
+  testIdPrefix,
+}: {
+  ids: string[];
+  onPress: (id: string) => void;
+  testIdPrefix: string;
+}) {
+  const { base } = useTheme();
+  return (
+    <View style={styles.chipRow}>
+      {ids.map((id) => (
+        <TouchableOpacity
+          key={id}
+          onPress={() => onPress(id)}
+          activeOpacity={0.7}
+          accessibilityRole="link"
+          accessibilityLabel={`Open ${testIdPrefix} ${id}`}
+          style={[
+            styles.chip,
+            { borderColor: base.gold + '55', backgroundColor: base.gold + '10' },
+          ]}
+        >
+          <Text style={[styles.chipText, { color: base.gold }]}>
+            {formatIdLabel(id)}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+function FurtherReadingRow({
+  item,
+  onPress,
+}: {
+  item: ExtrabiblicalFurtherReading;
+  onPress: (url: string) => void;
+}) {
+  const { base } = useTheme();
+  const hasUrl = typeof item.url === 'string' && item.url.length > 0;
+  const Container = hasUrl ? TouchableOpacity : View;
+  return (
+    <Container
+      {...(hasUrl
+        ? {
+            onPress: () => onPress(item.url!),
+            activeOpacity: 0.7,
+            accessibilityRole: 'link' as const,
+            accessibilityLabel: `Open ${item.title}`,
+          }
+        : {})}
+      style={styles.readingRow}
+    >
+      <Text style={[styles.readingTitle, { color: base.text }]}>{item.title}</Text>
+      {item.author ? (
+        <Text style={[styles.readingAuthor, { color: base.textDim }]}>
+          {item.author}
+        </Text>
+      ) : null}
+      {item.note ? (
+        <Text style={[styles.readingNote, { color: base.textMuted }]}>
+          {item.note}
+        </Text>
+      ) : null}
+    </Container>
+  );
+}
+
+// ── Ref parsing (extends parseReference with single-chapter-book shortcut) ──
+
+interface ParsedVerseRef {
+  bookId: string;
+  chapter: number;
+  verseStart?: number;
+}
+
+/**
+ * Wraps parseReference with single-chapter-book handling: "Jude 14",
+ * "Jude 14-15", "Philemon 6", "2 John 9", "Obadiah 10-11" are all parsed
+ * as chapter=1 with the number treated as a verse. The standard
+ * parseReference regex requires a colon before the verse, which is
+ * correct for multi-chapter books but wrong for these 1-chapter cases
+ * that appear throughout the extrabiblical content (Jude especially).
+ */
+function parseReferenceExtended(ref: string): ParsedVerseRef | null {
+  const standard = parseReference(ref);
+  if (standard) {
+    return {
+      bookId: standard.bookId,
+      chapter: standard.chapter,
+      verseStart: standard.verseStart,
+    };
+  }
+  // Fallback: "<Book> <n>" or "<Book> <n>-<m>" for single-chapter books.
+  const m = ref.trim().match(/^(\d?\s*[A-Za-z][A-Za-z .]+?)\s+(\d+)(?:\s*[-–—]\s*\d+)?$/);
+  if (!m) return null;
+  const book = getBookByName(m[1].trim());
+  if (!book || book.chapters !== 1) return null;
+  return {
+    bookId: book.id,
+    chapter: 1,
+    verseStart: parseInt(m[2], 10),
+  };
+}
+
+// ── Formatters ────────────────────────────────────────────────────
+
+function firstParagraphOf(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  const idx = trimmed.indexOf('\n\n');
+  return idx === -1 ? trimmed : trimmed.slice(0, idx).trim();
+}
+
+function formatIdLabel(id: string): string {
+  return id
+    .split(/[-_]/)
+    .map((s) => (s.length > 1 ? s[0].toUpperCase() + s.slice(1) : s))
+    .join(' ');
+}
+
+function formatScholarLabel(id: string): string {
+  if (!id) return '';
+  return id[0].toUpperCase() + id.slice(1);
+}
+
+function formatCitationType(type: 'direct_quotation' | 'allusion' | 'echo'): string {
+  switch (type) {
+    case 'direct_quotation':
+      return 'Direct quotation';
+    case 'allusion':
+      return 'Allusion';
+    case 'echo':
+      return 'Echo';
+  }
+}
+
+// ── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  backBtn: {
+    padding: spacing.xs,
+    marginRight: spacing.xs,
+  },
+  headerTitle: {
+    flex: 1,
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 16,
+  },
+  content: {
+    padding: spacing.md,
+    paddingBottom: spacing.xxl,
+    gap: spacing.md,
+  },
+  section: {
+    gap: spacing.xs,
+  },
+  sectionLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 11,
+    letterSpacing: 1,
+  },
+  bodyText: {
+    fontFamily: fontFamily.body,
+    fontSize: 15,
+    lineHeight: 24,
+  },
+  citationRow: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm,
+    gap: 4,
+    marginBottom: spacing.xs,
+  },
+  citationRef: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 14,
+  },
+  citationCites: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+  },
+  citationType: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 10,
+    letterSpacing: 0.5,
+    marginTop: 2,
+  },
+  voiceBlock: {
+    gap: 4,
+    marginBottom: spacing.sm,
+  },
+  voiceName: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+  },
+  chipText: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 12,
+  },
+  readingRow: {
+    gap: 2,
+    marginBottom: spacing.sm,
+  },
+  readingTitle: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 13,
+  },
+  readingAuthor: {
+    fontFamily: fontFamily.body,
+    fontSize: 12,
+  },
+  readingNote: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 12,
+  },
+  comingSoonCard: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    alignItems: 'center',
+  },
+  comingSoonText: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+  },
+  lockedCard: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  lockedTitle: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 15,
+  },
+  lockedDesc: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+});
+
+export default withErrorBoundary(ExtraBiblicalDetailScreen);

--- a/app/src/types/meta.ts
+++ b/app/src/types/meta.ts
@@ -204,6 +204,56 @@ export interface ExtrabiblicalSummary {
   tradition_status: ExtrabiblicalTraditionStatus;
 }
 
+// Parsed sub-shapes used by ExtraBiblicalDetailScreen (HWGTB-P2-03).
+
+export type ExtrabiblicalCitationType = 'direct_quotation' | 'allusion' | 'echo';
+
+export interface ExtrabiblicalNTCitation {
+  ref: string;
+  cites: string;
+  type?: ExtrabiblicalCitationType;
+}
+
+export interface ExtrabiblicalOTAllusion {
+  ref: string;
+  connection: string;
+}
+
+export interface ExtrabiblicalScholarVoice {
+  scholar_id: string;
+  position: string;
+}
+
+export interface ExtrabiblicalFurtherReading {
+  title: string;
+  author?: string;
+  note?: string;
+  /** Present if future entries add external links; the Phase-1 seed
+   *  (#1541) uses text-only references so this is rarely populated. */
+  url?: string;
+}
+
+/** Parsed entry — what the Detail screen consumes after JSON.parse. */
+export interface ExtrabiblicalEntry {
+  id: string;
+  title: string;
+  also_known_as: string[];
+  category: ExtrabiblicalCategory | null;
+  estimated_date: string | null;
+  original_language: string | null;
+  tradition_status: ExtrabiblicalTraditionStatus;
+  brief_summary: string;
+  full_summary: string | null;
+  nt_citations: ExtrabiblicalNTCitation[];
+  ot_allusions: ExtrabiblicalOTAllusion[];
+  scholar_voices: ExtrabiblicalScholarVoice[];
+  related_debate_ids: string[];
+  related_journey_ids: string[];
+  related_difficult_passage_ids: string[];
+  tags: string[];
+  further_reading: ExtrabiblicalFurtherReading[];
+}
+
 /** Raw row as stored in SQLite (serialized JSON columns). */
 export interface ExtrabiblicalRow {
   id: string;


### PR DESCRIPTION
## What this does
Detail view for a single extrabiblical entry (1 Enoch, Jubilees, Tobit, etc.) — the deep-link target for `SecondTemplePanel` chips (#1595) and `ExtraBiblicalIndexScreen` card taps (#1596). Renders **10 sections** per the issue spec.

## Closes
Closes #1548

## Sections (in order)

1. **Hero** — title + aliases + dates/language + 4-tradition status badges (`ExtraBiblicalHero` component)
2. **Brief summary** — always visible (full on premium, first paragraph only on free)
3. **NT citations** — tappable → Chapter screen w/ verse highlight
4. **OT allusions** — tappable → Chapter screen
5. **Scholar voices** — tappable → ScholarBio screen
6. **Related debates** — chips → DebateDetail
7. **Related difficult passages** — chips → DifficultPassageDetail
8. **Related journeys** — chips → JourneyDetail
9. **Further reading** — url → `Linking.openURL`; text-only rows render as non-tappable (the Phase-1 seed has no URLs)
10. **Full summary** — prose if populated, else **"Coming soon — expanded scholarly summary"** placeholder card

## Files added
- **`app/src/components/ExtraBiblicalHero.tsx`** — 170 LOC
- **`app/src/screens/ExtraBiblicalDetailScreen.tsx`** — 703 LOC
- **`app/src/hooks/useExtraBiblicalEntry.ts`** — single-entry loader, 51 LOC
- **`app/__tests__/screens/ExtraBiblicalDetailScreen.test.tsx`** — 312 LOC, 23 tests

## Files touched
- **`app/src/db/content/extrabiblical.ts`** — new `rowToEntry()` parser + `getExtraBiblicalEntry()` wrapper
- **`app/src/db/content/index.ts`** — barrel export
- **`app/src/types/meta.ts`** — `ExtrabiblicalEntry`, `ExtrabiblicalNTCitation`, `ExtrabiblicalOTAllusion`, `ExtrabiblicalScholarVoice`, `ExtrabiblicalFurtherReading`
- **`app/src/navigation/types.ts`** — `ExtraBiblicalDetail` route param
- **`app/src/navigation/ExploreStack.tsx`** — `Stack.Screen` registration

Some additions overlap with PR #1596 (#1547's Index screen) — the types, query-module file, and barrel exports are identical additions that merge cleanly regardless of order.

## Premium gating

Matches the `DebatePanel` / `DebateDetailScreen` precedent — **props-based, screen wires `usePremium()` itself**. 

- **Free tier**: Hero + first paragraph of `brief_summary` only; gated region replaced by **"✨ Unlock the full entry"** card with description; tap fires `showUpgrade('explore', 'Extra-Biblical Literature')`.
- **Premium tier**: all 10 sections visible with full deep-link behavior.

## Deep-link handling — verse ref parsing

The Phase-1 extrabiblical seed (#1541) uses **natural-language refs** like `"Jude 14-15"` and `"Genesis 6:1-4"`. The standard `parseReference` utility handles most of these but **fails on single-chapter book refs** ("Jude 14-15", "Obadiah 11", "Philemon 6") because its regex requires a colon before the verse.

Added a screen-local **`parseReferenceExtended`** that wraps `parseReference` with a fallback: if standard parsing fails and the book is single-chapter (Obadiah, Philemon, 2-3 John, Jude), treat the number as a verse and return chapter=1. This is the minimum needed to make Jude-heavy content (1 Enoch, Assumption of Moses) navigate correctly from their NT citations.

## Note on issue file-path text

Issue says `app/src/db/queries/extrabiblical.ts`, but the actual repo convention is `app/src/db/content/*.ts` (18 sibling query modules). Placed at `db/content/` to match real layout.

## Note on further-reading URLs

The issue specifies `Linking.openURL` for external links, but the Phase-1 `extrabiblical.json` seed (#1541) has no URL fields — further_reading entries are text-only (`title`, `author`, `note`). Code supports URLs when present (guarded: `TouchableOpacity` only when `url` is a non-empty string, else plain `View`); when the content author adds URLs in a future PR, the tap handler lights up automatically.

## How I verified

- `npx tsc --noEmit` — clean ✅
- `npm run lint` on touched files — **0 warnings** on new/touched files (the 4 pre-existing master warnings in unrelated files are out of scope) ✅
- `npx jest` (full suite) — **470 suites / 3497 tests pass** ✅

### Tests (23/23 passing)

```
render — premium tier
 ✓ renders hero title + aliases
 ✓ renders tradition badges
 ✓ renders full brief_summary (both paragraphs)
 ✓ renders NT citations with ref + source + type
 ✓ renders OT allusions
 ✓ renders scholar voices
 ✓ renders related-debate chip and section header
 ✓ renders related-difficult-passage and related-journey chips
 ✓ renders further-reading items
 ✓ renders "Coming soon" placeholder when full_summary is null
 ✓ renders full_summary when it is present instead of placeholder

deep-link navigation — premium tier
 ✓ tapping NT citation navigates to Chapter with parsed book/chapter/verse
 ✓ tapping OT allusion navigates to Chapter with bookId
 ✓ tapping scholar navigates to ScholarBio
 ✓ tapping debate chip navigates to DebateDetail
 ✓ tapping difficult-passage chip navigates to DifficultPassageDetail
 ✓ tapping journey chip navigates to JourneyDetail
 ✓ tapping further-reading with url calls Linking.openURL

free tier (premium gating)
 ✓ renders only first paragraph of brief_summary
 ✓ hides all gated sections (NT citations, scholars, debates, etc.)
 ✓ shows unlock CTA and fires showUpgrade on tap

loading + not-found states
 ✓ shows loading indicator when loading=true
 ✓ shows "Entry not found" when entry=null after load
```

## Merge order

**Depends on**: #1538 (extrabiblical schema), #1541 (12 seeded entries).

**Pairs with**:
- **PR #1595** (`SecondTemplePanel`) — its `onExtraBiblicalPress` chips will now navigate to this screen once both PRs are merged and `ChapterScreen` threads the callback through.
- **PR #1596** (`ExtraBiblicalIndexScreen`) — its card-tap `navigate('ExtraBiblicalDetail', { id })` lands on this screen. This PR overlaps with #1596 on types / query module / barrel exports — identical additions that merge cleanly in either order.

## Rollback
Revert this PR. `ExtraBiblicalDetail` route unregisters; `ExtraBiblicalDetailScreen` deleted. `SecondTemplePanel` chips and `ExtraBiblicalIndexScreen` tap handlers continue to call `navigation.navigate('ExtraBiblicalDetail', …)` — which will no longer resolve — but the guarded optional-callback in `SecondTemplePanel` means chips simply won't render if the parent doesn't wire them, and the Index screen would fail more loudly (acceptable if reverting deliberately).

---
_Generated by [Claude Code](https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa)_