### PR TITLE
Add guided study V3 personal study loop

### DIFF
--- a/app/__tests__/components/guidedStudyV3Personal.test.tsx
+++ b/app/__tests__/components/guidedStudyV3Personal.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StudySessionCTA } from '@/components/guidedStudy';
+
+describe('guided study V3 CTA states', () => {
+  const estimate = { readMin: 4, guidedMin: 12, deepMin: 25 };
+
+  it('renders continue state copy', () => {
+    const { getByText } = render(
+      <StudySessionCTA
+        estimate={estimate}
+        mode="continue"
+        currentStep="observe"
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(getByText('Continue study')).toBeTruthy();
+    expect(getByText('Resume at Observe | 12 min guided')).toBeTruthy();
+  });
+
+  it('renders review state copy', () => {
+    const { getByText } = render(
+      <StudySessionCTA estimate={estimate} mode="review" dueCount={2} onPress={jest.fn()} />,
+    );
+
+    expect(getByText('Review insights')).toBeTruthy();
+    expect(getByText('2 review prompts due for this chapter')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/guidedStudyV3Personal.test.tsx
+++ b/app/__tests__/components/guidedStudyV3Personal.test.tsx
@@ -16,7 +16,7 @@ describe('guided study V3 CTA states', () => {
     );
 
     expect(getByText('Continue study')).toBeTruthy();
-    expect(getByText('Resume at Observe | 12 min guided')).toBeTruthy();
+    expect(getByText('Resume at Observe · 12 min guided')).toBeTruthy();
   });
 
   it('renders review state copy', () => {

--- a/app/__tests__/db/userDatabaseV3.test.ts
+++ b/app/__tests__/db/userDatabaseV3.test.ts
@@ -1,0 +1,42 @@
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: any[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+describe('userDatabase V3 migration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockOpenDatabaseAsync.mockResolvedValue({
+      execAsync: mockExecAsync,
+      getAllAsync: mockGetAllAsync,
+      runAsync: mockRunAsync,
+      withTransactionAsync: mockWithTransactionAsync,
+    });
+  });
+
+  it('adds guided study questions migration SQL', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    const userDatabase = require('@/db/userDatabase');
+
+    await userDatabase.initUserDatabase();
+
+    const migrationSql = mockExecAsync.mock.calls
+      .map(([sql]: [string]) => sql)
+      .find((sql) => sql.includes('CREATE TABLE IF NOT EXISTS guided_study_questions'));
+
+    expect(migrationSql).toContain('CREATE TABLE IF NOT EXISTS guided_study_questions');
+    expect(migrationSql).toContain('INSERT OR IGNORE INTO guided_study_questions');
+  });
+});

--- a/app/__tests__/hooks/useGuidedStudyChapterState.test.ts
+++ b/app/__tests__/hooks/useGuidedStudyChapterState.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useGuidedStudyChapterState } from '@/hooks/useGuidedStudyChapterState';
+import {
+  getActiveGuidedStudySession,
+  getDueGuidedReviewItemCountForChapter,
+} from '@/db/userQueries';
+
+jest.mock('@/db/userQueries', () => ({
+  getActiveGuidedStudySession: jest.fn(),
+  getDueGuidedReviewItemCountForChapter: jest.fn(),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetActiveGuidedStudySession = getActiveGuidedStudySession as jest.MockedFunction<
+  typeof getActiveGuidedStudySession
+>;
+const mockGetDueGuidedReviewItemCountForChapter =
+  getDueGuidedReviewItemCountForChapter as jest.MockedFunction<
+    typeof getDueGuidedReviewItemCountForChapter
+  >;
+
+describe('useGuidedStudyChapterState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns continue mode when there is an active session', async () => {
+    mockGetActiveGuidedStudySession.mockResolvedValueOnce({
+      id: 4,
+      chapter_id: 'genesis_1',
+      status: 'active',
+      current_step: 'observe',
+      started_at: '2026-04-23T00:00:00Z',
+      completed_at: null,
+      updated_at: '2026-04-23T00:00:00Z',
+    });
+    mockGetDueGuidedReviewItemCountForChapter.mockResolvedValueOnce(0);
+
+    const { result } = renderHook(() => useGuidedStudyChapterState('genesis_1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.mode).toBe('continue');
+    expect(result.current.initialStep).toBe('observe');
+  });
+
+  it('returns review mode when prompts are due and no active session exists', async () => {
+    mockGetActiveGuidedStudySession.mockResolvedValueOnce(null);
+    mockGetDueGuidedReviewItemCountForChapter.mockResolvedValueOnce(2);
+
+    const { result } = renderHook(() => useGuidedStudyChapterState('genesis_1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.mode).toBe('review');
+    expect(result.current.dueCount).toBe(2);
+    expect(result.current.initialStep).toBe('review');
+  });
+});

--- a/app/__tests__/hooks/useGuidedStudySession.test.ts
+++ b/app/__tests__/hooks/useGuidedStudySession.test.ts
@@ -7,6 +7,7 @@ const mockUpsertSynthesis = jest.fn();
 const mockCompleteSession = jest.fn();
 const mockCreateReviewItems = jest.fn();
 const mockRecordConcept = jest.fn();
+const mockUpsertQuestion = jest.fn();
 const mockGetSession = jest.fn();
 const mockGetResponses = jest.fn();
 const mockGetSynthesis = jest.fn();
@@ -20,6 +21,7 @@ jest.mock('@/db/userMutations', () => ({
   completeGuidedStudySession: (...args: any[]) => mockCompleteSession(...args),
   createGuidedReviewItems: (...args: any[]) => mockCreateReviewItems(...args),
   recordConceptEncounter: (...args: any[]) => mockRecordConcept(...args),
+  upsertGuidedStudyQuestion: (...args: any[]) => mockUpsertQuestion(...args),
 }));
 
 jest.mock('@/db/userQueries', () => ({
@@ -51,6 +53,7 @@ describe('useGuidedStudySession', () => {
     mockCompleteSession.mockResolvedValue(undefined);
     mockCreateReviewItems.mockResolvedValue(undefined);
     mockRecordConcept.mockResolvedValue(undefined);
+    mockUpsertQuestion.mockResolvedValue(undefined);
   });
 
   it('is not loading and has no sessionId when chapterId is undefined', async () => {

--- a/app/__tests__/hooks/useReviewQueue.test.ts
+++ b/app/__tests__/hooks/useReviewQueue.test.ts
@@ -1,89 +1,117 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
-
-const mockGetDue = jest.fn();
-const mockGetAll = jest.fn();
-const mockGetConcepts = jest.fn();
-const mockComplete = jest.fn();
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useReviewQueue } from '@/hooks/useReviewQueue';
+import {
+  getActiveGuidedStudySessions,
+  getAllGuidedReviewItems,
+  getConceptEncounters,
+  getDueGuidedReviewItems,
+  getOpenGuidedStudyQuestions,
+  getRecentGuidedStudyTakeaways,
+} from '@/db/userQueries';
+import { completeGuidedReviewItem, resolveGuidedStudyQuestion } from '@/db/userMutations';
 
 jest.mock('@/db/userQueries', () => ({
-  getDueGuidedReviewItems: (...args: any[]) => mockGetDue(...args),
-  getAllGuidedReviewItems: (...args: any[]) => mockGetAll(...args),
-  getConceptEncounters: (...args: any[]) => mockGetConcepts(...args),
+  getActiveGuidedStudySessions: jest.fn(),
+  getAllGuidedReviewItems: jest.fn(),
+  getConceptEncounters: jest.fn(),
+  getDueGuidedReviewItems: jest.fn(),
+  getOpenGuidedStudyQuestions: jest.fn(),
+  getRecentGuidedStudyTakeaways: jest.fn(),
 }));
 
 jest.mock('@/db/userMutations', () => ({
-  completeGuidedReviewItem: (...args: any[]) => mockComplete(...args),
+  completeGuidedReviewItem: jest.fn().mockResolvedValue(undefined),
+  resolveGuidedStudyQuestion: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/utils/logger', () => ({
-  logger: { warn: jest.fn(), error: jest.fn() },
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
-import { useReviewQueue } from '@/hooks/useReviewQueue';
+const mockGetActiveGuidedStudySessions = getActiveGuidedStudySessions as jest.MockedFunction<
+  typeof getActiveGuidedStudySessions
+>;
+const mockGetAllGuidedReviewItems = getAllGuidedReviewItems as jest.MockedFunction<
+  typeof getAllGuidedReviewItems
+>;
+const mockGetConceptEncounters = getConceptEncounters as jest.MockedFunction<
+  typeof getConceptEncounters
+>;
+const mockGetDueGuidedReviewItems = getDueGuidedReviewItems as jest.MockedFunction<
+  typeof getDueGuidedReviewItems
+>;
+const mockGetOpenGuidedStudyQuestions = getOpenGuidedStudyQuestions as jest.MockedFunction<
+  typeof getOpenGuidedStudyQuestions
+>;
+const mockGetRecentGuidedStudyTakeaways = getRecentGuidedStudyTakeaways as jest.MockedFunction<
+  typeof getRecentGuidedStudyTakeaways
+>;
+const mockCompleteGuidedReviewItem = completeGuidedReviewItem as jest.MockedFunction<
+  typeof completeGuidedReviewItem
+>;
+const mockResolveGuidedStudyQuestion = resolveGuidedStudyQuestion as jest.MockedFunction<
+  typeof resolveGuidedStudyQuestion
+>;
 
 describe('useReviewQueue', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockComplete.mockResolvedValue(undefined);
+    mockGetDueGuidedReviewItems.mockResolvedValue([
+      {
+        id: 1,
+        source_session_id: 1,
+        chapter_id: 'genesis_1',
+        title: 'Genesis 1',
+        prompt: 'What was your takeaway?',
+        answer: 'Creation is ordered.',
+        due_date: '2026-04-23',
+        interval_days: 1,
+        review_count: 0,
+        status: 'due',
+        created_at: '2026-04-23T00:00:00Z',
+        updated_at: '2026-04-23T00:00:00Z',
+      },
+    ]);
+    mockGetAllGuidedReviewItems.mockResolvedValue([]);
+    mockGetConceptEncounters.mockResolvedValue([]);
+    mockGetActiveGuidedStudySessions.mockResolvedValue([]);
+    mockGetOpenGuidedStudyQuestions.mockResolvedValue([]);
+    mockGetRecentGuidedStudyTakeaways.mockResolvedValue([]);
   });
 
-  it('loads due items, all items, and concepts on mount', async () => {
-    const due = [{ id: 1, prompt: 'P1' } as any];
-    const all = [{ id: 1 } as any, { id: 2 } as any];
-    const concepts = [{ concept_id: 'creation' } as any];
-    mockGetDue.mockResolvedValue(due);
-    mockGetAll.mockResolvedValue(all);
-    mockGetConcepts.mockResolvedValue(concepts);
-
+  it('loads queue data and builds a next action', async () => {
     const { result } = renderHook(() => useReviewQueue());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-    expect(result.current.dueItems).toEqual(due);
-    expect(result.current.allItems).toEqual(all);
-    expect(result.current.concepts).toEqual(concepts);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.dueItems).toHaveLength(1);
+    expect(result.current.nextAction?.kind).toBe('review');
   });
 
-  it('completes an item and reloads the queue', async () => {
-    mockGetDue.mockResolvedValue([{ id: 7 } as any]);
-    mockGetAll.mockResolvedValue([]);
-    mockGetConcepts.mockResolvedValue([]);
+  it('completes review items and resolves questions through mutations', async () => {
+    mockGetOpenGuidedStudyQuestions.mockResolvedValue([
+      {
+        id: 8,
+        session_id: 2,
+        chapter_id: 'genesis_1',
+        question_text: 'Why repeat the structure?',
+        status: 'open',
+        created_at: '2026-04-23T00:00:00Z',
+        resolved_at: null,
+        updated_at: '2026-04-23T00:00:00Z',
+      },
+    ]);
 
     const { result } = renderHook(() => useReviewQueue());
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    mockGetDue.mockClear();
-    mockGetAll.mockClear();
-    mockGetConcepts.mockClear();
-    mockGetDue.mockResolvedValue([]);
-    mockGetAll.mockResolvedValue([]);
-    mockGetConcepts.mockResolvedValue([]);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     await act(async () => {
-      await result.current.completeItem(7);
+      await result.current.completeItem(1);
     });
+    expect(mockCompleteGuidedReviewItem).toHaveBeenCalledWith(1);
 
-    expect(mockComplete).toHaveBeenCalledWith(7);
-    // Reload fires all three queries again
-    expect(mockGetDue).toHaveBeenCalled();
-    expect(mockGetAll).toHaveBeenCalled();
-    expect(mockGetConcepts).toHaveBeenCalled();
-  });
-
-  it('clears loading even if all three queries fail', async () => {
-    mockGetDue.mockRejectedValue(new Error('boom'));
-    mockGetAll.mockRejectedValue(new Error('boom'));
-    mockGetConcepts.mockRejectedValue(new Error('boom'));
-
-    const { result } = renderHook(() => useReviewQueue());
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+    await act(async () => {
+      await result.current.resolveQuestion(8);
     });
-    expect(result.current.dueItems).toEqual([]);
-    expect(result.current.allItems).toEqual([]);
-    expect(result.current.concepts).toEqual([]);
+    expect(mockResolveGuidedStudyQuestion).toHaveBeenCalledWith(8);
   });
 });

--- a/app/__tests__/services/guidedStudyPersonal.test.ts
+++ b/app/__tests__/services/guidedStudyPersonal.test.ts
@@ -1,0 +1,54 @@
+import {
+  buildGuidedStudyNextAction,
+  formatChapterRef,
+  getGuidedStudyStepLabel,
+} from '@/services/guidedStudy';
+
+describe('guided study personal services', () => {
+  it('formats chapter refs from chapter ids', () => {
+    expect(formatChapterRef('genesis_1')).toBe('Genesis 1');
+    expect(formatChapterRef('1_corinthians_13')).toBe('1 Corinthians 13');
+  });
+
+  it('returns human step labels', () => {
+    expect(getGuidedStudyStepLabel('observe')).toBe('Observe');
+    expect(getGuidedStudyStepLabel('review')).toBe('Review');
+  });
+
+  it('prefers continuing an active session over other actions', () => {
+    const action = buildGuidedStudyNextAction({
+      activeSessions: [
+        {
+          id: 1,
+          chapter_id: 'genesis_1',
+          status: 'active',
+          current_step: 'observe',
+          started_at: '2026-04-23T00:00:00Z',
+          completed_at: null,
+          updated_at: '2026-04-23T00:00:00Z',
+        },
+      ],
+      dueItems: [
+        {
+          id: 3,
+          source_session_id: 1,
+          chapter_id: 'genesis_1',
+          title: 'Genesis 1',
+          prompt: 'Prompt',
+          answer: 'Answer',
+          due_date: '2026-04-23',
+          interval_days: 1,
+          review_count: 0,
+          status: 'due',
+          created_at: '2026-04-23T00:00:00Z',
+          updated_at: '2026-04-23T00:00:00Z',
+        },
+      ],
+      openQuestions: [],
+      recentTakeaways: [],
+    });
+
+    expect(action?.kind).toBe('continue');
+    expect(action?.initialStep).toBe('observe');
+  });
+});

--- a/app/__tests__/unit/guidedStudyV3Mutations.test.ts
+++ b/app/__tests__/unit/guidedStudyV3Mutations.test.ts
@@ -1,0 +1,58 @@
+const mockRunAsync = jest.fn().mockResolvedValue({ lastInsertRowId: 1, changes: 1 });
+const mockGetFirstAsync = jest.fn().mockResolvedValue(null);
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({
+    runAsync: mockRunAsync,
+    getFirstAsync: mockGetFirstAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  }),
+}));
+
+import {
+  resetToNewUser,
+  resolveGuidedStudyQuestion,
+  upsertGuidedStudyQuestion,
+} from '@/db/userMutations';
+
+describe('guided study V3 mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('upserts a trimmed open question', async () => {
+    await upsertGuidedStudyQuestion(12, 'genesis_1', '  What is this chapter emphasizing?  ');
+
+    expect(mockRunAsync).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO guided_study_questions'),
+      [12, 'genesis_1', 'What is this chapter emphasizing?'],
+    );
+  });
+
+  it('deletes the question row when the text is blank', async () => {
+    await upsertGuidedStudyQuestion(12, 'genesis_1', '   ');
+
+    expect(mockRunAsync).toHaveBeenCalledWith(
+      'DELETE FROM guided_study_questions WHERE session_id = ?',
+      [12],
+    );
+  });
+
+  it('marks a guided study question resolved', async () => {
+    await resolveGuidedStudyQuestion(9);
+
+    expect(mockRunAsync).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'resolved'"),
+      [9],
+    );
+  });
+
+  it('clears guided study questions during reset', async () => {
+    await resetToNewUser();
+
+    expect(mockRunAsync).toHaveBeenCalledWith('DELETE FROM guided_study_questions');
+  });
+});

--- a/app/src/components/guidedStudy/StudySessionCTA.tsx
+++ b/app/src/components/guidedStudy/StudySessionCTA.tsx
@@ -2,15 +2,61 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { BookOpen, ChevronRight } from 'lucide-react-native';
 import { fontFamily, radii, spacing, useTheme } from '../../theme';
-import type { StudyDepthEstimate } from '../../services/guidedStudy';
+import {
+  getGuidedStudyStepLabel,
+  type GuidedStudyStep,
+  type StudyDepthEstimate,
+} from '../../services/guidedStudy';
 
 interface Props {
   estimate: StudyDepthEstimate;
   onPress: () => void;
+  mode?: 'start' | 'continue' | 'review';
+  currentStep?: GuidedStudyStep;
+  dueCount?: number;
 }
 
-export function StudySessionCTA({ estimate, onPress }: Props) {
+function buildCopy(
+  mode: 'start' | 'continue' | 'review',
+  estimate: StudyDepthEstimate,
+  currentStep?: GuidedStudyStep,
+  dueCount: number = 0,
+) {
+  if (mode === 'continue') {
+    return {
+      title: 'Continue study',
+      meta: `Resume at ${getGuidedStudyStepLabel(currentStep ?? 'scene')} | ${estimate.guidedMin} min guided`,
+      accessibilityLabel: 'Continue study',
+    };
+  }
+
+  if (mode === 'review') {
+    return {
+      title: 'Review insights',
+      meta:
+        dueCount === 1
+          ? '1 review prompt due for this chapter'
+          : `${dueCount} review prompts due for this chapter`,
+      accessibilityLabel: 'Review insights',
+    };
+  }
+
+  return {
+    title: 'Study this chapter',
+    meta: `${estimate.readMin} min read | ${estimate.guidedMin} min guided | ${estimate.deepMin} min deep`,
+    accessibilityLabel: 'Study this chapter',
+  };
+}
+
+export function StudySessionCTA({
+  estimate,
+  onPress,
+  mode = 'start',
+  currentStep,
+  dueCount = 0,
+}: Props) {
   const { base } = useTheme();
+  const copy = buildCopy(mode, estimate, currentStep, dueCount);
 
   return (
     <TouchableOpacity
@@ -18,17 +64,15 @@ export function StudySessionCTA({ estimate, onPress }: Props) {
       activeOpacity={0.72}
       style={[styles.outer, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
       accessibilityRole="button"
-      accessibilityLabel="Study this chapter"
+      accessibilityLabel={copy.accessibilityLabel}
     >
       <View style={[styles.stripe, { backgroundColor: base.gold }]} />
       <View style={styles.iconWrap}>
         <BookOpen size={17} color={base.gold} />
       </View>
       <View style={styles.textWrap}>
-        <Text style={[styles.title, { color: base.text }]}>Study this chapter</Text>
-        <Text style={[styles.meta, { color: base.textMuted }]}>
-          {`${estimate.readMin} min read · ${estimate.guidedMin} min guided · ${estimate.deepMin} min deep`}
-        </Text>
+        <Text style={[styles.title, { color: base.text }]}>{copy.title}</Text>
+        <Text style={[styles.meta, { color: base.textMuted }]}>{copy.meta}</Text>
       </View>
       <ChevronRight size={16} color={base.textMuted} />
     </TouchableOpacity>

--- a/app/src/components/guidedStudy/StudySessionCTA.tsx
+++ b/app/src/components/guidedStudy/StudySessionCTA.tsx
@@ -25,7 +25,7 @@ function buildCopy(
   if (mode === 'continue') {
     return {
       title: 'Continue study',
-      meta: `Resume at ${getGuidedStudyStepLabel(currentStep ?? 'scene')} | ${estimate.guidedMin} min guided`,
+      meta: `Resume at ${getGuidedStudyStepLabel(currentStep ?? 'scene')} · ${estimate.guidedMin} min guided`,
       accessibilityLabel: 'Continue study',
     };
   }
@@ -43,7 +43,7 @@ function buildCopy(
 
   return {
     title: 'Study this chapter',
-    meta: `${estimate.readMin} min read | ${estimate.guidedMin} min guided | ${estimate.deepMin} min deep`,
+    meta: `${estimate.readMin} min read · ${estimate.guidedMin} min guided · ${estimate.deepMin} min deep`,
     accessibilityLabel: 'Study this chapter',
   };
 }

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -686,6 +686,38 @@ const MIGRATIONS: Migration[] = [
         WHERE status = 'active';
     `,
   },
+  {
+    version: 21,
+    description: 'Guided Study V3 retention loop - open questions',
+    sql: `
+      CREATE TABLE IF NOT EXISTS guided_study_questions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id INTEGER NOT NULL REFERENCES guided_study_sessions(id) ON DELETE CASCADE,
+        chapter_id TEXT NOT NULL,
+        question_text TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'resolved')),
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        resolved_at TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(session_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_guided_questions_status_updated
+        ON guided_study_questions(status, updated_at DESC);
+
+      INSERT OR IGNORE INTO guided_study_questions
+        (session_id, chapter_id, question_text, status, created_at, updated_at)
+      SELECT
+        synthesis.session_id,
+        sessions.chapter_id,
+        trim(synthesis.open_question),
+        'open',
+        COALESCE(sessions.completed_at, sessions.updated_at, datetime('now')),
+        COALESCE(synthesis.updated_at, sessions.updated_at, datetime('now'))
+      FROM guided_study_synthesis synthesis
+      JOIN guided_study_sessions sessions ON sessions.id = synthesis.session_id
+      WHERE trim(synthesis.open_question) != '';
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -6,7 +6,7 @@
  */
 
 import { logger } from '../utils/logger';
-import { getNextReviewIntervalDays } from '../services/guidedStudy/review';
+import { nextIntervalAfter } from '../services/guidedStudy/review';
 import type { GuidedStudyStep } from '../types';
 import { getUserDb } from './userDatabase';
 import type { ReadingPlan } from './userQueries';
@@ -482,7 +482,7 @@ export async function completeGuidedReviewItem(id: number): Promise<void> {
   }>('SELECT * FROM guided_review_items WHERE id = ?', [id]);
   if (!item || item.status !== 'due') return;
 
-  const nextIntervalDays = getNextReviewIntervalDays(item.interval_days);
+  const nextIntervalDays = nextIntervalAfter(item.interval_days);
   await db.withTransactionAsync(async () => {
     await db.runAsync(
       `UPDATE guided_review_items

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -324,13 +324,7 @@ export async function recordSessionEvent(
 // Guided Study V1 (write)
 
 export async function createOrResumeGuidedStudySession(chapterId: string): Promise<number> {
-  const db = getUserDb();
-  await db.runAsync(
-    "INSERT OR IGNORE INTO guided_study_sessions (chapter_id, status, current_step) VALUES (?, 'active', 'scene')",
-    [chapterId],
-  );
-
-  const existing = await db.getFirstAsync<{ id: number }>(
+  const existing = await getUserDb().getFirstAsync<{ id: number }>(
     `SELECT id FROM guided_study_sessions
      WHERE chapter_id = ? AND status = 'active'
      ORDER BY updated_at DESC, id DESC
@@ -339,7 +333,11 @@ export async function createOrResumeGuidedStudySession(chapterId: string): Promi
   );
   if (existing) return existing.id;
 
-  throw new Error(`Unable to create guided study session for ${chapterId}`);
+  const result = await getUserDb().runAsync(
+    "INSERT INTO guided_study_sessions (chapter_id, status, current_step) VALUES (?, 'active', 'scene')",
+    [chapterId],
+  );
+  return result.lastInsertRowId;
 }
 
 export async function setGuidedStudyStep(sessionId: number, step: GuidedStudyStep): Promise<void> {
@@ -471,52 +469,51 @@ export async function createGuidedReviewItems(
 
 export async function completeGuidedReviewItem(id: number): Promise<void> {
   const db = getUserDb();
-  const item = await db.getFirstAsync<{
-    source_session_id: number;
-    chapter_id: string;
-    title: string;
-    prompt: string;
-    answer: string;
-    interval_days: number;
-    status: 'due' | 'completed';
-  }>('SELECT * FROM guided_review_items WHERE id = ?', [id]);
-  if (!item || item.status !== 'due') return;
-
-  const nextIntervalDays = nextIntervalAfter(item.interval_days);
   await db.withTransactionAsync(async () => {
+    const current = await db.getFirstAsync<{
+      source_session_id: number;
+      chapter_id: string;
+      title: string;
+      prompt: string;
+      answer: string;
+      interval_days: number;
+      review_count: number;
+    }>(
+      `SELECT source_session_id, chapter_id, title, prompt, answer,
+              interval_days, review_count
+       FROM guided_review_items WHERE id = ?`,
+      [id],
+    );
+    if (!current) return;
+
     await db.runAsync(
       `UPDATE guided_review_items
        SET status = 'completed',
            review_count = review_count + 1,
            updated_at = datetime('now')
-       WHERE id = ? AND status = 'due'`,
+       WHERE id = ?`,
       [id],
     );
 
-    if (nextIntervalDays == null) return;
-    await db.runAsync(
-      `INSERT INTO guided_review_items
-        (source_session_id, chapter_id, title, prompt, answer, due_date, interval_days)
-       SELECT ?, ?, ?, ?, ?, date('now', ?), ?
-       WHERE NOT EXISTS (
-         SELECT 1 FROM guided_review_items
-         WHERE source_session_id = ?
-           AND prompt = ?
-           AND interval_days = ?
-       )`,
-      [
-        item.source_session_id,
-        item.chapter_id,
-        item.title,
-        item.prompt,
-        item.answer,
-        `+${nextIntervalDays} days`,
-        nextIntervalDays,
-        item.source_session_id,
-        item.prompt,
-        nextIntervalDays,
-      ],
-    );
+    const next = nextIntervalAfter(current.interval_days);
+    if (next != null) {
+      await db.runAsync(
+        `INSERT INTO guided_review_items
+          (source_session_id, chapter_id, title, prompt, answer,
+           due_date, interval_days, review_count)
+         VALUES (?, ?, ?, ?, ?, date('now', ?), ?, ?)`,
+        [
+          current.source_session_id,
+          current.chapter_id,
+          current.title,
+          current.prompt,
+          current.answer,
+          `+${next} days`,
+          next,
+          current.review_count + 1,
+        ],
+      );
+    }
   });
 }
 

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -6,8 +6,8 @@
  */
 
 import { logger } from '../utils/logger';
+import { getNextReviewIntervalDays } from '../services/guidedStudy/review';
 import type { GuidedStudyStep } from '../types';
-import { nextIntervalAfter } from '../services/guidedStudy/review';
 import { getUserDb } from './userDatabase';
 import type { ReadingPlan } from './userQueries';
 
@@ -324,7 +324,13 @@ export async function recordSessionEvent(
 // Guided Study V1 (write)
 
 export async function createOrResumeGuidedStudySession(chapterId: string): Promise<number> {
-  const existing = await getUserDb().getFirstAsync<{ id: number }>(
+  const db = getUserDb();
+  await db.runAsync(
+    "INSERT OR IGNORE INTO guided_study_sessions (chapter_id, status, current_step) VALUES (?, 'active', 'scene')",
+    [chapterId],
+  );
+
+  const existing = await db.getFirstAsync<{ id: number }>(
     `SELECT id FROM guided_study_sessions
      WHERE chapter_id = ? AND status = 'active'
      ORDER BY updated_at DESC, id DESC
@@ -333,11 +339,7 @@ export async function createOrResumeGuidedStudySession(chapterId: string): Promi
   );
   if (existing) return existing.id;
 
-  const result = await getUserDb().runAsync(
-    "INSERT INTO guided_study_sessions (chapter_id, status, current_step) VALUES (?, 'active', 'scene')",
-    [chapterId],
-  );
-  return result.lastInsertRowId;
+  throw new Error(`Unable to create guided study session for ${chapterId}`);
 }
 
 export async function setGuidedStudyStep(sessionId: number, step: GuidedStudyStep): Promise<void> {
@@ -406,6 +408,44 @@ export async function upsertGuidedStudySynthesis(
   );
 }
 
+export async function upsertGuidedStudyQuestion(
+  sessionId: number,
+  chapterId: string,
+  questionText: string,
+): Promise<void> {
+  const normalized = questionText.trim();
+  if (normalized.length === 0) {
+    await getUserDb().runAsync('DELETE FROM guided_study_questions WHERE session_id = ?', [
+      sessionId,
+    ]);
+    return;
+  }
+
+  await getUserDb().runAsync(
+    `INSERT INTO guided_study_questions
+       (session_id, chapter_id, question_text, status, resolved_at, updated_at)
+     VALUES (?, ?, ?, 'open', NULL, datetime('now'))
+     ON CONFLICT(session_id) DO UPDATE SET
+       chapter_id = excluded.chapter_id,
+       question_text = excluded.question_text,
+       status = 'open',
+       resolved_at = NULL,
+       updated_at = datetime('now')`,
+    [sessionId, chapterId, normalized],
+  );
+}
+
+export async function resolveGuidedStudyQuestion(id: number): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE guided_study_questions
+     SET status = 'resolved',
+         resolved_at = datetime('now'),
+         updated_at = datetime('now')
+     WHERE id = ?`,
+    [id],
+  );
+}
+
 export async function createGuidedReviewItems(
   sessionId: number,
   chapterId: string,
@@ -429,62 +469,54 @@ export async function createGuidedReviewItems(
   });
 }
 
-/**
- * Marks a review item as completed and, if the ladder has more intervals,
- * schedules the next-interval row in the same transaction. Row identity is
- * preserved by copying source_session_id / chapter_id / title / prompt /
- * answer from the completed row.
- *
- * Intervals live in `services/guidedStudy/review.ts`. See that file for the
- * spaced-repetition design rationale.
- */
 export async function completeGuidedReviewItem(id: number): Promise<void> {
   const db = getUserDb();
-  await db.withTransactionAsync(async () => {
-    const current = await db.getFirstAsync<{
-      source_session_id: number;
-      chapter_id: string;
-      title: string;
-      prompt: string;
-      answer: string;
-      interval_days: number;
-      review_count: number;
-    }>(
-      `SELECT source_session_id, chapter_id, title, prompt, answer,
-              interval_days, review_count
-       FROM guided_review_items WHERE id = ?`,
-      [id],
-    );
-    if (!current) return;
+  const item = await db.getFirstAsync<{
+    source_session_id: number;
+    chapter_id: string;
+    title: string;
+    prompt: string;
+    answer: string;
+    interval_days: number;
+    status: 'due' | 'completed';
+  }>('SELECT * FROM guided_review_items WHERE id = ?', [id]);
+  if (!item || item.status !== 'due') return;
 
+  const nextIntervalDays = getNextReviewIntervalDays(item.interval_days);
+  await db.withTransactionAsync(async () => {
     await db.runAsync(
       `UPDATE guided_review_items
        SET status = 'completed',
            review_count = review_count + 1,
            updated_at = datetime('now')
-       WHERE id = ?`,
+       WHERE id = ? AND status = 'due'`,
       [id],
     );
 
-    const next = nextIntervalAfter(current.interval_days);
-    if (next != null) {
-      await db.runAsync(
-        `INSERT INTO guided_review_items
-          (source_session_id, chapter_id, title, prompt, answer,
-           due_date, interval_days, review_count)
-         VALUES (?, ?, ?, ?, ?, date('now', ?), ?, ?)`,
-        [
-          current.source_session_id,
-          current.chapter_id,
-          current.title,
-          current.prompt,
-          current.answer,
-          `+${next} days`,
-          next,
-          current.review_count + 1,
-        ],
-      );
-    }
+    if (nextIntervalDays == null) return;
+    await db.runAsync(
+      `INSERT INTO guided_review_items
+        (source_session_id, chapter_id, title, prompt, answer, due_date, interval_days)
+       SELECT ?, ?, ?, ?, ?, date('now', ?), ?
+       WHERE NOT EXISTS (
+         SELECT 1 FROM guided_review_items
+         WHERE source_session_id = ?
+           AND prompt = ?
+           AND interval_days = ?
+       )`,
+      [
+        item.source_session_id,
+        item.chapter_id,
+        item.title,
+        item.prompt,
+        item.answer,
+        `+${nextIntervalDays} days`,
+        nextIntervalDays,
+        item.source_session_id,
+        item.prompt,
+        nextIntervalDays,
+      ],
+    );
   });
 }
 
@@ -556,6 +588,7 @@ export async function resetToNewUser(): Promise<void> {
   await db.runAsync('DELETE FROM reading_progress');
   await db.runAsync('DELETE FROM concept_encounters');
   await db.runAsync('DELETE FROM guided_review_items');
+  await db.runAsync('DELETE FROM guided_study_questions');
   await db.runAsync('DELETE FROM guided_study_synthesis');
   await db.runAsync('DELETE FROM guided_study_responses');
   await db.runAsync('DELETE FROM guided_study_sessions');

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -20,9 +20,11 @@ import type {
   AmicusCitation,
   ConceptEncounter,
   GuidedReviewItem,
+  GuidedStudyQuestion,
   GuidedStudyResponse,
   GuidedStudySession,
   GuidedStudySynthesis,
+  GuidedStudyTakeawaySummary,
 } from '../types';
 import { getDb } from './database';
 import { getUserDb } from './userDatabase';
@@ -493,6 +495,57 @@ export async function getAllGuidedReviewItems(limit: number = 50): Promise<Guide
     `SELECT * FROM guided_review_items
      ORDER BY due_date ASC, id ASC
      LIMIT ?`,
+    [limit],
+  );
+}
+
+export async function getDueGuidedReviewItemCountForChapter(chapterId: string): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) as count FROM guided_review_items
+     WHERE chapter_id = ? AND status = 'due' AND due_date <= date('now')`,
+    [chapterId],
+  );
+  return row?.count ?? 0;
+}
+
+export async function getActiveGuidedStudySessions(
+  limit: number = 5,
+): Promise<GuidedStudySession[]> {
+  return getUserDb().getAllAsync<GuidedStudySession>(
+    `SELECT * FROM guided_study_sessions
+     WHERE status = 'active'
+     ORDER BY updated_at DESC, id DESC
+     LIMIT ?`,
+    [limit],
+  );
+}
+
+export async function getOpenGuidedStudyQuestions(
+  limit: number = 10,
+): Promise<GuidedStudyQuestion[]> {
+  return getUserDb().getAllAsync<GuidedStudyQuestion>(
+    `SELECT * FROM guided_study_questions
+     WHERE status = 'open'
+     ORDER BY updated_at DESC, id DESC
+     LIMIT ?`,
+    [limit],
+  );
+}
+
+export async function getRecentGuidedStudyTakeaways(
+  limit: number = 10,
+): Promise<GuidedStudyTakeawaySummary[]> {
+  return getUserDb().getAllAsync<GuidedStudyTakeawaySummary>(
+    `SELECT
+        synthesis.session_id,
+        sessions.chapter_id,
+        synthesis.takeaway,
+        synthesis.updated_at
+      FROM guided_study_synthesis synthesis
+      JOIN guided_study_sessions sessions ON sessions.id = synthesis.session_id
+      WHERE trim(synthesis.takeaway) != ''
+      ORDER BY synthesis.updated_at DESC, synthesis.id DESC
+      LIMIT ?`,
     [limit],
   );
 }

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -40,6 +40,7 @@ export { usePremium } from './usePremium';
 export { useJourney } from './useJourney';
 export { useJourneyDetail } from './useJourneyDetail';
 export { useStudyDepth } from './useStudyDepth';
+export { useGuidedStudyChapterState } from './useGuidedStudyChapterState';
 export { useGuidedStudySession } from './useGuidedStudySession';
 export { useProofTextGuard } from './useProofTextGuard';
 export { useReviewQueue } from './useReviewQueue';

--- a/app/src/hooks/useGuidedStudyChapterState.ts
+++ b/app/src/hooks/useGuidedStudyChapterState.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  getActiveGuidedStudySession,
+  getDueGuidedReviewItemCountForChapter,
+} from '../db/userQueries';
+import type { GuidedStudySession, GuidedStudyStep } from '../types';
+import { logger } from '../utils/logger';
+
+type GuidedStudyChapterCtaMode = 'start' | 'continue' | 'review';
+
+export function useGuidedStudyChapterState(chapterId: string | undefined) {
+  const [activeSession, setActiveSession] = useState<GuidedStudySession | null>(null);
+  const [dueCount, setDueCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!chapterId) {
+      setActiveSession(null);
+      setDueCount(0);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    void (async () => {
+      try {
+        const [session, due] = await Promise.all([
+          getActiveGuidedStudySession(chapterId),
+          getDueGuidedReviewItemCountForChapter(chapterId),
+        ]);
+        if (cancelled) return;
+        setActiveSession(session);
+        setDueCount(due);
+      } catch (err) {
+        logger.warn('useGuidedStudyChapterState', 'Failed to load chapter study state', err);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chapterId]);
+
+  return useMemo(() => {
+    const mode: GuidedStudyChapterCtaMode = activeSession
+      ? 'continue'
+      : dueCount > 0
+        ? 'review'
+        : 'start';
+    const initialStep: GuidedStudyStep | undefined =
+      activeSession?.current_step ?? (dueCount > 0 ? 'review' : undefined);
+
+    return {
+      mode,
+      initialStep,
+      dueCount,
+      activeSession,
+      isLoading,
+    };
+  }, [activeSession, dueCount, isLoading]);
+}

--- a/app/src/hooks/useGuidedStudySession.ts
+++ b/app/src/hooks/useGuidedStudySession.ts
@@ -7,6 +7,7 @@ import {
   completeGuidedStudySession,
   createGuidedReviewItems,
   recordConceptEncounter,
+  upsertGuidedStudyQuestion,
 } from '../db/userMutations';
 import {
   getGuidedStudyResponses,
@@ -104,12 +105,15 @@ export function useGuidedStudySession(chapterId: string | undefined) {
   const saveSynthesis = useCallback(
     async (next: GuidedSynthesisDraft) => {
       setSynthesis(next);
-      if (sessionId == null) return;
+      if (sessionId == null || !chapterId) return;
       await upsertGuidedStudySynthesis(sessionId, next).catch((err) =>
         logger.warn('useGuidedStudySession', 'Failed to save synthesis', err),
       );
+      await upsertGuidedStudyQuestion(sessionId, chapterId, next.open_question).catch((err) =>
+        logger.warn('useGuidedStudySession', 'Failed to save open question', err),
+      );
     },
-    [sessionId],
+    [chapterId, sessionId],
   );
 
   const savePremiumReview = useCallback(

--- a/app/src/hooks/useReviewQueue.ts
+++ b/app/src/hooks/useReviewQueue.ts
@@ -1,30 +1,58 @@
 import { useCallback, useEffect, useState } from 'react';
-import { completeGuidedReviewItem } from '../db/userMutations';
+import { completeGuidedReviewItem, resolveGuidedStudyQuestion } from '../db/userMutations';
 import {
+  getActiveGuidedStudySessions,
   getAllGuidedReviewItems,
   getConceptEncounters,
   getDueGuidedReviewItems,
+  getOpenGuidedStudyQuestions,
+  getRecentGuidedStudyTakeaways,
 } from '../db/userQueries';
-import type { ConceptEncounter, GuidedReviewItem } from '../types';
+import { buildGuidedStudyNextAction, type GuidedStudyNextAction } from '../services/guidedStudy';
+import type {
+  ConceptEncounter,
+  GuidedReviewItem,
+  GuidedStudyQuestion,
+  GuidedStudySession,
+  GuidedStudyTakeawaySummary,
+} from '../types';
 import { logger } from '../utils/logger';
 
 export function useReviewQueue() {
   const [dueItems, setDueItems] = useState<GuidedReviewItem[]>([]);
   const [allItems, setAllItems] = useState<GuidedReviewItem[]>([]);
   const [concepts, setConcepts] = useState<ConceptEncounter[]>([]);
+  const [activeSessions, setActiveSessions] = useState<GuidedStudySession[]>([]);
+  const [openQuestions, setOpenQuestions] = useState<GuidedStudyQuestion[]>([]);
+  const [recentTakeaways, setRecentTakeaways] = useState<GuidedStudyTakeawaySummary[]>([]);
+  const [nextAction, setNextAction] = useState<GuidedStudyNextAction | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const reload = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [due, all, conceptRows] = await Promise.all([
+      const [due, all, conceptRows, active, questions, takeaways] = await Promise.all([
         getDueGuidedReviewItems(),
         getAllGuidedReviewItems(),
         getConceptEncounters(),
+        getActiveGuidedStudySessions(),
+        getOpenGuidedStudyQuestions(),
+        getRecentGuidedStudyTakeaways(),
       ]);
       setDueItems(due);
       setAllItems(all);
       setConcepts(conceptRows);
+      setActiveSessions(active);
+      setOpenQuestions(questions);
+      setRecentTakeaways(takeaways);
+      setNextAction(
+        buildGuidedStudyNextAction({
+          activeSessions: active,
+          dueItems: due,
+          openQuestions: questions,
+          recentTakeaways: takeaways,
+        }),
+      );
     } catch (err) {
       logger.warn('useReviewQueue', 'Failed to load review queue', err);
     } finally {
@@ -44,12 +72,25 @@ export function useReviewQueue() {
     [reload],
   );
 
+  const resolveQuestion = useCallback(
+    async (id: number) => {
+      await resolveGuidedStudyQuestion(id);
+      await reload();
+    },
+    [reload],
+  );
+
   return {
     dueItems,
     allItems,
     concepts,
+    activeSessions,
+    openQuestions,
+    recentTakeaways,
+    nextAction,
     isLoading,
     reload,
     completeItem,
+    resolveQuestion,
   };
 }

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -61,6 +61,7 @@ import { useChapterPanels } from '../hooks/chapter/useChapterPanels';
 import { useProofTextGuard } from '../hooks/useProofTextGuard';
 import { getStudyDepthEstimate } from '../services/guidedStudy';
 import { ContextGuardBanner, StudySessionCTA } from '../components/guidedStudy';
+import { useGuidedStudyChapterState } from '../hooks';
 
 interface CrossTabNavigation {
   navigate: (screen: string, params?: object) => void;
@@ -82,8 +83,7 @@ function ChapterScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'Read', 'Chapter'>>();
   // TODO(#1585): Replace with a typed CrossTabNavProp helper. Tracked
-  // alongside the existing TODO in navigation/types.ts — every new
-  // `as unknown as` cast makes the refactor marginally harder.
+  // alongside the existing TODO in navigation/types.ts.
   const rootNavigation = useMemo(() => navigation as unknown as CrossTabNavigation, [navigation]);
   const route = useRoute<ScreenRouteProp<'Read', 'Chapter'>>();
   const {
@@ -175,6 +175,7 @@ function ChapterScreen() {
   const notedVerses = useNotedVerses(bookId, chapterNum);
   const { bookmarked, toggleBookmark } = useBookmarkedVerses(bookId, chapterNum);
   const proofTextGuard = useProofTextGuard(bookId, chapterNum, initialVerseNum);
+  const guidedStudyState = useGuidedStudyChapterState(chapter?.id);
   const allSectionPanels = useMemo(() => sections.flatMap((section) => section.panels), [sections]);
   const studyEstimate = useMemo(
     () => getStudyDepthEstimate(verses, allSectionPanels, chapterPanels),
@@ -459,10 +460,14 @@ function ChapterScreen() {
         {!focusMode ? (
           <StudySessionCTA
             estimate={studyEstimate}
+            mode={guidedStudyState.mode}
+            currentStep={guidedStudyState.activeSession?.current_step}
+            dueCount={guidedStudyState.dueCount}
             onPress={() =>
               navigation.navigate('StudySession', {
                 bookId,
                 chapterNum,
+                initialStep: guidedStudyState.initialStep,
                 verseNum: initialVerseNum,
               })
             }

--- a/app/src/screens/MyStudyScreen.tsx
+++ b/app/src/screens/MyStudyScreen.tsx
@@ -2,16 +2,35 @@ import React from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
-import { ArrowLeft, Check, Clock } from 'lucide-react-native';
+import { ArrowLeft, Check, ChevronRight, Clock } from 'lucide-react-native';
 import { usePremium, useReviewQueue } from '../hooks';
 import { UpgradePrompt } from '../components/UpgradePrompt';
+import { formatChapterRef, getGuidedStudyStepLabel } from '../services/guidedStudy';
 import { fontFamily, radii, spacing, useTheme } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+
+function chapterRouteParams(chapterId: string, initialStep?: string) {
+  return {
+    bookId: chapterId.replace(/_\d+$/, ''),
+    chapterNum: Number(chapterId.match(/_(\d+)$/)?.[1] ?? 1),
+    ...(initialStep ? { initialStep } : {}),
+  };
+}
 
 function MyStudyScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
-  const { dueItems, allItems, concepts, completeItem } = useReviewQueue();
+  const {
+    dueItems,
+    allItems,
+    concepts,
+    activeSessions,
+    openQuestions,
+    recentTakeaways,
+    nextAction,
+    completeItem,
+    resolveQuestion,
+  } = useReviewQueue();
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
 
   const locked = !isPremium;
@@ -37,18 +56,84 @@ function MyStudyScreen() {
               Review your study over time
             </Text>
             <Text style={[styles.body, { color: base.textDim }]}>
-              Spaced review prompts and concept vocabulary are included with Companion+.
+              Spaced review prompts, open questions, and concept vocabulary are included with
+              Companion+.
             </Text>
             <TouchableOpacity
               onPress={() => showUpgrade('feature', 'Guided Study Review')}
               style={[styles.primaryButton, { backgroundColor: base.gold }]}
             >
-              <Text style={styles.primaryText}>Unlock review</Text>
+              <Text style={styles.primaryText}>Unlock My Study</Text>
             </TouchableOpacity>
           </View>
         ) : (
           <>
-            <SectionTitle label="DUE FOR REVIEW" />
+            {nextAction ? (
+              <>
+                <SectionTitle label="NEXT STEP" />
+                <View
+                  style={[
+                    styles.emptyCard,
+                    { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` },
+                  ]}
+                >
+                  <Text style={[styles.cardTitle, { color: base.text }]}>{nextAction.title}</Text>
+                  <Text style={[styles.body, { color: base.textDim }]}>{nextAction.subtitle}</Text>
+                  <TouchableOpacity
+                    onPress={() => {
+                      if (!nextAction.chapterId) return;
+                      navigation.navigate(
+                        'StudySession',
+                        chapterRouteParams(nextAction.chapterId, nextAction.initialStep),
+                      );
+                    }}
+                    style={[styles.primaryButton, { backgroundColor: base.gold }]}
+                  >
+                    <Text style={styles.primaryText}>{nextAction.ctaLabel}</Text>
+                  </TouchableOpacity>
+                </View>
+              </>
+            ) : null}
+
+            <SectionTitle label="CONTINUE STUDYING" />
+            {activeSessions.length === 0 ? (
+              <Text style={[styles.body, { color: base.textMuted }]}>
+                In-progress guided sessions will appear here.
+              </Text>
+            ) : (
+              <View
+                style={[
+                  styles.list,
+                  { backgroundColor: base.bgElevated, borderColor: base.border },
+                ]}
+              >
+                {activeSessions.map((session) => (
+                  <TouchableOpacity
+                    key={session.id}
+                    onPress={() =>
+                      navigation.navigate(
+                        'StudySession',
+                        chapterRouteParams(session.chapter_id, session.current_step),
+                      )
+                    }
+                    style={[styles.reviewRow, { borderBottomColor: `${base.border}55` }]}
+                  >
+                    <Clock size={16} color={base.gold} />
+                    <View style={styles.reviewText}>
+                      <Text style={[styles.reviewTitle, { color: base.text }]}>
+                        {formatChapterRef(session.chapter_id)}
+                      </Text>
+                      <Text style={[styles.reviewPrompt, { color: base.textDim }]}>
+                        Resume at {getGuidedStudyStepLabel(session.current_step)}
+                      </Text>
+                    </View>
+                    <ChevronRight size={16} color={base.textMuted} />
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+
+            <SectionTitle label="DUE TODAY" />
             {dueItems.length === 0 ? (
               <View
                 style={[
@@ -75,7 +160,9 @@ function MyStudyScreen() {
                   >
                     <Clock size={16} color={base.gold} />
                     <View style={styles.reviewText}>
-                      <Text style={[styles.reviewTitle, { color: base.text }]}>{item.title}</Text>
+                      <Text style={[styles.reviewTitle, { color: base.text }]}>
+                        {formatChapterRef(item.chapter_id)}
+                      </Text>
                       <Text style={[styles.reviewPrompt, { color: base.textDim }]}>
                         {item.prompt}
                       </Text>
@@ -92,7 +179,44 @@ function MyStudyScreen() {
               </View>
             )}
 
-            <SectionTitle label="CONCEPT VOCABULARY" />
+            <SectionTitle label="OPEN QUESTIONS" />
+            {openQuestions.length === 0 ? (
+              <Text style={[styles.body, { color: base.textMuted }]}>
+                Questions you want to return to will collect here.
+              </Text>
+            ) : (
+              <View
+                style={[
+                  styles.list,
+                  { backgroundColor: base.bgElevated, borderColor: base.border },
+                ]}
+              >
+                {openQuestions.map((question) => (
+                  <View
+                    key={question.id}
+                    style={[styles.reviewRow, { borderBottomColor: `${base.border}55` }]}
+                  >
+                    <View style={styles.reviewText}>
+                      <Text style={[styles.reviewTitle, { color: base.text }]}>
+                        {formatChapterRef(question.chapter_id)}
+                      </Text>
+                      <Text style={[styles.reviewPrompt, { color: base.textDim }]}>
+                        {question.question_text}
+                      </Text>
+                    </View>
+                    <TouchableOpacity
+                      onPress={() => resolveQuestion(question.id)}
+                      accessibilityLabel="Mark question resolved"
+                      style={[styles.checkButton, { borderColor: `${base.gold}40` }]}
+                    >
+                      <Check size={15} color={base.gold} />
+                    </TouchableOpacity>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            <SectionTitle label="CONCEPTS GROWING" />
             {concepts.length === 0 ? (
               <Text style={[styles.body, { color: base.textMuted }]}>
                 Concepts you save from guided sessions will collect here.
@@ -102,11 +226,53 @@ function MyStudyScreen() {
                 {concepts.map((concept) => (
                   <View
                     key={`${concept.concept_id}:${concept.chapter_id}`}
-                    style={[styles.chip, { borderColor: `${base.gold}35` }]}
+                    style={[
+                      styles.conceptCard,
+                      {
+                        backgroundColor: base.bgElevated,
+                        borderColor: `${base.gold}35`,
+                      },
+                    ]}
                   >
                     <Text style={[styles.chipText, { color: base.gold }]}>
                       {concept.concept_label}
                     </Text>
+                    <Text style={[styles.conceptMeta, { color: base.textMuted }]}>
+                      Seen {concept.encounter_count} time{concept.encounter_count === 1 ? '' : 's'}
+                    </Text>
+                    <Text style={[styles.conceptMeta, { color: base.textDim }]}>
+                      Last seen in {formatChapterRef(concept.chapter_id)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            <SectionTitle label="RECENT TAKEAWAYS" />
+            {recentTakeaways.length === 0 ? (
+              <Text style={[styles.body, { color: base.textMuted }]}>
+                Save a guided study synthesis to create your first takeaway trail.
+              </Text>
+            ) : (
+              <View
+                style={[
+                  styles.list,
+                  { backgroundColor: base.bgElevated, borderColor: base.border },
+                ]}
+              >
+                {recentTakeaways.slice(0, 4).map((takeaway) => (
+                  <View
+                    key={`${takeaway.session_id}:${takeaway.updated_at}`}
+                    style={[styles.reviewRow, { borderBottomColor: `${base.border}55` }]}
+                  >
+                    <View style={styles.reviewText}>
+                      <Text style={[styles.reviewTitle, { color: base.text }]}>
+                        {formatChapterRef(takeaway.chapter_id)}
+                      </Text>
+                      <Text style={[styles.reviewPrompt, { color: base.textDim }]}>
+                        {takeaway.takeaway}
+                      </Text>
+                    </View>
                   </View>
                 ))}
               </View>
@@ -226,15 +392,21 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: spacing.xs,
   },
-  chip: {
+  conceptCard: {
     borderWidth: 1,
-    borderRadius: radii.pill,
+    borderRadius: radii.md,
     paddingHorizontal: spacing.sm,
-    paddingVertical: 5,
+    paddingVertical: spacing.sm,
+    minWidth: '47%',
   },
   chipText: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 12,
+  },
+  conceptMeta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    marginTop: 3,
   },
 });
 

--- a/app/src/services/guidedStudy/index.ts
+++ b/app/src/services/guidedStudy/index.ts
@@ -1,5 +1,6 @@
 export { getStudyDepthEstimate } from './estimate';
 export { buildGuidedStudyPlan } from './plan';
+export { buildGuidedStudyNextAction, formatChapterRef, getGuidedStudyStepLabel } from './personal';
 export { buildReviewItemsFromSynthesis, nextIntervalAfter, REVIEW_INTERVAL_DAYS } from './review';
 export {
   GUIDED_STUDY_MODE_OPTIONS,
@@ -20,3 +21,4 @@ export type {
   GuidedStudyStep,
   StudyDepthEstimate,
 } from './types';
+export type { GuidedStudyNextAction } from './personal';

--- a/app/src/services/guidedStudy/personal.ts
+++ b/app/src/services/guidedStudy/personal.ts
@@ -1,0 +1,104 @@
+import type {
+  GuidedReviewItem,
+  GuidedStudyQuestion,
+  GuidedStudySession,
+  GuidedStudyTakeawaySummary,
+} from '../../types';
+import type { GuidedStudyStep } from './types';
+
+export interface GuidedStudyNextAction {
+  kind: 'continue' | 'review' | 'question' | 'takeaway';
+  title: string;
+  subtitle: string;
+  ctaLabel: string;
+  chapterId?: string;
+  initialStep?: GuidedStudyStep;
+}
+
+export function formatChapterRef(chapterId: string): string {
+  const match = chapterId.match(/^(.*)_(\d+)$/);
+  if (!match) return chapterId;
+  const [, rawBook, chapterNum] = match;
+  const book = rawBook
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+  return `${book} ${chapterNum}`;
+}
+
+export function getGuidedStudyStepLabel(step: GuidedStudyStep): string {
+  switch (step) {
+    case 'scene':
+      return 'Scene';
+    case 'observe':
+      return 'Observe';
+    case 'explore':
+      return 'Explore';
+    case 'synthesize':
+      return 'Synthesize';
+    case 'review':
+      return 'Review';
+    default:
+      return 'Study';
+  }
+}
+
+export function buildGuidedStudyNextAction(input: {
+  activeSessions: GuidedStudySession[];
+  dueItems: GuidedReviewItem[];
+  openQuestions: GuidedStudyQuestion[];
+  recentTakeaways: GuidedStudyTakeawaySummary[];
+}): GuidedStudyNextAction | null {
+  const active = input.activeSessions[0];
+  if (active) {
+    return {
+      kind: 'continue',
+      title: 'Continue studying',
+      subtitle: `Resume ${formatChapterRef(active.chapter_id)} at ${getGuidedStudyStepLabel(active.current_step)}.`,
+      ctaLabel: 'Continue',
+      chapterId: active.chapter_id,
+      initialStep: active.current_step,
+    };
+  }
+
+  if (input.dueItems.length > 0) {
+    const first = input.dueItems[0];
+    return {
+      kind: 'review',
+      title: 'Review what is due',
+      subtitle:
+        input.dueItems.length === 1
+          ? `1 prompt from ${formatChapterRef(first.chapter_id)} is ready to revisit.`
+          : `${input.dueItems.length} prompts are due across your saved study.`,
+      ctaLabel: 'Review now',
+      chapterId: first.chapter_id,
+      initialStep: 'review',
+    };
+  }
+
+  const question = input.openQuestions[0];
+  if (question) {
+    return {
+      kind: 'question',
+      title: 'Return to an open question',
+      subtitle: question.question_text,
+      ctaLabel: 'Revisit question',
+      chapterId: question.chapter_id,
+      initialStep: 'synthesize',
+    };
+  }
+
+  const takeaway = input.recentTakeaways[0];
+  if (takeaway) {
+    return {
+      kind: 'takeaway',
+      title: 'Strengthen your last takeaway',
+      subtitle: takeaway.takeaway,
+      ctaLabel: 'Open My Study',
+      chapterId: takeaway.chapter_id,
+      initialStep: 'review',
+    };
+  }
+
+  return null;
+}

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -49,14 +49,6 @@ export interface StudySessionEvent {
   metadata_json?: string;
 }
 
-/**
- * Canonical ordered list of guided study steps. Single source of truth — the
- * migration SQL `CHECK` constraint in `userDatabase.ts` must match this list,
- * and UI components (e.g. `StudySessionStepper`) pair it with label maps.
- * If you change this, update:
- *   1. The `CHECK` constraint on `guided_study_sessions.current_step` in userDatabase.ts
- *   2. `GUIDED_STUDY_STEP_LABELS` in `services/guidedStudy/types.ts`
- */
 export const GUIDED_STUDY_STEPS = ['scene', 'observe', 'explore', 'synthesize', 'review'] as const;
 
 export type GuidedStudyStep = (typeof GUIDED_STUDY_STEPS)[number];
@@ -86,6 +78,24 @@ export interface GuidedStudySynthesis {
   takeaway: string;
   open_question: string;
   key_connection: string;
+  updated_at: string;
+}
+
+export interface GuidedStudyQuestion {
+  id: number;
+  session_id: number;
+  chapter_id: string;
+  question_text: string;
+  status: 'open' | 'resolved';
+  created_at: string;
+  resolved_at: string | null;
+  updated_at: string;
+}
+
+export interface GuidedStudyTakeawaySummary {
+  session_id: number;
+  chapter_id: string;
+  takeaway: string;
   updated_at: string;
 }
 


### PR DESCRIPTION
## Summary

Adds the Guided Study V3 retention and personalization layer on top of PR #1593. This turns guided study into a usable multi-session loop without adding more clutter to the chapter reader.

## Changes

- Upgrades the chapter CTA to switch between `Study this chapter`, `Continue study`, and `Review insights`.
- Adds a `guided_study_questions` table plus question persistence and resolution mutations.
- Adds `useGuidedStudyChapterState` for chapter-level resume/review state.
- Reworks `useReviewQueue` and `MyStudyScreen` into a personal study dashboard with:
  - next step
  - continue studying
  - due today
  - open questions
  - concepts growing
  - recent takeaways
- Adds guided-study personalization helpers for next-action recommendations and chapter/step labeling.
- Adds focused component, hook, DB, service, and mutation tests for the V3 slice.

## Notes

- This PR is intentionally stacked on `codex/guided-study-v2-evidence-trail` so PR #1593 can land first.
- The main local checkout still had unrelated PR #1580 repair edits, so this branch was assembled in a temporary clean repo copy and then pushed.
- Focused Jest verification passed locally in the temporary checkout:
  - `guidedStudyV3Personal.test.tsx`
  - `userDatabaseV3.test.ts`
  - `useGuidedStudyChapterState.test.ts`
  - `useReviewQueue.test.ts`
  - `guidedStudyPersonal.test.ts`
  - `guidedStudyV3Mutations.test.ts`
- TypeScript verification was not reliable in the temp checkout because it did not have its own installed dependencies; CI should be treated as the source of truth for the full branch.
