### PR TITLE
content: 10 debate topics on canon & extra-biblical questions (replaces #1592)

### DIFF
--- a/app/__tests__/unit/debateTopicData.test.ts
+++ b/app/__tests__/unit/debateTopicData.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const VALID_CATEGORIES = ['theological', 'ethical', 'historical', 'textual', 'interpretive'];
-const VALID_FAMILIES = ['evangelical', 'critical', 'reformed', 'catholic', 'jewish', 'patristic'];
+const VALID_FAMILIES = ['evangelical', 'critical', 'reformed', 'catholic', 'jewish', 'patristic', 'second-temple'];
 
 describe('debate-topics.json integrity', () => {
   let topics: any[];

--- a/app/__tests__/unit/debateTopicData.test.ts
+++ b/app/__tests__/unit/debateTopicData.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const VALID_CATEGORIES = ['theological', 'ethical', 'historical', 'textual', 'interpretive'];
-const VALID_FAMILIES = ['evangelical', 'critical', 'reformed', 'catholic', 'jewish', 'patristic', 'second-temple'];
+const VALID_FAMILIES = ['evangelical', 'critical', 'reformed', 'catholic', 'jewish', 'patristic', 'second-temple', 'orthodox'];
 
 describe('debate-topics.json integrity', () => {
   let topics: any[];

--- a/app/src/theme/colors.ts
+++ b/app/src/theme/colors.ts
@@ -199,6 +199,9 @@ export const families = {
   patristic: '#BA68C8',
   reformed: '#4FC3F7',
   catholic: '#E57373',
+  // Second Temple Judaism reception (HWGTB epic) — sand/parchment tone
+  // evoking ancient manuscripts; distinct from jewish (rabbinic-era) green.
+  'second-temple': '#D4A373',
 } as const;
 
 // ── Prophecy Category Colors ───────────────────────────────────────

--- a/app/src/theme/colors.ts
+++ b/app/src/theme/colors.ts
@@ -202,6 +202,8 @@ export const families = {
   // Second Temple Judaism reception (HWGTB epic) — sand/parchment tone
   // evoking ancient manuscripts; distinct from jewish (rabbinic-era) green.
   'second-temple': '#D4A373',
+  // Eastern Orthodox tradition — deeper liturgical red, distinct from catholic.
+  orthodox: '#B85C5C',
 } as const;
 
 // ── Prophecy Category Colors ───────────────────────────────────────

--- a/content/meta/debate-topics.json
+++ b/content/meta/debate-topics.json
@@ -21505,5 +21505,749 @@
       "revelation",
       "judgment"
     ]
+  },
+  {
+    "id": "did-jude-affirm-enoch-as-scripture",
+    "title": "Did Jude Affirm 1 Enoch as Scripture?",
+    "category": "theological",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Jude 14-15",
+    "question": "When Jude quotes 1 Enoch 1:9 with the formula 'Enoch prophesied,' does he thereby treat 1 Enoch as canonical Scripture?",
+    "context": "Jude is the only NT book that introduces a non-OT text with explicit prophetic attribution. 'Enoch, the seventh from Adam, prophesied (epropheteusen) saying, Behold, the Lord comes with myriads of his holy ones to execute judgment.' The wording matches 1 Enoch 1:9 closely, and the citation formula ('prophesied') is exactly the formula Jude would use of any OT prophet. The question has shaped canon debates for two millennia: Tertullian argued on this basis that 1 Enoch should be Scripture; Jerome used Jude's citation as one reason some contemporaries questioned Jude itself; modern evangelical scholarship generally answers no — citation affirms the quoted matter as true but does not canonize the whole source. The Ethiopian Orthodox Tewahedo Church, uniquely, does include 1 Enoch in its canon.",
+    "positions": [
+      {
+        "id": "citation-affirms-content-not-canon",
+        "label": "Jude affirms the quoted content as true prophecy, not the whole book as canonical",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "schreiner",
+          "davids",
+          "kruger"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Schreiner (NAC Jude); Davids (Pillar); Bauckham (WBC Jude); Kruger (Canon Revisited)",
+        "argument": "Jude treats the quoted words as a genuine prophetic utterance — the verb epropheteusen is appropriate to the content, not a claim about the source's canonicity. Paul's quotations of Greek poets (Acts 17:28, Titus 1:12, 1 Cor 15:33) are the parallel case: the quoted content is affirmed as true without canonizing Aratus or Epimenides. Canonicity in the technical sense (an authoritative, closed list of inspired books) is a post-citation question the NT does not settle.",
+        "strengths": "Distinguishes citation from canonization cleanly; parallels Paul's pagan-poet citations; aligns with Jerome's position and the subsequent consensus in the Latin West; preserves the distinction between 'prophetic content' and 'authoritative canon.'",
+        "weaknesses": "Requires a technical definition of 'canon' the 1st century arguably did not share; Jude's phrasing is stronger than Paul's Greek-poet citations ('prophesied' versus 'as certain of your own poets have said'); does not explain why Jude uses the formula appropriate to Scripture.",
+        "key_verses": [
+          "Jude 14-15",
+          "Acts 17:28",
+          "Titus 1:12"
+        ]
+      },
+      {
+        "id": "citation-implies-scriptural-authority",
+        "label": "Jude's prophetic formula implies he treated 1 Enoch as authoritative Scripture",
+        "tradition_family": "patristic",
+        "scholar_ids": [
+          "tertullian"
+        ],
+        "proponents": "Tertullian (De Cultu Feminarum 1.3); Origen (in some contexts); early Ethiopian tradition; modern: James Charlesworth, Archie Wright",
+        "argument": "Tertullian's argument is simple: an apostolic writer quotes a text as prophecy; that quotation is itself Scripture (Jude); therefore the quoted text shares in scriptural authority. The Ethiopian Church inherited this logic through its pre-Chalcedonian connection to Alexandrian Christianity, and 1 Enoch remains in the Ethiopian canon as a continuous living tradition. Modern scholars who defend this position emphasize that 'prophecy' in a Jewish context meant divinely inspired authoritative utterance, and Jude uses the term in full force.",
+        "strengths": "Takes Jude's prophetic formula at face value; has the strongest continuous tradition argument (Ethiopian canon preserves 1 Enoch to this day); aligns with how Jude's original Jewish-Christian audience would have heard 'prophesied.'",
+        "weaknesses": "Did not prevail in the patristic West (Jerome, Augustine both reject); does not account for the fact that most early Christian canon lists explicitly exclude 1 Enoch while still affirming Jude; makes the doctrine of canon depend on a single NT citation.",
+        "key_verses": [
+          "Jude 14-15"
+        ]
+      },
+      {
+        "id": "sub-canonical-inspired-tradition",
+        "label": "Jude treats 1 Enoch as authoritative Jewish tradition, not canonical Scripture in the later technical sense",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "nickelsburg",
+          "vanderkam",
+          "metzger"
+        ],
+        "proponents": "Nickelsburg (Hermeneia 1 Enoch); VanderKam; Metzger (Canon of the NT); Stuckenbruck",
+        "argument": "The 1st-century Jewish category system had more gradations than later Christian canon-theology recognized. 1 Enoch was broadly honored as inspired and prophetic at Qumran (where the Aramaic fragments survive) and in diaspora Judaism without requiring a formal 'canon' decision. Jude participates in this authoritative-but-not-necessarily-canonical reading culture. The question 'is this in the canon?' presupposes a later hermeneutical framework that Jude himself did not operate within.",
+        "strengths": "Historically accurate about 1st-century Jewish reading culture; aligns with the Qumran evidence (where 1 Enoch sits alongside biblical texts without sharp differentiation); explains why Jude uses prophetic language without committing to later canon boundaries.",
+        "weaknesses": "Relativizes the canon question in ways some find theologically problematic; does not tell modern readers how to handle 1 Enoch in the absence of a closed 1st-century canon-list; leaves the Protestant/Catholic/Orthodox disputes under-adjudicated.",
+        "key_verses": [
+          "Jude 14-15"
+        ]
+      }
+    ],
+    "synthesis": "The most defensible evangelical reading is the first: Jude's formula affirms the quoted prophecy as true — 1 Enoch 1:9 accurately foretells the Lord's coming judgment — without committing to the whole book's canonical status. This preserves both the integrity of Jude's usage (he is not careless with 'prophesied') and the distinction between 'inspired prophetic matter' and 'canonical book.' The Ethiopian Orthodox Tewahedo tradition, which has received 1 Enoch as canonical for a millennium and a half, deserves respect as a serious theological choice rooted in genuine continuity with the earliest reception. The debate, however, is not merely historical: it surfaces what we mean by 'canon' — a closed list of books, or a field of recognized divine speech with stable core and permeable edges.",
+    "related_passages": [
+      "Acts 17:28",
+      "Titus 1:12",
+      "1 Corinthians 15:33",
+      "2 Peter 2:4"
+    ],
+    "tags": [
+      "canon-formation",
+      "pseudepigrapha",
+      "jude",
+      "1-enoch",
+      "inspiration",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "who-are-the-nephilim",
+    "title": "Who Are the Nephilim?",
+    "category": "interpretive",
+    "book_id": "genesis",
+    "chapters": [
+      6
+    ],
+    "passage": "Genesis 6:1-4",
+    "question": "Are the 'sons of God' fallen angels, the Sethite line, or semi-divine royal figures — and what are the Nephilim?",
+    "context": "Genesis 6:1-4 is four verses and the interpretive history stretches back 2,200 years. 'When man began to multiply... the sons of God saw that the daughters of man were attractive and took as their wives any they chose... The Nephilim were on the earth in those days, and also afterward, when the sons of God came in to the daughters of man and they bore children to them.' Second Temple Judaism overwhelmingly read bene ha-elohim as fallen angelic beings and expanded the narrative dramatically in 1 Enoch 6-16 and Jubilees 5. This angelic reading is assumed by 2 Peter 2:4 and Jude 6. Augustine shifted the Christian consensus in the 4th-5th century to the Sethite reading, which dominated medieval and Reformation thought. Recent evangelical scholarship has seen a partial return to the angelic reading; conservative interpreters remain divided.",
+    "positions": [
+      {
+        "id": "angelic-view-watchers",
+        "label": "Angelic (Watchers) view",
+        "tradition_family": "second-temple",
+        "scholar_ids": [
+          "nickelsburg",
+          "vanderkam",
+          "longman"
+        ],
+        "proponents": "1 Enoch 6-16; Jubilees 5; Justin Martyr, Irenaeus, Tertullian, Athenagoras (patristic); Heiser, Walton, Longman (modern evangelical); Collins, Nickelsburg, VanderKam (critical)",
+        "argument": "The phrase bene ha-elohim elsewhere in the OT unambiguously means divine/heavenly beings (Job 1:6, 2:1, 38:7; Psalm 29:1, 89:6). Second Temple Judaism assumed this reading and elaborated it; 2 Peter 2:4 and Jude 6 clearly assume it when they speak of 'angels who sinned' and 'abandoned their proper dwelling.' The Nephilim, from the root naphal (to fall), are the offspring of this cosmic boundary transgression. The narrative function — setting up the Flood as moral-cosmic purification — requires a transgression of the angelic-human boundary that the Sethite reading cannot supply.",
+        "strengths": "Preserves the OT semantic range of bene ha-elohim; matches Second Temple reception; coheres with 2 Peter 2:4 and Jude 6; explains the narrative's cosmic scale and the Nephilim's gigantic presence.",
+        "weaknesses": "Requires accepting angelic-human procreation, which Jesus's 'angels do not marry' (Matt 22:30) arguably excludes; creates theological difficulty around the ontology of angelic beings; 1 Enoch's elaboration goes far beyond anything Genesis itself says.",
+        "key_verses": [
+          "Genesis 6:1-4",
+          "Job 1:6",
+          "Psalm 82:6",
+          "Jude 6",
+          "2 Peter 2:4"
+        ]
+      },
+      {
+        "id": "sethite-view-augustinian",
+        "label": "Sethite view (Augustinian)",
+        "tradition_family": "patristic",
+        "scholar_ids": [
+          "augustine",
+          "waltke",
+          "hess"
+        ],
+        "proponents": "Augustine (City of God 15.23); Chrysostom; Cyril of Alexandria; Calvin, Luther; modern evangelical: Waltke, Mathews, Hamilton (partial), Hess",
+        "argument": "The 'sons of God' are the godly line of Seth (descended from the one who 'called on the name of the LORD,' Gen 4:26) intermarrying with the 'daughters of men,' the ungodly Cainite line. The Genesis 4-6 flow supports this: the Cainite/Sethite contrast is the chapter's narrative concern. Genesis 6:2's 'took wives' uses ordinary marriage vocabulary, not a supernatural union. The Nephilim are powerful human figures ('mighty men of old, men of renown'), not angelic-human hybrids. This reading coheres with Jesus's teaching that angels do not marry (Matt 22:30) and avoids the theological difficulties of the angelic reading.",
+        "strengths": "Coheres with the Cainite/Sethite contrast running through Genesis 4-6; avoids angelic-procreation difficulties; matches Jesus's teaching on angelic marriage; dominated Christian interpretation for 1,500 years.",
+        "weaknesses": "Bene ha-elohim elsewhere in the OT clearly means heavenly beings; the view requires the phrase to mean something different uniquely here; does not account for 2 Peter 2:4 and Jude 6 treating the event as angelic rebellion; Second Temple Judaism, closer in time, did not read the passage this way.",
+        "key_verses": [
+          "Genesis 4:26",
+          "Genesis 6:1-4",
+          "Matthew 22:30"
+        ]
+      },
+      {
+        "id": "royal-dynastic-view",
+        "label": "Royal/Dynastic view",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "collins",
+          "anderson"
+        ],
+        "proponents": "Meredith Kline ('Divine Kingship and Genesis 6:1-4'); Ronald Hendel; some ANE scholars who emphasize Mesopotamian parallels",
+        "argument": "In the ANE, kings frequently claimed divine or semi-divine status (cf. Ps 82 referring to earthly judges as 'gods'). The 'sons of God' are ancient kings — tyrants who exercised droit du seigneur ('took any they chose') over their subjects. The Nephilim are their dynastic heirs, legendary 'mighty men of old.' This reading fits the ANE royal ideology, explains the violent overtones of 'took' (same verb Deut 24:1 uses for marriage but with force here), and treats Genesis 6:1-4 as an indictment of tyrannical kingship rather than cosmic mythology.",
+        "strengths": "Coheres with ANE royal ideology; explains 'took any they chose' as coercive; avoids both angelic-procreation difficulties and the strain of reading bene ha-elohim as Sethites; fits the prophetic tradition of naming divine status-claims as blasphemy.",
+        "weaknesses": "Lacks direct lexical support for 'sons of God' as human kings in OT Hebrew; does not account for Second Temple and NT reception; does not explain why the Nephilim are 'heroes' celebrated for renown rather than condemned for violence.",
+        "key_verses": [
+          "Genesis 6:1-4",
+          "Psalm 82:6-7"
+        ]
+      }
+    ],
+    "synthesis": "The angelic reading has the strongest claim: it reflects the OT semantic range of bene ha-elohim, it was the overwhelming consensus of Second Temple and early patristic interpretation, and 2 Peter 2:4 and Jude 6 assume it. The Sethite reading, though dominant since Augustine, depends on giving bene ha-elohim a unique meaning not supported elsewhere. The royal-dynastic view has valuable ANE insights but lacks lexical grounding. An evangelical Protestant approach can acknowledge the angelic reading as most exegetically defensible while recognizing legitimate theological concerns behind the Sethite tradition — and can hold the passage's cosmic strangeness without feeling compelled to domesticate it. The Nephilim are real within the narrative world of Genesis; Second Temple literature expanded the story but did not invent it.",
+    "related_passages": [
+      "Job 1:6",
+      "Psalm 82:6-7",
+      "Jude 6-7",
+      "2 Peter 2:4-5",
+      "Matthew 22:30",
+      "Numbers 13:33"
+    ],
+    "tags": [
+      "genesis",
+      "nephilim",
+      "angelic-rebellion",
+      "1-enoch",
+      "jubilees",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "why-did-western-church-exclude-apocrypha",
+    "title": "Why Did the Protestant Reformation Exclude the Apocrypha?",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical)",
+    "question": "Why did the Protestant Reformers remove the deuterocanonical books from the Old Testament canon in the 16th century?",
+    "context": "Popular Protestant polemic sometimes says 'Rome added books at Trent.' Popular Catholic polemic sometimes says 'Luther removed books to fit his theology.' Neither is historically accurate. The Greek-only books (Tobit, Judith, 1-2 Maccabees, Wisdom, Sirach, Baruch, additions to Esther and Daniel) had circulated alongside the Hebrew OT in Christian usage for centuries, with their status contested. Jerome in the 4th century had already distinguished 'canonical' (Hebrew) from 'ecclesiastical' (deuterocanonical) books. Luther's 1534 Bible, Article VI of the Thirty-Nine Articles (1563), and the Westminster Confession (1646) drew a sharper boundary, treating the deuterocanon as edifying but not Scripture. Understanding why requires untangling three threads: Hebrew canon scholarship, theological dispute with Rome (especially on purgatory, prayers for the dead, and works-and-merit), and the Reformation's 'ad fontes' hermeneutic.",
+    "positions": [
+      {
+        "id": "hebrew-canon-return-to-sources",
+        "label": "Return to the Hebrew canon (ad fontes)",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "kruger",
+          "jerome"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Kruger (Canon Revisited); Beckwith (The Old Testament Canon of the New Testament Church); Roger Nicole",
+        "argument": "The Reformation's defining hermeneutic was 'ad fontes' — back to the sources, in the original languages. For the OT, that meant the Hebrew Bible, which the Jewish community had never received as including the Greek-only books. Jerome (5th century) had recognized this distinction a millennium earlier but was overruled by Augustine and the African councils. The Reformers retrieved Jerome's position: the canonical OT is the Hebrew canon, and books surviving only in Greek belong to 'ecclesiastical' usage but not Scripture. This is not 'removing' books but refusing to extend the canon beyond what the Hebrew community recognized.",
+        "strengths": "Grounded in legitimate philological scholarship (Hebrew Bible is the source); retrieves Jerome's patristic precedent; coheres with the Reformation's return-to-sources hermeneutic; matches rabbinic Jewish consensus about which books were sacred.",
+        "weaknesses": "The 'Jewish canon' in 1517 was not identical to the 1st-century Jewish canon (especially in diaspora); the early church overwhelmingly used the Septuagint, which included the deuterocanon; Jewish rejection in the later period may itself reflect reaction against Christian use of these books.",
+        "key_verses": []
+      },
+      {
+        "id": "theological-dispute-with-rome",
+        "label": "Theological dispute with Rome (purgatory, merit, prayers for the dead)",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "metzger"
+        ],
+        "proponents": "Historical-critical assessment common among Catholic scholars; some Lutheran historians (Gritsch); Metzger's The Canon of the NT discusses the dynamic",
+        "argument": "Several key Roman Catholic doctrines Protestants rejected found their strongest biblical support in the deuterocanon — most conspicuously 2 Maccabees 12:44-45 on prayer and sacrifice for the dead, cited by Rome as supporting purgatory; and Tobit 12:9 on almsgiving atoning for sins, which Protestants read as implying salvation by works. The Reformation's rejection of purgatory, indulgences, and the treasury of merit made the deuterocanon rhetorically inconvenient. Critics argue the canonical question and the doctrinal question were entangled in ways Protestant polemic tends to underplay.",
+        "strengths": "Acknowledges the historical reality that canon and doctrine were entangled in the 16th century; explains why the Reformation pushed the boundary harder than Jerome had; honest about the polemical context.",
+        "weaknesses": "Over-reads the causation: Luther himself accepted the 'canonical' Sirach without worrying about its works-oriented theology; the Reformers' position on Hebrew canon pre-dates the specific doctrinal disputes (Karlstadt 1520 argues from Hebrew canon before the purgatory dispute peaks); reduces theology to tactics.",
+        "key_verses": [
+          "2 Maccabees 12:44-45",
+          "Tobit 12:9"
+        ]
+      },
+      {
+        "id": "continuity-with-pre-trent-catholic-diversity",
+        "label": "Recovery of the pre-Trent Catholic distinction (canonical vs ecclesiastical)",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "athanasius",
+          "jerome"
+        ],
+        "proponents": "Beckwith; Roger Beckwith, 'The Canon of the Old Testament'; Ellis; Lee M. McDonald (mixed); Kruger",
+        "argument": "Before Trent (1546), the Western Catholic tradition itself was not uniform on the deuterocanon. Athanasius's 39th Festal Letter (367) listed the Hebrew canon as 'canonized' and the deuterocanon as 'appointed to be read by those who newly join us.' Jerome treated the deuterocanon as 'ecclesiastical' but not 'canonical.' Cardinal Cajetan (1518) agreed with Jerome against the broader scope. Trent (1546) narrowed this diversity into a binding definition. The Reformers did not innovate against an established Western position — they retrieved one legitimate strand of the pre-Trent Catholic tradition (the Jerome/Athanasius/Cajetan line) against the Augustine/Hippo/Carthage/Trent line.",
+        "strengths": "Historically accurate about pre-Trent Catholic diversity; names specific proponents (Athanasius, Jerome, Cajetan); shows the Reformation as retrieval rather than innovation; reframes the canon dispute as continuous with pre-Reformation Western debate.",
+        "weaknesses": "The Jerome/Cajetan line was always a minority in the West after Hippo and Carthage; the Reformers went further than Jerome ever did (printing the books in a separate appendix vs printing them as 'ecclesiastical' within the biblical text); contemporary Catholic apologetics dispute this framing.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "An evangelical Protestant reading can honestly hold all three factors: the 'ad fontes' hermeneutic genuinely did require Hebrew-canon boundaries; the theological dispute with Rome genuinely did make the deuterocanon rhetorically inconvenient; and the Reformers genuinely were retrieving a Jerome/Athanasius strand that pre-existed them. The strongest defense of the 66-book canon rests on the Hebrew-canon argument, not on 'the Reformers had to get rid of 2 Maccabees for theological reasons.' Protestant readers should acknowledge that the deuterocanonical books were read and honored by the early church (Augustine, Hippo, Carthage), treat them as valuable historical and devotional literature ('for example of life and instruction of manners,' Article VI), and not mis-tell the Reformation history as 'Luther removed books.' The contested boundary was already contested in the 4th century.",
+    "related_passages": [],
+    "tags": [
+      "canon-formation",
+      "apocrypha",
+      "reformation",
+      "trent",
+      "jerome",
+      "augustine",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "what-criteria-at-hippo-carthage",
+    "title": "What Criteria Did the Councils of Hippo and Carthage Use to Define the Canon?",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical — Hippo 393, Carthage 397)",
+    "question": "By what criteria did the 4th-century North African councils list the canonical books, and do those criteria support the Protestant, Catholic, or some other modern canon?",
+    "context": "The Councils of Hippo (393) and Carthage (397, with reaffirmations in 419) produced the first fully-stated Christian canon list including a 27-book NT. Augustine's theological influence shaped both councils; the lists they produced include the deuterocanon alongside the Hebrew OT. Modern canon scholarship (especially Bruce, Metzger, Kruger) has worked hard to identify what criteria actually drove the decisions. The four commonly cited criteria — apostolicity, catholicity, orthodoxy, and ecclesiastical usage — are explicit in some patristic sources and implicit in others. The question is whether these councils were constitutive (the canon came into being through their decision) or recognitive (they ratified what the churches already received).",
+    "positions": [
+      {
+        "id": "four-classical-criteria-recognitive",
+        "label": "Four classical criteria, recognitive function (the churches recognized books already functioning as Scripture)",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "kruger",
+          "metzger"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Metzger (Canon of the NT); Kruger (Canon Revisited)",
+        "argument": "The councils did not 'make' the canon; they recognized what the churches had been receiving for generations. The four criteria were: (1) apostolicity — written by an apostle or an apostolic associate; (2) catholicity — received by the universal church, not one region; (3) orthodoxy — consistent with the rule of faith; (4) usage — read in worship and catechesis across the churches. Books that met these criteria were listed; books that did not (Shepherd of Hermas, Didache, 1 Clement, Epistle of Barnabas) were honored but not canonized. The councils' function was ratification, not construction.",
+        "strengths": "Matches the historical evidence (Athanasius's 367 list pre-dates both councils and largely agrees); aligns with the patristic self-understanding that canon was received, not decreed; coheres with the Reformation principle that Scripture's authority is intrinsic, not conferred by the church.",
+        "weaknesses": "The four criteria are somewhat anachronistically clean — patristic sources do not always articulate them together; the councils did make decisions that contested books required (Hebrews, Revelation, 2-3 John, 2 Peter, Jude all had opponents); does not explain why Augustine included the deuterocanon (which lacks apostolic authorship).",
+        "key_verses": []
+      },
+      {
+        "id": "ecclesial-decree-constitutive",
+        "label": "Ecclesial decree, constitutive function (the church's authority constituted the canon)",
+        "tradition_family": "catholic",
+        "scholar_ids": [
+          "augustine"
+        ],
+        "proponents": "Traditional Roman Catholic ecclesiology (Dei Verbum, Vatican II); Augustine's practice (though not his theory); contemporary Catholic theologians: Avery Dulles, Raymond Brown",
+        "argument": "Augustine's De Doctrina Christiana 2.8.13 names the decisive criterion not as 'apostolicity' but as 'authority of the churches': what the churches actually read and receive defines the canon. On this view the councils do not merely ratify; they speak with the Spirit-guided authority of the Catholic Church, which receives and transmits the canon under divine guidance. The inclusion of the deuterocanon — which lacks clear apostolic origin — makes sense on this criterion: these are the books the (Septuagint-using) church received, therefore these are canonical. Vatican II's Dei Verbum restates this: Scripture and Tradition flow from the same source; the Magisterium recognizes what it has received.",
+        "strengths": "Explains Augustine's actual practice better than the 'four criteria' account; coheres with Catholic ecclesiology; accounts for the deuterocanon's inclusion without philological strain; matches what the councils themselves said about their authority.",
+        "weaknesses": "Places ultimate authority in the church's judgment rather than in Scripture itself (a Protestant concern); risks circularity (the church constitutes the canon by which the church is judged); was not binding on the whole Christian communion (Eastern churches did not participate).",
+        "key_verses": []
+      },
+      {
+        "id": "hybrid-criteria-spirit-led-reception",
+        "label": "Spirit-led reception — organic criteria converging on the received canon",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "kruger"
+        ],
+        "proponents": "Kruger (Canon Revisited: redemptive-historical self-authentication); Herman Ridderbos; Richard Gaffin",
+        "argument": "Canon is neither pure ecclesial decree nor a simple checklist of criteria applied to candidate books. It is the Spirit-led recognition by the covenant community of the books God has given — what Kruger calls 'self-authenticating' Scripture. Apostolicity, catholicity, orthodoxy, and usage all functioned as indicators, but the decisive reality was Spirit-wrought reception: the churches recognized their own Shepherd's voice in these books (John 10:27). The councils were moments of formal recognition in this ongoing organic process, not either pure ratification nor pure decree.",
+        "strengths": "Holds ecclesial action and scriptural authority together without collapsing either; coheres with a Reformed understanding of the Spirit's testimony (Westminster 1.5); avoids both constitutive-church and flat-criteria reductions.",
+        "weaknesses": "Hard to test historically — 'Spirit-led reception' is a theological category, not a historical datum; tends to under-describe the genuine uncertainty and debate in the patristic period (e.g., Hebrews contested for 300 years).",
+        "key_verses": [
+          "John 10:27",
+          "1 Corinthians 2:10-16",
+          "2 Timothy 3:16-17"
+        ]
+      }
+    ],
+    "synthesis": "The four-criteria account is historically defensible and most consonant with evangelical theology: the councils recognized what God had given, using apostolicity, catholicity, orthodoxy, and usage as signs of authentic reception. The Catholic view captures something real about the church's ecclesial role without which the four criteria would not have been applied, but collapses the distinction between God's act and the church's response. Kruger's 'self-authenticating' refinement correctly insists that canon is not merely a checklist mechanically applied. On the deuterocanon question, Hippo and Carthage reached conclusions the Reformation later revised — not because the councils were wrong to apply catholicity and usage (the Septuagint tradition did include these books in wide use), but because the Hebrew-canon criterion, not fully developed in the 4th century, later emerged as decisive. Canon formation was slow, organic, and messy; the councils were necessary but not all-decisive moments in a longer process.",
+    "related_passages": [
+      "John 10:27",
+      "2 Timothy 3:16-17"
+    ],
+    "tags": [
+      "canon-formation",
+      "hippo",
+      "carthage",
+      "augustine",
+      "apostolicity",
+      "criteria-of-canonicity",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "why-does-ethiopia-have-a-different-canon",
+    "title": "Why Does the Ethiopian Orthodox Tewahedo Church Have a Different Canon?",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical — Ethiopian tradition)",
+    "question": "Why does the Ethiopian Orthodox Tewahedo Church have a canon that includes 1 Enoch, Jubilees, and Meqabyan — and does this represent a preservation of ancient Scripture or a divergent later development?",
+    "context": "The Ethiopian Orthodox Tewahedo Church's canon is the broadest in mainstream Christianity: the 'narrower canon' used liturgically contains 81 books, adding 1 Enoch, Jubilees, 1 Esdras, 4 Ezra, 1-3 Meqabyan, and additional recensions of Proverbs to the Catholic canon. This is not a late medieval expansion but the continuous inheritance of a Christian church that was Christianized in the 4th century (under King Ezana, via Frumentius) and became non-Chalcedonian in 451. The Ethiopian preservation of 1 Enoch — lost to the Greek and Latin traditions for over a millennium, rediscovered only in 1773 when James Bruce returned from Ethiopia with three Geʽez manuscripts — raises the question whether Ethiopia preserved a genuine strand of early Christian Scripture or developed its own distinctive canon.",
+    "positions": [
+      {
+        "id": "preservation-of-early-christian-scripture",
+        "label": "Ethiopia preserved a genuine strand of early Christian Scripture",
+        "tradition_family": "orthodox",
+        "scholar_ids": [
+          "vanderkam",
+          "nickelsburg"
+        ],
+        "proponents": "Ephraim Isaac; Roger Cowley; VanderKam; Nickelsburg; Ethiopian Orthodox scholars (Abba Gorgorios); partial support in George Nickelsburg's work on Enochic traditions",
+        "argument": "1 Enoch was authoritative in 1st-century Judaism (attested in Aramaic at Qumran) and in the early patristic period (quoted approvingly by Tertullian, Irenaeus, Clement of Alexandria). Ethiopia's non-Chalcedonian separation in 451 preserved books the Chalcedonian East and the Latin West later de-emphasized. The Ethiopian canon thus represents what early Christianity broadly honored, before later centralizing decisions narrowed the scope in the Chalcedonian communions. Far from being idiosyncratic, Ethiopia is the continuous witness to 1st-4th century Christian reading practice.",
+        "strengths": "Strong historical case: 1 Enoch was in wide early Christian use; Ethiopia's manuscript tradition did preserve the complete text when all other Christian traditions lost it; Jude's citation of 1 Enoch 1:9 is coherent with a church that receives 1 Enoch as Scripture.",
+        "weaknesses": "1 Enoch was never formally canonical in the Greek or Latin churches (even Tertullian's defense was rejected); early quotation ≠ canonical reception; the specifically Ethiopian Meqabyan I-III are not 'preserved ancient' but Ethiopian-original compositions; conflates early Christian honoring with formal canonicity.",
+        "key_verses": [
+          "Jude 14-15"
+        ]
+      },
+      {
+        "id": "divergent-later-expansion",
+        "label": "Ethiopia's canon reflects local development within a uniquely preserved tradition",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "metzger",
+          "kruger"
+        ],
+        "proponents": "Metzger (Canon of the NT); Kruger; most Western canon historians; some Ethiopian scholars (Daniel Assefa) acknowledge historical variation",
+        "argument": "The Ethiopian canon is not a fossilized early Christian canon but an organic tradition that developed over centuries. Meqabyan I-III are Ethiopian-original compositions (possibly 14th century or later), not translations of any earlier Greek or Aramaic work. The 'narrower canon' of 81 books was not codified until the modern Haile Selassie Amharic Bible (1961). The Ethiopian tradition, like all Christian traditions, made canonical decisions over time — some preserving genuinely ancient material (1 Enoch, Jubilees) and some adding later material (Meqabyan, Tägsas).",
+        "strengths": "Historically accurate about Meqabyan's Ethiopian-origin composition; recognizes the modern codification of the 81-book list; aligns with mainstream Western canon scholarship; distinguishes between 'preserving ancient' (genuine for 1 Enoch) and 'always had' (not true for all 81 books).",
+        "weaknesses": "Can read reductively: 'later development' implies illegitimacy, but all canons developed over time; the 1 Enoch case is genuinely remarkable preservation regardless of how other books entered the Ethiopian canon; this framing risks Western-canon triumphalism.",
+        "key_verses": []
+      },
+      {
+        "id": "regional-tradition-plurality",
+        "label": "Multiple legitimate traditions with different canons",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce"
+        ],
+        "proponents": "F.F. Bruce (acknowledges Eastern diversity); modern ecumenical scholarship; Pontifical Biblical Commission (on Eastern canons); Anglican communion's historic tolerance of broader canons",
+        "argument": "Canon is not a univocal theological category. The Protestant 66-book canon, the Catholic 73-book canon, the Orthodox ~76-book canon, and the Ethiopian 81-book canon represent different Spirit-led decisions by different Christian communions. Each has a legitimate historical rationale: Protestant return to the Hebrew canon; Catholic reception of Hippo/Carthage and Trent; Orthodox reception of the broader LXX-plus tradition; Ethiopian preservation of pre-Chalcedonian Egyptian-Alexandrian tradition. No single communion has absolute authority to define the canon for all Christians. The evangelical Protestant holds the 66-book canon as authoritative but engages other canons as legitimate alternative ecclesial judgments.",
+        "strengths": "Respects each tradition's integrity; acknowledges genuine historical diversity; maps onto the actual current Christian landscape; avoids triumphalism in any direction.",
+        "weaknesses": "Can flatten the question to 'everyone's right' in ways that obscure where canon really matters; does not help a reader decide what to read as Scripture; leaves the theological question of 'what God has given' under-addressed.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "Ethiopia's canon is neither a fossil of original Christianity nor a medieval innovation — it is the continuous tradition of a church that became institutionally separate in 451 and made canonical decisions shaped by its own Alexandrian-Coptic inheritance and its own subsequent history. The preservation of 1 Enoch in Geʽez is genuinely remarkable and theologically significant: for a millennium Ethiopia alone possessed the complete text the rest of Christianity had lost, and the Qumran rediscovery confirmed Ethiopia's manuscripts preserve a 2nd-century BC Jewish work with high fidelity. The specifically Ethiopian additions (Meqabyan) are not 'preserved ancient Scripture' but local compositions. An evangelical Protestant can hold the 66-book canon while acknowledging Ethiopia's canon as a legitimate historical outcome of its own ecclesial life, rejecting conspiracy framings that treat Ethiopian extra books as 'the Scriptures Rome hid,' and reading 1 Enoch with appropriate historical interest as a window into Second Temple Judaism the NT authors inhabited.",
+    "related_passages": [
+      "Jude 14-15",
+      "2 Peter 2:4",
+      "Acts 8:26-39"
+    ],
+    "tags": [
+      "canon-formation",
+      "ethiopian-tewahedo",
+      "1-enoch",
+      "jubilees",
+      "chalcedon",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "athanasius-festal-letter-39-significance",
+    "title": "The Significance of Athanasius's 39th Festal Letter (367 AD)",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical)",
+    "question": "Is Athanasius's 39th Festal Letter the first instance of the 27-book New Testament canon, and what does its structure tell us about 4th-century canon formation?",
+    "context": "Athanasius of Alexandria, bishop in the year 367, wrote a traditional annual Festal Letter to announce the date of Easter. The 39th such letter, preserved in Coptic and Syriac fragments and extensively summarized by Photius, contains the earliest extant Christian list of 27 NT books exactly matching the modern canon — no more, no less, in an order only slightly different from modern printed Bibles. The letter also lists the OT books (Athanasius follows the Hebrew scope, treating deuterocanonical works as 'appointed by the Fathers to be read by those who newly join us'). The letter's significance is contested: was Athanasius ratifying a pre-existing consensus, or was his personal authority the decisive turning point? And does his two-tier structure (canonical + 'to be read') support Protestant or Catholic canon theology?",
+    "positions": [
+      {
+        "id": "first-canonical-list-crystallization",
+        "label": "First extant 27-book NT list — crystallization of growing consensus",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "athanasius",
+          "bruce",
+          "metzger"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Metzger (Canon of the NT); Ernst Hennecke; David Dungan",
+        "argument": "By 367 the 27-book NT was broadly functioning in Christian churches but had not yet been formally articulated as a closed list. Muratorian Fragment (c. 170) lists 22-23 NT books; Eusebius (c. 325) divides books into accepted, disputed, and rejected; Athanasius's 39th Letter is the first to name the 27 and to explicitly call them 'canonized' (kanonizomena). The letter crystallized what had been functionally received, giving it precise boundaries. Athanasius's personal authority as the leading bishop of the East (at that time still in exile, returning shortly before this letter) gave the list weight, but he was articulating consensus, not inventing.",
+        "strengths": "Historically accurate about the 4th-century state of canon-formation; Athanasius's own language ('canonized') is explicit; the letter's wide circulation (Coptic, Syriac, reception in Egypt, Palestine, Syria) matches its consensus-articulating role.",
+        "weaknesses": "Does not fully explain why earlier lists (Muratorian, Eusebius) lacked books like James, 2 Peter, Jude, 2-3 John; under-describes Athanasius's personal role as a shaper, not just articulator; Hebrews and Revelation remained disputed in parts of the church for centuries after Athanasius.",
+        "key_verses": []
+      },
+      {
+        "id": "athanasian-innovation-decisive-turning-point",
+        "label": "Athanasius's personal decisive turning point — one bishop's view that eventually prevailed",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "metzger"
+        ],
+        "proponents": "Lee M. McDonald (The Biblical Canon); Bart Ehrman; David Brakke (detailed work on the 39th Letter's social context)",
+        "argument": "Athanasius's 27-book NT was not the universal consensus in 367 — it was his view, and his view prevailed because of his ecclesiastical authority and the political dominance of his Alexandrian-Roman alliance. Earlier and contemporary Christians read with different canons: Syriac-speaking churches used the Diatessaron and included the Epistles of Clement; Gnostic and Marcionite canons existed. Athanasius's letter was an intervention in an ongoing contest, not a neutral description. Its success was partly theological (aligning with emerging Nicene orthodoxy) and partly political (Athanasius's network).",
+        "strengths": "Acknowledges the real contestation of 4th-century canon; resists the 'canon dropped from heaven at Athanasius' over-reading; accounts for the minority Christian traditions (Syriac, Ethiopian, Egyptian) that developed their own canons; honest about the political dimension.",
+        "weaknesses": "Over-weights the Athanasian personality at the expense of the broader patristic consensus he was articulating; does not explain why Athanasius's list achieved such rapid and durable uptake if it was merely one faction's position; can shade into an unhelpful 'canon is just politics' reductionism.",
+        "key_verses": []
+      },
+      {
+        "id": "two-tier-structure-supports-protestant-canon-with-apocrypha-as-edifying",
+        "label": "Athanasius's two-tier structure anticipates the Protestant canonical/ecclesiastical distinction",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "athanasius",
+          "jerome",
+          "kruger"
+        ],
+        "proponents": "Roger Beckwith (OT Canon of the New Testament Church); Bruce (Canon of Scripture); Kruger",
+        "argument": "Athanasius's 39th Letter does not flatly endorse or reject the deuterocanon — it creates a two-tier structure. Tier 1: 'canonized' (kanonizomena) books, the 22 Hebrew OT + 27 NT. Tier 2: 'appointed by the Fathers to be read' (anagignōskomena) — Wisdom, Sirach, Judith, Tobit, Esther (oddly), Didache, Shepherd of Hermas — for catechumens and edification but not as Scripture proper. This two-tier structure is exactly what Article VI of the Thirty-Nine Articles (1563) later reproduces: 39 canonical OT books, Apocrypha read for 'example of life and instruction of manners.' The Reformation's Apocrypha-in-appendix practice has Athanasian precedent.",
+        "strengths": "Historically accurate about Athanasius's two-tier structure; explains how Athanasius can be both broadly influential in the East and aligned with later Protestant canon theology; matches Article VI and Luther's practice; refutes the claim that the Protestant canon is a Reformation innovation.",
+        "weaknesses": "The 'anagignōskomena' category in the Greek East functionally came to mean 'read as Scripture in worship,' which is closer to Catholic canon than Protestant distinction; Athanasius's inclusion of Didache and Shepherd (rejected later) shows the second tier was not stable; the two-tier structure had Catholic and Orthodox readings as well.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "Athanasius's 39th Festal Letter is the most important single patristic document in canon history — the first extant Christian list of the 27-book NT and the earliest explicit two-tier OT canon. The evangelical Protestant reading honors all three observations: Athanasius articulated a real and growing consensus rather than inventing one; his personal authority was indeed decisive for the consensus achieving a durable list-form; and his two-tier structure (canonized vs. 'appointed to be read') is genuinely the precedent the Reformation retrieved in Article VI. Catholic and Orthodox readings rightly emphasize the Letter's East-facing ecclesial context and the reality that the 'appointed to be read' category functioned more authoritatively in Greek worship than the Protestant 'Apocrypha as edifying' framing captures. No single letter closed the canon (Hebrews, Revelation, 2 Peter, Jude all remained contested in places), but no single letter had greater influence on the shape the canon took.",
+    "related_passages": [],
+    "tags": [
+      "canon-formation",
+      "athanasius",
+      "new-testament-canon",
+      "apocrypha",
+      "festal-letter-39",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "jerome-vs-augustine-on-apocrypha",
+    "title": "Jerome vs Augustine on the Apocrypha",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical — late 4th / early 5th century)",
+    "question": "Why did Jerome and Augustine — contemporaries in the Western church, both Doctors of the Church — disagree about the canonical status of the deuterocanonical books?",
+    "context": "Jerome (c. 347-420) and Augustine (354-430) are the two most influential theologians of the Latin West in the late patristic period, and they disagreed sharply about the OT canon. Jerome, translating the Hebrew Bible into Latin (the Vulgate), championed the 'Hebrew verity' (hebraica veritas): the authentic OT is what the Hebrew community received, and books surviving only in Greek are 'ecclesiastical' rather than 'canonical.' Augustine, working within the African councils' consensus and the Septuagint tradition, treated the deuterocanon as canonical Scripture. Their correspondence preserves the dispute directly. The Reformation claimed Jerome's authority; Trent (1546) bound the Western Church to Augustine's. The debate therefore sits at the root of the Protestant/Catholic canon difference.",
+    "positions": [
+      {
+        "id": "jerome-hebrew-verity",
+        "label": "Jerome's Hebrew-verity position",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "jerome",
+          "kruger"
+        ],
+        "proponents": "Jerome (Prologus Galeatus, Prefaces to Vulgate OT books, Epistles 53 and 107); Cardinal Cajetan (1518); Protestant Reformers",
+        "argument": "The OT canon must be what the Hebrew-speaking Jewish community received and transmitted — the hebraica veritas. The Greek LXX contains translations of these Hebrew books plus several works composed originally in Greek (or extant only in Greek). These Greek-only works — Tobit, Judith, Wisdom, Sirach, 1-2 Maccabees, Baruch, additions to Daniel and Esther — are 'ecclesiastical' books that the church may read for edification but cannot appeal to for establishing doctrine. Jerome's Prologus Galeatus (Prologue to Samuel-Kings) lists the 22 canonical Hebrew OT books and explicitly distinguishes them from the deuterocanon. Jerome translated the deuterocanon into Latin for the Vulgate only reluctantly and under ecclesiastical pressure.",
+        "strengths": "Philologically rigorous — based on direct Hebrew knowledge, which Augustine lacked; historically grounded in Jewish canon consensus; distinguishes careful scholarly judgment from popular practice; retrieved by Reformation scholarship and sustained by modern Protestant canon work.",
+        "weaknesses": "Jerome still translated the deuterocanon and allowed its ecclesial use; his 'hebraica veritas' is not as absolute as later polemicists made it; the 'Jewish canon' Jerome knew was a post-70-AD rabbinic reckoning, not necessarily identical to 1st-century consensus; his view did not prevail in his own lifetime.",
+        "key_verses": []
+      },
+      {
+        "id": "augustine-septuagint-canonical",
+        "label": "Augustine's Septuagint-canonical position",
+        "tradition_family": "catholic",
+        "scholar_ids": [
+          "augustine"
+        ],
+        "proponents": "Augustine (De Doctrina Christiana 2.8.12-14; City of God 18.43; Letter 28 to Jerome); Pope Innocent I; Councils of Hippo and Carthage",
+        "argument": "The Septuagint is the Scripture the apostolic church received — the NT authors quote from it almost exclusively, and the early church's OT was the LXX including the deuterocanon. Augustine argues (De Doctrina 2.8.12) that Scripture's authority comes from 'the consent of the catholic churches' — what the universal church has received as Scripture is Scripture. Tobit, Judith, Wisdom, Sirach, 1-2 Maccabees, and Baruch had been read, quoted, and treated as Scripture by many patristic authors (Clement of Rome, Cyprian, Ambrose). Augustine treats Jerome's narrower 'Hebrew canon' as philological special pleading against ecclesial reality. In his letters to Jerome, Augustine is sharp: Jerome's project of going behind the LXX to the Hebrew threatens to disturb the faith of ordinary Christians.",
+        "strengths": "Matches the actual practice of the early church (LXX was the Christian OT); coheres with a strong ecclesial view of canon; accounts for why many patristic authors quote the deuterocanon as Scripture without apology; was overwhelmingly the majority Western position from 400 to 1517.",
+        "weaknesses": "Depends on 'consent of the catholic churches' as the canon-norm in a way that entangles canonicity with ecclesial authority; philologically less rigorous than Jerome's Hebrew-facing scholarship; cannot address the reality that the LXX itself varied (different manuscripts, different scope) in the 4th century.",
+        "key_verses": []
+      },
+      {
+        "id": "both-partially-right-different-questions",
+        "label": "Both partially right — they were answering different questions",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "metzger"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Metzger (Canon of the NT); Ellis (OT Canon); recent ecumenical scholarship",
+        "argument": "Jerome was answering a philological-historical question: what did the Hebrew-speaking Jewish community receive as Scripture? Augustine was answering an ecclesiological question: what has the catholic church in fact read as Scripture? Both answers are correct to their respective questions. The tension surfaces only when modern canon theology tries to hold both questions simultaneously. The Protestant Reformation prioritized Jerome's question (because it offered a clear objective boundary); Catholic tradition prioritized Augustine's (because it vested authority in the church's actual reception). Neither party was simply wrong.",
+        "strengths": "Dissolves some of the polemical heat by distinguishing the questions; fair to both figures; historically and logically careful; aligns with modern ecumenical canon scholarship.",
+        "weaknesses": "May soften a genuine theological disagreement into a semantic one; real-world readers have to make actual canonical decisions that cannot be suspended by distinguishing questions; does not tell us whose question is the more fundamental for Christian canon-theology.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "The Jerome/Augustine disagreement is the clearest articulation of the underlying logic that separates the Protestant and Catholic canons. Both men were right within their respective frames: Jerome was correct that philologically the canonical OT is the Hebrew canon the Jewish community recognized; Augustine was correct that ecclesiologically the deuterocanon had been widely received and read by the church. The Reformation's canon-judgment sides with Jerome — not because Augustine was stupid or dishonest, but because the Reformation's hermeneutical principle (ad fontes, back to the original sources) makes the Hebrew-canon question primary and treats ecclesial usage as confirmatory rather than constitutive. A fair evangelical Protestant position honors Augustine's ecclesiological concerns (tradition matters; the church's reading is not arbitrary) while holding Jerome's philological answer as the decisive criterion for the OT canon boundary. The Apocrypha is valuable historical and devotional literature, legitimately used by the Western church for centuries, while not belonging to the canonical Scripture.",
+    "related_passages": [],
+    "tags": [
+      "canon-formation",
+      "jerome",
+      "augustine",
+      "apocrypha",
+      "deuterocanon",
+      "hebrew-verity",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "trent-response-or-innovation",
+    "title": "Trent on the Canon: Definition of Received Tradition or Counter-Reformation Innovation?",
+    "category": "historical",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "Canon formation (historical — Trent 1546)",
+    "question": "Was the Council of Trent's Session IV canon decree (April 8, 1546) a definition of what the Western Church had always held, or a reactive innovation against the Protestant Reformation?",
+    "context": "On 8 April 1546, the Council of Trent in its Session IV decreed the 73-book Catholic canon 'with all its parts' to be sacred and canonical, anathematizing those who reject them. The decree was issued in the middle of the Reformation crisis, specifically responding to Luther's 1534 Bible (which had printed the Apocrypha as a separate section with a header indicating they are not equal to Scripture). Catholic theology has subsequently read Trent's decree as the formal definition of an always-received tradition; Protestant polemic has sometimes framed it as a reactive innovation — 'Rome added books at Trent.' Neither framing is entirely accurate; the historical reality is more nuanced and theologically instructive.",
+    "positions": [
+      {
+        "id": "trent-defined-received-tradition",
+        "label": "Trent defined what had been received in Western ecclesial practice since Hippo and Carthage",
+        "tradition_family": "catholic",
+        "scholar_ids": [
+          "augustine"
+        ],
+        "proponents": "Standard Roman Catholic historiography; Heinrich Denzinger (Enchiridion Symbolorum); Joseph Ratzinger / Benedict XVI; Raymond Brown",
+        "argument": "The Councils of Hippo (393) and Carthage (397, 419) had already listed the 73-book canon; Pope Innocent I (405) and Pope Damasus's Council of Rome (382, traditionally) confirmed it; Florence (1442) reiterated it in its bull Cantate Domino. Trent was not introducing new books in 1546 — it was formally defining the canon that had been in Western liturgical, patristic, and papal use for over a millennium. The definition became urgent only because the Reformation challenged what had been a stable (if occasionally disputed) consensus. Trent's contribution was dogmatic binding and explicit anathema, not substantive canonical change.",
+        "strengths": "Historically accurate about the pre-existing Catholic consensus from Hippo onward; coherent with Papal and conciliar continuity; names specific prior councils (Hippo, Carthage, Florence) that anticipate Trent; refutes the crude 'Rome added books' polemic.",
+        "weaknesses": "Under-describes the genuine internal diversity of medieval Catholicism (Jerome, Cajetan, scholastic theologians varied); treats Hippo-Carthage as more unified with modern Catholicism than they historically were; elides the fact that Cardinal Cajetan, a Catholic in 1518, held essentially the Protestant view without being censured until Trent.",
+        "key_verses": []
+      },
+      {
+        "id": "trent-reactive-innovation",
+        "label": "Trent's decree was a reactive hardening against Reformation challenges",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "kruger"
+        ],
+        "proponents": "F.F. Bruce (Canon of Scripture); Kruger; Reformed confessional historians; Lee M. McDonald",
+        "argument": "Before Trent, the Western Catholic tradition had significant internal diversity on the deuterocanon. Jerome, Gregory the Great, Hugh of St Victor, Cardinal Cajetan all held essentially the 'Hebrew canon with ecclesiastical Apocrypha' position without censure. Trent closed off this diversity, transforming an always-optional stricter view into heresy. In that specific sense Trent was innovative: not in adding books (the books had been in widespread Western use), but in formally dogmatizing the broader canon and anathematizing the stricter view. Had Trent not happened, Catholic theology might have remained hospitable to something closer to Jerome's position.",
+        "strengths": "Historically accurate about pre-Trent diversity; names specific pre-Trent Catholic figures (Cajetan, Jerome) who held the stricter view without censure; distinguishes 'adding books' from 'dogmatizing a position' with care; matches serious Catholic scholarship that acknowledges pre-Trent diversity.",
+        "weaknesses": "Can shade into Protestant polemic that over-weights pre-Trent minority voices; the Hippo-Carthage consensus was substantive even if not formally defined; 'reactive hardening' is historically true but need not imply theological illegitimacy; the Trent fathers believed they were definitionally articulating, not innovating.",
+        "key_verses": []
+      },
+      {
+        "id": "both-formal-definition-and-reactive-hardening",
+        "label": "Trent was both formal definition of long-held Western practice and a reactive hardening",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "metzger",
+          "bruce"
+        ],
+        "proponents": "Metzger (Canon of the NT); Hubert Jedin (most authoritative Catholic Trent historian); Bruce; most ecumenical canon scholarship",
+        "argument": "Both accounts are partially correct. Trent was formally defining a canon that had been in overwhelming Western practice for over a millennium — this is true. Trent was also hardening an always-contested boundary in reaction to Reformation pressure — this is also true. The proper question is not which narrative is 'correct' but which aspect best illuminates the theological significance. For Catholic theology, Trent's definitive character is primary. For Protestant theology, Trent's foreclosure of pre-existing Catholic diversity (the Jerome/Cajetan option) is primary. Both traditions have legitimate reasons to emphasize their respective framings.",
+        "strengths": "Historically comprehensive; fair to both Catholic and Protestant readings; matches careful modern scholarship (especially Jedin's work on Trent); avoids polemical extremes.",
+        "weaknesses": "May feel too ecumenical to be theologically decisive; does not tell readers how to handle the canonical question today; acknowledges the historical complexity at the cost of clear canonical guidance.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "The accurate historical picture is that Trent did both — it formally defined what had been the majority Western position since Hippo and Carthage, and it hardened that position against Reformation pressure by foreclosing the minority Jerome/Cajetan strand. The Protestant polemic 'Rome added books at Trent' is historically misleading: the deuterocanonical books had been in widespread Western ecclesial use since the 4th century. The Catholic presentation 'Trent merely defined always-received tradition' is also incomplete: it under-describes the genuine pre-Trent diversity that Trent foreclosed. An evangelical Protestant reading can honor Trent as a serious theological act within Catholic ecclesiology — the Catholic Church had the ecclesial authority within its own communion to bind its faithful to a particular canonical definition — while disagreeing with the decree's content and rejoicing that the Jerome/Cajetan strand, though suppressed within Catholicism after Trent, was retrieved and developed by the Reformation. The conspiracy framing 'Trent added books to control people' is historically false and should be explicitly rejected.",
+    "related_passages": [],
+    "tags": [
+      "canon-formation",
+      "trent",
+      "catholic-canon",
+      "apocrypha",
+      "reformation",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "second-temple-literature-and-nt-theology",
+    "title": "How Much Did Second Temple Literature Shape New Testament Theology?",
+    "category": "theological",
+    "book_id": "jude",
+    "chapters": [
+      1
+    ],
+    "passage": "NT theology (general)",
+    "question": "How decisively did 1 Enoch, Jubilees, the Dead Sea Scrolls, and other Second Temple Jewish literature shape the theology of the New Testament writers?",
+    "context": "Until the 20th-century rediscovery of the Dead Sea Scrolls (from 1947), Second Temple Jewish literature was a minor footnote in most NT scholarship. The Scrolls transformed the field by revealing the extraordinary diversity and vitality of 1st-century Judaism — with apocalyptic, messianic, priestly, and sectarian currents that had all been flattened in later rabbinic and Christian summaries. NT scholarship since the 1950s (Fitzmyer, Vermes, VanderKam, Collins) has increasingly documented how NT authors inherit Second Temple theological categories: apocalyptic eschatology, angelology, the two-ways tradition, messianic exegesis, covenantal renewal, sectarian boundary-language. The question for canon theology is: does this shape our understanding of where NT theology comes from, and does it affect how we read the NT today?",
+    "positions": [
+      {
+        "id": "deeply-formative-shared-cultural-matrix",
+        "label": "Second Temple literature is the deeply formative cultural matrix of NT theology",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "nickelsburg",
+          "vanderkam",
+          "collins"
+        ],
+        "proponents": "Nickelsburg (1 Enoch; Jewish Literature Between the Bible and the Mishnah); VanderKam; Collins (Apocalyptic Imagination); James Charlesworth; E.P. Sanders",
+        "argument": "NT theology does not drop from heaven or spring fully-formed from the OT alone. It is formed by 1st-century Jewish thought-worlds — apocalyptic eschatology (1 Enoch, 4 Ezra, 2 Baruch), sectarian self-understanding (Qumran), two-ages anthropology, messianic exegesis (the Dead Sea Scroll 4Q521, 11QMelchizedek), angelology (Jubilees, 1 Enoch), and resurrection hope (2 Maccabees, Daniel, Jubilees). Paul's two-Adams contrast, Jesus's apocalyptic parables, the letter to the Hebrews' priestly christology, Jude and 2 Peter's angelic-rebellion imagery, Revelation's cosmic conflict — none of these can be adequately read without their Second Temple matrix. NT theology emerges from this matrix, reshaped around the crucified-and-risen Christ.",
+        "strengths": "Historically accurate — the literary and conceptual parallels are extensive and well-documented; illuminates NT passages that are obscure when read only against the Hebrew OT; honors the 'Jewishness' of Jesus and the apostles; coheres with the best modern scholarship.",
+        "weaknesses": "Can be read as 'NT theology is just Second Temple Judaism with a Christian overlay,' collapsing the genuine theological novum; risks suggesting the NT is merely derivative; does not adequately account for the transformative impact of the resurrection.",
+        "key_verses": [
+          "Jude 14-15",
+          "Hebrews 11:35-37",
+          "2 Peter 2:4",
+          "Romans 5:12-21"
+        ]
+      },
+      {
+        "id": "superficial-influence-ot-primary",
+        "label": "Second Temple influence is mostly linguistic/cultural; OT remains the theological foundation",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "schreiner",
+          "moo",
+          "beale"
+        ],
+        "proponents": "Classic Reformed/evangelical hermeneutics; Schreiner; Moo; Beale (on Revelation); many dispensational and Reformed systematic theologies",
+        "argument": "The NT's theological core — law and grace, sin and atonement, covenant and kingdom, promise and fulfillment — comes directly from the OT and the teaching of Jesus. Second Temple literature provides the cultural vocabulary and idiomatic setting in which this theology is expressed (Jude's 'prophesied' formula; Hebrews' martyr catalogue; 2 Peter's Tartarus), but the substance is OT-and-Jesus. Treating Second Temple literature as 'formative' risks obscuring the primacy of the OT and the distinctive newness of the gospel. The NT writers draw on Second Temple categories the way Paul draws on Greek rhetoric — fluently, without canonizing the source.",
+        "strengths": "Preserves the theological primacy of the OT and the gospel's novum; aligns with classical Reformed hermeneutics; matches the way the NT itself foregrounds OT citation (hundreds of explicit quotations vs. a few Second Temple allusions); pastoral clarity for church teaching.",
+        "weaknesses": "Under-describes the extent of Second Temple influence (Jude's quotation of 1 Enoch is not just 'cultural' but substantive theological appeal); risks flattening the Jewish context of NT theology; tends to under-read apocalyptic passages (Revelation, 1 Thessalonians 4) whose Second Temple background is dense.",
+        "key_verses": [
+          "2 Timothy 3:16-17",
+          "Luke 24:27"
+        ]
+      },
+      {
+        "id": "formative-matrix-with-theological-transformation",
+        "label": "Second Temple is the formative matrix; Christ transforms the categories he inherits",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "longman"
+        ],
+        "proponents": "F.F. Bruce (The Book of Acts; Canon of Scripture); N.T. Wright (New Testament and the People of God); Richard Bauckham; Longman; growing Reformed engagement with Second Temple studies",
+        "argument": "Second Temple literature is genuinely formative — NT theology cannot be responsibly read without it — AND the gospel genuinely transforms the inherited categories. Jude uses 1 Enoch's apocalyptic framework, but the judgment he announces is Christ's coming, not 1 Enoch's watchers. Hebrews draws on martyr traditions but reframes them under the 'faith that lays hold of the promised land not yet seen.' Revelation uses Jewish apocalyptic vocabulary but centers it on 'the Lamb who was slain.' The formative and transformative are both real; neither the 'NT is derivative' nor the 'NT is self-sufficient' framing captures what the text actually does.",
+        "strengths": "Holds both realities without collapsing either; matches what the NT actually does with Second Temple material; coheres with confessional evangelical theology (gospel is transformative) and serious historical scholarship (context matters); most defensible both theologically and historically.",
+        "weaknesses": "Requires more interpretive work than simpler positions; pastoral communication needs patience to distinguish 'formative' from 'authoritative-as-source'; can be misread in either reductionist direction.",
+        "key_verses": [
+          "Jude 14-15",
+          "Hebrews 11:35-37",
+          "Revelation 12:7-12"
+        ]
+      }
+    ],
+    "synthesis": "The third position is most defensible both historically and theologically: Second Temple literature is a genuine formative matrix for NT theology — the NT writers inherit apocalyptic eschatology, angelology, martyrological categories, priestly christology, and sectarian boundary-language from their Jewish contemporaries — and the gospel transforms these categories around the crucified-and-risen Christ. Jude quotes 1 Enoch because 1 Enoch's vision of coming judgment is true and his readers share the category; his additional move is to identify the coming judge as the Lord Jesus Christ, which 1 Enoch did not. Protestant evangelical readers should acknowledge the deep formative influence of Second Temple literature without treating it as canonically authoritative, and should reject the simplistic framings (either 'NT is just Jewish apocalyptic' or 'NT can be read against the OT alone without loss'). The Jewishness of Jesus and the apostles is the formative context in which the gospel's novum lands with maximum theological force.",
+    "related_passages": [
+      "Jude 14-15",
+      "Hebrews 11:35-37",
+      "Revelation 12:7-12",
+      "2 Peter 2:4",
+      "Luke 24:27",
+      "1 Corinthians 15:3-4"
+    ],
+    "tags": [
+      "second-temple-judaism",
+      "nt-theology",
+      "apocalyptic",
+      "1-enoch",
+      "jubilees",
+      "dead-sea-scrolls",
+      "hwgtb"
+    ]
+  },
+  {
+    "id": "dead-sea-scrolls-and-canon-questions",
+    "title": "What Do the Dead Sea Scrolls Tell Us About 1st-Century Scripture?",
+    "category": "historical",
+    "book_id": "daniel",
+    "chapters": [
+      12
+    ],
+    "passage": "Canon formation (historical — Qumran discoveries)",
+    "question": "What did the discovery of the Dead Sea Scrolls reveal about the state of Jewish Scripture in the 1st century BC/AD — and does it change our understanding of the canon?",
+    "context": "Between 1947 and 1956, caves near Qumran on the northwest shore of the Dead Sea yielded roughly 900 manuscripts dating from c. 250 BC to 68 AD — the largest find of pre-Christian Hebrew and Aramaic biblical and parabiblical manuscripts in history. The Scrolls contain complete or fragmentary manuscripts of every OT book except Esther; substantial portions of 1 Enoch, Jubilees, Tobit, Sirach, Letter of Jeremiah, and Psalm 151; pesher commentaries treating OT books (Habakkuk, Psalms, Isaiah) as sacred Scripture; sectarian works (Community Rule, War Scroll, Damascus Document); and liturgical texts. The Scrolls transformed our understanding of 1st-century Judaism and sharply illuminated the canon question: what counted as 'Scripture' at Qumran, and does this help us answer 'what counted as Scripture for Jesus and the NT writers'?",
+    "positions": [
+      {
+        "id": "flexible-boundary-core-plus-fringe",
+        "label": "Qumran shows a flexible canon with stable core and permeable fringe",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "vanderkam",
+          "nickelsburg",
+          "collins"
+        ],
+        "proponents": "James VanderKam (The Meaning of the Dead Sea Scrolls); Eugene Ulrich (The Dead Sea Scrolls and the Origins of the Bible); Emanuel Tov; John Collins",
+        "argument": "The Qumran community treated the Torah, Prophets, and some wisdom books as unambiguously authoritative Scripture — and also treated 1 Enoch, Jubilees, and various pesher-able texts with functionally scriptural authority. There is no clear textual signal in the Qumran manuscripts distinguishing 'canonical' from 'other.' Pesher commentaries treat Habakkuk and Psalms the same way 4QpsJubilees treats Jubilees — as inspired texts open to interpretive application. This suggests the 1st-century BC/AD Jewish landscape had a stable core canon (Torah + Prophets + most of what became Writings) with a broader fringe of inspired-but-not-formally-canonical texts. 'Canon' in the later closed-list sense was not yet stable.",
+        "strengths": "Closely matches the textual evidence from Qumran; accounts for the presence and handling of 1 Enoch and Jubilees fragments; fits the broader picture of 1st-century Jewish diversity; widely held in current Qumran scholarship.",
+        "weaknesses": "The Qumran community was a sectarian group, not representative of mainstream 1st-century Judaism; absence of manuscripts of Esther may be accidental, not theological; 'flexible boundary' is sometimes overstated to obscure the genuine stability of the Torah-Prophets core.",
+        "key_verses": []
+      },
+      {
+        "id": "stable-core-canon-already-fixed",
+        "label": "Qumran confirms a stable 22-24 book canon already in place",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "bruce",
+          "kruger"
+        ],
+        "proponents": "Roger Beckwith (The Old Testament Canon of the New Testament Church); F.F. Bruce; Kruger; Ellis",
+        "argument": "The Dead Sea Scrolls contain manuscripts of every book of the Hebrew Bible except Esther, and these texts are treated with clear Scripture-level authority (pesher commentary only applies to Scripture). The presence of other books (1 Enoch, Jubilees) does not mean they held equal authority — the Qumran community was eccentric in some ways (sectarian identity, messianic expectation), and we should not read their practice as generalizable. Josephus (Against Apion 1.37-43, c. 93 AD) describes a 22-book canon as the settled Jewish Scripture, and 4 Ezra 14 (c. 100 AD) describes 24 books. The NT's use of OT Scripture confirms the core: Jesus refers to 'the Law, the Prophets, and the Psalms' (Luke 24:44) as the tripartite structure of Scripture. The canon was stable at its core before Qumran, during Qumran, and after.",
+        "strengths": "Grounded in the OT-manuscript evidence at Qumran (every book except Esther) and the Josephus/4 Ezra testimony; coheres with NT evidence of a tripartite Scripture; matches rabbinic Jewish consensus post-70 AD.",
+        "weaknesses": "Under-weights the actual Qumran treatment of 1 Enoch and Jubilees (pesher-adjacent attention, multiple copies, community formative documents); treats Qumran as representative despite its sectarian character; the Beckwith thesis of fixed pre-70 canon is contested by Ulrich, Tov, and others.",
+        "key_verses": [
+          "Luke 24:44"
+        ]
+      },
+      {
+        "id": "transformative-impact-on-canon-history",
+        "label": "Qumran's main contribution: textual history, not canon history",
+        "tradition_family": "critical",
+        "scholar_ids": [
+          "metzger",
+          "bruce"
+        ],
+        "proponents": "Metzger (Canon of the NT); Bruce; Emanuel Tov (Textual Criticism of the Hebrew Bible); Frank Moore Cross",
+        "argument": "The Dead Sea Scrolls' most significant contribution to biblical studies is text-critical, not canon-theological. They show that Hebrew OT manuscripts existed in multiple textual families (proto-Masoretic, proto-Septuagint, Samaritan-related) in the 1st century; that the Hebrew text Jesus and Paul read was broadly stable but not uniform; that the Septuagint was a translation of a genuine Hebrew textual stream, not a late paraphrase. The canon question is secondary: Qumran does not settle 'which books are Scripture' — it shows us that the question was live in 1st-century Judaism and that multiple plausible answers coexisted. Modern canon theology should take this seriously without trying to extract a definitive answer from the Scrolls.",
+        "strengths": "Acknowledges the real contribution of the Scrolls to textual studies; honest about the limits of what Qumran can settle for canon theology; aligns with most modern biblical scholarship's assessment; avoids both 'Qumran confirms Protestant canon' and 'Qumran invalidates canon' framings.",
+        "weaknesses": "Somewhat modest about the Scrolls' canon-theological significance; does not help readers decide how to handle 1 Enoch or Jubilees in light of Qumran; can shade into scholarly suspended-judgment that does not serve the church.",
+        "key_verses": []
+      }
+    ],
+    "synthesis": "The Dead Sea Scrolls are foundational evidence for modern canon and textual scholarship. They confirm that the core of the Hebrew OT (Torah + Prophets + most Writings) was settled and functioning as Scripture by the 1st century BC/AD — supporting an evangelical Protestant position that the 66-book canon's OT is the Scripture Jesus and the NT authors knew. They also show that the boundary was not yet a formally closed list in the later technical sense: 1 Enoch, Jubilees, and other Second Temple works received significant attention and, in sectarian contexts like Qumran, functional authority. This is consistent with 'stable core, permeable edge' as a description of 1st-century Jewish Scripture. An evangelical reader should: take the textual evidence (proto-MT, proto-LXX, Hebrew fidelity of manuscripts) seriously as God's providential preservation of the OT text; affirm the core-canon stability the Scrolls support; reject both the 'conspiracy of lost Scripture' framing and the reductionist 'canon is just politics' framing; and engage 1 Enoch, Jubilees, and related texts as historically invaluable witnesses to the thought-world Jesus and the apostles inhabited.",
+    "related_passages": [
+      "Luke 24:44",
+      "2 Timothy 3:16-17",
+      "Jude 14-15"
+    ],
+    "tags": [
+      "dead-sea-scrolls",
+      "qumran",
+      "canon-formation",
+      "second-temple-judaism",
+      "1-enoch",
+      "jubilees",
+      "textual-criticism",
+      "hwgtb"
+    ]
   }
 ]


### PR DESCRIPTION
Replaces #1592 which was built from a pre-Tier-2 base; its diff against current master showed deletions of everything merged in prior rounds.

This branch cherry-picks the single content file onto current master.

## Content

10 topics covering canon-formation and extra-biblical debates:

| ID |
|---|
| `did-jude-affirm-enoch-as-scripture` |
| `who-are-the-nephilim` (introduces `second-temple` tradition_family) |
| `second-temple-literature-and-nt-theology` |
| `dead-sea-scrolls-and-canon-questions` |
| `jerome-vs-augustine-on-apocrypha` |
| `trent-response-or-innovation` |
| `what-criteria-at-hippo-carthage` |
| `why-did-western-church-exclude-apocrypha` |
| `why-does-ethiopia-have-a-different-canon` |
| `athanasius-festal-letter-39-significance` |

## Infrastructure changes

One position in `who-are-the-nephilim` uses `second-temple` as its `tradition_family` — a new family for positions anchored in Second Temple Judaism reception (1 Enoch Watchers tradition, Jubilees, etc.) distinct from the rabbinic-era `jewish` family.

Two small updates to support it:

- `app/__tests__/unit/debateTopicData.test.ts`: added `'second-temple'` to `VALID_FAMILIES` allowlist
- `app/src/theme/colors.ts`: added `'second-temple': '#D4A373'` (sand/parchment tone evoking ancient manuscripts, visually distinct from rabbinic-era `jewish` green)

## Closes
- #1544
- Supersedes #1592
