### PR TITLE
content: expand st2 panel coverage — 12 new panels across NT (#1554)

### DIFF
--- a/content/1_timothy/5.json
+++ b/content/1_timothy/5.json
@@ -300,6 +300,38 @@
         },
         "hist": {
           "context": "This section addresses three distinct elder-related issues: remuneration for those who serve well (vv. 17–18), disciplinary procedures for accused elders (vv. 19–21), and caution in ordination (vv. 22–25). The two-witness rule for accusations (v. 19) draws directly on Deuteronomy 19:15, applying OT judicial procedure to church governance. The charge to impartiality (v. 21) ‘before God, Christ Jesus, and the elect angels’ invokes a heavenly tribunal as witness—a striking formulation that underscores the gravity of elder discipline."
+        },
+        "st2": {
+          "header": "The Elect Angels: 1 Timothy 5:21 and Second Temple Angelology",
+          "body": "1 Timothy 5:21 opens a solemn charge: 'In the presence of God and of Christ Jesus and of the elect angels I charge you to keep these rules without prejudging, doing nothing from partiality.' The phrase 'elect angels' (eklektoi angeloi) is unusual — it occurs nowhere else in the NT, and the specific adjective 'elect' applied to angelic beings has no direct parallel in the Hebrew Bible. To understand what Paul is doing, we have to look at the Second Temple Jewish angelology within which the phrase makes sense.\n\n1 Enoch provides the most developed context. Across its five books 1 Enoch distinguishes between the 'holy ones' (the unfallen angels serving before God's throne) and the 'Watchers' (the angels who fell in the days before the Flood, whose binding and judgment 1 Enoch narrates at length). The 'holy ones' are implicitly elect — chosen to remain in God's service, contrasted with the fallen Watchers who chose rebellion. 1 Enoch 9:3 refers to 'the holy ones in heaven' who intercede for human suffering; 1 Enoch 39:1 speaks of 'the holy ones of the Most High.' 2 Peter 2:4 and Jude 6, drawing on this tradition, imply the distinction between elect-and-faithful angels versus fallen-and-bound angels.\n\nPaul's 'elect angels' invokes this same distinction. The adjective does not imply a cosmic election-by-faith analogous to human election (that would be theologically strange); rather it designates the angelic beings who remain in God's service as witnesses of the church's judicial-disciplinary proceedings. The charge in 1 Tim 5:21 has forensic-courtroom overtones: Timothy is charged before a three-fold tribunal — God, Christ, and the elect angels — to carry out ecclesial discipline with impartiality.\n\nThe forensic-angelic witness is also a Second Temple commonplace. Dead Sea Scrolls texts (1QH, 1QM) frequently situate judicial proceedings 'in the presence of the holy ones of heaven' as a witness-array. Qumran sectarian self-understanding included the conviction that the community's worship and discipline were conducted in the presence of the angelic host. Hebrews 12:22's 'innumerable angels in festal gathering' draws on the same imagery. Paul in 1 Tim 5:21 is invoking this shared Second Temple vocabulary: ecclesial discipline is conducted before witnesses that include the cosmic heavenly assembly.\n\nThe theological move is pastoral: the church's internal judicial life is not a parochial matter. Angels watch; the cosmos is invested; the community's discipline has stakes that reach beyond the congregation's walls. The Second Temple vocabulary serves a specifically Christian pastoral-ecclesiological purpose.\n\nThe canonical implications: 1 Enoch's angelology is the fullest extant source for the 'holy ones' vs. 'watchers' distinction Paul presupposes, but the tradition was broadly diffused by Paul's day. 1 Enoch's canonicity in the Ethiopian tradition and non-canonical status elsewhere does not change the fact that its angelology shaped 1st-century Jewish-Christian vocabulary. Paul can invoke 'elect angels' knowing his readers will understand.",
+          "extrabiblical_ids": [
+            "1_enoch"
+          ],
+          "citation_refs": [
+            {
+              "nt": "1 Timothy 5:21",
+              "source": "1 Enoch 9:3, 39:1 (holy ones of heaven); broader Second Temple elect-angels tradition",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "mounce",
+              "tradition": "Evangelical Pastorals (WBC)",
+              "note": "Mounce treats 'elect angels' as a reference to the unfallen angels, distinguished from the fallen Watchers of 1 Enoch tradition. The phrase invokes Second Temple Jewish angelology as a courtroom-witness image for Timothy's disciplinary charge."
+            },
+            {
+              "scholar_id": "towner",
+              "tradition": "Evangelical Pastorals (NICNT)",
+              "note": "Towner notes the forensic-courtroom register of 1 Tim 5:21 — God, Christ, elect angels as a three-fold tribunal before whom Timothy is charged to act impartially. The tradition of angelic witness to ecclesial discipline is well-attested in Second Temple sectarian and apocalyptic literature."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg traces the 'holy ones of heaven' / 'elect angels' / 'watchers who fell' distinction across 1 Enoch's five books. By the 1st century this distinction was broadly diffused in Jewish apocalyptic; Paul presupposes it in 1 Tim 5:21."
+            }
+          ],
+          "takeaway": "1 Tim 5:21's 'elect angels' invokes the Second Temple distinction between unfallen 'holy ones' (1 Enoch) and fallen Watchers. The three-fold tribunal (God + Christ + elect angels) frames ecclesial discipline as cosmically witnessed. Paul uses the Jewish apocalyptic vocabulary for a specifically Christian pastoral-ecclesiological purpose."
         }
       }
     }

--- a/content/2_thessalonians/2.json
+++ b/content/2_thessalonians/2.json
@@ -130,6 +130,38 @@
         },
         "hist": {
           "context": "Some Thessalonians believed 'the day of the Lord has already come' (v.2). Paul corrects this with apocalyptic teaching: certain events must precede the end. The 'man of lawlessness' must be revealed first. The identity of this figure has been debated for two millennia — Rome, the papacy, various tyrants, a future Antichrist."
+        },
+        "st2": {
+          "header": "The Man of Lawlessness: 2 Thessalonians 2 and 4 Ezra's Eschatological Adversary",
+          "body": "2 Thessalonians 2:3-10 describes an eschatological adversary with unusual specificity: 'the man of lawlessness, the son of destruction, who opposes and exalts himself against every so-called god or object of worship, so that he takes his seat in the temple of God, proclaiming himself to be God.' The passage has been among the most widely interpreted NT texts in Christian history — connected to Antiochus IV Epiphanes retrospectively, to Caligula in living memory for Paul's audience, to various Roman emperors in subsequent centuries, to the Pope by Reformation polemic, and to an eschatological figure in dispensational and historic-premillennial readings. What is certain is that Paul is drawing on a pre-existing Second Temple Jewish eschatological tradition that envisioned a climactic figure of opposition before the Day of the Lord.\n\n4 Ezra, composed within a decade or two of 2 Thessalonians's likely date (though 4 Ezra is usually dated 90-100 AD and Paul c. 51-52), offers the clearest Jewish literary parallel. 4 Ezra 5 describes signs of the end including unnatural births, blood dripping from wood, the sun rising at night — cosmic disorder signaling the age's end. More pointedly, 4 Ezra 5:6 describes 'one shall reign over whom those who dwell on the earth look not' — an adversary-figure whose rule precedes the Messiah's advent. The Eagle Vision of 4 Ezra 11-12 develops this further, picturing the Roman imperial power as an eagle destroyed by a messianic lion.\n\nThe Dead Sea Scrolls' War Scroll (1QM) and related sectarian texts develop similar imagery: the 'Kittim' (Romans) as the eschatological oppressor, the 'sons of Belial' organized against the 'sons of light,' a final battle before the age to come. Daniel 7's 'little horn' and Daniel 8's 'horn that grew great' provide canonical templates that Paul and the Jewish apocalyptic writers develop.\n\nPaul's specific contribution in 2 Thessalonians 2 is the 'restrainer' (ho katechon, ho katechon) — something or someone currently holding back the full manifestation of the man of lawlessness, who will be removed at the appointed time. The identity of the restrainer has been debated for 2,000 years (Roman Empire? the Spirit? the Church? Michael the archangel?), and no consensus exists. The key theological point is Paul's: the final adversary-figure's rise is contained and scheduled; it cannot exceed what God permits.\n\nThe canonical implications: 4 Ezra is non-canonical in Protestant and standard Catholic reckonings (it sits in a Vulgate appendix); the Ethiopian Orthodox canon includes it. Paul's engagement with Second Temple apocalyptic tradition is atmospheric rather than direct-quotation — there is no single verse-level citation. The parallel illuminates the shared eschatological vocabulary Paul and the Second Temple Jewish writers inherited from Daniel and developed in their own ways.",
+          "extrabiblical_ids": [
+            "4_ezra"
+          ],
+          "citation_refs": [
+            {
+              "nt": "2 Thessalonians 2:3-10",
+              "source": "4 Ezra 5-6 (eschatological signs + adversary), 11-12 (Eagle Vision); Daniel 7-8 (little horn)",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "wanamaker",
+              "tradition": "Evangelical Thessalonians (NIGTC)",
+              "note": "Wanamaker treats 2 Thess 2's adversary-figure as drawing on shared Second Temple Jewish apocalyptic vocabulary rather than a single literary source. 4 Ezra and 2 Thess 2 are best read as cousin developments of common traditions, not as one depending on the other (4 Ezra postdates 2 Thess)."
+            },
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical biblical theology",
+              "note": "Beale connects 2 Thess 2 to Daniel 7-12 directly, with Second Temple apocalyptic as the intermediate vocabulary-layer. The 'takes his seat in the temple' echo of Daniel 11:36-37 is central; the Jewish apocalyptic expansions (1 Enoch, 4 Ezra) shape the broader imagery."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (Second Temple)",
+              "note": "Nickelsburg notes that 'man of lawlessness' figures in diverse Second Temple texts — Daniel, 1 Enoch's watchers, 4 Ezra's Eagle, 2 Baruch, Qumran War Scroll. Paul inherits and specifies this tradition for a pastoral purpose: reassuring the Thessalonians that the Day of the Lord has not already arrived."
+            }
+          ],
+          "takeaway": "2 Thess 2's 'man of lawlessness' draws on broadly diffused Second Temple Jewish apocalyptic tradition (Daniel 7-12; 4 Ezra's Eagle Vision; Qumran War Scroll imagery) of an eschatological adversary before the Day of the Lord. 4 Ezra postdates Paul, so the two are cousin developments of shared tradition rather than one depending on the other."
         }
       }
     },

--- a/content/ephesians/6.json
+++ b/content/ephesians/6.json
@@ -208,6 +208,44 @@
         },
         "hist": {
           "context": "The armour of God passage (vv. 10–20) is the climactic section of Ephesians, drawing together the letter’s themes of cosmic powers (1:21; 3:10), the heavenly realms (1:3, 20; 2:6; 3:10), and the believers’ union with the exalted Christ. The call to ‘be strong in the Lord’ (v. 10) introduces the military metaphor, which is developed through six pieces of armour drawn from Isaiah’s description of God as a warrior (Isa 11:5; 59:17) and the Roman legionary’s equipment. The belt of truth (v. 14a), the breastplate of righteousness (v. 14b), the shoes of the gospel of peace (v. 15), the shield of faith (v. 16), the helmet of salvation (v. 17a), and the sword of the Spirit (v. 17b) form a comprehensive spiritual arsenal. The passage concludes with a call to prayer (vv. 18–20)—the spiritual discipline that activates the armour."
+        },
+        "st2": {
+          "header": "Cosmic Powers: Ephesians 6:12 and 1 Enoch's Angelic Hierarchy",
+          "body": "Ephesians 6:12 introduces the spiritual-warfare passage with a dense list: 'For we do not wrestle against flesh and blood, but against the rulers, against the authorities, against the cosmic powers over this present darkness, against the spiritual forces of evil in the heavenly places.' The four-fold taxonomy — archas, exousias, kosmokratoras tou skotous, pneumatika tes ponerias — is the NT's most elaborate angelology of opposition, and its vocabulary is drawn from a Second Temple Jewish angelic-hierarchy tradition that 1 Enoch developed most extensively.\n\n1 Enoch across its five books names and orders multiple classes of angelic and demonic beings. The Book of the Watchers (chs 6-16) describes the fallen angels under Shemihazah and Azazel, bound beneath the earth awaiting judgment. The Book of Parables (chs 37-71) elaborates the angelic hierarchy around God's throne — 'the lords of mighty works' (46:2), the Sons of Light, the seven archangels (Michael, Gabriel, Raphael, Uriel, and three others). The Astronomical Book names angelic rulers of the astronomical cycles. The Book of Dreams (especially the Animal Apocalypse) narrates cosmic warfare in which angelic and beast-like figures contend. The Epistle of Enoch (chs 91-108) develops eschatological reward-and-punishment under the angel Phanuel. Across the corpus 1 Enoch names, ranks, locates, and characterizes angelic beings with unprecedented specificity — making it the fullest source for the kind of angelic taxonomy Ephesians 6:12 presupposes.\n\nThe Qumran literature (especially the War Scroll, 1QM) develops this further into a cosmic-warfare framework in which the 'sons of light' align with Michael's angelic host to defeat the 'sons of darkness' aligned with Belial's demonic forces. Ephesians 6's 'armor of God' imagery and 'heavenly places' battlefield concept both draw on this Qumran-adjacent Second Temple reservoir.\n\nWhat Ephesians does with this vocabulary is specifically Christian: the Christian is already located 'in Christ' in the heavenly places (Eph 2:6 — 'seated us with him in the heavenly places'), which means the battle against cosmic powers is fought from a position of Christ's accomplished victory rather than from eschatological doubt. The spiritual armor — belt of truth, breastplate of righteousness, shoes of gospel-peace, shield of faith, helmet of salvation, sword of the Spirit — is the Christian equipping for a battle whose outcome is determined by Christ's cross and resurrection. The Jewish apocalyptic vocabulary is inherited; the soteriological framework is specifically NT.\n\nThe identification of who exactly the 'rulers, authorities, cosmic powers' are has been contested across Christian history. Early patristic writers (especially Origen and pseudo-Dionysius) took the angelology as literal cosmic hierarchy. Modern readings range from literal demonology to sociological reading (structural powers = political / economic systems, influenced by Walter Wink's Powers trilogy). The text itself does not require a single interpretation, but does require that the believer recognize the battle is real, cosmic, and unwinnable apart from the armor of God.",
+          "extrabiblical_ids": [
+            "1_enoch",
+            "damascus_document"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Ephesians 6:12",
+              "source": "1 Enoch 6-16 (Watchers), 37-71 (Parables) — angelic hierarchies of opposition",
+              "type": "allusion"
+            },
+            {
+              "nt": "Ephesians 6:12",
+              "source": "Qumran War Scroll (1QM); Damascus Document on cosmic warfare",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "lincoln",
+              "tradition": "Evangelical Ephesians (WBC)",
+              "note": "Lincoln treats Eph 6:12's four-fold taxonomy as drawing on broadly shared Second Temple Jewish apocalyptic angelology. 1 Enoch is the fullest extant source, but the tradition was widely diffused; Paul can presuppose his Gentile audience has absorbed it through Jewish-Christian catechesis."
+            },
+            {
+              "scholar_id": "obrien",
+              "tradition": "Evangelical Ephesians",
+              "note": "O'Brien emphasizes the specifically Christian framing: the Christian is already 'in Christ' in the heavenly places, so cosmic-warfare imagery functions within already-accomplished-victory soteriology, not eschatological anxiety."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg's Hermeneia 1 Enoch catalogues the corpus's angelic-hierarchy language in detail. The kind of naming and ranking Eph 6:12 presupposes is 1 Enoch's signature contribution to Jewish apocalyptic theology."
+            }
+          ],
+          "takeaway": "Ephesians 6:12's four-fold cosmic-power taxonomy draws on Second Temple Jewish apocalyptic angelology, most fully developed in 1 Enoch's Book of Parables and Book of the Watchers. The Christian framing is distinctive: already-victorious-in-Christ soteriology rather than eschatological doubt. Vocabulary inherited; salvation-framework specifically NT."
         }
       }
     },

--- a/content/galatians/3.json
+++ b/content/galatians/3.json
@@ -280,6 +280,38 @@
         },
         "hist": {
           "context": "Paul addresses the obvious question: if the promise establishes justification by faith, what is the purpose of the law? First, the law was added ‘because of transgressions’ (v. 19)—to make sin visible and condemnable—until the Seed (Christ) should come. Second, the law was given ‘through angels’ and a mediator (Moses), while the promise was given directly by God (v. 20). Paul is careful not to set law and promise in contradiction (v. 21); rather, they serve different functions in God’s single plan."
+        },
+        "st2": {
+          "header": "The Law Ordained Through Angels: Galatians 3:19 and Jubilees",
+          "body": "In Galatians 3:19 Paul asks rhetorically 'Why then the law?' and offers a curt answer: 'It was added because of transgressions, until the offspring should come to whom the promise had been made, and it was put in place through angels by an intermediary.' The phrase 'through angels' (diatagheis di' angelon) is striking — it appears at no other point in the Hebrew Bible's own account of the Sinai revelation, which records Yahweh speaking directly to Moses. But it was a commonplace of Second Temple Jewish tradition that the Torah had been mediated through angelic agency. Acts 7:53 (Stephen's speech) and Hebrews 2:2 make similar claims; Deuteronomy 33:2 LXX ('the Lord came from Sinai with myriads of holy ones') was read as attestation.\n\nThe Book of Jubilees provides the most developed Second Temple source for this tradition. Jubilees 1:27-29 narrates that 'the angel of the presence' (one of the highest orders of angels in Jubilees' theology) is commanded by God to dictate to Moses the entire contents of the book that becomes Jubilees itself — which Jubilees presents as the true underlying revelation of Torah. Throughout Jubilees the angel of the presence speaks the law to Moses; Moses writes it down; the resulting books are the Torah proper (Genesis and the opening of Exodus) plus Jubilees' distinctive chronological-halakhic framework. The mediation is explicit and thoroughgoing.\n\nPaul's theological point in Galatians 3:19 is not about the mechanics of revelation but about hierarchy: the law's angel-mediated origin places it one step below the promise to Abraham, which God made directly. Paul is not denying the law's divine origin; he is ordering promise and law by their proximity to God. Promise comes straight from God; law comes through angels and a human intermediary (Moses). This subordinates law to promise without diminishing either.\n\nThe Second Temple background makes Paul's argument intelligible. A Galatian audience that had been shaped by Jewish teaching about angelic mediation at Sinai would have recognized immediately what Paul was doing: deploying an accepted piece of Jewish tradition (Jubilees' angel-of-the-presence, the broader 'myriads of holy ones' imagery) to establish the law's relative position in the covenant hierarchy. Paul is not inventing the angel-mediation claim; he is appealing to it.\n\nThe Galatian opponents' position — law as the decisive covenantal requirement — is rhetorically undermined by Paul's maneuver. If the Torah was given through angels (as Jewish tradition teaches), then the Torah operates at one remove from the direct divine voice. The promise, given directly, takes precedence. Jubilees' own theological framework provides Paul with the ammunition for his argument.",
+          "extrabiblical_ids": [
+            "jubilees"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Galatians 3:19",
+              "source": "Jubilees 1:27-29 (angel of the presence mediating Torah to Moses)",
+              "type": "allusion"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "bruce",
+              "tradition": "Evangelical NT (Pauline)",
+              "note": "Bruce identifies Jubilees' 'angel of the presence' as the clearest Second Temple source for Paul's 'through angels' phrasing in Gal 3:19. The tradition was widespread enough by Paul's day (Acts 7:53, Heb 2:2) that Paul could presuppose it."
+            },
+            {
+              "scholar_id": "vanderkam",
+              "tradition": "Critical (Jubilees specialist)",
+              "note": "VanderKam's Hermeneia Jubilees commentary establishes the book's pervasive angelic-mediation theology. Paul's Gal 3:19 argument depends on this Jewish-tradition backdrop; the rhetorical force collapses without it."
+            },
+            {
+              "scholar_id": "schreiner",
+              "tradition": "Evangelical NT (Galatians)",
+              "note": "Schreiner treats Gal 3:19 as drawing on widely shared Second Temple tradition rather than specifically Jubilees; the angel-mediation claim was a commonplace. The theological point is law-below-promise, not a cosmological claim about angels."
+            }
+          ],
+          "takeaway": "Galatians 3:19's 'through angels' draws on the widely diffused Second Temple Jewish tradition — most fully developed in Jubilees 1:27-29 — that the Sinai law was mediated through angelic agency. Paul uses the tradition to subordinate law to promise, not to downgrade the law's divine origin."
         }
       }
     },

--- a/content/hebrews/1.json
+++ b/content/hebrews/1.json
@@ -134,6 +134,38 @@
         "hist": {
           "historical": "Hebrews was written to Jewish Christians facing pressure to abandon their faith and return to Judaism. The destruction of the Jerusalem temple (AD 70) loomed or had just occurred, removing the visible center of Jewish worship. The author argues that Christ fulfills and supersedes all Old Testament institutions — priesthood, sacrifice, covenant, and tabernacle. The recipients faced persecution (10:32-34), some were drifting away (2:1), and the letter urges perseverance by demonstrating Christ's superiority to angels, Moses, Joshua, and the Levitical priesthood. The sophisticated Greek style and extensive use of the Septuagint suggest a Hellenistic Jewish-Christian author addressing a similarly educated audience, possibly in Rome (13:24).",
           "context": "Hebrews opens with one of the most majestic sentences in the NT—a single periodic sentence in Greek stretching from 1:1 to 1:4. The author employs seven descriptors of the Son: heir of all things, agent of creation, radiance of glory, exact imprint of being, sustainer of all things by his powerful word, maker of purification for sins, and enthroned at the right hand of Majesty. This sevenfold christology draws on Wisdom traditions (Wis 7:25–26; Sir 24), Ps 110:1 (right-hand enthronement), and pre-Pauline hymnic material (cf. Phil 2:6–11; Col 1:15–20). The prologue establishes the Son’s absolute supremacy before the angel comparison begins."
+        },
+        "st2": {
+          "header": "Christ as the Radiance: Echoes of Wisdom of Solomon 7:26",
+          "body": "Hebrews 1:3 opens the epistle's christological prologue with a description of the Son: 'He is the radiance of the glory of God and the exact imprint of his nature, and he upholds the universe by the word of his power.' The phrasing is striking in its density, and the density is not accidental. Both the structure and the specific vocabulary draw on Wisdom of Solomon 7:26, a first-century-BC Alexandrian Jewish description of personified Sophia: 'she is the radiance (apaugasma) of eternal light, a spotless mirror of the working of God, and an image (eikon) of his goodness.' The overlap is unmistakable. Hebrews uses apaugasma ('radiance') — a word that occurs in the entire Greek Bible only here and at Wisdom 7:26. The structural parallel (radiance of glory, imprint/image of God) is close. The theological move in Hebrews is decisive: the Sophia attributes that Wisdom of Solomon applies to personified Wisdom, Hebrews applies to the historical, crucified, risen Christ. The same thought-pattern Alexandrian Jewish sapiential reflection developed for the mediating divine Wisdom is now applied to Jesus.\n\nThis is not an isolated case. Colossians 1:15-20's 'He is the image of the invisible God, the firstborn of all creation…all things were created through him and for him' draws on the same Sophia-tradition. John 1:1-14's Logos identification with Christ operates in the same intellectual field. The early Christian movement read its developing Christology through the vocabulary Alexandrian Judaism had built up for talking about God's mediating agency — Wisdom as eternal companion, creator-instrument, and image-bearer — and applied that vocabulary to Jesus.\n\nWhat makes the Wisdom 7:26 parallel particularly rich is that Wisdom of Solomon itself is philosophically engaged literature. Its author works at the intersection of Jewish covenant theology, Platonic metaphysics, and Stoic cosmology. When Hebrews 1:3 reuses the apaugasma language, it is inheriting this philosophical freight. The Son is not merely God's agent; he is the kind of mediating figure Alexandrian Jewish reflection had theorized at length.\n\nThe canonical question this raises — does Hebrews quoting Wisdom of Solomon elevate Wisdom to Scripture-status? — is answered the same way as for Jude's use of 1 Enoch. Quotation and shared vocabulary do not constitute canonization. Hebrews' original audience shared with its author a familiarity with Wisdom of Solomon's prose that did not require the source to be canonical for the allusion to land. Modern readers encounter the text knowing Wisdom of Solomon sits in the Catholic, Orthodox, and Ethiopian canons but not the Protestant canon; either way, the point of the allusion is about Christ, not about Wisdom's canonicity.",
+          "extrabiblical_ids": [
+            "wisdom_of_solomon"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Hebrews 1:3",
+              "source": "Wisdom of Solomon 7:26",
+              "type": "allusion"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "cockerill",
+              "tradition": "Evangelical Hebrews (NICNT)",
+              "note": "Cockerill argues the apaugasma parallel is too specific to be coincidence — the single Septuagint attestation outside Hebrews is Wisdom 7:26, and Hebrews' wider Christological hymn (1:3-4) tracks Wisdom's structure. Hebrews inherits Alexandrian Jewish Sophia-language and applies it to the Son."
+            },
+            {
+              "scholar_id": "lane",
+              "tradition": "Evangelical Hebrews (WBC)",
+              "note": "Lane notes the polymorphic allusion: Hebrews 1:3 draws on Wisdom 7:26, Psalm 110:1, Isaiah's servant passages, and the imprint/image language of Platonic-Stoic metaphysics simultaneously. The prologue is a christological synthesis of multiple sources into a single sentence."
+            },
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical biblical theology",
+              "note": "Beale traces the Sophia-to-Christ move across the NT — Col 1:15-20, John 1, Heb 1 all read Christ through the vocabulary developed for personified Wisdom in Prov 8 + Wis 7 + Sir 24. The NT is not inventing this vocabulary; it is redirecting it."
+            }
+          ],
+          "takeaway": "The specific Greek word apaugasma that Hebrews 1:3 uses of the Son appears in the entire Greek Bible only here and at Wisdom of Solomon 7:26 — a near-certain allusion. Hebrews applies Alexandrian Jewish Sophia-theology to the risen Christ. The canonical status of Wisdom of Solomon is a separate question; the NT's use of its vocabulary does not settle it."
         }
       }
     },

--- a/content/hebrews/11.json
+++ b/content/hebrews/11.json
@@ -233,6 +233,44 @@
         },
         "hist": {
           "context": "The catalogue begins with pre-flood figures. Abel's faith is evidenced in offering; Enoch's in walking with God; Noah's in building. Each acted on divine revelation they could not verify empirically. The variety demonstrates that faith expresses itself differently depending on vocation and circumstance."
+        },
+        "st2": {
+          "header": "Enoch Taken: From Genesis 5:24 to Sirach 44:16",
+          "body": "Hebrews 11:5 mentions Enoch in the faith-catalogue: 'By faith Enoch was taken up so that he should not see death, and he was not found, because God had taken him. Now before he was taken he was commended as having pleased God.' The phrasing is drawn directly from Genesis 5:24 ('Enoch walked with God, and he was not, for God took him') in its Septuagint form ('Enoch pleased God and was not found'). But the specific detail Hebrews emphasizes — Enoch 'was commended as having pleased God' — matches the Sirach 44:16 expansion of Genesis: 'Enoch pleased the Lord and was translated; being an example of repentance to the generations.' Both the LXX Genesis wording and the Sirach gloss stand behind the Hebrews verse.\n\nThis matters because Sirach 44-50 — the Praise of the Ancestors (Laus Patrum) — is the first extant literary encomium of Israel's heroes, and Hebrews 11 is its clearest NT descendant. Sirach 44:1 ('Let us now praise famous men, and our fathers in their generations') inaugurates the sustained catalogue-genre; Hebrews 11 picks it up, expanding the specifically covenantal-faith frame and adding NT-era figures the Laus Patrum could not have included. The literary kinship is close enough that most Hebrews commentators (Cockerill, Lane, Attridge, Ellingworth) treat Sirach 44-50 as at least a probable source for the Hebrews 11 structure.\n\nBut Hebrews' framing of Enoch is not just literary-historical. The broader Second Temple tradition had developed Enoch enormously — into a patriarch-seer who ascended alive, saw the heavens, delivered apocalyptic revelations, and functioned as an eschatological witness. The Enochic corpus (1 Enoch, 2 Enoch) treats him this way throughout. Hebrews, by contrast, picks out only the single verse from Genesis: Enoch walked with God; he was taken. The Hebrews author is not rejecting the Enochic tradition — Hebrews elsewhere shows clear familiarity with Second Temple Jewish thought — but subsuming it into a covenantal-faith category. Enoch is a witness of faith, not a source of esoteric cosmological revelation.\n\nThe Sirach parallel reinforces this: Sirach's Enoch is 'an example of repentance to the generations' — a moral exemplar, not a mystical revealer. Hebrews shares this framing. The apocalyptic Enoch of 1 Enoch recedes; the covenantal Enoch of Genesis and Sirach steps forward.\n\nThe canonical implications are modest but real. Sirach is not quoted directly; its influence on Hebrews 11 is structural and atmospheric. Sirach's canonicity in the Catholic, Orthodox, and Ethiopian traditions and its position as Apocrypha in the Protestant tradition does not change the fact that its Laus Patrum is the proximate literary ancestor of Hebrews 11. Reading Hebrews 11 in awareness of Sirach 44-50 deepens rather than threatens the NT text — it shows the author drawing on his own community's received wisdom tradition to structure a christological encomium.",
+          "extrabiblical_ids": [
+            "sirach",
+            "1_enoch"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Hebrews 11:5",
+              "source": "Genesis 5:24 LXX + Sirach 44:16",
+              "type": "allusion"
+            },
+            {
+              "nt": "Hebrews 11:5",
+              "source": "1 Enoch (broader Enochic tradition, selectively appropriated)",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "cockerill",
+              "tradition": "Evangelical Hebrews (NICNT)",
+              "note": "Cockerill treats Sirach 44-50 as the proximate literary model for Hebrews 11's catalogue-form. The specific Enoch phrasing ('pleased God') follows LXX Genesis 5:24 + Sirach 44:16, not the Hebrew Masoretic Text."
+            },
+            {
+              "scholar_id": "lane",
+              "tradition": "Evangelical Hebrews (WBC)",
+              "note": "Lane argues Hebrews 11:5 deliberately selects the Genesis + Sirach Enoch material while bypassing the developed Enochic apocalyptic tradition. The author knows the Enochic literature but framing Enoch as a witness of faith, not a revealer of secrets."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg notes that by the 1st century AD, 'Enoch' was a rich and contested figure — both the covenantal-patriarchal Enoch of Genesis/Sirach and the apocalyptic-seer Enoch of 1 Enoch. Hebrews chooses the first framing deliberately."
+            }
+          ],
+          "takeaway": "Hebrews 11:5 follows the LXX Genesis 5:24 + Sirach 44:16 portrait of Enoch (moral exemplar, covenantal-faith patriarch) rather than the apocalyptic-seer Enoch of 1 Enoch. The broader Sirach 44-50 Laus Patrum is the literary ancestor of Hebrews 11 as a genre. NT use of extra-biblical structure is substantive without implying the source's canonicity."
         }
       }
     },

--- a/content/hebrews/12.json
+++ b/content/hebrews/12.json
@@ -473,6 +473,44 @@
         },
         "hist": {
           "context": "The contrast between Sinai and Zion is the chapter's theological climax. Sinai was physical, terrifying, untouchable—even Moses trembled. But believers have come to Mount Zion, the heavenly Jerusalem, innumerable angels, the assembly of the firstborn, God the judge of all, spirits of the righteous made perfect, Jesus the mediator, and sprinkled blood that speaks better than Abel's. Every element celebrates access, not exclusion. The contrast underscores: why would anyone return to Sinai?"
+        },
+        "st2": {
+          "header": "The Heavenly Assembly: Hebrews 12:22 and 1 Enoch's Throne Room",
+          "body": "Hebrews 12:22 announces: 'You have come to Mount Zion and to the city of the living God, the heavenly Jerusalem, and to innumerable angels in festal gathering, and to the assembly of the firstborn who are enrolled in heaven.' The imagery is explicitly heavenly-liturgical — a cosmic assembly of angels, saints, and the enthroned God, gathered in a festival of worship. This imagery has deep roots in Second Temple Jewish apocalyptic literature, nowhere more elaborately than in 1 Enoch's throne-room visions.\n\n1 Enoch 14 describes Enoch's ascent to the heavenly temple. He passes through walls of crystal and fire, arrives at a throne whose occupant is 'the Great Glory,' and sees 'ten thousand times ten thousand' ministering angels standing before him (14:22 — a phrasing that echoes and is echoed by Daniel 7:10 and Revelation 5:11). The throne-room is described as a heavenly sanctuary, more glorious than any earthly temple, with the righteous gathered in festive worship around the enthroned God. The Parables of Enoch (chapters 37-71) extend this imagery — the heavenly assembly becomes the setting for the Son of Man's messianic enthronement.\n\nHebrews 12:22-24 compresses all of this into a few dense lines. 'Innumerable angels in festal gathering' (myriasin angelon panegyrei) invokes the myriads of 1 Enoch 14 and Daniel 7. 'The city of the living God' is the heavenly Jerusalem that 4 Ezra's Lady-Jerusalem vision (4 Ezra 10) develops. 'The assembly of the firstborn' evokes both the Exodus firstborn motif and the broader Jewish apocalyptic language of the elect righteous gathered in heavenly worship.\n\nWhat Hebrews does with this imagery is distinctive: it maps the heavenly assembly onto the Christian worshiper's present experience. 'You have come' (proseleluthate, perfect tense) is not future eschatology but realized-eschatological claim. The believer gathered for worship on earth is already, in Christ, participating in the heavenly liturgy that 1 Enoch pictured as the eschatological climax. The mountain you've come to is Zion-above, not Sinai-below; the assembly is angelic-and-human-in-worship, not merely terrestrial.\n\nThis is typical of Hebrews' hermeneutical move throughout the letter: Second Temple Jewish apocalyptic imagery that traditionally depicted the eschatological future is applied to the present reality of the Christian community. The heavenly Jerusalem is not only 'above' and 'to come' but is already the worshiping assembly's true location. The imagery-pool is Jewish apocalyptic; the theological move is specifically Christian realized-eschatology.",
+          "extrabiblical_ids": [
+            "1_enoch",
+            "4_ezra"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Hebrews 12:22",
+              "source": "1 Enoch 14:18-25 (throne-room); Daniel 7:10 (ten thousand times ten thousand)",
+              "type": "allusion"
+            },
+            {
+              "nt": "Hebrews 12:22",
+              "source": "4 Ezra 9:38-10:57 (heavenly Jerusalem)",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "cockerill",
+              "tradition": "Evangelical Hebrews (NICNT)",
+              "note": "Cockerill reads Hebrews 12:22-24 as a realized-eschatological application of Second Temple Jewish heavenly-assembly imagery. The worshiping church on earth already participates in the cosmic liturgy the apocalyptic tradition envisioned."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg (Hermeneia 1 Enoch) analyzes the 1 Enoch 14 throne-room as the most elaborate Jewish heavenly-temple vision before Revelation. The 'myriads of angels' formula is an Enochic signature that Daniel 7, Hebrews 12, and Revelation 5 all share."
+            },
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical biblical theology",
+              "note": "Beale traces heavenly-Jerusalem imagery from Ezekiel 40-48 through 1 Enoch and 4 Ezra to Hebrews 12 and Revelation 21. The NT inherits this tradition-stream and centers it on Christ as the liturgical location of the heavenly assembly."
+            }
+          ],
+          "takeaway": "Hebrews 12:22's 'innumerable angels in festal gathering' and 'heavenly Jerusalem' draw on Second Temple Jewish apocalyptic imagery — most elaborately 1 Enoch 14's throne-room vision and 4 Ezra's Lady-Jerusalem — and apply it as realized-eschatology to the present Christian worshiping community. The imagery is Jewish; the realized-eschatological framing is specifically NT."
         }
       }
     },

--- a/content/hebrews/13.json
+++ b/content/hebrews/13.json
@@ -133,6 +133,38 @@
         "hist": {
           "historical": "Hebrews was written to Jewish Christians facing pressure to abandon their faith and return to Judaism. The destruction of the Jerusalem temple (AD 70) loomed or had just occurred, removing the visible center of Jewish worship. The author argues that Christ fulfills and supersedes all Old Testament institutions — priesthood, sacrifice, covenant, and tabernacle. The recipients faced persecution (10:32-34), some were drifting away (2:1), and the letter urges perseverance by demonstrating Christ's superiority to angels, Moses, Joshua, and the Levitical priesthood. The sophisticated Greek style and extensive use of the Septuagint suggest a Hellenistic Jewish-Christian author addressing a similarly educated audience, possibly in Rome (13:24).",
           "context": "The final chapter shifts to practical exhortations. The opening verses address community life: love for fellow believers, hospitality to strangers, compassion for prisoners and the mistreated. The warning against love of money leads to the promise of divine presence (Deuteronomy 31:6) and the confidence of Psalm 118:6: The Lord is my helper; I will not fear. The ethical exhortations are grounded in theological realities."
+        },
+        "st2": {
+          "header": "Angels Unawares: Hebrews 13:2 and the Tobit Tradition",
+          "body": "Hebrews 13:2 counsels: 'Do not neglect to show hospitality to strangers, for thereby some have entertained angels unawares.' The statement is arresting in its matter-of-factness — angels, disguised as travelers, sometimes accept hospitality from human hosts who do not recognize their true identity. The primary biblical referent is Abraham's three visitors at Mamre (Genesis 18, expanded by the NT into a broader tradition), but the specific formulation in Hebrews carries echoes of a second, much later biblical witness: the Book of Tobit.\n\nTobit 5 narrates exactly this scenario. The aged Tobit, blind and sending his son Tobias on a journey, hires a guide named Azariah who describes himself as 'Azariah son of Ananias' — a plausible human lineage. Tobit and his family treat the guide with hospitality; the young Tobias travels with him, marries under his guidance, and returns home. Only at the end of the book (Tobit 12:15) does the traveler reveal his true identity: 'I am Raphael, one of the seven holy angels who stand ready and enter before the glory of the Lord.' The Tobit family had been entertaining an angel unawares for the entire duration of their hospitality.\n\nMost commentators (Cockerill, Lane, Ellingworth) treat Tobit as the most probable proximate source for Hebrews 13:2's formulation — the Genesis 18 Abraham-and-visitors narrative was the foundational case, but Tobit made the 'unawares' motif a narrative commonplace of Second Temple Jewish piety. The phrase 'entertained angels unawares' (elathon tines xenisantes aggelous) is dense enough in Greek that translators consistently render it as a near-proverb, and the proverb-form almost certainly circulated in 1st-century Jewish-Christian communities who knew both the Genesis Abraham tradition and the Tobit Raphael narrative.\n\nThis matters for the Hebrews author's rhetorical move. He is not simply invoking a vague possibility of angel-encounters; he is appealing to a specific tradition that would have resonated with his audience. Jewish-Christian readers would have heard 'angels unawares' and thought both of Abraham and of Tobit's Raphael. The ethical force of the verse — hospitality is worth extending because you don't know who your guest might really be — draws on an entire narrative-theological reservoir.\n\nThe canonical implications are the familiar pattern. Tobit is deuterocanonical in Catholic, Orthodox, and Ethiopian Bibles; apocryphal in the Protestant canon. Hebrews 13:2's allusion to Tobit does not settle canonical status but does illustrate how deeply Second Temple Jewish devotional literature shaped the NT's moral reasoning. The ethical force of the verse works equally well in either canonical framework — what matters is the shared Jewish narrative-theological reservoir.",
+          "extrabiblical_ids": [
+            "tobit"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Hebrews 13:2",
+              "source": "Tobit 5 + 12:15 (Raphael unrecognized); Genesis 18 (Abraham at Mamre)",
+              "type": "allusion"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "cockerill",
+              "tradition": "Evangelical Hebrews (NICNT)",
+              "note": "Cockerill identifies Tobit as the proximate source for Hebrews 13:2's 'angels unawares' formulation. The Tobit-Raphael narrative made this motif a proverb-like commonplace in Second Temple Jewish devotion."
+            },
+            {
+              "scholar_id": "lane",
+              "tradition": "Evangelical Hebrews (WBC)",
+              "note": "Lane notes the layered allusion — Genesis 18's Abraham-and-visitors underlies the formulation, but the 'unawares' emphasis (the host's ignorance of the guest's identity) is Tobit's distinctive angle. Hebrews inherits both."
+            },
+            {
+              "scholar_id": "davids",
+              "tradition": "Evangelical NT (general)",
+              "note": "Davids notes the ethical rhetoric: Hebrews appeals to familiar Jewish narrative-theological tradition (Tobit's Raphael) to anchor hospitality as a Christian obligation with cosmic stakes."
+            }
+          ],
+          "takeaway": "Hebrews 13:2's 'angels unawares' proverb draws on Genesis 18's Abraham and — more proximately — Tobit 5+12:15's Raphael narrative. Tobit is Catholic/Orthodox/Ethiopian canon, Protestant apocrypha; the ethical force of Hebrews 13:2 works in either framework. Reading Hebrews with awareness of Tobit deepens the allusion."
         }
       }
     },

--- a/content/mark/13.json
+++ b/content/mark/13.json
@@ -172,6 +172,44 @@
         },
         "hist": {
           "context": "The Olivet Discourse is Jesus’s extended eschatological teaching, prompted by the disciples’ amazement at the Temple’s grandeur. Jesus’s prediction that not one stone will be left (v.2) was fulfilled in AD 70 when Titus destroyed Jerusalem. The discourse weaves together near-term events (the Jerusalem siege) and far-term events (the Son of Man’s coming) in a way that has produced sustained interpretive disagreement."
+        },
+        "st2": {
+          "header": "The Desolating Sacrilege: Mark 13's Danielic-Enochic Background",
+          "body": "Mark 13 is the Markan version of the Olivet Discourse, parallel to Matthew 24 and Luke 21. Mark's distinctive editorial note — 'let the reader understand' (13:14) — signals that Jesus's reference to 'the abomination of desolation (to bdelugma tes eremoseos) standing where it ought not to be' is an encoded reference the reader is invited to decode. The decoding requires Second Temple Jewish apocalyptic literacy, specifically familiarity with Daniel and with 1 Maccabees's application of Daniel's prophecy.\n\nDaniel uses the phrase 'the abomination that makes desolate' (Hebrew shiqquts meshomem) three times: Daniel 9:27, 11:31, 12:11. In Daniel's context (6th-2nd century depending on dating) the phrase refers to a pagan profanation of the Jerusalem Temple that cuts off regular sacrifice for a limited period. The LXX Greek bdelugma tes eremoseos became the standard translation.\n\n1 Maccabees 1:54 identifies the Danielic 'abomination of desolation' with a specific historical event: on the 15th of Kislev, 167 BC, Antiochus IV Epiphanes 'erected a desolating sacrilege on the altar of burnt offering' in the Jerusalem Temple — most probably an altar or image of Olympian Zeus. The sacrifice of unclean animals there, the cessation of Jewish worship for three years, and the eventual Maccabean rededication in 164 BC provided the original historical fulfillment of Daniel's oracle. By Jesus's day 'abomination of desolation' was a charged symbol in the Jewish apocalyptic imagination — it meant a pagan profanation of the Temple serious enough to trigger eschatological reckoning.\n\nMark 13:14's 'let the reader understand' invites a fresh identification. The text Mark wrote c. 65-70 AD was probably published in a Jewish-Christian community facing the Jewish War and the Roman siege of Jerusalem. The reader is invited to understand that the Temple's coming destruction — being perpetrated by Titus's Roman legions — is a new 'abomination of desolation' comparable to and fulfilling beyond Antiochus's. Some scholars argue for a specific event: Titus's setting of Roman ensigns with imperial iconography in the Temple courts during the siege; others for the general cultic disruption of the war period.\n\n1 Enoch provides the apocalyptic-eschatological layer. 1 Enoch 1:9's theophanic judgment ('Behold, the Lord comes with his myriads of holy ones') is the template for Mark 13:26's 'Son of Man coming in clouds with great power and glory.' 1 Enoch's Book of Dreams (especially the Animal Apocalypse, chs 85-90) narrates eschatological tribulation climaxing in theophany in patterns Mark 13 presupposes. 1 Enoch 46-48's Son of Man imagery (the Parables, chs 37-71) provides the nearest Jewish parallel to Jesus's self-designation in Mark 13:26.\n\nMark is not creating Jesus's apocalyptic teaching from 1 Enoch; he is reporting Jesus's inhabitation of a shared Jewish apocalyptic vocabulary that 1 Enoch, Daniel, and 1 Maccabees all participate in. The 'desolating sacrilege' is Daniel + 1 Maccabees; the theophanic advent is Daniel + 1 Enoch; the tribulation-framework is the broader Jewish apocalyptic tradition. Mark's reader is invited to decode the whole tradition-complex, not just one source.",
+          "extrabiblical_ids": [
+            "1_enoch",
+            "1_maccabees"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Mark 13:14",
+              "source": "Daniel 9:27, 11:31, 12:11 + 1 Maccabees 1:54 (historical abomination under Antiochus IV)",
+              "type": "direct_quotation"
+            },
+            {
+              "nt": "Mark 13:26-27",
+              "source": "1 Enoch 1:9 theophany + 1 Enoch 46-48 Son of Man",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "marcus",
+              "tradition": "Evangelical-critical Mark",
+              "note": "Marcus's AB Mark commentary treats Mark 13:14 as a deliberately encoded reference inviting the reader to decode via Daniel + 1 Maccabees + the contemporary Jewish War. The 'desolating sacrilege' is a charged symbol from the Antiochean crisis being redeployed for the 70 AD Temple destruction."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (Second Temple)",
+              "note": "Nickelsburg connects the Mark 13 apocalyptic discourse to the broader Jewish apocalyptic tradition — 1 Enoch, Daniel, 1 Maccabees, 4 Ezra, 2 Baruch — in which eschatological tribulation, cosmic disturbance, and theophanic advent are shared vocabulary."
+            },
+            {
+              "scholar_id": "keener",
+              "tradition": "Evangelical NT (backgrounds)",
+              "note": "Keener emphasizes the 1 Maccabees 1:54 hinge: 'abomination of desolation' was not an abstract phrase in 1st-century Jewish ears — it specifically meant the Antiochean crisis of 167 BC, which created a template for interpreting subsequent threats to Temple worship. Mark's 'let the reader understand' assumes this literacy."
+            }
+          ],
+          "takeaway": "Mark 13:14's 'abomination of desolation' draws on Daniel's oracle + 1 Maccabees's historical fulfillment under Antiochus IV. The Markan text invites the reader to decode the coming Roman siege of Jerusalem as a new fulfillment. The theophanic climax draws on 1 Enoch's Son of Man and judgment imagery."
         }
       }
     },

--- a/content/matthew/24.json
+++ b/content/matthew/24.json
@@ -155,6 +155,43 @@
         },
         "hist": {
           "context": "The Olivet Discourse (chs.24-25) is Matthew's fifth and final discourse. The first half addresses signs preceding the end: birth pains (wars, famines, persecution), the abomination, the great distress, and false messiahs. The discourse interweaves near fulfilment (Jerusalem, AD 70) and far fulfilment (the Son of Man's return) simultaneously."
+        },
+        "st2": {
+          "header": "The Olivet Discourse and the Animal Apocalypse of 1 Enoch",
+          "body": "Matthew 24 is the longest sustained eschatological teaching in the Synoptic tradition — Jesus's answer on the Mount of Olives to the disciples' double question about the destruction of the Temple and the sign of his coming at the end of the age. The imagery is dense with Second Temple Jewish apocalyptic vocabulary: 'wars and rumors of wars' (v6), 'famines and earthquakes' (v7), 'the abomination of desolation' (v15), 'great tribulation such as has not been from the beginning of the world' (v21), 'false christs and false prophets' (v24), 'the sun will be darkened, the moon will not give its light, the stars will fall from heaven' (v29), 'the Son of Man coming on the clouds of heaven with power and great glory' (v30).\n\nThe closest sustained Second Temple parallel is the Animal Apocalypse — 1 Enoch chapters 85-90, part of the Book of Dreams written during the Maccabean crisis (c. 165 BC). The Animal Apocalypse narrates Israel's history zoomorphically: Adam as a white bull, the patriarchs as bulls of various colors, Israel as sheep, Gentiles as beasts of prey. It culminates in a final eschatological battle — the sheep oppressed by wild animals, shepherds (the 70 angelic overseers) failing or colluding, then a climactic theophany: the Lord descending with his host, the unjust shepherds judged, the books opened, the bulls and sheep dwelling peacefully, a new 'white bull' arising as the messianic figure.\n\nSpecific parallels between Matt 24 and the Animal Apocalypse: (1) eschatological tribulation preceded by wars, betrayal, and apostasy; (2) false shepherds / false christs leading the flock astray; (3) cosmic disturbance — stars falling, sun and moon darkened; (4) climactic advent of the divine/messianic figure on the clouds with angelic host; (5) final judgment with books opened. The vocabulary is not word-for-word borrowing; it is shared apocalyptic vocabulary that both the Animal Apocalypse and Matt 24 draw from a common Jewish tradition pool.\n\nThe 'abomination of desolation' in Matt 24:15 is the most explicit direct citation — Jesus refers the disciples 'to what was spoken by the prophet Daniel' (Dan 9:27, 11:31, 12:11). But the Danielic abomination had already been interpreted in 1 Maccabees 1:54 as the specific desecration of the Jerusalem Temple under Antiochus IV Epiphanes in 167 BC. By Jesus's day the 'abomination of desolation' was a charged Jewish apocalyptic symbol that could be re-applied to any pagan profanation of the Temple — which is precisely what Jesus does, redirecting the Danielic oracle to the Temple's destruction in 70 AD (with broader eschatological resonance).\n\nThe synoptic apocalyptic of Matt 24 / Mark 13 / Luke 21 is not a new genre; it is Jesus inhabiting an existing Jewish apocalyptic vocabulary and redirecting its reference-frame around his own person and the coming destruction of Jerusalem. The Animal Apocalypse and similar Second Temple Jewish texts provide the closest literary context for how this vocabulary functioned in 1st-century Jewish hearing.",
+          "extrabiblical_ids": [
+            "1_enoch"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Matthew 24:15",
+              "source": "Daniel 9:27, 11:31, 12:11 + 1 Maccabees 1:54 (abomination of desolation)",
+              "type": "direct_quotation"
+            },
+            {
+              "nt": "Matthew 24:21-30",
+              "source": "1 Enoch 85-90 (Animal Apocalypse) + 1 Enoch 1:9 theophany",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "keener",
+              "tradition": "Evangelical NT (cultural backgrounds)",
+              "note": "Keener (Matthew commentary + IVP Background Commentary) traces the Second Temple apocalyptic vocabulary Jesus inherits — cosmic disturbance, false christs, clouds-of-heaven advent — across 1 Enoch, Daniel, and broader Jewish apocalyptic. Matt 24 inhabits an existing vocabulary rather than inventing one."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg's Hermeneia 1 Enoch treats the Animal Apocalypse (chs 85-90) as the fullest Second Temple narrative of eschatological tribulation climaxing in messianic advent. Matt 24's imagery draws from this tradition-stream even when the specific verbal links are loose."
+            },
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical biblical theology",
+              "note": "Beale emphasizes the Daniel-centered intertextuality of Matt 24 (abomination of desolation, Son of Man on clouds) with 1 Enoch and related Jewish apocalyptic as the interpretive medium through which 1st-century audiences heard Jesus's Danielic allusions."
+            }
+          ],
+          "takeaway": "Matt 24's Olivet Discourse inhabits Second Temple Jewish apocalyptic vocabulary — Danielic (abomination of desolation), Maccabean (1 Macc 1:54's profaned altar), Enochic (Animal Apocalypse's eschatological tribulation). Jesus redirects the inherited vocabulary around his own person and the 70 AD Temple destruction with broader eschatological resonance."
         }
       }
     },

--- a/content/revelation/20.json
+++ b/content/revelation/20.json
@@ -107,6 +107,40 @@
         },
         "hist": {
           "context": "Revelation 20:1–6 is arguably the most debated passage in the entire book, generating the three major eschatological systems that have divided Christianity for centuries. The binding of Satan (vv. 1–3) by an angel with 'the key to the Abyss and a great chain' raises the question of whether this is a future event following the second coming (premillennial view), a present reality initiated by Christ's first coming (amillennial view), or a future period of increasing gospel success (postmillennial view). The 'thousand years' during which the martyrs reign with Christ (vv. 4–6) is the central interpretive crux. The 'first resurrection' (v. 5) is either physical (bodily resurrection of believers before the millennium) or spiritual (regeneration or heavenly enthronement), with significant grammatical and contextual arguments on both sides. The fifth beatitude—'Blessed and holy are those who share in the first resurrection' (v. 6)—assures participants that 'the second death has no power over them,' linking resurrection status to immunity from final judgment. The passage must be read in light of its broader canonical context: Daniel 7:9–27, Isaiah 24–27, Ezekiel 37–39, and 1 Corinthians 15:20–28."
+        },
+        "st2": {
+          "header": "The Thousand-Year Reign: Revelation 20 and Second Temple Millennial Imagery",
+          "body": "Revelation 20:1-6 describes an angel descending from heaven with a great chain, seizing the dragon (the devil, Satan), binding him for a thousand years, and casting him into the abyss. During this thousand years the martyrs who had refused to worship the beast reign with Christ; at the thousand years' end, Satan is released for a final brief rebellion before the last judgment. The thousand-year reign (millennium, chiliastic era) has generated perhaps more interpretive debate than any other passage in Revelation — amillennialists, premillennialists, postmillennialists, and various symbolic readings have competed across Christian history. Whatever the eschatological interpretation preferred, the imagery's Second Temple Jewish roots deserve examination.\n\nThe 'thousand years' motif draws on several Jewish apocalyptic traditions. Psalm 90:4 ('a thousand years in your sight are but as yesterday when it is past') and the wordplay with 2 Peter 3:8 ('one day as a thousand years') established a theological link between 'a day' and 'a thousand years.' Genesis 1's six-day creation plus Sabbath rest became, in some Second Temple Jewish reflection, a template for cosmic history: six thousand years of world-history followed by a thousand-year messianic Sabbath — a pattern later called 'chiliastic' or 'millennial' in Christian usage. 2 Enoch 33:1-2 explicitly develops this: 'And on the eighth day I [God] also appointed, that the eighth day should be the first-created after my work, and that the first seven revolve in the form of the seventh thousand, and that at the beginning of the eighth thousand there should be a time of not-counting, endless.' The cosmic week of seven thousands + endless eighth-day is 2 Enoch's cosmology.\n\nJubilees provides a related framework. Jubilees organizes all history into 'jubilees' of 49 years each, with the total sweep of world-history carefully chronologized. Jubilees 23:26-31 envisions an eschatological age in which life-spans lengthen dramatically — 'their lives will approach a thousand years, and their days will be many and in years' — echoing Isaiah 65:20's vision of the new age. This is not strictly millennial but is a Second Temple vision of extended eschatological life. 4 Ezra 7 develops a specific messianic-interim doctrine: a Messiah reigns for 400 years, dies, and then the final judgment and new creation follow. The number differs from Revelation 20's thousand, but the structural pattern — interim messianic reign before final judgment — is the same.\n\nThe Qumran literature (especially the War Scroll) develops an eschatological-battle framework in which the sons of light defeat the sons of darkness in a climactic war, then an age of righteousness follows. The binding of Belial (the chief demonic adversary) in 1QM parallels Revelation 20's binding of Satan.\n\nWhat Revelation does with this inherited vocabulary is distinctive: the thousand-year reign is specifically Christic — the martyrs reign with Christ; the thousand is explicitly numbered (unlike the more general 'extended age' of Jubilees and 4 Ezra); the binding of Satan is explicit and reversible (he is loosed for a final rebellion). These details are Revelation's own contribution. But the underlying imagery-pool — extended eschatological interim, binding of chief adversary, reign of righteousness, final cosmic reversal — is shared Second Temple Jewish apocalyptic tradition.",
+          "extrabiblical_ids": [
+            "2_enoch",
+            "jubilees",
+            "4_ezra"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Revelation 20:1-6",
+              "source": "2 Enoch 33:1-2 (cosmic week of thousands); Jubilees 23:26-31 (extended eschatological life); 4 Ezra 7 (messianic interim)",
+              "type": "allusion"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical Revelation (NIGTC)",
+              "note": "Beale surveys the Second Temple sources (2 Enoch, Jubilees, 4 Ezra, 1 Enoch) for millennial imagery and concludes that Revelation 20 draws on shared apocalyptic vocabulary rather than any single source. His own position is amillennial, but he acknowledges the text's debt to Jewish apocalyptic traditions of extended eschatological interim."
+            },
+            {
+              "scholar_id": "osborne",
+              "tradition": "Evangelical Revelation",
+              "note": "Osborne traces the '1,000 year' number specifically to the Psalm 90 + Genesis 1 cosmic-week tradition developed in 2 Enoch 33 + rabbinic 'six thousand years and then the world to come' reflection. The millennium is Revelation's inheritance of this Jewish cosmological framework, not a cosmological innovation."
+            },
+            {
+              "scholar_id": "vanderkam",
+              "tradition": "Critical (Second Temple)",
+              "note": "VanderKam's work on Jubilees and the DSS highlights the structural pattern — finite interim age, binding of cosmic adversary, final age of righteousness — across Second Temple Jewish apocalyptic. Revelation 20 participates in this tradition; whether the 'thousand' is literal, symbolic, or a specific number in a larger symbolic framework depends on interpretive tradition."
+            }
+          ],
+          "takeaway": "Revelation 20's thousand-year reign draws on Second Temple Jewish cosmic-week tradition (2 Enoch 33's cosmic-sevens, Jubilees 23's extended eschatological life, 4 Ezra 7's messianic interim). The distinctive Christian move: the interim is specifically Christ-reigning-with-the-martyrs. Interpretive debate on the millennium's literal/symbolic status is ancient and ongoing; the imagery-pool is inherited Jewish apocalyptic."
         }
       }
     },

--- a/content/revelation/4.json
+++ b/content/revelation/4.json
@@ -114,6 +114,43 @@
         },
         "hist": {
           "context": "Chapter 4 marks a decisive literary transition: from the earthly setting of the seven churches to the heavenly throne room that controls all subsequent visions. The 'door standing open in heaven' (v. 1) and the invitation to 'come up here' transport John from Patmos to the cosmic control center. The vision draws extensively on three OT throne visions: Isaiah 6 (seraphim crying 'Holy, holy, holy'), Ezekiel 1 (four living creatures, wheels, expanse, throne above), and Daniel 7 (thrones set in place, the Ancient of Days). John synthesizes all three into a unified vision that becomes the theological foundation for everything that follows. The twenty-four elders are variously interpreted as: (1) representatives of the twelve tribes and twelve apostles (the complete people of God), (2) an angelic council (cf. the divine council of 1 Kgs 22:19; Ps 89:7), or (3) heavenly counterparts of the twenty-four priestly courses established by David (1 Chr 24:1-19). Their white clothes and golden crowns identify them as victorious, royal figures who derive their authority from the one on the throne."
+        },
+        "st2": {
+          "header": "The Throne Room: Revelation 4-5 and 1 Enoch 14",
+          "body": "Revelation 4-5 inaugurates the main vision-cycle of the Apocalypse with one of the most elaborate heavenly-throne-room scenes in all ancient literature. John sees a door standing open in heaven, enters 'in the Spirit,' and witnesses the enthroned God, the four living creatures, the twenty-four elders, the scroll with seven seals, and the Lamb standing as if slain. The imagery has roots across the Hebrew Bible — Isaiah 6's seraph-vision, Ezekiel 1's chariot-throne, Daniel 7's Ancient of Days. But the closest single literary precedent for the extended heavenly-temple tour Revelation 4-5 performs is 1 Enoch 14.\n\n1 Enoch 14:8-25 describes Enoch's ascent to the heavenly throne-room. He passes through walls of hail and flames of fire, arrives at a 'great house built of crystals,' and then a second house 'larger than the former, in the middle of which was a throne.' The throne is 'like crystal,' its wheels 'like the shining sun,' with cherubim underneath. 'The Great Glory' sits on the throne in garments 'brighter than the sun' and 'whiter than snow.' Ten thousand times ten thousand angels stand before him; 'the sanctuary was filled with incense,' and no one can approach because of the glory. Enoch falls on his face at the vision's conclusion.\n\nNearly every element of this vision reappears in Revelation 4: the throne, the crystal-like sea 'like glass,' the precious-stone-like appearance of the enthroned one (4:3), the myriads of angels (5:11 — 'ten thousand times ten thousand'), the incense-offering (5:8), the falling-down of the worshipers (4:10, 5:14). The structural sequence is parallel: ascent into heavenly temple, vision of the enthroned one, angelic myriads, liturgical worship.\n\nThe distinctive Christian element is the Lamb. In 1 Enoch 14 the focus remains entirely on the enthroned 'Great Glory' (God); there is no secondary figure receiving worship. Revelation 5 introduces a decisive Christian christological move: the Lamb standing between the throne and the living creatures, having taken the scroll the enthroned God held, receiving the universal worship of every creature. The transition from Rev 4 to Rev 5 is the Christian transformation of the Jewish apocalyptic throne-room vision: from God-enthroned-alone to God-and-the-Lamb-worshiped-together, 'to him who sits on the throne and to the Lamb' (5:13).\n\nDaniel 7:9-10 provides a second major source: the Ancient of Days on a throne of fiery flames, with 'a thousand thousands served him, and ten thousand times ten thousand stood before him,' books opened in judgment. Revelation 4-5 weaves together Daniel's and 1 Enoch's throne-room visions into a distinctively Christian climax — the Lamb who was slain now shares the throne and receives the worship.\n\n2 Enoch's ten-heavens ascent (chs 3-22) and 4 Ezra's vision of the heavenly Jerusalem (ch 10) add further Second Temple parallels, but 1 Enoch 14 remains the single closest source for the specific throne-room architecture and imagery Revelation 4 develops. Revelation is not creating apocalyptic throne-room imagery ex nihilo; it is inheriting and transforming a tradition that stretches from Ezekiel through Daniel to 1 Enoch and arrives in John's hand for christological reshaping.",
+          "extrabiblical_ids": [
+            "1_enoch"
+          ],
+          "citation_refs": [
+            {
+              "nt": "Revelation 4:1-11",
+              "source": "1 Enoch 14:8-25 (throne-room ascent); Daniel 7:9-10 (Ancient of Days)",
+              "type": "allusion"
+            },
+            {
+              "nt": "Revelation 5:11",
+              "source": "1 Enoch 14:22 + Daniel 7:10 (ten thousand times ten thousand)",
+              "type": "echo"
+            }
+          ],
+          "scholar_voices": [
+            {
+              "scholar_id": "beale",
+              "tradition": "Evangelical Revelation (NIGTC)",
+              "note": "Beale's massive Revelation commentary treats 1 Enoch 14 as the single closest literary precedent for Rev 4's throne-room architecture, with Ezekiel 1 and Daniel 7 as older canonical sources also in view. Rev 5's introduction of the Lamb is the Christian novum against this backdrop."
+            },
+            {
+              "scholar_id": "osborne",
+              "tradition": "Evangelical Revelation",
+              "note": "Osborne emphasizes Revelation's inheritance of the full Jewish apocalyptic tradition — Isaiah, Ezekiel, Daniel, 1 Enoch, 2 Enoch, 4 Ezra — and the christological centering around the Lamb as Revelation's distinctive contribution."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (1 Enoch)",
+              "note": "Nickelsburg treats the 1 Enoch 14 throne-room as the benchmark Second Temple Jewish heavenly-temple vision. Revelation 4-5 participates in this tradition rather than simply borrowing; the vocabulary of crystal, myriads, enthroned Glory, incense, and prostration is shared apocalyptic language."
+            }
+          ],
+          "takeaway": "Revelation 4-5's throne-room vision participates in the Second Temple Jewish heavenly-temple tradition (Ezekiel 1, Daniel 7, 1 Enoch 14, 2 Enoch, 4 Ezra), with 1 Enoch 14 as the nearest single literary precedent. The distinctive Christian move: from God-enthroned-alone to God-and-the-Lamb-worshiped-together in Rev 5."
         }
       }
     },


### PR DESCRIPTION
## What this does
Phase-4 `st2` panel expansion. Adds **12 new panels** across Hebrews, the Pauline corpus, Synoptic apocalyptic, and Revelation. Together with the 7 panels from HWGTB-P1-06 (PR #1591), total `st2` panel count rises to **19** (issue's target was 23; shortfall explained below).

## Closes
Closes #1554

## Panels authored (12)

### Hebrews (4)
| Anchor | extrabib sources | Section |
|---|---|---|
| Heb 1:3 | `wisdom_of_solomon` (Wis 7:26 → "radiance") | hebrews/1 S1 |
| Heb 11:5 | `sirach`, `1_enoch` (Sir 44:16 → Enoch pleased God) | hebrews/11 S2 |
| Heb 12:22 | `1_enoch`, `4_ezra` (1 En 14 throne-room + 4 Ezra Jerusalem) | hebrews/12 S4 |
| Heb 13:2 | `tobit` (Tob 5 + 12:15 — Raphael / angels unawares) | hebrews/13 S1 |

### Pauline (4)
| Anchor | extrabib sources | Section |
|---|---|---|
| Gal 3:19 | `jubilees` (Jub 1:27-29 angel-of-presence) | galatians/3 S3 |
| Eph 6:12 | `1_enoch`, `damascus_document` (Watchers + cosmic warfare) | ephesians/6 S2 |
| 2 Thess 2 | `4_ezra` (Eagle Vision + man of lawlessness) | 2_thessalonians/2 S1 |
| 1 Tim 5:21 | `1_enoch` (elect vs fallen Watchers) | 1_timothy/5 S3 |

### Synoptic apocalyptic (2)
| Anchor | extrabib sources | Section |
|---|---|---|
| Matt 24 | `1_enoch` (Animal Apocalypse) | matthew/24 S1 |
| Mark 13 | `1_enoch`, `1_maccabees` (Son of Man + desolating sacrilege) | mark/13 S1 |

### Revelation (2)
| Anchor | extrabib sources | Section |
|---|---|---|
| Rev 4-5 | `1_enoch` (1 En 14 throne-room) | revelation/4 S1 |
| Rev 20 | `2_enoch`, `jubilees`, `4_ezra` (cosmic week + extended age) | revelation/20 S1 |

Word counts: 390–520 per body. All within or slightly below the 400–700 floor; accurate to each passage's explanatory need. **3 scholar voices per panel**, spanning evangelical / critical / Second-Temple-specialist.

## Issue scope-lock compliance ✅

> Every `extrabiblical_ids[]` reference in the 15 new panels must resolve to one of the 12 entries shipped by HWGTB-P1-04.

Every `extrabiblical_ids[]` value in this PR resolves to one of the 12 Phase-1 entries. **Zero new entries added to `content/meta/extrabiblical.json`.**

## Panels NOT authored (3 of the 15 listed) — filed as follow-up

Per the issue's acceptance criterion *"any panel that required a non-existent extrabiblical ID is filed as a separate follow-up issue, not forced into this PR"*:

1. **1 Cor 10:4** — the "rock that followed" draws on the rabbinic Targum Onkelos / Tosefta Sukkah 3:11–12 tradition, which is **not in the 12-entry Phase-1 extrabiblical seed**.
2. **Luke 16:22** — Abraham's bosom references 2 Maccabees 7 / 4 Maccabees martyr-afterlife. **1 Maccabees is in the seed, but 2 and 4 Maccabees are not.**
3. **Heb 11:32 substitute** — the issue said to substitute Heb 11:32 for Heb 11:35-37 if the latter was already shipped (which it is, via PR #1591 on hebrews/11 S7 "Catalogue of the Faithful"). **Heb 11:32 falls in the same section as 11:35-37**; the `st2` schema allows only one `st2` per section, so adding a second panel would require restructuring Heb 11's sections — out of scope.

These 3 gaps should become follow-up issues to file before a subsequent PR can close them.

## How I verified

- `python _tools/schema_validator.py` — **136481 passed, 78 failed** (77 pre-existing baseline + 1 known artifact: "No unregistered scholars in panels — 12 unregistered st2". This clears automatically once **#1540 / PR #1588** merges to master and adds `'st2'` to the validator's `non_scholar_panels` set. This is the **same pattern** as PR #1591's validator output.)

## Merge order

**Depends on**:
- **#1540 (PR #1588)** — st2 panel validator; without it the "unregistered scholars" check fires on every st2 panel
- **#1541 (PR #1589)** — 12 extrabiblical entries, so `extrabiblical_ids[]` resolve in `validate_sqlite`

Both dependencies also gate PR #1591 (the original 7 st2 panels); they will be merged together before this PR lands.

## Rollback
Revert this PR. 12 chapter JSON files return to their prior state; 12 st2 rows disappear from `section_panels` on next build. No schema changes, no user.db impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa)_