### PR TITLE
feat(app): wire premium gating for HWGTB bundle (#1555)

### DIFF
--- a/app/__tests__/components/PanelContainer.test.tsx
+++ b/app/__tests__/components/PanelContainer.test.tsx
@@ -44,4 +44,57 @@ describe('PanelContainer', () => {
     // Verify it rendered something (not null)
     expect(root?.type).toBe('View');
   });
+
+  // HWGTB #1555 — st2 panels honor premium props threaded from
+  // ChapterScreen → PanelContainer → PanelRenderer → SecondTemplePanel.
+  describe('st2 premium gating', () => {
+    const st2Json = JSON.stringify({
+      header: "Jude's Use of Second Temple Literature",
+      body: 'In these twelve verses Jude draws on two works outside the Hebrew canon.',
+      extrabiblical_ids: ['1_enoch'],
+      citation_refs: [{ nt: 'Jude 14-15', source: '1 Enoch 1:9', type: 'direct_quotation' }],
+      scholar_voices: [],
+      takeaway: 'NT citation does not equal canonicity.',
+    });
+
+    it('free tier renders the upgrade CTA teaser', () => {
+      const { getByText } = renderWithProviders(
+        <PanelContainer
+          panelType="st2"
+          contentJson={st2Json}
+          isOpen
+          isPremium={false}
+        />,
+      );
+      expect(getByText(/Unlock Second Temple Context/)).toBeTruthy();
+    });
+
+    it('free tier tap on teaser fires onUpgradePress', () => {
+      const onUpgradePress = jest.fn();
+      const { getByLabelText } = renderWithProviders(
+        <PanelContainer
+          panelType="st2"
+          contentJson={st2Json}
+          isOpen
+          isPremium={false}
+          onUpgradePress={onUpgradePress}
+        />,
+      );
+      fireEvent.press(getByLabelText('Unlock Second Temple Context'));
+      expect(onUpgradePress).toHaveBeenCalledTimes(1);
+    });
+
+    it('premium tier renders the full body (no teaser)', () => {
+      const { getByText, queryByText } = renderWithProviders(
+        <PanelContainer
+          panelType="st2"
+          contentJson={st2Json}
+          isOpen
+          isPremium
+        />,
+      );
+      expect(getByText(/In these twelve verses Jude draws/)).toBeTruthy();
+      expect(queryByText(/Unlock Second Temple Context/)).toBeNull();
+    });
+  });
 });

--- a/app/__tests__/components/UpgradePrompt.test.tsx
+++ b/app/__tests__/components/UpgradePrompt.test.tsx
@@ -34,4 +34,21 @@ describe('UpgradePrompt', () => {
     fireEvent.press(getByText('Not Now'));
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
+
+  // HWGTB #1555 — copy deck for the four bundle features. Regression guard
+  // against the FEATURE_DESCRIPTIONS lookup falling back to the generic
+  // "Unlock {name} and other premium study tools." fallback.
+  describe('HWGTB feature descriptions', () => {
+    it.each([
+      ['Extra-Biblical Literature', /1 Enoch, Jubilees, the Apocrypha/],
+      ['Canon Comparison', /Protestant, Catholic, Orthodox, and Ethiopian/],
+      ['How We Got The Bible', /canon formation and textual transmission/],
+      ['Second Temple Context', /Intertestamental literature background/],
+    ])('shows the description for "%s"', (featureName, expected) => {
+      const { getByText } = renderWithProviders(
+        <UpgradePrompt {...defaultProps} featureName={featureName} />,
+      );
+      expect(getByText(expected)).toBeTruthy();
+    });
+  });
 });

--- a/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
+++ b/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
@@ -84,11 +84,6 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     expect(getByText('Guided Journeys')).toBeTruthy();
   });
 
-  it('Canon Comparison shows "Coming soon" label (HWGTB-P3-01 not yet shipped)', () => {
-    const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
-    expect(getByLabelText('Coming soon')).toBeTruthy();
-  });
-
   it('tapping Extra-Biblical Literature navigates to ExtraBiblicalIndex', () => {
     const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
     fireEvent.press(getByLabelText('Open Extra-Biblical Literature'));
@@ -103,11 +98,12 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     });
   });
 
-  it('Canon Comparison entry has no onPress handler (no navigation fired)', () => {
-    const { queryByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
-    // When locked, the container is a View (not TouchableOpacity) so it
-    // has no 'Open Canon Comparison' accessibility label.
-    expect(queryByLabelText('Open Canon Comparison')).toBeNull();
+  // HWGTB #1555 — CanonComparisonScreen shipped in #1550, so this entry is
+  // now live (the "Coming soon" label is gone).
+  it('tapping Canon Comparison navigates to CanonComparison', () => {
+    const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
+    fireEvent.press(getByLabelText('Open Canon Comparison'));
+    expect(mockNavigate).toHaveBeenCalledWith('CanonComparison');
   });
 
   it('back button fires navigation.goBack', () => {

--- a/app/src/components/ChapterReaderContext.tsx
+++ b/app/src/components/ChapterReaderContext.tsx
@@ -65,6 +65,14 @@ interface DisplayState {
   focusMode: boolean;
 }
 
+// ── Premium state (HWGTB #1555) ──
+// Lets PanelContainer render locked teasers for st2 panels without
+// prop-drilling from ChapterScreen.
+interface PremiumState {
+  isPremium: boolean;
+  onUpgradePress: () => void;
+}
+
 export interface ChapterReaderContextValue {
   verse: VerseState;
   panel: PanelState;
@@ -72,6 +80,7 @@ export interface ChapterReaderContextValue {
   layout: LayoutCallbacks;
   coaching: CoachingState;
   display: DisplayState;
+  premium: PremiumState;
 }
 
 const ChapterReaderCtx = createContext<ChapterReaderContextValue | null>(null);

--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -51,7 +51,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
   chapterMeta,
 }: Props) {
   const { base } = useTheme();
-  const { verse, panel, callbacks, layout, coaching, display } = useChapterReader();
+  const { verse, panel, callbacks, layout, coaching, display, premium } = useChapterReader();
   const relatedItems = useRelatedContent(chapterMeta, chapterPanels);
   const { chipData } = useMapChipData(chapterMeta?.map_story_link_id);
   const navigation = useNavigation();
@@ -137,6 +137,8 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
                 isOpen
                 onClose={callbacks.clearActivePanel}
                 onRefPress={callbacks.onRefPress}
+                isPremium={premium.isPremium}
+                onUpgradePress={premium.onUpgradePress}
                 defaultTab={
                   panel.openPanel?.tabKey && panel.openPanel.panelType === p.panel_type
                     ? panel.openPanel.tabKey
@@ -165,7 +167,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
 
       return elements;
     });
-  }, [sections, verse, panel, callbacks, layout, coaching, display, handlePanelLongPress]);
+  }, [sections, verse, panel, callbacks, layout, coaching, display, premium, handlePanelLongPress]);
 
   return (
     <>

--- a/app/src/components/PanelContainer.tsx
+++ b/app/src/components/PanelContainer.tsx
@@ -28,6 +28,11 @@ interface Props {
   onPersonPress?: (name: string) => void;
   onPlacePress?: (name: string) => void;
   onEventPress?: (name: string) => void;
+  /** Chip tap on st2 panels — deep-link to ExtraBiblicalDetail (HWGTB #1548). */
+  onExtraBiblicalPress?: (extrabiblicalId: string) => void;
+  /** Premium gating for st2 panels (HWGTB #1555). */
+  isPremium?: boolean;
+  onUpgradePress?: () => void;
   /** Override the initial tab for composite panels (deep-link). */
   defaultTab?: string;
 }
@@ -36,6 +41,9 @@ export function PanelContainer({
   panelType, contentJson, isOpen, onClose,
   onRefPress, onWordStudyPress, onScholarPress,
   onPersonPress, onPlacePress, onEventPress,
+  onExtraBiblicalPress,
+  isPremium,
+  onUpgradePress,
   defaultTab,
 }: Props) {
   const { base, getPanelColors } = useTheme();
@@ -83,6 +91,9 @@ export function PanelContainer({
           onPersonPress={onPersonPress}
           onPlacePress={onPlacePress}
           onEventPress={onEventPress}
+          onExtraBiblicalPress={onExtraBiblicalPress}
+          isPremium={isPremium}
+          onUpgradePress={onUpgradePress}
           defaultTab={defaultTab}
         />
       </PanelCallbacksProvider>

--- a/app/src/components/UpgradePrompt.tsx
+++ b/app/src/components/UpgradePrompt.tsx
@@ -48,6 +48,10 @@ const FEATURE_DESCRIPTIONS: Record<string, string> = {
   'Bible Periods': 'Explore all 12 eras of biblical history with key people, books, themes, and the redemptive thread connecting each period.',
   'The Story of the Bible': 'Trace the 8-act redemptive narrative from Creation to Restoration — see how every chapter fits into God\'s story.',
   'Person Journey': 'Follow key biblical figures across multiple books — see their full arc from calling to legacy.',
+  'Extra-Biblical Literature': 'Scholarly entries on 1 Enoch, Jubilees, the Apocrypha, Dead Sea Scrolls — what they are, what they contain, and why traditions treated them differently.',
+  'Canon Comparison': 'Side-by-side Protestant, Catholic, Orthodox, and Ethiopian canons — see what each includes and why.',
+  'How We Got The Bible': 'Two deep journeys tracing canon formation and textual transmission, from oral tradition to modern English translations.',
+  'Second Temple Context': 'Intertestamental literature background on NT passages that cite or allude to 1 Enoch, Jubilees, and other extra-biblical sources.',
 };
 
 export function UpgradePrompt({ visible, onClose, variant, featureName }: Props) {

--- a/app/src/components/panels/PanelRenderer.tsx
+++ b/app/src/components/panels/PanelRenderer.tsx
@@ -46,6 +46,9 @@ interface Props {
   onEventPress?: (name: string) => void;
   /** Chip tap on st2 panels — deep-link to ExtraBiblicalDetail (HWGTB #1548). */
   onExtraBiblicalPress?: (extrabiblicalId: string) => void;
+  /** Premium gating for st2 panels (HWGTB #1555). */
+  isPremium?: boolean;
+  onUpgradePress?: () => void;
   /** Override the initial tab for composite panels (deep-link). */
   defaultTab?: string;
 }
@@ -55,6 +58,8 @@ export function PanelRenderer({
   onRefPress, onWordStudyPress, onScholarPress,
   onPersonPress, onPlacePress, onEventPress,
   onExtraBiblicalPress,
+  isPremium,
+  onUpgradePress,
   defaultTab,
 }: Props) {
   const { base } = useTheme();
@@ -163,6 +168,8 @@ export function PanelRenderer({
             onRefPress={onRefPress}
             onScholarPress={onScholarPress}
             onExtraBiblicalPress={onExtraBiblicalPress}
+            isPremium={isPremium}
+            onUpgradePress={onUpgradePress}
           />
         );
       }

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -129,6 +129,10 @@ function ChapterScreen() {
     setActiveLens(lensId);
   }, [isPremium, showUpgrade]);
 
+  const handleSecondTempleUpgrade = useCallback(() => {
+    showUpgrade('feature', 'Second Temple Context');
+  }, [showUpgrade]);
+
   // Load book data for nav
   useEffect(() => {
     if (bookId) getBook(bookId).then(setBookData);
@@ -338,6 +342,7 @@ function ChapterScreen() {
             dismissedTips, onDismissTip: handleDismissTip,
           }}
           display={{ focusMode }}
+          premium={{ isPremium, onUpgradePress: handleSecondTempleUpgrade }}
         >
           <ChapterVerseList
             sections={sections}

--- a/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
+++ b/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
@@ -45,10 +45,9 @@ function HowWeGotTheBibleLandingScreen() {
     navigation.navigate('ExtraBiblicalIndex');
   }, [navigation]);
 
-  // Canon Comparison screen lands in HWGTB-P3-01 (#1550). The route is
-  // typed ahead in ExploreStackParamList so this handler stays ready;
-  // until #1550 ships it's surfaced as "Coming soon" with a no-op.
-  const canonComparisonReady = false;
+  // Canon Comparison screen ships with HWGTB-P3-01 (#1550) — route is
+  // registered in ExploreStackParamList and navigable from here.
+  const canonComparisonReady = true;
   const goCanonComparison = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     navigation.navigate('CanonComparison' as any);


### PR DESCRIPTION
## Summary

Threads the `usePremium` hook's `isPremium` + upgrade handler from `ChapterScreen` down through the panel render pipeline to `SecondTemplePanel` so `st2` panels show a free-tier teaser ("Unlock Second Temple Context" CTA) and the full body on premium. Also wires the four HWGTB-bundle `FEATURE_DESCRIPTIONS` into `UpgradePrompt` and flips the Canon Comparison "Coming soon" placeholder now that `CanonComparisonScreen` has shipped (#1550).

## Threading path

```
ChapterScreen (usePremium)
  → ChapterReaderProvider.premium
    → ChapterVerseList
      → PanelContainer
        → PanelRenderer ('st2' case)
          → SecondTemplePanel
```

`SecondTemplePanel` itself already accepted `isPremium` / `onUpgradePress` from the #1546 scaffold — this PR is the wiring, not the panel rewrite.

## Files touched

- `app/src/components/UpgradePrompt.tsx` — 4 new `FEATURE_DESCRIPTIONS` (Extra-Biblical Literature, Canon Comparison, How We Got The Bible, Second Temple Context)
- `app/src/components/ChapterReaderContext.tsx` — add `premium` slot
- `app/src/components/ChapterVerseList.tsx` — read `premium`, thread to `PanelContainer`
- `app/src/components/PanelContainer.tsx` — accept + thread `isPremium` / `onUpgradePress` / `onExtraBiblicalPress`
- `app/src/components/panels/PanelRenderer.tsx` — accept + thread to `st2` case
- `app/src/screens/ChapterScreen.tsx` — `handleSecondTempleUpgrade` calls `showUpgrade('feature', 'Second Temple Context')`; provide `premium={}` to the context
- `app/src/screens/HowWeGotTheBibleLandingScreen.tsx` — flip `canonComparisonReady = true`

## Tests

- `app/__tests__/components/UpgradePrompt.test.tsx` — 4 new tests assert each HWGTB `FEATURE_DESCRIPTIONS` entry renders (regression guard against the generic "Unlock {name}" fallback)
- `app/__tests__/components/PanelContainer.test.tsx` — 3 new tests cover the `st2`-premium threading path (free-tier CTA, upgrade tap, premium full-body)
- `app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx` — replaces "Coming soon" expectation with navigation assertion

## Out of scope / deferred

Gating for `ExtraBiblicalIndexScreen`, `ExtraBiblicalDetailScreen`, and `CanonComparisonScreen` — those screens live on separate feature branches (#1547 / #1548 / #1550). They'll be gated in a follow-up PR after those land on master.

## Merge order

Needs the following merged to master first so the base compiles:
- #1595 — SecondTemplePanel (`st2` case in PanelRenderer + SecondTemplePanel component)
- #1598 — Explore hero card + `HowWeGotTheBibleLandingScreen`
- #1550 — `CanonComparisonScreen` (so the `canonComparisonReady = true` flip lands on a branch that navigates to an existing route)

## Validation

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings (4 pre-existing, unrelated)
- [x] `npx jest UpgradePrompt PanelContainer SecondTemplePanel ChapterScreen HowWeGotTheBibleLandingScreen` → 54 pass, 0 fail

## Test plan

- [ ] Free tier: open an NT chapter with an `st2` panel (e.g. Jude 1); tap the panel button; teaser renders with "Unlock Second Temple Context" CTA; tap CTA → `UpgradePrompt` modal with the correct copy
- [ ] Premium tier: same flow renders the full body, citations, scholar voices, takeaway
- [ ] Canon Comparison card on `HowWeGotTheBibleLandingScreen` is tappable (not "Coming soon") and navigates to `CanonComparisonScreen`

Implements HWGTB-P5-01.

https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa

---
_Generated by [Claude Code](https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa)_