### PR TITLE
tools: accuracy extractors for extrabiblical + canon_traditions (#1556)

### DIFF
--- a/_tools/accuracy_meta_extractors.py
+++ b/_tools/accuracy_meta_extractors.py
@@ -53,6 +53,8 @@ class MetaClaimExtractor:
         claims.extend(self.extract_places())
         claims.extend(self.extract_map_stories())
         claims.extend(self.extract_cross_refs())
+        claims.extend(self.extract_extrabiblical())
+        claims.extend(self.extract_canon_traditions())
         return claims
 
     def _load(self, filename: str):
@@ -910,5 +912,241 @@ class MetaClaimExtractor:
                     verse_ref=None,
                     verification_tier=2,
                 ))
+
+        return claims
+
+    # ── Extra-Biblical Literature (HWGTB #1538 / #1556) ─────────
+
+    def extract_extrabiblical(self) -> list[Claim]:
+        """Extract claims from extrabiblical.json.
+
+        Covers 1 Enoch, Jubilees, Tobit, the Dead Sea Scrolls, etc. —
+        the Second Temple literature the Companion Study surfaces under
+        the "How We Got The Bible" bundle. Claim types:
+          - historical (summaries, dates, languages, NT citations)
+          - cross_reference (nt_citations / ot_allusions verse refs)
+          - scholar_attribution (scholar_voices entries)
+        """
+        data = self._load("extrabiblical.json")
+        if not data or not isinstance(data, list):
+            return []
+
+        claims = []
+        for entry in data:
+            eid = entry.get("id", "unknown")
+            title = entry.get("title", "")
+
+            # Brief summary — high-level historical claim
+            brief = entry.get("brief_summary", "")
+            if brief and len(brief) > 30:
+                claims.append(Claim(
+                    id=_meta_id("extrabib", eid, 0),
+                    chapter_id="meta_extrabiblical",
+                    book_dir="meta",
+                    section_num=None,
+                    panel_type="extrabiblical_entry",
+                    claim_type="historical",
+                    claim_text=f"[{title} — brief] {brief}",
+                    source_attribution=None,
+                    verse_ref=None,
+                    verification_tier=2,
+                ))
+
+            # Full summary — deeper historical claim (long-form)
+            full = entry.get("full_summary", "")
+            if full and len(full) > 30:
+                claims.append(Claim(
+                    id=_meta_id("extrabib", eid, 1),
+                    chapter_id="meta_extrabiblical",
+                    book_dir="meta",
+                    section_num=None,
+                    panel_type="extrabiblical_entry",
+                    claim_type="historical",
+                    claim_text=f"[{title} — full] {full}",
+                    source_attribution=None,
+                    verse_ref=None,
+                    verification_tier=2,
+                ))
+
+            # Estimated date / original language — historical metadata
+            for field, offset in [("estimated_date", 2), ("original_language", 3)]:
+                text = entry.get(field, "")
+                if text and len(text) > 10:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, offset),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="historical",
+                        claim_text=f"[{title} — {field}] {text}",
+                        source_attribution=None,
+                        verse_ref=None,
+                        verification_tier=2,
+                    ))
+
+            # NT citations — cross-reference claims (NT verse + source book).
+            # Schema: {"ref": "Jude 14-15", "cites": "1 Enoch 1:9", "type": "..."}
+            for j, cite in enumerate(entry.get("nt_citations", [])):
+                ref = cite.get("ref", "")
+                cites = cite.get("cites", "")
+                ctype = cite.get("type", "")
+                if ref:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, 100 + j * 2),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="cross_reference",
+                        claim_text=ref,
+                        source_attribution=None,
+                        verse_ref=ref,
+                        verification_tier=0,
+                    ))
+                if ref and cites:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, 100 + j * 2 + 1),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="historical",
+                        claim_text=f"[{title}: {ref} {ctype or 'cites'} {cites}]",
+                        source_attribution=None,
+                        verse_ref=ref or None,
+                        verification_tier=2,
+                    ))
+
+            # OT allusions — cross-reference claims.
+            # Schema: {"ref": "Genesis 6:1-4", "connection": "..."}
+            for j, allu in enumerate(entry.get("ot_allusions", [])):
+                ref = allu.get("ref", "")
+                connection = allu.get("connection", "")
+                if ref:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, 200 + j * 2),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="cross_reference",
+                        claim_text=ref,
+                        source_attribution=None,
+                        verse_ref=ref,
+                        verification_tier=0,
+                    ))
+                if connection and len(connection) > 20:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, 200 + j * 2 + 1),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="historical",
+                        claim_text=f"[{title}: {ref}] {connection}",
+                        source_attribution=None,
+                        verse_ref=ref or None,
+                        verification_tier=2,
+                    ))
+
+            # Scholar voices — scholar_attribution.
+            # Schema: {"scholar_id": "...", "position": "..."}
+            for j, voice in enumerate(entry.get("scholar_voices", [])):
+                scholar_id = voice.get("scholar_id", "")
+                position = voice.get("position", "")
+                if position and len(position) > 30:
+                    claims.append(Claim(
+                        id=_meta_id("extrabib", eid, 300 + j),
+                        chapter_id="meta_extrabiblical",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="extrabiblical_entry",
+                        claim_type="scholar_attribution",
+                        claim_text=f"[{title}] {position}",
+                        source_attribution=scholar_id,
+                        verse_ref=None,
+                        verification_tier=3,
+                    ))
+
+        return claims
+
+    # ── Canon Traditions (HWGTB #1539 / #1556) ──────────────────
+
+    def extract_canon_traditions(self) -> list[Claim]:
+        """Extract claims from canon_traditions.json.
+
+        Covers the Protestant / Catholic / Eastern Orthodox / Ethiopian
+        Tewahedo canon entries. Claim types:
+          - historical (short_description, distinctives, formation_events)
+          - cross_reference (not applicable — book lists are validated by
+            the schema, not the accuracy audit)
+        """
+        data = self._load("canon_traditions.json")
+        if not data or not isinstance(data, list):
+            return []
+
+        claims = []
+        for tradition in data:
+            tid = tradition.get("id", "unknown")
+            label = tradition.get("label", tid)
+
+            # Short description — historical summary of the tradition
+            desc = tradition.get("short_description", "")
+            if desc and len(desc) > 30:
+                claims.append(Claim(
+                    id=_meta_id("canon", tid, 0),
+                    chapter_id="meta_canon",
+                    book_dir="meta",
+                    section_num=None,
+                    panel_type="canon_tradition",
+                    claim_type="historical",
+                    claim_text=f"[{label}] {desc}",
+                    source_attribution=None,
+                    verse_ref=None,
+                    verification_tier=2,
+                ))
+
+            # Distinctives — each is a historical/theological claim about
+            # what makes this tradition's canon different.
+            for j, dist in enumerate(tradition.get("distinctives", [])):
+                title = dist.get("title", "")
+                detail = dist.get("detail", "")
+                if detail and len(detail) > 30:
+                    claims.append(Claim(
+                        id=_meta_id("canon", tid, 100 + j),
+                        chapter_id="meta_canon",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="canon_tradition",
+                        claim_type="historical",
+                        claim_text=f"[{label} — {title}] {detail}",
+                        source_attribution=None,
+                        verse_ref=None,
+                        verification_tier=2,
+                    ))
+
+            # Formation events — dated historical claims (councils,
+            # confessions, translations).
+            for j, evt in enumerate(tradition.get("formation_events", [])):
+                year = evt.get("year", "")
+                ev_label = evt.get("label", "")
+                detail = evt.get("detail", "")
+                if detail and len(detail) > 30:
+                    year_str = f"{year} AD" if isinstance(year, int) and year >= 0 else (
+                        f"{abs(year)} BC" if isinstance(year, int) else str(year)
+                    )
+                    claims.append(Claim(
+                        id=_meta_id("canon", tid, 200 + j),
+                        chapter_id="meta_canon",
+                        book_dir="meta",
+                        section_num=None,
+                        panel_type="canon_tradition",
+                        claim_type="historical",
+                        claim_text=f"[{label} — {year_str} — {ev_label}] {detail}",
+                        source_attribution=None,
+                        verse_ref=None,
+                        verification_tier=2,
+                    ))
 
         return claims

--- a/_tools/accuracy_verifiers.py
+++ b/_tools/accuracy_verifiers.py
@@ -584,6 +584,8 @@ class Tier0Verifier:
                 "book_intro", "prophecy_chain", "concept", "topic",
                 "word_study", "timeline", "synoptic", "place",
                 "map_story", "cross_ref_thread", "cross_ref_pair", "people",
+                # HWGTB bundle (#1538 / #1539 / #1556)
+                "extrabiblical_entry", "canon_tradition",
             }
             is_meta = claim.panel_type in META_PANEL_TYPES
 


### PR DESCRIPTION
## Summary

Wires the two HWGTB meta tables (`extrabiblical.json` / `canon_traditions.json`) into the accuracy audit pipeline so the new content is graded alongside debate topics, difficult passages, prophecy chains, etc.

Adds 168 new claims to the corpus (10,422 → 10,590 total).

## Claim breakdown

**117 extrabiblical claims** across the 12 seeded entries:
- 58 historical (brief summary, full summary, estimated_date, original_language, OT allusion notes)
- 37 scholar_attribution (one per `scholar_voices[]` entry)
- 22 cross_reference (NT citation refs + OT allusion refs — all validated by Tier 0)

**51 canon_tradition claims** across the 4 traditions:
- All historical: short_description, each distinctive title+detail, each formation event with BC/AD-formatted year

## Files touched

- `_tools/accuracy_meta_extractors.py`
  - `MetaClaimExtractor.extract_extrabiblical` — `nt_citations` use `ref`/`cites`/`type`; `ot_allusions` use `ref`/`connection`; `scholar_voices` use `scholar_id`/`position` per the real schema
  - `MetaClaimExtractor.extract_canon_traditions` — `short_description`, `distinctives[]` (title + detail), `formation_events[]` (year, label, detail) with BC/AD year formatting
  - `extract_all()` registers both new methods

- `_tools/accuracy_verifiers.py`
  - `extrabiblical_entry` + `canon_tradition` added to `META_PANEL_TYPES` so the Tier 0 scholar-format check exempts them (they don't correspond to `panel_key`s in the scholar_validator registry)

## Validation

- Dry-run extractor: `MetaClaimExtractor().extract_all()` → **10,590 claims** (up from 10,422 on master — exactly +168)
- Full Tier 0 audit: `python3 _tools/accuracy_auditor.py --meta-only --tier 0 --no-save --json` →
  ```json
  {"corpus_average": 100.0, "chapters_audited": 1, "total_claims": 10590, "elapsed_seconds": 2.2}
  ```
- Tier 0/1 over just the 168 new claims: **22 SKIPPED** (cross-refs validated), **146 UNVERIFIED** (queued for Tier 2/3 API), **0 FLAGGED** — same distribution shape as existing meta extractors.

## Out of scope

- Tier 2/3 API-backed verification of the 146 queued historical/scholar claims — that's ongoing corpus work that the full audit run picks up automatically next time it's executed with Tier 2+ against an API key.

## Merge order

No dependencies — extracts from `content/meta/extrabiblical.json` (#1538, merged) and `content/meta/canon_traditions.json` (#1539, merged), both already on master.

## Test plan

- [x] `python3 _tools/accuracy_auditor.py --meta-only --tier 0 --no-save --json` returns `{"total_claims": 10590, ...}` with zero errors
- [x] New claims verify cleanly through Tier 0/1 (22 SKIPPED, 146 UNVERIFIED, 0 FLAGGED)
- [ ] Next full audit run with Tier 2/3 API access picks up the 146 new historical/scholar claims

Implements HWGTB-P5-02.

https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa

---
_Generated by [Claude Code](https://claude.ai/code/session_017PjHtcT6nwsAAzUvHXZYXa)_