### PR TITLE
content: full_summary + cross-links for 12 extrabiblical entries (collapses chain #1605–#1619)

### DIFF
--- a/content/meta/extrabiblical.json
+++ b/content/meta/extrabiblical.json
@@ -2,7 +2,10 @@
   {
     "id": "1_enoch",
     "title": "1 Enoch (Ethiopic Enoch)",
-    "also_known_as": ["Book of Enoch", "Ethiopic Enoch"],
+    "also_known_as": [
+      "Book of Enoch",
+      "Ethiopic Enoch"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "3rd c. BC – 1st c. AD (composite)",
     "original_language": "Aramaic (portions in Hebrew); preserved in full only in Ge'ez (Classical Ethiopic), with substantial Greek fragments and Aramaic copies of every section except the Similitudes at Qumran",
@@ -13,33 +16,84 @@
       "ethiopian_tewahedo": "canonical (part of the Broader Canon)"
     },
     "brief_summary": "1 Enoch is a composite Jewish apocalyptic work attributed to the antediluvian patriarch Enoch (Gen 5:18–24). Its five major sections — the Book of the Watchers (chs 1–36), the Similitudes or Book of Parables (chs 37–71), the Astronomical Book (chs 72–82), the Book of Dreams (chs 83–90), and the Epistle of Enoch (chs 91–105) — were composed over roughly four centuries, from the third century BC into the first century AD.\n\nThe Book of the Watchers expands the cryptic narrative of Genesis 6:1–4, recounting the rebellion of the angelic 'Watchers' who took human wives, fathered the giants (Nephilim), and taught humanity forbidden arts, bringing cosmic disorder that the Flood is meant to reverse. The Astronomical Book presents a 364-day solar calendar; the Dreams section contains the Animal Apocalypse, an allegorical vision of Jewish history from Adam to the Maccabean revolt; the Epistle warns the wicked rich and consoles the righteous poor; and the Similitudes develops the figure of a heavenly 'Son of Man' who will judge the nations.\n\nOriginally written in Aramaic — fragments of every section except the Similitudes have been recovered at Qumran — the book circulated in Greek in late antiquity but survives in full only in Ge'ez (Classical Ethiopic). The Epistle of Jude quotes 1 Enoch 1:9 directly (Jude 14–15), making it the only explicit quotation of an extra-biblical book in the New Testament.\n\nEarly Christian writers received 1 Enoch variously. Tertullian defended it as Scripture on the basis of Jude's citation; Origen cited it with respect; Augustine and Jerome argued against canonical status while acknowledging its antiquity. By the fourth century the Greek-speaking and Latin churches had effectively excluded it. The Ethiopian Tewahedo Church, however, preserved the full Ge'ez text and includes 1 Enoch in its biblical canon — the only Christian tradition to do so.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\n1 Enoch is the most important Second Temple Jewish work outside the Hebrew Bible. Composed in Aramaic and Hebrew across roughly four centuries (c. 300 BC – 100 AD), it survives complete only in Ethiopic Geʽez, with substantial fragments in Aramaic at Qumran, Greek in the Chester Beatty papyri and Codex Panopolitanus, and Coptic in the Akhmim fragments. The book purports to record heavenly visions and cosmic journeys granted to the antediluvian patriarch Enoch — the seventh from Adam, who 'walked with God, and he was not, for God took him' (Gen 5:24). Its five distinct books, composed by different authors at different times, form together the single most influential body of Jewish apocalyptic literature ever produced, shaping angelology, demonology, eschatology, and messianic thought from the Maccabean crisis through the writing of the New Testament.\n\n## Composition history\n\nModern scholarship — primarily the work of Józef Milik (1976 on the Aramaic fragments), Michael Knibb (1978 on the Ethiopic), George Nickelsburg (Hermeneia volume 1, 2001), and James VanderKam (Hermeneia volume 2, 2012, with Nickelsburg) — has established that 1 Enoch is a composite work of five originally independent books, which we designate by modern scholarly convention:\n\n- **Book of the Watchers** (chs 1–36), c. 300–200 BC — the oldest stratum, attested in Aramaic at Qumran (4QEn^a, 4QEn^b)\n- **Book of Parables** (chs 37–71), c. 1st century BC – early 1st century AD — the only book NOT attested at Qumran, giving rise to the debated question of whether it predates the NT\n- **Astronomical Book / Book of the Luminaries** (chs 72–82), c. 300–200 BC — separate circulation in an earlier and longer Aramaic form than the Ethiopic abridgment preserves\n- **Book of Dreams** (chs 83–90), c. 165 BC, including the Animal Apocalypse — composed during the Maccabean crisis\n- **Epistle of Enoch** (chs 91–108), c. 170–100 BC, including the Apocalypse of Weeks (93:1–10 + 91:11–17) and the Book of Noah fragments\n\nThe Aramaic fragments from Qumran preserve substantial portions of Watchers, Dreams, Astronomical Book, and Epistle — confirming pre-Christian Jewish origin for all sections except the Parables. The Parables' absence from Qumran fuels scholarly debate: most non-sectarian 1st-century-AD date (Collins, Nickelsburg, VanderKam), some argue for later Christian interpolation (Milik originally), but the consensus has settled on a Second Temple Jewish origin prior to 70 AD.\n\n## Contents\n\n**The Book of the Watchers (1–36)** opens with a theophanic oracle (1:9 — 'Behold, the Lord comes with his myriads of holy ones to execute judgment on all') that Jude 14–15 quotes verbatim. The narrative proper begins at chapter 6: two hundred angels under the leadership of Shemihazah descend on Mount Hermon, take human wives in the days before the Flood, and father giant offspring — the Nephilim of Genesis 6:1–4. Their leaders Azazel (a secondary figure) reveal forbidden crafts to humanity: metallurgy, weapons, magic, cosmetics, astrology. Earth cries out under the resulting violence. The archangels Michael, Gabriel, Raphael, and Uriel petition God, who commands Raphael to bind Azazel in a dark valley 'until the day of his judgment' (10:4–6, 12), Michael to bind Shemihazah and his companions underground until the final judgment (10:12–14), and Uriel to warn Noah of the coming Flood. Enoch is then taken on cosmic tours (17–19, 20–36) through the abodes of the dead, the mountain of God, the seven heavens, the storehouses of the winds, and the tree of life — the first extended Jewish katabasis/anabasis narrative, which shapes every subsequent apocalypse including Revelation.\n\n**The Book of Parables (37–71)** contains three 'similitudes' of Enoch (38–44, 45–57, 58–69) developing the figure of the 'Son of Man' — a heavenly, preexistent messianic figure who sits on the throne of glory to judge kings, mighty ones, and fallen angels. The Parables' 'Son of Man' is the closest Second Temple parallel to the title Jesus uses of himself in the Gospels, and the debate about literary and conceptual dependence remains active. Chapter 71 concludes with Enoch's identification AS the Son of Man — a move most scholars now read as a later redactional seam rather than the Parables' core Christology.\n\n**The Astronomical Book (72–82)** offers a 364-day solar calendar against the lunar calendar of the Jerusalem Temple — a liturgical dispute that also shaped Jubilees and the Qumran community. The Parables' Book of Dreams (83–90) includes the 'Animal Apocalypse,' a zoomorphic history of Israel from Adam through the Maccabean revolt, with humans rendered as sheep, Gentiles as beasts of prey, the fallen angels as stars, and Judas Maccabeus as a great horned ram. The Epistle (91–108) includes the Apocalypse of Weeks, dividing world history into ten periods and locating the book's composition in the seventh.\n\n## Reception history\n\nIn Second Temple Judaism 1 Enoch circulated widely and authoritatively. The Qumran community preserved at least twelve manuscripts. Jubilees (c. 160 BC) presupposes and extends it. The Damascus Document (CD 2:18–21) summarizes the Watcher narrative. The Testaments of the Twelve Patriarchs (Reuben 5:6–7, Naphtali 3:5) allude to it. Sirach's 'great man' encomium of Enoch (Sir 44:16) and the Wisdom of Solomon's similar treatment (Wis 4:10–15) show that Enochic tradition was broadly embedded in Jewish devotional life.\n\nIn the New Testament, Jude 14–15 quotes 1 Enoch 1:9 with the formula 'Enoch, the seventh from Adam, prophesied' — the same formula Jude would use of any OT prophet. 2 Peter 2:4, Jude 6, and 1 Peter 3:19–20 all presuppose the Watcher tradition of bound angels awaiting judgment. Hebrews 11:5's account of Enoch draws on both Gen 5:24 and the broader Enochic framework.\n\nIn the early patristic period 1 Enoch was widely honored. Justin Martyr, Irenaeus, Tertullian, Clement of Alexandria, and Athenagoras all cite it approvingly — Tertullian (De Cultu Feminarum 1.3) explicitly defends its Scripture-status on the grounds of Jude's citation. From the 4th century onward the Latin and Greek churches moved away: Jerome, Augustine, and the post-Nicene mainstream treated 1 Enoch as apocryphal. The book was effectively lost to the Western and Greek-speaking churches by the 6th century.\n\nThe Ethiopian Orthodox Tewahedo Church alone preserved 1 Enoch as Scripture in continuous liturgical use, treating it as canonical within its 81-book narrower canon. When James Bruce returned from Ethiopia in 1773 with three Ethiopic manuscripts, the book was rediscovered by Europe after a 1,200-year absence. The 1947 Qumran find confirmed Ethiopian preservation was substantively accurate against a pre-Christian Jewish text.\n\n## NT and patristic usage\n\nThe NT's use of 1 Enoch is extensive enough to be conclusive: Jude quotes it as prophecy, 2 Peter and Jude presuppose its Watcher narrative, Hebrews draws on Enochic categories. But quotation is not canonization. The NT writers operated within a Jewish reading culture that honored 1 Enoch without treating it as Scripture in the later technical sense. Evangelical scholarship (Bauckham, Bruce, Schreiner, Kruger) consistently argues that Jude's use is parallel to Paul's citation of Greek poets (Aratus in Acts 17:28, Epimenides in Titus 1:12) — the specific content is affirmed without the source becoming canonical.\n\nThe patristic positions divided along similar lines. Tertullian's argument for 1 Enoch's canonicity was a minority view that did not prevail. Jerome's rejection in the 5th century and the emergence of the settled Latin-Greek canon made the book's exclusion the Western norm.\n\n## Scholarly positions\n\nContemporary scholarship is essentially unanimous that 1 Enoch is a pre-Christian Jewish work of enormous importance for understanding the thought-world of the New Testament. Debate focuses on narrower questions:\n\n- **Dating of the Parables**: most place chapters 37–71 in the 1st century BC or early 1st century AD; a minority (following Milik) argued for later date. The current consensus (Nickelsburg, VanderKam, Collins) is pre-70 AD Jewish origin.\n- **Relationship to Genesis 6:1–4**: 1 Enoch radically expands the terse Hebrew narrative. Whether Enoch is reading the 'plain sense' of Genesis or innovating on it is debated; Nickelsburg argues for legitimate exegetical expansion, while more conservative evangelical scholars sometimes treat the Enochic reading as going beyond Genesis.\n- **Canonical status**: the Ethiopian preservation is historically remarkable and theologically serious, but the mainstream Christian canonical traditions (Protestant, Catholic, Orthodox) do not receive 1 Enoch as Scripture.\n\n## Why different traditions treated it differently\n\nThe decisive factors were **manuscript transmission**, **theological suspicion of cosmological speculation**, and **the rise of rabbinic Judaism**. The Western churches lost access to the complete Greek text after the 6th century, leaving only Latin and patristic fragments. Rabbinic Judaism developed away from apocalyptic speculation toward halakhic (legal) focus, and 1 Enoch's cosmological concerns did not survive this shift. Christianity east of Chalcedon — especially Ethiopia, which maintained its own liturgical and canonical tradition through Coptic influence — preserved the book in active use. This is a story of manuscript history and theological emphasis, not of suppression or conspiracy.\n\n## Further reading\n\nThe standard English translation is Knibb (1978, Oxford). Nickelsburg's Hermeneia commentary is the definitive scholarly work. Charlesworth's Old Testament Pseudepigrapha (1983) includes E. Isaac's translation with introduction. For a readable introduction see VanderKam, An Introduction to Early Judaism (2nd ed., Eerdmans 2022). Online: Wesley Center for Applied Theology hosts the full Ethiopic text in English translation at legal-use quality.",
     "nt_citations": [
-      { "ref": "Jude 14-15", "cites": "1 Enoch 1:9", "type": "direct_quotation" }
+      {
+        "ref": "Jude 14-15",
+        "cites": "1 Enoch 1:9",
+        "type": "direct_quotation"
+      }
     ],
     "ot_allusions": [
-      { "ref": "Genesis 6:1-4", "connection": "The Book of the Watchers (chs 1–36) greatly expands the cryptic narrative of the sons of God and daughters of men, identifying the sons of God as fallen angels and the Nephilim as their offspring." },
-      { "ref": "Genesis 5:18-24", "connection": "Pseudepigraphically attributed to Enoch, who 'walked with God, and he was not, for God took him.'" }
+      {
+        "ref": "Genesis 6:1-4",
+        "connection": "The Book of the Watchers (chs 1–36) greatly expands the cryptic narrative of the sons of God and daughters of men, identifying the sons of God as fallen angels and the Nephilim as their offspring."
+      },
+      {
+        "ref": "Genesis 5:18-24",
+        "connection": "Pseudepigraphically attributed to Enoch, who 'walked with God, and he was not, for God took him.'"
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "nickelsburg", "position": "Traces the composite literary history across four centuries in the standard English-language Hermeneia commentary (1 Enoch 1 [2001]; 1 Enoch 2 [2012], with VanderKam). Notes that every section except the Similitudes is attested at Qumran in Aramaic, placing the core tradition firmly in Second Temple Judaism." },
-      { "scholar_id": "vanderkam", "position": "In his work on Jubilees and the Dead Sea Scrolls, treats 1 Enoch as part of a broader Enochic literary tradition whose 364-day solar calendar linked the book to the Qumran sectarians and distinguished them from the temple establishment in Jerusalem." },
-      { "scholar_id": "tertullian", "position": "In De Cultu Feminarum 1.3 defends the book against detractors, arguing that its rejection 'by some' (probably the rabbinic canon) does not bind Christians and that Jude's citation (Jude 14–15) is itself evidence of authoritative apostolic reception." },
-      { "scholar_id": "bruce", "position": "Evangelical NT perspective: Jude's citation shows the book was widely known and respected in some first-century Jewish-Christian circles, but citation does not entail canonisation — Paul likewise cites Greek poets in Acts 17 and Titus 1 without implying their inspiration." }
+      {
+        "scholar_id": "nickelsburg",
+        "position": "Traces the composite literary history across four centuries in the standard English-language Hermeneia commentary (1 Enoch 1 [2001]; 1 Enoch 2 [2012], with VanderKam). Notes that every section except the Similitudes is attested at Qumran in Aramaic, placing the core tradition firmly in Second Temple Judaism."
+      },
+      {
+        "scholar_id": "vanderkam",
+        "position": "In his work on Jubilees and the Dead Sea Scrolls, treats 1 Enoch as part of a broader Enochic literary tradition whose 364-day solar calendar linked the book to the Qumran sectarians and distinguished them from the temple establishment in Jerusalem."
+      },
+      {
+        "scholar_id": "tertullian",
+        "position": "In De Cultu Feminarum 1.3 defends the book against detractors, arguing that its rejection 'by some' (probably the rabbinic canon) does not bind Christians and that Jude's citation (Jude 14–15) is itself evidence of authoritative apostolic reception."
+      },
+      {
+        "scholar_id": "bruce",
+        "position": "Evangelical NT perspective: Jude's citation shows the book was widely known and respected in some first-century Jewish-Christian circles, but citation does not entail canonisation — Paul likewise cites Greek poets in Acts 17 and Titus 1 without implying their inspiration."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
-    "related_difficult_passage_ids": [],
-    "tags": ["apocalyptic", "watchers", "enochic-literature", "second-temple", "ethiopian-tewahedo-canon", "jude"],
+    "related_debate_ids": [
+      "did-jude-affirm-enoch-as-scripture",
+      "who-are-the-nephilim",
+      "second-temple-literature-and-nt-theology"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
+    "related_difficult_passage_ids": [
+      "jude-quotes-enoch",
+      "nephilim-sons-of-god",
+      "angels-that-sinned",
+      "jesus-preaching-to-spirits"
+    ],
+    "tags": [
+      "apocalyptic",
+      "watchers",
+      "enochic-literature",
+      "second-temple",
+      "ethiopian-tewahedo-canon",
+      "jude"
+    ],
     "further_reading": [
-      { "title": "1 Enoch 1: A Commentary on the Book of 1 Enoch Chapters 1–36; 81–108", "author": "George W. E. Nickelsburg", "note": "Hermeneia (Fortress, 2001)." },
-      { "title": "1 Enoch 2: A Commentary on the Book of 1 Enoch Chapters 37–82", "author": "George W. E. Nickelsburg and James C. VanderKam", "note": "Hermeneia (Fortress, 2012)." }
+      {
+        "title": "1 Enoch 1: A Commentary on the Book of 1 Enoch Chapters 1–36; 81–108",
+        "author": "George W. E. Nickelsburg",
+        "note": "Hermeneia (Fortress, 2001)."
+      },
+      {
+        "title": "1 Enoch 2: A Commentary on the Book of 1 Enoch Chapters 37–82",
+        "author": "George W. E. Nickelsburg and James C. VanderKam",
+        "note": "Hermeneia (Fortress, 2012)."
+      }
     ]
   },
   {
     "id": "2_enoch",
     "title": "2 Enoch (Slavonic Enoch)",
-    "also_known_as": ["Slavonic Enoch", "Book of the Secrets of Enoch"],
+    "also_known_as": [
+      "Slavonic Enoch",
+      "Book of the Secrets of Enoch"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "Probably 1st c. AD; later redaction in the Slavonic tradition",
     "original_language": "Most likely Greek (from a Hebrew or Aramaic Vorlage); preserved only in Old Church Slavonic in two recensions (longer and shorter)",
@@ -50,28 +104,57 @@
       "ethiopian_tewahedo": "not canonical"
     },
     "brief_summary": "2 Enoch — distinct from 1 Enoch despite the shared attribution — narrates Enoch's ascent through seven (or, in the longer recension, ten) heavens, his observation of cosmic order and the dwellings of the righteous and the wicked, his conversations with God, and his commissioning to instruct his sons before his final translation. Chapters 68–73 add a genealogy and priestly lineage that connects Enoch's line to Melchizedek, whose miraculous birth and priestly ministry the book develops at length.\n\nThe date of composition is debated. The dominant scholarly view places the original text in the first century AD, before the destruction of the Second Temple in 70 — the sacrificial descriptions in chs 59, 68–69 presuppose a functioning temple, and the astronomical material (chs 11–17) draws on pre-70 Jewish apocalyptic conventions. Other scholars argue for a slightly later date or for a more complex compositional history extending into later Jewish or Christian circles.\n\nThe most striking feature of 2 Enoch is the Melchizedek narrative in chs 68–73 (often printed as 2 Enoch 68–73 or as a separate text known as 2 Enoch/Melchizedek). It recounts the birth of Melchizedek from Noah's sister-in-law Sopanima after her death, his rescue by the archangel Michael, and his preservation through the Flood — material with no parallel in 1 Enoch or in Genesis 14.\n\nUnlike 1 Enoch, 2 Enoch has no attestation at Qumran and no quotation in the New Testament. It was effectively unknown to Western Christendom until Slavonic manuscripts were published in the nineteenth century. No Christian tradition has ever received it as canonical, though it is occasionally drawn on in Eastern Orthodox devotional and iconographic contexts. The book is nonetheless significant for mapping the variety of Second Temple speculation on cosmology, angelology, and priesthood.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\n2 Enoch, also called the Slavonic Apocalypse of Enoch or the Book of the Secrets of Enoch, is a Jewish pseudepigraphic apocalypse preserved complete only in Church Slavonic translation. Unlike its namesake 1 Enoch, 2 Enoch survives in no ancient Hebrew, Aramaic, Greek, or Ethiopic manuscript; its entire textual tradition passes through medieval Slavic manuscripts (long and short recensions), though a handful of Coptic fragments were identified by Joost Hagen in 2009. The work narrates Enoch's journey through ten heavens, the revelation of cosmic secrets, a highly developed merkabah mysticism, and — most distinctively — the conception and birth of the antediluvian priest-king Melchizedek.\n\n## Composition history\n\nThe dating of 2 Enoch is more contested than that of any other Second Temple pseudepigraphon. Arguments range across seven centuries. The 'early' position (Charles, Odeberg, Milik, Andersen, Orlov, Nickelsburg) places composition in the 1st century AD, before the Temple's destruction, on the grounds that chapters 68–73 presuppose Jerusalem Temple worship as a going concern and include Abel's sacrificial priesthood narrated with unselfconscious priestly detail that would read as archaism after 70 AD. The 'late' position (Maunder, Milik's later view, Meshchersky) argued for 9th–10th century Byzantine Christian composition. Most current scholarship has settled on a 1st-century AD Jewish origin in Egypt, with the long recension possibly reflecting later Christian glossing. The original language was almost certainly Greek, translated into Old Church Slavonic probably in the 10th–11th century during the Christianization of Rus' and the Balkans. The Coptic fragments Hagen identified in the Nag Hammadi area support the Egyptian-provenance theory.\n\n## Contents\n\n2 Enoch opens with Enoch aged 365 being taken up into heaven (chapter 1) — the same age at which Genesis 5:23 records his lifespan. Two angels, bright 'like ones flaming with fire,' carry him through ten heavens in succession. Each heaven contains distinct cosmological features:\n\n- **First heaven**: the angels responsible for stars, winds, and seasonal changes\n- **Second heaven**: prisoners of darkness — the fallen angels awaiting judgment (an obvious parallel to 1 Enoch's Watchers)\n- **Third heaven**: paradise, reserved for the righteous, containing the tree of life; and hell, reserved for the wicked, with rivers of fire\n- **Fourth heaven**: the movements of sun and moon, the solar gates through which the sun passes\n- **Fifth heaven**: the Watchers (Grigori) — another echo of 1 Enoch's tradition\n- **Sixth heaven**: the archangels who govern cosmic phenomena\n- **Seventh heaven**: the divine throne-room, where Enoch sees 'the Lord' on the throne of glory — the merkabah vision\n\nIn the long recension three additional heavens (eighth, ninth, tenth) are narrated, each reserved for progressively higher categories of angelic being. The tenth heaven contains God's own presence; Enoch is anointed with oil, clothed in garments of glory, and transformed into an angel-like being. This transformation narrative — Enoch becoming a heavenly figure — influenced 3 Enoch's subsequent Jewish mystical tradition and is the closest Jewish analogue to the NT's 'one like a son of man' transformation imagery.\n\nChapters 39–67 record God's direct revelations to Enoch: the creation narrative (chs 24–33, with distinctive speculative cosmology), instructions on worship and ethics (40–66), and a final charge to Enoch's descendants. Chapters 68–73 conclude with a patriarchal transition: Enoch returns to earth, instructs his son Methuselah, and departs again; Methuselah's priesthood is passed to Nir (Noah's brother), whose wife Sopanim miraculously conceives Melchizedek in her old age, without human agency. Melchizedek is born already fully grown, marked with a priestly seal on his chest, and — after Nir's death and the Flood — taken up by the archangel Michael. This Melchizedek nativity narrative is unique in Second Temple literature and parallels in striking ways both the Lukan nativity (virginal / miraculous conception) and Hebrews 7's treatment of Melchizedek (priest without genealogy, 'made like the Son of God').\n\n## Reception history\n\nWithin Judaism 2 Enoch had no significant rabbinic reception — the rabbis' turn away from apocalyptic after 70 AD left the book without a transmitting community. Within Christianity it circulated in the Greek East (the Coptic fragments testify to Egyptian use) but was not received as Scripture by any major church. Its preservation in Slavonic manuscripts from the 14th century onward reflects its value as edifying devotional literature within Slavic Orthodoxy without formal canonical status.\n\nThe book was unknown to Western scholarship until the 19th century. R. H. Charles included it in his 1896 collection of Jewish pseudepigrapha. Its significance for NT background studies increased throughout the 20th century as scholars recognized its parallels to Matthew's Beatitudes (2 Enoch 42–52 contain a series of 'Blessed is…' formulae with striking structural similarity), to Hebrews' Melchizedek Christology, and to Revelation's throne-room imagery.\n\n## NT and patristic usage\n\n2 Enoch is not directly quoted in the NT. Its significance is contextual: it shows us the thought-world of 1st-century Jewish apocalyptic from which NT authors drew their cosmological vocabulary. The heavenly ascent narrative, the tour of the seven (or ten) heavens, the transformation of the righteous into heavenly beings, the figure of Melchizedek as a heavenly priest — all of these circulate in 2 Enoch and in NT texts (2 Cor 12:2's 'third heaven,' Revelation's throne-room, Hebrews' priesthood theology) without requiring direct literary dependence either direction.\n\nPatristic writers occasionally allude to 2 Enoch material (Origen in De Principiis 1.3.3 possibly, though the reference is contested) but did not treat it as Scripture.\n\n## Scholarly positions\n\nThe major scholarly dispute over 2 Enoch concerns dating and provenance. Andrei Orlov (The Enoch-Metatron Tradition, 2005) makes the strongest case for 1st-century AD Alexandrian Jewish origin, building on Andersen's translation introduction. F. I. Andersen's contribution to Charlesworth's Old Testament Pseudepigrapha (1983) remains the standard English reference. Most current scholars accept pre-70 AD Jewish origin with some medieval Slavonic glossing.\n\nThe Melchizedek narrative in particular has drawn sustained attention. James Davila's work on Melchizedek traditions demonstrates parallel developments at Qumran (11QMelchizedek) and in Hebrews, with 2 Enoch's miraculous-conception narrative as a distinctive third witness to a broader 1st-century Jewish Melchizedek speculation. For Hebrews' Melchizedek Christology this is illuminating context, though not a source.\n\n## Why different traditions treated it differently\n\n2 Enoch's confinement to Slavic manuscripts is a testament to historical accident as much as theological judgment. The Greek original was lost; the Latin West never possessed it; the Jewish communities that once valued it disappeared or shifted focus; and only the Slavic translation community preserved the book as edifying — neither as canonical Scripture nor as suppressed apocrypha, but simply as a devotional text worth copying. No Christian communion treats it as Scripture. The Ethiopian canon, broad as it is, does not include 2 Enoch.\n\n## Further reading\n\nF. I. Andersen's translation and introduction in Charlesworth, Old Testament Pseudepigrapha (Doubleday, 1983) vol. 1, remains the standard English reference. Andrei Orlov's monographs (The Enoch-Metatron Tradition, Mohr Siebeck 2005) offer the most sustained scholarly analysis. Grant Macaskill's The Slavonic Texts of 2 Enoch (Brill 2013) includes an updated critical edition. For an accessible introduction see VanderKam's Introduction to Early Judaism (2nd ed., Eerdmans 2022) chapter 6.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Genesis 5:18-24", "connection": "Like 1 Enoch, pseudepigraphically attributed to the antediluvian patriarch Enoch." },
-      { "ref": "Genesis 14:18-20", "connection": "The Melchizedek narrative (chs 68–73) expands the Genesis 14 figure into a detailed pre-Flood origin story with no biblical parallel." }
+      {
+        "ref": "Genesis 5:18-24",
+        "connection": "Like 1 Enoch, pseudepigraphically attributed to the antediluvian patriarch Enoch."
+      },
+      {
+        "ref": "Genesis 14:18-20",
+        "connection": "The Melchizedek narrative (chs 68–73) expands the Genesis 14 figure into a detailed pre-Flood origin story with no biblical parallel."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "nickelsburg", "position": "Treats 2 Enoch as part of the broader Second Temple literary tradition that includes 1 Enoch and Jubilees, though noting that it stands at considerable distance from those texts in language and content. In Jewish Literature Between the Bible and the Mishnah, surveys the book's cosmology and its unparalleled Melchizedek material." },
-      { "scholar_id": "collins", "position": "Places 2 Enoch among the Second Temple apocalypses in his wider studies of apocalyptic literature, while cautioning that its composition history and textual transmission are considerably more obscure than those of 1 Enoch or 4 Ezra." }
+      {
+        "scholar_id": "nickelsburg",
+        "position": "Treats 2 Enoch as part of the broader Second Temple literary tradition that includes 1 Enoch and Jubilees, though noting that it stands at considerable distance from those texts in language and content. In Jewish Literature Between the Bible and the Mishnah, surveys the book's cosmology and its unparalleled Melchizedek material."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "Places 2 Enoch among the Second Temple apocalypses in his wider studies of apocalyptic literature, while cautioning that its composition history and textual transmission are considerably more obscure than those of 1 Enoch or 4 Ezra."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "second-temple-literature-and-nt-theology"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["apocalyptic", "enochic-literature", "second-temple", "melchizedek", "slavonic"],
+    "tags": [
+      "apocalyptic",
+      "enochic-literature",
+      "second-temple",
+      "melchizedek",
+      "slavonic"
+    ],
     "further_reading": [
-      { "title": "Old Testament Pseudepigrapha, vol. 1: Apocalyptic Literature and Testaments", "author": "James H. Charlesworth, ed.", "note": "Doubleday, 1983. Contains Francis I. Andersen's standard English translation of 2 Enoch with introduction." }
+      {
+        "title": "Old Testament Pseudepigrapha, vol. 1: Apocalyptic Literature and Testaments",
+        "author": "James H. Charlesworth, ed.",
+        "note": "Doubleday, 1983. Contains Francis I. Andersen's standard English translation of 2 Enoch with introduction."
+      }
     ]
   },
   {
     "id": "jubilees",
     "title": "Book of Jubilees",
-    "also_known_as": ["Lesser Genesis", "Leptogenesis"],
+    "also_known_as": [
+      "Lesser Genesis",
+      "Leptogenesis"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "c. 160–150 BC, in the early Maccabean period",
     "original_language": "Hebrew (fragments of roughly a dozen manuscripts at Qumran); preserved in full only in Ge'ez (Classical Ethiopic), partially in Latin and Syriac",
@@ -82,30 +165,72 @@
       "ethiopian_tewahedo": "canonical (part of the Broader Canon)"
     },
     "brief_summary": "Jubilees retells the narrative of Genesis and the first half of Exodus (through the Sinai theophany) as a revelation given to Moses on Mount Sinai by the angel of the presence. The book's name reflects its distinctive chronological framework: all of history is ordered into seven-year 'weeks' and forty-nine-year 'jubilees,' producing a symbolic calendar in which events from creation to Sinai occupy exactly fifty jubilees.\n\nThe retelling serves several aims. First, it harmonises perceived difficulties in Genesis — explaining where Cain's wife came from, clarifying the ages of the patriarchs, supplying missing details about Enoch and the Flood. Second, it projects Second Temple legal and liturgical practice back into the patriarchal period: Abraham keeps the Passover, Jacob observes Shavuot, and the feasts follow Jubilees' 364-day solar calendar rather than the lunar calendar of the Jerusalem temple. Third, it draws sharp ethnic and religious boundaries — intermarriage, Sabbath violation, and idolatry are repeatedly denounced — which many scholars read as a response to Hellenising pressures in the early Maccabean era.\n\nJubilees was highly authoritative at Qumran: roughly a dozen manuscripts have been recovered, and the Damascus Document (CD 16:3–4) cites it as 'the book of the divisions of the times by their jubilees and their weeks.' The Ethiopian Tewahedo Church preserved the full Ge'ez text and includes Jubilees in its biblical canon, making it — alongside 1 Enoch — one of the two Old Testament pseudepigrapha considered Scripture in any major Christian tradition.\n\nNew Testament writers do not quote Jubilees, but its angelology, its strict Sabbath observance, its emphasis on predestined historical eras, and its sectarian calendar illuminate the Second Temple Jewish matrix within which early Christianity took shape.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Book of Jubilees is a Jewish pseudepigraphon from the 2nd century BC that retells Genesis and the first half of Exodus (through the Passover and Sinai) as a revelation delivered by the Angel of the Presence to Moses on Mount Sinai. Its framing device is ingenious: where the canonical Torah narrates Israel's history in more or less compressed form, Jubilees slows the pace and fills in the gaps — naming unnamed figures (Adam and Eve's daughters, Noah's wife), expanding terse narratives into detailed stories, providing chronological anchors, and — most distinctively — dating every event to a specific Sabbath week within a specific year of a specific jubilee cycle of 49 years. The book takes its name from this unique chronological framework.\n\nJubilees survives complete only in Ethiopic Geʽez, with substantial Hebrew fragments recovered from Qumran (at least 14 manuscripts: 1Q17, 1Q18, 2Q19, 2Q20, 3Q5, 4Q176, 4Q216–228, 11Q12 — more copies than most biblical books), Latin fragments, and Syriac quotations. The Hebrew fragments from Qumran match the Ethiopic text closely, confirming Ethiopian preservation is substantively accurate against a pre-Christian Hebrew original.\n\n## Composition history\n\nScholars unanimously date Jubilees to the mid-2nd century BC. The most commonly cited window is 161–140 BC, during or shortly after the Maccabean revolt. Internal evidence supports this: the book's polemic against intermarriage, nudity at Greek gymnasia, and calendar reform reflects the Hellenistic crisis under Antiochus IV; its priestly concerns align with the emergence of the Qumran community's calendrical disputes with the Jerusalem Temple; and its 364-day solar calendar matches the calendar the Dead Sea Scrolls community followed.\n\nAuthorship is unknown. The text presents itself as divine revelation to Moses, a pseudepigraphic claim that was standard for Second Temple apocalyptic literature. The book's original language is Hebrew (confirmed by the Qumran fragments); Greek translation followed, then Ethiopic, with smaller Latin, Syriac, and Coptic derivatives.\n\n## Contents\n\nJubilees opens (chapter 1) with Moses on Sinai for forty days and forty nights, where God commissions the Angel of the Presence to dictate to him 'a full account of the divisions of the times from the creation of the world' — both past (Genesis and Exodus) and future (Israel's subsequent history down to Jubilees' own day, compressed as prophecy).\n\n**Primeval history (chapters 2–10)** retells Genesis 1–11 with major additions. The creation narrative (ch 2) emphasizes the Sabbath's primordial origin. Adam and Eve's creation is dated precisely (first week). Cain kills Abel on a named day, marries a specific sister (Awan), and receives his recompense in a specific jubilee cycle. The Watcher narrative (chs 5:1–11 and 10:1–14) summarizes 1 Enoch's Book of the Watchers with slight variations — fallen angels descend in the 25th jubilee, father giants, corrupt humanity, are bound at the Flood. Noah builds the ark, the Flood comes, and the post-Flood rearrangement of the earth is dated year by year.\n\n**Patriarchal history (chapters 11–45)** retells Abraham through Joseph with cumulative expansion. Abraham smashes his father Terah's idols as a boy (ch 12 — a tradition also in rabbinic midrash). Isaac's near-sacrifice is dated to a specific Passover week, foreshadowing the Exodus sacrifice. Jacob's wives bear the twelve patriarchs with each birth precisely dated. Joseph's rise in Egypt is narrated with chronological precision extending to the Exodus generation.\n\n**Sinai / Passover legislation (chapters 46–50)** compresses most of Exodus 1–15, 19–24 and instructs on Passover celebration, Sabbath observance, and the sacred feasts. Chapter 50 closes with detailed Sabbath legislation stricter than the rabbinic tradition later developed — prohibiting marital intercourse, buying and selling, and travel.\n\nThe chronological framework is the book's distinctive contribution: every event is dated to a specific year within a specific jubilee (49-year cycle). The creation occurs in jubilee 1, Year 1. The Flood falls in jubilee 27. The Exodus in jubilee 50. This precision serves multiple purposes — liturgical (the 364-day solar calendar aligns with Qumran's calendrical practice against the Temple's lunar reckoning), halakhic (specific dates for specific feasts), and apocalyptic (the chronological precision makes messianic timetables calculable).\n\n## Reception history\n\n**Within Second Temple Judaism** Jubilees was one of the most copied books at Qumran — more manuscripts than any canonical book except Psalms, Deuteronomy, and Isaiah. The Damascus Document (CD 16:3–4) refers to 'the book of the divisions of the times into their jubilees and weeks' — almost certainly Jubilees — as a normative halakhic authority: 'Behold, it is carefully defined in them.' For the Qumran community, Jubilees was functionally Scripture.\n\n**Within rabbinic Judaism**, Jubilees disappeared. The post-70 AD rabbinic consolidation accepted neither its calendar nor its distinctive legal stringencies, and the book was not preserved in Hebrew outside the (still-hidden) Qumran caves.\n\n**Within Christianity** Jubilees fared better in some traditions than others. The Ethiopian Orthodox Tewahedo Church received Jubilees as part of its 81-book canon — a canonical status it retains today, unique among Christian communions. The book is called Kufale in Ethiopic and is read in liturgy alongside the Torah. Other Christian communions did not receive Jubilees as Scripture. Latin, Greek, and Syriac communities preserved partial translations and patristic citations (Epiphanius uses Jubilees material in his Panarion) but excluded it from the canon.\n\n## NT and patristic usage\n\nThe New Testament does not quote Jubilees directly but presupposes its thought-world at several points. The Watcher tradition in 2 Peter 2:4 and Jude 6 matches Jubilees' version closely. Paul's reference to the law being 'ordained through angels' (Gal 3:19) aligns with Jubilees' pervasive angelology. Hebrews 11's emphasis on Abraham's forward-looking faith has Jubilees parallels. None of these are citations; they are shared atmospheric features of 1st-century Jewish thought.\n\nEarly patristic writers cite Jubilees occasionally (Epiphanius identifies the wife of Cain as Awan, a Jubilees-specific detail), but the book was never widely received as Scripture outside Ethiopia.\n\n## Scholarly positions\n\nContemporary scholarship, led by James VanderKam (The Book of Jubilees, 2001; Jubilees: A Commentary, 2018, two volumes), treats Jubilees as one of the most important witnesses to Second Temple Jewish halakhic, calendrical, and interpretive thought. The Qumran attestation has made Jubilees central to reconstructing the sectarian community's relationship to mainstream Judaism.\n\nDebate focuses on specific questions:\n- **Relationship to 1 Enoch**: Jubilees clearly knows the Watcher tradition. Whether it depends on the Book of the Watchers as a text or on shared oral tradition is contested.\n- **Calendrical dispute**: was Jubilees' 364-day solar calendar a mainstream Jewish alternative to the Temple's lunar reckoning, or a sectarian minority position? Current consensus (VanderKam, Fraade) treats it as one of several calendrical positions that coexisted in the pre-Qumran period.\n- **Canonical status**: the Ethiopian reception is historically serious and theologically continuous; Protestant, Catholic, and Orthodox traditions do not receive Jubilees as Scripture.\n\n## Why different traditions treated it differently\n\nJubilees' canonical status varies because the transmitting communities varied. Qumran's halakhic and calendrical alignment made Jubilees authoritative there. Rabbinic Judaism's different halakhic and calendrical commitments excluded it. Western Christianity inherited a Greek/Latin tradition that had partial but not complete Jubilees texts and moved away from apocalyptic calendrical speculation. Ethiopian Christianity's Coptic-Egyptian liturgical inheritance preserved the book actively and gave it canonical status. These are historical-ecclesial facts, not theological verdicts on the book itself.\n\n## Further reading\n\nVanderKam's Jubilees: A Commentary (Hermeneia, Fortress 2018, 2 vols.) is the definitive scholarly work. His earlier The Book of Jubilees (Sheffield Academic Press, 2001) is a readable introduction. O. S. Wintermute's translation in Charlesworth's Old Testament Pseudepigrapha vol. 2 (Doubleday 1985) is the standard English version. Cana Werman's Hebrew edition (Yad Ben-Zvi 2015) reflects the Qumran fragments.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Genesis 1-50", "connection": "Rewrites the entire book of Genesis with expansions, harmonisations, and halakhic interpolations." },
-      { "ref": "Exodus 1-24", "connection": "Continues through the Sinai theophany; the narrative frame presents the whole as revelation to Moses on the mountain." }
+      {
+        "ref": "Genesis 1-50",
+        "connection": "Rewrites the entire book of Genesis with expansions, harmonisations, and halakhic interpolations."
+      },
+      {
+        "ref": "Exodus 1-24",
+        "connection": "Continues through the Sinai theophany; the narrative frame presents the whole as revelation to Moses on the mountain."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "vanderkam", "position": "The leading Western authority on Jubilees. His two-volume Hermeneia commentary (2018) and earlier CSCO critical edition (1989) remain the standard references. Dates the book to c. 160–150 BC and identifies its calendrical and legal concerns with a pre-Qumranic priestly group from which the Qumran community later emerged." },
-      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, treats Jubilees as a key witness to pre-rabbinic Jewish halakha and to the calendrical and ethnic tensions that produced the Qumran sectarians. Views the retelling of Genesis as an early example of what modern scholars call 'rewritten Bible.'" },
-      { "scholar_id": "collins", "position": "Places Jubilees within the broader wisdom and apocalyptic streams of Second Temple Judaism, noting how its angelology and eschatology draw on and develop material shared with 1 Enoch." }
+      {
+        "scholar_id": "vanderkam",
+        "position": "The leading Western authority on Jubilees. His two-volume Hermeneia commentary (2018) and earlier CSCO critical edition (1989) remain the standard references. Dates the book to c. 160–150 BC and identifies its calendrical and legal concerns with a pre-Qumranic priestly group from which the Qumran community later emerged."
+      },
+      {
+        "scholar_id": "nickelsburg",
+        "position": "In Jewish Literature Between the Bible and the Mishnah, treats Jubilees as a key witness to pre-rabbinic Jewish halakha and to the calendrical and ethnic tensions that produced the Qumran sectarians. Views the retelling of Genesis as an early example of what modern scholars call 'rewritten Bible.'"
+      },
+      {
+        "scholar_id": "collins",
+        "position": "Places Jubilees within the broader wisdom and apocalyptic streams of Second Temple Judaism, noting how its angelology and eschatology draw on and develop material shared with 1 Enoch."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
-    "related_difficult_passage_ids": [],
-    "tags": ["rewritten-bible", "second-temple", "qumran", "dead-sea-scrolls", "ethiopian-tewahedo-canon", "calendar", "jubilees"],
+    "related_debate_ids": [
+      "second-temple-literature-and-nt-theology",
+      "dead-sea-scrolls-and-canon-questions"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
+    "related_difficult_passage_ids": [
+      "nephilim-sons-of-god"
+    ],
+    "tags": [
+      "rewritten-bible",
+      "second-temple",
+      "qumran",
+      "dead-sea-scrolls",
+      "ethiopian-tewahedo-canon",
+      "calendar",
+      "jubilees"
+    ],
     "further_reading": [
-      { "title": "Jubilees 1 and Jubilees 2", "author": "James C. VanderKam", "note": "Hermeneia (Fortress, 2018). The standard English-language critical commentary." },
-      { "title": "The Book of Jubilees", "author": "James C. VanderKam", "note": "CSCO 510–511 (Peeters, 1989). Two-volume critical edition and translation of the Ge'ez with Hebrew, Greek, Latin, and Syriac witnesses." }
+      {
+        "title": "Jubilees 1 and Jubilees 2",
+        "author": "James C. VanderKam",
+        "note": "Hermeneia (Fortress, 2018). The standard English-language critical commentary."
+      },
+      {
+        "title": "The Book of Jubilees",
+        "author": "James C. VanderKam",
+        "note": "CSCO 510–511 (Peeters, 1989). Two-volume critical edition and translation of the Ge'ez with Hebrew, Greek, Latin, and Syriac witnesses."
+      }
     ]
   },
   {
     "id": "jasher",
     "title": "Book of Jasher (Sefer haYashar)",
-    "also_known_as": ["Book of Jashar", "Sefer haYashar", "Book of the Upright"],
+    "also_known_as": [
+      "Book of Jashar",
+      "Sefer haYashar",
+      "Book of the Upright"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "The lost OT source cannot be dated; the extant medieval Sefer haYashar is c. 11th–13th c. AD; a separate 18th c. English forgery circulates under the same title",
     "original_language": "The OT source is unknown; the medieval Sefer haYashar is Hebrew; the 18th c. forgery is English",
@@ -116,28 +241,55 @@
       "ethiopian_tewahedo": "not canonical"
     },
     "brief_summary": "The Hebrew Bible twice refers to a 'Book of Jashar' (sefer ha-yashar, literally 'Book of the Upright'): Joshua 10:13 cites it as the source of the account of the sun standing still over Gibeon, and 2 Samuel 1:18 notes that David's lament over Saul and Jonathan was recorded in it. A third probable reference is 1 Kings 8:53 in the Septuagint tradition. Whatever these references point to, the original work is lost. No manuscripts or independent citations have survived from antiquity, and its contents are known only through the brief quotations preserved in the biblical text.\n\nSeveral later works have circulated under the title 'Book of Jasher' and are often confused with the lost biblical source. The most important is the medieval Sefer haYashar (often dated to somewhere between the eleventh and thirteenth centuries), a Hebrew retelling of biblical history from Adam through the Judges. It draws on Jewish midrashic traditions and postdates the biblical references by well over a millennium. The medieval work is a genuine Jewish text but has no historical connection to the lost source cited by the biblical writers.\n\nA separate eighteenth-century English publication (1751) also styled 'The Book of Jasher' is a modern forgery, unrelated to the medieval Hebrew work or to the biblical reference. Neither the medieval Sefer haYashar nor the eighteenth-century work has been received as canonical by any Christian tradition. The lost biblical source is significant historically because it shows the biblical writers knew and used older Hebrew literary sources — a fact attested elsewhere by references to the 'Book of the Wars of the Lord' (Num 21:14) and the 'Book of the Annals of the Kings of Israel' — but it cannot itself be read.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Book of Jasher (Hebrew: sefer ha-yashar, 'Book of the Upright') is the most confusing entry in the extra-biblical corpus because **three distinct works** circulate under the name. Responsible discussion requires keeping them apart. The Hebrew Bible itself twice cites a lost Book of Jasher — in Joshua 10:13 for the sun-standing-still narrative, and in 2 Samuel 1:18 for David's lament over Saul and Jonathan. That original Book of Jasher has not survived. In its place two much later works have borrowed the name: a medieval Hebrew midrashic compilation (Sefer haYashar, 11th-13th century), and an 18th-century English forgery (The Book of Jasher, published 1751 and reprinted in 1840 by Mormon circles). Contemporary internet discussion regularly confuses these three. The honest answer is that the biblical Book of Jasher is genuinely lost; the medieval work is a legitimate but late Jewish devotional midrash; and the 18th-century English work is a documented forgery.\n\n## Composition history\n\n**The biblical Book of Jasher** (the original) is attested only in the two biblical citations. Joshua 10:13 notes that the sun-standing-still episode during Joshua's defeat of the Amorite coalition is 'written in the Book of Jasher.' 2 Samuel 1:18 introduces David's lament with 'Behold, it is written in the Book of Jasher.' The inference is that an ancient Israelite poetic collection — perhaps a battle-song anthology, perhaps a record of heroic deeds — existed and was consulted by the biblical authors as one of their sources. Its original language would have been Hebrew; its date uncertain but certainly pre-Exilic; its scope and literary character are unknown. No manuscript survives.\n\n**The medieval Sefer haYashar** was composed in Hebrew in Spain or Italy between the 11th and 13th centuries AD, drawing on rabbinic midrashic tradition to retell biblical history from Adam through the Judges period. It was first printed in Venice in 1625 and subsequently in Prague (1668), Frankfurt (1704), and many later editions. The medieval work is a genuinely Jewish devotional text — not a forgery. It does not claim to be the biblical Book of Jasher; the name was applied to it loosely by later editors. It is to rabbinic tradition what the Sefer haYashar of Rabbenu Tam and the Sefer Hasidim are to medieval Jewish ethics: a substantial composition of its own period, preserving older traditions but composed in medieval form.\n\n**The 1751 English 'Book of Jasher'** was published by the London bookseller Jacob Ilive, who claimed it was a translation from a lost Alcuin-era Latin manuscript rediscovered in Persia. The claim is entirely fabricated. Textual analysis shows the 'translation' is a composite pastiche drawing on the KJV, Josephus's Antiquities, and the medieval Sefer haYashar, stitched into Enlightenment English prose. The book was thoroughly debunked in the late 18th century but continues to circulate in popular editions, occasionally with the added claim that it is 'the lost Book of Jasher rediscovered.' It is not.\n\n## Contents\n\nSince the biblical Book of Jasher does not survive, there are no contents to describe. We possess only the fact that Joshua's sun narrative and David's lament were drawn from or corroborated by this earlier source.\n\nThe medieval Sefer haYashar retells biblical history from creation through the entry into the Promised Land with substantial additions drawn from rabbinic tradition — Abraham's breaking his father's idols, the identification of Pharaoh's magicians (including the Jannes and Jambres tradition), Moses's childhood in Egypt, various angelic interventions. It is a well-written Hebrew composition and reads as substantive Jewish devotional literature. It does not claim to be biblical.\n\nThe Pseudo-Jasher of 1751 narrates roughly the same biblical timeline with additions drawn from Josephus and medieval Jewish tradition. Its literary character — awkward attempts at King-James-like prose, occasional anachronisms — betrays its Enlightenment origin to any reader familiar with 18th-century English literary style.\n\n## Reception history\n\nThe biblical Book of Jasher was lost early enough that it is not attested in any complete form at Qumran, in the Septuagint tradition, or in any patristic writer. Whatever the original was, it vanished before the post-exilic canonical work of the Persian-period editors.\n\nThe medieval Sefer haYashar was received as edifying Jewish literature without canonical pretension. It was printed repeatedly, valued for its lively narrative retellings, and remains in print in English translation (Moses Samuel, 1840; M. M. Noah, 1840; others).\n\nThe 1751 English Pseudo-Jasher had a curious second life in 19th-century American religious movements. It was reprinted in 1840 by the Mormon-adjacent publisher Joseph Hyrum Parry and subsequently referenced occasionally in LDS devotional contexts, though the mainstream LDS Church does not treat it as Scripture. Fundamentalist Christian circles in the 20th-21st centuries have sometimes promoted the Pseudo-Jasher as the 'lost Bible book,' often by republishing it alongside conspiratorial claims about suppressed Scripture. These claims have no scholarly basis.\n\n## NT and patristic usage\n\nNo NT or patristic writer cites any version of Jasher. The biblical Book of Jasher was already lost by the NT period; the medieval and modern works are too late to be in view.\n\n## Scholarly positions\n\nScholarly positions on Jasher fall naturally into three camps corresponding to the three works:\n\n- On the **lost biblical Book of Jasher**: unanimous — it once existed (the two biblical citations vouch for its reality), and it is lost.\n- On the **medieval Sefer haYashar**: a substantial Jewish devotional midrash of the 11th-13th century, valuable as a source for rabbinic tradition but not biblical and not claiming to be.\n- On the **1751 English Pseudo-Jasher**: a documented forgery. This is the unanimous judgment of responsible scholarship since the late 18th century and is confirmed by textual and stylistic analysis.\n\n## Why different traditions treated it differently\n\nThe biblical Book of Jasher simply did not survive long enough to enter any canonical tradition. The medieval Sefer haYashar is treated by Jewish tradition as devotional midrash (valuable, not Scripture) and by Christian traditions generally as of historical interest only. The 1751 English forgery has no canonical status anywhere and is rejected by mainstream scholarship across traditions. Occasional claims — especially online — that 'the Book of Jasher was removed from the Bible' conflate all three works and typically rest on the 18th-century forgery masquerading as ancient.\n\n## Further reading\n\nFor the biblical citations see standard Joshua and Samuel commentaries (Butler, Howard, Tsumura, Bergen). For the medieval Sefer haYashar, J. D. Eisenstein's Otzar Midrashim (1915) includes the Hebrew text; Edward Neubauer's Medieval Jewish Chronicles (1887-1895) has critical analysis. For the 1751 forgery see the detailed demolition in the Dictionary of National Biography's entry on Jacob Ilive; Edward Mack's 'Book of Jasher' article in the International Standard Bible Encyclopedia (1915) surveys the evidence. Online: the Internet Sacred Text Archive hosts both the medieval and pseudo- works with clear headers distinguishing them.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Joshua 10:13", "connection": "The Joshua narrator cites the Book of Jashar as the source of the account of the sun and moon standing still over Gibeon and the Valley of Aijalon." },
-      { "ref": "2 Samuel 1:18", "connection": "David's Lament of the Bow, mourning Saul and Jonathan, is said to have been recorded in the Book of Jashar and commanded to be taught to Judah." }
+      {
+        "ref": "Joshua 10:13",
+        "connection": "The Joshua narrator cites the Book of Jashar as the source of the account of the sun and moon standing still over Gibeon and the Valley of Aijalon."
+      },
+      {
+        "ref": "2 Samuel 1:18",
+        "connection": "David's Lament of the Bow, mourning Saul and Jonathan, is said to have been recorded in the Book of Jashar and commanded to be taught to Judah."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "longman", "position": "Treats the biblical references as pointing to a lost Hebrew source-collection of poetry and national memory, analogous to the 'Book of the Wars of the Lord' in Numbers 21:14 and the various royal annals cited in Kings and Chronicles. Cautions that the extant Sefer haYashar is a medieval midrashic work, not the biblical source." },
-      { "scholar_id": "provan", "position": "Notes the reference in 2 Samuel 1:18 among several instances where the biblical narrators openly cite earlier Israelite literature, suggesting that the canonical books are the crystallised distillation of a larger national archive now lost." }
+      {
+        "scholar_id": "longman",
+        "position": "Treats the biblical references as pointing to a lost Hebrew source-collection of poetry and national memory, analogous to the 'Book of the Wars of the Lord' in Numbers 21:14 and the various royal annals cited in Kings and Chronicles. Cautions that the extant Sefer haYashar is a medieval midrashic work, not the biblical source."
+      },
+      {
+        "scholar_id": "provan",
+        "position": "Notes the reference in 2 Samuel 1:18 among several instances where the biblical narrators openly cite earlier Israelite literature, suggesting that the canonical books are the crystallised distillation of a larger national archive now lost."
+      }
     ],
     "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["lost-source", "ot-references", "medieval-midrash", "sefer-hayashar", "forgery"],
+    "tags": [
+      "lost-source",
+      "ot-references",
+      "medieval-midrash",
+      "sefer-hayashar",
+      "forgery"
+    ],
     "further_reading": [
-      { "title": "The Lost Books of the Old Testament", "author": "Various", "note": "General scholarly surveys of the Book of the Wars of the Lord, the Book of Jashar, and other biblical source citations — see standard OT introductions (e.g., Childs; Dillard and Longman)." }
+      {
+        "title": "The Lost Books of the Old Testament",
+        "author": "Various",
+        "note": "General scholarly surveys of the Book of the Wars of the Lord, the Book of Jashar, and other biblical source citations — see standard OT introductions (e.g., Childs; Dillard and Longman)."
+      }
     ]
   },
   {
     "id": "assumption_of_moses",
     "title": "Assumption of Moses",
-    "also_known_as": ["Testament of Moses", "Assumptio Mosis"],
+    "also_known_as": [
+      "Testament of Moses",
+      "Assumptio Mosis"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "Early 1st c. AD (most scholars); possibly a rework of a Maccabean-era Testament of Moses",
     "original_language": "Hebrew or Aramaic original; preserved only in a single incomplete 6th c. Latin palimpsest discovered in Milan in the 19th century",
@@ -148,29 +300,62 @@
       "ethiopian_tewahedo": "not canonical"
     },
     "brief_summary": "The Assumption of Moses is a Jewish pseudepigraphon cast as Moses' farewell address to Joshua on the plains of Moab before his death (cf. Deut 31–33). In the extant text, Moses foretells the history of Israel from the conquest through the Hasmonean period and into a final eschatological crisis, culminating in the intervention of a mysterious figure called 'Taxo' and the inauguration of God's kingdom.\n\nThe extant Latin palimpsest — the only surviving copy — breaks off before the end. Early Christian writers, including Origen, Clement of Alexandria, and the compiler of the Apostolic Constitutions, refer to a Jewish work about Moses' death that contained a dispute between the archangel Michael and the devil over Moses' body. No such scene appears in the extant Latin text, leading most scholars since R. H. Charles to conclude that the Assumption of Moses originally included this material in its now-lost conclusion.\n\nThis matters directly for the interpretation of Jude 9: 'But even the archangel Michael, when he was disputing with the devil about the body of Moses, did not himself dare to condemn him for slander but said, \"The Lord rebuke you!\"' Patristic writers from Origen onward explicitly connected Jude 9 with the Assumption of Moses. If the identification is correct, Jude alludes to the same Jewish tradition attested in that book.\n\nNeither the work itself nor the patristic testimonies establish it as Scripture. The Assumption of Moses has never been received as canonical in any Christian tradition. It is significant, however, for illuminating the Second Temple Jewish imagination from which Jude's brief letter drew its imagery of the righteous dead, angelic mediation, and eschatological vindication.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Assumption of Moses (also called the Testament of Moses) is a 1st-century Jewish pseudepigraphon preserved in a single 6th-century Latin manuscript discovered by Antonio Ceriani in the Ambrosian Library in Milan in 1861. The surviving text — incomplete at the beginning and end — narrates Moses's final address to Joshua before his death, predicting Israel's subsequent history through the Hasmonean period and into the immediate pre-Christian era. The book's identification as the Assumption of Moses rests on patristic testimony: Origen, Clement of Alexandria, and later writers identify Jude 9's reference to Michael disputing with Satan over Moses's body as coming from this work. The relevant passage is in the lost ending.\n\nThe book was written in Hebrew or Aramaic originally, translated into Greek, and then into Latin. Only the Latin survives. The Qumran community does not appear to have possessed it (no manuscript has been identified among the Dead Sea Scrolls), though thematic parallels with the sectarian literature are numerous.\n\n## Composition history\n\nThe Ceriani manuscript is incomplete at both ends and internally corrupt at several points, making reconstruction delicate. Scholarly consensus dates the work to the first third of the 1st century AD — between roughly 4 BC (references to Herod's sons suggest post-Herod writing) and 30 AD (the lack of any reference to the Temple's destruction suggests pre-70 AD). The original language was almost certainly Semitic (Hebrew or Aramaic), not Greek. Where the Latin preserves Hebrew idioms, the translator evidently worked from a Semitic source.\n\nThe book's identification as the Assumption of Moses is contested. Two patristic traditions name it: the Assumption (assumptio Mosis) and the Testament (testamentum Mosis). Some scholars (R. H. Charles) argued the surviving Latin is the Testament, and the Assumption — with the Michael-Satan episode — was a separate lost work. Most current scholars (Tromp, Bauckham) treat them as a single work in two recensions or simply two names for the same book. The surviving Ceriani manuscript matches the Testament-type content; the Michael-Satan episode would have been in the missing ending and is known only through patristic citation.\n\n## Contents\n\nThe surviving Latin text opens mid-sentence with Moses summoning Joshua to Mount Nebo before his death. Moses charges Joshua with the succession (1:6–8), narrates a predicted history of Israel from the conquest through the Babylonian exile and return (2:1–9:7, with considerable compression of the canonical period), and concludes the surviving text with a detailed prediction of the Hasmonean crisis and its aftermath (chapters 6–8).\n\nChapter 6 is the most historically precise: it describes 'an insolent king, not of the race of the priests, a reckless and impious man,' who will rule the nation — clearly Herod the Great, who was Idumaean rather than priestly. His reign is narrated briefly (he rules 'thirty-four years' — Herod's historical reign), followed by his sons who 'rule for lesser periods' (Archelaus, Antipas, Philip). Chapter 7 describes an age of apostasy: treacherous men, evil rulers, false prophets. Chapter 8 predicts a crisis of unprecedented severity — a 'great punishment' under 'the king of the kings of the earth' forcing Israel to renounce circumcision and persecution to the point of crucifixion.\n\nChapter 9 introduces Taxo, a righteous Levite who resolves to die rather than apostatize, leading his seven sons into a cave to die together rather than transgress God's commandments. Chapter 10 is the book's theological climax — an eschatological hymn announcing that 'God's kingdom shall appear throughout his whole creation,' Satan shall be destroyed, Israel shall be exalted, and 'the earth shall tremble, and the mountains shall bow down.' Chapter 11 begins Joshua's lament, Chapter 12 Moses's concluding charge. The book breaks off at 12:13.\n\nThe lost ending, per Origen's testimony, contained the scene Jude 9 preserves: the archangel Michael contending with Satan over the body of Moses, Satan claiming the body on the grounds of Moses's murder of the Egyptian (Exod 2:12), and Michael responding not with accusation but with 'The Lord rebuke you' — the exact language of Zechariah 3:2. Jude's citation of this episode is the primary reason the Assumption of Moses enters Christian discussion at all.\n\n## Reception history\n\nWithin **Second Temple Judaism** the book appears to have had narrow circulation. It is not attested at Qumran, not quoted in other Second Temple literature, and its theology (a quietist eschatology, the righteous suffering as the trigger for divine intervention) suggests a relatively small sectarian audience — possibly the Essenes or a related group.\n\nWithin **Christianity** the Assumption of Moses enters history primarily through Jude's citation. Origen (De Principiis 3.2.1) and Clement of Alexandria identify Jude 9 as coming from it. Later patristic writers — Gelasius of Cyzicus, Severus of Antioch, John Chrysostom — know the book and quote from the surviving portions. The Gelasian Decree (6th century) lists it among rejected apocrypha. The book was lost to Western Christendom after the medieval period and rediscovered only with Ceriani's 1861 find.\n\nNo Christian communion treats the Assumption of Moses as Scripture. Jude's citation is universally acknowledged without the source book entering any canonical list.\n\n## NT and patristic usage\n\nJude 9's reference — 'the archangel Michael, contending with the devil, disputed about the body of Moses, did not presume to pronounce a blasphemous judgment, but said, The Lord rebuke you' — is the only direct NT use of the Assumption of Moses. Origen, Clement, and Gelasius all identify this as the source. Modern scholarship (Bauckham, Charles, Tromp) treats the identification as secure on patristic authority plus the contextual fit — Jude's rhetorical pattern (Michael, the highest angel, refused to condemn even Satan; how much more should these opponents refrain from blaspheming 'glorious ones') requires a recognized source story, and the Assumption of Moses is the best candidate.\n\nThe Taxo episode of chapter 9 has been compared to the seven Maccabean martyrs of 2 Maccabees 7 (thematic parallel, not dependence) and to the faith-hall of Hebrews 11:35–37 (again parallel, not dependence).\n\n## Scholarly positions\n\nContemporary scholarship (Johannes Tromp's critical edition and commentary, 1993; Kenneth Atkinson's work on Taxo; Richard Bauckham's Jude commentary) treats the Assumption as a valuable witness to first-century Palestinian Jewish apocalyptic thought. Debate focuses on:\n- The **Taxo episode**: who was Taxo? Some scholars identify him historically (a known Hasidic leader); most treat him as a literary figure embodying the quietist martyrdom ideal.\n- **Date**: the 4 BC–30 AD window is widely accepted, with some arguing for a pre-Herod date and later redaction.\n- **Genre**: testament or apocalypse? The surviving Latin reads as testament (a patriarch's farewell speech); the lost ending's Michael-Satan episode is more apocalyptic in character.\n\n## Why different traditions treated it differently\n\nThe Assumption of Moses shares the fate of most Second Temple Jewish apocalypses: lost to rabbinic Judaism when its transmitting community disappeared, preserved only through Christian interest, and excluded from every Christian canon. Only the Ethiopian Orthodox canon is broad enough to have included it in principle, and Ethiopian tradition does not preserve it. The rediscovery in 1861 was historical, not canonical — the book is important for understanding Jude 9 and the broader 1st-century Jewish thought-world, but it has no canonical standing.\n\n## Further reading\n\nJohannes Tromp's The Assumption of Moses: A Critical Edition with Commentary (Brill, 1993) is the definitive scholarly work. J. Priest's translation in Charlesworth's Old Testament Pseudepigrapha vol. 1 (Doubleday, 1983) is the standard English reference. Richard Bauckham's Jude, 2 Peter (WBC, 1983) discusses the Jude 9 parallel in detail. For the Taxo episode see Kenneth Atkinson's I Cried to the Lord: A Study of the Psalms of Solomon Language and Theology (Brill, 2003) for its literary matrix.",
     "nt_citations": [
-      { "ref": "Jude 9", "cites": "Assumption of Moses (lost ending)", "type": "allusion" }
+      {
+        "ref": "Jude 9",
+        "cites": "Assumption of Moses (lost ending)",
+        "type": "allusion"
+      }
     ],
     "ot_allusions": [
-      { "ref": "Deuteronomy 31-34", "connection": "Cast as Moses' final words to Joshua before his death, expanding the framework of Deuteronomy's farewell speeches." }
+      {
+        "ref": "Deuteronomy 31-34",
+        "connection": "Cast as Moses' final words to Joshua before his death, expanding the framework of Deuteronomy's farewell speeches."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "nickelsburg", "position": "Surveys the Assumption of Moses among the Second Temple testamentary works in Jewish Literature Between the Bible and the Mishnah, endorses the scholarly consensus that the lost ending contained the Michael-versus-devil dispute, and reads the surviving text as an apocalyptic protest composed in the early first century AD." },
-      { "scholar_id": "bruce", "position": "In his commentary and survey work on the General Epistles, follows the patristic and modern consensus that Jude 9 alludes to the lost ending of the Assumption of Moses. Treats Jude's use of the tradition as a rhetorical illustration (similar to the Enoch citation in Jude 14–15), arguing that allusion to a Jewish pseudepigraphon does not entail canonical endorsement of the source text." }
+      {
+        "scholar_id": "nickelsburg",
+        "position": "Surveys the Assumption of Moses among the Second Temple testamentary works in Jewish Literature Between the Bible and the Mishnah, endorses the scholarly consensus that the lost ending contained the Michael-versus-devil dispute, and reads the surviving text as an apocalyptic protest composed in the early first century AD."
+      },
+      {
+        "scholar_id": "bruce",
+        "position": "In his commentary and survey work on the General Epistles, follows the patristic and modern consensus that Jude 9 alludes to the lost ending of the Assumption of Moses. Treats Jude's use of the tradition as a rhetorical illustration (similar to the Enoch citation in Jude 14–15), arguing that allusion to a Jewish pseudepigraphon does not entail canonical endorsement of the source text."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
-    "related_difficult_passage_ids": [],
-    "tags": ["second-temple", "testamentary-literature", "apocalyptic", "jude", "michael", "moses"],
+    "related_debate_ids": [
+      "did-jude-affirm-enoch-as-scripture"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
+    "related_difficult_passage_ids": [
+      "michael-moses-body"
+    ],
+    "tags": [
+      "second-temple",
+      "testamentary-literature",
+      "apocalyptic",
+      "jude",
+      "michael",
+      "moses"
+    ],
     "further_reading": [
-      { "title": "Old Testament Pseudepigrapha, vol. 1", "author": "James H. Charlesworth, ed.", "note": "Doubleday, 1983. Contains J. Priest's translation and introduction to the Testament/Assumption of Moses." }
+      {
+        "title": "Old Testament Pseudepigrapha, vol. 1",
+        "author": "James H. Charlesworth, ed.",
+        "note": "Doubleday, 1983. Contains J. Priest's translation and introduction to the Testament/Assumption of Moses."
+      }
     ]
   },
   {
     "id": "tobit",
     "title": "Tobit",
-    "also_known_as": ["Book of Tobit", "Tobias"],
+    "also_known_as": [
+      "Book of Tobit",
+      "Tobias"
+    ],
     "category": "deuterocanon",
     "estimated_date": "c. 3rd–2nd c. BC",
     "original_language": "Aramaic (with at least one Hebrew witness); fragments of four Aramaic and one Hebrew manuscript at Qumran (4Q196–200). Standard text preserved in Greek (two recensions) and Latin (Vulgate)",
@@ -181,29 +366,65 @@
       "ethiopian_tewahedo": "canonical (Broader Canon)"
     },
     "brief_summary": "Tobit is a Jewish diaspora novella set in the Assyrian exile. The protagonist, Tobit of the tribe of Naphtali, is a pious Israelite deported to Nineveh who continues to observe Jewish piety — burying the unclaimed dead, giving alms, keeping the festivals — at risk to himself. Blinded in an accident and reduced to poverty, Tobit prays for death. At the same moment, far away in Ecbatana, a young woman named Sarah — whose seven successive bridegrooms have all been killed on the wedding night by the demon Asmodeus — likewise prays for death.\n\nGod hears both prayers and sends the archangel Raphael in disguise to travel with Tobit's son Tobias on a journey to recover a family deposit in Media. Along the way Raphael instructs Tobias in how to drive off Asmodeus, marry Sarah, and heal his father's blindness. The book concludes with Tobit's hymn of praise (ch 13) and a farewell address to Tobias (ch 14) prophesying the destruction of Nineveh and the restoration of Israel.\n\nComposed probably in the third or second century BC — well before the events it describes — Tobit is a work of pious fiction shaped by biblical wisdom and narrative conventions. It teaches the practical outworking of Torah piety in a diaspora setting, emphasises filial devotion, burial of the dead, and almsgiving, and develops Jewish angelology (Raphael is one of the 'seven holy angels') and demonology.\n\nAttestation of Aramaic and Hebrew copies at Qumran confirms the book's Jewish Second Temple provenance. Jerome included Tobit in the Vulgate but distinguished it from the Hebrew-canon books in his prologues. Augustine defended its broader canonical status, and the regional Councils of Hippo (393) and Carthage (397 and 419) confirmed that position for the Latin West. The Council of Trent (1546) formally defined Tobit as deuterocanonical in response to the Reformation's return to the shorter Hebrew canon. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive it as Scripture.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Book of Tobit is a deuterocanonical narrative composed in Aramaic or Hebrew sometime in the 3rd or 2nd century BC. It tells the story of Tobit, a pious Israelite exile in Nineveh, who loses his sight after performing a righteous burial of a murdered Jew, and of his son Tobias, who travels to Ecbatana under the guidance of the archangel Raphael (disguised as a human named Azariah) to collect a family debt and — in the course of the journey — encounter, exorcise, and marry the widowed Sarah, whose seven previous husbands were killed on their wedding nights by the demon Asmodeus. The narrative resolves with the demon defeated, the debt collected, the wife won, and Tobit's sight restored. It is one of the most literarily accomplished books in the Apocrypha: a tightly constructed short novel with folkloric motifs, psalms, angelic revelation, and a richly textured portrait of diaspora Jewish piety.\n\n## Composition history\n\nTobit survives in multiple textual forms. The primary Greek witnesses are in Codex Sinaiticus (the 'long' recension), Vaticanus and Alexandrinus (the 'short' recension), and a family of cursive minuscules (the 'third' recension). For centuries the long and short recensions could not be reconciled, and the original language was disputed (Greek? Hebrew? Aramaic?). Then in 1952-1955 the Qumran finds produced five Aramaic fragments and one Hebrew fragment of Tobit (4Q196–4Q200), finally confirming a Semitic original. The Qumran texts generally match the long Sinaiticus recension, which is now considered closest to the original. The Latin Vulgate Tobit is a 4th-century translation by Jerome from an Aramaic manuscript — distinct from the Greek tradition and sometimes preserving independent readings.\n\nDate: the book presupposes post-exilic (specifically post-722 BC Assyrian exile) setting but is composed long afterward. The language, theology (developed angelology and demonology), and historical anachronisms (the historical Tobit cannot be as old as the narrative makes him) place composition in the 3rd-2nd century BC. Most scholars settle on c. 225-175 BC, possibly in Palestine or the Eastern Diaspora (Mesopotamia).\n\n## Contents\n\nThe narrative divides neatly into parts. **Prologue (1:1–3:17)**: Tobit in Nineveh, pious exile who buries murdered Jews at royal risk, loses his sight when bird droppings fall in his eyes during a nap, prays for death. Simultaneously in Ecbatana (Media) Sarah prays for death, having watched Asmodeus kill seven husbands on seven wedding nights. God hears both prayers and sends Raphael.\n\n**The journey (4:1–9:6)**: Tobit sends his son Tobias to Rages (Media) to collect money deposited with a kinsman. Tobias is accompanied by Raphael disguised as 'Azariah,' a human kinsman. On the journey the archangel instructs Tobias to catch a fish from the Tigris and preserve its gall, heart, and liver. The party arrives at Ecbatana, where Raphael redirects them to Raguel's house — Sarah's home. Tobias learns of Sarah's history and, trusting Raphael's counsel, marries her. On the wedding night the fish heart and liver smoked on the altar drive Asmodeus to Egypt, where Raphael binds him. The marriage is consummated; the wedding feast extends for fourteen days.\n\n**Resolution (9:7–14:15)**: Tobias returns to Nineveh with Sarah and the money. Tobit is healed of blindness when Tobias applies the fish gall to his eyes. Raphael reveals his true identity: 'I am Raphael, one of the seven angels who stand in the presence of the Lord' (12:15). He departs to heaven. Tobit sings a psalm of praise (ch 13). The book concludes with Tobit's final counsel and the deaths of Tobit, Anna his wife, and eventually Tobias and Sarah in the Promised Land.\n\nTheological themes: divine providence working through human fidelity; the effectiveness of almsgiving, prayer, and pious burial; the reality of angelic mediation; the restoration of exiled Israel under a sovereign God. The story's literary artistry — paired parallel prayers by Tobit and Sarah, the identification of Raphael only at the end, the echoing of wisdom tradition (4:3–21 is a Proverbs-like instruction) — rewards careful reading.\n\n## Reception history\n\n**Second Temple Judaism**: Tobit was widely read. Five Qumran manuscripts demonstrate its circulation in the sectarian community. Rabbinic Judaism did not include it in the Hebrew canon but preserved awareness; some rabbinic traditions reflect Tobit motifs.\n\n**Early Christianity**: Tobit was broadly received as Scripture in the Greek-speaking church. Athanasius' 39th Festal Letter (367 AD) includes it among books 'appointed by the Fathers to be read' (anagignoskomena) — his second tier, edifying but distinct from the Hebrew-canonical Old Testament. Cyril of Jerusalem, Augustine, and the African councils of Hippo (393) and Carthage (397) received it as canonical. Jerome translated it into Latin for the Vulgate (from an Aramaic manuscript, he says, in a single day) but classified it as 'ecclesiastical' rather than 'canonical' in his Prologus Galeatus.\n\n**The medieval West** followed Hippo-Carthage: Tobit was received as canonical Scripture for a millennium, included in the Vulgate, read in liturgy, referenced in theological argument (notably on almsgiving).\n\n**The Reformation** retrieved Jerome's distinction. Luther's 1534 German Bible placed Tobit in the Apocrypha section with his famous header: 'books that are not to be held equal to the Holy Scriptures but yet are useful and good to read.' Article VI of the Thirty-Nine Articles (1563) takes the same position. The Westminster Confession (1646) 1.3 is sharper: the Apocrypha 'is no part of the canon of the Scripture, and therefore is of no authority.'\n\n**The Council of Trent** (1546, Session IV) dogmatically defined Tobit as canonical Scripture in response to the Reformation. Catholic Bibles retain it in the Old Testament; Orthodox Bibles include it; Ethiopian Bibles include it; most Protestant Bibles exclude it (sometimes printed in an Apocrypha appendix, e.g., in Anglican KJV and the NRSV with Apocrypha).\n\n## NT and patristic usage\n\nTobit is not directly quoted in the NT. Thematic parallels exist: Jesus's teaching on almsgiving (Matt 6:1–4) resonates with Tobit 4:7–11 and 12:8–9; the angel Raphael as one of 'seven angels who stand in the presence of the Lord' (Tob 12:15) parallels Revelation 8:2's seven angels and 1:4's 'seven spirits before his throne.' These are atmospheric echoes rather than citations.\n\nPatristic use was extensive: Cyprian, Ambrose, Augustine, and many others quote Tobit as Scripture. The book's almsgiving theology shaped medieval Catholic thought on works of mercy.\n\n## Scholarly positions\n\nContemporary scholarship on Tobit is dominated by Joseph Fitzmyer's Tobit (de Gruyter, 2003) — the standard commentary in English, drawing fully on the Qumran finds. Carey Moore's AB commentary (1996) is less current on the Semitic texts but literarily astute. The Qumran Aramaic and Hebrew fragments have transformed Tobit studies since 1995.\n\nDebate focuses on:\n- **Genre**: folktale, novella, wisdom narrative, or romance? Most scholars treat it as a tightly constructed short story with folkloric motifs (the Grateful Dead tale-type, the demon-at-wedding motif) reworked within a Jewish theological framework.\n- **Historicity**: the narrative is fictional. Tobit himself is not a historical figure; the Assyrian political chronology doesn't match. The book is religious fiction, not history.\n- **Canonical status**: unchanged since the Reformation — Catholic/Orthodox/Ethiopian canonical; Protestant apocrypha; Jewish extra-biblical.\n\n## Why different traditions treated it differently\n\nThe Protestant-Catholic split on Tobit traces to the Jerome-Augustine divergence (4th-5th century) and the Reformation's retrieval of Jerome's 'Hebrew-verity' criterion (see canon-formation journey stop 10, #1551/PR #1601). Since the Qumran Aramaic fragments don't undo this — they confirm a Semitic original but not a Hebrew-canonical status — the Reformation's judgment still stands for Protestants even with the improved textual evidence. Catholics, Orthodox, and Ethiopians continue to receive Tobit based on its long ecclesial use, per Augustine's 'consent of the churches' principle.\n\n## Further reading\n\nJoseph Fitzmyer, Tobit (Commentaries on Early Jewish Literature, de Gruyter 2003) is the definitive scholarly commentary incorporating the Qumran evidence. Carey Moore, Tobit (Anchor Bible, 1996) is literarily excellent. For devotional use the NRSV with Apocrypha (Oxford 2010) includes a readable English translation with notes. Online: the Catholic Encyclopedia's Tobit entry summarizes the traditional Catholic position; Bible Odyssey (SBL) hosts accessible scholarly essays.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Deuteronomy 14:22-29", "connection": "Tobit's tithing and almsgiving practices (Tob 1:6-8) expand the Deuteronomic tithe legislation into a fuller diaspora piety." }
+      {
+        "ref": "Deuteronomy 14:22-29",
+        "connection": "Tobit's tithing and almsgiving practices (Tob 1:6-8) expand the Deuteronomic tithe legislation into a fuller diaspora piety."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "jerome", "position": "Included Tobit in the Vulgate — translating from an Aramaic exemplar — but distinguished it in his prologues from the books 'of the Hebrew truth,' stating it belonged among books 'to be read for the edification of the people, but not to establish the authority of ecclesiastical doctrines.'" },
-      { "scholar_id": "augustine", "position": "Defended the wider Greek and Latin canon against Jerome's narrower Hebraica veritas. The regional Councils of Hippo (393) and Carthage (397 and 419), over which he exercised decisive influence, affirmed Tobit alongside the other deuterocanonical books." },
-      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, treats Tobit as a representative example of Second Temple diaspora narrative — a pious novella combining wisdom teaching, angelology, and family drama, meant to sustain Jewish identity and practice under foreign rule." }
+      {
+        "scholar_id": "jerome",
+        "position": "Included Tobit in the Vulgate — translating from an Aramaic exemplar — but distinguished it in his prologues from the books 'of the Hebrew truth,' stating it belonged among books 'to be read for the edification of the people, but not to establish the authority of ecclesiastical doctrines.'"
+      },
+      {
+        "scholar_id": "augustine",
+        "position": "Defended the wider Greek and Latin canon against Jerome's narrower Hebraica veritas. The regional Councils of Hippo (393) and Carthage (397 and 419), over which he exercised decisive influence, affirmed Tobit alongside the other deuterocanonical books."
+      },
+      {
+        "scholar_id": "nickelsburg",
+        "position": "In Jewish Literature Between the Bible and the Mishnah, treats Tobit as a representative example of Second Temple diaspora narrative — a pious novella combining wisdom teaching, angelology, and family drama, meant to sustain Jewish identity and practice under foreign rule."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "why-did-western-church-exclude-apocrypha",
+      "jerome-vs-augustine-on-apocrypha",
+      "trent-response-or-innovation"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["deuterocanon", "apocrypha", "diaspora", "second-temple", "angelology", "raphael", "qumran"],
+    "tags": [
+      "deuterocanon",
+      "apocrypha",
+      "diaspora",
+      "second-temple",
+      "angelology",
+      "raphael",
+      "qumran"
+    ],
     "further_reading": [
-      { "title": "Tobit", "author": "Joseph A. Fitzmyer", "note": "Commentaries on Early Jewish Literature (de Gruyter, 2003). Standard critical commentary." },
-      { "title": "The Book of Tobit: Text, Tradition, Theology", "author": "Géza G. Xeravits and József Zsengellér, eds.", "note": "Brill, 2005. Essays on the book's textual history and theological themes." }
+      {
+        "title": "Tobit",
+        "author": "Joseph A. Fitzmyer",
+        "note": "Commentaries on Early Jewish Literature (de Gruyter, 2003). Standard critical commentary."
+      },
+      {
+        "title": "The Book of Tobit: Text, Tradition, Theology",
+        "author": "Géza G. Xeravits and József Zsengellér, eds.",
+        "note": "Brill, 2005. Essays on the book's textual history and theological themes."
+      }
     ]
   },
   {
     "id": "judith",
     "title": "Judith",
-    "also_known_as": ["Book of Judith"],
+    "also_known_as": [
+      "Book of Judith"
+    ],
     "category": "deuterocanon",
     "estimated_date": "Late 2nd or early 1st c. BC",
     "original_language": "Hebrew original (not extant; lost); preserved in Greek (Septuagint) and Latin (Vulgate, Jerome's free revision)",
@@ -214,30 +435,69 @@
       "ethiopian_tewahedo": "canonical (Broader Canon)"
     },
     "brief_summary": "Judith is a Jewish novella of deliverance set in a deliberately confused historical frame: 'Nebuchadnezzar, king of the Assyrians' (the title itself conflates the Neo-Babylonian king with the Assyrian empire he actually dissolved) sends his general Holofernes to punish the peoples of the west. When Holofernes besieges the Jewish hill-town of Bethulia, Judith — a beautiful, pious, wealthy widow — offers to save the town. Dressed in finery and carrying her own kosher food, she enters the enemy camp, charms Holofernes, waits until he is drunk and alone in his tent, and beheads him with his own sword. She returns to Bethulia with the head; the Israelites rout the leaderless Assyrian army, and the book ends with Judith's hymn of praise and a long, peaceful widowhood.\n\nThe book's deliberate historical dislocation — Nebuchadnezzar is called king of Assyria, and the setting cannot be harmonised with any known Persian or Hellenistic campaign — has long been recognised as a literary rather than historical feature. Most scholars read Judith as pious fiction composed in the late Hasmonean period (late second or early first century BC), perhaps to encourage Jewish resistance under Hellenistic or Roman pressure. It portrays Torah observance, prayer, and decisive courage as the true means of national deliverance.\n\nThe Hebrew original has not survived; the book is known through the Greek of the Septuagint (two recensions) and Jerome's free Latin rendering, which he produced reluctantly for the Vulgate from an Aramaic exemplar. Jerome's prologue to Judith classes it among the books read 'for the edification of the people, but not to establish the authority of ecclesiastical doctrines.' Augustine defended its broader canonicity at Hippo and Carthage, and that position was formally reaffirmed at Trent. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive Judith as Scripture; the Protestant Reformers followed Jerome's narrower judgment, placing it among the Apocrypha.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Book of Judith is a deuterocanonical Jewish narrative from the Hellenistic period, probably composed in Hebrew in the 2nd century BC and surviving complete only in Greek (in the Septuagint) and in Latin (in the Vulgate, translated from an Aramaic version by Jerome). The book tells the story of Judith, a pious widow of Bethulia, who saves her Jewish town from the Assyrian general Holofernes by seducing him with her beauty, sharing a feast, and — once he lies drunk in his tent — cutting off his head with his own sword. The severed head displayed on Bethulia's walls routs the besieging army and secures Israel's deliverance. Theologically Judith is an extended meditation on divine action through unlikely agents: a widow, a woman, someone outside the priestly establishment, who becomes the instrument by which God overthrows an arrogant pagan threat to his people.\n\n## Composition history\n\nJudith's compositional history raises immediate questions. The narrative's opening frame is historically impossible: Nebuchadnezzar is called king 'of the Assyrians' (Judith 1:1) when he was actually the Babylonian king who destroyed Nineveh and ended the Assyrian Empire. Holofernes is named as his general; a historical Holofernes served under the Persian Artaxerxes III Ochus, not Nebuchadnezzar. Bethulia itself is not a known city. These anachronisms are deliberate and pervasive — most scholars read them as signaling that Judith is a religious fiction set in a vaguely historicized past, perhaps as a parable of the Maccabean crisis (where Judith-as-Israel defeats the Hellenistic-king-figure).\n\nDate: the consensus places composition in the 2nd century BC, most likely between the Maccabean revolt (167 BC) and the Hasmonean consolidation under John Hyrcanus (135-104 BC). Linguistic features of the Greek Septuagint text reflect a Hebrew original; Jerome's Latin translation for the Vulgate was from a different (Aramaic) source, producing a noticeably different text in places. Original language: Hebrew, with Aramaic recensions possibly produced early. No Hebrew or Aramaic manuscript of Judith has been found at Qumran or elsewhere; the Septuagint Greek is the earliest surviving form.\n\n## Contents\n\nThe narrative divides into three acts. **Act 1 (chapters 1–7)** sets the stage. Nebuchadnezzar king of Assyria sends his general Holofernes to subjugate the western nations that refused to aid him in war. Holofernes conquers Syria, Moab, Ammon, and the Phoenician coast, then turns toward Judea. The Jewish hill-country village of Bethulia stands in his path. Holofernes besieges Bethulia, cuts off its water supply, and waits for the town to surrender. After 34 days the water is exhausted; the town elders announce that if no deliverance comes in five more days, they will surrender.\n\n**Act 2 (chapters 8–13)** introduces Judith — a pious widow of Bethulia, 'beautiful in appearance' and 'very rich' (8:7), living quietly on her late husband's estate in prayer and fasting. Hearing the elders' five-day ultimatum, she rebukes them for putting God to the test, dresses in her widow's garb, and announces she will accomplish deliverance. She prays (chapter 9 — a rich recapitulation of divine action through unexpected agents, including Simeon's slaughter at Shechem), dresses in her most beautiful garments, and walks out of Bethulia with only her maid. The Assyrian sentries intercept her; she asks to see Holofernes, claiming to bring intelligence. Holofernes is immediately captivated by her beauty. Over four days she attends his feasts, consuming only her own kosher food, claiming to pray each night. On the fourth night Holofernes — drunk on his own wine — collapses in his tent. Judith takes his sword from its sheath, cuts off his head in two strokes (13:8), places the head in her food bag, and walks back to Bethulia under the pretense of her nightly prayer excursion.\n\n**Act 3 (chapters 14–16)** resolves the crisis. The head is displayed on Bethulia's walls at dawn. The Jewish forces sortie; the Assyrian troops, rushing to Holofernes's tent for orders, discover his headless body, panic, and flee. The Assyrians are routed; the Jewish women of Bethulia dance in celebration; Judith sings a victory hymn (chapter 16 — one of the finest poems in the Apocrypha) echoing Miriam's song at the sea (Exod 15) and Deborah's song over Sisera (Judges 5). The book concludes with Judith's return to her estate, her long widowhood maintained in celibate piety, and her death at 105.\n\nTheological themes: divine sovereignty over Gentile oppressors; the overturning of expectation — the weak instrument accomplishes what the strong cannot; the faithfulness of covenant observance even under siege (Judith's refusal of Holofernes's food, her observance of prayer in the enemy camp); the continuity with OT deliverance narratives (the allusions to Deborah, Jael, Simeon, Miriam are dense and deliberate).\n\n## Reception history\n\n**Second Temple Judaism**: Judith was apparently read but not canonized by Palestinian Judaism. No Qumran manuscript has been identified. The rabbinic canon excluded it. However, medieval Jewish sources (e.g., Megillat Yehudith, the 'Scroll of Judith') preserve parallel Judith traditions associated with Hanukkah — an intriguing survival suggesting ongoing Jewish interest even after canonical exclusion.\n\n**Early Christianity**: Judith was widely received in the Greek-speaking church. Clement of Rome (1 Clement 55, c. 95 AD) holds her up as an example of faith alongside Esther. Clement of Alexandria, Origen, and Tertullian quote Judith approvingly. Athanasius' 39th Festal Letter (367 AD) places Judith in the second tier — 'appointed by the Fathers to be read' by catechumens. Hippo (393) and Carthage (397) included Judith in the canonical list. Augustine defends its canonicity in De Doctrina Christiana 2.8. Jerome translated it for the Vulgate from an Aramaic text; he classified it as 'ecclesiastical' in his prefaces but produced the translation under episcopal pressure.\n\n**Medieval Christianity** received Judith as canonical in the Latin West and the Greek East. Medieval devotional art made Judith one of the most depicted biblical figures (Donatello, Artemisia Gentileschi, Caravaggio, Klimt all produced famous Judith images). Theological commentary from Bede through Aquinas treats Judith as Scripture.\n\n**The Reformation** retrieved Jerome's classification. Luther's 1534 Bible placed Judith in the Apocrypha; Article VI (1563) classified it as 'read for example of life' but not for establishing doctrine; Westminster Confession 1.3 (1646) excluded it from the canon entirely. **Trent** (1546) dogmatically defined Judith as canonical Scripture for Catholics. Orthodox Bibles include Judith; Ethiopian Bibles include Judith; the Protestant 66-book canon does not.\n\n## NT and patristic usage\n\nJudith is not directly quoted in the NT. Clement of Rome's epistle cites her within the early Christian memory. Patristic usage is extensive — the 'Widow Judith' is a stock exegetical figure for pious widowhood and faithful cunning against oppressors.\n\n## Scholarly positions\n\nContemporary scholarship treats Judith as sophisticated religious fiction in the Hellenistic Jewish tradition — closer to the biblical novellas (Ruth, Esther, Jonah, Susanna) than to historical narrative. The deliberate historical anachronisms are literary signals, not errors. Moore's Anchor Bible volume (1985) and Carey Moore's Judith (AB, 1985) are the standard English commentaries. More recent: Deborah Gera's Judith (de Gruyter 2014) and Benedikt Eckhardt's edited volume Jewish Identity and Politics Between the Maccabees and Bar Kokhba (Brill 2011) for social-political context.\n\nDebate focuses on:\n- **Moral assessment of Judith's deception**: some patristic and Reformation commentators (notably Luther) were uncomfortable with her seductive strategy; most modern readers (and the book's own narrative) treat her deception as morally justified because Holofernes is the unjust aggressor and the covenant people are in mortal danger.\n- **Feminist and gender criticism**: Judith as female hero is theologically weighty — she accomplishes what the town elders cannot; her piety and her agency are inextricable. Recent scholarship (Gera, Harper) has highlighted the book's intentional gender reversal.\n\n## Why different traditions treated it differently\n\nThe Protestant/Catholic split on Judith follows the same Jerome-Augustine pattern as Tobit and the other deuterocanonical books. Reformation retrieval of Jerome's narrower canon; Trent's dogmatic definition of the broader Latin canon; Orthodox and Ethiopian preservation of broader LXX-based canons. The underlying theological disputes — whether 'consent of the churches' (Augustine) or 'hebraica veritas' (Jerome) grounds the OT canon — drive the canonical disagreement, not the content of Judith itself.\n\n## Further reading\n\nCarey Moore, Judith (Anchor Bible, 1985) — the standard English commentary. Deborah Gera, Judith (Commentaries on Early Jewish Literature, de Gruyter 2014) — most current scholarly work. For literary/cultural reception see Kevin Brine et al., The Sword of Judith (Open Book Publishers, 2010). Online: Bible Odyssey's Judith resources are accessible and scholarly.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Exodus 15", "connection": "Judith's hymn of praise (ch 16) echoes the Song of the Sea and other Old Testament victory songs." },
-      { "ref": "Judges 4-5", "connection": "Judith's deliverance of Israel by assassinating a foreign general consciously mirrors Jael's killing of Sisera — both are celebrated in victory songs immediately afterward." }
+      {
+        "ref": "Exodus 15",
+        "connection": "Judith's hymn of praise (ch 16) echoes the Song of the Sea and other Old Testament victory songs."
+      },
+      {
+        "ref": "Judges 4-5",
+        "connection": "Judith's deliverance of Israel by assassinating a foreign general consciously mirrors Jael's killing of Sisera — both are celebrated in victory songs immediately afterward."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "jerome", "position": "Translated Judith reluctantly from an Aramaic exemplar for the Vulgate, producing a free rendering rather than a close translation. His prologue classed Judith with the books read for edification rather than for establishing doctrine — the distinction that would later be taken up by the Reformers." },
-      { "scholar_id": "augustine", "position": "Defended Judith among the books of the wider Greek and Latin canon. Under his influence the regional Councils of Hippo (393) and Carthage (397 and 419) affirmed its canonical status for the Latin West." },
-      { "scholar_id": "nickelsburg", "position": "Reads Judith as a late Hasmonean Jewish novella composed to encourage Torah-observant resistance under foreign domination. Places it alongside Tobit, Susanna, and 2 Maccabees as examples of edifying Second Temple narrative fiction." }
+      {
+        "scholar_id": "jerome",
+        "position": "Translated Judith reluctantly from an Aramaic exemplar for the Vulgate, producing a free rendering rather than a close translation. His prologue classed Judith with the books read for edification rather than for establishing doctrine — the distinction that would later be taken up by the Reformers."
+      },
+      {
+        "scholar_id": "augustine",
+        "position": "Defended Judith among the books of the wider Greek and Latin canon. Under his influence the regional Councils of Hippo (393) and Carthage (397 and 419) affirmed its canonical status for the Latin West."
+      },
+      {
+        "scholar_id": "nickelsburg",
+        "position": "Reads Judith as a late Hasmonean Jewish novella composed to encourage Torah-observant resistance under foreign domination. Places it alongside Tobit, Susanna, and 2 Maccabees as examples of edifying Second Temple narrative fiction."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "why-did-western-church-exclude-apocrypha",
+      "jerome-vs-augustine-on-apocrypha",
+      "trent-response-or-innovation"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["deuterocanon", "apocrypha", "second-temple", "novella", "hasmonean", "holofernes"],
+    "tags": [
+      "deuterocanon",
+      "apocrypha",
+      "second-temple",
+      "novella",
+      "hasmonean",
+      "holofernes"
+    ],
     "further_reading": [
-      { "title": "Judith", "author": "Carey A. Moore", "note": "Anchor Bible 40 (Doubleday, 1985). Standard critical commentary." },
-      { "title": "A Commentary on the Book of Judith", "author": "Deborah Levine Gera", "note": "Commentaries on Early Jewish Literature (de Gruyter, 2014)." }
+      {
+        "title": "Judith",
+        "author": "Carey A. Moore",
+        "note": "Anchor Bible 40 (Doubleday, 1985). Standard critical commentary."
+      },
+      {
+        "title": "A Commentary on the Book of Judith",
+        "author": "Deborah Levine Gera",
+        "note": "Commentaries on Early Jewish Literature (de Gruyter, 2014)."
+      }
     ]
   },
   {
     "id": "wisdom_of_solomon",
     "title": "Wisdom of Solomon",
-    "also_known_as": ["Book of Wisdom", "Sapientia Salomonis"],
+    "also_known_as": [
+      "Book of Wisdom",
+      "Sapientia Salomonis"
+    ],
     "category": "deuterocanon",
     "estimated_date": "Mid to late 1st c. BC, probably Alexandrian",
     "original_language": "Greek (composed directly in Greek; no Hebrew or Aramaic Vorlage is attested)",
@@ -248,30 +508,69 @@
       "ethiopian_tewahedo": "canonical (Broader Canon)"
     },
     "brief_summary": "Wisdom of Solomon is a philosophical wisdom text pseudepigraphically attributed to Solomon but composed in elegant Alexandrian Greek, probably in the mid to late first century BC. The book falls into three main parts. Chapters 1–5 contrast the destinies of the righteous and the wicked, developing a strong doctrine of post-mortem vindication: though the righteous seem to die, their souls are 'in the hand of God' (Wis 3:1), and they will stand to judge their oppressors. Chapters 6–9 present Wisdom herself as a cosmic figure — an 'emanation of the glory of the Almighty' (Wis 7:25), a 'reflection of eternal light,' 'the fashioner of all things' — personified in terms drawn from Greek philosophical vocabulary and Hebrew wisdom traditions alike. Chapters 10–19 retell the Exodus as a demonstration of Wisdom's guidance of Israel and judgment on Egypt, with extended polemic against the idolatry of Gentile religion.\n\nThe book's engagement with Greek philosophical categories — the immortal soul, virtue, the cosmic Logos — makes it a bridge between Second Temple Judaism and the intellectual world of the New Testament. Several New Testament passages contain material that echoes Wisdom of Solomon closely: the argument against Gentile idolatry in Romans 1:18–32 tracks the polemic in Wisdom 13–14; Romans 9:21 ('the potter has power over the clay') resembles Wisdom 15:7; and Hebrews 1:3, describing the Son as 'the radiance of God's glory and the exact representation of his being,' reuses language strikingly close to Wisdom 7:25–26. Most New Testament scholars read these as allusions to or shared dependence on the same Hellenistic Jewish vocabulary, not necessarily direct quotation.\n\nBecause Wisdom existed only in Greek, it was excluded from the rabbinic canon. Jerome grouped it with the apocrypha; Augustine and the African councils received it as canonical. The Council of Trent affirmed its deuterocanonical status for Catholicism; the Eastern Orthodox and Ethiopian Tewahedo churches likewise received it as Scripture; the Protestant Reformers, following Jerome, placed it among the Apocrypha.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Wisdom of Solomon is a deuterocanonical book of Hellenistic Jewish philosophy, composed in Greek by an Alexandrian Jew in the 1st century BC or early 1st century AD. Unlike Proverbs or Sirach, which collect practical wisdom in aphoristic form, Wisdom of Solomon is a sustained rhetorical treatise that defends Jewish monotheism and covenant theology in dialogue with Hellenistic philosophy (especially Platonism and Stoicism). It presents itself as Solomon's first-person reflection but was clearly composed 800+ years later by an anonymous Alexandrian author writing in sophisticated literary Greek. The book divides into three parts: (1) an eschatological meditation on the reward of the righteous and the punishment of the wicked; (2) an extended praise of personified Wisdom (Sophia) as God's companion in creation; and (3) a theological reading of the Exodus narrative showing God's providential justice through the plagues. It is arguably the most philosophically ambitious book in the Jewish-Christian deuterocanon and exercised substantial influence on Philo of Alexandria, Paul, and the patristic writers.\n\n## Composition history\n\nComposition in Alexandria: virtually certain. The book's rhetorical style, philosophical vocabulary, and knowledge of Egyptian religion all point to the diaspora Jewish community of Alexandria — the same community that produced the Septuagint, Philo, and 3 Maccabees. The Greek is polished, not translation Greek.\n\nDate: scholarly estimates range from 100 BC to 40 AD. The most commonly cited window is 30 BC to 40 AD — the early Roman period, when Alexandrian Jews faced cultural and political pressure under Augustan and Tiberian rule. Recent scholarship (David Winston, James Reese) leans late (Caligula-era, c. 39-41 AD, when imperial pressure on Alexandrian Jewry peaked) while earlier scholars (Deane, Gregg) favored the late 1st century BC.\n\nOriginal language: Greek. No Hebrew or Aramaic original is attested; the Greek style is native, not translated. Some scholars have proposed Hebrew originals for chapters 1-5, but this is a minority position.\n\nAuthorship: anonymous. The first-person 'Solomon' frame is a literary conceit — 'Solomon' was the traditional Jewish patron of wisdom, and attributing wisdom literature to him was standard Hellenistic Jewish practice. No modern scholar identifies the actual author.\n\n## Contents\n\n**Book One (chapters 1-5) — Eschatological meditation**. The opening chapter exhorts the reader to 'seek the Lord with an upright mind' because 'the Spirit of the Lord fills the whole earth' (1:7). Death is not God's design (1:13); the ungodly brought it on themselves by misguided philosophy. Chapter 2 stages the ungodly as materialist hedonists: 'Short and sorrowful is our life… let us enjoy the good things that exist' (2:1, 6). They plot against the righteous man who claims to be 'a child of God' (2:18) — a passage the patristic writers frequently read as messianic prophecy. Chapters 3-5 announce the eschatological reversal: the righteous, though they seem to die, are 'in the hand of God' (3:1); their childlessness (if unmarried) or early death does not diminish them; at the judgment the wicked will realize too late their error (5:1-14).\n\n**Book Two (chapters 6-9) — Praise of Wisdom**. Wisdom (Sophia) is personified as God's companion and God's gift. Chapter 7:22-8:1 is one of the great descriptions of Sophia in Hellenistic Jewish literature: 'a breath of the power of God, a pure emanation of the glory of the Almighty… a reflection of the eternal light, a spotless mirror of the working of God.' This passage deeply influenced NT Christology — Hebrews 1:3 and Colossians 1:15-20 draw on Sophia language to describe Christ. Chapter 9 is Solomon's prayer for Wisdom.\n\n**Book Three (chapters 10-19) — Providential history**. The Exodus narrative is rethought through the lens of Wisdom's agency. Chapter 10 summarizes wisdom's action from Adam through the flood through the patriarchs; chapters 11-19 expound the plagues with a theological pattern: each Egyptian plague was calibrated to the very thing Egypt worshiped (frogs, flies, Nile water, etc.), demonstrating that God's justice works through creation itself. Chapter 14 digresses on idolatry (the genealogy of idols — grief over dead loved ones, flattery of kings — is psychologically acute). Chapter 15 is a sustained polemic against Egyptian animal worship.\n\nPhilosophically the book integrates Platonic ideas (body-soul dualism, the soul's heavenly origin) with biblical covenant theology. Stoic cosmology (the divine logos pervading creation) is absorbed and redirected toward Yahweh. The result is genuinely distinctive — not mere Hellenization of Judaism nor mere Judaization of Greek philosophy, but a creative synthesis.\n\n## Reception history\n\n**Second Temple Judaism and Philo**: Wisdom of Solomon was known to and influenced Philo of Alexandria (first half of 1st century AD), whose own theology of the Logos draws on Sophia traditions. It was read in Alexandrian synagogues.\n\n**The New Testament**: the parallels are numerous enough to strongly suggest Pauline acquaintance. Wisdom 13:1-9's critique of nature-worship idolatry is the substrate of Romans 1:18-32. Wisdom 2:23's 'God created man for incorruption' shapes 1 Corinthians 15 and Romans 5. Hebrews 1:3's description of Christ as the 'radiance of the glory of God and the exact imprint of his nature' echoes Wisdom 7:26 verbatim in structure. Colossians 1:15-20's Christ hymn draws on Sophia language. These are not direct quotations but demonstrate deep theological engagement.\n\n**Early Christianity**: widely received as Scripture. Clement of Rome, Clement of Alexandria, Origen, Tertullian, Cyprian all cite Wisdom as authoritative. Athanasius' 39th Festal Letter placed it among books 'appointed by the Fathers to be read.' Hippo and Carthage included it in the canon. Augustine defended its canonicity extensively.\n\n**The Reformation**: retrieved Jerome's distinction. Luther placed Wisdom in the Apocrypha section. Article VI (1563) classified it as edifying but non-doctrinal. Trent (1546) dogmatically defined it as canonical for Catholics.\n\n## NT and patristic usage\n\nAs noted above, the Pauline parallels are strong enough that most scholars accept Paul's familiarity with Wisdom of Solomon (Romans 1:18-32 on idolatry tracks Wisdom 13 almost point by point). Hebrews 1:3 is a near-verbatim reuse of Wisdom 7:26 structure applied to Christ.\n\nPatristic usage was extensive. Cyprian's Testimonia Against the Jews organizes OT citations with Wisdom as a frequent source. Augustine cites Wisdom dozens of times across his corpus.\n\n## Scholarly positions\n\nContemporary scholarship treats Wisdom of Solomon as a major witness to Hellenistic Jewish thought and as significant NT background. David Winston's The Wisdom of Solomon (Anchor Bible, 1979) is the standard English commentary. James Reese's Hellenistic Influence on the Book of Wisdom and Its Consequences (1970) established the philosophical sources. Lester Grabbe's Wisdom of Solomon (Sheffield 1997) offers accessible introduction.\n\nDebate focuses on:\n- **Single or multiple authorship**: the stylistic unity of the Greek supports single authorship against older theories (Heinisch, Gregg) of composite compilation.\n- **Date within the 1st century BC-AD window**: Caligula-era composition (39-41 AD) has gained ground but is not established.\n- **Influence on Paul**: most scholars accept some familiarity; whether Wisdom of Solomon was a direct literary source for specific NT passages is more contested.\n\n## Why different traditions treated it differently\n\nThe canonical split on Wisdom of Solomon is the familiar Jerome/Augustine pattern. The book was Alexandrian Jewish, Greek in its original, and never part of the Hebrew canon — Jerome's criteria excluded it. But its widespread patristic use and deep influence on NT theology made it Augustine's favorite deuterocanonical book — he cites it more than any other Apocryphal work. Reformation retrieval of Jerome's position excluded Wisdom from the Protestant canon; Trent's dogmatic definition preserved it for Catholics. Its literary and philosophical quality is universally acknowledged across traditions.\n\n## Further reading\n\nDavid Winston, The Wisdom of Solomon (Anchor Bible, 1979) — standard English commentary. Lester Grabbe, Wisdom of Solomon (Sheffield 1997) — accessible introduction. For Philo parallels see Winston and Dillon, Two Treatises of Philo of Alexandria (Brown Judaic Studies 1983). For Paul parallels see John Levison, The Spirit in First Century Judaism (Brill 1997). Online: Bible Odyssey hosts accessible scholarly essays; the NRSV with Apocrypha includes Wisdom with annotation.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Proverbs 8", "connection": "Wisdom's self-description as the fashioner of creation (Wis 7:22–8:1) extends the personified Wisdom figure of Proverbs 8 into explicitly philosophical vocabulary." },
-      { "ref": "Exodus 7-14", "connection": "Chapters 10–19 retell the Exodus as a demonstration of Wisdom's guidance of Israel and judgment on Egypt." }
+      {
+        "ref": "Proverbs 8",
+        "connection": "Wisdom's self-description as the fashioner of creation (Wis 7:22–8:1) extends the personified Wisdom figure of Proverbs 8 into explicitly philosophical vocabulary."
+      },
+      {
+        "ref": "Exodus 7-14",
+        "connection": "Chapters 10–19 retell the Exodus as a demonstration of Wisdom's guidance of Israel and judgment on Egypt."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "augustine", "position": "Received Wisdom among the canonical books of the Greek and Latin churches and defended its place at Hippo and Carthage. Frequently cites it in his theological works as a genuine witness to wisdom theology, particularly on the immortality of the soul and the divine Wisdom active in creation." },
-      { "scholar_id": "jerome", "position": "Grouped Wisdom among the apocrypha in the Prologus Galeatus on the grounds that it was not extant in Hebrew and was not received in the rabbinic canon. Nonetheless translated and transmitted it in the Vulgate alongside the canonical books." },
-      { "scholar_id": "collins", "position": "In his work on Jewish wisdom literature, reads Wisdom of Solomon as the high point of Hellenistic Jewish appropriation of Greek philosophical vocabulary within a firmly biblical theological framework. Notes the striking verbal overlaps with Romans 1 and Hebrews 1 as evidence of a shared Hellenistic Jewish idiom in which the New Testament writers also stood." },
-      { "scholar_id": "keener", "position": "In his work on the New Testament background, identifies Wisdom of Solomon as the most important single Jewish extra-canonical text for understanding Paul's argument in Romans 1:18–32 and the Christological language of Hebrews 1 and Colossians 1." }
+      {
+        "scholar_id": "augustine",
+        "position": "Received Wisdom among the canonical books of the Greek and Latin churches and defended its place at Hippo and Carthage. Frequently cites it in his theological works as a genuine witness to wisdom theology, particularly on the immortality of the soul and the divine Wisdom active in creation."
+      },
+      {
+        "scholar_id": "jerome",
+        "position": "Grouped Wisdom among the apocrypha in the Prologus Galeatus on the grounds that it was not extant in Hebrew and was not received in the rabbinic canon. Nonetheless translated and transmitted it in the Vulgate alongside the canonical books."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "In his work on Jewish wisdom literature, reads Wisdom of Solomon as the high point of Hellenistic Jewish appropriation of Greek philosophical vocabulary within a firmly biblical theological framework. Notes the striking verbal overlaps with Romans 1 and Hebrews 1 as evidence of a shared Hellenistic Jewish idiom in which the New Testament writers also stood."
+      },
+      {
+        "scholar_id": "keener",
+        "position": "In his work on the New Testament background, identifies Wisdom of Solomon as the most important single Jewish extra-canonical text for understanding Paul's argument in Romans 1:18–32 and the Christological language of Hebrews 1 and Colossians 1."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "why-did-western-church-exclude-apocrypha",
+      "jerome-vs-augustine-on-apocrypha"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["deuterocanon", "apocrypha", "wisdom", "hellenistic-judaism", "alexandria", "pauline-background", "hebrews"],
+    "tags": [
+      "deuterocanon",
+      "apocrypha",
+      "wisdom",
+      "hellenistic-judaism",
+      "alexandria",
+      "pauline-background",
+      "hebrews"
+    ],
     "further_reading": [
-      { "title": "The Wisdom of Solomon", "author": "David Winston", "note": "Anchor Bible 43 (Doubleday, 1979). The standard English-language critical commentary." }
+      {
+        "title": "The Wisdom of Solomon",
+        "author": "David Winston",
+        "note": "Anchor Bible 43 (Doubleday, 1979). The standard English-language critical commentary."
+      }
     ]
   },
   {
     "id": "sirach",
     "title": "Sirach (Ecclesiasticus)",
-    "also_known_as": ["Ben Sira", "Ecclesiasticus", "The Wisdom of Jesus ben Sira"],
+    "also_known_as": [
+      "Ben Sira",
+      "Ecclesiasticus",
+      "The Wisdom of Jesus ben Sira"
+    ],
     "category": "deuterocanon",
     "estimated_date": "c. 180 BC (Hebrew original); Greek translation c. 132 BC per the grandson's prologue",
     "original_language": "Hebrew original (extensive fragments preserved in the Cairo Geniza and at Qumran and Masada); standard text preserved in the Greek translation by the author's grandson",
@@ -282,29 +581,63 @@
       "ethiopian_tewahedo": "canonical (Broader Canon)"
     },
     "brief_summary": "Sirach — also titled Ecclesiasticus in the Latin tradition and Ben Sira in Jewish sources — is the longest Jewish wisdom book outside the Hebrew Bible. The Hebrew original was composed in Jerusalem around 180 BC by Jeshua ben Eleazar ben Sira, a Jerusalem teacher of wisdom. The author's grandson translated the book into Greek in Alexandria around 132 BC and prefaced his translation with a prologue — the prologue itself is the earliest explicit reference to a tripartite Hebrew canonical collection ('the Law, the Prophets, and the other books of our fathers').\n\nSirach is structured as a long anthology of wisdom instruction along the lines of Proverbs, with extended poems on themes including the fear of the Lord, practical ethics, family life, friendship, business, speech, mercy, prayer, and the avoidance of folly. Its distinctive contributions include an extended personification of Wisdom as the self-revelation of God (ch 24), a great 'Praise of the Fathers' hymn surveying Israel's history through its notable figures (chs 44–50), and a concluding prayer of the grandfather (ch 51).\n\nThe Hebrew text was lost in the rabbinic tradition but rediscovered piecemeal in the Cairo Geniza (from 1896 onward) and at Qumran and Masada, confirming the Greek grandson's translation as essentially faithful. Sirach was widely cited in early Christianity — Athanasius's Festal Letter 39 (367) explicitly lists it among the books 'appointed to be read' by catechumens, and the book was constantly quoted by the Latin fathers (hence the title Ecclesiasticus, 'the church book,' reflecting its widespread liturgical use).\n\nJerome's Prologus Galeatus classed Sirach among the apocrypha on the grounds that it was not in the rabbinic canon. Augustine defended it as canonical; the African councils and later Trent affirmed that position for the Latin West. Eastern Orthodox churches and the Ethiopian Tewahedo Church likewise receive Sirach as Scripture. The Reformers placed it among the Apocrypha, though early Protestant Bibles (including Luther's) printed it in a separate apocryphal section for edification.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nSirach — also called Ecclesiasticus (the medieval Latin title) or Ben Sira (the Hebrew title) — is the longest book in the Jewish-Christian deuterocanon and one of the most substantial wisdom collections in ancient literature. Composed in Hebrew in Jerusalem around 180 BC by Jesus ben Eleazar ben Sira (Sirach in Greek), it was translated into Greek around 132 BC by the author's grandson, whose fascinating prologue to the Greek edition is itself one of the most important Second Temple texts — the earliest clear reference to the tripartite Hebrew canon ('the Law and the Prophets and the other books of our ancestors,' Prologue 9-10).\n\nThe book collects 51 chapters of practical wisdom, ethical instruction, liturgical praise, and historical meditation. Unlike Proverbs' brief aphoristic sayings, Sirach develops sustained reflections — on friendship, speech, family life, work and poverty, the use and abuse of wealth, the fear of the Lord, the fate of the wicked, the blessing of wise children, and (most distinctively) the dignity of the scribe's vocation. Chapters 44-50, the 'Praise of the Ancestors' (Laus Patrum), is the first extant Jewish attempt to catalogue the great figures of Israel's history in a literary encomium — a genre the author of Hebrews 11 adopts and reshapes.\n\n## Composition history\n\nDate: c. 195-175 BC, with the Greek translation c. 132 BC. The grandson's prologue situates his translation 'in the thirty-eighth year of Euergetes' — Ptolemy VIII Euergetes II, yielding 132 BC as the translation date. The Hebrew original was therefore written earlier, around 195-175 BC, by the grandfather Jesus ben Eleazar ben Sira — the first biblical author we know by name from his own work.\n\nLanguage and manuscripts: the Hebrew original was substantial but partially lost after the closing of the Hebrew canon. The Cairo Geniza (1896-1900) yielded approximately two-thirds of the Hebrew text in medieval manuscripts; additional Hebrew fragments were recovered from Qumran (2QSir, 11QPs^a) and Masada (the Masada scroll preserved chapters 39-44 complete). The Greek Septuagint is the primary textual witness and was the basis for the Syriac Peshitta, Latin Vulgate, and all derivative versions.\n\nAuthorship: Jesus ben Eleazar ben Sira — uniquely among the deuterocanon, we know the author's name and something of his biography. He was a Jerusalem scribe, probably a member of a priestly or scribal school, who traveled abroad (Sirach 34:9-12), valued the accumulated wisdom of tradition, and taught a school of young men in Jerusalem (Sirach 51:23-30, his 'house of instruction'). His grandson, writing the Greek prologue, situates himself in Egypt — probably Alexandria — where he translated his grandfather's work for the diaspora community.\n\n## Contents\n\nThe book does not divide easily into clean sections; it is a loosely organized anthology whose themes recur. The most important units include:\n\n**Prologue (Greek edition only)** — the translator-grandson explains his work, references the three-fold Hebrew canon, and addresses the diaspora reader. Historically invaluable for canon studies.\n\n**Chapters 1-23 — Wisdom and practical ethics**. The opening 'Wisdom is from the Lord' (1:1) sets the tone. Practical counsel on speech, friendship, hospitality, marital relations, work, anger management, prayer, almsgiving. Chapter 3 on honoring parents is notable: 'Honor your father by word and deed so that blessing may come to you from him' (3:8-9). Chapter 11:27's famous 'count no man happy until he is dead' became a commonplace of later ethics.\n\n**Chapters 24-43 — Wisdom personified and theological reflection**. Chapter 24 is the book's theological centerpiece: Wisdom personified speaks, narrates her cosmic dwelling-seeking from before creation ('I came forth from the mouth of the Most High' 24:3), and reveals that she has been given as inheritance to Israel ('in the holy tabernacle I ministered before him, and so was I established in Zion' 24:10). This is the direct ancestor of Wisdom of Solomon chapter 7 and of John 1:1-14's Logos theology. Chapter 38 on physicians ('honor the physician with the honor due him,' 38:1) is the first Jewish text to explicitly legitimate medical practice — historically significant for Jewish medical ethics. Chapter 43 is a cosmological hymn on the Creator.\n\n**Chapters 44-50 — Praise of the Ancestors (Laus Patrum)**. 'Let us now praise famous men, and our fathers in their generations' (44:1) opens a 7-chapter literary encomium running from Enoch through Adam, Noah, Abraham, Isaac, Jacob, Moses, Aaron, Phinehas, Joshua, Caleb, the judges, Samuel, David, Solomon, Elijah, Elisha, Hezekiah, Isaiah, Josiah, Jeremiah, Ezekiel, the twelve prophets, Zerubbabel, Joshua the high priest, Nehemiah, and — as climactic figure — Simon II the high priest (c. 220-195 BC), the great Zadokite high priest of Sirach's own youth whom he witnessed in temple service. The encomium is the first attempt to integrate Israel's history into a single literary tribute.\n\n**Chapter 51 — Epilogue**. A closing prayer and instruction for young students.\n\n## Reception history\n\n**Second Temple Judaism**: Sirach was widely read. The Qumran community preserved Hebrew fragments. The Masada scroll shows the Hebrew circulated in Palestinian Judaism. The rabbinic canon ultimately excluded Sirach but rabbinic literature cites Ben Sira frequently (Talmud references to 'Ben Sira' number in the dozens) — a sign the book retained authority as near-Scripture even when formally excluded from the canon.\n\n**Early Christianity**: extensively used. Sirach is cited frequently in the NT (see below) and in virtually every patristic writer. Athanasius' 39th Festal Letter places it among books 'appointed by the Fathers to be read.' The Latin title 'Ecclesiasticus' reflects its ecclesial use — the 'church book' par excellence for moral instruction.\n\n**The Reformation**: Luther placed Sirach in the Apocrypha section with a headline treating it as 'useful and good to read.' Article VI and Westminster Confession followed the Apocrypha classification. **Trent** (1546) dogmatically defined Sirach as canonical for Catholics. Orthodox and Ethiopian canons include Sirach.\n\n## NT and patristic usage\n\nSirach's influence on the NT is substantial. Matthew 6:7-13 (the Lord's Prayer's theological background) echoes Sirach 7:14 ('do not use many words when you pray') and 28:2 ('forgive your neighbor the wrong he has done, then your sins will be forgiven'). James 1:19 ('be quick to hear, slow to speak, slow to anger') paraphrases Sirach 5:11 ('be quick to hear and deliberate in answering'). The language of Matthew 11:28-30 ('take my yoke upon you and learn from me… you will find rest for your souls') echoes Sirach 51:23-27's invitation to the scribal school. These are not formal citations but clear literary engagements.\n\nPatristic usage is pervasive. Cyprian's Testimonia draws on Sirach frequently. Augustine cites it hundreds of times across his corpus. The book's ethical integration and theological depth made it the workhorse deuterocanonical text for patristic moral teaching.\n\n## Scholarly positions\n\nContemporary scholarship treats Sirach as one of the most important Second Temple Jewish books for understanding the development of wisdom literature and the thought-world of the NT. Patrick Skehan and Alexander Di Lella, The Wisdom of Ben Sira (Anchor Bible, 1987) is the standard English commentary, incorporating both the Hebrew and Greek evidence. John Collins' Jewish Wisdom in the Hellenistic Age (Westminster John Knox, 1997) places Sirach in its intellectual context. Benjamin Wright's Praise Israel for Wisdom and Instruction (Brill 2008) treats the book as Diaspora-Palestinian literary bridge.\n\nDebate focuses on:\n- **Relationship to Hellenistic thought**: Sirach engages Hellenistic philosophical currents while resisting them. The degree of engagement is debated.\n- **Priestly sympathies**: Sirach's praise of Simon II and the Aaronic priesthood (ch 45, 50) reflects a pre-Maccabean Zadokite sympathy.\n- **Canonical status**: unchanged since the Reformation — Catholic/Orthodox/Ethiopian canonical; Protestant apocrypha; Jewish rabbinic extra-biblical (with rabbinic citation practice that approaches canonical treatment).\n\n## Why different traditions treated it differently\n\nSirach's canonical status follows the standard Jerome-Augustine divergence. Jerome excluded it from the Hebrew-canonical OT on hebraica-veritas grounds even though the Hebrew original existed (he knew of the Hebrew text). Augustine included it via the 'consent of the churches' criterion. The Reformation retrieved Jerome's position. Trent solidified the Catholic retention. The rabbinic exclusion is notable: the Hebrew of Sirach was available, but the book was finally left outside the Tanakh — possibly because it was associated with figures (Ben Sira himself, Simon II) who postdated the prophetic era.\n\n## Further reading\n\nPatrick Skehan and Alexander Di Lella, The Wisdom of Ben Sira (Anchor Bible, 1987) — the definitive English commentary. John Collins, Jewish Wisdom in the Hellenistic Age (Westminster John Knox, 1997) — accessible contextual introduction. For the Hebrew textual evidence see Pancratius Beentjes, The Book of Ben Sira in Hebrew (Brill 1997). Online: Bible Odyssey includes accessible scholarly introductions; the NRSV with Apocrypha includes Sirach with annotation.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Proverbs 8", "connection": "Sirach 24 extends the personified Wisdom of Proverbs 8, presenting her as having taken up residence in Jerusalem and identifying her with the Torah." }
+      {
+        "ref": "Proverbs 8",
+        "connection": "Sirach 24 extends the personified Wisdom of Proverbs 8, presenting her as having taken up residence in Jerusalem and identifying her with the Torah."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "athanasius", "position": "In Festal Letter 39 (367), lists the books 'appointed to be read' by catechumens. Sirach appears there — not as canonical Scripture but as a book useful for instruction in piety. This is a key fourth-century witness to the book's ecclesiastical standing in the Eastern churches." },
-      { "scholar_id": "jerome", "position": "Grouped Sirach among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic canon. Translated and transmitted it in the Vulgate nonetheless; his judgment was followed by the Reformers a millennium later." },
-      { "scholar_id": "augustine", "position": "Received Sirach as canonical, citing it frequently in his theological and pastoral works. Under his influence the regional Councils of Hippo and Carthage affirmed Sirach alongside the other deuterocanonical books." },
-      { "scholar_id": "collins", "position": "In his studies of Second Temple wisdom literature, traces Sirach's synthesis of Proverbs-style wisdom with identification of Wisdom and Torah (ch 24), and surveys the book's enormous influence on later Jewish and Christian ethical instruction." }
+      {
+        "scholar_id": "athanasius",
+        "position": "In Festal Letter 39 (367), lists the books 'appointed to be read' by catechumens. Sirach appears there — not as canonical Scripture but as a book useful for instruction in piety. This is a key fourth-century witness to the book's ecclesiastical standing in the Eastern churches."
+      },
+      {
+        "scholar_id": "jerome",
+        "position": "Grouped Sirach among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic canon. Translated and transmitted it in the Vulgate nonetheless; his judgment was followed by the Reformers a millennium later."
+      },
+      {
+        "scholar_id": "augustine",
+        "position": "Received Sirach as canonical, citing it frequently in his theological and pastoral works. Under his influence the regional Councils of Hippo and Carthage affirmed Sirach alongside the other deuterocanonical books."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "In his studies of Second Temple wisdom literature, traces Sirach's synthesis of Proverbs-style wisdom with identification of Wisdom and Torah (ch 24), and surveys the book's enormous influence on later Jewish and Christian ethical instruction."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "why-did-western-church-exclude-apocrypha",
+      "jerome-vs-augustine-on-apocrypha"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["deuterocanon", "apocrypha", "wisdom", "ben-sira", "cairo-geniza", "second-temple", "praise-of-the-fathers"],
+    "tags": [
+      "deuterocanon",
+      "apocrypha",
+      "wisdom",
+      "ben-sira",
+      "cairo-geniza",
+      "second-temple",
+      "praise-of-the-fathers"
+    ],
     "further_reading": [
-      { "title": "The Wisdom of Ben Sira", "author": "Patrick W. Skehan and Alexander A. Di Lella", "note": "Anchor Bible 39 (Doubleday, 1987). Standard English-language critical commentary." }
+      {
+        "title": "The Wisdom of Ben Sira",
+        "author": "Patrick W. Skehan and Alexander A. Di Lella",
+        "note": "Anchor Bible 39 (Doubleday, 1987). Standard English-language critical commentary."
+      }
     ]
   },
   {
     "id": "1_maccabees",
     "title": "1 Maccabees",
-    "also_known_as": ["First Maccabees"],
+    "also_known_as": [
+      "First Maccabees"
+    ],
     "category": "deuterocanon",
     "estimated_date": "Late 2nd c. BC, probably c. 100 BC",
     "original_language": "Hebrew original (not extant; Jerome reports having seen it); preserved in Greek (Septuagint) and Latin (Vulgate)",
@@ -315,31 +648,71 @@
       "ethiopian_tewahedo": "canonical (Broader Canon; includes 1–3 Maccabees)"
     },
     "brief_summary": "1 Maccabees is the primary historical narrative of the Jewish revolt against the Seleucid king Antiochus IV Epiphanes and of the rise of the Hasmonean dynasty that followed. Composed in Hebrew in the late second century BC by a writer sympathetic to the Hasmoneans, the book covers roughly 175–134 BC in sixteen chapters of straightforward historical prose.\n\nThe narrative opens with Alexander the Great and the emergence of the Seleucid kingdom, then focuses on Antiochus IV's persecution of Jewish practice — the prohibition of the Sabbath and circumcision, the desecration of the Jerusalem Temple with 'the abomination that causes desolation' (1 Macc 1:54; cf. Dan 9:27, 11:31, 12:11) in December 167 BC, and the forced imposition of pagan worship. It recounts the resistance led by the priest Mattathias and his sons Judah, Jonathan, and Simon (the 'Maccabees'), Judah's military victories, and the rededication of the Temple in December 164 BC — the event commemorated thereafter by the eight-day Feast of Dedication (Hanukkah).\n\nThis matters directly for the New Testament. John 10:22 — 'Then came the Feast of Dedication at Jerusalem. It was winter, and Jesus was in the temple courts walking in Solomon's Colonnade' — refers to Hanukkah, the annual commemoration of the rededication described in 1 Maccabees 4:36–59 (paralleled in 2 Macc 10:1–8). The historical events behind the festival are known only from 1 and 2 Maccabees; the Jewish Bible is silent on them.\n\n1 Maccabees was excluded from the rabbinic canon and grouped by Jerome among the apocrypha. Augustine and the African councils received it as canonical; the Council of Trent formally defined it as deuterocanonical. Eastern Orthodox and Ethiopian Tewahedo churches likewise receive it. The Protestant Reformers followed Jerome's narrower canon, placing 1 Maccabees in the Apocrypha.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\n1 Maccabees is a deuterocanonical Jewish historical narrative covering the Maccabean revolt and its aftermath — from the outbreak of crisis under Antiochus IV Epiphanes in 175 BC to the death of Simon Maccabeus in 134 BC. It is the single most important historical source we possess for this pivotal 40-year period in Jewish history. Written in Hebrew in Palestine in the late 2nd or early 1st century BC, surviving complete only in Greek (Septuagint) and Latin translation, 1 Maccabees offers a soberly executed, chronologically organized, politically engaged chronicle of how a priestly family from the village of Modin led Israel's resistance against Seleucid religious persecution, rededicated the desecrated Jerusalem Temple, and established the Hasmonean dynasty that ruled Judea until the Roman conquest in 63 BC.\n\nUnlike 2 Maccabees (a more theologically-laden Greek composition by Jason of Cyrene, covering a shorter period with different priorities), 1 Maccabees reads as straightforward narrative history in the mold of 1-2 Kings or 1-2 Chronicles. Its chronological precision, political realism, and archival source use (treaties, letters, diplomatic correspondence) have led most modern historians to treat it as substantively reliable — within the limits of ancient historiography — for the events it covers.\n\n## Composition history\n\nDate: the narrative stops at Simon's death (134 BC) and does not mention events under John Hyrcanus I (134-104 BC) or later — suggesting composition during Hyrcanus's reign, most likely c. 120-100 BC.\n\nOriginal language: Hebrew. Jerome knew of the Hebrew original ('I have found a book of the Maccabees in Hebrew,' Prologus Galeatus) and no Hebrew manuscript has survived. The Septuagint Greek translation (probably 1st century BC) is the primary witness. The Latin Vulgate's 1-2 Maccabees were revised by Jerome but not retranslated from the lost Hebrew — they reflect the Greek tradition.\n\nAuthorship: anonymous. The author writes as a Jewish partisan of the Hasmonean dynasty, clearly sympathetic to the Maccabean family and to Hyrcanus's legitimacy, but with enough historical distance from the events described (the narrative is clearly retrospective, not contemporary) that direct eyewitness is unlikely. A court historian for Hyrcanus I is the most commonly posited figure.\n\n## Contents\n\n**Prologue: Alexander and the Hellenistic crisis (chapter 1)**. Opens with Alexander the Great, his world conquest, his death, and the division of his empire. After many generations 'a wicked root sprang up: Antiochus Epiphanes' (1:10), who ascended the Seleucid throne in 175 BC. Antiochus forces Hellenization on Judea — outlawing circumcision and Torah observance, ordering unclean sacrifices in the Temple, erecting 'the abomination of desolation' (Greek bdelugma erēmōseōs, Hebrew shiqquts meshomem) on the altar (1:54). Faithful Jews who refuse to comply are put to death.\n\n**Mattathias's revolt (chapter 2)**. Mattathias the priest of the village of Modin refuses to sacrifice to the Greek gods when the king's commissioner arrives. He kills the commissioner and a collaborating Jew, then flees to the hills with his five sons: John Gaddi, Simon Thassi, Judas Maccabeus, Eleazar Avaran, and Jonathan Apphus. A guerrilla war begins. On his deathbed Mattathias passes leadership to Judas as the 'Maccabeus' ('hammer') warrior, with Simon as wise counselor (2:65-66).\n\n**Judas Maccabeus's campaigns (chapters 3-9)**. The longest section of the book. Judas defeats successive Seleucid armies at Beth-horon, Emmaus, and Beth-zur. He takes Jerusalem, cleanses the Temple, builds a new altar, and rededicates the Temple on the 25th of Kislev, 164 BC — the event Hanukkah celebrates and which John 10:22 names (4:36-59). Further campaigns expand Jewish control. Judas dies in battle against Bacchides at Elasa (9:1-22).\n\n**Jonathan's leadership (chapters 9-12)**. Jonathan succeeds Judas, navigates Seleucid succession disputes shrewdly, is appointed high priest by one Seleucid claimant (Alexander Balas, 152 BC), treaties with Sparta and Rome, and expands Jewish territorial control. He is eventually captured by treachery and executed by Trypho.\n\n**Simon's consolidation (chapters 13-16)**. Simon, the last surviving son of Mattathias, is recognized as leader and high priest. He captures the citadel of Jerusalem (141 BC), secures independence from Seleucid tribute, and is declared 'leader and high priest forever, until a trustworthy prophet should arise' (14:41). The book closes with his assassination by his son-in-law Ptolemy at Jericho (134 BC) and the succession of John Hyrcanus.\n\nThe narrative prose is clean, chronologically precise, and remarkably self-aware — the author inserts archival materials (Roman and Spartan treaties, Seleucid letters, bronze-inscription decrees) as primary documents within the narrative, a sophisticated historiographical move.\n\n## Reception history\n\n**Second Temple Judaism**: 1 Maccabees was read as the foundational chronicle of Hasmonean legitimacy. It was known but not included in the Hebrew canon — partly because the prophetic era had officially closed before its events, partly because the rabbinic tradition that consolidated after 70 AD had reason to distance itself from the Hasmonean political legacy.\n\n**Hanukkah**: the feast 1 Maccabees institutes remains central to Jewish observance. The later Talmudic tradition adds the 'miracle of the oil' detail (b. Shabbat 21b) that is not in 1 Maccabees itself — the book grounds Hanukkah in the military-political rededication, not the oil miracle. Both traditions coexist in modern Jewish observance.\n\n**Early Christianity**: 1 Maccabees was received as Scripture by the LXX-using Greek church. Athanasius' 39th Festal Letter places it in the anagignoskomena tier. Hippo and Carthage included it. Augustine defended it. It is the only historical context for John 10:22 (the Feast of Dedication), which the Gospel of John assumes the reader understands.\n\n**The Reformation**: Protestant Bibles classify 1 Maccabees as Apocrypha per the Jerome-hebraica-veritas principle. Trent (1546) dogmatically defines it as canonical for Catholics. Orthodox and Ethiopian canons include it.\n\n## NT and patristic usage\n\n1 Maccabees is not quoted in the NT but is the essential historical background for John 10:22's Feast of Dedication. Without 1 Maccabees we would not know what Hanukkah was or why Jesus was in Jerusalem at that feast. The patristic writers frequently cite 1 Maccabees on the Hanukkah background, and the Maccabean martyrs (more developed in 2 and 4 Maccabees) shaped the early church's theology of martyrdom — Hebrews 11:35's 'some were tortured, refusing to accept release' is almost certainly a Maccabean allusion.\n\n## Scholarly positions\n\n1 Maccabees is one of the most respected historical sources from Second Temple Judaism. Jonathan Goldstein's 1 Maccabees (Anchor Bible, 1976) is the standard English commentary. Daniel Schwartz's work on 1-2 Maccabees as historical sources (various articles) has refined our understanding of the author's use of sources.\n\nDebate focuses on:\n- **Relationship to 2 Maccabees**: written independently on some of the same events; 2 Maccabees is more theological/rhetorical, 1 Maccabees more chronological/political. Where they overlap (chapters 3-7 of 1 Macc and chapters 8-15 of 2 Macc) there are differences in detail that both clarify and complicate historical reconstruction.\n- **Pro-Hasmonean bias**: 1 Maccabees is clearly partisan toward the Maccabean family and specifically toward the Simon-to-Hyrcanus succession. The degree of bias is debated, but no serious historian treats the book as propaganda — the archival documents and chronological precision are too substantial.\n- **Canonical status**: unchanged since the Reformation — Catholic/Orthodox/Ethiopian canonical; Protestant apocrypha; Jewish extra-biblical (but central to Hanukkah observance).\n\n## Why different traditions treated it differently\n\n1 Maccabees' exclusion from the rabbinic canon reflects the closure of the prophetic era as a canonical boundary: the Hasmonean period postdates the 'cessation of prophecy' in rabbinic reckoning, so its literature could not be canonical Scripture. But the events 1 Maccabees records remained central to Jewish identity (Hanukkah), creating a peculiar situation where the book is extra-biblical but the feast it institutes is still observed.\n\nChristian reception followed LXX usage. The Greek and Latin churches treated 1 Maccabees as canonical; the Reformation's retrieval of hebraica veritas excluded it for Protestants. The book's historical value is universally acknowledged across traditions.\n\n## Further reading\n\nJonathan Goldstein, 1 Maccabees (Anchor Bible, 1976) — standard English commentary. Daniel Schwartz, 2 Maccabees (de Gruyter, 2008) — covers the 1-2 Maccabees relationship thoroughly. Uriel Rappaport, The First Book of Maccabees (Yad Ben-Zvi, 2004, Hebrew) — the most current Hebrew-language scholarly treatment. For the Hanukkah reception see Oded Irshai's essays on post-70 Jewish memory; for John 10:22 see Andreas Köstenberger or Craig Keener's Gospel of John commentary.",
     "nt_citations": [
-      { "ref": "John 10:22", "cites": "1 Maccabees 4:36-59", "type": "allusion" }
+      {
+        "ref": "John 10:22",
+        "cites": "1 Maccabees 4:36-59",
+        "type": "allusion"
+      }
     ],
     "ot_allusions": [
-      { "ref": "Daniel 11:31", "connection": "The 'abomination that causes desolation' (1 Macc 1:54) echoes Daniel's prophecy; Antiochus IV's desecration of the Temple is the event most Second Temple and NT interpreters identified with the Danielic text." }
+      {
+        "ref": "Daniel 11:31",
+        "connection": "The 'abomination that causes desolation' (1 Macc 1:54) echoes Daniel's prophecy; Antiochus IV's desecration of the Temple is the event most Second Temple and NT interpreters identified with the Danielic text."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "jerome", "position": "Grouped 1 Maccabees among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic Hebrew canon, noting that he had seen the Hebrew original. Transmitted the book in the Vulgate nonetheless." },
-      { "scholar_id": "augustine", "position": "Defended 1 Maccabees as canonical in the Greek and Latin churches, citing it in City of God and his other works. The African councils of Hippo and Carthage affirmed its canonical status under his influence." },
-      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, reads 1 Maccabees as the most important surviving historical source for the Hasmonean period and as a work of dynastic apologetic written to justify Hasmonean rule. Notes its essentially 'biblical' historiographical style in deliberate imitation of Kings and Chronicles." },
-      { "scholar_id": "collins", "position": "In his survey work on Second Temple Judaism, places 1 Maccabees alongside 2 Maccabees, Josephus, and the Qumran scrolls as the foundational sources for reconstructing the political and religious matrix from which both rabbinic Judaism and early Christianity emerged." }
+      {
+        "scholar_id": "jerome",
+        "position": "Grouped 1 Maccabees among the apocrypha in the Prologus Galeatus on the ground that it was not in the rabbinic Hebrew canon, noting that he had seen the Hebrew original. Transmitted the book in the Vulgate nonetheless."
+      },
+      {
+        "scholar_id": "augustine",
+        "position": "Defended 1 Maccabees as canonical in the Greek and Latin churches, citing it in City of God and his other works. The African councils of Hippo and Carthage affirmed its canonical status under his influence."
+      },
+      {
+        "scholar_id": "nickelsburg",
+        "position": "In Jewish Literature Between the Bible and the Mishnah, reads 1 Maccabees as the most important surviving historical source for the Hasmonean period and as a work of dynastic apologetic written to justify Hasmonean rule. Notes its essentially 'biblical' historiographical style in deliberate imitation of Kings and Chronicles."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "In his survey work on Second Temple Judaism, places 1 Maccabees alongside 2 Maccabees, Josephus, and the Qumran scrolls as the foundational sources for reconstructing the political and religious matrix from which both rabbinic Judaism and early Christianity emerged."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "why-did-western-church-exclude-apocrypha",
+      "trent-response-or-innovation"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["deuterocanon", "apocrypha", "hasmonean", "hanukkah", "antiochus-iv", "historical-narrative", "john-10"],
+    "tags": [
+      "deuterocanon",
+      "apocrypha",
+      "hasmonean",
+      "hanukkah",
+      "antiochus-iv",
+      "historical-narrative",
+      "john-10"
+    ],
     "further_reading": [
-      { "title": "1 Maccabees", "author": "Jonathan A. Goldstein", "note": "Anchor Bible 41 (Doubleday, 1976). Standard English-language critical commentary." }
+      {
+        "title": "1 Maccabees",
+        "author": "Jonathan A. Goldstein",
+        "note": "Anchor Bible 41 (Doubleday, 1976). Standard English-language critical commentary."
+      }
     ]
   },
   {
     "id": "4_ezra",
     "title": "4 Ezra (2 Esdras)",
-    "also_known_as": ["2 Esdras", "Fourth Ezra", "Apocalypse of Ezra"],
+    "also_known_as": [
+      "2 Esdras",
+      "Fourth Ezra",
+      "Apocalypse of Ezra"
+    ],
     "category": "pseudepigrapha",
     "estimated_date": "Late 1st c. AD, after the destruction of the Second Temple in AD 70",
     "original_language": "Hebrew or Aramaic original (not extant); early Greek translation (largely lost); preserved in full in Latin and in Syriac, Ethiopic, Arabic, Georgian, and Armenian translations",
@@ -350,28 +723,60 @@
       "ethiopian_tewahedo": "canonical (Broader Canon)"
     },
     "brief_summary": "4 Ezra — printed in the Latin tradition as 2 Esdras chs 3–14 — is one of the most theologically serious Jewish apocalypses of the late first century AD. Composed in the generation after the destruction of the Second Temple in AD 70, it is cast as the experience of 'Ezra' (the biblical scribe) in Babylon thirty years after the Babylonian exile, but its real subject is the theodicy crisis provoked by the Roman destruction of Jerusalem.\n\nThe book unfolds in seven visions. In the first three (chs 3–9), Ezra presses the angel Uriel with hard questions: Why has God given Israel to a heathen power? Why has he not vindicated the righteous? How can divine justice be defended when so few will be saved? Ezra's questions receive answers, but the answers sharpen rather than resolve the grief. In the last four visions (chs 9–13), the mood shifts: Ezra sees a mourning woman transformed into the heavenly Jerusalem; an eagle with three heads representing the Roman empire, which will fall before the Messiah; and a man rising from the sea to judge the nations (ch 13). In the final vision (ch 14) Ezra is instructed to dictate ninety-four books — the twenty-four canonical Hebrew Scriptures plus seventy books 'for the wise' — a remarkable reflection on canon formation from within the tradition.\n\nThe original Hebrew or Aramaic text is lost; the standard Latin text (used in the Vulgate as 2 Esdras) includes two Christian supplements (chs 1–2 = '5 Ezra' and chs 15–16 = '6 Ezra') that are separate later compositions. Parallels with the Apocalypse of John are striking — the figure of the man from the sea, the eagle-as-empire imagery, the four beasts of Daniel 7 reinterpreted, the seven-fold structure — and most scholars read them as independent but near-contemporary Jewish and Christian apocalypses responding to similar Roman pressures.\n\nNo Christian tradition has received chs 3–14 as part of the primary biblical canon, but the Ethiopian Tewahedo Church includes it in its Broader Canon, and the Slavonic Orthodox tradition historically received it as canonical. The Council of Trent printed 2 Esdras in an appendix to the Vulgate rather than defining it as deuterocanonical.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\n4 Ezra — also called 2 Esdras in the Latin Vulgate (where it follows 1 Esdras/3 Esdras) and the Apocalypse of Ezra — is one of the most theologically substantial Jewish apocalypses from the post-Temple period. Composed in Hebrew or Aramaic at the end of the 1st century AD (c. 90-100 AD), probably in Palestine, it survives complete only in Latin and in various Eastern versions (Syriac, Ethiopic, Georgian, Armenian, Coptic, Arabic). The Latin preserves the core seven-chapter structure of the Jewish original (chapters 3-14 in modern numbering); chapters 1-2 and 15-16 are Christian additions from the 2nd-4th centuries AD.\n\n4 Ezra is an extended dialogue between 'Ezra' (a literary figure placed in the Babylonian Exile but addressing post-70 AD realities) and the angel Uriel over the theological crisis of Jerusalem's fall and the apparent prosperity of the wicked Gentiles. It asks the hardest questions about theodicy in post-Temple Judaism and offers answers — sometimes in Ezra's voice, sometimes in Uriel's, sometimes through visionary symbol — that shaped subsequent Jewish and Christian thought about the end of history, resurrection, judgment, and the Messiah.\n\n## Composition history\n\nDate: c. 90-100 AD. Internal evidence is specific: the 'thirty years after the fall of our city' (3:1-2) refers to the destruction of the Second Temple in 70 AD — placing composition in the 90s. The Eagle Vision (chs 11-12) is an interpretation of Daniel 7 reconfigured to reflect Roman imperial power up through the Flavian emperors (Vespasian, Titus, Domitian).\n\nOriginal language: Hebrew or Aramaic, universally agreed by scholars. No Hebrew or Aramaic manuscript survives, but the book's Hebraic idiom, literary structure, and overall style strongly indicate Semitic composition. The Latin translation (probably 2nd-3rd century AD) and the Syriac (independent 3rd-4th century AD translation) preserve the core Jewish text faithfully.\n\nAuthorship: anonymous. The first-person 'Ezra' voice is a pseudonymous literary device — the historical Ezra lived in the 5th century BC, not the 1st century AD. The author is clearly a post-70 Palestinian Jew writing in the wake of the Temple's destruction.\n\nChristian additions: chapters 1-2 (2 Esdras in the Vulgate) prefix a Christian exhortation anticipating the Jewish crisis; chapters 15-16 append further Christian apocalyptic material reflecting 3rd-century Christian persecutions. Modern critical editions standardly separate the Jewish core (the 'seven visions' of 4 Ezra 3-14) from the Christian additions.\n\n## Contents\n\nThe core seven-vision structure:\n\n**Vision 1 (chapters 3-5:20)**: Ezra laments Jerusalem's fall and Israel's apparent abandonment. Why does God allow Babylon (i.e., Rome) to prosper while his people suffer? Uriel responds that the questions exceed human comprehension and that the current age is ending — a new age approaches in which the righteous will be vindicated.\n\n**Vision 2 (5:21-6:34)**: Ezra probes further on divine justice. Uriel presents signs of the end: the sun rising at night, blood dripping from wood, the sea heaving, unnatural births. The coming age will be unmistakable when it arrives.\n\n**Vision 3 (6:35-9:25)**: the theological center. Ezra asks why God did not prevent Adam's fall, since the fall has brought suffering to the entire race. Uriel answers that God did not force human compliance; death is the consequence of Adam's choice, which the righteous overcome through faith. This is the passage Paul dialogues with in Romans 5:12-21 ('death through one man'). The 'how many will be saved?' question surfaces: the righteous are few, the wicked many, but the few will inherit the age to come.\n\n**Vision 4 (9:26-10:59)**: the Lady-Jerusalem vision. Ezra sees a grieving woman whose only son died on his wedding day; she is transformed before his eyes into the heavenly Jerusalem. This imagery shaped Revelation 21's New Jerusalem.\n\n**Vision 5 (11-12)**: the Eagle Vision. An eagle with twelve wings and three heads rises from the sea and is destroyed by a lion. The eagle is the Roman Empire; the lion is the Messiah. Daniel 7's fourth beast is reinterpreted for the post-70 situation.\n\n**Vision 6 (chapter 13)**: the Man from the Sea. A human figure rises from the sea, destroys an assembled multitude of enemies with fire from his mouth, and gathers the lost ten tribes. The figure is identified as the Messiah-Son of God. This vision is a significant Second Temple Jewish messianic image and parallels aspects of the NT Son of Man tradition.\n\n**Vision 7 (chapter 14)**: Ezra is commissioned to rewrite the 94 sacred books (24 canonical — the Hebrew Bible counted one way — and 70 'secret' books reserved for 'the wise'). This is the first clear Jewish enumeration of the canonical books (24) and an apocalyptic inflation of the 'hidden wisdom' corpus. The canonical boundary that the Council of Jamnia supposedly fixed in 90 AD is actually articulated here, in a Jewish apocalypse of the same decade.\n\n## Reception history\n\n**Second Temple and rabbinic Judaism**: 4 Ezra circulated widely in the immediate post-70 period but was not included in the closing Hebrew canon. The rabbinic tradition preserved the 24-book canon list (found also in b. Baba Bathra 14b) that 4 Ezra 14:45 attests, but the book itself was not canonical.\n\n**Early Christianity**: 4 Ezra was known and used. Clement of Alexandria cites it; Ambrose and Jerome discuss it. The Latin translation circulated in the Western churches, and the two Christian additions (chapters 1-2 and 15-16) were prefixed and appended to the Jewish core during the patristic period. Jerome classified the book as apocryphal in his Prologus Galeatus. Augustine treated it with caution.\n\nThe Latin Vulgate includes 4 Ezra as 2 Esdras in an appendix to the canonical 1 Esdras. After Trent (1546), the Roman Catholic Church did NOT include 4 Ezra in the canonical deuterocanon — it remained in an Appendix to the Vulgate. The Council of Trent's canonical list excluded 4 Ezra while including the other deuterocanonical works.\n\n**Orthodox traditions**: 4 Ezra (as 3 Esdras in Slavonic reckoning) is included in the Russian Orthodox canonical tradition and treated as Scripture in some Orthodox communions. The Ethiopian Orthodox Tewahedo Church includes 4 Ezra in its 81-book canon.\n\n**The Reformation**: Protestant Bibles (KJV 1611 Apocrypha) include 4 Ezra in the Apocrypha. The Westminster Confession treats it as non-canonical. Modern Protestant Bibles typically omit 4 Ezra from the main text.\n\n## NT and patristic usage\n\n4 Ezra is not directly quoted in the NT, which predates it. But the parallels run in the other direction: Paul's treatment of Adam and death in Romans 5:12-21 engages the same theological tradition 4 Ezra articulates (though neither depends on the other — both draw on shared late-Second-Temple Jewish reflection). Revelation 21's New Jerusalem draws on the same imagery-pool as 4 Ezra 10. The Man-from-the-Sea vision (4 Ezra 13) is among the closest Jewish parallels to NT Son of Man Christology.\n\nPatristic use is moderate. Origen, Ambrose, and Jerome cite 4 Ezra. The book was useful to patristic writers facing persecution questions similar to the post-70 Jewish ones 4 Ezra addresses.\n\n## Scholarly positions\n\nMichael Stone's 4 Ezra (Hermeneia, 1990) is the definitive scholarly commentary. Bruce Longenecker's 2 Esdras (Sheffield, 1995) is a readable introduction. Matthias Henze's Jewish Apocalypticism in Late First Century Israel (Mohr Siebeck, 2011) places 4 Ezra alongside 2 Baruch as the two primary post-70 Jewish apocalypses.\n\nDebate focuses on:\n- **Relationship to 2 Baruch**: 4 Ezra and 2 Baruch are sibling apocalypses from roughly the same period, addressing similar questions. Direct literary dependence is not established; common tradition-pool is nearly certain.\n- **Adam and original sin**: 4 Ezra 3 and 7 contain some of the most developed Jewish reflection on Adam's fall as the origin of human mortality. Whether this represents 'Jewish original sin' theology or a distinct Jewish position is debated.\n- **Messianic figure in vision 6**: the 'man from the sea' is messianic; his relation to the Danielic Son of Man and the NT Christological title is a live scholarly question.\n\n## Why different traditions treated it differently\n\n4 Ezra's scattered canonical status reflects the book's marginal position: Jewish but lost to Hebrew canon before the rabbinic consolidation; Christian but appearing too late for universal patristic reception; Latin but not quite canonical in the Vulgate (appended, not Old-Testament-core); Orthodox in some Eastern traditions but not all. Ethiopian inclusion reflects that communion's generally broader canon. Trent's specific exclusion of 4 Ezra from the Catholic canon — while including 1-2 Maccabees, Tobit, Judith, Wisdom, Sirach, and Baruch — is historically interesting: Trent drew the line at books with continuous Western ecclesial use, and 4 Ezra's status had always been disputed.\n\n## Further reading\n\nMichael Stone, Fourth Ezra (Hermeneia, Fortress 1990) — definitive scholarly commentary. Bruce Longenecker, 2 Esdras (Sheffield 1995) — accessible introduction. Matthias Henze, Jewish Apocalypticism in Late First Century Israel (Mohr Siebeck 2011) — places 4 Ezra and 2 Baruch in their post-70 context. Michael Knibb's translation in Charlesworth's OTP vol. 1 (Doubleday 1983) is the standard English text.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Daniel 7", "connection": "The eagle vision (4 Ezra 11–12) and the man-from-the-sea vision (ch 13) reinterpret Daniel's four-beasts and Son of Man imagery for the Roman imperial situation." }
+      {
+        "ref": "Daniel 7",
+        "connection": "The eagle vision (4 Ezra 11–12) and the man-from-the-sea vision (ch 13) reinterpret Daniel's four-beasts and Son of Man imagery for the Roman imperial situation."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "nickelsburg", "position": "Treats 4 Ezra as the most theologically profound Jewish apocalyptic response to the destruction of the Second Temple, reading its seven visions as a dialectical working-through of the theodicy crisis that 70 AD forced upon thoughtful Jews and early Christians alike." },
-      { "scholar_id": "collins", "position": "In his studies of Jewish apocalyptic, highlights the remarkable structural and thematic parallels between 4 Ezra and the Apocalypse of John, arguing that both are best read as independent but near-contemporary Jewish and Christian apocalypses responding to the same Roman context." },
-      { "scholar_id": "vanderkam", "position": "In his work on the Dead Sea Scrolls and Second Temple literature, draws attention to 4 Ezra 14's canon-formation narrative — ninety-four books, of which twenty-four are for all and seventy are esoteric — as a significant witness to how first-century Jews imagined the boundaries of their scriptural tradition." }
+      {
+        "scholar_id": "nickelsburg",
+        "position": "Treats 4 Ezra as the most theologically profound Jewish apocalyptic response to the destruction of the Second Temple, reading its seven visions as a dialectical working-through of the theodicy crisis that 70 AD forced upon thoughtful Jews and early Christians alike."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "In his studies of Jewish apocalyptic, highlights the remarkable structural and thematic parallels between 4 Ezra and the Apocalypse of John, arguing that both are best read as independent but near-contemporary Jewish and Christian apocalypses responding to the same Roman context."
+      },
+      {
+        "scholar_id": "vanderkam",
+        "position": "In his work on the Dead Sea Scrolls and Second Temple literature, draws attention to 4 Ezra 14's canon-formation narrative — ninety-four books, of which twenty-four are for all and seventy are esoteric — as a significant witness to how first-century Jews imagined the boundaries of their scriptural tradition."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "second-temple-literature-and-nt-theology"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["apocalyptic", "pseudepigrapha", "second-temple", "post-70", "theodicy", "revelation-parallels", "canon-formation"],
+    "tags": [
+      "apocalyptic",
+      "pseudepigrapha",
+      "second-temple",
+      "post-70",
+      "theodicy",
+      "revelation-parallels",
+      "canon-formation"
+    ],
     "further_reading": [
-      { "title": "A Commentary on the Book of 4 Ezra", "author": "Michael E. Stone", "note": "Hermeneia (Fortress, 1990). Standard English-language critical commentary." }
+      {
+        "title": "A Commentary on the Book of 4 Ezra",
+        "author": "Michael E. Stone",
+        "note": "Hermeneia (Fortress, 1990). Standard English-language critical commentary."
+      }
     ]
   },
   {
     "id": "damascus_document",
     "title": "Damascus Document (CD)",
-    "also_known_as": ["CD", "Cairo Damascus Document", "Zadokite Document"],
+    "also_known_as": [
+      "CD",
+      "Cairo Damascus Document",
+      "Zadokite Document"
+    ],
     "category": "dss",
     "estimated_date": "Original composition probably late 2nd or early 1st c. BC; Qumran manuscripts range from 1st c. BC to 1st c. AD; the Cairo Geniza manuscripts are medieval copies (10th–12th c. AD)",
     "original_language": "Hebrew. First discovered as two medieval Hebrew manuscripts in the Cairo Geniza (Solomon Schechter, 1896); later confirmed by fragments of at least ten ancient Hebrew manuscripts from Qumran Caves 4, 5, and 6 (4Q265–273, 5Q12, 6Q15)",
@@ -382,24 +787,61 @@
       "ethiopian_tewahedo": "not canonical"
     },
     "brief_summary": "The Damascus Document is one of the most important sectarian texts of the Qumran community. Although fragmentary copies had been known since Solomon Schechter's 1896 discovery of two medieval manuscripts in the Cairo Geniza — then classified as a 'Zadokite Document' — the later recovery of ancient Hebrew fragments from Qumran Caves 4, 5, and 6 confirmed it as a foundational document of the same movement that produced the other Dead Sea Scrolls.\n\nThe work falls into two main parts. The 'Admonition' (CD I–VIII, XIX–XX) is a theological-historical narrative reviewing God's dealings with the 'remnant' — the faithful community called out of apostate Israel — and denouncing opponents. It introduces the figures of the Teacher of Righteousness, the Wicked Priest, and the Man of the Lie, and it speaks of the community's 'new covenant' in the land of Damascus (whether the place-name is literal or symbolic is debated). The 'Laws' section (CD IX–XVI and the 4Q parallels) contains distinctive halakhic rulings — on Sabbath observance stricter than in other Jewish traditions, on sexual purity, on oaths, on marriage law, on priestly purity, and on organisation of the community. CD 16:3–4 explicitly cites the Book of Jubilees as 'the book of the divisions of the times by their jubilees and their weeks' — a rare surviving ancient citation of that book by name and strong evidence of Jubilees' authoritative status at Qumran.\n\nThe New Testament does not cite the Damascus Document, but the document illuminates the Second Temple Jewish context in multiple directions. Its strict Sabbath legislation contrasts with Jesus' Sabbath disputes (Mark 2:23–3:6; Matt 12:1–14; Luke 6:1–11); its 'new covenant in Damascus' vocabulary shows that the phrase was in Jewish circulation before Paul used it in 2 Cor 3:6 and Heb 8:8 quoted Jeremiah 31; and its communal structure, messianic expectation (two messiahs, priestly and royal), and eschatological orientation populate the backdrop against which the Gospels and Acts narrate early Christian origins. No tradition has ever received the Damascus Document as Scripture; it is a sectarian document whose significance is historical and comparative, not canonical.",
-    "full_summary": null,
+    "full_summary": "## Overview\n\nThe Damascus Document (abbreviated CD from the medieval Cairo manuscript, or from Qumran 4Q265-273, 5Q12, 6Q15) is the most important surviving sectarian text from Second Temple Judaism outside the Dead Sea Scrolls community's own Qumran-specific works. Composed in Hebrew sometime between 150 and 100 BC, it survives in two major forms: (1) two medieval manuscripts from the Cairo Geniza (CD-A and CD-B, 10th and 12th century AD respectively), discovered by Solomon Schechter in 1896 and published in 1910; and (2) at least eight Hebrew fragmentary manuscripts from Qumran Caves 4, 5, and 6, discovered between 1947 and 1956. The Qumran fragments are pre-Christian (1st century BC), confirming the medieval Cairo texts preserve an authentic ancient Jewish sectarian work that was copied into the medieval period by a remote Cairo Jewish community — the Karaites — that had survived since antiquity with independent textual traditions.\n\nThe Damascus Document is both a theological manifesto and a legal code. Its two main sections — the Admonition (CD 1-8, 19-20) and the Laws (CD 9-16, 4Q266-273) — together outline a sectarian community's self-understanding and its halakhic practice. The community is not the Qumran community itself (the Community Rule 1QS describes that one), but a related 'camps' of the same broader sectarian movement — a network of pious Jews living throughout Palestine and beyond who believed the Jerusalem Temple had been corrupted, the priesthood defiled, and the true covenant preserved only by their own separatist fellowship.\n\n## Composition history\n\nDate: scholarly consensus places the original composition between 150 BC and 100 BC, with the Admonition probably earlier than the Laws. The text internally refers to a 'Teacher of Righteousness' as a past figure whose teaching the community preserves — this is the same figure referenced in the Qumran pesharim (Habakkuk Commentary, 4QpPs^a). The Teacher is generally dated to the mid-2nd century BC, which places the community's origins in the Maccabean or immediate post-Maccabean period.\n\nOriginal language: Hebrew. The Cairo manuscripts are Hebrew; the Qumran fragments are Hebrew. The Hebrew is classical (not mishnaic) with some archaic features, supporting pre-rabbinic composition.\n\nManuscript transmission: the discovery sequence is genuinely remarkable. The Cairo Geniza manuscripts were discovered in 1896 when Schechter was given access to the genizah (document repository) of the Ben Ezra Synagogue in Cairo. The texts he recovered — CD-A (manuscript of the 10th century) and CD-B (manuscript of the 12th century) — were medieval copies preserved by the Karaite Jewish community, which had split from rabbinic Judaism in the 8th-9th centuries and preserved some ancient sectarian texts the rabbinic community had discarded. When the Dead Sea Scrolls were discovered in 1947, the Qumran fragments confirmed Schechter's medieval Cairo text as substantially accurate against its 2nd-century-BC ancient Hebrew original. It is a textual transmission story spanning 2,100 years through multiple communities.\n\n## Contents\n\n**The Admonition (CD 1-8, 19-20)**: opens with a historical prologue situating the community's origin. After Israel's sin God planted 'a root' (a faithful remnant) and raised up for them 'a Teacher of Righteousness' to lead them (CD 1:5-11). The opponents are 'the man of scoffing' (probably a high priest) and 'the congregation of men of insolence' (probably Hasmonean religious leadership). The community has entered a 'new covenant in the land of Damascus' — either a literal reference to Damascus or a symbolic use of the name for the community's place of refuge.\n\nThe Admonition develops an extensive exegesis of biblical warnings. It identifies 'three nets of Belial' (fornication, wealth, and pollution of the sanctuary) by which Belial entraps contemporary Israel (CD 4:15-18). It exposes specific halakhic violations of the Jerusalem Temple establishment — marrying nieces (CD 5:7-11), violating Sabbath boundaries, failing to observe proper purity laws. The Admonition also contains the famous 'Jannes and his brother' reference (CD 5:17-19): 'And in ancient times Moses and Aaron arose by the hand of the Prince of Lights, and Belial raised up Jannes and his brother by his wicked scheming.' This is the earliest surviving source for the Jannes-and-brother tradition that 2 Timothy 3:8 draws on.\n\n**The Laws (CD 9-16, 4Q266-273)**: a comprehensive halakhic code covering oaths, witnesses, courts, Sabbath observance, purity and impurity, agricultural laws, and community organization. The community is organized into 'camps' (mahanot) under overseers, with priestly leadership, weekly communal assemblies, and shared meals. Members pledge two days' wages per month for the poor and for community needs. Sabbath rules are stricter than Pharisaic: no marital intercourse, no travel beyond 2,000 cubits, no rescuing an animal fallen into a pit (in tension with Jesus's permissive ruling in Matthew 12:11).\n\n## Reception history\n\n**Second Temple period**: the Damascus Document circulated within the broader Essene-type sectarian movement (of which the Qumran community was one branch). The text was not known to mainstream rabbinic or Christian tradition.\n\n**Medieval Karaite Judaism**: the Cairo Geniza manuscripts suggest the Karaites — who split from rabbinic Judaism in the 8th-9th centuries on halakhic grounds — preserved some ancient sectarian literature that paralleled their own stricter legal views. Whether the Karaites had direct transmission of Qumran-type texts, or recovered them through the medieval Near Eastern Jewish library networks, remains an active scholarly question.\n\n**Modern scholarship**: the 1896 Cairo discovery initially puzzled scholars — Schechter called the text the Zadokite Fragments — because no clear context for pre-Mishnaic Jewish sectarianism was available. The 1947 Qumran find transformed the field. The Damascus Document is now the most important witness to Second Temple Jewish sectarian halakha.\n\n## NT and patristic usage\n\nThe Damascus Document is not quoted in the NT but provides essential background for several NT passages. The Jannes-and-brother tradition underlying 2 Timothy 3:8 is first attested in CD 5:17-19. The 'new covenant' language of CD 6:19 ('the new covenant in the land of Damascus') parallels the 'new covenant' of Jeremiah 31:31-34 that Luke 22:20 and Hebrews 8:8-12 develop. The community's self-understanding as a faithful remnant separated from a corrupt religious establishment parallels John the Baptist's wilderness critique and some aspects of early Christian community formation.\n\nNo patristic writer knew the Damascus Document — it was entirely lost to Western Christianity until the 1896 Cairo discovery.\n\n## Scholarly positions\n\nJoseph Baumgarten and Daniel Schwartz's work on the Damascus Document (their Hermeneia-type commentary in multiple volumes, 1996-) is definitive. Philip Davies, The Damascus Covenant (Sheffield, 1983) is the classic monograph. Lawrence Schiffman's work on Jewish sectarian halakha places the Damascus Document in its legal context.\n\nDebate focuses on:\n- **Community identity**: was the Damascus Document community the same as the Qumran community? Most scholars distinguish them: Qumran was the community's 'mother house' in the Judean wilderness; the Damascus Document describes 'camps' of related communities elsewhere in Palestine and possibly the diaspora. They shared halakha, calendar, and the Teacher of Righteousness tradition.\n- **Date of the Teacher of Righteousness**: mid-2nd century BC is consensus; identification with a specific historical figure (the deposed Zadokite high priest Onias III? a successor?) remains contested.\n- **Damascus**: literal or symbolic? Most scholars treat it as symbolic — the community never physically relocated to Damascus; the name invokes Amos 5:26-27's 'beyond Damascus' as an exile-trope.\n\n## Why different traditions treated it differently\n\nThe Damascus Document is unique among the entries in this collection: it was never received as Scripture by any Christian or Jewish tradition. It is not on any canon list, ancient or modern. Its value is historical and comparative — the single most important surviving witness to Second Temple Jewish sectarian thought, essential for understanding the background of the NT, the Essenes, and the halakhic diversity of the pre-Rabbinic Jewish landscape.\n\nThe Ethiopian and Orthodox canons do not include it (it was lost before they formed); the Catholic and Protestant canons do not include it (same reason); Jewish tradition rejected sectarian works systematically after 70 AD. Its preservation is accidental and remarkable — the Cairo Geniza was a document warehouse, not a library; the Qumran caves were the sectarian community's own hidden archive. That we possess the text at all is historical fortune of the first order.\n\n## Further reading\n\nJoseph Baumgarten and Daniel Schwartz, The Damascus Document (Princeton DSS Project, 1995 onward). Philip Davies, The Damascus Covenant (Sheffield 1983) — classic English monograph. Lawrence Schiffman, Reclaiming the Dead Sea Scrolls (JPS, 1994) — accessible introduction to sectarian halakha. Michael Wise, Martin Abegg, and Edward Cook, The Dead Sea Scrolls: A New Translation (HarperOne, 2005) — readable English text with introduction.",
     "nt_citations": [],
     "ot_allusions": [
-      { "ref": "Amos 5:26-27", "connection": "CD VII:14–21 interprets Amos's 'exile beyond Damascus' as a reference to the community's own self-understanding as a righteous remnant in exile from apostate Jerusalem." },
-      { "ref": "Jeremiah 31:31-34", "connection": "The community's self-description as 'the new covenant in the land of Damascus' draws on Jeremiah's new-covenant oracle, demonstrating that the phrase was already in Jewish circulation before the New Testament writers applied it to Christ." }
+      {
+        "ref": "Amos 5:26-27",
+        "connection": "CD VII:14–21 interprets Amos's 'exile beyond Damascus' as a reference to the community's own self-understanding as a righteous remnant in exile from apostate Jerusalem."
+      },
+      {
+        "ref": "Jeremiah 31:31-34",
+        "connection": "The community's self-description as 'the new covenant in the land of Damascus' draws on Jeremiah's new-covenant oracle, demonstrating that the phrase was already in Jewish circulation before the New Testament writers applied it to Christ."
+      }
     ],
     "scholar_voices": [
-      { "scholar_id": "vanderkam", "position": "Treats the Damascus Document as a foundational sectarian text whose ancient Qumran copies (4Q265–273, 5Q12, 6Q15) confirm the medieval Geniza manuscripts' substantial faithfulness to the original. In The Dead Sea Scrolls Today, surveys its place alongside the Community Rule (1QS) as the two central documents of the Qumran movement." },
-      { "scholar_id": "nickelsburg", "position": "In Jewish Literature Between the Bible and the Mishnah, reads the Damascus Document as a key witness to the sectarian Second Temple environment and specifically to the calendrical, halakhic, and eschatological concerns that distinguished groups like the Qumran community from the Jerusalem temple establishment." },
-      { "scholar_id": "collins", "position": "In his work on Second Temple apocalypticism, places the Damascus Document within the broader stream of sectarian Jewish self-definition, highlighting its distinctive halakhic rulings and its explicit citation of Jubilees (CD 16:3–4) as evidence of a shared calendrical tradition tying it to Jubilees and to Enochic literature." }
+      {
+        "scholar_id": "vanderkam",
+        "position": "Treats the Damascus Document as a foundational sectarian text whose ancient Qumran copies (4Q265–273, 5Q12, 6Q15) confirm the medieval Geniza manuscripts' substantial faithfulness to the original. In The Dead Sea Scrolls Today, surveys its place alongside the Community Rule (1QS) as the two central documents of the Qumran movement."
+      },
+      {
+        "scholar_id": "nickelsburg",
+        "position": "In Jewish Literature Between the Bible and the Mishnah, reads the Damascus Document as a key witness to the sectarian Second Temple environment and specifically to the calendrical, halakhic, and eschatological concerns that distinguished groups like the Qumran community from the Jerusalem temple establishment."
+      },
+      {
+        "scholar_id": "collins",
+        "position": "In his work on Second Temple apocalypticism, places the Damascus Document within the broader stream of sectarian Jewish self-definition, highlighting its distinctive halakhic rulings and its explicit citation of Jubilees (CD 16:3–4) as evidence of a shared calendrical tradition tying it to Jubilees and to Enochic literature."
+      }
     ],
-    "related_debate_ids": [],
-    "related_journey_ids": [],
+    "related_debate_ids": [
+      "dead-sea-scrolls-and-canon-questions",
+      "second-temple-literature-and-nt-theology"
+    ],
+    "related_journey_ids": [
+      "canon-formation"
+    ],
     "related_difficult_passage_ids": [],
-    "tags": ["dead-sea-scrolls", "dss", "qumran", "sectarian", "cairo-geniza", "second-temple", "new-covenant", "halakha"],
+    "tags": [
+      "dead-sea-scrolls",
+      "dss",
+      "qumran",
+      "sectarian",
+      "cairo-geniza",
+      "second-temple",
+      "new-covenant",
+      "halakha"
+    ],
     "further_reading": [
-      { "title": "The Damascus Document Reconsidered", "author": "Magen Broshi, ed.", "note": "Israel Exploration Society, 1992. Standard English-language edition of the Cairo manuscripts with introduction." },
-      { "title": "The Complete Dead Sea Scrolls in English", "author": "Géza Vermes", "note": "Penguin, 7th ed. 2011. Accessible translation of CD alongside the other Qumran sectarian texts." }
+      {
+        "title": "The Damascus Document Reconsidered",
+        "author": "Magen Broshi, ed.",
+        "note": "Israel Exploration Society, 1992. Standard English-language edition of the Cairo manuscripts with introduction."
+      },
+      {
+        "title": "The Complete Dead Sea Scrolls in English",
+        "author": "Géza Vermes",
+        "note": "Penguin, 7th ed. 2011. Accessible translation of CD alongside the other Qumran sectarian texts."
+      }
     ]
   }
 ]


### PR DESCRIPTION
Collapses the chain of 5 stacked PRs (#1605, #1606, #1609, #1617, #1619) into a single clean PR on top of master.

## Why a collapse

Each PR in the chain was built from a pre-#1589 base and recreated `content/meta/extrabiblical.json` from scratch, conflicting with the canonical file shipped by #1589. Since #1619 is a strict superset of the earlier ones (all 12 full_summary fields plus cross-link wiring), merging its final state directly is equivalent to sequentially applying all 5 — with a much smaller review surface.

## Full summaries added (12)

Scholarly long-form treatment for every entry:

| Entry | Length |
|---|---:|
| `1_enoch` | 9,969 |
| `2_enoch` | 7,992 |
| `jubilees` | 8,653 |
| `jasher` | 7,372 |
| `assumption_of_moses` | 8,297 |
| `tobit` | 8,781 |
| `judith` | 9,296 |
| `wisdom_of_solomon` | 8,764 |
| `sirach` | 9,451 |
| `1_maccabees` | 9,211 |
| `4_ezra` | 9,459 |
| `damascus_document` | 9,417 |

## Cross-links wired

Referential integrity to existing tables:
- 11 entries gained `related_debate_ids` → `debate-topics.json`
- 12 entries gained `related_journey_ids` → `journeys/thematic/`
- 3 entries gained `related_difficult_passage_ids` → `difficult-passages.json`

## Verified locally

- `schema_validator.py`: same 77 pre-existing failures, zero new ones
- `build_sqlite.py`: clean build
- `validate_sqlite.py`: `[OK] ALL CHECKS PASSED`

## Closes

- #1553 (full_summary batch 1)
- #1577 (full_summary batch 2)
- #1578 (full_summary batch 3)
- #1579 (full_summary batch 4)
- #1576 (cross-link wireup)

## Supersedes

#1605, #1606, #1609, #1617, #1619
