### PR TITLE
fix(explore): surface HWGTB and ContentLibrary in Scholarly Analysis carousel

### DIFF
--- a/app/__tests__/screens/ExploreMenuScreen.test.tsx
+++ b/app/__tests__/screens/ExploreMenuScreen.test.tsx
@@ -69,9 +69,12 @@ describe('ExploreMenuScreen', () => {
       expect(getByText('Map')).toBeTruthy();
       // Language split row contains Concordance + Dictionary (Word Studies moves to the preview list)
       expect(getByText('Concordance')).toBeTruthy();
-      // Scholarly split row contains Scholars + Difficult Passages
+      // Scholarly carousel contains Scholars, Difficult Passages, How We Got The Bible, Content Library
+      // (Debates is rendered as the preview list strip above the carousel)
       expect(getByText('Scholars')).toBeTruthy();
       expect(getByText('Difficult Passages')).toBeTruthy();
+      expect(getByText('How We Got The Bible')).toBeTruthy();
+      expect(getByText('Content Library')).toBeTruthy();
     });
   });
 

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -252,8 +252,12 @@ function ExploreMenuScreen() {
           </View>
         );
       case 'scholarly': {
-        const splitFeatures = section.features.filter(
-          (f) => f.screen === 'ScholarBrowse' || f.screen === 'DifficultPassagesBrowse',
+        // Debates renders as the preview strip above; everything else flows
+        // into the horizontal carousel below. Denylist (vs. allowlist) so
+        // future cards added to SECTIONS surface automatically — same
+        // pattern as the 'language' case for WordStudyBrowse.
+        const carouselFeatures = section.features.filter(
+          (f) => f.screen !== 'DebateBrowse',
         );
         const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
         return (
@@ -263,26 +267,30 @@ function ExploreMenuScreen() {
               onSeeAll={() => handleNavigate('DebateBrowse')}
               totalCount={totalDebates ?? undefined}
             />
-            <View style={styles.row2}>
-              {splitFeatures.map((f, i) => {
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+            >
+              {carouselFeatures.map((f, cardIndex) => {
                 const imgData = getScreenImages(f.screen);
                 return (
-                  <View key={f.screen} style={styles.rowCell}>
-                    <FeatureCard
-                      feature={f}
-                      onPress={() => handleNavigate(f.screen)}
-                      isPremium={isPremium}
-                      images={imgData?.images}
-                      count={imgData?.count}
-                      noun={imgData?.noun}
-                      onImagePress={handleDeepLink}
-                      staggerMs={i * 1200}
-                      compact
-                    />
-                  </View>
+                  <FeatureCard
+                    key={f.screen}
+                    feature={f}
+                    onPress={() => handleNavigate(f.screen)}
+                    isPremium={isPremium}
+                    images={imgData?.images}
+                    count={imgData?.count}
+                    noun={imgData?.noun}
+                    onImagePress={handleDeepLink}
+                    staggerMs={cardIndex * 1200}
+                    compact
+                  />
                 );
               })}
-            </View>
+            </ScrollView>
           </View>
         );
       }
@@ -531,7 +539,6 @@ const styles = StyleSheet.create({
 
   // Split/grid rows
   sectionGap: { gap: spacing.md },
-  row2: { flexDirection: 'row', gap: spacing.sm },
   row3: { flexDirection: 'row', gap: spacing.sm },
   rowCell: { flex: 1 },
 


### PR DESCRIPTION
## Summary

Fixes #1631. The Scholarly Analysis section of Explore was silently dropping two of its five declared cards.

## Diagnosis

`ExploreMenuScreen.tsx:254-257` filtered `section.features` through a hardcoded allowlist (`ScholarBrowse` + `DifficultPassagesBrowse` only). HWGTB and ContentLibrary were defined in `SECTIONS` but never reached the renderer. Pre-existing pattern, became a bug when the section grew past two cards.

## Change

Two coupled edits to `case 'scholarly'`:

1. **Allowlist → denylist:** `f.screen !== 'DebateBrowse'` instead of explicit allowlist. Matches the pattern the `case 'language'` block uses for WordStudyBrowse. Future cards added to the section render automatically — no renderer edit required.

2. **`row2` grid → horizontal carousel:** four 130px compact cards no longer fit a phone viewport as a fixed grid. Adopted the carousel pattern from `case 'themes'` (lines 228-251) verbatim — same `staggerMs`, same `carouselContent` style, same `compact` prop. Visual rhythm matches the sibling section.

The `DebatePreviewList` strip continues to render above the carousel — it's still doing useful work (specific debate topics inline, like `WordStudyPreviewList` in language).

Also dropped the now-orphaned `styles.row2` definition (`row3` is still used by language).

## Resulting card order

Scholars → Difficult Passages → How We Got The Bible → Content Library

(Debates renders as the strip above the carousel; same as before.)

## Files

- `app/src/screens/ExploreMenuScreen.tsx` — replaced `case 'scholarly'` block, removed unused `row2` style
- `app/__tests__/screens/ExploreMenuScreen.test.tsx` — extended assertion to cover HWGTB + Content Library

## Verification

- Premium gating unchanged: `handleNavigate` still routes through `PREMIUM_SCREENS` lookup → upgrade modal for non-premium users tapping HWGTB or Content Library
- `count: null` for HWGTB renders correctly (FeatureCard already handles missing count badge)
- HWGTB hero image is registered at `content/meta/explore-images.json:300-311`
- Existing `HowWeGotTheBibleLandingScreen.test.tsx` unchanged — destination screen behavior unaffected

## Out of scope

- Dead `canonComparisonReady = false` flag in `HowWeGotTheBibleLandingScreen.tsx:51` — separate concern, separate PR
- Reordering or restructuring other Explore sections

## Rollback

`git revert` — single-file behavior change, no schema/nav/data touched.