### PR TITLE
fix(hwgtb): replace generic Guided Journeys entry with specific journeys + escape hatch

### DIFF
--- a/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
+++ b/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
@@ -32,6 +32,8 @@ jest.mock('lucide-react-native', () => ({
   BookOpen: () => null,
   Scale: () => null,
   Map: () => null,
+  BookCopy: () => null,
+  Languages: () => null,
 }));
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -77,11 +79,17 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     expect(getByText(/Evangelical in framing/)).toBeTruthy();
   });
 
-  it('renders all three landing entries', () => {
+  it('renders all four landing entries', () => {
     const { getByText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
     expect(getByText('Extra-Biblical Literature')).toBeTruthy();
     expect(getByText('Canon Comparison')).toBeTruthy();
-    expect(getByText('Guided Journeys')).toBeTruthy();
+    expect(getByText('Canon Formation')).toBeTruthy();
+    expect(getByText('Text & Translation')).toBeTruthy();
+  });
+
+  it('renders the escape hatch row', () => {
+    const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
+    expect(getByLabelText('Browse all guided journeys')).toBeTruthy();
   });
 
   it('Canon Comparison shows "Coming soon" label (HWGTB-P3-01 not yet shipped)', () => {
@@ -95,12 +103,26 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('ExtraBiblicalIndex');
   });
 
-  it('tapping Guided Journeys navigates to JourneyBrowse with featured tab', () => {
+  it('tapping Canon Formation navigates to JourneyDetail with canon-formation id', () => {
     const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
-    fireEvent.press(getByLabelText('Open Guided Journeys'));
-    expect(mockNavigate).toHaveBeenCalledWith('JourneyBrowse', {
-      tab: 'featured',
+    fireEvent.press(getByLabelText('Open Canon Formation'));
+    expect(mockNavigate).toHaveBeenCalledWith('JourneyDetail', {
+      journeyId: 'canon-formation',
     });
+  });
+
+  it('tapping Text & Translation navigates to JourneyDetail with text-and-translation id', () => {
+    const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
+    fireEvent.press(getByLabelText('Open Text & Translation'));
+    expect(mockNavigate).toHaveBeenCalledWith('JourneyDetail', {
+      journeyId: 'text-and-translation',
+    });
+  });
+
+  it('tapping the escape hatch navigates to JourneyBrowse with no params', () => {
+    const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
+    fireEvent.press(getByLabelText('Browse all guided journeys'));
+    expect(mockNavigate).toHaveBeenCalledWith('JourneyBrowse', undefined);
   });
 
   it('Canon Comparison entry has no onPress handler (no navigation fired)', () => {

--- a/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
+++ b/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
@@ -18,7 +18,7 @@ import {
 } from 'react-native';
 import { Image } from 'expo-image';
 import { useNavigation } from '@react-navigation/native';
-import { ChevronLeft, ChevronRight, BookOpen, Scale, Map } from 'lucide-react-native';
+import { ChevronLeft, ChevronRight, BookOpen, Scale, Map, BookCopy, Languages } from 'lucide-react-native';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { useExploreImages } from '../hooks/useExploreImages';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
@@ -54,13 +54,24 @@ function HowWeGotTheBibleLandingScreen() {
     navigation.navigate('CanonComparison' as any);
   }, [navigation]);
 
-  // JourneyBrowseScreen supports { tab?, filterLens? } today; filter-by-id
-  // for specific journeys is not yet wired in the browse screen, so we
-  // land on the full browse with the 'featured' tab (HWGTB-P3-02 / #1551
-  // and HWGTB-P4-01 / #1552 will surface canon-formation and
-  // text-and-translation via the FEATURED_IDS list).
-  const goGuidedJourneys = useCallback(() => {
-    navigation.navigate('JourneyBrowse', { tab: 'featured' });
+  // Direct navigation to the two HWGTB-specific journeys. The journey
+  // content already exists at content/meta/journeys/thematic/{slug}.json
+  // and JourneyDetail accepts { journeyId } per navigation/types.ts —
+  // so the bundle surfaces curated, specific destinations rather than
+  // bouncing the user back to the generic JourneyBrowse.
+  const goCanonFormationJourney = useCallback(() => {
+    navigation.navigate('JourneyDetail', { journeyId: 'canon-formation' });
+  }, [navigation]);
+
+  const goTextAndTranslationJourney = useCallback(() => {
+    navigation.navigate('JourneyDetail', { journeyId: 'text-and-translation' });
+  }, [navigation]);
+
+  // Escape hatch — for users whose interest was piqued by the topic
+  // and want to see the rest of the journey library. Default tab,
+  // no filter, so they get the full 60+ journeys.
+  const goAllJourneys = useCallback(() => {
+    navigation.navigate('JourneyBrowse', undefined);
   }, [navigation]);
 
   const entries: LandingEntry[] = [
@@ -73,7 +84,7 @@ function HowWeGotTheBibleLandingScreen() {
       onPress: goExtraBiblicalIndex,
     },
     {
-      key: 'canon',
+      key: 'canon-comparison',
       title: 'Canon Comparison',
       description:
         'Protestant, Catholic, Orthodox, and Ethiopian canons side by side — where traditions agree, where they differ, and why.',
@@ -81,12 +92,20 @@ function HowWeGotTheBibleLandingScreen() {
       onPress: canonComparisonReady ? goCanonComparison : undefined,
     },
     {
-      key: 'journeys',
-      title: 'Guided Journeys',
+      key: 'canon-formation',
+      title: 'Canon Formation',
       description:
-        'Canon formation from Moses to the Reformation, and the story of how the Bible was translated into every major language.',
-      Icon: Map,
-      onPress: goGuidedJourneys,
+        'A 12-stop journey from oral tradition to Trent — how the 66 (or 73, or 76, or 81) books were written, collected, debated, and recognized as Scripture.',
+      Icon: BookCopy,
+      onPress: goCanonFormationJourney,
+    },
+    {
+      key: 'text-and-translation',
+      title: 'Text & Translation',
+      description:
+        'From manuscripts to your Bible — 2,000 years of scribes, monks, printers, and reformers in 10 stops.',
+      Icon: Languages,
+      onPress: goTextAndTranslationJourney,
     },
   ];
 
@@ -144,8 +163,42 @@ function HowWeGotTheBibleLandingScreen() {
             <LandingEntryCard key={e.key} entry={e} />
           ))}
         </View>
+
+        <EscapeHatchRow onPress={goAllJourneys} />
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+/**
+ * Subtle "see more like this" affordance below the curated entries.
+ * Visually lighter than the primary cards so it reads as a contextual
+ * suggestion rather than a peer entry — for users whose interest in
+ * the topic warrants a look at the wider journey library.
+ */
+function EscapeHatchRow({ onPress }: { onPress: () => void }) {
+  const { base } = useTheme();
+  return (
+    <View
+      style={[
+        styles.escapeHatchSection,
+        { borderTopColor: base.gold + '20' },
+      ]}
+    >
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel="Browse all guided journeys"
+        style={styles.escapeHatch}
+      >
+        <Map size={14} color={base.textMuted} />
+        <Text style={[styles.escapeHatchText, { color: base.textMuted }]}>
+          Browse all guided journeys
+        </Text>
+        <ChevronRight size={14} color={base.textMuted} />
+      </TouchableOpacity>
+    </View>
   );
 }
 
@@ -309,6 +362,23 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 10,
     letterSpacing: 0.5,
+  },
+  escapeHatchSection: {
+    marginTop: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  escapeHatch: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.sm,
+  },
+  escapeHatchText: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 12,
+    letterSpacing: 0.3,
   },
 });
 


### PR DESCRIPTION
## Summary

Fixes #1633. Rewires the HWGTB landing to surface the two HWGTB-specific journeys directly via `JourneyDetail`, with a subtle escape-hatch row pointing to the full `JourneyBrowse` for users who want to explore the wider library.

## Diagnosis

The previous "Guided Journeys" entry routed to `JourneyBrowse` with `tab: 'featured'` — generic, no filter, same destination users could already reach from the top-level Themes & Connections section. The user passed through Explore → Scholarly → HWGTB to land on a curated bundle, then the card sent them backward into the uncurated browse. Wrong abstraction at the wrong layer.

The two journeys that actually belong in this bundle (`canon-formation` and `text-and-translation`) already exist as content under `content/meta/journeys/thematic/`, and `JourneyDetail` already accepts `{ journeyId: string }` per `navigation/types.ts:107`. The infrastructure for direct deep-linking was already in place — just not wired from the landing.

## Change

**`HowWeGotTheBibleLandingScreen.tsx`:**
- Removed the generic `goGuidedJourneys` callback
- Added three new callbacks: `goCanonFormationJourney`, `goTextAndTranslationJourney`, `goAllJourneys`
- Entries array grew from 3 to 4: Extra-Biblical · Canon Comparison · Canon Formation · Text & Translation
- New icons: `BookCopy` (Canon Formation), `Languages` (Text & Translation)
- Added `EscapeHatchRow` component beneath the entries block — uses muted typography, hairline divider above, `Map` icon (repurposed from the old generic entry), centered "Browse all guided journeys" with a chevron
- New styles: `escapeHatchSection`, `escapeHatch`, `escapeHatchText`

**`HowWeGotTheBibleLandingScreen.test.tsx`:**
- Lucide mock extended for `BookCopy` and `Languages`
- "renders all three landing entries" → "renders all four landing entries" with new titles
- New test: "renders the escape hatch row"
- Replaced the single Guided Journeys nav test with three: Canon Formation nav, Text & Translation nav, escape-hatch nav

## Verification

- `JourneyDetail` and `JourneyBrowse` are both registered in `ExploreStack` (lines 78–79), so navigation works without any stack changes
- Existing Extra-Biblical and Canon Comparison behavior unchanged (Canon Comparison still gated by `canonComparisonReady = false` flag — separate concern, not touched here)
- Premium gate on the parent HWGTB card (in ExploreMenuScreen) unchanged — non-premium users still see the upgrade modal before reaching this screen at all

## Relationship to existing tickets

- **Likely supersedes #1551 (HWGTB-P3-02) and #1552 (HWGTB-P4-01).** Those proposed a `FEATURED_IDS` list in `JourneyBrowseScreen` to surface canon-formation and text-and-translation in the Featured tab. That approach (a) didn't actually solve the HWGTB landing being a dispatcher, (b) diluted the Featured tab as a curated rotation by adding permanent residents, and (c) made the journeys discoverable in the generic browse rather than bundled in HWGTB. Direct navigation from the HWGTB landing solves the actual problem at the actual layer. Recommend closing both as superseded — but that's a separate decision, not part of this PR.

## Files

- `app/src/screens/HowWeGotTheBibleLandingScreen.tsx` (+78 / -16)
- `app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx` (+30 / -8)

## Out of scope

- Dead `canonComparisonReady = false` flag at line 51 — separate issue
- Closing/modifying #1551/#1552
- Any changes to `JourneyBrowseScreen` or `JourneyDetailScreen`

## Rollback

`git revert` — single-screen behavior change, no schema/nav/data touched. Two journeys being unwired from direct nav reverts cleanly to the generic browse fallback.