### PR TITLE
epic #1625 Tier A: panel_taxonomy + coverage_auditor + debate template + first audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ _tools/embedding_manifest.json
 prompts.db
 _tools/prompts_manifest.json
 
-# Expo export output (from `npx expo export`) 
-app/bundle.log 
-app/dist/ 
+# Expo export output (from `npx expo export`)
+app/bundle.log
+app/dist/
+
+# Coverage audit artifacts (epic #1625) — regenerable snapshots, never tracked.
+_audit/

--- a/_tools/audit_emitters.py
+++ b/_tools/audit_emitters.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+audit_emitters.py — Output formatters for coverage_auditor.py (#1628).
+
+Split from coverage_auditor.py for readability. Contains the Markdown
+report builder and per-book issue-body generator. JSON output is inlined
+in coverage_auditor.AuditReport.to_json because it's a trivial dataclass
+dump.
+
+Public API:
+    render_markdown(report, book_order) -> str
+    render_issue_bodies(report, book_order, book_meta) -> dict[book_id, body_md]
+    render_template_candidates(panel_key, clusters) -> str
+
+See parent epic #1625 for the full plan and rubric definitions.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Iterable
+
+TIER_EMOJI = {
+    "deficient": "🔴",
+    "thin": "🟡",
+    "adequate": "🟢",
+    "rich": "✨",
+}
+
+
+# ─── Markdown report ────────────────────────────────────────────────
+
+def render_markdown(report, book_order: list[str]) -> str:
+    """Produce the full Markdown audit report."""
+    lines: list[str] = []
+    lines.append(f"# Content Coverage Audit — {report.generated_at}")
+    lines.append("")
+    lines.append("## Cover Note")
+    lines.append("")
+    lines.append("_(authored in A4; leave this section for the A4 tracking issue.)_")
+    lines.append("")
+    lines.append(_executive_summary_md(report))
+    lines.append(_per_book_section_md(report, book_order))
+    return "\n".join(lines)
+
+
+def _executive_summary_md(report) -> str:
+    s = report.summary()
+    total_sections = s["total_sections"]
+    tiers = s["tier_counts"]
+
+    def pct(n):
+        return f"{(100.0 * n / total_sections):.1f}%" if total_sections else "n/a"
+
+    lines = [
+        "## Executive Summary",
+        "",
+        f"Sections: {total_sections} total",
+        (f"  🔴 Deficient: {tiers['deficient']} ({pct(tiers['deficient'])}) | "
+         f"🟡 Thin: {tiers['thin']} ({pct(tiers['thin'])}) | "
+         f"🟢 Adequate: {tiers['adequate']} ({pct(tiers['adequate'])}) | "
+         f"✨ Rich: {tiers['rich']} ({pct(tiers['rich'])})"),
+        "",
+        f"Panel quality: {s['total_panels']} panels evaluated",
+        (f"  substantive: {s['panel_verdicts']['substantive']} | "
+         f"empty: {s['panel_verdicts']['empty']} | "
+         f"stub: {s['panel_verdicts']['stub']} | "
+         f"placeholder: {s['panel_verdicts']['placeholder']} | "
+         f"template: {s['panel_verdicts']['template']}"),
+        "",
+        "Chapter-panel completeness (per genre rubric):",
+        (f"  Expected: {s['chapter_panel_expected']} | "
+         f"Present substantive: {s['chapter_panel_substantive']} | "
+         f"Missing: {s['chapter_panel_missing']} | "
+         f"Present but deficient: {s['chapter_panel_deficient']}"),
+        "",
+        "Top 5 books by total finding count:",
+    ]
+    for i, (book_id, count) in enumerate(s["top_books_by_findings"][:5], 1):
+        lines.append(f"  {i}. {book_id}: {count} findings")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _per_book_section_md(report, book_order: list[str]) -> str:
+    by_book = report.by_book()
+    lines = ["## Per-Book Breakdown", ""]
+
+    for book_id in book_order:
+        if book_id not in by_book:
+            continue
+        entry = by_book[book_id]
+        sections = entry["sections"]
+        chapter_panels = entry["chapter_panels"]
+        genre = entry.get("genre", "?")
+        total_chapters = entry.get("total_chapters", 0)
+
+        tier_counts = Counter(v.tier for v in sections)
+        lines.append(
+            f"### {book_id} ({genre} — {total_chapters} chapters, {len(sections)} sections)"
+        )
+        lines.append("")
+        lines.append(
+            "  🔴 {d} | 🟡 {t} | 🟢 {a} | ✨ {r}".format(
+                d=tier_counts.get("deficient", 0),
+                t=tier_counts.get("thin", 0),
+                a=tier_counts.get("adequate", 0),
+                r=tier_counts.get("rich", 0),
+            )
+        )
+
+        # L1 findings (deficient + thin only; adequate/rich skipped)
+        problem_sections = [v for v in sections if v.tier in ("deficient", "thin")]
+        if problem_sections:
+            lines.append("")
+            lines.append("**L1 sections needing enrichment:**")
+            for v in problem_sections[:25]:
+                lines.append(_format_section_line(v))
+            if len(problem_sections) > 25:
+                lines.append(f"  …({len(problem_sections) - 25} more)")
+
+        # L2 non-substantive panels
+        bad_panels = [
+            (v, p) for v in sections for p in v.panels
+            if p.verdict != "substantive"
+        ]
+        if bad_panels:
+            lines.append("")
+            lines.append("**L2 panels needing rewrite:**")
+            for v, p in bad_panels[:25]:
+                lines.append(
+                    f"  - Ch {v.chapter_num} §{v.section_num} "
+                    f"`{p.panel_key}`: {p.verdict}"
+                    + (f" ({p.details})" if p.details else "")
+                )
+            if len(bad_panels) > 25:
+                lines.append(f"  …({len(bad_panels) - 25} more)")
+
+        # L3 chapter-panel findings
+        l3_problems = [cp for cp in chapter_panels if cp.verdict != "substantive"]
+        if l3_problems:
+            lines.append("")
+            lines.append("**L3 chapter panels:**")
+            for cp in l3_problems[:25]:
+                tag = "missing" if cp.verdict == "missing" else cp.verdict
+                lines.append(
+                    f"  - Ch {cp.chapter_num} `{cp.panel_key}`: {tag}"
+                    + (f" ({cp.details})" if cp.details else "")
+                )
+            if len(l3_problems) > 25:
+                lines.append(f"  …({len(l3_problems) - 25} more)")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_section_line(v) -> str:
+    emoji = TIER_EMOJI.get(v.tier, "?")
+    reasons = []
+    if v.commentator_count < 2:
+        reasons.append(f"commentators={v.commentator_count}")
+    if v.categories_hit < 2:
+        reasons.append(f"categories={v.categories_hit}")
+    if v.panel_weight < 3:
+        reasons.append(f"weight={v.panel_weight:g}")
+    reason_str = ", ".join(reasons) if reasons else "boundary"
+    return (
+        f"  - {emoji} Ch {v.chapter_num} §{v.section_num} "
+        f"(v.{v.verse_start}-{v.verse_end}) — {reason_str}"
+    )
+
+
+# ─── Per-book issue bodies ──────────────────────────────────────────
+
+def render_issue_bodies(report, book_order: list[str], book_meta: dict) -> dict[str, str]:
+    """Produce one Tier-C-style draft issue body per book with any findings.
+
+    Returns { book_id: markdown_body }. Books with zero findings are omitted.
+    """
+    by_book = report.by_book()
+    bodies: dict[str, str] = {}
+    for book_id in book_order:
+        if book_id not in by_book:
+            continue
+        entry = by_book[book_id]
+        body = _single_book_issue_body(book_id, entry, book_meta.get(book_id, {}))
+        if body:
+            bodies[book_id] = body
+    return bodies
+
+
+def _single_book_issue_body(book_id: str, entry: dict, meta: dict) -> str:
+    sections = entry["sections"]
+    chapter_panels = entry["chapter_panels"]
+    genre = entry.get("genre", "?")
+    total_chapters = entry.get("total_chapters", 0)
+
+    l1 = [v for v in sections if v.tier in ("deficient", "thin")]
+    l2 = [(v, p) for v in sections for p in v.panels if p.verdict != "substantive"]
+    l3 = [cp for cp in chapter_panels if cp.verdict != "substantive"]
+
+    if not l1 and not l2 and not l3:
+        return ""
+
+    lines: list[str] = []
+    lines.append(
+        f"**Goal:** Bring {meta.get('name', book_id)} ({genre} — "
+        f"{total_chapters} chapters) to full coverage "
+        "(L1 sections + L2 panel quality + L3 chapter-panel completeness)."
+    )
+    lines.append("")
+    if l1:
+        lines.append(f"**Level 1 — Sections to enrich ({len(l1)}):**")
+        for v in l1:
+            emoji = TIER_EMOJI.get(v.tier, "?")
+            lines.append(
+                f"- [ ] {book_id} {v.chapter_num}:{v.verse_start}–{v.verse_end} "
+                f"({emoji} {v.tier}) — §{v.section_num}; "
+                f"commentators={v.commentator_count}, "
+                f"categories={v.categories_hit}, weight={v.panel_weight:g}"
+            )
+        lines.append("")
+    if l2:
+        lines.append(f"**Level 2 — Panels to rewrite ({len(l2)}):**")
+        for v, p in l2:
+            lines.append(
+                f"- [ ] {book_id} ch {v.chapter_num} §{v.section_num} "
+                f"`{p.panel_key}` — {p.verdict}"
+                + (f" ({p.details})" if p.details else "")
+            )
+        lines.append("")
+    if l3:
+        lines.append(f"**Level 3 — Chapter panels ({len(l3)}):**")
+        for cp in l3:
+            lines.append(
+                f"- [ ] {book_id} ch {cp.chapter_num} `{cp.panel_key}` — {cp.verdict}"
+                + (f" ({cp.details})" if cp.details else "")
+            )
+        lines.append("")
+
+    lines.append("**Acceptance criteria:**")
+    lines.append(f"- [ ] `coverage_auditor --book {book_id}` shows zero findings")
+    lines.append("- [ ] `quality_scorer` ≥ 90 for affected chapters")
+    lines.append("- [ ] No new placeholder/stub/template content")
+    lines.append("- [ ] NIV verse text unchanged")
+    lines.append("")
+    lines.append(
+        "**Out of scope:** sections already 🟢/✨; panels already substantive; "
+        "chapter panels not in this genre's expected set; section header changes (Phase 3)."
+    )
+    return "\n".join(lines)
+
+
+# ─── Template-candidates report ─────────────────────────────────────
+
+def render_template_candidates(panel_key: str, clusters: list[dict]) -> str:
+    """Produce the markdown report for `--template-candidates` output.
+
+    Each cluster is a dict: { signature, count, chapters, samples (list[str]) }.
+    Only clusters with ≥5 members should be passed in; filtering is the caller's job.
+    """
+    lines = [f"# Template Candidates — `{panel_key}` panels", ""]
+    if not clusters:
+        lines.append("_No ≥5-member clusters found._")
+        return "\n".join(lines)
+
+    for i, cluster in enumerate(clusters, 1):
+        lines.append(f"## Cluster {i} — {cluster['count']} members")
+        lines.append("")
+        lines.append("**Signature prefix:**")
+        lines.append("")
+        lines.append("```")
+        lines.append(cluster["signature"])
+        lines.append("```")
+        lines.append("")
+        lines.append("**Chapters:**")
+        for ch in sorted(cluster["chapters"])[:50]:
+            lines.append(f"- {ch}")
+        if len(cluster["chapters"]) > 50:
+            lines.append(f"- …({len(cluster['chapters']) - 50} more)")
+        lines.append("")
+        lines.append("**Samples:**")
+        for j, sample in enumerate(cluster["samples"][:3], 1):
+            lines.append(f"### Sample {j}")
+            lines.append("")
+            lines.append("```")
+            lines.append(sample)
+            lines.append("```")
+            lines.append("")
+        lines.append("---")
+        lines.append("")
+    return "\n".join(lines)

--- a/_tools/coverage_auditor.py
+++ b/_tools/coverage_auditor.py
@@ -122,7 +122,12 @@ class AuditReport:
 
     def summary(self) -> dict:
         tier_counts = Counter(v.tier for v in self.sections)
-        panel_counts = Counter(p.verdict for v in self.sections for p in v.panels)
+        # panel_verdicts spans every evaluated panel (sections + chapter panels).
+        # 'missing' is L3-only and not a panel verdict, so exclude it.
+        panel_counts: Counter = Counter(p.verdict for v in self.sections for p in v.panels)
+        for cp in self.chapter_panels:
+            if cp.verdict != "missing":
+                panel_counts[cp.verdict] += 1
         cp_counts = Counter(cp.verdict for cp in self.chapter_panels if cp.expected)
         finding_counts: Counter = Counter()
         for v in self.sections:
@@ -140,7 +145,10 @@ class AuditReport:
                 "adequate": tier_counts.get("adequate", 0),
                 "rich": tier_counts.get("rich", 0),
             },
-            "total_panels": sum(len(v.panels) for v in self.sections),
+            "total_panels": (
+                sum(len(v.panels) for v in self.sections)
+                + sum(1 for cp in self.chapter_panels if cp.verdict != "missing")
+            ),
             "panel_verdicts": {
                 "substantive": panel_counts.get("substantive", 0),
                 "empty": panel_counts.get("empty", 0),
@@ -459,6 +467,17 @@ def evaluate_chapter_panels(
                 book_id=book_id, chapter_num=chapter_num, panel_key=ptype,
                 verdict="substantive", expected=False, char_count=pv.char_count,
                 details="bonus (not in genre expected set)",
+            ))
+        elif pv.verdict in ("template", "placeholder"):
+            # Slight extension over epic §1.6: surface boilerplate on
+            # non-expected chapter panels too. Otherwise the 165 epistle
+            # `debate` templates would be silently dropped, defeating the
+            # purpose of L2 detection. Keep `expected=False` so emitters
+            # can rank these as informational rather than rubric failures.
+            out.append(ChapterPanelVerdict(
+                book_id=book_id, chapter_num=chapter_num, panel_key=ptype,
+                verdict=pv.verdict, expected=False, char_count=pv.char_count,
+                details=pv.details,
             ))
     return out
 

--- a/_tools/coverage_auditor.py
+++ b/_tools/coverage_auditor.py
@@ -1,0 +1,807 @@
+#!/usr/bin/env python3
+"""
+coverage_auditor.py — Three-layer content coverage audit (#1628).
+
+Audits the Companion Study corpus across three integrated layers (see
+parent epic #1625 for the full plan and rubric):
+
+    L1 — Section coverage tiers (deficient | thin | adequate | rich)
+    L2 — Panel content quality (substantive | empty | stub | placeholder | template)
+    L3 — Chapter-panel completeness (per genre rubric)
+
+Reuses panel taxonomy + helpers from `panel_taxonomy.py` (#1627). Does NOT
+import from `quality_scorer.py` — that tool serves a different scoring
+purpose and stays separate.
+
+Usage:
+    python _tools/coverage_auditor.py --all
+    python _tools/coverage_auditor.py --sections          # L1 only
+    python _tools/coverage_auditor.py --panel-quality     # L2 only
+    python _tools/coverage_auditor.py --chapter-panels    # L3 only
+    python _tools/coverage_auditor.py --book genesis --section-detail
+    python _tools/coverage_auditor.py --template-candidates
+    python _tools/coverage_auditor.py --format json|markdown|issues
+    python _tools/coverage_auditor.py --output-dir _audit
+    python _tools/coverage_auditor.py --all --ci [--baseline _audit/baseline.json]
+    python _tools/coverage_auditor.py --parables   # Phase 2 stub
+    python _tools/coverage_auditor.py --concepts   # Phase 3 stub
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Ensure local _tools/ is on sys.path so panel_taxonomy + audit_emitters import cleanly.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from panel_taxonomy import (
+    LINGUISTIC_PANELS, HISTORICAL_PANELS, CONNECTIVE_PANELS,
+    GENRE_EXPECTED_PANELS, TEMPLATE_PATTERNS, CHAPTER_PANEL_TYPES,
+    DENSITY_TIERS, PANEL_THRESHOLD_MULTIPLIERS, PLACEHOLDER_PATTERNS,
+    extract_panel_text, get_density_score, load_scholar_keys,
+    categorize_panel,
+)
+from audit_emitters import (
+    render_markdown, render_issue_bodies, render_template_candidates,
+)
+
+RUBRIC_VERSION = "3.0"
+
+
+# ─── Dataclasses ────────────────────────────────────────────────────
+
+@dataclass
+class PanelVerdict:
+    """Result of L2 evaluation for a single panel."""
+    panel_key: str
+    scope: str                    # 'section' | 'chapter'
+    char_count: int
+    verdict: str                  # 'substantive' | 'empty' | 'stub' | 'placeholder' | 'template'
+    details: str | None = None
+
+
+@dataclass
+class SectionVerdict:
+    """L1 tier assignment + accumulated panel evaluations for one section."""
+    book_id: str
+    chapter_num: int
+    section_num: int
+    verse_start: int
+    verse_end: int
+    panel_weight: float
+    categories_hit: int
+    commentator_count: int
+    tier: str                     # 'deficient' | 'thin' | 'adequate' | 'rich'
+    panels: list[PanelVerdict] = field(default_factory=list)
+    findings: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class ChapterPanelVerdict:
+    """L3 evaluation for one expected chapter panel."""
+    book_id: str
+    chapter_num: int
+    panel_key: str
+    verdict: str                  # 'substantive' | 'missing' | 'empty' | 'stub' | 'placeholder' | 'template'
+    expected: bool
+    char_count: int = 0
+    details: str | None = None
+
+
+@dataclass
+class TemplateCandidate:
+    """A panel grouped into a same-signature cluster for review."""
+    panel_key: str
+    signature: str
+    book_id: str
+    chapter_num: int
+    sample_body: str
+
+
+@dataclass
+class AuditReport:
+    """Aggregate report — input for emitters and JSON dump."""
+    generated_at: str
+    rubric_version: str
+    sections: list[SectionVerdict] = field(default_factory=list)
+    chapter_panels: list[ChapterPanelVerdict] = field(default_factory=list)
+    template_candidates: list[TemplateCandidate] = field(default_factory=list)
+    book_meta: dict = field(default_factory=dict)
+    book_order: list[str] = field(default_factory=list)
+
+    def summary(self) -> dict:
+        tier_counts = Counter(v.tier for v in self.sections)
+        panel_counts = Counter(p.verdict for v in self.sections for p in v.panels)
+        cp_counts = Counter(cp.verdict for cp in self.chapter_panels if cp.expected)
+        finding_counts: Counter = Counter()
+        for v in self.sections:
+            finding_counts[v.book_id] += len(v.findings)
+            finding_counts[v.book_id] += sum(1 for p in v.panels if p.verdict != "substantive")
+        for cp in self.chapter_panels:
+            if cp.verdict != "substantive":
+                finding_counts[cp.book_id] += 1
+        top_books = sorted(finding_counts.items(), key=lambda kv: -kv[1])
+        return {
+            "total_sections": len(self.sections),
+            "tier_counts": {
+                "deficient": tier_counts.get("deficient", 0),
+                "thin": tier_counts.get("thin", 0),
+                "adequate": tier_counts.get("adequate", 0),
+                "rich": tier_counts.get("rich", 0),
+            },
+            "total_panels": sum(len(v.panels) for v in self.sections),
+            "panel_verdicts": {
+                "substantive": panel_counts.get("substantive", 0),
+                "empty": panel_counts.get("empty", 0),
+                "stub": panel_counts.get("stub", 0),
+                "placeholder": panel_counts.get("placeholder", 0),
+                "template": panel_counts.get("template", 0),
+            },
+            "chapter_panel_expected": sum(1 for cp in self.chapter_panels if cp.expected),
+            "chapter_panel_substantive": cp_counts.get("substantive", 0),
+            "chapter_panel_missing": cp_counts.get("missing", 0),
+            "chapter_panel_deficient": sum(
+                cp_counts.get(v, 0) for v in ("empty", "stub", "placeholder", "template")
+            ),
+            "top_books_by_findings": top_books,
+        }
+
+    def by_book(self) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for v in self.sections:
+            entry = out.setdefault(v.book_id, {
+                "sections": [], "chapter_panels": [],
+                "genre": self.book_meta.get(v.book_id, {}).get("genre", "?"),
+                "total_chapters": self.book_meta.get(v.book_id, {}).get("total_chapters", 0),
+            })
+            entry["sections"].append(v)
+        for cp in self.chapter_panels:
+            entry = out.setdefault(cp.book_id, {
+                "sections": [], "chapter_panels": [],
+                "genre": self.book_meta.get(cp.book_id, {}).get("genre", "?"),
+                "total_chapters": self.book_meta.get(cp.book_id, {}).get("total_chapters", 0),
+            })
+            entry["chapter_panels"].append(cp)
+        return out
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "generated_at": self.generated_at,
+            "rubric_version": self.rubric_version,
+            "summary": self.summary(),
+            "sections": [asdict(v) for v in self.sections],
+            "chapter_panels": [asdict(cp) for cp in self.chapter_panels],
+            "template_candidates": [asdict(tc) for tc in self.template_candidates],
+            "book_order": self.book_order,
+            "book_meta": self.book_meta,
+        }, indent=2, ensure_ascii=False, default=str)
+
+    def to_markdown(self) -> str:
+        return render_markdown(self, self.book_order)
+
+    def to_issue_bodies(self) -> dict[str, str]:
+        return render_issue_bodies(self, self.book_order, self.book_meta)
+
+
+# ─── Books discovery ────────────────────────────────────────────────
+
+def load_books(content_dir: Path) -> list[dict]:
+    """Return live books from content/meta/books.json in canonical order.
+
+    Never hardcodes the book list. Non-book content directories
+    (archaeology, journeys, timeline, etc.) are excluded automatically
+    because they don't appear in books.json.
+    """
+    meta_path = content_dir / "meta" / "books.json"
+    if not meta_path.exists():
+        return []
+    books = json.loads(meta_path.read_text(encoding="utf-8"))
+    live = [b for b in books if b.get("is_live")]
+    live.sort(key=lambda b: b.get("book_order", 9999))
+    return live
+
+
+def iter_chapter_files(book_dir: Path) -> Iterable[Path]:
+    """Yield chapter JSON files in numeric order (1.json, 2.json, ..., 10.json)."""
+    files = list(book_dir.glob("*.json"))
+
+    def keyfn(p: Path) -> tuple[int, str]:
+        stem = p.stem
+        try:
+            return (int(stem), "")
+        except ValueError:
+            return (10**9, stem)
+
+    for p in sorted(files, key=keyfn):
+        yield p
+
+
+def load_chapter(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ─── L2: Panel content quality ──────────────────────────────────────
+
+def _is_empty_panel(panel_data) -> bool:
+    """A panel is empty if its data is structurally empty or all whitespace."""
+    if panel_data is None:
+        return True
+    if isinstance(panel_data, (dict, list, str)) and len(panel_data) == 0:
+        return True
+    return False
+
+
+def _matches_template(panel_key: str, panel_data) -> tuple[bool, str | None]:
+    """Type-specific template detection.
+
+    Each pattern is a tuple of substrings; ALL must appear in the serialized
+    panel JSON for a match. Returns (matched, details_or_none).
+    """
+    patterns = TEMPLATE_PATTERNS.get(panel_key, [])
+    if not patterns:
+        return False, None
+    serialized = json.dumps(panel_data, ensure_ascii=False)
+    for i, pattern in enumerate(patterns):
+        if all(substr in serialized for substr in pattern):
+            return True, f"matches pattern {i}"
+    return False, None
+
+
+def evaluate_panel(panel_key: str, panel_data, scope: str = "section") -> PanelVerdict:
+    """Apply the L2 verdict ladder: empty → placeholder → template → stub → substantive.
+
+    See epic #1625 §1.5 for rationale. The empirical 100*0.5=50 floor for
+    `heb` panels means only genuinely malformed Hebrew word-study panels
+    register as stubs (corpus median is ~484 chars).
+    """
+    if _is_empty_panel(panel_data):
+        return PanelVerdict(
+            panel_key=panel_key, scope=scope, char_count=0,
+            verdict="empty", details=None,
+        )
+
+    text = extract_panel_text(panel_key, panel_data)
+    char_count = len(text.strip())
+
+    if char_count == 0:
+        return PanelVerdict(
+            panel_key=panel_key, scope=scope, char_count=0,
+            verdict="empty", details=None,
+        )
+
+    for pattern in PLACEHOLDER_PATTERNS:
+        if pattern.search(text):
+            return PanelVerdict(
+                panel_key=panel_key, scope=scope, char_count=char_count,
+                verdict="placeholder", details=pattern.pattern,
+            )
+
+    matched, detail = _matches_template(panel_key, panel_data)
+    if matched:
+        return PanelVerdict(
+            panel_key=panel_key, scope=scope, char_count=char_count,
+            verdict="template", details=detail,
+        )
+
+    multiplier = PANEL_THRESHOLD_MULTIPLIERS.get(panel_key, 1.0)
+    stub_threshold = 100 * multiplier
+    if char_count < stub_threshold:
+        return PanelVerdict(
+            panel_key=panel_key, scope=scope, char_count=char_count,
+            verdict="stub", details=f"below {stub_threshold:g}-char threshold",
+        )
+
+    return PanelVerdict(
+        panel_key=panel_key, scope=scope, char_count=char_count,
+        verdict="substantive", details=None,
+    )
+
+
+# ─── L1: Section tier ───────────────────────────────────────────────
+
+def _section_chapter_bonus(chapter_panel_verdicts: list[ChapterPanelVerdict]) -> float:
+    """+0.5 per distinct chapter-panel category with ≥1 substantive panel."""
+    cats = set()
+    for cp in chapter_panel_verdicts:
+        if cp.verdict == "substantive":
+            cats.add(cp.panel_key)
+    return 0.5 * len(cats)
+
+
+def evaluate_section(
+    book_id: str,
+    chapter_num: int,
+    section: dict,
+    scholar_keys: set[str],
+    chapter_panel_verdicts: list[ChapterPanelVerdict],
+) -> SectionVerdict:
+    """Compute the L1 tier for one section based on its substantive panels."""
+    sec_num = section.get("section_num", 0)
+    vs = section.get("verse_start", 0)
+    ve = section.get("verse_end", 0)
+    panels = section.get("panels", {}) or {}
+
+    panel_verdicts: list[PanelVerdict] = []
+    for panel_key, panel_data in panels.items():
+        panel_verdicts.append(evaluate_panel(panel_key, panel_data, scope="section"))
+
+    substantive = [p for p in panel_verdicts if p.verdict == "substantive"]
+    categories = {categorize_panel(p.panel_key, scholar_keys) for p in substantive}
+    categories.discard("unknown")
+    commentator_count = len({
+        p.panel_key for p in substantive
+        if categorize_panel(p.panel_key, scholar_keys) == "commentary"
+    })
+
+    # panel_weight: each non-commentary substantive = 1.0; commentary collapses to 1.0
+    weight = sum(
+        1.0 for p in substantive
+        if categorize_panel(p.panel_key, scholar_keys) != "commentary"
+    )
+    if commentator_count > 0:
+        weight += 1.0
+    weight += _section_chapter_bonus(chapter_panel_verdicts)
+
+    # categories_hit caps at 4 (linguistic|historical|connective|commentary)
+    hit_categories = set()
+    for p in substantive:
+        cat = categorize_panel(p.panel_key, scholar_keys)
+        if cat in ("linguistic", "historical", "connective", "commentary"):
+            hit_categories.add(cat)
+    categories_hit = min(len(hit_categories), 4)
+
+    tier = _assign_tier(weight, categories_hit, commentator_count)
+
+    findings: list[dict] = []
+    if commentator_count == 0:
+        findings.append({"code": "no_commentary"})
+    elif commentator_count == 1:
+        findings.append({"code": "single_commentator"})
+    if commentator_count > 0 and len([p for p in substantive
+                                      if categorize_panel(p.panel_key, scholar_keys) != "commentary"]) == 0:
+        findings.append({"code": "commentary_only"})
+    if "linguistic" not in hit_categories:
+        findings.append({"code": "linguistic_missing"})
+    if "historical" not in hit_categories:
+        findings.append({"code": "historical_missing"})
+    if "connective" not in hit_categories:
+        findings.append({"code": "connective_missing"})
+    for p in panel_verdicts:
+        if p.verdict != "substantive":
+            findings.append({
+                "code": f"panel_{p.verdict}",
+                "panel_key": p.panel_key,
+                "details": p.details,
+            })
+
+    return SectionVerdict(
+        book_id=book_id,
+        chapter_num=chapter_num,
+        section_num=sec_num,
+        verse_start=vs,
+        verse_end=ve,
+        panel_weight=weight,
+        categories_hit=categories_hit,
+        commentator_count=commentator_count,
+        tier=tier,
+        panels=panel_verdicts,
+        findings=findings,
+    )
+
+
+def _assign_tier(weight: float, categories_hit: int, commentator_count: int) -> str:
+    """Apply the rubric in epic #1625 §1.4. Order matters: rich → adequate → thin → deficient."""
+    if weight >= 6 and categories_hit == 4 and commentator_count >= 3:
+        return "rich"
+    if weight >= 4 and categories_hit >= 3 and commentator_count >= 2:
+        return "adequate"
+    if weight == 3 and categories_hit == 2 and commentator_count == 2:
+        return "thin"
+    return "deficient"
+
+
+# ─── L3: Chapter-panel completeness ─────────────────────────────────
+
+def evaluate_chapter_panels(
+    book_id: str,
+    chapter_num: int,
+    chapter_data: dict,
+    genre: str,
+) -> list[ChapterPanelVerdict]:
+    """Compare a chapter's panels against the genre rubric.
+
+    Emits one ChapterPanelVerdict per expected type (missing or evaluated)
+    and one INFO-style 'bonus' verdict per substantive panel not in the
+    expected set.
+    """
+    expected_set = GENRE_EXPECTED_PANELS.get(genre, set())
+    chapter_panels = chapter_data.get("chapter_panels", {}) or {}
+    out: list[ChapterPanelVerdict] = []
+
+    for ptype in sorted(expected_set):
+        if ptype not in chapter_panels:
+            out.append(ChapterPanelVerdict(
+                book_id=book_id, chapter_num=chapter_num, panel_key=ptype,
+                verdict="missing", expected=True, char_count=0,
+                details="not present in chapter_panels",
+            ))
+            continue
+        pv = evaluate_panel(ptype, chapter_panels[ptype], scope="chapter")
+        out.append(ChapterPanelVerdict(
+            book_id=book_id, chapter_num=chapter_num, panel_key=ptype,
+            verdict=pv.verdict, expected=True, char_count=pv.char_count,
+            details=pv.details,
+        ))
+
+    for ptype, pdata in chapter_panels.items():
+        if ptype in expected_set:
+            continue
+        pv = evaluate_panel(ptype, pdata, scope="chapter")
+        if pv.verdict == "substantive":
+            out.append(ChapterPanelVerdict(
+                book_id=book_id, chapter_num=chapter_num, panel_key=ptype,
+                verdict="substantive", expected=False, char_count=pv.char_count,
+                details="bonus (not in genre expected set)",
+            ))
+    return out
+
+
+# ─── Audit driver ───────────────────────────────────────────────────
+
+_NUMERIC_REF_RE = re.compile(r"\b\d+(?::\d+)?\b")
+
+
+def _signature_of(panel_data) -> str:
+    """Lowercased, numeric-stripped JSON serialization, first 300 chars."""
+    serialized = json.dumps(panel_data, ensure_ascii=False).lower()
+    serialized = _NUMERIC_REF_RE.sub("", serialized)
+    return serialized[:300]
+
+
+def collect_template_candidates(
+    content_dir: Path,
+    books: list[dict],
+    panel_keys_with_patterns: set[str],
+) -> dict[str, list[dict]]:
+    """Group panels by (panel_key, signature_prefix). Yields ≥5-member clusters
+    only for panel keys NOT already covered by TEMPLATE_PATTERNS.
+
+    Returns { panel_key: [ {signature, count, chapters, samples}, ... ] }.
+    """
+    buckets: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
+    sample_bodies: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for book in books:
+        book_id = book["id"]
+        book_dir = content_dir / book_id
+        if not book_dir.is_dir():
+            continue
+        for ch_path in iter_chapter_files(book_dir):
+            data = load_chapter(ch_path)
+            if data is None:
+                continue
+            chapter_num = data.get("chapter_num", 0)
+
+            chapter_panels = data.get("chapter_panels", {}) or {}
+            for ptype, pdata in chapter_panels.items():
+                if ptype in panel_keys_with_patterns:
+                    continue
+                sig = _signature_of(pdata)
+                if not sig:
+                    continue
+                key = (ptype, sig)
+                buckets[key].append((book_id, f"{book_id} {chapter_num}"))
+                if len(sample_bodies[key]) < 3:
+                    sample_bodies[key].append(
+                        json.dumps(pdata, indent=2, ensure_ascii=False)[:1500]
+                    )
+
+            for sec in data.get("sections", []) or []:
+                if not isinstance(sec, dict):
+                    continue
+                sec_num = sec.get("section_num", 0)
+                for ptype, pdata in (sec.get("panels", {}) or {}).items():
+                    if ptype in panel_keys_with_patterns:
+                        continue
+                    sig = _signature_of(pdata)
+                    if not sig:
+                        continue
+                    key = (ptype, sig)
+                    buckets[key].append(
+                        (book_id, f"{book_id} {chapter_num}:§{sec_num}")
+                    )
+                    if len(sample_bodies[key]) < 3:
+                        sample_bodies[key].append(
+                            json.dumps(pdata, indent=2, ensure_ascii=False)[:1500]
+                        )
+
+    by_panel: dict[str, list[dict]] = defaultdict(list)
+    for (ptype, sig), members in buckets.items():
+        if len(members) < 5:
+            continue
+        by_panel[ptype].append({
+            "signature": sig,
+            "count": len(members),
+            "chapters": [m[1] for m in members],
+            "samples": sample_bodies[(ptype, sig)],
+        })
+    for ptype in by_panel:
+        by_panel[ptype].sort(key=lambda c: -c["count"])
+    return dict(by_panel)
+
+
+def run_audit(
+    content_dir: Path,
+    *,
+    book_filter: str | None = None,
+    do_sections: bool = True,
+    do_chapter_panels: bool = True,
+) -> AuditReport:
+    """Walk the corpus and produce an AuditReport.
+
+    `do_sections` controls whether L1/L2 are run; `do_chapter_panels`
+    controls L3. Both default to True (the `--all` behavior).
+    """
+    books = load_books(content_dir)
+    if book_filter:
+        books = [b for b in books if b["id"] == book_filter]
+    book_order = [b["id"] for b in books]
+    book_meta = {b["id"]: b for b in books}
+    scholar_keys = load_scholar_keys(content_dir)
+
+    sections: list[SectionVerdict] = []
+    chapter_panels_out: list[ChapterPanelVerdict] = []
+
+    for book in books:
+        book_id = book["id"]
+        genre = book.get("genre", "?")
+        book_dir = content_dir / book_id
+        if not book_dir.is_dir():
+            continue
+        for ch_path in iter_chapter_files(book_dir):
+            data = load_chapter(ch_path)
+            if data is None:
+                continue
+            chapter_num = data.get("chapter_num", 0)
+
+            cp_verdicts: list[ChapterPanelVerdict] = []
+            if do_chapter_panels or do_sections:
+                cp_verdicts = evaluate_chapter_panels(book_id, chapter_num, data, genre)
+
+            if do_chapter_panels:
+                chapter_panels_out.extend(cp_verdicts)
+
+            if do_sections:
+                for sec in data.get("sections", []) or []:
+                    if not isinstance(sec, dict):
+                        continue
+                    sv = evaluate_section(
+                        book_id, chapter_num, sec, scholar_keys, cp_verdicts,
+                    )
+                    sections.append(sv)
+
+    return AuditReport(
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        rubric_version=RUBRIC_VERSION,
+        sections=sections,
+        chapter_panels=chapter_panels_out,
+        template_candidates=[],
+        book_meta=book_meta,
+        book_order=book_order,
+    )
+
+
+# ─── CI baseline diffing ────────────────────────────────────────────
+
+def _baseline_finding_keys(baseline: dict) -> set[str]:
+    """Reduce a baseline JSON to a set of stable finding keys."""
+    keys: set[str] = set()
+    for sv in baseline.get("sections", []):
+        if sv.get("tier") == "deficient":
+            keys.add(f"L1:{sv['book_id']}:{sv['chapter_num']}:{sv['section_num']}:deficient")
+        for p in sv.get("panels", []) or []:
+            if p.get("verdict") != "substantive":
+                keys.add(
+                    f"L2:{sv['book_id']}:{sv['chapter_num']}:{sv['section_num']}"
+                    f":{p['panel_key']}:{p['verdict']}"
+                )
+    for cp in baseline.get("chapter_panels", []):
+        if cp.get("expected") and cp.get("verdict") != "substantive":
+            keys.add(
+                f"L3:{cp['book_id']}:{cp['chapter_num']}"
+                f":{cp['panel_key']}:{cp['verdict']}"
+            )
+    return keys
+
+
+def report_finding_keys(report: AuditReport) -> set[str]:
+    keys: set[str] = set()
+    for sv in report.sections:
+        if sv.tier == "deficient":
+            keys.add(f"L1:{sv.book_id}:{sv.chapter_num}:{sv.section_num}:deficient")
+        for p in sv.panels:
+            if p.verdict != "substantive":
+                keys.add(
+                    f"L2:{sv.book_id}:{sv.chapter_num}:{sv.section_num}"
+                    f":{p.panel_key}:{p.verdict}"
+                )
+    for cp in report.chapter_panels:
+        if cp.expected and cp.verdict != "substantive":
+            keys.add(f"L3:{cp.book_id}:{cp.chapter_num}:{cp.panel_key}:{cp.verdict}")
+    return keys
+
+
+def ci_check(report: AuditReport, baseline_path: Path | None) -> tuple[int, list[str]]:
+    """Compute regressions vs baseline. Returns (exit_code, regression_lines).
+
+    Without baseline → informational, exits 0.
+    With baseline → exits 1 on any new finding key not in the baseline.
+    """
+    if baseline_path is None or not baseline_path.exists():
+        return 0, []
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return 1, [f"Failed to read baseline: {e}"]
+    new_keys = report_finding_keys(report) - _baseline_finding_keys(baseline)
+    if not new_keys:
+        return 0, []
+    return 1, sorted(new_keys)
+
+
+# ─── CLI ────────────────────────────────────────────────────────────
+
+def _format_section_detail(report: AuditReport) -> str:
+    """Per-section detail dump used by --section-detail."""
+    lines = ["# Section Detail", ""]
+    for sv in report.sections:
+        lines.append(
+            f"- {sv.book_id} {sv.chapter_num}:{sv.verse_start}–{sv.verse_end} "
+            f"§{sv.section_num} → {sv.tier} "
+            f"(weight={sv.panel_weight:g}, cats={sv.categories_hit}, "
+            f"commentators={sv.commentator_count})"
+        )
+        for p in sv.panels:
+            lines.append(
+                f"    · `{p.panel_key}` → {p.verdict} ({p.char_count} chars)"
+                + (f" — {p.details}" if p.details else "")
+            )
+    return "\n".join(lines)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Three-layer content coverage audit")
+    parser.add_argument("--all", action="store_true",
+                        help="Run all three audit layers (default if no layer flag)")
+    parser.add_argument("--sections", action="store_true",
+                        help="L1 + L2 only (sections + per-panel quality)")
+    parser.add_argument("--panel-quality", action="store_true",
+                        help="L2 only (per-panel quality on sections + chapters)")
+    parser.add_argument("--chapter-panels", action="store_true",
+                        help="L3 only (chapter-panel completeness)")
+    parser.add_argument("--book", type=str, default=None,
+                        help="Limit audit to a single book id (e.g. genesis)")
+    parser.add_argument("--section-detail", action="store_true",
+                        help="Emit per-section detail (use with --book)")
+    parser.add_argument("--template-candidates", action="store_true",
+                        help="Surface ≥5-member panel clusters for template review")
+    parser.add_argument("--format", type=str, default="markdown",
+                        choices=["json", "markdown", "issues"],
+                        help="Output format")
+    parser.add_argument("--output-dir", type=str, default="_audit",
+                        help="Directory for generated artifacts (default _audit)")
+    parser.add_argument("--ci", action="store_true",
+                        help="CI mode: diff against baseline, exit 1 on regressions")
+    parser.add_argument("--baseline", type=str, default=None,
+                        help="Path to baseline JSON (default _audit/baseline.json)")
+    parser.add_argument("--content-dir", type=str, default="content",
+                        help="Content root directory (default content)")
+    parser.add_argument("--parables", action="store_true",
+                        help="(Phase 2 stub — not yet implemented)")
+    parser.add_argument("--concepts", action="store_true",
+                        help="(Phase 3 stub — not yet implemented)")
+
+    args = parser.parse_args(argv)
+
+    if args.parables:
+        print("Phase 2 — not yet implemented")
+        return 0
+    if args.concepts:
+        print("Phase 3 — not yet implemented")
+        return 0
+
+    root = Path(__file__).resolve().parent.parent
+    os.chdir(root)
+    content_dir = Path(args.content_dir)
+    out_dir = Path(args.output_dir)
+
+    do_sections = args.all or args.sections or args.panel_quality or (
+        not (args.chapter_panels or args.template_candidates or args.section_detail)
+    )
+    do_chapter_panels = args.all or args.chapter_panels or args.panel_quality or (
+        not (args.sections or args.template_candidates or args.section_detail)
+    )
+    if args.section_detail:
+        do_sections = True
+        do_chapter_panels = True
+
+    if args.template_candidates:
+        books = load_books(content_dir)
+        if args.book:
+            books = [b for b in books if b["id"] == args.book]
+        clusters = collect_template_candidates(
+            content_dir, books, set(TEMPLATE_PATTERNS.keys()),
+        )
+        if not clusters:
+            print("No ≥5-member clusters found.")
+            return 0
+        for ptype, cs in sorted(clusters.items()):
+            md = render_template_candidates(ptype, cs)
+            target = out_dir / f"template-candidates-{ptype}.md"
+            _write_text(target, md)
+            print(f"  wrote {target}  ({len(cs)} cluster(s))")
+        return 0
+
+    report = run_audit(
+        content_dir,
+        book_filter=args.book,
+        do_sections=do_sections,
+        do_chapter_panels=do_chapter_panels,
+    )
+
+    if args.ci:
+        baseline = Path(args.baseline) if args.baseline else (out_dir / "baseline.json")
+        exit_code, regressions = ci_check(report, baseline)
+        if regressions:
+            print("Regressions vs baseline:")
+            for r in regressions[:50]:
+                print(f"  + {r}")
+            if len(regressions) > 50:
+                print(f"  …({len(regressions) - 50} more)")
+        else:
+            print("CI: no regressions vs baseline.")
+        return exit_code
+
+    if args.section_detail:
+        print(_format_section_detail(report))
+        return 0
+
+    if args.format == "json":
+        print(report.to_json())
+    elif args.format == "issues":
+        bodies = report.to_issue_bodies()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for book_id, body in bodies.items():
+            target = out_dir / "issues" / f"{book_id}.md"
+            _write_text(target, body)
+            print(f"  wrote {target}")
+    else:
+        print(report.to_markdown())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_tools/panel_taxonomy.py
+++ b/_tools/panel_taxonomy.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+panel_taxonomy.py — Shared panel taxonomy for quality + coverage tooling.
+
+This module is imported by both `_tools/quality_scorer.py` (existing) and
+`_tools/coverage_auditor.py` (upcoming, see epic #1625). It holds the single
+source of truth for panel type classification, density thresholds, and the
+text/density extraction helpers used across both tools.
+
+Deliberate separation from `_tools/accuracy_config.py`: that module serves the
+accuracy auditor's claim-extraction logic and defines its own (overlapping
+but distinct) panel taxonomy — for example, `accuracy_config.CORE_SECTION_PANELS`
+includes scholar keys like `"mac"` / `"net"` which this taxonomy excludes.
+Do not attempt to consolidate the two.
+
+Symbols moved verbatim from quality_scorer.py:
+    CORE_SECTION_PANELS, REQUIRED_SECTION_PANELS, CHAPTER_PANEL_TYPES
+    (exported from quality_scorer as KNOWN_CHAPTER_PANELS for backwards compat),
+    DENSITY_TIERS, PANEL_THRESHOLD_MULTIPLIERS, PLACEHOLDER_PATTERNS,
+    SOURCE_PATTERN, extract_panel_text(), get_density_score(),
+    load_scholar_keys() (extracted from QualityEvaluator._load_scholar_keys).
+
+Added for the upcoming coverage auditor (#1628):
+    LINGUISTIC_PANELS, HISTORICAL_PANELS, CONNECTIVE_PANELS,
+    GENRE_EXPECTED_PANELS, TEMPLATE_PATTERNS (populated by A3 curation),
+    categorize_panel().
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# ─── Panel type sets (quality_scorer origin) ────────────────────────
+
+# Core (non-scholar) section panel types used by the quality scorer.
+CORE_SECTION_PANELS = {"heb", "cross", "hist", "tl", "places", "poi", "ctx"}
+
+# Minimum expected section panels (every section ideally has these).
+REQUIRED_SECTION_PANELS = {"heb", "cross"}
+
+# Known chapter panel types. Renamed from the legacy `KNOWN_CHAPTER_PANELS`
+# to `CHAPTER_PANEL_TYPES` for the coverage auditor; quality_scorer.py
+# re-exports the old name for backwards compatibility.
+CHAPTER_PANEL_TYPES = {
+    "lit", "themes", "ppl", "trans", "src", "rec",
+    "hebtext", "thread", "tx", "debate", "discourse",
+}
+
+
+# ─── Density thresholds ─────────────────────────────────────────────
+
+# Maps content length ranges to (rating_name, score_out_of_10).
+DENSITY_TIERS = [
+    (0,       "empty",     0),
+    (100,     "stub",      2),
+    (250,     "thin",      5),
+    (500,     "adequate",  7),
+    (1000,    "good",      9),
+    (999999,  "rich",     10),
+]
+
+# Per-panel-type threshold multipliers — lower = more lenient for shorter panels.
+PANEL_THRESHOLD_MULTIPLIERS = {
+    "heb": 0.5,      # Hebrew panels are naturally shorter (word studies)
+    "cross": 0.5,    # Cross-ref panels are citations, not commentary
+}
+
+
+# ─── Placeholder / source patterns ──────────────────────────────────
+
+# Generic placeholder / template artifact patterns.
+PLACEHOLDER_PATTERNS = [
+    re.compile(r"\bTODO\b", re.IGNORECASE),
+    re.compile(r"\bplaceholder\b", re.IGNORECASE),
+    re.compile(r"\bLorem\b"),
+    re.compile(r"\binsert here\b", re.IGNORECASE),
+    re.compile(r"\.{4,}"),  # four or more dots
+    re.compile(r"^This passage is significant because\b"),
+    re.compile(r"^This section describes\b"),
+    re.compile(r"\[fill in\]", re.IGNORECASE),
+]
+
+# Source field format: "Author Name, Work Title — Paraphrase Type".
+SOURCE_PATTERN = re.compile(r"^.+[,\s].+\s*[—–-]\s*.+$")
+
+
+# ─── Coverage auditor additions (L1/L2/L3 classification) ──────────
+
+# Section-panel category assignment used by coverage_auditor.py.
+# Commentary category is derived dynamically via load_scholar_keys().
+LINGUISTIC_PANELS = {"heb", "hebtext"}
+HISTORICAL_PANELS = {"hist", "ctx"}
+CONNECTIVE_PANELS = {"cross", "thread", "debate", "themes", "tl", "poi", "places"}
+
+# Evidence-based per-genre expected chapter panels (≥60% present-rate
+# in current content). Used by L3 chapter-panel completeness.
+GENRE_EXPECTED_PANELS = {
+    "theological_narrative": {"ppl", "trans", "src", "rec", "lit", "hebtext", "thread", "tx", "themes"},
+    "law":                   {"ppl", "src", "rec", "lit", "hebtext", "thread", "tx", "debate", "themes"},
+    "history":               {"ppl", "trans", "lit", "thread", "themes"},
+    "wisdom":                {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes"},
+    "poetry":                {"ppl", "trans", "rec", "lit", "hebtext", "themes"},
+    "love_poetry":           {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes"},
+    "lament":                {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes"},
+    "prophecy":              {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes"},
+    "apocalyptic":           {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes"},
+    "gospel":                {"ppl", "trans", "src", "rec", "lit", "hebtext", "tx", "debate", "themes"},
+    "epistle":               {"ppl", "trans", "rec", "lit", "hebtext", "thread", "themes", "discourse"},
+}
+
+# Type-specific template patterns. Each value is a list of tuples; every
+# substring in a tuple must appear in the serialized panel JSON for a match.
+# Populated by the A3 curation pass (#1629); empty at refactor time.
+TEMPLATE_PATTERNS: dict[str, list[tuple[str, ...]]] = {}
+
+
+# ─── Text extraction + density scoring ──────────────────────────────
+
+def extract_panel_text(panel_key, panel_data):
+    """Extract meaningful text content from any panel type.
+
+    Returns the combined text as a single string for length measurement
+    and content analysis. Handles all known panel structures.
+    """
+    if panel_data is None:
+        return ""
+
+    # Hebrew word studies — list of dicts
+    if panel_key == "heb" and isinstance(panel_data, list):
+        parts = []
+        for entry in panel_data:
+            if isinstance(entry, dict):
+                parts.append(entry.get("paragraph", ""))
+                parts.append(entry.get("gloss", ""))
+        return " ".join(p for p in parts if p)
+
+    # Cross-references — dict with refs list + echoes list
+    if panel_key == "cross" and isinstance(panel_data, dict):
+        parts = []
+        for r in panel_data.get("refs", []):
+            if isinstance(r, dict):
+                parts.append(r.get("note", ""))
+        for e in panel_data.get("echoes", []):
+            if isinstance(e, dict):
+                parts.append(e.get("source_context", ""))
+                parts.append(e.get("target_context", ""))
+        return " ".join(p for p in parts if p)
+
+    # Historical context — dict with historical + context + ane + audience fields
+    if panel_key == "hist" and isinstance(panel_data, dict):
+        parts = [
+            panel_data.get("historical", ""),
+            panel_data.get("context", ""),
+            panel_data.get("audience", ""),
+        ]
+        ane = panel_data.get("ane", [])
+        if isinstance(ane, list):
+            parts.extend(str(item) for item in ane)
+        elif isinstance(ane, str):
+            parts.append(ane)
+        return " ".join(p for p in parts if p)
+
+    # Timeline — list of dicts with text
+    if panel_key == "tl" and isinstance(panel_data, list):
+        return " ".join(
+            entry.get("text", "") for entry in panel_data if isinstance(entry, dict)
+        )
+
+    # Places — dict, possibly with _raw_html
+    if panel_key == "places" and isinstance(panel_data, dict):
+        raw = panel_data.get("_raw_html", "")
+        # Strip HTML for length measurement
+        return re.sub(r"<[^>]+>", " ", raw).strip() if raw else ""
+
+    # Points of interest — list of dicts with text
+    if panel_key == "poi" and isinstance(panel_data, list):
+        return " ".join(
+            entry.get("text", "") for entry in panel_data if isinstance(entry, dict)
+        )
+
+    # Scholar panels — dict with source + notes list
+    if isinstance(panel_data, dict) and "notes" in panel_data:
+        notes = panel_data.get("notes", [])
+        if isinstance(notes, list):
+            return " ".join(
+                n.get("note", "") for n in notes if isinstance(n, dict)
+            )
+        return ""
+
+    # Fallback: stringify
+    if isinstance(panel_data, str):
+        return panel_data
+    if isinstance(panel_data, dict):
+        return " ".join(str(v) for v in panel_data.values())
+    if isinstance(panel_data, list):
+        return " ".join(str(item) for item in panel_data)
+
+    return str(panel_data)
+
+
+def get_density_score(char_count, panel_key=None):
+    """Score a panel's content density based on character count.
+
+    Returns (score_out_of_10, tier_name).
+    """
+    multiplier = PANEL_THRESHOLD_MULTIPLIERS.get(panel_key, 1.0)
+    adjusted = char_count / multiplier if multiplier > 0 else char_count
+
+    prev_threshold = 0
+    for threshold, name, score in DENSITY_TIERS:
+        if adjusted < threshold:
+            return score, name
+        prev_threshold = threshold
+
+    return 10, "rich"
+
+
+# ─── Scholar key discovery ──────────────────────────────────────────
+
+def load_scholar_keys(content_dir) -> set[str]:
+    """Build the set of valid scholar panel keys from all available sources.
+
+    Reads `{content_dir}/meta/scholars.json` (both `id` and `panel_key` fields)
+    and, if importable, the `SCHOLAR_REGISTRY` from `_tools/config.py`.
+    Empty strings are discarded. Used by QualityEvaluator and coverage_auditor.
+    """
+    content_dir = Path(content_dir)
+    keys: set[str] = set()
+
+    meta_path = content_dir / "meta" / "scholars.json"
+    if meta_path.exists():
+        scholars = json.loads(meta_path.read_text(encoding='utf-8'))
+        for s in scholars:
+            keys.add(s.get("panel_key", ""))
+            keys.add(s.get("id", ""))
+
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from config import SCHOLAR_REGISTRY
+        for entry in SCHOLAR_REGISTRY:
+            if isinstance(entry, (tuple, list)) and len(entry) >= 4:
+                keys.add(entry[3])  # panel_key
+                keys.add(entry[0])  # config_id
+    except (ImportError, Exception):
+        pass
+
+    keys.discard("")
+    return keys
+
+
+# ─── Category classification ────────────────────────────────────────
+
+def categorize_panel(panel_key: str, scholar_keys: set[str]) -> str:
+    """Return 'linguistic' | 'historical' | 'commentary' | 'connective' | 'unknown'.
+
+    Commentary check comes BEFORE others because scholar keys like 'mac'
+    (MacArthur) look like historical codes but are actually scholars.
+    """
+    if panel_key in scholar_keys:      return "commentary"
+    if panel_key in LINGUISTIC_PANELS: return "linguistic"
+    if panel_key in HISTORICAL_PANELS: return "historical"
+    if panel_key in CONNECTIVE_PANELS: return "connective"
+    return "unknown"

--- a/_tools/panel_taxonomy.py
+++ b/_tools/panel_taxonomy.py
@@ -114,8 +114,23 @@ GENRE_EXPECTED_PANELS = {
 
 # Type-specific template patterns. Each value is a list of tuples; every
 # substring in a tuple must appear in the serialized panel JSON for a match.
-# Populated by the A3 curation pass (#1629); empty at refactor time.
-TEMPLATE_PATTERNS: dict[str, list[tuple[str, ...]]] = {}
+# Curated by the A3 pass (#1629). Err over-specific: false positives are
+# worse than false negatives here. Add new patterns only after a curation
+# log + manual review (do NOT silently expand from --template-candidates).
+TEMPLATE_PATTERNS: dict[str, list[tuple[str, ...]]] = {
+    "debate": [
+        # Boilerplate "Critical/Analytical vs Traditional/Confessional"
+        # pairing applied across 173 chapters in epistles + Leviticus +
+        # Numbers + minor prophets. All three substrings must appear.
+        # Confirmed substantive cases (Genesis 22, John 1, Matthew 5,
+        # 2 Corinthians 6) do NOT match.
+        (
+            "Critical/Analytical scholarship",
+            "Traditional/Confessional reading",
+            "Emphasises historical-critical",
+        ),
+    ],
+}
 
 
 # ─── Text extraction + density scoring ──────────────────────────────

--- a/_tools/quality_scorer.py
+++ b/_tools/quality_scorer.py
@@ -36,49 +36,22 @@ from collections import Counter
 
 # ─── Configuration ──────────────────────────────────────────────────
 
-# Core (non-scholar) section panel types
-CORE_SECTION_PANELS = {"heb", "cross", "hist", "tl", "places", "poi", "ctx"}
-
-# Minimum expected section panels (every section ideally has these)
-REQUIRED_SECTION_PANELS = {"heb", "cross"}
-
-# Known chapter panel types
-KNOWN_CHAPTER_PANELS = {
-    "lit", "themes", "ppl", "trans", "src", "rec",
-    "hebtext", "thread", "tx", "debate", "discourse",
-}
-
-# ── Density thresholds (character counts) ──
-# Maps content length ranges to (rating_name, score_out_of_10)
-DENSITY_TIERS = [
-    (0,       "empty",     0),
-    (100,     "stub",      2),
-    (250,     "thin",      5),
-    (500,     "adequate",  7),
-    (1000,    "good",      9),
-    (999999,  "rich",     10),
-]
-
-# Per-panel-type threshold multipliers — lower = more lenient for shorter panels
-PANEL_THRESHOLD_MULTIPLIERS = {
-    "heb": 0.5,      # Hebrew panels are naturally shorter (word studies)
-    "cross": 0.5,    # Cross-ref panels are citations, not commentary
-}
-
-# Placeholder / template artifact patterns
-PLACEHOLDER_PATTERNS = [
-    re.compile(r"\bTODO\b", re.IGNORECASE),
-    re.compile(r"\bplaceholder\b", re.IGNORECASE),
-    re.compile(r"\bLorem\b"),
-    re.compile(r"\binsert here\b", re.IGNORECASE),
-    re.compile(r"\.{4,}"),  # four or more dots
-    re.compile(r"^This passage is significant because\b"),
-    re.compile(r"^This section describes\b"),
-    re.compile(r"\[fill in\]", re.IGNORECASE),
-]
-
-# Source field format: "Author Name, Work Title — Paraphrase Type"
-SOURCE_PATTERN = re.compile(r"^.+[,\s].+\s*[—–-]\s*.+$")
+# Panel taxonomy lives in _tools/panel_taxonomy.py so it can be shared with
+# coverage_auditor.py (see epic #1625) without duplication or drift.
+# KNOWN_CHAPTER_PANELS is re-exported under its legacy name for backwards
+# compat with any external caller that may already import it from here.
+from panel_taxonomy import (
+    CORE_SECTION_PANELS,
+    REQUIRED_SECTION_PANELS,
+    CHAPTER_PANEL_TYPES as KNOWN_CHAPTER_PANELS,
+    DENSITY_TIERS,
+    PANEL_THRESHOLD_MULTIPLIERS,
+    PLACEHOLDER_PATTERNS,
+    SOURCE_PATTERN,
+    extract_panel_text,
+    get_density_score,
+    load_scholar_keys,
+)
 
 
 # ─── Data Classes ───────────────────────────────────────────────────
@@ -151,107 +124,6 @@ class ChapterScore:
                 if severity_order.get(f.severity, 0) >= min_level:
                     findings.append(f)
         return findings
-
-
-# ─── Text Extraction ────────────────────────────────────────────────
-
-def extract_panel_text(panel_key, panel_data):
-    """Extract meaningful text content from any panel type.
-
-    Returns the combined text as a single string for length measurement
-    and content analysis. Handles all known panel structures.
-    """
-    if panel_data is None:
-        return ""
-
-    # Hebrew word studies — list of dicts
-    if panel_key == "heb" and isinstance(panel_data, list):
-        parts = []
-        for entry in panel_data:
-            if isinstance(entry, dict):
-                parts.append(entry.get("paragraph", ""))
-                parts.append(entry.get("gloss", ""))
-        return " ".join(p for p in parts if p)
-
-    # Cross-references — dict with refs list + echoes list
-    if panel_key == "cross" and isinstance(panel_data, dict):
-        parts = []
-        for r in panel_data.get("refs", []):
-            if isinstance(r, dict):
-                parts.append(r.get("note", ""))
-        for e in panel_data.get("echoes", []):
-            if isinstance(e, dict):
-                parts.append(e.get("source_context", ""))
-                parts.append(e.get("target_context", ""))
-        return " ".join(p for p in parts if p)
-
-    # Historical context — dict with historical + context + ane + audience fields
-    if panel_key == "hist" and isinstance(panel_data, dict):
-        parts = [
-            panel_data.get("historical", ""),
-            panel_data.get("context", ""),
-            panel_data.get("audience", ""),
-        ]
-        ane = panel_data.get("ane", [])
-        if isinstance(ane, list):
-            parts.extend(str(item) for item in ane)
-        elif isinstance(ane, str):
-            parts.append(ane)
-        return " ".join(p for p in parts if p)
-
-    # Timeline — list of dicts with text
-    if panel_key == "tl" and isinstance(panel_data, list):
-        return " ".join(
-            entry.get("text", "") for entry in panel_data if isinstance(entry, dict)
-        )
-
-    # Places — dict, possibly with _raw_html
-    if panel_key == "places" and isinstance(panel_data, dict):
-        raw = panel_data.get("_raw_html", "")
-        # Strip HTML for length measurement
-        return re.sub(r"<[^>]+>", " ", raw).strip() if raw else ""
-
-    # Points of interest — list of dicts with text
-    if panel_key == "poi" and isinstance(panel_data, list):
-        return " ".join(
-            entry.get("text", "") for entry in panel_data if isinstance(entry, dict)
-        )
-
-    # Scholar panels — dict with source + notes list
-    if isinstance(panel_data, dict) and "notes" in panel_data:
-        notes = panel_data.get("notes", [])
-        if isinstance(notes, list):
-            return " ".join(
-                n.get("note", "") for n in notes if isinstance(n, dict)
-            )
-        return ""
-
-    # Fallback: stringify
-    if isinstance(panel_data, str):
-        return panel_data
-    if isinstance(panel_data, dict):
-        return " ".join(str(v) for v in panel_data.values())
-    if isinstance(panel_data, list):
-        return " ".join(str(item) for item in panel_data)
-
-    return str(panel_data)
-
-
-def get_density_score(char_count, panel_key=None):
-    """Score a panel's content density based on character count.
-
-    Returns (score_out_of_10, tier_name).
-    """
-    multiplier = PANEL_THRESHOLD_MULTIPLIERS.get(panel_key, 1.0)
-    adjusted = char_count / multiplier if multiplier > 0 else char_count
-
-    prev_threshold = 0
-    for threshold, name, score in DENSITY_TIERS:
-        if adjusted < threshold:
-            return score, name
-        prev_threshold = threshold
-
-    return 10, "rich"
 
 
 # ─── Scoring Functions ──────────────────────────────────────────────
@@ -957,29 +829,7 @@ class QualityEvaluator:
 
     def _load_scholar_keys(self):
         """Build set of valid scholar panel keys from all available sources."""
-        keys = set()
-
-        # From scholars.json meta
-        meta_path = self.content_dir / "meta" / "scholars.json"
-        if meta_path.exists():
-            scholars = json.loads(meta_path.read_text(encoding='utf-8'))
-            for s in scholars:
-                keys.add(s.get("panel_key", ""))
-                keys.add(s.get("id", ""))
-
-        # From config.py SCHOLAR_REGISTRY if available
-        try:
-            sys.path.insert(0, str(Path(__file__).resolve().parent))
-            from config import SCHOLAR_REGISTRY
-            for entry in SCHOLAR_REGISTRY:
-                if isinstance(entry, (tuple, list)) and len(entry) >= 4:
-                    keys.add(entry[3])  # panel_key
-                    keys.add(entry[0])  # config_id
-        except (ImportError, Exception):
-            pass
-
-        keys.discard("")
-        return keys
+        return load_scholar_keys(self.content_dir)
 
     def _load_llm_cache(self):
         cache_path = Path(__file__).resolve().parent / ".quality_cache.json"

--- a/_tools/test_coverage_auditor.py
+++ b/_tools/test_coverage_auditor.py
@@ -308,6 +308,30 @@ class ChapterPanelTests(unittest.TestCase):
         finally:
             pt.TEMPLATE_PATTERNS.pop("discourse", None)
 
+    def test_non_expected_template_surfaces(self):
+        # `debate` is NOT in epistle's expected set, but a templated debate
+        # panel must still surface (with expected=False) so the 165 silently-
+        # dropped epistle templates aren't lost. See A3 curation note.
+        pt.TEMPLATE_PATTERNS["debate"] = [(
+            "Critical/Analytical scholarship",
+            "Traditional/Confessional reading",
+            "Emphasises historical-critical",
+        )]
+        try:
+            chapter = {"chapter_panels": {"debate": [[
+                "Q",
+                [["Critical/Analytical scholarship", "x" * 100, "Emphasises historical-critical."],
+                 ["Traditional/Confessional reading", "y" * 100, ""]],
+                "summary",
+            ]]}}
+            out = ca.evaluate_chapter_panels("romans", 9, chapter, "epistle")
+            debate = [cp for cp in out if cp.panel_key == "debate"]
+            self.assertEqual(len(debate), 1)
+            self.assertEqual(debate[0].verdict, "template")
+            self.assertFalse(debate[0].expected)
+        finally:
+            pt.TEMPLATE_PATTERNS.pop("debate", None)
+
     def test_bonus_panel(self):
         # poetry doesn't expect debate; if substantive debate present → bonus
         chapter = {"chapter_panels": {

--- a/_tools/test_coverage_auditor.py
+++ b/_tools/test_coverage_auditor.py
@@ -1,0 +1,449 @@
+"""Unit tests for _tools/coverage_auditor.py and panel_taxonomy.py.
+
+Run locally with:
+    python3 _tools/test_coverage_auditor.py
+
+Inline fixtures only — no real-corpus reads, no network. Stdlib unittest.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import panel_taxonomy as pt  # noqa: E402
+import coverage_auditor as ca  # noqa: E402
+
+
+SCHOLAR_KEYS = {
+    "macarthur", "mac", "netbible", "net", "sarna", "alter", "calvin",
+    "cat", "catena", "marcus", "mar", "rhoads", "rho",
+}
+
+
+# ─── L2: Panel verdict tests ────────────────────────────────────────
+
+class PanelVerdictTests(unittest.TestCase):
+    def test_empty_dict(self):
+        v = ca.evaluate_panel("hist", {})
+        self.assertEqual(v.verdict, "empty")
+
+    def test_empty_list(self):
+        v = ca.evaluate_panel("heb", [])
+        self.assertEqual(v.verdict, "empty")
+
+    def test_empty_string(self):
+        v = ca.evaluate_panel("trans", "")
+        self.assertEqual(v.verdict, "empty")
+
+    def test_empty_none(self):
+        v = ca.evaluate_panel("debate", None)
+        self.assertEqual(v.verdict, "empty")
+
+    def test_placeholder_panel(self):
+        sec = {"notes": [{"note": "This passage is significant because of its theology."}]}
+        v = ca.evaluate_panel("sarna", sec)
+        self.assertEqual(v.verdict, "placeholder")
+
+    def test_template_panel_debate(self):
+        # Inject a test pattern, then restore.
+        original = pt.TEMPLATE_PATTERNS.get("debate")
+        pt.TEMPLATE_PATTERNS["debate"] = [(
+            "Critical/Analytical scholarship",
+            "Traditional/Confessional reading",
+            "Emphasises historical-critical",
+        )]
+        try:
+            data = [[
+                "Interpretive Question: 9:1",
+                [
+                    ["Critical/Analytical scholarship",
+                     "The NET note explains some scattering metaphor — many words to clear the threshold here.",
+                     "Emphasises historical-critical, literary, or text-critical analysis."],
+                    ["Traditional/Confessional reading",
+                     "Reads within the canonical framework of fulfilled prophecy and covenant.",
+                     "Represented by Calvin, MacArthur, and the evangelical tradition."],
+                ],
+                "Both readings engage seriously.",
+            ]]
+            v = ca.evaluate_panel("debate", data)
+            self.assertEqual(v.verdict, "template")
+        finally:
+            if original is None:
+                pt.TEMPLATE_PATTERNS.pop("debate", None)
+            else:
+                pt.TEMPLATE_PATTERNS["debate"] = original
+
+    def test_stub_panel_heb(self):
+        # heb threshold = 100 * 0.5 = 50 chars; 30 chars = stub
+        data = [{"paragraph": "x" * 20, "gloss": "abc"}]
+        v = ca.evaluate_panel("heb", data)
+        self.assertEqual(v.verdict, "stub")
+
+    def test_stub_panel_generic(self):
+        # Non-heb threshold = 100 chars; 50 chars = stub
+        data = {"notes": [{"note": "x" * 50}]}
+        v = ca.evaluate_panel("sarna", data)
+        self.assertEqual(v.verdict, "stub")
+
+    def test_substantive_panel_heb(self):
+        data = [{"paragraph": "x" * 200, "gloss": "y"}]
+        v = ca.evaluate_panel("heb", data)
+        self.assertEqual(v.verdict, "substantive")
+
+    def test_substantive_panel_scholar(self):
+        data = {"notes": [{"note": "z" * 800}]}
+        v = ca.evaluate_panel("sarna", data)
+        self.assertEqual(v.verdict, "substantive")
+
+    def test_heb_50_char_boundary(self):
+        # Exactly 50 chars in extracted text → adjusted=100, NOT below 50 stub-floor.
+        # Confirms the empirical floor described in epic §1.5.
+        data = [{"paragraph": "a" * 49, "gloss": ""}]
+        v = ca.evaluate_panel("heb", data)
+        # 49 chars < 50 → stub
+        self.assertEqual(v.verdict, "stub")
+        data2 = [{"paragraph": "a" * 60, "gloss": ""}]
+        v2 = ca.evaluate_panel("heb", data2)
+        self.assertEqual(v2.verdict, "substantive")
+
+
+# ─── L1: Section tier tests ─────────────────────────────────────────
+
+def _scholar_panel(notes_chars: int = 600) -> dict:
+    return {"notes": [{"note": "x" * notes_chars}]}
+
+
+def _heb_panel(chars: int = 300) -> list:
+    return [{"paragraph": "y" * chars, "gloss": "z"}]
+
+
+def _hist_panel(chars: int = 300) -> dict:
+    return {"historical": "h" * chars, "context": "", "audience": ""}
+
+
+def _cross_panel(chars: int = 80) -> dict:
+    return {"refs": [{"note": "c" * chars}]}
+
+
+class SectionTierTests(unittest.TestCase):
+    def _eval(self, panels: dict, *, cp_verdicts=None) -> ca.SectionVerdict:
+        section = {
+            "section_num": 1, "verse_start": 1, "verse_end": 5,
+            "panels": panels,
+        }
+        return ca.evaluate_section(
+            "genesis", 1, section, SCHOLAR_KEYS, cp_verdicts or [],
+        )
+
+    def test_rich_section(self):
+        # Rich rubric requires weight >= 6; heb+hist+cross+commentary collapses
+        # to weight 4 alone. Real corpus reaches 'rich' via the chapter-panel
+        # bonus (+0.5 per substantive chapter-panel type), so model that here.
+        cp = [
+            ca.ChapterPanelVerdict("genesis", 1, k, "substantive", True, 600)
+            for k in ("ppl", "trans", "src", "rec")
+        ]
+        sv = self._eval({
+            "heb": _heb_panel(300),
+            "hist": _hist_panel(300),
+            "cross": _cross_panel(80),
+            "sarna": _scholar_panel(),
+            "alter": _scholar_panel(),
+            "calvin": _scholar_panel(),
+        }, cp_verdicts=cp)
+        # weight = 3 (non-commentary) + 1 (commentary) + 4*0.5 = 6.0
+        self.assertGreaterEqual(sv.panel_weight, 6.0)
+        self.assertEqual(sv.tier, "rich")
+
+    def test_adequate_section(self):
+        sv = self._eval({
+            "heb": _heb_panel(300),
+            "hist": _hist_panel(300),
+            "cross": _cross_panel(80),
+            "sarna": _scholar_panel(),
+            "alter": _scholar_panel(),
+        })
+        self.assertEqual(sv.tier, "adequate")
+
+    def test_thin_single_commentator(self):
+        sv = self._eval({
+            "heb": _heb_panel(300),
+            "cross": _cross_panel(80),
+            "sarna": _scholar_panel(),
+        })
+        # 1 commentator → fails commentator floor → deficient
+        self.assertEqual(sv.tier, "deficient")
+        self.assertEqual(sv.commentator_count, 1)
+
+    def test_thin_boundary(self):
+        # heb + hist + sarna + alter:
+        #   weight = 1(heb) + 1(hist) + 1(commentary collapsed) = 3
+        #   categories_hit = {linguistic, historical, commentary} = 3
+        # Rubric: thin requires weight==3 AND categories==2 AND commentators==2.
+        # Here categories=3 so this isn't a strict "thin" — falls to deficient.
+        sv = self._eval({
+            "heb": _heb_panel(300),
+            "hist": _hist_panel(300),
+            "sarna": _scholar_panel(),
+            "alter": _scholar_panel(),
+        })
+        self.assertEqual(sv.commentator_count, 2)
+        # weight=3, cats=3 → fails 'thin' (cats!=2) and fails 'adequate' (weight<4)
+        self.assertEqual(sv.tier, "deficient")
+
+    def test_thin_exact(self):
+        # Construct exact thin: 2 categories, weight=3, 2 commentators
+        # heb (linguistic) + sarna + alter (commentary collapsed) = weight 1+1=2,
+        # add one more linguistic substantive panel
+        sv = self._eval({
+            "heb": _heb_panel(300),
+            "hebtext": _heb_panel(300),  # also linguistic, second non-commentary
+            "sarna": _scholar_panel(),
+            "alter": _scholar_panel(),
+        })
+        # weight = 1(heb) + 1(hebtext) + 1(commentary) = 3
+        # categories_hit = {linguistic, commentary} = 2
+        # commentators = 2
+        self.assertEqual(sv.tier, "thin")
+
+    def test_commentary_only(self):
+        sv = self._eval({
+            "sarna": _scholar_panel(),
+            "alter": _scholar_panel(),
+            "calvin": _scholar_panel(),
+            "macarthur": _scholar_panel(),
+            "netbible": _scholar_panel(),
+        })
+        # commentary collapses to weight 1, categories_hit = 1 → deficient
+        self.assertEqual(sv.tier, "deficient")
+        codes = {f["code"] for f in sv.findings}
+        self.assertIn("commentary_only", codes)
+
+    def test_template_demotes_section(self):
+        # Inject debate template pattern temporarily
+        pt.TEMPLATE_PATTERNS["debate"] = [(
+            "Critical/Analytical scholarship",
+            "Traditional/Confessional reading",
+            "Emphasises historical-critical",
+        )]
+        try:
+            template_data = [[
+                "Q",
+                [["Critical/Analytical scholarship", "x" * 100, "Emphasises historical-critical."],
+                 ["Traditional/Confessional reading", "y" * 100, "tradition"]],
+                "summary",
+            ]]
+            # All panels substantive except `debate` which is template.
+            sv_with_tpl = self._eval({
+                "heb": _heb_panel(300),
+                "hist": _hist_panel(300),
+                "debate": template_data,
+                "sarna": _scholar_panel(),
+                "alter": _scholar_panel(),
+            })
+            sv_substantive = self._eval({
+                "heb": _heb_panel(300),
+                "hist": _hist_panel(300),
+                "debate": _heb_panel(800),  # any substantive content
+                "sarna": _scholar_panel(),
+                "alter": _scholar_panel(),
+            })
+            # Templated debate doesn't count → categories_hit goes from 4→3,
+            # weight from 5→4. Both still adequate but with strictly fewer.
+            self.assertLess(sv_with_tpl.panel_weight, sv_substantive.panel_weight)
+        finally:
+            pt.TEMPLATE_PATTERNS.pop("debate", None)
+
+    def test_chapter_bonus_lifts_weight(self):
+        cp = [
+            ca.ChapterPanelVerdict("genesis", 1, "ppl", "substantive", True, 600),
+            ca.ChapterPanelVerdict("genesis", 1, "trans", "substantive", True, 600),
+        ]
+        sv = self._eval(
+            {"heb": _heb_panel(300), "cross": _cross_panel(80), "sarna": _scholar_panel()},
+            cp_verdicts=cp,
+        )
+        # Two chapter-panel categories → +1.0 to weight
+        self.assertGreaterEqual(sv.panel_weight, 1 + 1 + 1 + 1.0)
+
+
+# ─── L3: Chapter-panel completeness ────────────────────────────────
+
+class ChapterPanelTests(unittest.TestCase):
+    def test_gospel_missing_debate(self):
+        chapter = {"chapter_panels": {"ppl": _scholar_panel(), "trans": _scholar_panel()}}
+        out = ca.evaluate_chapter_panels("matthew", 5, chapter, "gospel")
+        debate = [cp for cp in out if cp.panel_key == "debate"]
+        self.assertEqual(len(debate), 1)
+        self.assertEqual(debate[0].verdict, "missing")
+        self.assertTrue(debate[0].expected)
+
+    def test_poetry_missing_debate_no_finding(self):
+        chapter = {"chapter_panels": {"ppl": _scholar_panel()}}
+        out = ca.evaluate_chapter_panels("psalms", 23, chapter, "poetry")
+        debate = [cp for cp in out if cp.panel_key == "debate"]
+        # poetry doesn't expect debate → no finding emitted
+        self.assertEqual(debate, [])
+
+    def test_epistle_discourse_template(self):
+        pt.TEMPLATE_PATTERNS["discourse"] = [("standard discourse marker A",
+                                              "standard discourse marker B")]
+        try:
+            chapter = {"chapter_panels": {
+                "discourse": {"notes": [{
+                    "note": "This panel includes standard discourse marker A and standard discourse marker B" + " x" * 200,
+                }]},
+            }}
+            out = ca.evaluate_chapter_panels("romans", 1, chapter, "epistle")
+            disc = [cp for cp in out if cp.panel_key == "discourse"][0]
+            self.assertEqual(disc.verdict, "template")
+        finally:
+            pt.TEMPLATE_PATTERNS.pop("discourse", None)
+
+    def test_bonus_panel(self):
+        # poetry doesn't expect debate; if substantive debate present → bonus
+        chapter = {"chapter_panels": {
+            "debate": [{"title": "T", "positions": [{"name": "A", "argument": "x" * 200}]}],
+            "ppl": _scholar_panel(),
+        }}
+        out = ca.evaluate_chapter_panels("psalms", 1, chapter, "poetry")
+        bonus = [cp for cp in out if cp.panel_key == "debate"]
+        self.assertEqual(len(bonus), 1)
+        self.assertFalse(bonus[0].expected)
+        self.assertEqual(bonus[0].verdict, "substantive")
+
+
+# ─── Algorithm tests ────────────────────────────────────────────────
+
+class CategorizeTests(unittest.TestCase):
+    def test_heb_linguistic(self):
+        self.assertEqual(pt.categorize_panel("heb", SCHOLAR_KEYS), "linguistic")
+
+    def test_hist_historical(self):
+        self.assertEqual(pt.categorize_panel("hist", SCHOLAR_KEYS), "historical")
+
+    def test_cross_connective(self):
+        self.assertEqual(pt.categorize_panel("cross", SCHOLAR_KEYS), "connective")
+
+    def test_mac_is_commentary(self):
+        # Critical: scholar key 'mac' must NOT be misclassified as historical.
+        self.assertEqual(pt.categorize_panel("mac", SCHOLAR_KEYS), "commentary")
+
+    def test_sarna_commentary(self):
+        self.assertEqual(pt.categorize_panel("sarna", SCHOLAR_KEYS), "commentary")
+
+    def test_themes_connective(self):
+        self.assertEqual(pt.categorize_panel("themes", SCHOLAR_KEYS), "connective")
+
+    def test_unknown_key(self):
+        self.assertEqual(pt.categorize_panel("zzz_unknown", SCHOLAR_KEYS), "unknown")
+
+
+class BooksDiscoveryTests(unittest.TestCase):
+    def test_excludes_non_book_dirs(self):
+        with tempfile.TemporaryDirectory() as td:
+            content = Path(td)
+            (content / "meta").mkdir()
+            (content / "meta" / "books.json").write_text(json.dumps([
+                {"id": "genesis", "is_live": True, "book_order": 1, "genre": "theological_narrative"},
+                {"id": "fakebook", "is_live": False, "book_order": 99, "genre": "history"},
+            ]), encoding="utf-8")
+            books = ca.load_books(content)
+            ids = {b["id"] for b in books}
+            self.assertEqual(ids, {"genesis"})
+
+    def test_canonical_order(self):
+        with tempfile.TemporaryDirectory() as td:
+            content = Path(td)
+            (content / "meta").mkdir()
+            (content / "meta" / "books.json").write_text(json.dumps([
+                {"id": "matthew", "is_live": True, "book_order": 40},
+                {"id": "genesis", "is_live": True, "book_order": 1},
+                {"id": "psalms", "is_live": True, "book_order": 19},
+            ]), encoding="utf-8")
+            books = ca.load_books(content)
+            self.assertEqual([b["id"] for b in books], ["genesis", "psalms", "matthew"])
+
+
+class TemplateSignatureTests(unittest.TestCase):
+    def test_signature_strips_numeric_refs(self):
+        sig1 = ca._signature_of([{"title": "Question 9:22", "body": "x"}])
+        sig2 = ca._signature_of([{"title": "Question 11:5", "body": "x"}])
+        # Verse refs stripped → signatures should match
+        self.assertEqual(sig1, sig2)
+
+    def test_signature_truncates_300(self):
+        big = ca._signature_of("x" * 1000)
+        self.assertLessEqual(len(big), 300)
+
+
+# ─── Integration: run_audit on synthetic corpus ────────────────────
+
+class RunAuditIntegrationTests(unittest.TestCase):
+    def _make_corpus(self, td: Path) -> Path:
+        content = td / "content"
+        (content / "meta").mkdir(parents=True)
+        (content / "meta" / "books.json").write_text(json.dumps([
+            {"id": "genesis", "is_live": True, "book_order": 1,
+             "genre": "theological_narrative", "total_chapters": 1},
+        ]), encoding="utf-8")
+        (content / "meta" / "scholars.json").write_text(json.dumps([
+            {"id": "sarna", "panel_key": "sarna"},
+            {"id": "alter", "panel_key": "alter"},
+        ]), encoding="utf-8")
+        (content / "genesis").mkdir()
+        (content / "genesis" / "1.json").write_text(json.dumps({
+            "chapter_id": "gen1", "book_dir": "genesis", "chapter_num": 1,
+            "chapter_panels": {
+                "ppl": {"notes": [{"note": "x" * 600}]},
+            },
+            "sections": [{
+                "section_num": 1, "verse_start": 1, "verse_end": 5,
+                "panels": {
+                    "heb": [{"paragraph": "y" * 300, "gloss": "z"}],
+                    "hist": {"historical": "h" * 300},
+                    "cross": {"refs": [{"note": "c" * 80}]},
+                    "sarna": {"notes": [{"note": "n" * 600}]},
+                    "alter": {"notes": [{"note": "n" * 600}]},
+                },
+            }],
+        }), encoding="utf-8")
+        return content
+
+    def test_run_audit_end_to_end(self):
+        with tempfile.TemporaryDirectory() as td:
+            content = self._make_corpus(Path(td))
+            report = ca.run_audit(content)
+            self.assertEqual(len(report.sections), 1)
+            self.assertEqual(report.sections[0].tier, "adequate")
+            # JSON serializes
+            data = json.loads(report.to_json())
+            self.assertEqual(data["summary"]["total_sections"], 1)
+            # Markdown renders
+            md = report.to_markdown()
+            self.assertIn("genesis", md)
+            self.assertIn("Executive Summary", md)
+
+
+# ─── Phase 2 / 3 stubs ─────────────────────────────────────────────
+
+class StubFlagTests(unittest.TestCase):
+    def test_parables_stub(self):
+        rc = ca.main(["--parables"])
+        self.assertEqual(rc, 0)
+
+    def test_concepts_stub(self):
+        rc = ca.main(["--concepts"])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #1627, #1628, #1629, #1630.

Implements all four Tier A items for epic **#1625 — Content Coverage Audit**
(parent sub-epic #1626) in a single branch. The new tracking issue produced by
A4 is **#1635** and is now linked from #1626 under Tier A.

> **Reviewer note:** the branch sat ahead of `master` before this work
> started, so the cumulative diff is large. **Only the top 3 commits** are
> the Tier A work — they're the only ones touching `_tools/panel_taxonomy.py`,
> `_tools/coverage_auditor.py`, `_tools/audit_emitters.py`,
> `_tools/test_coverage_auditor.py`, and `.gitignore`:
>
> - `dbf5307` — A3: commit `debate` TEMPLATE_PATTERN
> - `9927789` — A2: coverage_auditor.py three-layer audit
> - `3633617` — A1: extract panel_taxonomy.py (byte-identical refactor)

## Summary

### A1 — `panel_taxonomy.py` (#1627)
Behavior-preserving refactor. Moves `CORE_SECTION_PANELS`,
`REQUIRED_SECTION_PANELS`, `KNOWN_CHAPTER_PANELS` (renamed
`CHAPTER_PANEL_TYPES`, re-exported under old name for compat),
`DENSITY_TIERS`, `PANEL_THRESHOLD_MULTIPLIERS`, `PLACEHOLDER_PATTERNS`,
`SOURCE_PATTERN`, `extract_panel_text`, `get_density_score`, and
`load_scholar_keys` into the new shared module. `accuracy_config.py`
intentionally untouched (separate taxonomy by design).

Adds for #1628 consumption: `LINGUISTIC_PANELS`, `HISTORICAL_PANELS`,
`CONNECTIVE_PANELS`, `GENRE_EXPECTED_PANELS`, `TEMPLATE_PATTERNS`
(empty until A3), `categorize_panel()`.

**Validation (all empty):**
```
diff /tmp/qs_stdout_before.txt /tmp/qs_stdout_after.txt   →  (no output)
diff /tmp/qs_stderr_before.txt /tmp/qs_stderr_after.txt   →  (no output)
diff /tmp/qs_json_before.json  /tmp/qs_json_after.json    →  (no output)
```

### A2 — `coverage_auditor.py` (#1628)
Three-layer audit. CLI surface matches the spec exactly:

```
python _tools/coverage_auditor.py --all
python _tools/coverage_auditor.py --sections | --panel-quality | --chapter-panels
python _tools/coverage_auditor.py --book genesis --section-detail
python _tools/coverage_auditor.py --template-candidates
python _tools/coverage_auditor.py --format json|markdown|issues
python _tools/coverage_auditor.py --all --ci [--baseline _audit/baseline.json]
python _tools/coverage_auditor.py --parables   # Phase 2 stub
python _tools/coverage_auditor.py --concepts   # Phase 3 stub
```

- L1 tier rubric exact per epic §1.4 (rich/adequate/thin/deficient)
- L2 verdict ladder: empty → placeholder → template → stub → substantive
- L3 genre rubric per epic §1.6, with one small extension: non-substantive
  panels on non-expected types (e.g. epistle `debate` templates) are also
  surfaced as findings with `expected=False` — otherwise the 165 epistle
  templates would be silently dropped because `debate` isn't in the
  epistle expected set.
- `_audit/` added to `.gitignore`. All audit artifacts regenerable.
- `panel_verdicts` summary now spans both section and chapter panels.
- Books discovered from `content/meta/books.json` (no hardcoded list).
- Full-corpus run completes in <5s.

**Tests:** `python3 _tools/test_coverage_auditor.py` — 38 stdlib unittest
cases pass. Inline fixtures, no real-corpus reads, no network.

### A3 — debate `TEMPLATE_PATTERN` (#1629)
Curated and committed:
```python
TEMPLATE_PATTERNS = {
    "debate": [(
        "Critical/Analytical scholarship",
        "Traditional/Confessional reading",
        "Emphasises historical-critical",
    )],
}
```

Hand-counted matches across 493 chapters with a debate panel: **173 hit all
three substrings — exact match to the pre-investigation finding cited in
#1625.**

Regression suite (10 hand-picked chapters from #1629) all green:

| Chapter | Expected | Actual |
|---|---|---|
| 2 Cor 9 | template | template ✓ |
| 2 Cor 6 | missing (no debate panel) | missing ✓ |
| Genesis 22 | substantive (Akedah) | substantive ✓ |
| Leviticus 10 | template (Nadab/Abihu) | template ✓ |
| Romans 9 | template | template ✓ |
| John 1 | substantive | substantive ✓ |
| Matthew 5 | substantive | substantive ✓ |
| Psalms 23 | missing (poetry) | missing ✓ |
| Revelation 1 | (verify) | template (newly confirmed) |
| 1 Cor 13 | (verify) | template (newly confirmed) |

### A4 — initial audit + tracking issue (#1630)
Full-corpus run produced `_audit/latest.md` (48 KB) and `_audit/latest.json`
(6.4 MB) — both gitignored, no files committed.

Spot-checks all pass:
- Tier sum = 2,784 ✓
- All 10 investigation 🔴 candidates land deficient (john 1/3/8 §4,
  1_chronicles 22 §2, 1_samuel 1/2/13 §3, 2_samuel 5 §3, joshua 22 §3,
  psalms 123 §2) ✓
- 2 Cor 9 chapter `debate` → template ✓
- Books in canonical order (genesis → revelation) ✓
- Top-5 books by findings: psalms (236), isaiah (108), 2_kings (85),
  genesis (79), proverbs (75) ✓

**Headline numbers:**
- 2,784 sections | 🔴 328 (11.8%) · 🟡 0 · 🟢 149 (5.4%) · ✨ 2,307 (82.9%)
- 29,905 panels evaluated | 173 templates · 101 stubs · 1 placeholder
- L3: 8,944 expected · 626 missing · 102 deficient

**Tracking issue:** #1635 — `[Phase 1] Audit Report — 2026-04-24 — Tier B/C
Decision Gate`. Authored cover note flags Psalms (single-section structural
issue) and the 173-chapter debate template concentration as the two
dominant remediation themes. @CraigBuckmaster sign-off on #1635 gates Tier
B/C bulk creation.

#1626 body updated to reference #1635 under Tier A.

## Test plan

- [x] `python3 _tools/quality_scorer.py --json` — byte-identical pre/post A1
- [x] `python3 _tools/test_coverage_auditor.py` — all 38 cases pass
- [x] `python3 _tools/build_sqlite.py` — completes
- [x] `python3 _tools/validate_sqlite.py` — 101 passed, 0 failed
- [x] `python3 _tools/accuracy_auditor.py --help` — completes (smoke test)
- [x] `python3 _tools/coverage_auditor.py --all` — runs in <5s
- [x] `python3 _tools/coverage_auditor.py --book genesis --section-detail`
- [x] `python3 _tools/coverage_auditor.py --template-candidates`
- [x] `python3 _tools/coverage_auditor.py --parables` → "Phase 2 — not yet implemented"
- [x] `python3 _tools/coverage_auditor.py --concepts` → "Phase 3 — not yet implemented"
- [x] `_audit/` confirmed gitignored after run (no files staged)

## Out of scope (per epic plan)

- Tier B per-book epics — gated on Craig's review of #1635
- Tier C chapter-range enrichment issues — same
- Tier D `--ci` wiring into `content-pipeline.yml` — last
- Phase 2 parable / Phase 3 concept-mapping logic — stubs only
- Any content fixes (no `content/` writes)


---
_Generated by [Claude Code](https://claude.ai/code/session_011Bcx2hjuGxgb1HzQp5UHAr)_