### PR TITLE
fix(hwgtb): remove stale canonComparisonReady gate

### DIFF
--- a/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
+++ b/app/__tests__/screens/HowWeGotTheBibleLandingScreen.test.tsx
@@ -92,9 +92,10 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     expect(getByLabelText('Browse all guided journeys')).toBeTruthy();
   });
 
-  it('Canon Comparison shows "Coming soon" label (HWGTB-P3-01 not yet shipped)', () => {
+  it('Canon Comparison entry navigates to CanonComparison when tapped', () => {
     const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
-    expect(getByLabelText('Coming soon')).toBeTruthy();
+    fireEvent.press(getByLabelText('Open Canon Comparison'));
+    expect(mockNavigate).toHaveBeenCalledWith('CanonComparison');
   });
 
   it('tapping Extra-Biblical Literature navigates to ExtraBiblicalIndex', () => {
@@ -123,13 +124,6 @@ describe('HowWeGotTheBibleLandingScreen', () => {
     const { getByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
     fireEvent.press(getByLabelText('Browse all guided journeys'));
     expect(mockNavigate).toHaveBeenCalledWith('JourneyBrowse', undefined);
-  });
-
-  it('Canon Comparison entry has no onPress handler (no navigation fired)', () => {
-    const { queryByLabelText } = renderWithProviders(<HowWeGotTheBibleLandingScreen />);
-    // When locked, the container is a View (not TouchableOpacity) so it
-    // has no 'Open Canon Comparison' accessibility label.
-    expect(queryByLabelText('Open Canon Comparison')).toBeNull();
   });
 
   it('back button fires navigation.goBack', () => {

--- a/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
+++ b/app/src/screens/HowWeGotTheBibleLandingScreen.tsx
@@ -45,13 +45,8 @@ function HowWeGotTheBibleLandingScreen() {
     navigation.navigate('ExtraBiblicalIndex');
   }, [navigation]);
 
-  // Canon Comparison screen lands in HWGTB-P3-01 (#1550). The route is
-  // typed ahead in ExploreStackParamList so this handler stays ready;
-  // until #1550 ships it's surfaced as "Coming soon" with a no-op.
-  const canonComparisonReady = false;
   const goCanonComparison = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('CanonComparison' as any);
+    navigation.navigate('CanonComparison');
   }, [navigation]);
 
   // Direct navigation to the two HWGTB-specific journeys. The journey
@@ -89,7 +84,7 @@ function HowWeGotTheBibleLandingScreen() {
       description:
         'Protestant, Catholic, Orthodox, and Ethiopian canons side by side — where traditions agree, where they differ, and why.',
       Icon: Scale,
-      onPress: canonComparisonReady ? goCanonComparison : undefined,
+      onPress: goCanonComparison,
     },
     {
       key: 'canon-formation',


### PR DESCRIPTION
## Summary

Fixes #1637. Removes the stale `canonComparisonReady = false` gate at `HowWeGotTheBibleLandingScreen.tsx:51`, which was the only thing keeping users out of the fully-shipped `CanonComparisonScreen`.

## Why now

I went looking for evidence that the gate was still legitimate before flipping it. Found the opposite:

- **#1550 (HWGTB-P3-01: `CanonComparisonScreen`) closed as completed on 2026-04-23**
- `CanonComparisonScreen.tsx` is 568 lines, zero TODOs/FIXMEs, with full premium gating, error boundary, logger usage, and 12 test cases including premium gating on Orthodox + Ethiopian and the formation-timeline expansion
- `useCanonTraditions` hook reads from the `canon_traditions` SQLite table, populated from `content/meta/canon_traditions.json` (all 4 traditions complete with `canon_list`, `distinctives`, and `formation_events`)
- `<Stack.Screen name="CanonComparison" />` registered in `ExploreStack.tsx:97`
- `CanonComparison: undefined` typed in `navigation/types.ts:80`

The gate was correct when written — the screen wasn't ready. It's now the only thing keeping users out.

## Change

**`HowWeGotTheBibleLandingScreen.tsx`:**
- Removed the `canonComparisonReady` constant and the comment block above it
- Dropped the `as any` cast and `eslint-disable-next-line @typescript-eslint/no-explicit-any` in `goCanonComparison` — the route is properly typed, the cast was only there to suppress friction during the gate period
- Changed `onPress: canonComparisonReady ? goCanonComparison : undefined` → `onPress: goCanonComparison`

**`HowWeGotTheBibleLandingScreen.test.tsx`:**
- Removed `'Canon Comparison shows "Coming soon" label'` assertion (the label no longer renders)
- Replaced `'Canon Comparison entry has no onPress handler'` with the positive inverse: `'navigates to CanonComparison when tapped'`

Net diff: +5 / -16 across the two files.

## Sequencing with #1634

This PR conflicts trivially with #1634 (HWGTB landing journeys rewire) — both touch the same file. They edit different lines:
- #1634 replaces the `goGuidedJourneys` callback and entries-array Guided Journeys row, plus adds the EscapeHatchRow
- This PR removes the `canonComparisonReady` gate and the `goCanonComparison` cleanup

Whichever lands second rebases. The conflict region is the entries array (specifically the Canon Comparison entry's `onPress`). Mechanical resolution: keep `onPress: goCanonComparison` (this PR's change) inside whatever shape #1634 left the array in.

If you want to land them in a specific order, suggest #1634 first (it's already in review) so this rebase is the only one needed.

## Verification

After both PRs land, the HWGTB landing should show:
1. Extra-Biblical Literature (live)
2. Canon Comparison (live — no more "Coming soon" pill, taps through to the 4-column comparison)
3. Canon Formation (live, opens the 12-stop journey)
4. Text & Translation (live, opens the 10-stop journey)
5. Escape hatch: "Browse all guided journeys" → JourneyBrowse

Worth verifying on the rentmac. The 4 entries each route to a distinct, real destination, no "Coming soon" anywhere on the screen.

## Out of scope

- Anything inside `CanonComparisonScreen` itself (premium gating, layout, content) — already shipped via #1550
- Any other gates or feature flags elsewhere in the app

## Rollback

`git revert` — single-screen behavior change, restores the "Coming soon" state.