### PR TITLE
ci: wire coverage auditor into content-pipeline (warning mode)

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -55,6 +55,30 @@ jobs:
         run: |
           python3 _tools/validate_sqlite.py 2>&1 | tee validate_db.log
 
+      # ── Coverage audit (warning-only, Phase 1) ───────────────
+      # Non-blocking: continue-on-error is essential. Flips to strict
+      # (--ci against _audit/baseline.json) as part of Phase 1 close — see #1626.
+
+      - name: Coverage audit (warning-only)
+        id: coverage_audit
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          # Only audit when the PR actually touches content/** (mirrors the
+          # gating used by "Detect changed content" below).
+          CONTENT_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^content/' || true)
+          if [ -z "$CONTENT_CHANGED" ]; then
+            echo "No content/** changes in this PR — skipping coverage audit."
+            exit 0
+          fi
+
+          python3 _tools/coverage_auditor.py --all --format markdown > /tmp/audit-run.md
+          echo "## Coverage audit" >> $GITHUB_STEP_SUMMARY
+          head -80 /tmp/audit-run.md >> $GITHUB_STEP_SUMMARY
+          echo "..." >> $GITHUB_STEP_SUMMARY
+          echo "Full audit in job logs." >> $GITHUB_STEP_SUMMARY
+          cat /tmp/audit-run.md
+
       # ── Upload to R2 (master only) ───────────────────────────
 
       - name: Upload to CloudFlare R2


### PR DESCRIPTION
Closes #1649. Parent epic: #1626.

## Rationale

The coverage auditor shipped in #1636 and the first snapshot is #1635, but nothing yet surfaces audit feedback automatically on content PRs. This change wires `_tools/coverage_auditor.py` into `content-pipeline.yml` in **non-blocking warning mode**:

- Every PR touching `content/**` now runs the auditor after DB validation.
- Output goes to `$GITHUB_STEP_SUMMARY` (top 80 lines) and the full markdown dumps to job logs.
- `continue-on-error: true` is non-negotiable for Phase 1 — a red audit step must never fail the job while remediation work is still in flight.

The flip to strict mode (`--ci` against a committed `_audit/baseline.json`) is the Phase 1 closing task, not this one.

## Scope

- Touches `.github/workflows/content-pipeline.yml` only.
- `content.yml` and `app.yml` are untouched per the issue.
- No changes to the auditor itself — ships as-is from #1636.

## Gating

The step runs only when:
- `github.event_name == 'pull_request'` (at the `if:` level), AND
- the PR's diff against base touches `content/**` (inline `git diff` check, mirroring the "Detect changed content" step that appears later in the same job).

A `_tools/**`-only PR that triggers the workflow will see the coverage-audit step no-op with a short log line, so audit noise is kept to content PRs.

## What CI output looks like

The step summary renders like this (smoke-tested locally on current master):

```markdown
## Coverage audit
# Content Coverage Audit — 2026-04-24

## Cover Note

_(authored in A4; leave this section for the A4 tracking issue.)_

## Executive Summary

Sections: 2784 total
  🔴 Deficient: 328 (11.8%) | 🟡 Thin: 0 (0.0%) | 🟢 Adequate: 149 (5.4%) | ✨ Rich: 2307 (82.9%)

Panel quality: 29905 panels evaluated
  substantive: 29630 | empty: 0 | stub: 101 | placeholder: 1 | template: 173

Chapter-panel completeness (per genre rubric):
  Expected: 8944 | Present substantive: 8216 | Missing: 626 | Present but deficient: 102

Top 5 books by total finding count:
  1. psalms: 236 findings
  2. isaiah: 108 findings
  3. 2_kings: 85 findings
  4. genesis: 79 findings
  5. proverbs: 75 findings

...
Full audit in job logs.
```

## Rollback plan

Single-file, additive change. To revert: drop the `Coverage audit (warning-only)` step from `.github/workflows/content-pipeline.yml`. No other steps reference `steps.coverage_audit.*` and no outputs are consumed downstream, so removal is clean.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/content-pipeline.yml'))"` — parses cleanly.
- [x] `python3 _tools/coverage_auditor.py --all --format markdown` — produces expected summary locally.
- [ ] On merge: first subsequent content PR surfaces the audit in its job summary without failing the job.
- [ ] A `_tools/**`-only PR logs the "No content/** changes" skip line and exits 0.

## Out of scope

- Strict / blocking mode — Phase 1 closing task.
- PR comment bot for the audit summary (optional extension called out in #1649; can follow in a separate PR if desired).
- Any changes to the auditor itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_