### PR TITLE
content(genesis): coverage enrichment — 71 audit findings to zero

### DIFF
--- a/content/genesis/10.json
+++ b/content/genesis/10.json
@@ -570,9 +570,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 6
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 7
+        },
+        {
+          "label": "Nations",
+          "score": 10
+        },
+        {
+          "label": "Imago Dei",
+          "score": 7
+        },
+        {
+          "label": "Typology",
+          "score": 6
+        }
+      ],
+      "note": "Genesis 10 — the Table of Nations — is Scripture's fullest theological statement that ethnic diversity is providentially appointed. Seventy nations descended from Noah's three sons, each 'by their clans, their languages, their lands, and their nations' (vv.5, 20, 31) — the same fourfold formula Revelation 7:9 will use to describe the redeemed multitude before the throne. The chapter sits before Babel (ch.11) but narratively after it: the dispersion of nations is shown as God's good creational diversity before the chapter that explains how it happened. Nimrod's empire-building (vv.8-12) introduces the imperial archetype the prophets will later target. Israel's election in ch.12 is set against a richly populated, providentially-ordered world."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 10:1-32",
+        "target": "Acts 17:26",
+        "type": "Echo",
+        "text": "'From one man he made every nation of men, to inhabit the whole earth; and he determined the times set for them and the exact places where they should live.' Paul's Areopagus speech is a direct theological summary of the Table of Nations: ethnic diversity is providentially appointed, not accidental or hierarchical.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 10:5, 20, 31",
+        "target": "Rev 7:9",
+        "type": "Fulfilment",
+        "text": "The refrain 'by their clans, their languages, their lands, and their nations' in Gen 10 becomes the redemptive pattern of Rev 7:9: 'a great multitude... from every nation, tribe, people, and language.' The seventy nations of Genesis are gathered back to the throne in Revelation — the Table of Nations in reverse.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 10:8-12",
+        "target": "Mic 5:6",
+        "type": "Echo",
+        "text": "Nimrod, founder of Babel-Erech-Akkad and Nineveh — the great imperial cities of Mesopotamia — is named as the archetype of hubristic empire. Micah 5:6 calls Assyria 'the land of Nimrod,' a prophetic shorthand that reaches back to Gen 10 to frame every imperial power as a Babel-Nimrod echo.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 10:32",
+        "target": "Deut 32:8",
+        "type": "Echo",
+        "text": "'When the Most High divided to the nations their inheritance, when he separated the sons of Adam' (Deut 32:8) looks back to the Gen 10 dispersion and reads it theologically: the seventy nations of Gen 10 correspond to the seventy sons of Israel in Gen 46:27, the covenant people embedded as a microcosm of the world God has divided.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/11.json
+++ b/content/genesis/11.json
@@ -687,9 +687,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 9
+        },
+        {
+          "label": "Covenant",
+          "score": 7
+        },
+        {
+          "label": "Providence",
+          "score": 8
+        },
+        {
+          "label": "Creation Order",
+          "score": 6
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 5
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 11 is the primeval history's last word — and its darkest self-portrait. Babel is Eden's ambition writ civilisational: humanity gathering to 'make a name for ourselves, lest we be dispersed' (v.4) inverts both the creation mandate to fill the earth and the divine prerogative of name-giving. The judgment is precisely fitted to the sin: confused speech and forced scattering accomplish what willing obedience refused. Then the narrative pivots: the Shem genealogy moves through Eber, Peleg, Reu, Serug, Nahor, Terah — and lands on Abram. Sarai's barrenness (v.30) is the one-line obstacle the entire Bible's plot will hang on. The primeval problem (Babel) and the particular solution (Abram) are introduced in the same chapter."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 11:4",
+        "target": "Gen 3:5",
+        "type": "Echo",
+        "text": "Babel's builders say 'let us make a name for ourselves, lest we be dispersed' — the same grasping self-elevation the serpent offered in Eden ('you will be like God'). Babel is Eden's sin replayed at civilisational scale: autonomy, ascent, self-naming.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 11:7-9",
+        "target": "Acts 2:4-11",
+        "type": "Fulfilment",
+        "text": "Pentecost is Babel reversed. Where Babel scattered one language into many as judgment, Pentecost gathers many languages into one gospel as grace. Luke's list of nations at Pentecost (Acts 2:9-11) is deliberately Babel-shaped — a Table-of-Nations-in-miniature now hearing, not babbling, the works of God.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 11:9",
+        "target": "Rev 18:2",
+        "type": "Echo",
+        "text": "'Babel' and 'Babylon' are the same Hebrew word (bavel). The Babel of Gen 11 becomes the Babylon of Revelation — the archetypal city of humanity-against-God — and its final fall ('fallen, fallen is Babylon the great,' Rev 18:2) is the last echo of the original confusion.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 11:30",
+        "target": "Rom 4:19",
+        "type": "Fulfilment",
+        "text": "'Now Sarai was barren; she had no child' — the one-line obstacle the entire Bible's plot will hang on — is the text Paul treats in Rom 4 as the proving ground of Abraham's faith: he considered his body as good as dead and Sarah's womb as barren, yet believed the God who gives life to the dead.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/12.json
+++ b/content/genesis/12.json
@@ -457,9 +457,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 8
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 12 is the hinge of the Old Testament. The sevenfold promise of vv.1-3 — leave, become a great nation, be blessed, have your name made great, be a blessing, those who bless and curse you will be blessed and cursed, all families of the earth blessed in you — is the seed of every later covenant and ultimately the gospel itself (Gal 3:8). Abram's obedient departure 'not knowing where he was going' (Heb 11:8) establishes the paradigm of pilgrim faith. The chapter's second half (the Egypt deception) immediately complicates any heroic reading: God protects the promise from the patriarch's fear, not because of his courage but in spite of his cowardice. Grace, not virtue, is the engine of covenant history."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 12:3",
+        "target": "Gal 3:8-14",
+        "type": "Fulfilment",
+        "text": "'In you all the families of the earth will be blessed' is the sevenfold promise's climax, and Paul calls it 'the gospel preached beforehand to Abraham' (Gal 3:8). Every gentile inclusion in Acts-to-Revelation is an instalment on Gen 12:3.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 12:1-3",
+        "target": "Heb 11:8-10",
+        "type": "Fulfilment",
+        "text": "The call to leave country, kindred, and father's house for a land he would be shown is Hebrews' paradigm of pilgrim faith: 'he went out, not knowing where he was going,' and looked for 'the city that has foundations, whose builder and maker is God.' Abraham's obedience is the template for all subsequent covenant faith.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 12:7",
+        "target": "Gal 3:16",
+        "type": "Fulfilment",
+        "text": "'To your seed (zeraʿ) I will give this land' — the singular collective noun Paul exegetes in Gal 3:16, arguing that the promise finally terminates on Christ. Genesis's repeated 'seed' language becomes the thread Paul follows to the Messiah.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 12:10-20",
+        "target": "Gen 20; 26:1-11",
+        "type": "Echo",
+        "text": "The wife-sister deception is told three times in Genesis (12, 20, 26) — Abram twice, Isaac once. The pattern is deliberate: the covenant family's survival hangs not on its patriarch's courage but on God's intervention against foreign kings who, ironically, often behave more righteously than the patriarch.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/13.json
+++ b/content/genesis/13.json
@@ -298,8 +298,8 @@
           }
         ],
         "hist": {
-          "historical": "None",
-          "context": "None"
+          "historical": "The triangle of Hebron, Mamre, and the nearby cave of Machpelah (23:17) becomes the patriarchal heartland. Hebron sits roughly 3,000 feet above sea level on the Judean ridge, a strategic high-country location on the watershed road — the main north–south artery of the hill country. The Middle Bronze Age layer at Tell Rumeida (biblical Hebron) shows substantial fortified occupation, consistent with the kind of settled Canaanite city-state culture Abram's tent-dwelling pastoralism moves alongside rather than inside. Mamre itself, about two miles north of the city, is identified with Ramat el-Khalil, where Herod later built a sacred enclosure around the traditional oak — evidence of how early and persistent the memory of Abraham's altar here became.",
+          "context": "The altar at Mamre is Abram's third (after Shechem 12:7 and Bethel 12:8) and it corresponds to the third, fullest land promise (13:14–17). The pattern is deliberate: God speaks, Abram marks the ground with worship. The land is possessed first by faith and altar-building long before it is possessed by political control — a priestly, liturgical claim rather than a military one. The chapter also silently reverses the Babel pattern: instead of humanity gathering to build a tower and make a name (11:4), Abram allows separation for peace and receives the promise that his name will be made by God (12:2)."
         },
         "cross": {
           "refs": [
@@ -506,9 +506,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 6
+        },
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 8
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 8
+        },
+        {
+          "label": "Typology",
+          "score": 6
+        }
+      ],
+      "note": "Genesis 13 is a chapter about generosity making space for promise. Abram's voluntary deference to Lot — letting his nephew choose first, though as patriarch he had every right to the prime land — is the moral counter-image of Babel's self-grasping in ch.11. By yielding the apparent best (the well-watered Jordan plain, 'like the garden of the LORD,' v.10), Abram receives the actual best: the renewed land promise from God himself, surveyed in all four directions (vv.14-17). The chapter quietly sets up Sodom's coming destruction by introducing it as Eden-like; the irony will land in ch.19. Faith builds an altar (v.18) where it cannot yet build a city."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 13:8-9",
+        "target": "Phil 2:3-4",
+        "type": "Echo",
+        "text": "Abram's yielding of first-choice to Lot — though as patriarch he has every right to claim it — prefigures the cruciform deference Paul commands: 'in humility count others more significant than yourselves.' Abram loses the strategic high-ground and gains the promise.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 13:10",
+        "target": "Gen 2:8-10; 19:24-25",
+        "type": "Echo",
+        "text": "The Jordan plain is 'like the garden of the LORD, like the land of Egypt' — an Eden-echo laid down the very chapter before it will be destroyed (19). Genesis sets up Sodom's apparent paradise precisely so the fire-and-brimstone reversal lands as a second Eden-loss.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 13:14-15",
+        "target": "Eph 3:17-19",
+        "type": "Echo",
+        "text": "'Look from the place where you are northward and southward and eastward and westward... all the land that you see I will give to you and to your offspring forever.' The four-direction surveying of promised inheritance becomes the template for Paul's prayer that the Ephesians grasp 'the breadth and length and height and depth' of Christ's love — another covenantal inheritance measured in all directions.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 13:16",
+        "target": "Rom 4:16-17",
+        "type": "Fulfilment",
+        "text": "The promise that Abram's offspring will be 'like the dust of the earth' — uncountable — is the same promise Paul invokes when he calls Abraham 'the father of us all' in Rom 4:16. Gentile inclusion is not a later-day innovation; it was encoded in the dust-count of Gen 13.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/14.json
+++ b/content/genesis/14.json
@@ -523,9 +523,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 8
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 8
+        },
+        {
+          "label": "Worship",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 10
+        }
+      ],
+      "note": "Genesis 14 introduces the most theologically loaded cameo in the OT: Melchizedek, king of Salem and priest of God Most High, who blesses Abram and receives his tithe. Two NT texts (Ps 110:4 and Hebrews 7) treat this brief encounter as the warrant for a priesthood prior to and superior to Levi's, ultimately fulfilled in Christ. The chapter also frames Abram's first military action — a successful rescue of Lot — but pointedly refuses worldly enrichment (vv.22-23) lest the king of Sodom claim credit for Abram's prosperity. Wealth received from God and wealth claimed by patron-power are kept rigorously distinct. The first tithe in Scripture is paid by the one who has just refused royal patronage."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 14:18-20",
+        "target": "Ps 110:4",
+        "type": "Fulfilment",
+        "text": "Melchizedek, king of Salem and priest of God Most High, is named exactly once more in the OT — Ps 110:4's messianic oracle: 'You are a priest forever after the order of Melchizedek.' The unlikely priest-king of Gen 14 becomes the template for the Davidic messiah's dual office.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 14:18-20",
+        "target": "Heb 7:1-10",
+        "type": "Fulfilment",
+        "text": "Hebrews 7 is the NT's most sustained exegesis of any Genesis passage: Melchizedek's superiority to Abraham (who paid him a tithe) and his priesthood 'without genealogy' prove that a priesthood exists prior to and outside the Levitical line — the order Christ himself holds.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 14:20",
+        "target": "Heb 7:4-10",
+        "type": "Echo",
+        "text": "Abram's tithe to Melchizedek — the first tithe in Scripture — establishes the practice centuries before the Mosaic law institutionalises it. Hebrews argues that because Levi (Abram's great-grandson) was 'still in the loins of his ancestor' when the tithe was paid, Levi himself paid tithes to Melchizedek — a hierarchy-reversing argument for Melchizedek's superior priesthood.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 14:22-23",
+        "target": "Heb 11:8-16",
+        "type": "Echo",
+        "text": "Abram refuses to let Sodom's king enrich him — 'lest you should say, I have made Abram rich' — preferring God's provision over pagan patronage. Hebrews 11 reads this as the hallmark of faith: those who confessed they were strangers and sought a better country.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/15.json
+++ b/content/genesis/15.json
@@ -546,9 +546,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 8
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 10
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 15 is the foundational chapter of biblical soteriology. Verse 6 — 'Abram believed the LORD, and he credited it to him as righteousness' — is quoted three times in the NT (Rom 4; Gal 3; Jas 2) as the textual pillar of justification by faith. The covenant ceremony of vv.7-21 is the second pillar: animals divided, a smoking firepot and flaming torch (theophany) passing between the pieces while Abram sleeps. The covenant is unilateral — God alone takes the curse-oath. Together the two halves of ch.15 establish the OT pattern of covenant: divine initiative, human faith, self-maledictory divine commitment. Hebrews 6 reads it as the guarantee that God's promises are unbreakable."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 15:6",
+        "target": "Rom 4:3; Gal 3:6; Jas 2:23",
+        "type": "Fulfilment",
+        "text": "'Abram believed the LORD, and it was credited to him as righteousness.' This single verse is quoted three times in the NT as the foundational statement of justification by faith — Paul builds the argument of Romans 4 and Galatians 3 on it, and James cites it to show that living faith produces works.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 15:13-14",
+        "target": "Acts 7:6-7; Exod 12:40-41",
+        "type": "Fulfilment",
+        "text": "The prophecy that Abram's offspring will be strangers in a land not theirs, afflicted 400 years, and then brought out with great possessions is quoted by Stephen in Acts 7 and fulfilled in Exod 12 — the exodus is already on the horizon before Isaac is even conceived.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 15:17-18",
+        "target": "Jer 34:18-20",
+        "type": "Echo",
+        "text": "The smoking firepot and flaming torch passing between the divided animals is a self-maledictory oath ceremony. Jeremiah 34 explicitly invokes this ceremony as the template for covenant-making — 'those who cut the calf in two and passed between its parts' — and announces covenant-breakers' destruction in the same terms.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 15:18-21",
+        "target": "Josh 21:43-45",
+        "type": "Fulfilment",
+        "text": "The land boundaries 'from the river of Egypt to the great river, the Euphrates' with ten named nations dispossessed — is the territorial promise. Joshua 21:43-45 declares it fulfilled: 'not one word of all the good promises that the LORD had made to the house of Israel had failed; all came to pass.'",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/16.json
+++ b/content/genesis/16.json
@@ -365,9 +365,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 8
+        },
+        {
+          "label": "Covenant",
+          "score": 6
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 5
+        },
+        {
+          "label": "Typology",
+          "score": 7
+        }
+      ],
+      "note": "Genesis 16 is the chapter of the human shortcut. Faced with the apparent failure of God's promise — Sarai still barren a decade after the call — the patriarchal couple resorts to cultural ANE practice (surrogate childbearing through a slave). The result is generations of pain, beginning with Hagar's mistreatment and flight. Yet God's care is shown most tenderly here: the Angel of the LORD's first named appearance in Scripture is to a used Egyptian slave woman in the wilderness. She names God 'El-roi' — 'the God who sees me' — the first instance in Scripture of a person naming God. Paul's allegory in Galatians 4 will turn this episode into the type of works-righteousness over against the freedom of promise."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 16:7-13",
+        "target": "Exod 3:2-6",
+        "type": "Echo",
+        "text": "The Angel of the LORD's first named appearance in Scripture is to a used Egyptian slave woman in the wilderness — and speaks in the first person as God ('I will multiply your offspring,' v.10). The same figure appears to Moses at the burning bush, another wilderness theophany to a fugitive. Genesis 16 establishes the pattern.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 16:13",
+        "target": "Ps 139:7-12",
+        "type": "Echo",
+        "text": "Hagar names God 'El-roi,' 'the God who sees me' — the first time in Scripture a person names God. The psalmist's confession that there is no place one can flee from God's sight echoes Hagar's astonishment: even here, in the wilderness of Shur, he sees.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 16:15",
+        "target": "Gal 4:22-31",
+        "type": "Fulfilment",
+        "text": "Paul's Hagar-Sarah allegory in Galatians 4 turns on Gen 16 vs Gen 21: Ishmael born 'according to the flesh' represents slavery under the law; Isaac born 'through promise' represents the freedom of the new covenant. Genesis 16's shortcut becomes Paul's theological pivot.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 16:11-12",
+        "target": "Gen 25:12-18",
+        "type": "Fulfilment",
+        "text": "The prediction that Ishmael will be 'a wild donkey of a man,' dwelling east of his brothers, is fulfilled in the Ishmaelite genealogy of Gen 25 — twelve princes, settled 'from Havilah to Shur... before Egypt,' the nomadic desert peoples of the northern Arabian peninsula.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/17.json
+++ b/content/genesis/17.json
@@ -568,9 +568,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 6
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 8
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 8
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 17 institutes the covenant's permanent sign — circumcision — and renames Abram and Sarai as Abraham and Sarah. The renaming is theological: 'father of a multitude' and 'princess' encode the very promise the couple's bodies have not yet fulfilled. Paul's argument in Rom 4 turns on the chapter's chronology: Abraham was justified (Gen 15) before he was circumcised (Gen 17), making him the father both of believing Jews and believing Gentiles. The everlasting covenant clause (v.7) — 'I will be God to you and to your offspring after you' — becomes Peter's Pentecost text (Acts 2:39) for the Gospel's reach across generations."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 17:5",
+        "target": "Rom 4:17",
+        "type": "Fulfilment",
+        "text": "'No longer shall your name be called Abram, but Abraham, for I have made you the father of a multitude of nations.' Paul quotes this line in Rom 4:17 as the anchor of his argument that Abraham is the father of all who believe — the name-change is the textual warrant for gentile inclusion.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 17:10-14",
+        "target": "Rom 4:9-12",
+        "type": "Echo",
+        "text": "Circumcision as the covenant sign. Paul's key move in Rom 4 is the sequence: Abraham believed (15:6) before he was circumcised (17). Therefore circumcision is 'a seal of the righteousness that he had by faith while he was still uncircumcised' — making him the father of believing gentiles as well as Jews.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 17:19",
+        "target": "Luke 1:31-33",
+        "type": "Echo",
+        "text": "God overrides Abraham's laughter with 'No, but Sarah your wife shall bear you a son, and you shall call his name Isaac.' Gabriel's annunciation to Mary ('you will conceive... and shall call his name Jesus') deliberately rehearses this pattern — promised son, divinely named, destined to inherit an everlasting covenant.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 17:7",
+        "target": "Acts 2:39",
+        "type": "Fulfilment",
+        "text": "'I will be God to you and to your offspring after you' — the generational extension of the covenant. Peter echoes it on Pentecost: 'the promise is for you and for your children and for all who are far off, everyone whom the Lord our God calls to himself.'",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/18.json
+++ b/content/genesis/18.json
@@ -381,9 +381,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 9
+        },
+        {
+          "label": "Prayer",
+          "score": 10
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 18 is the OT's richest theology of intercessory prayer. Abraham hosts three strangers at Mamre — the famous Rublev-icon scene — and discovers he is hosting YHWH. The promise of Isaac is renewed with a divinely-comic 'is anything too hard for the LORD?' (v.14) — the very question Gabriel will echo to Mary (Luke 1:37). Then comes the intercession for Sodom: Abraham bargains God down from fifty righteous to ten, grounded in confidence in God's character ('shall not the Judge of all the earth do right?,' v.25). The chapter establishes that God reveals his plans to his covenant friends and that they may negotiate from those revealed plans."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 18:1-8",
+        "target": "Heb 13:2",
+        "type": "Echo",
+        "text": "Abraham's hospitality to three strangers at Mamre is the OT's paradigm scene of welcoming the divine in the guise of the unknown traveller. Hebrews 13:2 distils the lesson: 'do not neglect to show hospitality to strangers, for thereby some have entertained angels unawares.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 18:14",
+        "target": "Luke 1:37",
+        "type": "Fulfilment",
+        "text": "'Is anything too hard for the LORD?' becomes Gabriel's 'For nothing will be impossible with God' to Mary. The Sarah-conceiving question is reprised at the virgin-conceiving moment — the same divine power answering the same skeptical laugh-turned-belief.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 18:18-19",
+        "target": "Acts 3:25",
+        "type": "Fulfilment",
+        "text": "The inner monologue of God — 'shall I hide from Abraham what I am about to do, seeing that Abraham shall surely become a great nation, and in him all the nations of the earth shall be blessed?' — is quoted by Peter at Solomon's Portico: 'in your offspring shall all the families of the earth be blessed' (Acts 3:25).",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 18:22-33",
+        "target": "Jas 5:16-18",
+        "type": "Echo",
+        "text": "Abraham's intercession for Sodom — bargaining God down from fifty to ten — is the archetype of intercessory prayer: grounded in God's character ('shall not the Judge of all the earth do right?'), persistent, and effective. James holds up Elijah as the paradigm; the Genesis template is Abraham.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/19.json
+++ b/content/genesis/19.json
@@ -516,9 +516,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 9
+        },
+        {
+          "label": "Covenant",
+          "score": 7
+        },
+        {
+          "label": "Providence",
+          "score": 8
+        },
+        {
+          "label": "Justice",
+          "score": 10
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 5
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 19 is the OT's most graphic enactment of divine judgment in the patriarchal narratives — the cities of the plain destroyed by fire and brimstone, with Lot's family barely extracted by angelic mercy. Jesus uses Sodom as the eschatological warning ('as it was in the days of Lot... so will it be on the day when the Son of Man is revealed,' Luke 17:28-32) and explicitly commands 'Remember Lot's wife' (v.32). The chapter is also a study in the slow compromise of a believer: Lot pitched toward Sodom (13:12), lived in Sodom (14:12), sat in the gate of Sodom (19:1), and offered his daughters there. The closing scene of Lot's daughters in the cave seeds Moab and Ammon — Israel's perennial enemies — yet Ruth the Moabitess will redeem the line."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 19:24-25",
+        "target": "Luke 17:28-32",
+        "type": "Fulfilment",
+        "text": "Jesus names Sodom as the eschatological warning: 'as it was in the days of Lot... so will it be on the day when the Son of Man is revealed.' He explicitly commands 'Remember Lot's wife' — turning Gen 19:26 into an urgent parable about divided loyalties on the day of judgment.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 19:1-11",
+        "target": "Judg 19",
+        "type": "Echo",
+        "text": "The horrifying Gibeah atrocity of Judges 19 is told in deliberate parallel to Sodom: strangers arrive in a city square, are reluctantly taken in by a sojourner, the townsmen demand them for sexual violence. The intertextual message is that Israel has become Sodom — Gentile-level depravity inside the covenant people.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 19:29",
+        "target": "2 Pet 2:6-9",
+        "type": "Echo",
+        "text": "'God remembered Abraham and sent Lot out' — rescue through intercession. 2 Peter 2 draws the theological conclusion: 'the Lord knows how to rescue the godly from trials and to keep the unrighteous under punishment for the day of judgment,' citing Sodom and Lot as the paradigm.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 19:30-38",
+        "target": "Ruth 4:13-17",
+        "type": "Echo",
+        "text": "Lot's daughters produce Moab and Ammon — the hereditary enemies of Israel — through incest. Yet Ruth the Moabitess becomes the great-grandmother of David. Genesis 19 seeds a nation the canon will later redeem through the specific Moabite woman who gleans in Boaz's field; Ruth is the reverse image of Lot's daughter.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/20.json
+++ b/content/genesis/20.json
@@ -366,9 +366,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 6
+        },
+        {
+          "label": "Covenant",
+          "score": 8
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 5
+        },
+        {
+          "label": "Typology",
+          "score": 7
+        }
+      ],
+      "note": "Genesis 20 is the second wife-sister deception — Abraham repeating in Gerar what he did in Egypt — and the second narrative where God protects the covenant promise through a pagan king's integrity rather than the patriarch's courage. The shock is that Abimelech behaves more righteously than Abraham. God speaks to Abimelech in a dream and calls Abraham 'a prophet' (v.7) — Scripture's first use of the word, applied paradoxically to the man who has just lied. The closing scene (vv.17-18) shows Abraham praying for Abimelech's household to be healed of barrenness — the same condition that defines his own household. The covenant is preserved by divine sovereignty working through unexpected channels."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 20:7",
+        "target": "1 Sam 9:9",
+        "type": "Echo",
+        "text": "'For he is a prophet (nabi) and he will pray for you' — the first use of the word 'prophet' in Scripture, applied surprisingly to Abraham. The prophet's defining function here is intercessory prayer (v.17), which 1 Samuel's note on the older term ('seer') implicitly confirms: the prophet is the one who stands between God and the people.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 20:3-7",
+        "target": "Ps 105:14-15",
+        "type": "Echo",
+        "text": "'He allowed no one to oppress them; he rebuked kings on their account: Do not touch my anointed ones; do my prophets no harm.' Psalm 105 explicitly turns Gen 20 (and 12, 26) into a theological precedent: God protects his covenant bearers even from the most powerful foreign rulers.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 20:11",
+        "target": "Rom 3:18",
+        "type": "Echo",
+        "text": "Abraham assumes 'there is no fear of God at all in this place' — and is wrong; Abimelech shows more fear of God than Abraham shows of truth. Paul's universal indictment in Rom 3:18 ('there is no fear of God before their eyes') takes a sharper edge when read against Gen 20's reversal: who is 'the people of God' and who is 'the nations' is never as tidy as insiders think.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 20:17-18",
+        "target": "Jas 5:16",
+        "type": "Echo",
+        "text": "'Abraham prayed to God, and God healed Abimelech.' The prophet-as-intercessor motif here is the earliest Scriptural datum for James's 'the prayer of a righteous person has great power as it is working.' Abraham prays and wombs open — the very mechanism that his own line depends on in the next chapter.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/21.json
+++ b/content/genesis/21.json
@@ -51,8 +51,8 @@
           }
         ],
         "hist": {
-          "historical": "None",
-          "context": "None"
+          "historical": "Isaac's birth around 2066 BC on the standard biblical chronology caps a 25-year wait from the initial call of 12:1. The narrator's repeated emphasis — 'as he had said,' 'as he had promised,' 'at the very time God had promised' (21:1–2) — stacks three formulas of fulfilment in two verses, a density found nowhere else in the Abraham cycle. In an ANE culture where barrenness was read as divine disfavour, Sarah's conception at 90 is presented as a sign-event: the covenant future hangs on a womb that biology has closed, which makes the promise-keeper unambiguously God, not the patriarch. The name Isaac (yiṣḥāq, 'he laughs') freezes into the covenant line the laughter of both parents (17:17; 18:12) — disbelief transposed into praise.",
+          "context": "Isaac is the pivot of the Pentateuch. Without his birth, Genesis 12 fails and everything downstream collapses: no Jacob, no twelve tribes, no exodus, no Sinai. The NT reaches back to this moment with Paul (Rom 4:19–21; 9:9), who treats it as the textbook case of faith trusting God 'who gives life to the dead,' and with Hebrews (11:11–12), which reads it as eschatological prototype — one dead-as-good-as-dead body producing descendants as numerous as the stars. Luke frames the annunciations to Zechariah and Mary against this Genesis 21 template: the elderly-couple miracle and the virgin miracle are the bookends of redemptive history's impossible births."
         },
         "cross": {
           "refs": [
@@ -534,9 +534,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 7
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 9
+        }
+      ],
+      "note": "Genesis 21 is the chapter where God's promise materialises. Isaac is born exactly 'at the time of which God had spoken' (v.2) — the narrator stacks three formulas of fulfilment in two verses. Sarah's 'God has made laughter for me; everyone who hears will laugh with me' (v.6) transposes the earlier skeptical laughter (17:17; 18:12) into doxology. The chapter also stages the painful separation of Hagar and Ishmael — which Paul reads in Galatians 4 as the type of law-and-grace incompatibility. God's care for the rejected son is explicit: 'God heard the voice of the boy' (v.17), and Ishmael becomes a great nation in his own right. Romans 9 uses Isaac's birth as the textual proof of election by promise rather than flesh."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 21:1-7",
+        "target": "Rom 9:7-9",
+        "type": "Fulfilment",
+        "text": "'About this time next year I will return, and Sarah shall have a son' (quoting Gen 18:10, fulfilled in 21:2) is Paul's proof-text in Rom 9 that 'it is not the children of the flesh who are the children of God, but the children of the promise.' Isaac's birth is the category-creating event for election theology.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 21:12",
+        "target": "Heb 11:17-19",
+        "type": "Fulfilment",
+        "text": "'In Isaac shall your offspring be named' — quoted in Heb 11:18 as the very line Abraham is willing to sacrifice in ch.22. The promise's specificity creates the Akedah's tension: the covenant future and the sacrificial knife hang on the same boy.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 21:17-19",
+        "target": "Gen 16:7-13",
+        "type": "Echo",
+        "text": "Hagar's second wilderness rescue echoes her first. Both times she is sent out, both times the Angel of God speaks, both times she is given a son-promise. Gen 21 completes Gen 16: 'God heard the voice of the boy,' and the name Ishmael ('God hears') gets its second, explicit fulfilment.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 21:10",
+        "target": "Gal 4:28-31",
+        "type": "Fulfilment",
+        "text": "Sarah's demand 'cast out this slave woman with her son' is quoted verbatim by Paul in Gal 4:30 as the covenantal principle: law and grace cannot co-inherit. The narrative moment of a mother protecting her son becomes the apostolic warrant for the freedom of the gospel.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/22.json
+++ b/content/genesis/22.json
@@ -232,8 +232,8 @@
           }
         ],
         "hist": {
-          "historical": "None",
-          "context": "None"
+          "historical": "The Angel of the LORD intervention (22:11) belongs to a distinctive Genesis pattern: the angel speaks in the first person as God (22:12, 16) while remaining distinguishable from him — the same pattern that appears to Hagar (16:7–13), at the burning bush (Exod 3:2–6), and to Gideon (Judg 6:11–23). Jewish and Christian exegesis have read this figure very differently; most pre-critical Christian interpreters saw the pre-incarnate Son, while rabbinic tradition treated the Angel as a distinguishable divine messenger without positing a person. Either way the narrative is careful: the voice that stops the knife is the same voice that commanded it, and the ram-substitute is explicitly divine provision (22:13–14). Mount Moriah becomes, in 2 Chr 3:1, the temple mount — so the place where a son was bound and a ram substituted becomes the place where lambs would be substituted for sinners for a millennium.",
+          "context": "The naming 'YHWH-yireh' ('the LORD will see / provide,' 22:14) is the theological summary of the Akedah and arguably the summary of OT sacrificial theology: the God who tests the covenant man is the God who supplies the substitute himself. The repeated oath of 22:16–18 intensifies the Abrahamic promises (12:1–3; 15; 17) into their strongest form — now sworn by God's own self because nothing greater exists to swear by (cf. Heb 6:13–18). The addition here is that the promise of blessing-to-the-nations becomes explicitly tied to the 'seed' (zeraʿ, singular) — the hinge on which Paul's Christological reading of Galatians 3:16 turns."
         },
         "cross": {
           "refs": [
@@ -345,8 +345,8 @@
           }
         ],
         "hist": {
-          "historical": "None",
-          "context": "None"
+          "historical": "The Nahor genealogy (22:20–24) looks like a narrative anticlimax after the Akedah, but it is load-bearing: it introduces Bethuel (v.22), father of Rebekah — the next covenant matriarch — and so supplies the marriage partner for Isaac before the narrative needs her (ch.24). The twelve sons listed here (eight by Milcah + four by the concubine Reumah) form a deliberate counterpoint to the twelve sons of Jacob and the twelve princes of Ishmael (17:20; 25:13–16) — Genesis repeatedly pairs the covenant twelve with other twelves, a structural reminder that Israel's election is embedded inside a wider world of related peoples. Aram (v.21) is the eponym of the Arameans; Buz (v.21) reappears in Jer 25:23 and Job 32:2; Kemuel fathers the Arameans of Damascus (v.21).",
+          "context": "The placement is not accidental. Immediately after Abraham has passed the definitive test of covenant faith, the narrator quietly shows that God has already been arranging the next generation's marriage partner back in the Haran clan. The 'meanwhile' structure is the same as 11:27–32's Terah genealogy that set up the call of Abram itself: Genesis consistently pairs the high-tension covenant moment with a low-key genealogical note that marks how providence is already moving on the next hinge. By the time Isaac walks down Moriah, Rebekah has effectively been born on the page."
         },
         "cross": {
           "refs": [
@@ -568,9 +568,71 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 10
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 10
+        },
+        {
+          "label": "Typology",
+          "score": 10
+        }
+      ],
+      "note": "Genesis 22 — the Akedah, the binding of Isaac — is the OT's most theologically charged narrative. Abraham is asked to sacrifice 'your son, your only son Isaac, whom you love' — Scripture's first 'beloved son' formula, the exact phrase the Father will speak over Jesus at the baptism. Mount Moriah (v.2) becomes, in 2 Chr 3:1, the Temple Mount — the place where a son was bound and a ram substituted becomes the place where lambs would be substituted for sinners. Abraham's prophetic 'God will provide for himself the lamb' (v.8) finds its ultimate fulfilment when John the Baptist points at Jesus (John 1:29). The divine self-oath of vv.16-18 is Hebrews 6's proof that God's promises are unbreakable; the singular 'seed' is Paul's hinge in Gal 3:16 for Christ as covenant terminus."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 22:2",
+        "target": "John 3:16",
+        "type": "Typology",
+        "text": "'Take your son, your only son Isaac, whom you love' is the first appearance in Scripture of the phrase 'beloved son' — the exact phrase that will recur at Jesus' baptism and transfiguration ('this is my beloved son'). The Akedah supplies John 3:16's 'gave his only son' its entire theological vocabulary.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 22:8",
+        "target": "John 1:29",
+        "type": "Typology",
+        "text": "'God will provide (yireh) for himself the lamb for a burnt offering' — Abraham's prophetic answer to Isaac — is fulfilled when John the Baptist points at Jesus: 'Behold, the Lamb of God, who takes away the sin of the world.' Moriah becomes Calvary; the provided Lamb was hinted at long before a ram was caught in a thicket.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 22:16-18",
+        "target": "Heb 6:13-18",
+        "type": "Fulfilment",
+        "text": "'By myself I have sworn, declares the LORD' — the divine self-oath of Gen 22:16 is Hebrews 6's proof that God's promises are unbreakable: 'because he had no one greater by whom to swear, he swore by himself.' Every Christian assurance rests on this particular oath.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 22:18",
+        "target": "Gal 3:16",
+        "type": "Fulfilment",
+        "text": "'In your offspring (zeraʿ, singular) shall all the nations of the earth be blessed.' Paul's whole argument in Gal 3:16 turns on the grammatical singularity: 'it does not say, And to offsprings, referring to many, but referring to one, And to your offspring, who is Christ.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 22:1-14",
+        "target": "Jas 2:21-23",
+        "type": "Fulfilment",
+        "text": "James reads the Akedah as the completion — not replacement — of Gen 15:6: 'was not Abraham our father justified by works when he offered up his son Isaac on the altar?' The faith that believed God in Gen 15 is the faith that climbs Moriah in Gen 22. The two texts are one motion.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/23.json
+++ b/content/genesis/23.json
@@ -355,9 +355,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 6
+        },
+        {
+          "label": "Covenant",
+          "score": 8
+        },
+        {
+          "label": "Providence",
+          "score": 7
+        },
+        {
+          "label": "Creation Order",
+          "score": 4
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 9
+        },
+        {
+          "label": "Death & Promise",
+          "score": 10
+        }
+      ],
+      "note": "Genesis 23 dwells on a single piece of land — the cave of Machpelah — bought from Hittite owners as Sarah's burial plot. The legal detail of the negotiation (the only contract-cutting in Genesis recorded with such care) is theological: the first piece of Canaan Abraham actually possesses is a grave. Hebrews 11:13 reads it precisely this way — 'these all died in faith, not having received the things promised, but having seen them and greeted them from afar.' Abraham calls himself a 'sojourner and foreigner' (v.4) — the LXX phrasing Peter applies to all Christians (1 Pet 2:11). Machpelah will eventually hold Abraham, Isaac, Rebekah, Leah, and Jacob: the patriarchal land claim, for centuries, will be one cave."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 23:1-20",
+        "target": "Heb 11:13-16",
+        "type": "Echo",
+        "text": "The purchase of Machpelah — the first piece of Canaan Abraham actually owns is a burial plot — embodies the paradox Hebrews 11 names: he 'died in faith, not having received the things promised, but having seen them and greeted them from afar... seeking a homeland.' The promised land is possessed by faith from a grave, not by conquest.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 23:4",
+        "target": "1 Pet 2:11",
+        "type": "Echo",
+        "text": "'I am a sojourner and foreigner (ger wə-toshav) among you.' Abraham's self-description to the Hittites becomes the NT's standard posture for the people of God in the world: Peter addresses believers as 'sojourners and exiles' (paroikous kai parepidēmous), the LXX's translation of Abraham's phrase.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 23:17-20",
+        "target": "Gen 49:29-32; 50:13",
+        "type": "Echo",
+        "text": "Machpelah becomes the patriarchal tomb: Sarah here, then Abraham (25:9), Isaac and Rebekah (49:31), Leah (49:31), and Jacob (50:13). Genesis begins with a creation-wide scope and ends with a single family plot — the covenant's entire land-claim, for a generation, is one cave.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 23:4",
+        "target": "Phil 3:20",
+        "type": "Echo",
+        "text": "Paul's 'our citizenship (politeuma) is in heaven' recasts the Abrahamic sojourner identity: God's people on earth are always here on behalf of a homeland elsewhere, purchasing only what hope requires.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/24.json
+++ b/content/genesis/24.json
@@ -499,9 +499,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 9
+        },
+        {
+          "label": "Prayer",
+          "score": 10
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 24 — the longest single chapter in the book — is Scripture's richest narrative of providential guidance. Abraham's servant prays for a sign at the well; Rebekah appears before he has finished praying. The chapter is built on three speeches: Abraham's commission, the servant's prayer-and-providence, and the servant's retelling to Laban's household — each one rehearsing how God 'has prospered my way' (v.56). The well-betrothal type-scene established here (Rebekah, Rachel, Zipporah, Mary at the well of John 4) becomes a recurring covenant motif. The chapter ends with the first explicit 'and he loved her' (v.67) about a husband for his wife in Scripture — a template Eph 5:25-32 will read as Christ-and-church."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 24:7",
+        "target": "Heb 1:14",
+        "type": "Echo",
+        "text": "Abraham's confidence that 'the LORD... will send his angel before you' for his servant's mission is Scripture's first explicit use of 'angel' for a providential guide. Hebrews 1:14 generalises the theology: angels are 'ministering spirits sent out to serve for the sake of those who are to inherit salvation.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 24:12-27",
+        "target": "Prov 18:22",
+        "type": "Echo",
+        "text": "The servant's prayer-and-sign for a bride by a well — answered before he finished praying — is the OT's richest narrative of answered prayer in marriage. Proverbs' aphorism 'he who finds a wife finds a good thing and obtains favor from the LORD' has its narrative template here.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 24:11, 15-20",
+        "target": "John 4:6-15",
+        "type": "Echo",
+        "text": "The well-betrothal type-scene — man meets woman at a well, water exchanged, marriage follows (Rebekah, Rachel, Zipporah) — stands behind the Samaritan woman encounter at Jacob's well. Jesus consciously inhabits the role of the betrothing suitor offering living water to a foreign bride.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 24:67",
+        "target": "Eph 5:31-32",
+        "type": "Echo",
+        "text": "'Isaac brought her into the tent of Sarah his mother and took Rebekah, and she became his wife, and he loved her.' The tenderness and covenantal weight of this first explicit-love marriage in Genesis feeds into Paul's Eph 5 mystery: marriage as image of Christ and the church — a bride brought home from afar.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/25.json
+++ b/content/genesis/25.json
@@ -548,9 +548,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 7
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 7
+        },
+        {
+          "label": "Typology",
+          "score": 8
+        }
+      ],
+      "note": "Genesis 25 is a transitional chapter: Abraham dies at 175, the Ishmaelite genealogy fulfils 17:20, and Esau and Jacob are born wrestling. The pre-natal oracle 'the older shall serve the younger' (v.23) becomes Paul's key text for elective grace in Romans 9:10-13: God's purpose 'not by works but by him who calls' is dramatised before the twins have done anything. The chapter's climactic scene — Esau selling his birthright for a bowl of red stew — is Hebrews' archetype of profane shortsightedness (Heb 12:16-17). One generation gives place to another, and the patterns of election, sibling rivalry, and appetite-driven loss are all set in motion."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 25:23",
+        "target": "Rom 9:10-13",
+        "type": "Fulfilment",
+        "text": "'The older shall serve the younger' is Paul's proof-text in Rom 9:12 for elective grace that precedes works: 'though they were not yet born and had done nothing either good or bad... she was told.' Election in Genesis is narrated; in Romans it becomes doctrine.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 25:29-34",
+        "target": "Heb 12:16-17",
+        "type": "Echo",
+        "text": "Esau's sale of his birthright for a bowl of stew is Hebrews' archetype of profane shortsightedness: 'that no one is sexually immoral or unholy like Esau, who sold his birthright for a single meal.' A moment's appetite forfeits an irrevocable inheritance.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 25:21",
+        "target": "1 Sam 1:10-20",
+        "type": "Echo",
+        "text": "'Isaac prayed to the LORD for his wife, because she was barren. And the LORD granted his prayer.' The pattern of barren-then-conceiving-then-covenant-son continues: Sarah, Rebekah, Rachel, Hannah, Elizabeth. Hannah's prayer in 1 Sam 1 is directly in this Rebekah-line of intercession answered.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 25:8",
+        "target": "Heb 11:13",
+        "type": "Echo",
+        "text": "'Abraham breathed his last and died in a good old age, an old man and full of years.' The patriarchal death formula is Hebrews' proof that 'these all died in faith' — they finished the race without seeing the promise, but with fullness because faith holds what the eye doesn't see.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/26.json
+++ b/content/genesis/26.json
@@ -497,9 +497,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 6
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 7
+        },
+        {
+          "label": "Worship",
+          "score": 7
+        },
+        {
+          "label": "Typology",
+          "score": 7
+        }
+      ],
+      "note": "Genesis 26 is Isaac's standalone chapter and shows the Abrahamic promise transferring intact to the next generation: land, multiplied seed, blessing of nations, all explicitly re-granted (vv.3-5) on the basis of Abraham's obedience. Isaac's well-reopening campaign (re-digging the wells stopped up by the Philistines) is covenant continuity in agricultural form: living water restored to the place. The chapter also features a third wife-sister deception (Isaac repeating his father's sin) and a third pagan-king-protected-by-God episode. Yet by the chapter's end Abimelech can confess 'we see plainly that the LORD has been with you' (v.28) — the patriarch's blessedness is unmistakable even to those outside the covenant."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 26:3-5",
+        "target": "Gen 22:16-18",
+        "type": "Echo",
+        "text": "The promise to Isaac — land, multiplied offspring, blessing of nations — is the exact Abrahamic promise transferred across generations. The wording consciously echoes the Moriah oath: 'because Abraham obeyed my voice and kept my charge.' The covenant passes on as an heirloom, not a renegotiation.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 26:12",
+        "target": "Mark 4:20",
+        "type": "Echo",
+        "text": "'Isaac sowed in that land and reaped in the same year a hundredfold' — the OT's most striking instance of the hundredfold blessing motif that Jesus's parable of the sower picks up in Mark 4:20. Abundant agricultural return as a covenant sign becomes a metaphor for kingdom fruitfulness.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 26:18-22",
+        "target": "Isa 12:3; John 7:37-38",
+        "type": "Echo",
+        "text": "Isaac's well-reopening program — re-digging his father's wells stopped up by the Philistines — is a stock covenant image: living water restored. Isaiah 12 ('you will draw water from the wells of salvation') and John 7 ('out of his belly shall flow rivers of living water') both draw on this well-theology.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 26:24",
+        "target": "Matt 28:20",
+        "type": "Echo",
+        "text": "'I am with you and will bless you' — the first time the divine 'I am with you' formula is spoken to Isaac. It runs through to Jacob (28:15; 31:3), Moses (Exod 3:12), Joshua (Josh 1:5), and culminates in Jesus' 'I am with you always, to the end of the age.' One sentence threading the whole canon.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/27.json
+++ b/content/genesis/27.json
@@ -496,9 +496,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 9
+        },
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Family Dysfunction",
+          "score": 10
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 5
+        },
+        {
+          "label": "Typology",
+          "score": 6
+        }
+      ],
+      "note": "Genesis 27 is the most morally fraught chapter in the book: a blind father, a scheming mother, a deceiving son, and a betrayed brother — each pursuing their own version of the covenant blessing through deceit. The narrator refuses to moralise the deception explicitly, yet the consequences are immediate and lasting: Jacob flees, Rebekah never sees her favorite son again, Esau's grief becomes ancestral hatred (later prophesied against Edom in Obadiah). And yet — Hebrews 11:20 reads Isaac's blessing as 'by faith,' since the prophetic word landed on God's chosen one despite the deception. Genesis insists that God's elective purposes work through, not in spite of, the messy moral choices of the covenant family."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 27:27-29",
+        "target": "Heb 11:20",
+        "type": "Fulfilment",
+        "text": "'By faith Isaac invoked future blessings on Jacob and Esau.' Hebrews 11:20 reads the blessing of Gen 27 not as Isaac's tragic misfire but as a prophetic act of faith: even though deceived about which son was before him, the blessing he spoke landed on God's chosen one.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 27:36",
+        "target": "Obad 10-21",
+        "type": "Echo",
+        "text": "Esau's cry 'Is he not rightly named Jacob ('Yaʿaqov,' heel-grabber, deceiver)? For he has cheated me (yaʿqəveni) two times' is the seedbed of Edom's long-standing grievance. Obadiah's prophecy against Edom reaches back to Gen 27's blessing-theft as the ancestral wound the brother nations never healed.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 27:41",
+        "target": "Mal 1:2-3; Rom 9:13",
+        "type": "Echo",
+        "text": "Esau's murderous hatred of Jacob supplies the context for the covenantal formula 'Jacob I loved, but Esau I hated' (Mal 1:2-3; Rom 9:13) — a phrase that is not arbitrary preference but the long history of Esau's rejection of the covenant, shown first here.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 27:42-45",
+        "target": "Gen 32:3-21",
+        "type": "Echo",
+        "text": "Rebekah's plan for Jacob to flee 'until your brother's fury turns away' sets up the twenty-year exile resolved only in Gen 32-33. The blessing-theft of Gen 27 costs Jacob two decades with Laban — a narrative consequence that Genesis never lets off the hook.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/28.json
+++ b/content/genesis/28.json
@@ -371,9 +371,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 5
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 8
+        },
+        {
+          "label": "Worship",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 10
+        }
+      ],
+      "note": "Genesis 28 is the founding chapter of Jacob's personal encounter with the God of his fathers. Fleeing Esau's wrath, alone in the wilderness with a stone for a pillow, he sees the ladder/stairway with angels ascending and descending — and at the top, the LORD who renews the Abrahamic covenant directly to him. Jesus' direct self-identification with the ladder ('you will see heaven opened, and the angels of God ascending and descending on the Son of Man,' John 1:51) is the most explicit NT gloss on any Genesis vision. Bethel ('house of God') becomes the patriarchal sanctuary, and Jacob's vow — including the second tithe in Scripture — establishes this site as the center of his religious life until ch.35."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 28:12",
+        "target": "John 1:51",
+        "type": "Fulfilment",
+        "text": "'Truly, truly, I say to you, you will see heaven opened, and the angels of God ascending and descending on the Son of Man' — Jesus explicitly identifies himself as the ladder of Bethel. The Gen 28 vision of heaven-earth commerce terminates on the person of Christ.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 28:13-15",
+        "target": "Gen 12:1-3",
+        "type": "Echo",
+        "text": "The Bethel promise to Jacob is the Abrahamic promise explicitly re-granted: land, innumerable offspring, blessing of all the families of the earth. Covenant inheritance is passed through vision: what Abraham received on Ur's doorstep, Jacob receives on the road to exile.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 28:15",
+        "target": "Heb 13:5-6",
+        "type": "Echo",
+        "text": "'Behold, I am with you and will keep you wherever you go, and will bring you back to this land. For I will not leave you until I have done what I have promised you.' The LXX wording behind this verse feeds the promise cited in Heb 13:5 ('I will never leave you nor forsake you').",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 28:22",
+        "target": "Mal 3:10",
+        "type": "Echo",
+        "text": "Jacob's vow 'of all that you give me I will give a full tenth to you' is the second tithe scene in Genesis (after Abram-Melchizedek, 14:20), establishing tithing as a patriarchal practice centuries before Mosaic legislation institutionalises it in Mal 3:10.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/29.json
+++ b/content/genesis/29.json
@@ -539,7 +539,37 @@
         }
       ],
       "note": "Genesis 29 turns on the axis of divine providence compensating human injustice. The deceiver Jacob is deceived; the unloved Leah is given sons; the loved Rachel is given time to wait. Each injustice is met with a divine response that is neither simple reversal nor obvious vindication but the slow working of a purpose larger than any single character's desire."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 29:1-14",
+        "target": "Exod 2:15-22",
+        "type": "Echo",
+        "text": "Jacob rolls the stone from the well and waters Rachel's flock; Moses drives off shepherds and waters Zipporah's flock. The well-betrothal type-scene is consciously repeated across the patriarchal-Mosaic arc, marking each covenant-bearer's providential marriage.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 29:25",
+        "target": "Gal 6:7",
+        "type": "Echo",
+        "text": "Jacob the deceiver is himself deceived: the younger-for-elder substitution he performed on Isaac (Gen 27) is done to him by Laban with Leah for Rachel. Paul's 'whatever one sows, that will he also reap' has its Genesis narrative template here.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 29:31-35",
+        "target": "Luke 1:25, 48",
+        "type": "Echo",
+        "text": "Leah's 'when the LORD saw that Leah was hated, he opened her womb' — and her third-son naming Judah ('I will praise the LORD') — is the OT's most sustained meditation on God favoring the overlooked. Mary's 'he has looked on the humble estate of his servant' stands in the same theological line.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 29:35",
+        "target": "Matt 1:2-3; Rev 5:5",
+        "type": "Fulfilment",
+        "text": "Leah's fourth son Judah — named for praise — is the tribe through which the Davidic king and the Lion of Judah will come. The overlooked wife's overlooked son becomes the royal line. The genealogical hinge is set here before anyone in the story could know.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/30.json
+++ b/content/genesis/30.json
@@ -512,7 +512,30 @@
         }
       ],
       "note": "Genesis 30 is structured around the tension between human strategy and divine sovereignty. Rachel's surrogate births, Leah's mandrake deal, Jacob's breeding technique — all are human attempts to control outcomes. God's single act of remembering Rachel (v.22) and his guidance of Jacob's breeding strategy (31:10-12) show that the outcomes belong to the divine economy, not to human calculation."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 30:22",
+        "target": "1 Sam 1:19-20; Luke 1:57-58",
+        "type": "Echo",
+        "text": "'Then God remembered Rachel; God listened to her and opened her womb.' The 'God remembered' formula becomes the covenant-keeper's signature move throughout Scripture — remembering Noah (8:1), Hannah (1 Sam 1), Elizabeth (Luke 1). Rachel stands in this line of barren-womb interventions.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 30:24",
+        "target": "Gen 37; 41; 50",
+        "type": "Echo",
+        "text": "'May the LORD add to me another son!' — the naming of Joseph (yosef, 'he adds') — foreshadows the entire Joseph cycle and Ephraim/Manasseh blessings. The name Rachel gives in momentary maternal joy becomes the structural hinge of the last fourteen chapters of Genesis.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 30:27-30",
+        "target": "Prov 10:22",
+        "type": "Echo",
+        "text": "Laban's admission 'the LORD has blessed me because of you' is a gentile confession of covenantal providence. Proverbs' 'the blessing of the LORD makes rich' has its narrative embodiment in Jacob — whose prosperity is so obviously supernatural that even the exploiting employer can name its source.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/31.json
+++ b/content/genesis/31.json
@@ -547,7 +547,30 @@
         }
       ],
       "note": "Genesis 31 brings the Haran episode to a close with a formal covenant that demarcates Jacob from Laban, Hebrew from Aramean, covenant people from the nations. The divine presence that was promised at Bethel (28:15) and reiterated at the departure (31:3) has been active throughout: restraining Laban (v.24), guiding Jacob's breeding strategy (vv.10-12), and overseeing the Mizpah covenant (v.49). The twenty-year sojourn was under God's watch from beginning to end."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 31:3, 42",
+        "target": "Heb 13:5",
+        "type": "Echo",
+        "text": "'Return to the land of your fathers... I will be with you' (v.3), and Jacob's testimony 'if the God of my father, the God of Abraham and the Fear of Isaac, had not been on my side...' (v.42) — the 'God with me' theme runs through this chapter as the hinge of Jacob's courage to leave.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 31:19, 30-35",
+        "target": "Josh 24:14-15",
+        "type": "Echo",
+        "text": "The theft of Laban's household gods (teraphim) and Rachel's cunning concealment of them reveals that the patriarchal family still carries domestic idolatry. Joshua's closing call — 'put away the gods that your fathers served beyond the River' — names exactly this ancestral baggage and demands its final renunciation.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 31:49",
+        "target": "Mizpah benedictions",
+        "type": "Echo",
+        "text": "'The LORD watch between you and me, when we are out of one another's sight' — the Mizpah covenant. Ironically invoked as a parting blessing between estranged parties, the verse anchors a sober theology: God's watchfulness guarantees accountability even where humans cannot oversee each other.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/32.json
+++ b/content/genesis/32.json
@@ -438,7 +438,30 @@
         }
       ],
       "note": "Genesis 32 is the transformation chapter. The man who has lived by strategy and cunning — grasping heel, birthright, blessing, flocks — is reduced to prayer (v.9-12) and wounded by God (v.25), and emerges with a new name. Israel is defined not by moral perfection but by tenacious engagement with God. The chapter is simultaneously the most frightening and most hopeful in the Jacob narrative."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 32:24-30",
+        "target": "Hos 12:3-4",
+        "type": "Echo",
+        "text": "'He strove with the angel and prevailed; he wept and sought his favor' — Hosea 12 is the OT's own reflection on the Peniel wrestling, reading it as the pattern for Israel's ongoing relation with God: prevailing through tearful supplication, not brute strength.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 32:28",
+        "target": "Gen 35:10",
+        "type": "Fulfilment",
+        "text": "'Your name shall no longer be called Jacob, but Israel, for you have striven with God and with men, and have prevailed.' The name change is confirmed publicly at Bethel in Gen 35:10. The hidden night-encounter produces the national name that every subsequent book of the OT will use.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 32:30",
+        "target": "John 1:18; Exod 33:20",
+        "type": "Echo",
+        "text": "'I have seen God face to face, and yet my life has been delivered.' The exceptional claim sits in tension with Exod 33:20 ('man shall not see me and live') and is finally resolved by John 1:18 — 'no one has ever seen God; the only God, who is at the Father's side, he has made him known.' Christ is the face Jacob glimpsed.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/33.json
+++ b/content/genesis/33.json
@@ -380,7 +380,30 @@
         }
       ],
       "note": "Genesis 33 is the grace chapter of the Jacob narrative. After twenty years of flight and wrestling, the feared encounter with Esau becomes the most unexpected scene in the entire story: the wronged brother runs to embrace the deceiver. Jacob interprets the encounter theologically: Esau's face is like God's face — the same grace that met him in the night wrestling meets him in his brother's embrace. The chapter ends with an altar and a new name."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 33:4",
+        "target": "Luke 15:20",
+        "type": "Echo",
+        "text": "'Esau ran to meet him and embraced him and fell on his neck and kissed him, and they wept' — a scene Luke will recast in the prodigal son's return: 'his father saw him and felt compassion, and ran and embraced him and kissed him.' The OT's most unexpected reconciliation becomes Jesus' paradigm of the Father's welcome.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 33:10",
+        "target": "2 Cor 5:18-20",
+        "type": "Echo",
+        "text": "'For I have seen your face, which is like seeing the face of God, and you have accepted me.' Jacob's description of reconciled Esau collapses the divine and fraternal faces — the horizontal reconciliation mirrors the vertical. Paul's ministry of reconciliation has its Genesis template in this sentence.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 33:18-20",
+        "target": "John 4:5-6",
+        "type": "Echo",
+        "text": "Jacob buys land at Shechem and erects an altar — the same plot of ground that, centuries later, holds 'Jacob's well' where Jesus sits and meets the Samaritan woman. Genesis 33 quietly deeds a piece of redemptive-historical real estate.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/34.json
+++ b/content/genesis/34.json
@@ -403,7 +403,30 @@
         }
       ],
       "note": "Genesis 34 is the darkest chapter in the Jacob narrative. It raises questions about sexual violence, honour, covenant identity, and the limits of justice that the narrative refuses to answer. Jacob's silence throughout — when Dinah is violated, when the brothers respond, when the massacre occurs — is the chapter's most disturbing feature. The chapter stands as a warning: the people of God can perpetrate as well as suffer injustice, and the covenant sign can be desecrated in the service of violence."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 34:1-31",
+        "target": "Gen 49:5-7",
+        "type": "Echo",
+        "text": "The Dinah-Shechem atrocity and Simeon/Levi's deceptive massacre is not narratively condoned; Jacob's deathbed blessing in Gen 49:5-7 explicitly curses their anger: 'cursed be their anger, for it is fierce.' The covenant family is shown to contain grievous violence that God will not bless.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 34:13-29",
+        "target": "Rom 3:8",
+        "type": "Echo",
+        "text": "The brothers' misuse of circumcision — the covenant sign — as a deceptive instrument of vengeance is Scripture's first dramatization of 'Why not do evil that good may come?' (Rom 3:8). The covenant can be weaponised; its signs require covenant hearts.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 34:30",
+        "target": "1 Sam 13:13-14",
+        "type": "Echo",
+        "text": "'You have brought trouble on me by making me stink to the inhabitants of the land' — Jacob's realisation that his sons' violence endangers the covenant family. The tension between covenant security and visible moral integrity becomes Israel's political dilemma throughout the monarchy.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/35.json
+++ b/content/genesis/35.json
@@ -423,7 +423,30 @@
         }
       ],
       "note": "Genesis 35 is structured around the paradox of covenant renewal and death. God reappears, confirms the name Israel, restates the full covenant promise — and yet the chapter is framed by three deaths. The covenant promises are being given to a people in the process of losing those who received them first. The faithfulness of God and the mortality of his servants are placed side by side without resolution."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 35:1-7",
+        "target": "Josh 24:23",
+        "type": "Echo",
+        "text": "'Put away the foreign gods that are among you, and purify yourselves and change your garments' — Jacob's demand before returning to Bethel is Joshua's demand at Shechem: covenant renewal requires putting away household idolatries. Genesis 35 sets the liturgical pattern.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 35:10-12",
+        "target": "Exod 3:6, 15",
+        "type": "Echo",
+        "text": "The Bethel re-naming and re-promising consolidates 'the God of Abraham, Isaac, and Jacob' as the divine identity Exodus will use at the burning bush: 'the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, has sent me to you.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 35:18",
+        "target": "Jer 31:15; Matt 2:18",
+        "type": "Echo",
+        "text": "Rachel's death in childbirth near Bethlehem, naming Benjamin (son of sorrow / right hand), supplies the Jer 31:15 image Matthew quotes at Herod's slaughter: 'Rachel weeping for her children... because they are no more.' The matriarch's grave becomes the national mourning-site.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/36.json
+++ b/content/genesis/36.json
@@ -373,7 +373,30 @@
         }
       ],
       "note": "Genesis 36 demonstrates that God's providential care extends beyond the covenant line. Esau receives a complete genealogy, a territory, a political structure, and kings — all expressions of the Abrahamic blessing on the rejected brother. The chapter is a theological pause before the Joseph cycle: the non-covenant world is fully ordered and accounted for; the covenant world is about to experience its most severe test."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 36:1-43",
+        "target": "Obad 1-14",
+        "type": "Echo",
+        "text": "The Edomite genealogy — Esau's settled royal line with chiefs and kings — becomes Obadiah's prophetic target. Edom's pride ('who can bring me down to the ground?') traces back to Gen 36's political establishment long before Israel had its first king.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 36:31",
+        "target": "1 Sam 8:4-9",
+        "type": "Echo",
+        "text": "'These are the kings who reigned in the land of Edom, before any king reigned over the Israelites' — an editorial note pointing forward to the eventual monarchy. Edom gets kings generations before Israel asks Samuel for one; the theological point is that covenant people do not require political kingship to be God's people.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 36:8",
+        "target": "Deut 2:5",
+        "type": "Echo",
+        "text": "Esau's settlement in Seir becomes non-negotiable Edomite territory: Deuteronomy 2:5 explicitly forbids Israel from taking any of Esau's land — Seir is his inheritance from God. Genesis 36 is not just genealogy; it is land-allotment theology.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/37.json
+++ b/content/genesis/37.json
@@ -550,7 +550,30 @@
         }
       ],
       "note": "Genesis 37 is the pivot chapter of Genesis. The Joseph cycle begins with the same themes that have driven the patriarchal narrative — favouritism, sibling rivalry, deception — but now with a scale and complexity that will carry the story all the way to Egypt. The dreams are the theological guarantee: what God has spoken cannot be stopped by hatred, a cistern, or a slave market. Providence uses the brothers' violence as its instrument."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 37:28",
+        "target": "Matt 26:15",
+        "type": "Typology",
+        "text": "Twenty pieces of silver for Joseph by his brothers; thirty pieces of silver for Jesus by Judas ('what will you give me if I deliver him over to you?'). The NT deliberately signals that the betrayal-by-Judah pattern is being replayed: Judah-selling-Joseph is the first panel of a diptych the NT completes.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 37:24",
+        "target": "Ps 88:6; Acts 2:24",
+        "type": "Typology",
+        "text": "Joseph cast into the pit (bor) — the word for Sheol-pit throughout the Psalms — and then raised out to be sold is the Genesis prototype of death-and-deliverance that the psalms of lament elaborate and the resurrection definitively fulfils.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 37:5-11",
+        "target": "Dan 2:1-49; Matt 2:13-15",
+        "type": "Echo",
+        "text": "Joseph's prophetic dreams — eleven sheaves, eleven stars bowing down — establish the pattern that will run through Daniel and Matthew: God speaks the future through dreams to covenant figures in foreign lands, and dreams are validated by their later fulfilment.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/38.json
+++ b/content/genesis/38.json
@@ -413,7 +413,30 @@
         }
       ],
       "note": "Genesis 38 is the story of the preservation of the Davidic line through the most unlikely instrument. Judah's moral failure, Tamar's legal courage, and the birth of Perez together constitute an act of providential rescue: the covenant line that would have died with Judah's sons is preserved by the woman Judah was willing to sacrifice. The chapter's theology is the theology of the entire Joseph cycle: God uses human failure to accomplish divine purpose."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 38:6-30",
+        "target": "Ruth 4:12; Matt 1:3",
+        "type": "Fulfilment",
+        "text": "Tamar's twins Perez and Zerah enter the Davidic line (Ruth 4:12; Matt 1:3). Judah's sordid failure becomes, through Tamar's risky pursuit of her levirate right, the genealogical hinge: no Perez, no David, no Messiah. Genesis 38 is not a digression but a load-bearing genealogical pillar.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 38:26",
+        "target": "Luke 18:9-14",
+        "type": "Echo",
+        "text": "'She is more righteous than I.' Judah's confession about Tamar — an outsider woman whose desperate faithfulness to the covenant puts the patriarch to shame — anticipates Jesus' reversal: the tax collector is justified rather than the Pharisee. Gen 38 teaches the motif.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 38:1-11",
+        "target": "Deut 25:5-10; Matt 22:23-32",
+        "type": "Echo",
+        "text": "The Er-Onan-Shelah sequence introduces the levirate marriage institution later codified in Deut 25, still in play in Jesus' day (the Sadducees' hypothetical in Matt 22). Gen 38 shows the institution in raw pre-legal form — and what happens when it is violated.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/39.json
+++ b/content/genesis/39.json
@@ -409,7 +409,30 @@
         }
       ],
       "note": "Genesis 39 is organised by the repeated assertion of divine presence under every circumstance. Slave quarters, position of trust, temptation, prison — the LORD accompanies Joseph through each stage. The chapter's central ethical moment — Joseph's God-centred refusal of Potiphar's wife — is the moral foundation of the entire Joseph cycle: the man who says \"how can I sin against God?\" is the man God can trust with the salvation of Egypt and Israel."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 39:2, 21",
+        "target": "Rom 8:28",
+        "type": "Echo",
+        "text": "'The LORD was with Joseph' bracketing the chapter — at Potiphar's and in prison — is the narrator's refusal to let circumstance define providence. Paul's 'all things work together for good to those who love God' has its Genesis embodiment in the slave-falsely-accused narrative of ch. 39.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 39:9",
+        "target": "Ps 51:4",
+        "type": "Echo",
+        "text": "'How then can I do this great wickedness and sin against God?' Joseph's first-person refusal grounds sexual ethics vertically: adultery is finally God-ward. David's 'against you, you only, have I sinned' (Ps 51:4) sits in the same theological register, even though David failed where Joseph succeeded.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 39:19-20",
+        "target": "1 Pet 2:19-23",
+        "type": "Echo",
+        "text": "Joseph's unjust imprisonment — suffering for right conduct without retaliation — is the OT's clearest proto-Christ pattern of 1 Pet 2: 'when he was reviled, he did not revile in return; when he suffered, he did not threaten, but continued entrusting himself to him who judges justly.'",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/40.json
+++ b/content/genesis/40.json
@@ -386,7 +386,30 @@
         }
       ],
       "note": "Genesis 40 is the pivot chapter — the moment at which Joseph's gifts are first deployed in Egypt, and the moment at which human failure (the cupbearer's forgetting) extends the wait. The chapter's theology is the theology of divine timing: the right man with the right gift at the wrong human moment must wait for the right divine moment. Two years of prison after the cupbearer's restoration are not abandonment but preparation."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 40:8",
+        "target": "Dan 2:27-28",
+        "type": "Echo",
+        "text": "'Do not interpretations belong to God?' Joseph's theological claim in the dungeon is Daniel's position before Nebuchadnezzar: 'no wise men, enchanters, magicians, or astrologers can show the king the mystery... but there is a God in heaven who reveals mysteries.' The Joseph-Daniel pattern is deliberate.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 40:14-15, 23",
+        "target": "Ps 105:17-19",
+        "type": "Echo",
+        "text": "The cupbearer's two-year forgetting of Joseph — 'yet the chief cupbearer did not remember Joseph, but forgot him' — is the narrative form of what Psalm 105 calls the 'testing of his word.' Providence works through apparent abandonment as much as through deliverance.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 40:20-22",
+        "target": "Matt 27:38",
+        "type": "Typology",
+        "text": "Two prisoners, one restored and one executed on the third day — a narrative many Fathers read as a distant shadow of the two crucified alongside Jesus (Luke 23:39-43), one taken into life and one not, on a day that was also the third day in the death-and-resurrection sequence.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/41.json
+++ b/content/genesis/41.json
@@ -536,7 +536,30 @@
         }
       ],
       "note": "Genesis 41 is the vindication chapter. Joseph's God-centred ethics (39:9), his pastoral attentiveness (40:7), his accurate interpretation (40:12-19), and his patient waiting (40:23-41:1) all converge in a single day of divine reversal. The chapter's theology is the theology of Psalm 75:6-7: \"Exaltation comes neither from east nor west nor south — God is the judge; he brings one down and exalts another.\""
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 41:16",
+        "target": "1 Cor 4:7",
+        "type": "Echo",
+        "text": "'It is not in me; God will give Pharaoh a favorable answer.' Joseph's deflection of credit before the most powerful man on earth is Paul's 'what have you that you did not receive?' in narrative form — the foundational humility of every covenant bearer before God.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 41:40-44",
+        "target": "Phil 2:9-11; Acts 7:10",
+        "type": "Typology",
+        "text": "The slave-prisoner elevated to the second throne of the world — 'only as regards the throne will I be greater than you' — is Stephen's prophetic summary (Acts 7:10) and feeds the Christ-pattern Paul summarises: humbled to the lowest, exalted to the highest name.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 41:55-57",
+        "target": "John 2:5",
+        "type": "Echo",
+        "text": "'Whatever he says to you, do.' Pharaoh's instruction to the starving nation is verbally echoed by Mary at Cana: the identical formula pointing toward the provider. Joseph's grain-storehouses become a background image of Christ's abundance.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/42.json
+++ b/content/genesis/42.json
@@ -391,7 +391,30 @@
         }
       ],
       "note": "Genesis 42 begins the moral reversal of the Joseph cycle. The brothers who showed no compassion toward Joseph (37:24-25) now display guilt, fear, and retrospective awareness of his suffering. The test Joseph applies is not revenge but diagnosis: are these men capable of moral transformation? Chapter 42 gives the first evidence that they might be."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 42:21",
+        "target": "2 Cor 7:10-11",
+        "type": "Echo",
+        "text": "'In truth we are guilty concerning our brother.' The brothers' delayed realisation — triggered by innocent suffering — is Scripture's clearest OT instance of what Paul calls 'godly grief' producing repentance: external pressure surfaces long-buried guilt.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 42:8",
+        "target": "John 20:14-16",
+        "type": "Echo",
+        "text": "'Joseph recognized his brothers, but they did not recognize him.' The one-sided recognition of the glorified saviour by those who rejected him runs through to Mary at the tomb, the Emmaus road, and the lakeshore in John 21 — the redeemer recognises first, and waits.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 42:36",
+        "target": "Rom 8:31",
+        "type": "Echo",
+        "text": "Jacob's despairing 'all these things are against me' is the patriarchal mirror-image of Paul's 'if God is for us, who can be against us?' The same events will be read entirely differently in Gen 45 once providence is disclosed.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/43.json
+++ b/content/genesis/43.json
@@ -383,7 +383,30 @@
         }
       ],
       "note": "Genesis 43 is the chapter of transformed faith — Judah's surety and Jacob's resigned acceptance. Judah, who proposed profit from Joseph's sale, now volunteers permanent personal liability for Benjamin. Jacob, who refused comfort and refused to release Benjamin, now releases both with prayer. The transformation of the brothers' moral character is the real subject of Genesis 42-44, and chapter 43 is its middle stage."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 43:14",
+        "target": "Esth 4:16",
+        "type": "Echo",
+        "text": "'If I am bereaved of my children, I am bereaved.' Jacob's resigned surrender of Benjamin is quoted almost verbatim by Esther: 'if I perish, I perish.' Both are statements of covenant courage where the only ground is God's providence.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 43:9",
+        "target": "John 10:11",
+        "type": "Echo",
+        "text": "Judah's pledge to be a personal surety for Benjamin ('I will be a pledge of his safety; from my hand you shall require him') foreshadows the shepherd-laying-down-his-life motif and anticipates Judah's great substitutionary speech in 44:33.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 43:30",
+        "target": "Luke 19:41; John 11:35",
+        "type": "Echo",
+        "text": "Joseph weeps — the first of several weepings in the Joseph cycle — over the brother who betrayed him yet stands before him. The pattern of the ruler who weeps over those he is about to save anticipates Jesus' tears over Jerusalem and at Lazarus's tomb.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/44.json
+++ b/content/genesis/44.json
@@ -370,7 +370,30 @@
         }
       ],
       "note": "Genesis 44 completes the moral arc of the Joseph cycle's three test chapters. Judah's substitution offer is the answer to every test Joseph has applied. The man who calculated profit from a brother's suffering now offers to bear suffering for his brother's benefit. This is what genuine repentance looks like: not a feeling of regret but a changed pattern of action. The speech breaks the deadlock — Joseph cannot contain himself any longer."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 44:33",
+        "target": "Isa 53:4-6; John 15:13",
+        "type": "Typology",
+        "text": "Judah's offer — 'let your servant remain instead of the boy as a servant to my lord, and let the boy go back with his brothers' — is the OT's most striking pre-Christ substitutionary speech: the one who sold Joseph offers himself in Benjamin's place. The tribe of the coming substitute enters the narrative through a substitute's plea.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 44:16",
+        "target": "Rom 5:20",
+        "type": "Echo",
+        "text": "'What can we say to my lord?... God has found out the guilt of your servants.' The brothers' confession — without qualifying the charge — is the posture that Paul says is the threshold of grace: 'where sin abounded, grace abounded all the more.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 44:18-34",
+        "target": "Heb 7:22",
+        "type": "Echo",
+        "text": "Judah's speech — the longest single speech in Genesis — is the tribe's first act of sacrificial intercession. Hebrews 7:22 will name Jesus as 'the surety (enguos) of a better covenant,' the same role Judah improvises here.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/45.json
+++ b/content/genesis/45.json
@@ -391,7 +391,30 @@
         }
       ],
       "note": "Genesis 45 delivers the theological thesis of the Joseph cycle in Joseph's own words: \"It was not you who sent me here, but God.\" The chapter does not excuse the brothers' sin — it contextualises it within a divine purpose that transcends it. The forgiveness that flows from this theology is genuine, comprehensive, and immediate. The weeping and kissing that follow are not the performance of reconciliation but its natural expression."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 45:5-8",
+        "target": "Rom 8:28; Acts 2:23",
+        "type": "Fulfilment",
+        "text": "'It was not you who sent me here, but God... to preserve for you a remnant on earth, and to keep alive for you many survivors.' Joseph's theology of providence — human intent and divine intent diverging on the same act — is the template Peter applies at Pentecost to the cross: 'this Jesus, delivered up according to the definite plan and foreknowledge of God, you crucified.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 45:3",
+        "target": "Acts 9:5; Rev 1:17-18",
+        "type": "Echo",
+        "text": "'I am Joseph your brother, whom you sold into Egypt.' The self-revelation of the one they betrayed is echoed at Damascus ('I am Jesus, whom you are persecuting') and in Revelation's enthroned-Lamb formula. The betrayed brother-king identifies himself to those who put him there.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 45:14-15",
+        "target": "Eph 2:14-16",
+        "type": "Echo",
+        "text": "The weeping embrace of estranged brothers made one — reconciliation through the suffering of the one wronged — prefigures Paul's 'he himself is our peace, who has made us both one.' Genesis 45 is the OT's fullest scene of vertical forgiveness producing horizontal reunion.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/46.json
+++ b/content/genesis/46.json
@@ -364,7 +364,30 @@
         }
       ],
       "note": "Genesis 46 is the pivot chapter between the patriarchal era and the Egyptian era of Israel's history. The descent is divinely commanded and divinely accompanied. The seventy who descend are a distinct covenant people — counted, named, preserved. Joseph's Goshen strategy uses cultural separation to maintain covenant identity. The reunion of Jacob and Joseph is the personal miracle within the national miracle."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 46:3-4",
+        "target": "Exod 3:6-8",
+        "type": "Fulfilment",
+        "text": "'I will go down with you to Egypt, and I will also bring you up again.' The descent-and-return promise at Beersheba is the exodus in embryo — Exodus 3 picks up exactly this God ('the God of Abraham, Isaac, and Jacob') to begin the bringing-up.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 46:27",
+        "target": "Deut 10:22; Acts 7:14",
+        "type": "Echo",
+        "text": "Seventy souls of Jacob's house enter Egypt — a number Deuteronomy 10:22 recalls to emphasise God's multiplication, and Stephen's 'seventy-five' (Acts 7:14) reflects an LXX-influenced count. The seventy echoes the seventy nations of Gen 10: Israel is a covenantal world-in-miniature descending into exile.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 46:4",
+        "target": "Heb 13:5; Matt 28:20",
+        "type": "Echo",
+        "text": "'I will go down with you' — the 'I am with you' formula travels with the covenant family into the land of exile-as-provision. The assurance that God accompanies his people into descent runs all the way to Jesus' parting 'I am with you always, even to the end of the age.'",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/47.json
+++ b/content/genesis/47.json
@@ -545,9 +545,57 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Covenant",
+          "score": 8
+        },
+        {
+          "label": "Providence",
+          "score": 10
+        },
+        {
+          "label": "Creation Order",
+          "score": 6
+        },
+        {
+          "label": "Faith & Obedience",
+          "score": 8
+        },
+        {
+          "label": "Death & Promise",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 7
+        }
+      ],
+      "note": "Genesis 47 spans the practical settlement of Jacob's house in Goshen, Joseph's centralised famine economy that turns Egyptians into state-tenants of Pharaoh, and Jacob's deathbed insistence on burial in Canaan. Three theological notes dominate. First, Jacob — standing before Pharaoh — blesses him (vv.7, 10): the patriarchal lesser-blesses-greater inversion of normal protocol, a preview of Hebrews 7:7's logic. Second, Jacob's self-identification as a 'sojourner' (v.9) feeds the NT's pilgrim theology (Heb 11:13; 1 Pet 2:11). Third, the centralisation of Egyptian economic power that Joseph engineers will become — 'a new king arose who did not know Joseph' (Exod 1:8) — the structural setup for Israel's enslavement. Providence works in long arcs."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 47:9",
+        "target": "Heb 11:13; 1 Pet 2:11",
+        "type": "Echo",
+        "text": "'The days of the years of my sojourning are 130 years. Few and evil have been the days of the years of my life.' Jacob's self-identification as 'sojourner' before Pharaoh feeds directly into Hebrews 11's pilgrim theology and Peter's address to the church as 'sojourners and exiles.'",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 47:13-26",
+        "target": "Exod 1:8-14",
+        "type": "Echo",
+        "text": "Joseph's famine administration — Egyptians selling themselves to Pharaoh in exchange for grain, becoming state-dependent tenants — sets up the structural slavery of Exod 1. A new king who 'did not know Joseph' finds an already-centralised economy easy to turn against Israel.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 47:29-31",
+        "target": "Gen 49:29-33; Heb 11:21",
+        "type": "Echo",
+        "text": "Jacob's oath-bound demand that Joseph bury him in the ancestral ground — 'do not bury me in Egypt' — is the patriarchal refusal to let Egypt become the covenant's home. Heb 11:21 reads this as the culminating act of Jacob's faith: worship from a deathbed, eyes set on the promised land.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/48.json
+++ b/content/genesis/48.json
@@ -361,7 +361,30 @@
         }
       ],
       "note": "Genesis 48 is about the transmission of covenant inheritance against natural expectation. The adoption of Ephraim and Manasseh gives Joseph the double portion of the firstborn. The crossing of hands gives Ephraim the primary blessing over Manasseh. Both acts reverse natural expectations in favour of divine election. The younger-over-elder pattern that has structured Genesis from Abel to Joseph receives its final and most deliberate enactment."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 48:15-16",
+        "target": "Num 6:24-26",
+        "type": "Echo",
+        "text": "Jacob's threefold blessing — 'the God before whom my fathers walked... the God who has been my shepherd... the angel who has redeemed me' — is the first triadic blessing formula in Scripture and feeds the liturgical shape of the Aaronic benediction.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 48:14, 19",
+        "target": "Rom 9:11-13",
+        "type": "Echo",
+        "text": "Jacob's deliberate crossing of hands to bless younger Ephraim over elder Manasseh — over Joseph's objection — is another instance of the Genesis pattern ('the older shall serve the younger') that Paul grounds election in: divine choice does not follow primogeniture.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 48:21-22",
+        "target": "John 4:5",
+        "type": "Echo",
+        "text": "Jacob bequeaths Shechem (the plot he purchased in 33:19) to Joseph as an extra portion — the very field that becomes, in John 4:5, the location of Jesus' encounter with the Samaritan woman ('the field that Jacob had given to his son Joseph').",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/49.json
+++ b/content/genesis/49.json
@@ -394,7 +394,30 @@
         }
       ],
       "note": "Genesis 49 is the most explicitly prophetic chapter in Genesis. Jacob speaks from the threshold of death about the destinies of nations. The moral failures of the Joseph cycle (Reuben, Simeon, Levi) carry tribal consequences; the faithfulness of Judah and Joseph carries tribal promise. The Shiloh verse makes this the most messianic chapter in Genesis — the sceptre of Judah points forward across a thousand years to David, and beyond David to Christ."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 49:10",
+        "target": "Num 24:17; Rev 5:5",
+        "type": "Fulfilment",
+        "text": "'The sceptre shall not depart from Judah... until Shiloh comes (or: until he comes to whom it belongs), and to him shall be the obedience of the peoples.' Balaam's oracle (Num 24:17) and Rev 5:5's 'Lion of the tribe of Judah' both name Gen 49:10 as prophecy of the messianic king.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 49:18",
+        "target": "Luke 2:30",
+        "type": "Echo",
+        "text": "'I wait for your salvation, O LORD' — a dying patriarch's interjection mid-blessing. Luke's Simeon (2:30) echoes it: 'my eyes have seen your salvation.' The Genesis-wide ache is resolved in the Spirit-led old man holding the infant Christ.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 49:24",
+        "target": "Ps 23:1; John 10:11",
+        "type": "Echo",
+        "text": "'By the hand of the Mighty One of Jacob, the Shepherd, the Stone of Israel' — two messianic titles (Shepherd, Stone) applied to God in the same line, both picked up throughout the OT (Ps 23; Isa 28:16) and in Jesus' self-naming ('I am the good shepherd,' John 10).",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/5.json
+++ b/content/genesis/5.json
@@ -762,9 +762,71 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 8
+        },
+        {
+          "label": "Covenant",
+          "score": 5
+        },
+        {
+          "label": "Providence",
+          "score": 7
+        },
+        {
+          "label": "Creation Order",
+          "score": 6
+        },
+        {
+          "label": "Imago Dei",
+          "score": 8
+        },
+        {
+          "label": "Typology",
+          "score": 6
+        }
+      ],
+      "note": "Genesis 5 is a chapter shaped by death. The genealogy from Adam to Noah carries the relentless refrain 'and he died' — eight times in 32 verses — establishing the universal reign of mortality as the first generation's inheritance. The theological weight is the gap between the chapter's opening ('in the likeness of God he made him,' v.1, echoing 1:26) and its drumbeat of obituaries: the image-bearer is dying. Enoch's translation ('he was not, for God took him,' v.24) breaks the pattern just long enough to plant a death-resisting hope, and Lamech's naming of Noah ('rest... from the painful toil of our hands caused by the ground the LORD has cursed,' v.29) anticipates the post-flood relief. The chapter is a tomb with two windows: Enoch and Noah."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 5:1",
+        "target": "Matt 1:1",
+        "type": "Echo",
+        "text": "'This is the book of the generations of Adam' (Gen 5:1 LXX, biblos geneseōs Adam) is verbally mirrored in Matthew's opening: 'the book of the genealogy (biblos geneseōs) of Jesus Christ, son of David, son of Abraham.' Matthew is deliberately re-opening Genesis — announcing a new Adam and the reversal of Gen 5's death-drumbeat.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 5:5, 8, 11...",
+        "target": "Rom 5:12-14",
+        "type": "Fulfilment",
+        "text": "The refrain 'and he died,' repeated eight times in Gen 5, establishes the universal reign of death that Paul traces back to Adam in Rom 5. Genesis 5 is Paul's data: death passed to all because all sinned, and the proof is this chapter's obituary structure broken only by Enoch (5:24).",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 5:24",
+        "target": "Heb 11:5",
+        "type": "Fulfilment",
+        "text": "Enoch 'walked with God, and he was not, for God took him' is picked up in Heb 11:5 as the paradigm of pleasing faith. The death-interrupting translation of Enoch — one bright line in a chapter of tombstones — becomes the eschatological signpost that death is not the final word on the image-bearer.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 5:24",
+        "target": "Jude 14-15",
+        "type": "Echo",
+        "text": "Jude quotes 1 Enoch as the words of 'Enoch, the seventh from Adam' — counting via Gen 5's genealogy (Adam-Seth-Enosh-Kenan-Mahalalel-Jared-Enoch). The seventh generation motif foregrounds Enoch as an eschatological prophet from the antediluvian world.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 5:29",
+        "target": "Gen 3:17",
+        "type": "Echo",
+        "text": "Lamech names Noah ('rest') with the prayer that he would bring relief 'from the painful toil of our hands caused by the ground the LORD has cursed' — a direct verbal echo of the curse of Gen 3:17. The hope of reversal precedes the flood; Noah is framed as a Second-Adam candidate before the narrative even needs him.",
+        "direction": "back"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/50.json
+++ b/content/genesis/50.json
@@ -568,7 +568,30 @@
         }
       ],
       "note": "Genesis 50:20 is the theological thesis of the book of Genesis: \"You intended it for evil; God intended it for good.\" Every act of human sin and divine response in the fifty chapters has been building to this sentence. From the fall of Adam to the sale of Joseph, from the flood to the famine, the same pattern repeats: human malice and divine purpose operating on the same event; the divine purpose comprehending, redeeming, and overruling the human malice. Genesis ends with a coffin — and a promise."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Gen 50:20",
+        "target": "Rom 8:28; Acts 2:23",
+        "type": "Fulfilment",
+        "text": "'You meant evil against me, but God meant it for good.' The high-water mark of OT providence-theology. The exact logic Paul applies to the crucifixion ('delivered up according to the definite plan and foreknowledge of God, you crucified') and to the Christian's life ('all things work together for good') has its canonical foundation in this verse.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 50:24-26",
+        "target": "Exod 13:19; Heb 11:22",
+        "type": "Fulfilment",
+        "text": "'God will surely visit you, and you shall carry up my bones from here.' Joseph's deathbed faith in the future exodus is so explicit that Hebrews 11:22 singles it out as his defining act of faith, and Exod 13:19 records Moses carrying the bones. Genesis closes pointing to Exodus.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 50:19",
+        "target": "Rom 12:19",
+        "type": "Echo",
+        "text": "'Am I in the place of God?' Joseph's rhetorical refusal to retaliate — the last spoken words of the book to his brothers — anticipates Paul's 'never avenge yourselves... leave it to the wrath of God.' Genesis ends with a forgiveness practically indistinguishable from the cross's logic.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/8.json
+++ b/content/genesis/8.json
@@ -707,9 +707,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 7
+        },
+        {
+          "label": "Covenant",
+          "score": 9
+        },
+        {
+          "label": "Providence",
+          "score": 9
+        },
+        {
+          "label": "Creation Order",
+          "score": 8
+        },
+        {
+          "label": "New Creation",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 7
+        }
+      ],
+      "note": "Genesis 8 is the world's first re-creation. The narrative arc — wind (ruaḥ) over the waters, dry ground emerging, ordered rhythms reasserted — is a deliberate reenactment of Genesis 1, miniaturised inside Noah's narrative. God 'remembers' Noah (v.1) and the same divine memory that initiated creation re-initiates it. The dove with the olive leaf (v.11) becomes one of Scripture's most enduring images: the sign that the cosmos can again support life. The chapter ends with Noah's altar and God's irrevocable 'never again' (v.21-22) — covenant stability grounded in sacrifice. Seasons, day and night, seedtime and harvest are guaranteed not by nature's reliability but by divine oath."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 8:1",
+        "target": "Gen 1:2",
+        "type": "Echo",
+        "text": "'God made a wind (ruaḥ) pass over the earth, and the waters subsided' deliberately echoes Gen 1:2, where 'the Spirit (ruaḥ) of God was hovering over the waters.' The flood is a de-creation and the receding of the waters is a re-creation — the same ruaḥ, the same cosmogonic structure, now reenacted in miniature.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 8:11",
+        "target": "Matt 3:16",
+        "type": "Typology",
+        "text": "The dove returning with an olive leaf — the first sign that creation is habitable again — finds its typological climax at Jesus' baptism, when the Spirit descends 'like a dove' on the true Noah who will bring the rest the flood could not secure. Early Christian iconography read Gen 8:11 this way explicitly.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 8:20-22",
+        "target": "Rom 8:19-22",
+        "type": "Echo",
+        "text": "God's 'never again' oath to curse the ground and destroy all creatures (8:21) grounds Paul's confidence in Rom 8 that creation will not be abandoned but 'liberated from its bondage to decay.' The covenant stability of Genesis 8 is the guarantee that cosmic redemption remains on the table.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 8:21",
+        "target": "1 Pet 3:20-21",
+        "type": "Typology",
+        "text": "Peter reads the ark through the waters as a type of baptism — not cleansing from dirt but 'the pledge of a good conscience toward God.' The emergence from the flood onto a new earth becomes the template for coming through the waters of baptism into new-creation life.",
+        "direction": "forward"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/genesis/9.json
+++ b/content/genesis/9.json
@@ -559,9 +559,64 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
-    }
+      "scores": [
+        {
+          "label": "Fall & Redemption",
+          "score": 7
+        },
+        {
+          "label": "Covenant",
+          "score": 10
+        },
+        {
+          "label": "Providence",
+          "score": 8
+        },
+        {
+          "label": "Creation Order",
+          "score": 8
+        },
+        {
+          "label": "Imago Dei",
+          "score": 9
+        },
+        {
+          "label": "Typology",
+          "score": 6
+        }
+      ],
+      "note": "Genesis 9 introduces the first formal covenant in Scripture — the Noahic covenant, made not just with Noah's family but with 'every living creature' (v.10). The bow in the clouds is a covenant sign before circumcision, before sabbath, before the tablets at Sinai. The chapter also re-grounds human dignity in the imago Dei (v.6) as the basis for prohibiting murder, establishing the first principle of biblical ethics: human life is sacrosanct because it bears the divine image. Yet the chapter ends with Noah's drunken nakedness and Ham's sin — the second Adam falls in his own vineyard. Covenant renewal does not undo the fall; it carries it forward under grace."
+    },
+    "thread": [
+      {
+        "anchor": "Gen 9:1, 7",
+        "target": "Gen 1:28",
+        "type": "Echo",
+        "text": "'Be fruitful and multiply and fill the earth' is repeated to Noah verbatim from the creation mandate. Genesis 9 is Adam's commission renewed for a post-flood humanity — Noah stands at the head of a second humanity with the same creational vocation.",
+        "direction": "back"
+      },
+      {
+        "anchor": "Gen 9:6",
+        "target": "Matt 26:52",
+        "type": "Echo",
+        "text": "'Whoever sheds the blood of man, by man shall his blood be shed' stands behind Jesus' 'all who take the sword will perish by the sword' — the lex talionis principle rooted in the imago Dei. Genesis 9:6 is also Paul's warrant for the sword of the state in Rom 13:4.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 9:11-15",
+        "target": "Isa 54:9-10",
+        "type": "Echo",
+        "text": "Isaiah invokes the Noahic oath as the template for God's eternal covenant of peace: 'as I swore the waters of Noah should no more go over the earth, so I have sworn that I will not be angry with you.' The bow in the clouds becomes the OT's strongest image of God's irrevocable mercy.",
+        "direction": "forward"
+      },
+      {
+        "anchor": "Gen 9:20-25",
+        "target": "Gen 3:7, 21",
+        "type": "Echo",
+        "text": "Noah's nakedness and the sons' covering of him re-stages Eden's nakedness and covering. The Second Adam falls into his own vineyard (a garden-echo), and the shameful exposure of Ham rehearses the post-fall dynamic. The covenant has been renewed, but the fall has not been undone.",
+        "direction": "back"
+      }
+    ]
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Closes #1647. Parent epic: #1626. Audit source: #1635.

## Audit delta — Genesis

Both numbers are from `python3 _tools/coverage_auditor.py --book genesis`. Issue header states 79 findings; the live rubric (3.0) reports 71 today — that 8-finding delta likely reflects auditor updates between the #1635 snapshot and now (raised on the issue thread). The post-state is **zero** either way.

| Layer | Finding | Before | After |
|---|---|---:|---:|
| L1 | 🔴 Deficient sections | 0 | 0 |
| L1 | 🟡 Thin sections | 0 | 0 |
| L2 | Stub `hist` section panels | 4 | 0 |
| L3 | Missing `thread` chapter panels | 44 | 0 |
| L3 | Stub `themes` chapter panels | 23 | 0 |
| **Total** | | **71** | **0** |

Post-state section tiers: 🔴 0 | 🟡 0 | 🟢 0 | ✨ **135 (100%)**.
Post-state chapter-panel completeness: 450 expected, 450 substantive, 0 missing, 0 deficient.

Quality scorer (Tier 1, no LLM): all 50 chapters score ≥ 92.2 against the 90 floor. Worst three are `gen36` (92.2 — pre-existing section-structure note), `gen24` (93.2), `gen18` (94.6); none are caused by this PR.

## Sample new panel — Genesis 22 themes

```json
{
  "scores": [
    { "label": "Fall & Redemption", "score": 10 },
    { "label": "Covenant",          "score": 10 },
    { "label": "Providence",        "score": 10 },
    { "label": "Creation Order",    "score":  4 },
    { "label": "Faith & Obedience", "score": 10 },
    { "label": "Typology",          "score": 10 }
  ],
  "note": "Genesis 22 — the Akedah, the binding of Isaac — is the OT's most theologically charged narrative. Abraham is asked to sacrifice 'your son, your only son Isaac, whom you love' — Scripture's first 'beloved son' formula, the exact phrase the Father will speak over Jesus at the baptism. Mount Moriah (v.2) becomes, in 2 Chr 3:1, the Temple Mount — the place where a son was bound and a ram substituted becomes the place where lambs would be substituted for sinners. Abraham's prophetic 'God will provide for himself the lamb' (v.8) finds its ultimate fulfilment when John the Baptist points at Jesus (John 1:29). The divine self-oath of vv.16-18 is Hebrews 6's proof that God's promises are unbreakable; the singular 'seed' is Paul's hinge in Gal 3:16 for Christ as covenant terminus."
}
```

(`themes.note` is 781 chars; well above the 100-char substantive threshold and into "good"-density territory.)

A representative new `thread` entry — Genesis 22:2 → John 3:16:

```json
{
  "anchor": "Gen 22:2",
  "target": "John 3:16",
  "type": "Typology",
  "text": "'Take your son, your only son Isaac, whom you love' is the first appearance in Scripture of the phrase 'beloved son' — the exact phrase that will recur at Jesus' baptism and transfiguration ('this is my beloved son'). The Akedah supplies John 3:16's 'gave his only son' its entire theological vocabulary.",
  "direction": "forward"
}
```

Genesis 22's full new `thread` panel has 5 such entries totalling 1,444 chars of text.

## Scope confirmation (out-of-scope items per #1647)

- ❌ **No Psalms work** — that's Phase 1b, #1644.
- ❌ **No new scholars introduced.** All commentator panels in the touched chapters are unchanged; `SCHOLAR_REGISTRY` not modified.
- ❌ **No NIV verse text changes.** Verse-text fields in the chapter JSONs are untouched.
- ❌ **No section-header rewrites.** Existing section structures (`header`, `verse_start`, `verse_end`) are unchanged on every edited chapter.
- ❌ **No app-layer drift.** `app/`, `_tools/`, and workflow files all untouched. Build artifacts (`db-manifest.json`, `explore-images.json`) deliberately reverted from the local rebuild — CI rebuilds them on master post-merge.
- ❌ **No new section-panel types added.** Only the four pre-existing stub `hist` panels were rewritten.

Patch surface: 44 `content/genesis/*.json` files modified; +1,904 / -142 lines (almost entirely new substantive prose; the 142 deletions are stub `{"historical": "None", "context": "None"}` and empty `themes`/`thread` placeholders being replaced).

## Pipeline

- ✅ `python3 _tools/schema_validator.py` — 137,950 passed, 77 failed; failure count identical to master (all pre-existing topic / era_config / PLAYBOOK issues, none from this PR — verified by `git stash` round-trip).
- ✅ `python3 _tools/build_sqlite.py` — clean build, 100MB.
- ✅ `python3 _tools/validate_sqlite.py` — 101 passed, 0 failed, 2 unrelated warnings (embeddings/prompts not built locally).
- ✅ `python3 _tools/coverage_auditor.py --book genesis` — **0 findings**.
- ✅ `python3 _tools/quality_scorer.py --book genesis` — all 50 chapters above 90 floor.

## Pilot feedback (also captured on #1647)

Two Tier B template issues worth fixing before spinning up the next 56 books:

1. The pre-work command in the spec (`coverage_auditor.py --book X --section-detail --format json`) silently emits markdown — `--section-detail` short-circuits `--format` (auditor lines 806-808). Either drop `--section-detail` from the JSON line or extend the auditor.
2. `save_chapter()` is a full-rewrite from generator-format input, not a panel-level patch. For additive enrichment the spec's "use save_chapter()" route requires reverse-normalising every existing panel back to generator format. This PR's generator instead loaded existing JSON, patched the specific panels, and wrote back — diffs stay surgical. Suggest the template standardise on direct JSON patching for enrichment passes and reserve save_chapter() for new-chapter work.

## Test plan

- [x] Coverage auditor reports 0 Genesis findings.
- [x] Quality scorer ≥ 90 on every chapter.
- [x] Schema validator failure count unchanged vs master.
- [x] DB builds and validates clean.
- [ ] On merge: content-pipeline CI green; coverage-audit step (warning-only, see #1650) surfaces zero Genesis findings on the master rebuild.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_