### PR TITLE
fix(canon-comparison): shrink oversized tradition tab buttons in portrait

### DIFF
--- a/app/src/screens/CanonComparisonScreen.tsx
+++ b/app/src/screens/CanonComparisonScreen.tsx
@@ -269,6 +269,7 @@ function PortraitLayout({
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.tabRow}
+        style={styles.tabScroll}
       >
         {traditions.map((tr, i) => {
           const active = i === activeIndex;
@@ -492,10 +493,21 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: spacing.sm,
   },
+  tabScroll: {
+    // Prevent the horizontal ScrollView from filling the remaining
+    // vertical flex space in portraitRoot — otherwise Yoga's default
+    // cross-axis stretch makes each pill inflate to the full row height
+    // and the tradition buttons render as huge vertical ovals.
+    flexGrow: 0,
+  },
   tabRow: {
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.xs,
     gap: spacing.xs,
+    // Belt-and-suspenders: even if flexGrow:0 above fails to clamp the
+    // ScrollView height on some RN/iOS version, centering children on
+    // the cross axis keeps each pill at its intrinsic text height.
+    alignItems: 'center',
   },
   tabButton: {
     borderWidth: 1,


### PR DESCRIPTION
## Problem

When the Canon Comparison screen loads in portrait orientation (the 99% case on iPhone), the four tradition tabs render as huge vertical pill-shaped ovals that chew up a massive chunk of the screen above the actual content.

## Root cause

```tsx
<View style={styles.portraitRoot}>             // flex: 1, column
  <ScrollView horizontal ...>                   // no flex -> stretches vertically
    {tradition tab buttons}                     // no height -> Yoga stretches them
  </ScrollView>
  <View style={styles.portraitColumnWrap} />    // flex: 1
</View>
```

The horizontal ScrollView had no explicit flex constraint. Yoga default cross-axis `alignItems: stretch` then sizes each tab button to the full row height, and each pill ends up several hundred points tall with the text label floating in the center.

## Fix

Two-layer defense so a future refactor cannot quietly regress this:

1. **`flexGrow: 0` on the ScrollView** — the primary fix. Clamps the ScrollView to its content height so the row only occupies as much space as the pills need.
2. **`alignItems: center` on `tabRow` contentContainer** — secondary guard. If a future edit re-inflates the ScrollView height (e.g. someone adds `flex:1` or an explicit height), the pills still render at their intrinsic text height instead of stretching.

Both changes are CSS-only; no JSX restructuring, no behavior change. Landscape layout is untouched (it has its own `landscapeColumnWrap: { height: "100%" }` and was not affected).

## Test plan

- Existing `CanonComparisonScreen.test.tsx` still passes (no DOM assertions changed).
- Manual: verify in the simulator that tabs now render as ~30pt pills with normal gold highlighting for the active tradition.
- Landscape smoke check: rotate the simulator and confirm the 4-column landscape layout is unchanged.

## Rollback

Revert the single commit. No migrations, no schema, no runtime state touched.

Found during post-merge review of the Guided Study CTA flow on the rentamac.