### PR TITLE
feat: reading-scale editor + legacy fontSize removal (PR 3/3)

### DIFF
--- a/app/__tests__/components/settings/ReadingScaleEditor.test.tsx
+++ b/app/__tests__/components/settings/ReadingScaleEditor.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for ReadingScaleEditor — the Settings font-size editor.
+ *
+ * Covers: preview renders, segment selection calls setReadingScale,
+ * Reset returns to 1.0×, and the OS-large note appears when PixelRatio
+ * reports a getFontScale() > 1.5.
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { PixelRatio } from 'react-native';
+import { ReadingScaleEditor } from '@/components/settings/ReadingScaleEditor';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+jest.mock('@/db/user', () => ({
+  getPreference: jest.fn().mockResolvedValue(null),
+  setPreference: jest.fn().mockResolvedValue(undefined),
+  deletePreference: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('ReadingScaleEditor', () => {
+  beforeEach(() => {
+    jest.spyOn(PixelRatio, 'getFontScale').mockReturnValue(1.0);
+    useSettingsStore.setState({ readingScale: 1.0 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the preview copy (section header + verse + commentary + chrome sample)', () => {
+    const { getByText } = render(<ReadingScaleEditor />);
+    expect(getByText('In the Beginning')).toBeTruthy();
+    expect(
+      getByText('In the beginning, God created the heavens and the earth.'),
+    ).toBeTruthy();
+    expect(getByText(/Calvin:/)).toBeTruthy();
+    expect(getByText(/Chrome stays the same/)).toBeTruthy();
+  });
+
+  it('shows the current reading-size readout', () => {
+    useSettingsStore.setState({ readingScale: 1.2 });
+    const { getByText } = render(<ReadingScaleEditor />);
+    expect(getByText(/Reading size: 1\.2×/)).toBeTruthy();
+  });
+
+  it('calls setReadingScale when a segment is pressed', () => {
+    const { getByLabelText } = render(<ReadingScaleEditor />);
+    fireEvent.press(getByLabelText('Reading size 1.35×'));
+    expect(useSettingsStore.getState().readingScale).toBeCloseTo(1.35, 5);
+  });
+
+  it('shows Reset button only when not at 1.0× and returns to 1.0 when pressed', () => {
+    useSettingsStore.setState({ readingScale: 1.35 });
+    const { getByText, queryByText, rerender } = render(<ReadingScaleEditor />);
+
+    fireEvent.press(getByText('Reset'));
+    expect(useSettingsStore.getState().readingScale).toBe(1.0);
+
+    rerender(<ReadingScaleEditor />);
+    expect(queryByText('Reset')).toBeNull();
+  });
+
+  it('shows the OS-large note when PixelRatio.getFontScale() > 1.5', () => {
+    jest.spyOn(PixelRatio, 'getFontScale').mockReturnValue(1.75);
+    const { getByText } = render(<ReadingScaleEditor />);
+    expect(
+      getByText(/device is set to a large text size/i),
+    ).toBeTruthy();
+  });
+
+  it('does not show the OS-large note when scale is within normal range', () => {
+    jest.spyOn(PixelRatio, 'getFontScale').mockReturnValue(1.3);
+    const { queryByText } = render(<ReadingScaleEditor />);
+    expect(queryByText(/device is set to a large text size/i)).toBeNull();
+  });
+
+  it('surfaces the effective content scale in the secondary readout', () => {
+    jest.spyOn(PixelRatio, 'getFontScale').mockReturnValue(1.5);
+    useSettingsStore.setState({ readingScale: 1.5 });
+    const { getByText } = render(<ReadingScaleEditor />);
+    // 1.5 × 1.5 = 2.25 → capped at 2.2×
+    expect(getByText(/Effective: 2\.2× \(content\)/)).toBeTruthy();
+    // Device readout should show the OS scale
+    expect(getByText(/Device text size: 1\.5×/)).toBeTruthy();
+  });
+});

--- a/app/__tests__/stores/settingsStore.test.ts
+++ b/app/__tests__/stores/settingsStore.test.ts
@@ -4,16 +4,16 @@ import { useSettingsStore } from '@/stores/settingsStore';
 jest.mock('@/db/user', () => ({
   getPreference: jest.fn().mockResolvedValue(null),
   setPreference: jest.fn().mockResolvedValue(undefined),
+  deletePreference: jest.fn().mockResolvedValue(undefined),
 }));
 
-const { getPreference, setPreference } = require('@/db/user');
+const { getPreference, setPreference, deletePreference } = require('@/db/user');
 
 describe('settingsStore', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useSettingsStore.setState({
       translation: 'kjv',
-      fontSize: 16,
       readingScale: 1.0,
       vhlEnabled: true,
       bookListMode: 'canonical',
@@ -26,7 +26,7 @@ describe('settingsStore', () => {
   it('starts with default state', () => {
     const state = useSettingsStore.getState();
     expect(state.translation).toBe('kjv');
-    expect(state.fontSize).toBe(16);
+    expect(state.readingScale).toBe(1.0);
     expect(state.theme).toBe('dark');
     expect(state.isHydrated).toBe(false);
   });
@@ -36,23 +36,6 @@ describe('settingsStore', () => {
       await useSettingsStore.getState().setTranslation('asv');
       expect(useSettingsStore.getState().translation).toBe('asv');
       expect(setPreference).toHaveBeenCalledWith('translation', 'asv');
-    });
-  });
-
-  describe('setFontSize', () => {
-    it('sets font size', async () => {
-      await useSettingsStore.getState().setFontSize(20);
-      expect(useSettingsStore.getState().fontSize).toBe(20);
-    });
-
-    it('clamps to minimum of 12', async () => {
-      await useSettingsStore.getState().setFontSize(8);
-      expect(useSettingsStore.getState().fontSize).toBe(12);
-    });
-
-    it('clamps to maximum of 24', async () => {
-      await useSettingsStore.getState().setFontSize(30);
-      expect(useSettingsStore.getState().fontSize).toBe(24);
     });
   });
 
@@ -80,7 +63,6 @@ describe('settingsStore', () => {
       getPreference.mockImplementation((key: string) => {
         const map: Record<string, string> = {
           translation: 'asv',
-          fontSize: '18',
           vhlEnabled: '1',
           bookListMode: 'canonical',
           studyCoachEnabled: '0',
@@ -92,7 +74,6 @@ describe('settingsStore', () => {
       await useSettingsStore.getState().hydrate();
       const state = useSettingsStore.getState();
       expect(state.translation).toBe('asv');
-      expect(state.fontSize).toBe(18);
       expect(state.vhlEnabled).toBe(true);
       expect(state.studyCoachEnabled).toBe(false);
       expect(state.theme).toBe('sepia');
@@ -103,7 +84,6 @@ describe('settingsStore', () => {
       getPreference.mockImplementation((key: string) => {
         const map: Record<string, string> = {
           translation: 'bad',
-          fontSize: 'NaN',
           theme: 'neon',
         };
         return Promise.resolve(map[key] ?? null);
@@ -112,7 +92,6 @@ describe('settingsStore', () => {
       await useSettingsStore.getState().hydrate();
       const state = useSettingsStore.getState();
       expect(state.translation).toBe('kjv');
-      expect(state.fontSize).toBe(16);
       expect(state.theme).toBe('dark');
     });
 
@@ -316,6 +295,33 @@ describe('settingsStore', () => {
       });
       await useSettingsStore.getState().hydrate();
       expect(useSettingsStore.getState().readingScale).toBeCloseTo(1.5, 5);
+    });
+
+    it('deletes the legacy fontSize preference after migration', async () => {
+      getPreference.mockImplementation((key: string) => {
+        if (key === 'fontSize') return Promise.resolve('20');
+        return Promise.resolve(null);
+      });
+      await useSettingsStore.getState().hydrate();
+      expect(deletePreference).toHaveBeenCalledWith('fontSize');
+    });
+
+    it('deletes legacy fontSize preference even if readingScale was already stored', async () => {
+      getPreference.mockImplementation((key: string) => {
+        const map: Record<string, string> = {
+          readingScale: '1.2',
+          fontSize: '18',
+        };
+        return Promise.resolve(map[key] ?? null);
+      });
+      await useSettingsStore.getState().hydrate();
+      expect(deletePreference).toHaveBeenCalledWith('fontSize');
+    });
+
+    it('does not delete fontSize when no legacy value is present', async () => {
+      getPreference.mockResolvedValue(null);
+      await useSettingsStore.getState().hydrate();
+      expect(deletePreference).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/components/AuthorshipSheet.tsx
+++ b/app/src/components/AuthorshipSheet.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, Modal, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 
 interface Props {
   visible: boolean;
@@ -14,6 +14,7 @@ interface Props {
 
 export function AuthorshipSheet({ visible, onClose }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <Modal visible={visible} transparent animationType="slide">
       <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} accessibilityRole="button" accessibilityLabel="Close about content" />
@@ -27,13 +28,13 @@ export function AuthorshipSheet({ visible, onClose }: Props) {
             About This Content
           </Text>
 
-          <Text style={[styles.bodyText, { color: base.textDim }]}>
+          <Text style={[content.bodyMd, { color: base.textDim }]}>
             Companion Study presents the Bible text alongside scholarly commentary from multiple traditions —
             evangelical, reformed, Jewish, critical, and patristic. Each chapter features Hebrew/Greek word studies,
             historical context, cross-references, and curated notes from recognized scholars.
           </Text>
 
-          <Text style={[styles.bodyText, styles.bodyGap, { color: base.textDim }]}>
+          <Text style={[content.bodyMd, styles.bodyGap, { color: base.textDim }]}>
             Verse text is from the NIV and ESV translations. Scholarly notes are curated summaries of published
             commentaries, not direct quotations. The theological themes radar chart uses keyword frequency analysis
             to visualize emphasis patterns.
@@ -72,11 +73,6 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.displayMedium,
     fontSize: 16,
     marginBottom: spacing.md,
-  },
-  bodyText: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 24,
   },
   bodyGap: {
     marginTop: spacing.md,

--- a/app/src/components/ChapterReaderContext.tsx
+++ b/app/src/components/ChapterReaderContext.tsx
@@ -15,7 +15,6 @@ interface VerseState {
   vhlGroups: VHLGroup[];
   activeVhlGroups: string[];
   notedVerses: Set<number>;
-  fontSize: number;
   redLetterVerses: Set<number>;
   highlightMap: Map<number, string>;
   comparisonVerses: Verse[] | undefined;

--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -97,7 +97,6 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
             activeVhlGroups={verse.activeVhlGroups}
             notedVerses={verse.notedVerses}
             activePanel={panel.activeSectionPanel}
-            fontSize={verse.fontSize}
             onPanelToggle={callbacks.handleSectionPanelToggle}
             onNotePress={callbacks.onNotePress}
             onVerseLongPress={callbacks.onVerseLongPress}

--- a/app/src/components/GrammarSheet.tsx
+++ b/app/src/components/GrammarSheet.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { X, BookOpen } from 'lucide-react-native';
 import { useMorphologyDecode, useGrammarArticle } from '../hooks/useGrammar';
-import { useTheme, spacing, radii, fontFamily, panels } from '../theme';
+import { useTheme, spacing, radii, fontFamily, panels, useTypography } from '../theme';
 import { LoadingSkeleton } from './LoadingSkeleton';
 
 interface Props {
@@ -25,6 +25,7 @@ interface Props {
 
 export function GrammarSheet({ visible, morphologyCode, onClose, onArticlePress }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   const decoded = useMorphologyDecode(morphologyCode);
   const { article, loading: articleLoading } = useGrammarArticle(decoded?.articleId ?? null);
 
@@ -102,7 +103,7 @@ export function GrammarSheet({ visible, morphologyCode, onClose, onArticlePress 
                           <Text style={[styles.sectionLabel, { color: base.gold }]}>GRAMMAR ARTICLE</Text>
                           <View style={[styles.articleCard, { backgroundColor: base.bg, borderColor: base.border }]}>
                             <Text style={[styles.articleTitle, { color: base.text }]}>{article.title}</Text>
-                            <Text style={[styles.articleSummary, { color: base.textDim }]} numberOfLines={3}>
+                            <Text style={[content.bodySm, { color: base.textDim }]} numberOfLines={3}>
                               {article.summary}
                             </Text>
                             {onArticlePress && (
@@ -227,11 +228,6 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.displayMedium,
     fontSize: 14,
     marginBottom: 4,
-  },
-  articleSummary: {
-    fontFamily: fontFamily.ui,
-    fontSize: 12,
-    lineHeight: 18,
   },
   readMoreBtn: {
     flexDirection: 'row',

--- a/app/src/components/InterlinearSheet.tsx
+++ b/app/src/components/InterlinearSheet.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { X } from 'lucide-react-native';
 import { getInterlinearWords } from '../db/content';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import type { InterlinearWord } from '../types';
 import { LoadingSkeleton } from './LoadingSkeleton';
 import { GrammarSheet } from './GrammarSheet';
@@ -43,6 +43,7 @@ export function InterlinearSheet({
   onClose, onWordStudyPress, onConcordancePress, onLexiconPress, onGrammarArticlePress,
 }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   const [words, setWords] = useState<InterlinearWord[]>([]);
   const [loading, setLoading] = useState(true);
   const [grammarCode, setGrammarCode] = useState<string | null>(null);
@@ -174,7 +175,7 @@ export function InterlinearSheet({
 
                       {/* Gloss */}
                       {w.gloss ? (
-                        <Text style={[styles.gloss, { color: base.text }]} numberOfLines={2}>{w.gloss}</Text>
+                        <Text style={[content.bodySm, styles.gloss, { color: base.text }]} numberOfLines={2}>{w.gloss}</Text>
                       ) : null}
 
                       {/* Word study indicator */}
@@ -286,8 +287,6 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   gloss: {
-    fontFamily: fontFamily.ui,
-    fontSize: 11,
     textAlign: 'center',
   },
   wsIndicator: {

--- a/app/src/components/LexiconSheet.tsx
+++ b/app/src/components/LexiconSheet.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { ArrowLeft, X, BookOpen, Search } from 'lucide-react-native';
 import { useLexicon } from '../hooks/useLexicon';
-import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET, panels } from '../theme';
+import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET, panels, useTypography } from '../theme';
 import type { DefinitionJSON } from '../types/lexicon';
 import { LexiconDefinition } from './LexiconDefinition';
 import { RelatedWordCard } from './RelatedWordCard';
@@ -41,6 +41,7 @@ export function LexiconSheet({
   onWordStudyPress, onConcordancePress, wordStudyId,
 }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   const [strongsStack, setStrongsStack] = useState<string[]>([]);
 
   // Sync stack with prop changes
@@ -174,7 +175,7 @@ export function LexiconSheet({
                     {entry.etymology && (
                       <>
                         <Text style={[styles.sectionLabel, { color: base.gold }]}>ETYMOLOGY</Text>
-                        <Text style={[styles.etymology, { color: base.textDim }]}>{entry.etymology}</Text>
+                        <Text style={[content.bodySm, { color: base.textDim }]}>{entry.etymology}</Text>
                       </>
                     )}
 
@@ -317,11 +318,6 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     marginTop: spacing.md,
     marginBottom: spacing.xs,
-  },
-  etymology: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
   },
   relatedRow: {
     gap: spacing.sm,

--- a/app/src/components/SectionBlock.tsx
+++ b/app/src/components/SectionBlock.tsx
@@ -21,7 +21,6 @@ interface Props {
   activeVhlGroups?: string[];
   notedVerses: Set<number>;
   activePanel: { sectionId: string; panelType: string } | null;
-  fontSize?: number;
   onPanelToggle: (sectionId: string, panelType: string) => void;
   onNotePress?: (verseNum: number) => void;
   onRefPress?: (ref: ParsedRef) => void;
@@ -49,7 +48,7 @@ interface Props {
 
 function SectionBlock({
   section, panels, verses, vhlGroups, activeVhlGroups,
-  notedVerses, activePanel, fontSize,
+  notedVerses, activePanel,
   onPanelToggle, onNotePress, onRefPress: _onRefPress, onVerseLongPress, onVerseNumPress, activeVerseNum,
   renderButtonRow, renderPanel,
   depthExplored, depthTotal, onDepthRecord,
@@ -95,7 +94,6 @@ function SectionBlock({
         activeVhlGroups={activeVhlGroups}
         notedVerses={notedVerses}
         sectionId={section.id}
-        fontSize={fontSize}
         onVhlWordPress={handleVhlWordPress}
         onNotePress={onNotePress}
         onVerseLongPress={onVerseLongPress}

--- a/app/src/components/SectionHeader.tsx
+++ b/app/src/components/SectionHeader.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useTheme, spacing, useTypography } from '../theme';
 import { DepthDots } from './DepthDots';
 
 interface Props {
@@ -20,10 +20,11 @@ interface Props {
 
 function SectionHeader({ header, explored, total }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <View style={styles.container} accessibilityRole="header">
       <View style={[styles.bar, { backgroundColor: base.gold }]} />
-      <Text style={[styles.text, { color: base.gold }]} numberOfLines={2}>{header}</Text>
+      <Text style={[content.displayMd, styles.text, { color: base.gold }]} numberOfLines={2}>{header}</Text>
       {total != null && total > 0 ? (
         <View style={styles.depthWrap}>
           <DepthDots explored={explored ?? 0} total={total} />
@@ -53,10 +54,6 @@ const styles = StyleSheet.create({
     borderRadius: 1.5,
   },
   text: {
-    fontFamily: fontFamily.displayMedium,
-    fontSize: 13,
-    lineHeight: 20,
-    letterSpacing: 0.4,
     flex: 1,
     marginRight: spacing.sm,
   },

--- a/app/src/components/VerseBlock.tsx
+++ b/app/src/components/VerseBlock.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../theme';
 import type { Verse, VHLGroup } from '../types';
 import { HighlightedText } from './HighlightedText';
 import { NoteIndicator } from './NoteIndicator';
@@ -17,7 +17,6 @@ interface Props {
   activeVhlGroups?: string[];
   notedVerses: Set<number>;
   sectionId: string;
-  fontSize?: number;
   onVhlWordPress?: (panelTypes: string[], sectionId: string) => void;
   onNotePress?: (verseNum: number) => void;
   onVerseLongPress?: (verseNum: number, text: string) => void;
@@ -39,16 +38,19 @@ interface Props {
 
 export const VerseBlock = React.memo(function VerseBlock({
   verses, vhlGroups, activeVhlGroups, notedVerses, sectionId,
-  fontSize = 16, onVhlWordPress, onNotePress, onVerseLongPress, onVerseNumPress, activeVerseNum,
+  onVhlWordPress, onNotePress, onVerseLongPress, onVerseNumPress, activeVerseNum,
   comparisonVerses, comparisonLabel, primaryLabel,
   redLetterVerses, onVerseLayout, highlightMap,
 }: Props) {
   const { base } = useTheme();
+  const { content } = useTypography();
   if (!verses.length) return null;
 
-  // Card #1362: 1.7× line-height per spec (was 1.6×) — improves reading ergonomics
-  // at the default 16px / 1.125× dynamic-type bump scales.
-  const lineHeight = fontSize * 1.7;
+  // Verse sizing now flows from useTypography (content.bodyLg) so OS
+  // Dynamic Type + reading-multiplier combine per epic #1639. Card #1362
+  // kept the 1.7× ratio inside the preset; the spread below preserves it.
+  const fontSize = content.bodyLg.fontSize;
+  const lineHeight = content.bodyLg.lineHeight ?? fontSize * 1.7;
   const numSize = Math.max(11, fontSize * 0.65);
   const isComparing = !!comparisonVerses && comparisonVerses.length > 0;
 

--- a/app/src/components/panels/CommentaryPanel.tsx
+++ b/app/src/components/panels/CommentaryPanel.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { TappableReference } from '../TappableReference';
 import { ScholarTag } from '../ScholarTag';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { CommentaryNote, ParsedRef } from '../../types';
 
 interface Props {
@@ -21,6 +21,7 @@ interface Props {
 
 export function CommentaryPanel({ notes, scholarId, onScholarPress, onRefPress }: Props) {
   const { base, getScholarColor } = useTheme();
+  const { content } = useTypography();
   const color = getScholarColor(scholarId);
 
   return (
@@ -37,7 +38,7 @@ export function CommentaryPanel({ notes, scholarId, onScholarPress, onRefPress }
           </Text>
           <TappableReference
             text={note.note}
-            style={[styles.noteText, { color: base.textDim }]}
+            style={[content.bodyMd, { color: base.textDim }]}
             onRefPress={onRefPress}
           />
         </View>
@@ -61,9 +62,5 @@ const styles = StyleSheet.create({
   noteRef: {
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 12,
-  },
-  noteText: {
-    fontSize: 14,
-    lineHeight: 22,
   },
 });

--- a/app/src/components/panels/DebatePanel.tsx
+++ b/app/src/components/panels/DebatePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../../theme';
 import type { DebateEntry } from '../../types';
 
 interface Props {
@@ -22,6 +22,7 @@ export function DebatePanel({
   onUpgradePress,
 }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('debate');
   if (!entries?.length) return null;
 
@@ -55,7 +56,7 @@ export function DebatePanel({
                       {sublabel}
                     </Text>
                   ) : null}
-                  <Text style={[styles.body, { color: base.textDim }]}>
+                  <Text style={[content.bodyMd, { color: base.textDim }]}>
                     {body}
                   </Text>
                 </View>
@@ -115,11 +116,6 @@ const styles = StyleSheet.create({
   sublabel: {
     fontFamily: fontFamily.bodyItalic,
     fontSize: 11,
-  },
-  body: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
   },
   debateModeCard: {
     borderWidth: 1,

--- a/app/src/components/panels/HebrewReadingPanel.tsx
+++ b/app/src/components/panels/HebrewReadingPanel.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { HebTextEntry } from '../../types';
 
 interface Props { entries: HebTextEntry[]; }
 
 export function HebrewReadingPanel({ entries }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('hebText');
   return (
     <View style={[styles.container, { gap: spacing.md }]}>
@@ -17,7 +18,7 @@ export function HebrewReadingPanel({ entries }: Props) {
             <Text style={[styles.transliterationText, { color: base.goldDim }]}>{e.tlit}</Text>
             <Text style={[styles.glossText, { color: base.gold }]}>— {e.gloss}</Text>
           </View>
-          {e.note ? <Text style={[styles.noteText, { color: base.textDim }]}>{e.note}</Text> : null}
+          {e.note ? <Text style={[content.bodySm, { color: base.textDim }]}>{e.note}</Text> : null}
         </View>
       ))}
     </View>
@@ -46,10 +47,5 @@ const styles = StyleSheet.create({
   glossText: {
     fontSize: 13,
     fontFamily: fontFamily.bodySemiBold,
-  },
-  noteText: {
-    fontSize: 13,
-    lineHeight: 20,
-    fontFamily: fontFamily.body,
   },
 });

--- a/app/src/components/panels/LiteraryStructurePanel.tsx
+++ b/app/src/components/panels/LiteraryStructurePanel.tsx
@@ -8,7 +8,7 @@
 
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { LitPanel } from '../../types';
 import { TabbedPanelRenderer } from './TabbedPanelRenderer';
 import type { TabConfig } from './TabbedPanelRenderer';
@@ -38,6 +38,7 @@ export function LiteraryStructurePanel({ data, defaultTab }: Props) {
 
 function StructureView({ data }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('lit');
 
   return (
@@ -53,13 +54,13 @@ function StructureView({ data }: Props) {
           <Text style={[styles.rowLabel, { color: colors.accent }]}>
             {row.label}
           </Text>
-          <Text style={[styles.rowText, { color: base.textDim }]}>
+          <Text style={[content.bodyMd, styles.rowText, { color: base.textDim }]}>
             {row.text}
           </Text>
         </View>
       ))}
       {data.note ? (
-        <Text style={[styles.note, { color: base.textMuted }]}>{data.note}</Text>
+        <Text style={[content.bodyItalic, { color: base.textMuted }]}>{data.note}</Text>
       ) : null}
     </View>
   );
@@ -85,13 +86,6 @@ const styles = StyleSheet.create({
     minWidth: 55,
   },
   rowText: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
     flex: 1,
-  },
-  note: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 13,
-    marginTop: spacing.xs,
   },
 });

--- a/app/src/components/panels/PeoplePanel.tsx
+++ b/app/src/components/panels/PeoplePanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { TappableReference } from '../TappableReference';
-import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../../theme';
 import type { PeopleEntry, ParsedRef } from '../../types';
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 
 export function PeoplePanel({ entries, onPersonPress, onRefPress }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('ppl');
   return (
     <View style={styles.container}>
@@ -29,7 +30,7 @@ export function PeoplePanel({ entries, onPersonPress, onRefPress }: Props) {
             {p.role}
           </Text>
           {p.text ? (
-            <TappableReference text={p.text} style={[styles.personText, { color: base.textDim }]} onRefPress={onRefPress} />
+            <TappableReference text={p.text} style={[content.bodySm, styles.personText, { color: base.textDim }]} onRefPress={onRefPress} />
           ) : null}
         </View>
       ))}
@@ -59,8 +60,6 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   personText: {
-    fontSize: 12,
-    lineHeight: 18,
     marginTop: 4,
   },
 });

--- a/app/src/components/panels/ReceptionPanel.tsx
+++ b/app/src/components/panels/ReceptionPanel.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { TappableReference } from '../TappableReference';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { ParsedRef, RecEntry } from '../../types';
 
 interface Props { entries: RecEntry[]; onRefPress?: (ref: ParsedRef) => void; }
 
 export function ReceptionPanel({ entries, onRefPress }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('rec');
   if (!entries?.length) {
     return (
@@ -33,12 +34,12 @@ export function ReceptionPanel({ entries, onRefPress }: Props) {
               </Text>
             ) : null}
             {body ? (
-              <Text style={[styles.quoteText, { color: base.textDim }]}>
+              <Text style={[content.bodyItalic, { color: base.textDim }]}>
                 {body}
               </Text>
             ) : null}
             {note ? (
-              <TappableReference text={note} style={[styles.noteText, { color: base.textMuted }]} onRefPress={onRefPress} />
+              <TappableReference text={note} style={[content.bodySm, { color: base.textMuted }]} onRefPress={onRefPress} />
             ) : null}
           </View>
         );
@@ -59,14 +60,5 @@ const styles = StyleSheet.create({
   headingText: {
     fontFamily: fontFamily.display,
     fontSize: 12,
-  },
-  quoteText: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 14,
-    lineHeight: 22,
-  },
-  noteText: {
-    fontSize: 13,
-    lineHeight: 20,
   },
 });

--- a/app/src/components/panels/SourcesPanel.tsx
+++ b/app/src/components/panels/SourcesPanel.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { TappableReference } from '../TappableReference';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { SourceEntry, ParsedRef } from '../../types';
 
 interface Props { entries: SourceEntry[]; onRefPress?: (ref: ParsedRef) => void; }
 
 export function SourcesPanel({ entries, onRefPress }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('src');
   return (
     <View style={styles.container}>
@@ -16,10 +17,10 @@ export function SourcesPanel({ entries, onRefPress }: Props) {
           <Text style={[styles.entryTitle, { color: colors.accent }]}>
             {e.title}
           </Text>
-          <Text style={[styles.entryQuote, { color: base.textDim }]}>
+          <Text style={[content.bodyItalic, { color: base.textDim }]}>
             {e.quote}
           </Text>
-          <TappableReference text={e.note} style={[styles.entryNote, { color: base.textMuted }]} onRefPress={onRefPress} />
+          <TappableReference text={e.note} style={[content.bodySm, { color: base.textMuted }]} onRefPress={onRefPress} />
         </View>
       ))}
     </View>
@@ -36,14 +37,5 @@ const styles = StyleSheet.create({
   entryTitle: {
     fontFamily: fontFamily.display,
     fontSize: 12,
-  },
-  entryQuote: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 14,
-    lineHeight: 22,
-  },
-  entryNote: {
-    fontSize: 13,
-    lineHeight: 20,
   },
 });

--- a/app/src/components/panels/TextualPanel.tsx
+++ b/app/src/components/panels/TextualPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../../theme';
 import type { TextualEntry } from '../../types';
 import { ManuscriptStoriesView } from './ManuscriptStoriesView';
 import type { ManuscriptStory } from './ManuscriptStoriesView';
@@ -9,6 +9,7 @@ interface Props { entries: TextualEntry[]; }
 
 export function TextualPanel({ entries }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('tx');
   return (
     <View style={styles.entryList}>
@@ -18,9 +19,9 @@ export function TextualPanel({ entries }: Props) {
             <Text style={[styles.entryRef, { color: colors.accent }]}>{e.ref}</Text>
             <Text style={[styles.entryTitle, { color: base.textDim }]}>{e.title}</Text>
           </View>
-          <Text style={[styles.entryContent, { color: base.textDim }]}>{e.content}</Text>
+          <Text style={[content.bodyMd, { color: base.textDim }]}>{e.content}</Text>
           {e.note ? (
-            <Text style={[styles.entryNote, { color: base.textMuted }]}>{e.note}</Text>
+            <Text style={[content.bodyItalic, { color: base.textMuted }]}>{e.note}</Text>
           ) : null}
         </View>
       ))}
@@ -110,16 +111,6 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.display,
     fontSize: 11,
   },
-  entryContent: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
-  },
-  entryNote: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: 13,
-  },
-
   // Composite tab bar
   tabBar: {
     flexDirection: 'row',

--- a/app/src/components/panels/ThreadingPanel.tsx
+++ b/app/src/components/panels/ThreadingPanel.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { TappableReference } from '../TappableReference';
 import { BadgeChip } from '../BadgeChip';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { ThreadEntry, ParsedRef } from '../../types';
 
 interface Props { entries: ThreadEntry[]; onRefPress?: (ref: ParsedRef) => void; }
 
 export function ThreadingPanel({ entries, onRefPress }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('thread');
   return (
     <View style={[styles.container, { gap: spacing.md }]}>
@@ -24,7 +25,7 @@ export function ThreadingPanel({ entries, onRefPress }: Props) {
             </Text>
             {e.type ? <BadgeChip label={e.type} color={colors.accent} /> : null}
           </View>
-          <TappableReference text={e.text} style={[styles.bodyText, { color: base.textDim }]} onRefPress={onRefPress} />
+          <TappableReference text={e.text} style={[content.bodySm, { color: base.textDim }]} onRefPress={onRefPress} />
         </View>
       ))}
     </View>
@@ -47,9 +48,5 @@ const styles = StyleSheet.create({
   },
   arrowText: {
     fontSize: 14,
-  },
-  bodyText: {
-    fontSize: 13,
-    lineHeight: 20,
   },
 });

--- a/app/src/components/panels/TranslationPanel.tsx
+++ b/app/src/components/panels/TranslationPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme, spacing, fontFamily } from '../../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../../theme';
 import type { TransPanel } from '../../types';
 
 interface TransRow {
@@ -74,6 +74,7 @@ function parseHtmlTable(html: string): TransRow[] {
 
 export function TranslationPanel({ data }: Props) {
   const { base, getPanelColors } = useTheme();
+  const { content } = useTypography();
   const colors = getPanelColors('trans');
 
   // Handle both structured data and legacy HTML strings
@@ -120,7 +121,7 @@ export function TranslationPanel({ data }: Props) {
               <Text style={[styles.versionLabel, { color: colors.accent }]}>
                 {t.version}
               </Text>
-              <Text style={[styles.transText, { color: base.textDim }]}>
+              <Text style={[content.bodyMd, styles.transText, { color: base.textDim }]}>
                 {t.text}
               </Text>
             </View>
@@ -161,8 +162,6 @@ const styles = StyleSheet.create({
     minWidth: 32,
   },
   transText: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
     flex: 1,
   },
 });

--- a/app/src/components/settings/ReadingScaleEditor.tsx
+++ b/app/src/components/settings/ReadingScaleEditor.tsx
@@ -1,0 +1,225 @@
+/**
+ * ReadingScaleEditor — Settings editor for reading text size.
+ *
+ * Segmented control (8 stops between 0.85× and 1.60×) with a live
+ * preview card showing a section header, a sample verse, a commentary
+ * snippet, and a chrome sample row. The chrome sample uses
+ * `typography.chrome.*` so users can see that chrome size doesn't move
+ * when the slider does — only content scales.
+ *
+ * See epic #1639 for the content/chrome split.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, PixelRatio } from 'react-native';
+import { useTheme, spacing, radii, fontFamily, useTypography, useOsFontScale, READING_SCALE_DEFAULT } from '../../theme';
+import { useSettingsStore } from '../../stores';
+
+/** 8 perceptually-graded stops between MIN (0.85) and MAX (1.60). */
+const STOPS = [0.85, 0.90, 1.00, 1.10, 1.20, 1.35, 1.50, 1.60] as const;
+
+function formatScale(n: number): string {
+  // Trim trailing zeros on whole values ("1.0×" → "1×") but keep 2 dp
+  // on in-between stops so the readout stays readable.
+  if (Math.abs(n - Math.round(n)) < 0.005) return `${Math.round(n)}×`;
+  return `${n.toFixed(2).replace(/0$/, '')}×`;
+}
+
+/** Closest stop to a given value — guards against fp drift after migration. */
+function closestStop(value: number): number {
+  let best: number = STOPS[0];
+  let bestDelta = Math.abs(value - best);
+  for (const s of STOPS) {
+    const d = Math.abs(value - s);
+    if (d < bestDelta) { best = s; bestDelta = d; }
+  }
+  return best;
+}
+
+interface Props {
+  /** Optional — test override for `PixelRatio.getFontScale()`. */
+  osScaleOverride?: number;
+}
+
+export function ReadingScaleEditor({ osScaleOverride }: Props = {}) {
+  const { base } = useTheme();
+  const typography = useTypography();
+  const liveOsScale = useOsFontScale();
+  const osScale = osScaleOverride ?? liveOsScale;
+  const readingScale = useSettingsStore((s) => s.readingScale);
+  const setReadingScale = useSettingsStore((s) => s.setReadingScale);
+
+  const activeStop = closestStop(readingScale);
+  const osLargeNote = osScale > 1.5;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.readoutRow}>
+        <Text style={[styles.readoutPrimary, { color: base.text }]}>
+          Reading size: {formatScale(readingScale)}
+        </Text>
+        {readingScale !== READING_SCALE_DEFAULT && (
+          <TouchableOpacity
+            onPress={() => setReadingScale(READING_SCALE_DEFAULT)}
+            accessibilityRole="button"
+            accessibilityLabel="Reset reading size to default"
+          >
+            <Text style={[styles.resetText, { color: base.gold }]}>Reset</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      <Text style={[styles.readoutSecondary, { color: base.textMuted }]}>
+        Device text size: {formatScale(osScale)} · Effective: {formatScale(typography.effective.content)} (content)
+      </Text>
+
+      {osLargeNote && (
+        <Text style={[styles.osNote, { color: base.textDim }]}>
+          Your device is set to a large text size. The app is honoring that setting.
+        </Text>
+      )}
+
+      <View
+        style={[styles.segmented, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+        accessibilityRole="adjustable"
+        accessibilityLabel="Reading size"
+        accessibilityValue={{ text: formatScale(readingScale) }}
+      >
+        {STOPS.map((stop) => {
+          const active = stop === activeStop;
+          return (
+            <TouchableOpacity
+              key={stop}
+              onPress={() => setReadingScale(stop)}
+              style={[
+                styles.segment,
+                active && { backgroundColor: base.gold + '25' },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Reading size ${formatScale(stop)}`}
+              accessibilityState={{ selected: active }}
+            >
+              <Text
+                style={[
+                  styles.segmentText,
+                  { color: active ? base.gold : base.textMuted },
+                ]}
+              >
+                {formatScale(stop)}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* Live preview */}
+      <View
+        style={[styles.preview, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+        accessibilityLabel="Reading size preview"
+      >
+        <Text style={[typography.content.displayLg, { color: base.gold }]}>
+          In the Beginning
+        </Text>
+        <Text style={[typography.content.bodyLg, styles.previewVerse, { color: base.text }]}>
+          In the beginning, God created the heavens and the earth.
+        </Text>
+        <Text style={[typography.content.bodyMd, styles.previewCommentary, { color: base.textDim }]}>
+          Calvin: &ldquo;The simple and genuine sense, which will best agree with the
+          meaning of Moses, is that God, by the power of his Word and Spirit,
+          created out of nothing the heaven and the earth.&rdquo;
+        </Text>
+        <View style={[styles.chromeRow, { borderTopColor: base.border }]}>
+          <Text style={[typography.chrome.uiBold, { color: base.textMuted }]}>
+            Chrome stays the same →
+          </Text>
+          <View style={[styles.chip, { backgroundColor: base.gold + '15', borderColor: base.gold + '40' }]}>
+            <Text style={[typography.chrome.uiSm, { color: base.gold }]}>chip</Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// Preserved for tests that probe segmentation logic.
+export const READING_SCALE_STOPS = STOPS;
+
+/** @internal */
+export const _internal = { closestStop, formatScale };
+
+// Expose PixelRatio for tests that want to mock module-scope fallbacks.
+export const _pixelRatio = PixelRatio;
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  readoutRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+  },
+  readoutPrimary: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+  },
+  resetText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+  readoutSecondary: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+  },
+  osNote: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  segmented: {
+    flexDirection: 'row',
+    borderRadius: radii.md,
+    borderWidth: 1,
+    padding: 2,
+    marginTop: spacing.xs,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: spacing.xs + 2,
+    alignItems: 'center',
+    borderRadius: radii.sm,
+  },
+  segmentText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+  },
+  preview: {
+    borderRadius: radii.md,
+    borderWidth: 1,
+    padding: spacing.md,
+    marginTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  previewVerse: {
+    marginTop: spacing.xs,
+  },
+  previewCommentary: {
+    fontFamily: fontFamily.bodyItalic,
+    marginTop: spacing.xs,
+  },
+  chromeRow: {
+    marginTop: spacing.sm,
+    paddingTop: spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  chip: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+  },
+});

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -78,6 +78,13 @@ export async function setPreference(key: string, value: string): Promise<void> {
   );
 }
 
+export async function deletePreference(key: string): Promise<void> {
+  await getUserDb().runAsync(
+    'DELETE FROM user_preferences WHERE key = ?',
+    [key],
+  );
+}
+
 // ── Highlights (write) ───────────────────────────────────────────
 
 export async function setHighlight(

--- a/app/src/hooks/chapter/useChapterTTS.ts
+++ b/app/src/hooks/chapter/useChapterTTS.ts
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback, type RefObject } from 'react';
 import type { ScrollView } from 'react-native';
 import { useTTS } from '../useTTS';
 import { useSettingsStore } from '../../stores';
+import { useTypography } from '../../theme';
 import type { Verse, Section } from '../../types';
 
 interface UseChapterTTSOptions {
@@ -30,7 +31,8 @@ export function useChapterTTS({
   chapterNum,
 }: UseChapterTTSOptions) {
   const ttsVoice = useSettingsStore((s) => s.ttsVoice);
-  const fontSize = useSettingsStore((s) => s.fontSize);
+  const { content } = useTypography();
+  const verseFontSize = content.bodyLg.fontSize;
   const tts = useTTS(verses, ttsVoice || undefined);
   const [ttsActive, setTtsActive] = useState(false);
 
@@ -57,7 +59,7 @@ export function useChapterTTS({
     const sectionY = sectionYMap.current[sec.id];
     if (sectionY == null) return;
     const verseIndex = verseNum - sec.verse_start;
-    const estimatedVerseHeight = fontSize * 1.6 + 16;
+    const estimatedVerseHeight = verseFontSize * 1.6 + 16;
     const verseOffsetY = 52 + verseIndex * estimatedVerseHeight;
 
     scrollRef.current?.scrollTo({
@@ -65,7 +67,7 @@ export function useChapterTTS({
       animated: true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollRef, sectionYMap, verseYMap are stable refs
-  }, [ttsActive, tts.currentVerse, verses, sections, fontSize]);
+  }, [ttsActive, tts.currentVerse, verses, sections, verseFontSize]);
 
   // Stop TTS on chapter change
   useEffect(() => {

--- a/app/src/screens/ArchaeologyDetailScreen.tsx
+++ b/app/src/screens/ArchaeologyDetailScreen.tsx
@@ -30,12 +30,13 @@ import { MetadataPill } from '../components/MetadataPill';
 import { GoldSeparator } from '../components/GoldSeparator';
 import { useArchaeologyDetail } from '../hooks/useArchaeology';
 import { usePremium } from '../hooks/usePremium';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import type { ArchaeologyVerseLink } from '../types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function ArchaeologyDetailScreen() {
   const { base } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'ArchaeologyDetail'>>();
   const route = useRoute<ScreenRouteProp<'Explore', 'ArchaeologyDetail'>>();
   const { discoveryId } = route.params;
@@ -99,13 +100,13 @@ function ArchaeologyDetailScreen() {
           {/* Significance — always visible */}
           <View style={[styles.significanceCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '30' }]}>
             <DetailSectionTitle title="Significance" transform="uppercase" />
-            <Text style={[styles.significanceText, { color: base.text }]}>
+            <Text style={[content.bodyMd, styles.significanceText, { color: base.text }]}>
               {discovery.significance}
             </Text>
           </View>
 
           {/* Description */}
-          <Text style={[styles.bodyText, { color: base.text }]}>
+          <Text style={[content.bodyMd, styles.bodyText, { color: base.text }]}>
             {discovery.description}
           </Text>
 
@@ -124,7 +125,7 @@ function ArchaeologyDetailScreen() {
                       {vl.verse_ref}
                     </Text>
                     {vl.relevance && (
-                      <Text style={[styles.verseRelevance, { color: base.textDim }]}>
+                      <Text style={[content.bodySm, styles.verseRelevance, { color: base.textDim }]}>
                         {vl.relevance}
                       </Text>
                     )}
@@ -139,7 +140,7 @@ function ArchaeologyDetailScreen() {
             <View style={styles.sourceSection}>
               <GoldSeparator marginBottom={spacing.md} />
               <DetailSectionTitle title="Source" transform="uppercase" />
-              <Text style={[styles.sourceText, { color: base.textDim }]}>
+              <Text style={[content.bodySm, styles.sourceText, { color: base.textDim }]}>
                 {discovery.source}
               </Text>
             </View>
@@ -152,7 +153,7 @@ function ArchaeologyDetailScreen() {
               <Text style={[styles.gateTitle, { color: base.text }]}>
                 Full discovery details available with Companion+
               </Text>
-              <Text style={[styles.gateDesc, { color: base.textDim }]}>
+              <Text style={[content.bodySm, styles.gateDesc, { color: base.textDim }]}>
                 Unlock linked verses, source references, and more.
               </Text>
               <BadgeChip
@@ -200,14 +201,8 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   significanceText: {
-    fontFamily: fontFamily.body,
-    fontSize: 15,
-    lineHeight: 25,
   },
   bodyText: {
-    fontFamily: fontFamily.body,
-    fontSize: 15,
-    lineHeight: 25,
     marginBottom: spacing.md,
   },
   verseCard: {
@@ -222,17 +217,11 @@ const styles = StyleSheet.create({
     marginBottom: 2,
   },
   verseRelevance: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
   },
   sourceSection: {
     marginTop: spacing.md,
   },
   sourceText: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
   },
   gateCard: {
     borderWidth: 1,
@@ -252,10 +241,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.xs,
   },
   gateDesc: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
     textAlign: 'center',
-    lineHeight: 20,
     marginBottom: spacing.md,
   },
   loadingPad: { padding: spacing.lg },

--- a/app/src/screens/BookIntroScreen.tsx
+++ b/app/src/screens/BookIntroScreen.tsx
@@ -21,11 +21,12 @@ import { useBookIntro } from '../hooks/useBookIntro';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { BadgeChip } from '../components/BadgeChip';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function BookIntroScreen() {
   const { base } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<ScreenNavProp<'Read', 'BookIntro'>>();
   const route = useRoute<ScreenRouteProp<'Read', 'BookIntro'>>();
   const { bookId } = route.params ?? {};
@@ -65,7 +66,7 @@ function BookIntroScreen() {
               ] as [string, string][]).map(([label, value]) => (
                 <View key={label} style={styles.atAGlanceCell}>
                   <Text style={[styles.atAGlanceCellLabel, { color: base.gold }]}>{label}</Text>
-                  <Text style={[styles.atAGlanceCellValue, { color: base.text }]}>{value}</Text>
+                  <Text style={[content.bodySm, styles.atAGlanceCellValue, { color: base.text }]}>{value}</Text>
                 </View>
               ))}
             </View>
@@ -127,7 +128,7 @@ function BookIntroScreen() {
                   style={[styles.keyVerseCard, { backgroundColor: base.bgElevated, borderColor: base.gold + '20' }]}
                 >
                   <Text style={[styles.keyVerseRef, { color: base.gold }]}>{verse.ref}</Text>
-                  <Text style={[styles.keyVerseText, { color: base.text }]}>{verse.text}</Text>
+                  <Text style={[content.bodyItalic, styles.keyVerseText, { color: base.text }]}>{verse.text}</Text>
                   <Text style={[styles.keyVerseWhy, { color: base.textMuted }]}>{verse.why}</Text>
                 </TouchableOpacity>
               ))}
@@ -139,7 +140,7 @@ function BookIntroScreen() {
         {intro.christ_in && (
           <View style={[styles.christInBlock, { backgroundColor: base.gold + '0D', borderColor: base.gold + '30' }]}>
             <Text style={[styles.enrichLabel, { color: base.gold }]}>CHRIST IN THIS BOOK</Text>
-            <Text style={[styles.bodyText, { color: base.text }]}>{intro.christ_in}</Text>
+            <Text style={[content.bodyMd, styles.bodyText, { color: base.text }]}>{intro.christ_in}</Text>
           </View>
         )}
 
@@ -148,25 +149,25 @@ function BookIntroScreen() {
           <View style={[styles.authorshipBlock, { borderBottomColor: base.border }]}>
             <Text style={[styles.authorshipLabel, { color: base.gold }]}>AUTHORSHIP</Text>
             {typeof intro.authorship === 'string' ? (
-              <Text style={[styles.bodyText, { color: base.textDim }]}>{intro.authorship}</Text>
+              <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{intro.authorship}</Text>
             ) : (
               <View style={styles.authorshipDetails}>
                 {intro.authorship.author && (
                   <View>
                     <Text style={[styles.authorshipSubLabel, { color: base.gold }]}>Author</Text>
-                    <Text style={[styles.bodyText, { color: base.textDim }]}>{intro.authorship.author}</Text>
+                    <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{intro.authorship.author}</Text>
                   </View>
                 )}
                 {intro.authorship.date && (
                   <View>
                     <Text style={[styles.authorshipSubLabel, { color: base.gold }]}>Date</Text>
-                    <Text style={[styles.bodyText, { color: base.textDim }]}>{intro.authorship.date}</Text>
+                    <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{intro.authorship.date}</Text>
                   </View>
                 )}
                 {intro.authorship.prompt && (
                   <View>
                     <Text style={[styles.authorshipSubLabel, { color: base.gold }]}>Purpose</Text>
-                    <Text style={[styles.bodyText, { color: base.textDim }]}>{intro.authorship.prompt}</Text>
+                    <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{intro.authorship.prompt}</Text>
                   </View>
                 )}
               </View>
@@ -183,7 +184,7 @@ function BookIntroScreen() {
 
             {/* Prose content — field is "content" in JSON, not "body" */}
             {(section.content || section.body) && (
-              <Text style={[styles.bodyText, { color: base.textDim }]}>
+              <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>
                 {section.content ?? section.body}
               </Text>
             )}
@@ -234,7 +235,7 @@ function BookIntroScreen() {
 
         {/* Fallback text (no sections) */}
         {!intro.sections && intro.text && (
-          <Text style={[styles.bodyText, { color: base.textDim }]}>{intro.text}</Text>
+          <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{intro.text}</Text>
         )}
       </ScrollView>
     </SafeAreaView>
@@ -287,9 +288,6 @@ const styles = StyleSheet.create({
     marginBottom: 2,
   },
   atAGlanceCellValue: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 20,
   },
   outlineBar: {
     flexDirection: 'row',
@@ -325,9 +323,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.xs,
   },
   keyVerseText: {
-    fontFamily: fontFamily.bodyItalic ?? fontFamily.body,
-    fontSize: 15,
-    lineHeight: 24,
     marginBottom: spacing.xs,
   },
   keyVerseWhy: {
@@ -370,9 +365,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   bodyText: {
-    fontFamily: fontFamily.body,
-    fontSize: 15,
-    lineHeight: 24,
   },
   outlineBlock: {
     marginTop: spacing.sm,

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -62,7 +62,6 @@ function ChapterScreen() {
   const route = useRoute<ScreenRouteProp<'Read', 'Chapter'>>();
   const { bookId, chapterNum, openPanel, planId, planDayNum, verseNum: initialVerseNum } = route.params ?? {};
 
-  const fontSize = useSettingsStore((s) => s.fontSize);
   const translation = useSettingsStore((s) => s.translation);
   const comparisonTranslation = useSettingsStore((s) => s.comparisonTranslation);
   const setComparisonTranslation = useSettingsStore((s) => s.setComparisonTranslation);
@@ -306,7 +305,7 @@ function ChapterScreen() {
 
         <ChapterReaderProvider
           verse={{
-            verses, vhlGroups, activeVhlGroups, notedVerses, fontSize,
+            verses, vhlGroups, activeVhlGroups, notedVerses,
             redLetterVerses, highlightMap, activeVerseNum: ttsHook.activeVerseNum,
             comparisonVerses: comparisonTranslation ? comparisonVerses : undefined,
             comparisonLabel, primaryLabel,

--- a/app/src/screens/DebateDetailScreen.tsx
+++ b/app/src/screens/DebateDetailScreen.tsx
@@ -18,7 +18,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeft } from 'lucide-react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import { useDebateTopic } from '../hooks/useDebateTopics';
 import { usePremium } from '../hooks/usePremium';
 import { UpgradePrompt } from '../components/UpgradePrompt';
@@ -33,6 +33,7 @@ type Route = ScreenRouteProp<'Explore', 'DebateDetail'>;
 
 function DebateDetailScreen() {
   const { base } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<Nav>();
   const route = useRoute<Route>();
   const { topicId } = route.params;
@@ -116,7 +117,7 @@ function DebateDetailScreen() {
         {/* Question card */}
         <View style={[styles.questionCard, { backgroundColor: base.bgElevated, borderLeftColor: base.gold }]}>
           <Text style={[styles.questionLabel, { color: base.textMuted }]}>THE QUESTION</Text>
-          <Text style={[styles.questionText, { color: base.text }]}>{topic.question}</Text>
+          <Text style={[content.bodyLg, { color: base.text }]}>{topic.question}</Text>
           {topic.passage ? (
             <Text style={[styles.passageText, { color: base.gold }]}>{topic.passage}</Text>
           ) : null}
@@ -126,7 +127,7 @@ function DebateDetailScreen() {
         {topic.context ? (
           <View style={styles.section}>
             <Text style={[styles.sectionLabel, { color: base.textMuted }]}>CONTEXT</Text>
-            <Text style={[styles.bodyText, { color: base.text }]}>{topic.context}</Text>
+            <Text style={[content.bodyMd, { color: base.text }]}>{topic.context}</Text>
           </View>
         ) : null}
 
@@ -176,7 +177,7 @@ function DebateDetailScreen() {
         {topic.synthesis ? (
           <View style={[styles.synthesisCard, { borderColor: base.gold + '40', backgroundColor: base.gold + '08' }]}>
             <Text style={[styles.synthesisLabel, { color: base.gold }]}>SYNTHESIS</Text>
-            <Text style={[styles.bodyText, { color: base.text }]}>{topic.synthesis}</Text>
+            <Text style={[content.bodyMd, { color: base.text }]}>{topic.synthesis}</Text>
           </View>
         ) : null}
 
@@ -259,11 +260,6 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     marginBottom: spacing.xs,
   },
-  questionText: {
-    fontFamily: fontFamily.displaySemiBold,
-    fontSize: 16,
-    lineHeight: 24,
-  },
   passageText: {
     fontFamily: fontFamily.ui,
     fontSize: 12,
@@ -278,11 +274,6 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.8,
     marginBottom: spacing.sm,
-  },
-  bodyText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 14,
-    lineHeight: 22,
   },
   synthesisCard: {
     borderWidth: 1,

--- a/app/src/screens/DictionaryDetailScreen.tsx
+++ b/app/src/screens/DictionaryDetailScreen.tsx
@@ -18,7 +18,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeft } from 'lucide-react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import { useDictionaryDetail } from '../hooks/useDictionary';
 import { DictionaryCrossLink } from '../components/DictionaryCrossLink';
 import { TappableRefs } from '../components/TappableRefs';
@@ -33,6 +33,7 @@ type Route = ScreenRouteProp<'Explore', 'DictionaryDetail'>;
 
 function DictionaryDetailScreen() {
   const { base } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<Nav>();
   const route = useRoute<Route>();
   const { entryId } = route.params;
@@ -146,7 +147,7 @@ function DictionaryDetailScreen() {
 
         {/* Definition with inline tappable refs */}
         <Text style={[styles.sectionLabel, { color: base.textMuted }]}>DEFINITION</Text>
-        <Text style={[styles.definition, { color: base.text }]}>
+        <Text style={[content.bodyMd, styles.definition, { color: base.text }]}>
           {segments.map((seg, i) =>
             seg.type === 'ref' ? (
               <Text
@@ -253,9 +254,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   definition: {
-    fontFamily: fontFamily.ui,
-    fontSize: 14,
-    lineHeight: 22,
   },
   relatedRow: {
     flexDirection: 'row',

--- a/app/src/screens/DifficultPassageDetailScreen.tsx
+++ b/app/src/screens/DifficultPassageDetailScreen.tsx
@@ -37,7 +37,7 @@ import {
   useDifficultPassage,
   DifficultPassageResponse,
 } from '../hooks/useDifficultPassages';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import type { ExploreStackParamList } from '../navigation/types';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
@@ -68,6 +68,7 @@ function ResponseCard({
   onScholarPress: (id: string) => void;
 }) {
   const { base, families } = useTheme();
+  const { content } = useTypography();
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   const toggleExpanded = useCallback(() => {
@@ -118,7 +119,7 @@ function ResponseCard({
       )}
 
       {/* Summary */}
-      <Text style={[styles.summaryText, { color: base.textDim }]}>{response.summary}</Text>
+      <Text style={[content.bodySm, styles.summaryText, { color: base.textDim }]}>{response.summary}</Text>
 
       {/* Expand/Collapse toggle */}
       {hasAnalysis && (
@@ -179,6 +180,7 @@ function ResponseCard({
 
 function DifficultPassageDetailScreen() {
   const { base, categories: catColors, severity: sevColors } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<Nav>();
   const route = useRoute<Route>();
   const { passageId } = route.params;
@@ -278,7 +280,7 @@ function DifficultPassageDetailScreen() {
             <Text style={[styles.sectionTitle, { color: base.gold }]}>The Question</Text>
           </View>
           <View style={[styles.questionCard, { backgroundColor: base.bgElevated, borderLeftColor: base.gold }]}>
-            <Text style={[styles.questionText, { color: base.text }]}>{passage.question}</Text>
+            <Text style={[content.bodyMd, styles.questionText, { color: base.text }]}>{passage.question}</Text>
           </View>
         </View>
 
@@ -290,7 +292,7 @@ function DifficultPassageDetailScreen() {
               <Text style={[styles.sectionTitle, { color: base.gold }]}>Context</Text>
             </View>
             <View style={[styles.contextBlock, { borderLeftColor: base.border }]}>
-              <Text style={[styles.contextText, { color: base.textDim }]}>{passage.context}</Text>
+              <Text style={[content.bodySm, styles.contextText, { color: base.textDim }]}>{passage.context}</Text>
             </View>
           </View>
         ) : null}
@@ -508,9 +510,6 @@ const styles = StyleSheet.create({
     padding: spacing.md,
   },
   questionText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 15,
-    lineHeight: 24,
     fontStyle: 'italic',
   },
 
@@ -520,9 +519,6 @@ const styles = StyleSheet.create({
     borderLeftWidth: 2,
   },
   contextText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 13,
-    lineHeight: 21,
   },
 
   // Key Verses
@@ -623,9 +619,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
   },
   summaryText: {
-    fontFamily: fontFamily.ui,
-    fontSize: 13,
-    lineHeight: 21,
   },
   expandToggle: {
     flexDirection: 'row',

--- a/app/src/screens/ExtraBiblicalDetailScreen.tsx
+++ b/app/src/screens/ExtraBiblicalDetailScreen.tsx
@@ -32,7 +32,7 @@ import {
 } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeft } from 'lucide-react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import { usePremium } from '../hooks/usePremium';
 import { useExtraBiblicalEntry } from '../hooks/useExtraBiblicalEntry';
 import { UpgradePrompt } from '../components/UpgradePrompt';
@@ -54,6 +54,7 @@ type Route = ScreenRouteProp<'Explore', 'ExtraBiblicalDetail'>;
 
 function ExtraBiblicalDetailScreen() {
   const { base } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<Nav>();
   const route = useRoute<Route>();
   const { id } = route.params;
@@ -130,7 +131,7 @@ function ExtraBiblicalDetailScreen() {
       <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
         <ScreenHeader onBack={() => navigation.goBack()} title="Not Found" />
         <View style={styles.center}>
-          <Text style={[styles.bodyText, { color: base.textDim }]}>
+          <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>
             Entry not found.
           </Text>
         </View>
@@ -151,7 +152,7 @@ function ExtraBiblicalDetailScreen() {
         {/* Section 2: Brief summary — free users get first paragraph only */}
         <View style={styles.section}>
           <Text style={[styles.sectionLabel, { color: base.textMuted }]}>SUMMARY</Text>
-          <Text style={[styles.bodyText, { color: base.text }]}>
+          <Text style={[content.bodyMd, styles.bodyText, { color: base.text }]}>
             {isPremium ? entry.brief_summary : firstParagraph}
           </Text>
         </View>
@@ -222,6 +223,7 @@ function PremiumSections({
   onExternalLink: (url: string) => void;
 }) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <>
       {entry.nt_citations.length > 0 ? (
@@ -288,7 +290,7 @@ function PremiumSections({
 
       <Section label="FULL SUMMARY">
         {entry.full_summary ? (
-          <Text style={[styles.bodyText, { color: base.text }]}>
+          <Text style={[content.bodyMd, styles.bodyText, { color: base.text }]}>
             {entry.full_summary}
           </Text>
         ) : (
@@ -310,6 +312,7 @@ function PremiumSections({
 
 function LockedFooter({ onUpgrade }: { onUpgrade: () => void }) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <TouchableOpacity
       onPress={onUpgrade}
@@ -324,7 +327,7 @@ function LockedFooter({ onUpgrade }: { onUpgrade: () => void }) {
       <Text style={[styles.lockedTitle, { color: base.gold }]}>
         {'✨ Unlock the full entry'}
       </Text>
-      <Text style={[styles.lockedDesc, { color: base.textDim }]}>
+      <Text style={[content.bodySm, styles.lockedDesc, { color: base.textDim }]}>
         NT citations, OT allusions, scholar voices, related debates,
         difficult passages, journeys, and further reading.
       </Text>
@@ -356,6 +359,7 @@ function NTCitationRow({
   onPress: (ref: string) => void;
 }) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <TouchableOpacity
       onPress={() => onPress(cit.ref)}
@@ -365,7 +369,7 @@ function NTCitationRow({
       style={[styles.citationRow, { borderColor: base.gold + '30' }]}
     >
       <Text style={[styles.citationRef, { color: base.gold }]}>{cit.ref}</Text>
-      <Text style={[styles.citationCites, { color: base.textDim }]}>
+      <Text style={[content.bodySm, styles.citationCites, { color: base.textDim }]}>
         {'→ '}
         {cit.cites}
       </Text>
@@ -386,6 +390,7 @@ function OTAllusionRow({
   onPress: (ref: string) => void;
 }) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <TouchableOpacity
       onPress={() => onPress(allusion.ref)}
@@ -397,7 +402,7 @@ function OTAllusionRow({
       <Text style={[styles.citationRef, { color: base.gold }]}>
         {allusion.ref}
       </Text>
-      <Text style={[styles.bodyText, { color: base.textDim }]}>
+      <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>
         {allusion.connection}
       </Text>
     </TouchableOpacity>
@@ -412,6 +417,7 @@ function ScholarVoiceRow({
   onPress: (scholarId: string) => void;
 }) {
   const { base } = useTheme();
+  const { content } = useTypography();
   return (
     <View style={styles.voiceBlock}>
       <TouchableOpacity
@@ -423,7 +429,7 @@ function ScholarVoiceRow({
           {formatScholarLabel(voice.scholar_id)}
         </Text>
       </TouchableOpacity>
-      <Text style={[styles.bodyText, { color: base.textDim }]}>
+      <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>
         {voice.position}
       </Text>
     </View>
@@ -607,9 +613,6 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
   },
   bodyText: {
-    fontFamily: fontFamily.body,
-    fontSize: 15,
-    lineHeight: 24,
   },
   citationRow: {
     borderWidth: 1,
@@ -623,8 +626,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   citationCites: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
   },
   citationType: {
     fontFamily: fontFamily.uiSemiBold,
@@ -693,9 +694,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   lockedDesc: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
     textAlign: 'center',
   },
 });

--- a/app/src/screens/ProphecyDetailScreen.tsx
+++ b/app/src/screens/ProphecyDetailScreen.tsx
@@ -23,7 +23,7 @@ import { ContentImageGallery } from '../components/ContentImageGallery';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { BadgeChip } from '../components/BadgeChip';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, useTypography } from '../theme';
 import type { ProphecyChainLink } from '../types';
 import { logger } from '../utils/logger';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
@@ -77,6 +77,7 @@ function formatLinkRef(link: ProphecyChainLink): string {
 
 function ProphecyDetailScreen() {
   const { base, prophecyCategories, roles: roleColors, testament } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'ProphecyDetail'>>();
   const route = useRoute<ScreenRouteProp<'Explore', 'ProphecyDetail'>>();
   const { chainId } = route.params ?? {};
@@ -138,7 +139,7 @@ function ProphecyDetailScreen() {
         {/* Summary callout */}
         {chain.summary && (
           <View style={[styles.summaryBox, { backgroundColor: base.bgElevated, borderLeftColor: base.gold }]}>
-            <Text style={[styles.summaryText, { color: base.textDim }]}>{chain.summary}</Text>
+            <Text style={[content.bodySm, styles.summaryText, { color: base.textDim }]}>{chain.summary}</Text>
           </View>
         )}
 
@@ -236,9 +237,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   summaryText: {
-    fontFamily: fontFamily.body,
-    fontSize: 14,
-    lineHeight: 22,
   },
   tagRow: {
     flexDirection: 'row',

--- a/app/src/screens/SettingsScreen.tsx
+++ b/app/src/screens/SettingsScreen.tsx
@@ -46,10 +46,8 @@ function SettingsScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'More', 'Settings'>>();
   const translation = useSettingsStore((s) => s.translation);
-  const fontSize = useSettingsStore((s) => s.fontSize);
   const vhlEnabled = useSettingsStore((s) => s.vhlEnabled);
   const { switchTranslation } = useTranslationSwitch();
-  const setFontSize = useSettingsStore((s) => s.setFontSize);
   const setVhlEnabled = useSettingsStore((s) => s.setVhlEnabled);
   const redLetterEnabled = useSettingsStore((s) => s.redLetterEnabled);
   const setRedLetterEnabled = useSettingsStore((s) => s.setRedLetterEnabled);
@@ -94,8 +92,6 @@ function SettingsScreen() {
           onTranslationChange={switchTranslation}
           theme={theme}
           setTheme={setTheme}
-          fontSize={fontSize}
-          setFontSize={setFontSize}
           vhlEnabled={vhlEnabled}
           setVhlEnabled={setVhlEnabled}
           redLetterEnabled={redLetterEnabled}

--- a/app/src/screens/WordStudyDetailScreen.tsx
+++ b/app/src/screens/WordStudyDetailScreen.tsx
@@ -14,13 +14,14 @@ import { ContentImageGallery } from '../components/ContentImageGallery';
 import { BadgeChip } from '../components/BadgeChip';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useTheme, spacing, fontFamily, useTypography } from '../theme';
 import type { WordStudy } from '../types';
 import { logger } from '../utils/logger';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function WordStudyDetailScreen() {
   const { base, panels } = useTheme();
+  const { content } = useTypography();
   const navigation = useNavigation<ScreenNavProp<'Explore', 'WordStudyDetail'>>();
   const route = useRoute<ScreenRouteProp<'Explore', 'WordStudyDetail'>>();
   const { wordId } = route.params ?? {};
@@ -107,7 +108,7 @@ function WordStudyDetailScreen() {
         {word.semantic_range && (
           <View style={styles.section}>
             <Text style={[styles.sectionLabel, { color: base.gold }]}>SEMANTIC RANGE</Text>
-            <Text style={[styles.bodyText, { color: base.textDim }]}>{word.semantic_range}</Text>
+            <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{word.semantic_range}</Text>
           </View>
         )}
 
@@ -115,7 +116,7 @@ function WordStudyDetailScreen() {
         {word.note && (
           <View style={styles.section}>
             <Text style={[styles.sectionLabel, { color: base.gold }]}>THEOLOGICAL NOTE</Text>
-            <Text style={[styles.bodyText, { color: base.textDim }]}>{word.note}</Text>
+            <Text style={[content.bodyMd, styles.bodyText, { color: base.textDim }]}>{word.note}</Text>
           </View>
         )}
 
@@ -129,7 +130,7 @@ function WordStudyDetailScreen() {
                   <BadgeChip label={occ.ref} color={base.textMuted} />
                   {occ.gloss ? <Text style={[styles.occurrenceGloss, { color: base.goldDim }]}>{occ.gloss}</Text> : null}
                 </View>
-                {occ.ctx ? <Text style={[styles.occurrenceCtx, { color: base.textDim }]}>{occ.ctx}</Text> : null}
+                {occ.ctx ? <Text style={[content.bodySm, styles.occurrenceCtx, { color: base.textDim }]}>{occ.ctx}</Text> : null}
               </View>
             ))}
           </View>
@@ -199,9 +200,6 @@ const styles = StyleSheet.create({
     marginTop: spacing.xs,
   },
   bodyText: {
-    fontFamily: fontFamily.body,
-    fontSize: 15,
-    lineHeight: 24,
     marginTop: spacing.xs,
   },
   occurrenceRow: {
@@ -219,9 +217,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   occurrenceCtx: {
-    fontFamily: fontFamily.body,
-    fontSize: 13,
-    lineHeight: 20,
     marginTop: 4,
   },
 });

--- a/app/src/screens/settings/PreferencesSection.tsx
+++ b/app/src/screens/settings/PreferencesSection.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Switch, StyleSheet } from 'react-native';
+import { Switch } from 'react-native';
 import type { BaseColors } from '../../theme/palettes';
 import type { DropdownOption } from '../../components/CompactDropdown';
 import { CompactDropdown } from '../../components/CompactDropdown';
 import { ThemePicker } from '../../components/ThemePicker';
-import { spacing, fontFamily } from '../../theme';
+import { ReadingScaleEditor } from '../../components/settings/ReadingScaleEditor';
 import { SectionLabel } from './SectionLabel';
 import { SettingsRow } from './SettingsRow';
 
@@ -17,8 +17,6 @@ interface PreferencesSectionProps {
   onTranslationChange: (key: string) => void;
   theme: ThemePreference;
   setTheme: (t: ThemePreference) => void;
-  fontSize: number;
-  setFontSize: (s: number) => void;
   vhlEnabled: boolean;
   setVhlEnabled: (v: boolean) => void;
   redLetterEnabled: boolean;
@@ -36,8 +34,6 @@ export function PreferencesSection({
   onTranslationChange,
   theme,
   setTheme,
-  fontSize,
-  setFontSize,
   vhlEnabled,
   setVhlEnabled,
   redLetterEnabled,
@@ -63,35 +59,8 @@ export function PreferencesSection({
       {/* Appearance */}
       <ThemePicker theme={theme} setTheme={setTheme} />
 
-      {/* Font Size */}
-      <SettingsRow label={`Font Size: ${fontSize}pt`} base={base}>
-        <View style={localStyles.sizeControls}>
-          <TouchableOpacity
-            onPress={() => setFontSize(fontSize - 1)}
-            style={[localStyles.sizeButton, { backgroundColor: base.bgElevated, borderColor: base.border }]}
-          >
-            <Text style={[localStyles.sizeButtonText, { color: base.gold }]}>{'\u2212'}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => setFontSize(fontSize + 1)}
-            style={[localStyles.sizeButton, { backgroundColor: base.bgElevated, borderColor: base.border }]}
-          >
-            <Text style={[localStyles.sizeButtonText, { color: base.gold }]}>+</Text>
-          </TouchableOpacity>
-        </View>
-      </SettingsRow>
-
-      {/* Font preview */}
-      <View style={localStyles.preview}>
-        <Text
-          style={[
-            localStyles.previewText,
-            { fontSize, lineHeight: fontSize * 1.6, color: base.textDim },
-          ]}
-        >
-          In the beginning God created the heavens and the earth.
-        </Text>
-      </View>
+      {/* Reading size (replaces legacy Font Size +/- row, #1642) */}
+      <ReadingScaleEditor />
 
       {/* VHL Toggle */}
       <SettingsRow label="Verse Highlighting" base={base}>
@@ -135,28 +104,3 @@ export function PreferencesSection({
     </>
   );
 }
-
-const localStyles = StyleSheet.create({
-  sizeControls: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-    alignItems: 'center',
-  },
-  sizeButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 1,
-  },
-  sizeButtonText: {
-    fontSize: 16,
-  },
-  preview: {
-    paddingVertical: spacing.sm,
-  },
-  previewText: {
-    fontFamily: fontFamily.body,
-  },
-});

--- a/app/src/stores/settingsStore.ts
+++ b/app/src/stores/settingsStore.ts
@@ -4,7 +4,7 @@
  * Hydrated from SQLite user_preferences table on app start.
  * Changes are written back to SQLite immediately.
  *
- * NOTE: Setter functions (setTranslation, setFontSize, etc.) update
+ * NOTE: Setter functions (setTranslation, setReadingScale, etc.) update
  * Zustand state synchronously then persist to SQLite in the background.
  * Callers intentionally fire-and-forget — the UI reflects the new value
  * instantly while the DB write completes asynchronously. If persistence
@@ -13,7 +13,7 @@
  */
 
 import { create } from 'zustand';
-import { getPreference, setPreference } from '../db/user';
+import { deletePreference, getPreference, setPreference } from '../db/user';
 import { TRANSLATION_MAP } from '../db/translationRegistry';
 import { clampReadingScale, READING_SCALE_DEFAULT } from '../theme/scale';
 import { logger } from '../utils/logger';
@@ -24,7 +24,6 @@ const VALID_THEMES: ThemePreference[] = ['dark', 'sepia', 'light', 'system'];
 
 interface SettingsState {
   translation: string;
-  fontSize: number;
   readingScale: number;
   vhlEnabled: boolean;
   bookListMode: string;
@@ -39,7 +38,6 @@ interface SettingsState {
   isHydrated: boolean;
 
   setTranslation: (t: string) => void;
-  setFontSize: (s: number) => void;
   setReadingScale: (n: number) => void;
   setVhlEnabled: (v: boolean) => void;
   setBookListMode: (m: string) => void;
@@ -56,7 +54,6 @@ interface SettingsState {
 
 export const useSettingsStore = create<SettingsState>((set) => ({
   translation: 'kjv',
-  fontSize: 16,
   readingScale: READING_SCALE_DEFAULT,
   vhlEnabled: false,
   bookListMode: 'canonical',
@@ -73,12 +70,6 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setTranslation: (t) => {
     set({ translation: t });
     setPreference('translation', t).catch((err) => { logger.warn('settingsStore', 'Failed to persist translation', err); });
-  },
-
-  setFontSize: (s) => {
-    const clamped = Math.min(24, Math.max(12, s));
-    set({ fontSize: clamped });
-    setPreference('fontSize', String(clamped)).catch((err) => { logger.warn('settingsStore', 'Failed to persist fontSize', err); });
   },
 
   setReadingScale: (n) => {
@@ -145,7 +136,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   hydrate: async () => {
     try {
       const t = await getPreference('translation');
-      const f = await getPreference('fontSize');
+      const legacyFontSize = await getPreference('fontSize');
       const rs = await getPreference('readingScale');
       const v = await getPreference('vhlEnabled');
       const blm = await getPreference('bookListMode');
@@ -167,15 +158,16 @@ export const useSettingsStore = create<SettingsState>((set) => ({
         }
       }
 
-      // readingScale: prefer stored value; else migrate from legacy
-      // fontSize (px) by dividing by the 16 px base; else default.
-      // When migrating, persist the derived value so the computation
-      // only happens once per install.
+      // readingScale: prefer stored value; else one-time migration from
+      // the legacy `fontSize` (px) preference by dividing by the 16 px
+      // baseline. Either way, drop the legacy key afterwards — no other
+      // code reads it now that PR 2 migrated every reading surface to
+      // useTypography().
       let readingScale = READING_SCALE_DEFAULT;
       if (rs !== null && rs !== undefined && rs !== '') {
         readingScale = clampReadingScale(parseFloat(rs));
-      } else if (f !== null && f !== undefined && f !== '') {
-        const px = parseFloat(f);
+      } else if (legacyFontSize !== null && legacyFontSize !== undefined && legacyFontSize !== '') {
+        const px = parseFloat(legacyFontSize);
         if (Number.isFinite(px)) {
           readingScale = clampReadingScale(px / 16);
           setPreference('readingScale', String(readingScale)).catch((err) => {
@@ -183,10 +175,14 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           });
         }
       }
+      if (legacyFontSize !== null && legacyFontSize !== undefined) {
+        deletePreference('fontSize').catch((err) => {
+          logger.warn('settingsStore', 'Failed to delete legacy fontSize preference', err);
+        });
+      }
 
       set({
         translation: (t && TRANSLATION_MAP.has(t) ? t : 'kjv'),
-        fontSize: f ? Math.min(24, Math.max(12, parseInt(f, 10) || 16)) : 16,
         readingScale,
         vhlEnabled: v === '1',
         bookListMode: blm === 'canonical' ? 'canonical' : 'thematic',


### PR DESCRIPTION
Part of epic #1639. Implements #1642.

**Stacked on top of #1655** (which is stacked on #1643). This branch
was cut from `feat/typography-migrate-surfaces` so the migrated
surfaces and `useTypography` hook are available. Once #1643 and
#1655 merge, this PR will rebase cleanly onto master.

## Rationale

The legacy Font Size +/- row in Settings only affected verse text,
topped out at 24 pt, didn't show users what their OS was doing, and
gave no feedback on whether they were about to hit the cap. After
PR 2 migrated every reading surface to `useTypography()`, the
`fontSize` state field exists purely as legacy carry-over. This PR
ships the user-facing slider and removes the dead state.

## New

- `app/src/components/settings/ReadingScaleEditor.tsx`
  - 8-stop segmented control (0.85 / 0.90 / 1.00 / 1.10 / 1.20 /
    1.35 / 1.50 / 1.60) — matches the `READING_SCALE_MIN`/`MAX`
    range from #1640.
  - Primary readout: `Reading size: 1.15×`.
  - Secondary readout: `Device text size: 1.30× · Effective: 1.50×
    (content)` — OS + combined scale visible so users understand
    why 1.5× might not visually grow when OS is already large.
  - Inline note when `PixelRatio.getFontScale() > 1.5`: *"Your
    device is set to a large text size. The app is honoring that
    setting."*
  - Preview card — live-updating — with section header
    (`content.displayLg`), Genesis 1:1 verse (`content.bodyLg`), a
    short Calvin commentary (`content.bodyItalic`), and a chrome
    sample row using `chrome.uiBold` / `chrome.uiSm` so users see
    chrome doesn't move when they drag the slider.
  - `Reset` text-button returns to 1.0× (hidden when already at
    default).
  - All colors from `useTheme()` — no hardcoded hex.
  - `accessibilityRole="adjustable"` on the segmented row plus per-
    segment labels/states for screen-reader support.

- `app/__tests__/components/settings/ReadingScaleEditor.test.tsx`
  covers: preview renders; segment press dispatches
  `setReadingScale`; Reset returns to 1.0× and disappears; OS-large
  note renders above 1.5×; effective content scale reflects the
  2.2× cap.

## Modified

- `app/src/screens/settings/PreferencesSection.tsx` — removed the
  +/- Font Size row, its ad-hoc inline preview, and the `fontSize` /
  `setFontSize` props. Replaced with `<ReadingScaleEditor />`.
- `app/src/screens/SettingsScreen.tsx` — dropped the `fontSize`
  store read and setter.
- `app/src/stores/settingsStore.ts` — removed `fontSize` field +
  `setFontSize` setter + initial state + hydrate state write. The
  legacy preference key is read one more time during hydrate for
  migration, then deleted via the new `deletePreference` mutation.
- `app/src/db/userMutations.ts` — added `deletePreference(key)`.
- `app/__tests__/stores/settingsStore.test.ts` — removed the 3
  `setFontSize` tests and the 2 hydrate cases that asserted on the
  legacy field; added 3 tests for the delete-after-migration
  behavior.

## Acceptance gates

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` — 3560 tests pass (+7 new editor tests, +3 new
      hydrate-cleanup tests, −5 legacy `fontSize` tests)
- [x] `npx eslint` on touched files — clean
- [x] `grep -n fontSize app/src/stores/settingsStore.ts` returns only
      the legacy preference key string used for migration + cleanup;
      no field or setter remains anywhere in the store.

## Rollback plan

Low risk, but non-trivial: this PR deletes the legacy `fontSize`
preference row on hydrate, so a straight revert would leave old
users without a stored `fontSize` and (on the reverted codebase)
reset them to the 16 px default. In practice no user data is lost —
their preference has already been translated into `readingScale` by
PR #1643 and is fully used by PR #1655. If the editor itself
proves problematic, the safer rollback is to revert only
`PreferencesSection.tsx` + `SettingsScreen.tsx` to restore the old
+/- row while leaving the store and migration in place (the old row
can drive `readingScale` if re-wired: `setReadingScale((px)/16)`).

## Out of scope

- Line-spacing control (future)
- Font-family selector (future)
- Reader-inline Aa control (intentionally deferred per epic)

Refs #1642, epic #1639. Closes the epic once this lands and the
manual device matrix passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfYWkFqR29WM71yZRFpjTT)_