### PR TITLE
content(isaiah): coverage enrichment — 108 audit findings to zero

### DIFF
--- a/content/isaiah/23.json
+++ b/content/isaiah/23.json
@@ -243,7 +243,30 @@
         }
       ],
       "note": "Sovereignty peaks: God plans Tyre’s fall and Tyre’s consecration. The oracles-against-nations section ends with the pattern complete: judgment, then surprising inclusion."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 23:1-18",
+        "target": "Ezek 26-28; Rev 18",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The Tyre oracle feeds directly into Ezekiel's extended Tyre judgments (chs. 26-28) and ultimately into Revelation's Babylon-the-prostitute imagery (Rev 18), which draws heavily on Tyre's mercantile language. Tyre as paradigmatic commercial empire becomes the biblical type for all city-states whose glory is trade rather than justice."
+      },
+      {
+        "anchor": "Isa 23:8-9",
+        "target": "1 Cor 1:27-29",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The LORD Almighty planned it, to bring down her pride in all her splendor and to humble all who are renowned on the earth.' The humbling-of-the-exalted motif becomes Paul's argument in 1 Cor 1 that God deliberately chooses weak and foolish things to shame the strong and wise."
+      },
+      {
+        "anchor": "Isa 23:17-18",
+        "target": "Acts 21:3-7",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The 'holy to the LORD' dedication of Tyre's final profits anticipates the NT presence of a Christian community in Tyre (Acts 21:3-7) — the very city under prophetic judgment becomes a gospel-receiving city. Judgment and mercy run on the same axis."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/24.json
+++ b/content/isaiah/24.json
@@ -270,7 +270,30 @@
         }
       ],
       "note": "Judgment peaks at 10: cosmic devastation, everlasting covenant broken, earth un-created. Sovereignty at 9: God reigns, outshining sun and moon. The Isaiah Apocalypse begins."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 24:1-6",
+        "target": "Gen 3:17-19; Rom 8:20-22",
+        "type": "Echo",
+        "direction": "back",
+        "text": "'The earth dries up and withers... the earth is defiled by its people.' The earth-suffering-for-human-sin theology echoes Gen 3's original curse (ground cursed because of the man) and anticipates Paul's 'creation was subjected to frustration' in Rom 8:20-22."
+      },
+      {
+        "anchor": "Isa 24:5",
+        "target": "Gen 9:8-17",
+        "type": "Echo",
+        "direction": "back",
+        "text": "'They have violated the everlasting covenant' — most likely the Noahic covenant with all creation, since the breach is cosmic and not Israel-specific. Human wickedness has broken the covenant that preserved the earth's stability since the flood."
+      },
+      {
+        "anchor": "Isa 24:21-23",
+        "target": "Rev 19:17-21; 20:1-3",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'In that day the LORD will punish the powers in the heavens above and the kings on the earth below. They will be herded together like prisoners.' The simultaneous heavenly-and-earthly judgment feeds directly into Revelation's Armageddon imagery and millennium-bound hostile powers."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/25.json
+++ b/content/isaiah/25.json
@@ -256,7 +256,30 @@
         }
       ],
       "note": "Mercy AND Prophecy both peak at 10: death swallowed (1 Cor 15:54), tears wiped (Rev 21:4), feast for all peoples (Matt 22). The OT’s most explicit death-destruction promise. Mission: ALL peoples, ALL nations."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 25:6-8",
+        "target": "Rev 19:7-9; 21:4",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "The banquet on the mountain — 'a feast of rich food for all peoples' — becomes Revelation's marriage supper of the Lamb. 'He will swallow up death forever' is quoted in 1 Cor 15:54 at the resurrection climax; 'wipe away the tears from all faces' is quoted verbatim in Rev 21:4."
+      },
+      {
+        "anchor": "Isa 25:8",
+        "target": "1 Cor 15:54; Hos 13:14",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'He will swallow up death forever.' Paul merges this verse with Hosea 13:14 ('where, O death, is your victory?') to climax his resurrection chapter. The eschatological abolition of death is Isaiah's contribution to the NT's resurrection theology."
+      },
+      {
+        "anchor": "Isa 25:9",
+        "target": "John 14:3; 2 Tim 4:8",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Surely this is our God; we trusted in him, and he saved us.' The eschatological recognition-cry of the covenant community meeting its delivering God becomes the shape of all NT parousia-anticipation: those who have loved his appearing."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/26.json
+++ b/content/isaiah/26.json
@@ -259,7 +259,30 @@
         }
       ],
       "note": "Prophecy peaks at 10: resurrection text alongside Daniel 12:2. Earth gives birth to the dead. Faith at 9: perfect peace through trust in the eternal Rock. The Passover-shelter image."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 26:3",
+        "target": "Phil 4:7",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You will keep in perfect peace those whose minds are steadfast, because they trust in you.' The mind-set-on-God produces peace logic feeds directly into Paul's 'peace of God which transcends all understanding will guard your hearts and minds.'"
+      },
+      {
+        "anchor": "Isa 26:19",
+        "target": "Dan 12:2; John 11:24-26",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Your dead will live, LORD; their bodies will rise. Let those who dwell in the dust wake up and shout for joy.' One of the OT's clearest resurrection texts, feeding Daniel 12:2 and Jesus' resurrection-promise to Martha in John 11."
+      },
+      {
+        "anchor": "Isa 26:20-21",
+        "target": "1 Thess 5:3; Rev 6:10",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Hide yourselves for a little while until his wrath has passed by.' The temporary-hiding language anticipates NT eschatology: the day of the LORD comes like a thief, and the martyrs under the altar cry 'how long?' until vindication lands."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/27.json
+++ b/content/isaiah/27.json
@@ -265,7 +265,30 @@
         }
       ],
       "note": "Sovereignty and Prophecy peak: Leviathan slain (Rev 12–13), vineyard redeemed, great trumpet (Matt 24:31). The Isaiah Apocalypse concludes: chaos-monster dead, vineyard fruitful, scattered gathered, worship restored."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 27:1",
+        "target": "Rev 12:9; 20:2",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'In that day, the LORD will punish with his sword... Leviathan the gliding serpent, Leviathan the coiling serpent; he will slay the monster of the sea.' The mythological-serpent imagery feeds directly into Revelation's dragon, 'the ancient serpent called the devil or Satan.'"
+      },
+      {
+        "anchor": "Isa 27:2-6",
+        "target": "John 15:1-8",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'A fruitful vineyard, sing of it! I, the LORD, watch over it.' The vineyard-Israel metaphor (5:1-7's failed vineyard redeemed) stands behind Jesus' 'I am the true vine' — the vineyard that finally produces the intended fruit is Christ and his disciples."
+      },
+      {
+        "anchor": "Isa 27:13",
+        "target": "Matt 24:31",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'In that day a great trumpet will sound. Those who were perishing in Assyria and those who were exiled in Egypt will come and worship the LORD.' Jesus' Olivet Discourse picks up the trumpet-gathering imagery for the eschatological assembly of the elect."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/28.json
+++ b/content/isaiah/28.json
@@ -260,7 +260,30 @@
         }
       ],
       "note": "Prophecy peaks: the cornerstone (1 Pet 2:6; Rom 9:33; Eph 2:20). Faith: relying on the stone = no panic. Justice: measuring line and plumb line. God the skilled farmer."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 28:16",
+        "target": "1 Pet 2:6; Rom 9:33; 10:11",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'See, I lay a stone in Zion, a tested stone, a precious cornerstone for a sure foundation; the one who relies on it will never be stricken with panic.' Quoted by both Peter and Paul as the OT cornerstone text now applied to Christ — the foundation of the spiritual house."
+      },
+      {
+        "anchor": "Isa 28:11-12",
+        "target": "1 Cor 14:21",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'With foreign lips and strange tongues God will speak to this people.' Paul cites this verse in 1 Cor 14:21 regarding tongues as a sign of judgment on unbelievers — the prophet's judgment-sign becomes the apostle's hermeneutical key."
+      },
+      {
+        "anchor": "Isa 28:21",
+        "target": "Lam 3:33; Heb 12:10",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The LORD will rise up as he did at Mount Perazim... to do his work, his strange work, and perform his task, his alien task.' Judgment is called Yahweh's 'strange work' — mercy is his native work. The distinction feeds Lamentations' 'he does not willingly afflict' and Hebrews' disciplinary theology."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/29.json
+++ b/content/isaiah/29.json
@@ -268,7 +268,30 @@
         }
       ],
       "note": "Prophecy peaks: Jesus quotes v.13 against the Pharisees; Paul quotes v.14 and v.16. The deaf-hear/blind-see reversal: Jesus enacts this literally. Potter/clay logic (Rom 9:20)."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 29:13",
+        "target": "Matt 15:8-9; Mark 7:6-7",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'These people come near to me with their mouth and honor me with their lips, but their hearts are far from me. Their worship of me is based on merely human rules they have been taught.' Jesus quotes this verse against the Pharisees' hand-washing tradition in Matt 15:8-9 and Mark 7:6-7 — Isaiah 29 is the definitive biblical text on lip-service religion."
+      },
+      {
+        "anchor": "Isa 29:14",
+        "target": "1 Cor 1:19",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will destroy the wisdom of the wise; the intelligence of the intelligent I will frustrate.' Paul quotes this directly in 1 Cor 1:19 as the OT basis for the cross-as-scandal argument: God deliberately confounds human wisdom through apparent foolishness."
+      },
+      {
+        "anchor": "Isa 29:18-19",
+        "target": "Matt 11:5; Luke 7:22",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'In that day the deaf will hear the words of the scroll, and out of gloom and darkness the eyes of the blind will see.' Along with Isa 35:5-6 and 61:1, this verse supplies the content of Jesus' reply to John the Baptist — the signs of the Messiah's arrival."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/30.json
+++ b/content/isaiah/30.json
@@ -264,7 +264,30 @@
         }
       ],
       "note": "Mercy AND Faith both peak at 9: God LONGS to be gracious; salvation is in repentance and rest. The guidance voice: \"this is the way.\" Sun seven times brighter."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 30:1-5",
+        "target": "Jer 2:18, 36",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The pattern of seeking Egypt's help rather than Yahweh's — 'woe to the obstinate children who carry out plans that are not mine, forming an alliance but not by my Spirit' — is picked up by Jeremiah (Jer 2:18, 36) as the perennial covenantal unfaithfulness of Judah."
+      },
+      {
+        "anchor": "Isa 30:15",
+        "target": "Matt 11:28-29",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'In repentance and rest is your salvation, in quietness and trust is your strength.' The foundational spiritual-posture verse of the prophets — not political alliance, not military preparation, but trust. Jesus' 'come to me... and I will give you rest' voices the same invitation now focused christologically."
+      },
+      {
+        "anchor": "Isa 30:26",
+        "target": "Rev 21:23; 22:5",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The moon will shine like the sun, and the sunlight will be seven times brighter.' The eschatological light-intensification becomes Revelation's 'no need of sun or moon... for the glory of God gives it light' — culmination of the cosmological renewal motif."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/31.json
+++ b/content/isaiah/31.json
@@ -247,7 +247,23 @@
         }
       ],
       "note": "Faith peaks: flesh vs spirit, the fundamental binary. Sovereignty: Assyria falls by no human sword. The Passover verb applied to Jerusalem’s rescue."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 31:1-3",
+        "target": "Ps 20:7; 33:17",
+        "type": "Echo",
+        "direction": "back",
+        "text": "'Woe to those who go down to Egypt for help, who rely on horses, who trust in the multitude of their chariots and in the great strength of their horsemen, but do not look to the Holy One of Israel.' The same trust-polemic as Ps 20:7 ('some trust in chariots and some in horses, but we trust in the name of the LORD') — the Psalter's and the prophets' shared theological vocabulary."
+      },
+      {
+        "anchor": "Isa 31:4-5",
+        "target": "Deut 32:10-12; Matt 23:37",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Like birds hovering overhead, the LORD Almighty will shield Jerusalem; he will shield it and deliver it.' The protective-bird imagery runs from Deut 32:10-12 (eagle-teaching-young) to Jesus' 'how often I have longed to gather your children together, as a hen gathers her chicks under her wings.'"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/32.json
+++ b/content/isaiah/32.json
@@ -251,7 +251,30 @@
         }
       ],
       "note": "Justice and Prophecy peak: the righteous king + the Spirit-outpouring. Peace as the fruit of righteousness. The equation from 30:15 fulfilled: rest, quietness, confidence."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 32:1-2",
+        "target": "John 4:13-14; 7:37-38",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'A king will reign in righteousness... each one will be like a shelter from the wind and a refuge from the storm, like streams of water in the desert and the shadow of a great rock in a thirsty land.' The king-and-princes-as-living-water imagery anticipates Jesus' living-water offer at the well and the Feast of Tabernacles."
+      },
+      {
+        "anchor": "Isa 32:15",
+        "target": "Joel 2:28-29; Acts 2:17-18",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Till the Spirit is poured on us from on high, and the desert becomes a fertile field.' The Spirit-outpouring promise is one of a cluster (Ezek 36:26-27; Joel 2:28-29; Isa 44:3) that Peter will cite at Pentecost as fulfilled."
+      },
+      {
+        "anchor": "Isa 32:17-18",
+        "target": "Rom 5:1; 14:17",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The fruit of that righteousness will be peace; its effect will be quietness and confidence forever.' Paul's 'having been justified by faith, we have peace with God' and 'the kingdom of God is righteousness, peace, and joy in the Holy Spirit' develop this Isaianic triad."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/33.json
+++ b/content/isaiah/33.json
@@ -268,7 +268,30 @@
         }
       ],
       "note": "Sovereignty peaks: judge, lawgiver, king — all three held by God. Worship and Holiness: the beatific vision, seeing the King in his beauty. The six woe oracles conclude with the ultimate reward: seeing God."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 33:14-17",
+        "target": "Heb 12:29",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Who of us can dwell with the consuming fire? Who of us can dwell with everlasting burning?' The answer ('he who walks righteously and speaks what is right') sets the ethical template for Hebrews' 'our God is a consuming fire' — access to Yahweh requires a specific moral character."
+      },
+      {
+        "anchor": "Isa 33:22",
+        "target": "Jas 4:12",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The LORD is our judge, the LORD is our lawgiver, the LORD is our king; it is he who will save us.' The threefold governmental identification feeds James's 'there is only one Lawgiver and Judge, the one who is able to save and destroy' — Yahweh alone occupies all three offices."
+      },
+      {
+        "anchor": "Isa 33:24",
+        "target": "Jer 31:34; Rev 21:4",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'No one living in Zion will say, I am ill; and the sins of those who dwell there will be forgiven.' The twin-promise — no disease, no guilt — anticipates the new-covenant forgiveness of Jer 31:34 and the no-more-pain of Rev 21:4."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/34.json
+++ b/content/isaiah/34.json
@@ -264,7 +264,23 @@
         }
       ],
       "note": "Judgment peaks at 10: heavens rolled up, creation reversed, Edom un-made. Rev 6:14 quotes directly. The measuring line of chaos (tohu)."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 34:4",
+        "target": "Matt 24:29; Rev 6:13-14",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'All the stars in the sky will be dissolved and the heavens rolled up like a scroll; all the starry host will fall like withered leaves from the vine.' The cosmic-dissolution imagery becomes Jesus' Olivet Discourse and Revelation's sixth-seal catastrophe."
+      },
+      {
+        "anchor": "Isa 34:1-17",
+        "target": "Obad; Mal 1:2-5",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The extended Edom judgment-oracle — vengeance for Edom's complicity in Judah's fall — is the matrix from which Obadiah and Malachi's Edom oracles emerge. Edom becomes the paradigm-enemy of the covenant community throughout the prophets."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/35.json
+++ b/content/isaiah/35.json
@@ -175,9 +175,24 @@
   "chapter_panels": {
     "ppl": [
       {
-        "name": "LORD",
-        "role": "Key biblical figure",
-        "text": "\"Those the LORD has rescued will return…"
+        "name": "The Redeemed",
+        "role": "Returning exiles",
+        "text": "Those ransomed by Yahweh who walk the Way of Holiness back to Zion with singing and everlasting joy (v.10). The chapter's climactic figures — not individual characters but the collective end-state people of God, the ones for whom the desert has become a highway. Their journey is the reverse of Israel's original wilderness experience: formerly wanderers in a hostile wilderness, now safe travellers on a protected road through a transformed one."
+      },
+      {
+        "name": "The Blind, Deaf, Lame, Mute",
+        "role": "Recipients of healing",
+        "text": "Four disability categories (vv.5-6) specifying what Yahweh's salvation concretely means: eyes opened, ears unstopped, lame leaping like a deer, mute tongue shouting for joy. The list becomes Jesus' template for identifying his own ministry when John the Baptist asks 'are you the one?' (Matt 11:5; Luke 7:22). Isaiah 35 provides the rubric by which the Messiah's arrival is recognised."
+      },
+      {
+        "name": "The Unclean and the Fool",
+        "role": "Excluded from the Way",
+        "text": "Two categories explicitly barred from the Way of Holiness (v.8): the ritually unclean and the wicked-foolish. The highway is not for everyone indiscriminately — it has a moral geometry. Yet the chapter insists that even simpletons ('wayfaring men, though fools') will not stray on it. The road is safe because it is holy, not merely because it is paved."
+      },
+      {
+        "name": "Yahweh (the LORD)",
+        "role": "Redeemer",
+        "text": "The one whose coming transforms the desert (v.4: 'he will come and save you') and whose glory the redeemed see (v.2). The chapter's action is entirely Yahweh-driven; the blooming of the wilderness, the healing of bodies, the construction of the highway, the ransom of the exiles are all his deeds. Isaiah 35 is a theophany-landscape: where God comes, creation flourishes."
       }
     ],
     "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>And a highway will be there; it will be called the Way of Holiness; it will be for those who walk on that Way. The unclean will not journey on it; wicked fools will not go about on it.</td></tr><tr><td class=\"t-label\">ESV</td><td>And a highway shall be there, and it shall be called the Way of Holiness; the unclean shall not pass over it. It shall belong to those who walk on the way; even if they are fools, they shall not go astray.</td></tr><tr><td class=\"t-label\">NIV</td><td>No lion will be there, nor any ravenous beast; they will not be found there. But only the redeemed will walk there,</td></tr><tr><td class=\"t-label\">ESV</td><td>No lion shall be there, nor shall any ravenous beast come up on it; they shall not be found there, but the redeemed shall walk there.</td></tr>",
@@ -255,7 +270,30 @@
         }
       ],
       "note": "Mercy AND Prophecy peak at 10: the four reversals (Matt 11:5), the highway of holiness, sorrow flees. Holiness: the Way itself is holy. Ch.35 is the positive mirror of ch.34."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 35:5-6",
+        "target": "Matt 11:5; Luke 7:22",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Then will the eyes of the blind be opened and the ears of the deaf unstopped. Then will the lame leap like a deer, and the mute tongue shout for joy.' Jesus' reply to John the Baptist is a catena drawing directly on this verse with Isa 29:18-19 and 61:1 — a self-identification as the Messianic figure Isaiah described."
+      },
+      {
+        "anchor": "Isa 35:8-10",
+        "target": "John 14:6; Rev 21:27",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'A highway will be there; it will be called the Way of Holiness; it will be for those who walk on that Way... they will enter Zion with singing; everlasting joy will crown their heads.' The 'Way' language is picked up as the earliest self-designation of Christians in Acts (9:2; 19:9, 23) and in Jesus' 'I am the way.'"
+      },
+      {
+        "anchor": "Isa 35:1-2",
+        "target": "Rom 8:19-22",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The desert and the parched land will be glad; the wilderness will rejoice and blossom.' Creation's eschatological delight anticipates Paul's 'creation itself will be liberated from its bondage to decay and brought into the glorious freedom of the children of God.'"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/36.json
+++ b/content/isaiah/36.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "In 701 BC, Sennacherib of Assyria invaded Judah after Hezekiah joined an anti-Assyrian coalition. The Rabshakeh (chief cupbearer) was a high official sent to negotiate Jerusalem's surrender. His speech, delivered in Hebrew rather than Aramaic, was psychological warfare aimed at undermining civilian morale. The mention of Egypt as a 'splintered reed' reflects the failed Egyptian alliance that had encouraged Judah's rebellion."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "36:1-10",
+              "note": "Oswalt reads chapters 36-39 as the pivot of the book: they re-present, in narrative form, the dilemma of chapters 7-39 (trust God or trust the nations?) so that the comfort of chapter 40 can land. Sennacherib's envoys arrive 'on the highway to the Launderer's Field' — the exact spot where Isaiah met Ahaz in 7:3. The narrative is deliberately echoing the Ahaz episode: same place, same threat-category, now a different king."
+            },
+            {
+              "ref": "36:4-10",
+              "note": "Oswalt emphasises the Rabshakeh's rhetorical sophistication: he knows Judah's theology and weaponises it ('the LORD himself sent me against this land,' v.10). The temptation is not to abandon faith but to redirect it — to read Yahweh's will through imperial circumstance rather than prophetic word."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The Rabshakeh's demand that officials speak Aramaic (the diplomatic lingua franca) rather than Hebrew reveals the propaganda dimension of the confrontation. Assyrian royal inscriptions boasted of making conquered peoples' gods powerless; the Rabshakeh applies this template to YHWH. The officials' silence and torn clothes signal both grief and the gravity of blasphemy against Israel's God."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "36:11-12",
+              "note": "Oswalt: the Rabshakeh's refusal to switch to Aramaic exposes the psychological warfare aim. He is not negotiating with officials; he is preaching surrender-theology to the wall-top audience. Isaiah's later answer (37:6) — 'do not be afraid of the words' — treats this as the central threat: not the army but the rhetoric."
+            },
+            {
+              "ref": "36:18-20",
+              "note": "The comparative-gods taunt ('has any god of any nation delivered his land?') is the doctrinal climax of the speech. Oswalt reads it as the Assyrian proposal of a closed immanent universe: all gods have failed against Assyria, and there is no reason to suppose Yahweh is any different. Chapter 37 is engineered to answer exactly this claim."
+            }
+          ]
         }
       }
     }
@@ -204,7 +230,30 @@
         }
       ],
       "note": "Faith peaks: the theological crisis. Everything Isaiah preached about trusting God, not Egypt, is now tested at the wall. The Rabshakeh’s challenge is the exam."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 36:1-22",
+        "target": "2 Kgs 18:13-37; 2 Chr 32:1-19",
+        "type": "Echo",
+        "direction": "back",
+        "text": "The Sennacherib-siege narrative is recorded in parallel in 2 Kings 18-19 and 2 Chronicles 32 — the rare case of a historical narrative reproduced in three canonical books, signalling its structural importance for the OT's theology of divine deliverance."
+      },
+      {
+        "anchor": "Isa 36:4-10",
+        "target": "1 Sam 17:43-47",
+        "type": "Echo",
+        "direction": "back",
+        "text": "The Rabshakeh's intimidating speech echoes Goliath's taunts — and the outcome matches: the pagan champion's contempt for Yahweh becomes the occasion for Yahweh's spectacular intervention. Theophany through military-political reversal is a consistent OT pattern."
+      },
+      {
+        "anchor": "Isa 36:18-20",
+        "target": "Dan 3:15",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Has the god of any nation ever delivered his land from the hand of the king of Assyria?' The comparative-gods-challenge reappears verbatim in Daniel 3:15 from Nebuchadnezzar — the same imperial theological posture, the same divine rebuke to come."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/37.json
+++ b/content/isaiah/37.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Hezekiah's act of spreading the letter before YHWH in the temple was a formal appeal to the divine King whose throne sat above the cherubim. The gesture acknowledged that the real conflict was between Sennacherib's claims and YHWH's sovereignty. Tirhakah of Egypt (mentioned in v.9) was the Nubian pharaoh whose approach may have drawn Assyrian forces temporarily away from Jerusalem."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "37:1-4",
+              "note": "Oswalt highlights Hezekiah's sackcloth-to-the-temple response as the inversion of Ahaz's dismissive posture in ch.7. Where Ahaz refused to ask a sign, Hezekiah begs for prophetic intercession. The king who learned nothing from Isaiah's ministry (Ahaz) is paired with the king who learned everything — and that contrast is the book's implicit answer to 'what is faith?'"
+            },
+            {
+              "ref": "37:14-20",
+              "note": "The Temple-prayer is Oswalt's theological centre of chapters 36-39. Hezekiah 'spread out the letter before the LORD' and grounds his appeal not in Judah's righteousness but in Yahweh's uniqueness ('you alone are God over all the kingdoms of the earth'). The prayer converts the Assyrian taunt into a theological opportunity: let Yahweh answer for his own name."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The death of 185,000 Assyrian soldiers in one night remains historically debated. Herodotus records a tradition of mice destroying Assyrian bowstrings (perhaps a plague metaphor). Sennacherib's own annals, while boasting of conquests, never claim to have taken Jerusalem — a telling silence. His assassination in 681 BC by his sons Adrammelech and Sharezer is confirmed by Assyrian records."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "37:22-29",
+              "note": "Oswalt on the Sennacherib oracle: the Assyrian king's pride is theologically diagnosed as a creaturely mistake about agency. 'Have you not heard? Long ago I ordained it' — Assyria's conquests were Yahweh's instrument, not Sennacherib's genius. The hook-in-nose image (v.29) is a direct judgment-echo of Assyria's own treatment of prisoners."
+            },
+            {
+              "ref": "37:36-38",
+              "note": "The single-verse destruction of 185,000 Assyrians (v.36) is Oswalt's OT climax of the 'salvation comes not by human strength' theme that runs from Genesis through the entire book. The siege ends without any Judahite military action; Yahweh alone is the deliverer. The patriarchal 'shall not the Judge of all the earth do right?' is answered in blood."
+            }
+          ]
         }
       }
     }
@@ -218,7 +244,30 @@
         }
       ],
       "note": "Sovereignty peaks at 10: one angel, 185,000, one night. God’s hook in Assyria’s nose. Faith at 9: Hezekiah’s prayer model. The test passed. Everything Isaiah preached vindicated."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 37:14-20",
+        "target": "2 Kgs 19:14-19; Neh 9:5-37",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "Hezekiah's temple-prayer — spreading the letter before the LORD, grounding the appeal in Yahweh's unique deity — becomes the OT template for national intercession. Nehemiah's long prayer (Neh 9) follows the same pattern: recital of God's uniqueness, confession, appeal."
+      },
+      {
+        "anchor": "Isa 37:31-32",
+        "target": "Rom 11:5; Rev 7:4",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The surviving remnant of the house of Judah will take root below and bear fruit above.' The remnant-theology of Isaiah feeds Paul's argument in Rom 11:5 ('there is a remnant chosen by grace') and the Revelation 7 sealed-tribes."
+      },
+      {
+        "anchor": "Isa 37:36-38",
+        "target": "Exod 12:29-30; 2 Chr 32:21",
+        "type": "Echo",
+        "direction": "back",
+        "text": "The Angel of the LORD striking 185,000 Assyrians overnight parallels the death-of-the-firstborn plague in Egypt — divine deliverance through nocturnal angelic agency is Isaiah's exodus-rhyme. Herodotus preserves a garbled Egyptian memory of the same campaign's sudden reversal."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/38.json
+++ b/content/isaiah/38.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Hezekiah's illness occurred around 701 BC, during or shortly after the Assyrian crisis. The fifteen added years would place his death around 686 BC. The poultice of figs was standard ancient Near Eastern medicine for boils. The shadow retreating on Ahaz's sundial (or stairway) served as a visible sign confirming Isaiah's word — physical phenomena validating prophetic authority."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "38:1-5",
+              "note": "Oswalt reads Hezekiah's illness-and-healing narrative as a theological mirror of chapter 37: the king who trusted Yahweh against Assyria now trusts Yahweh against death. The fifteen added years are framed as specifically covenant-protective — 'I will defend this city' is repeated (v.6), tying Hezekiah's life and Jerusalem's preservation into a single divine act."
+            },
+            {
+              "ref": "38:7-8",
+              "note": "The retreating sundial shadow is, in Oswalt's reading, the cosmological sign that corresponds to Hezekiah's healing: creation itself moves backwards to signify the reversal of death. It is paired with the Ahaz-Immanuel sign of 7:14 — both kings are offered cosmic signs; the difference is one accepted and one refused."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "Hezekiah's psalm (vv.10-20) is a thanksgiving for recovery, structured like individual psalms of lament that move from distress to praise. The imagery of Sheol and the Pit reflects standard Israelite afterlife concepts where the dead exist in shadowy half-life, unable to praise YHWH. The temple procession mentioned in v.20 indicates the psalm's liturgical use after recovery."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "38:9-20",
+              "note": "Oswalt treats Hezekiah's psalm as genuine royal liturgy in the lament-to-thanksgiving pattern of the Psalter: description of crisis (vv.10-14), turn of divine action (v.15), thanksgiving vow (vv.18-20). The psalm is theologically honest about Sheol: 'death cannot praise you' frames death not as transition-to-presence but as silence — a view Isaiah itself will push beyond in 26:19 and ultimately in 53:10-11."
+            },
+            {
+              "ref": "38:17",
+              "note": "'You have put all my sins behind your back' — Oswalt notes this is one of the OT's strongest forgiveness-images: sin consigned to the place Yahweh refuses to look. It sits inside a chapter where physical and spiritual healing are presented as the same divine act, setting up the same-act theology of ch.53."
+            }
+          ]
         }
       }
     }
@@ -199,7 +225,23 @@
         }
       ],
       "note": "Mercy peaks at 9: death-verdict reversed, fifteen years added, sins behind God’s back. Worship: the living praise. Prayer changes God’s stated intention."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 38:1-5",
+        "target": "2 Kgs 20:1-6",
+        "type": "Echo",
+        "direction": "back",
+        "text": "Hezekiah's illness and healing is the only narrative outside the Kings history that the Chronicler also preserves (2 Chr 32:24-26), indicating the episode's theological weight: the covenant-king whose prayer extends his life becomes the type for covenant-hope against death."
+      },
+      {
+        "anchor": "Isa 38:17-20",
+        "target": "Ps 6; Ps 116",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "Hezekiah's thanksgiving psalm ('you have kept me from the pit of destruction... I will walk humbly all my years') stands alongside the deliverance-from-death psalms of the Psalter, particularly Ps 6 and 116 — royal-theological liturgy for the same experience."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/39.json
+++ b/content/isaiah/39.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Merodach-Baladan (Marduk-apla-iddina II) was a Chaldean king who twice seized Babylon's throne and repeatedly sought allies against Assyria. His envoys to Hezekiah around 703-701 BC were diplomatic reconnaissance, probing Judah's military capacity for potential coalition. Hezekiah's eager display of treasures suggests he saw opportunity in Babylonian alliance rather than recognizing the emerging threat."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "39:1-2",
+              "note": "Oswalt frames the Babylonian-envoys episode as Hezekiah's failure-of-faith counterpart to his success in ch.37. Where the Assyrian threat drove him to the Temple, the Babylonian flattery drives him to the treasury. Merodach-Baladan's diplomatic gesture (a get-well visit) is accepted at face value; there is no prophetic consultation, no discernment."
+            },
+            {
+              "ref": "39:2",
+              "note": "'There was nothing in his palace or in all his kingdom that Hezekiah did not show them.' Oswalt: the completeness of the display is itself the theological problem. Hezekiah shows everything Judah has — except, tellingly, Yahweh. The Babylonian gaze receives the treasures; the covenantal centre of the kingdom is nowhere acknowledged."
+            }
+          ]
         }
       }
     },
@@ -108,6 +121,19 @@
         },
         "hist": {
           "context": "Isaiah's prophecy bridges the book's two halves: chapter 39 announces Babylonian exile, chapter 40 begins with comfort for exiles in Babylon. This literary hinge transforms a diplomatic episode into the pivot of Israel's history. Hezekiah's response ('there will be peace and security in my lifetime') has been read as either relieved acceptance or selfish short-sightedness — Isaiah leaves the ambiguity unresolved."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "39:5-7",
+              "note": "Oswalt reads Isaiah's Babylon-exile oracle as the deliberate narrative bridge to chapter 40: everything you just showed them will be carried to Babylon. The first-Isaiah (Assyrian-period) material closes with Babylon on the horizon, and the second-Isaiah (exilic-voice) material opens in ch.40 addressing that Babylon. Oswalt argues for Isaian unity: this is the same prophet speaking across the seam, not two books."
+            },
+            {
+              "ref": "39:8",
+              "note": "Hezekiah's response — 'the word of the LORD you have spoken is good,' because peace is in his own days — is, in Oswalt's reading, the saddest sentence in the Hezekiah cycle. The king who prayed for the nation now accepts a prophecy of national catastrophe as acceptable because personally insulating. Covenant concern has contracted to dynastic comfort."
+            }
+          ]
         }
       }
     }
@@ -200,7 +226,23 @@
         }
       ],
       "note": "Prophecy peaks: the exile foretold. Daniel 1 fulfils this. First Isaiah closes on failure: the king who trusted God against Assyria trusts Babylon with everything. The bridge to \"Comfort, comfort my people.\""
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 39:5-7",
+        "target": "2 Kgs 20:16-18; Dan 1:3-4",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Some of your descendants... will be taken away, and they will become eunuchs in the palace of the king of Babylon.' The specific fulfilment begins with Daniel and his companions in Dan 1:3-4 — royal-seed youths carried to serve in Nebuchadnezzar's court. Isaiah's word lands exactly."
+      },
+      {
+        "anchor": "Isa 39:1-8",
+        "target": "2 Chr 32:25-31",
+        "type": "Echo",
+        "direction": "back",
+        "text": "The Chronicler's gloss on the Babylonian-envoys episode — 'God left him to test him, to know everything that was in his heart' — supplies the theological frame Isaiah lets stand implicit. Hezekiah's heart is revealed by the test, and found proud."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/40.json
+++ b/content/isaiah/40.json
@@ -68,6 +68,19 @@
         },
         "hist": {
           "context": "Isaiah 40 marks the theological hinge of the book, shifting from judgment oracles to consolation addressed to exiles in Babylon. The imperatives 'comfort, comfort' (naḥamū) are plural, summoning the heavenly council to announce that Jerusalem's warfare is ended and her iniquity pardoned. The highway-in-the-wilderness motif reimagines the exodus: just as YHWH led Israel through the desert from Egypt, so he will lead the exiles home from Babylon. The date is roughly 550–540 BC, as Cyrus's rise makes return imaginable."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "40:1-2",
+              "note": "Oswalt treats the doubled imperative 'comfort, comfort' as the structural hinge of the whole book. The first half (chs. 1-39) diagnoses the disease; chs. 40-66 announce the cure. The shift is not from one book to another but from judgment-for-sin to salvation-through-servant within a single prophetic vision. 'Speak tenderly to Jerusalem' is literally 'speak to the heart' — the covenant wooing-formula of Hos 2:14."
+            },
+            {
+              "ref": "40:3-5",
+              "note": "The wilderness highway. Oswalt emphasises the new-exodus theology: Yahweh will lead his people home from Babylon on a road he is making in the desert. The same language John the Baptist appropriates (Matt 3:3 and parallels) because the ultimate new exodus is the Messiah's work — the voice in the wilderness prepares for Yahweh's own coming."
+            }
+          ]
         }
       }
     },
@@ -128,6 +141,19 @@
         },
         "hist": {
           "context": "The incomparability hymn (vv.12–26) employs rhetorical questions to demolish any notion that YHWH can be measured, advised, or compared. Nations are drops in a bucket; islands are dust on scales. The polemic has a specific target: Babylonian astral religion, which deified the stars (v.26). By naming and numbering the host of heaven, YHWH demonstrates sovereignty over what Babylon worships. The closing promise (vv.28–31) addresses weary exiles: waiting on YHWH renews strength when human energy fails."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "40:12-17",
+              "note": "Oswalt reads the cosmic-scale rhetorical questions ('who has measured the waters in the hollow of his hand?') as the answer to the Rabshakeh's taunt in ch.36: 'has any god of any nation delivered his land?' Yes — the God who holds the oceans in his palm. The second-half's central theological move is to reground Yahweh's uniqueness in creator-power, not just historical deliverance."
+            },
+            {
+              "ref": "40:27-31",
+              "note": "The 'wait for the LORD, renew strength' ending is, for Oswalt, the pastoral payoff of the cosmological opening. The God who measures oceans is also the God who gives strength to the weary. The chapter moves deliberately from transcendence to intimacy: knowing Yahweh's bigness is what makes his personal care trustworthy."
+            }
+          ]
         }
       }
     }
@@ -230,7 +256,30 @@
         }
       ],
       "note": "Mercy AND Prophecy peak at 10: the hinge of Isaiah. \"Comfort, comfort.\" All four Gospels quote v.3. 1 Peter quotes vv.6–8. Sovereignty at 9: nations are a drop. Faith at 9: eagles, running, walking. The most beloved chapter in Isaiah."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 40:3-5",
+        "target": "Matt 3:3; Mark 1:2-3; Luke 3:4-6; John 1:23",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'A voice of one calling: In the wilderness prepare the way for the LORD.' Quoted by all four Gospels as the prophetic framework for John the Baptist's ministry — the most important single text for locating John's prophetic role in redemptive history."
+      },
+      {
+        "anchor": "Isa 40:6-8",
+        "target": "1 Pet 1:24-25; Jas 1:10-11",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'All people are like grass... the grass withers and the flowers fall, but the word of our God endures forever.' Peter quotes this in 1 Pet 1:24-25 as the theological basis for the gospel's reliability: the imperishable seed is the enduring word."
+      },
+      {
+        "anchor": "Isa 40:13-14",
+        "target": "Rom 11:34; 1 Cor 2:16",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Who has understood the mind of the LORD, or instructed him as his counselor?' Paul quotes this verse in both Rom 11:34 (doxological) and 1 Cor 2:16 (cross-related) — Yahweh's incomparability finds its NT development in the mind-of-Christ Christology."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/41.json
+++ b/content/isaiah/41.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Chapter 41 opens a courtroom drama: YHWH summons the nations to trial and asks who stirred up the conqueror from the east (v.2) — an oblique reference to Cyrus. The idol-makers are exposed as frauds who cannot predict or act. Against this background, the 'fear not' oracle (vv.8–16) addresses Israel as servant and chosen seed of Abraham, promising divine presence and transformed circumstances. The worm-and-threshing-sledge imagery (v.14–15) is jarring but deliberate: the weakest creature becomes an instrument of YHWH's judgment."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "41:1-7",
+              "note": "Oswalt frames the courtroom-of-the-nations scene as the pattern of chs. 40-48: Yahweh summons the idol-gods to trial, and the case turns on their failure to predict or control history. The rise of 'one from the east' (Cyrus, explicitly named in 44:28-45:1) will be introduced to reach the point that only Yahweh could have predicted it in advance."
+            },
+            {
+              "ref": "41:8-10",
+              "note": "Oswalt on 'you are my servant, I have chosen you': the servant identity is first introduced as corporate Israel — the covenant people as Yahweh's agent. Later the servant narrows progressively (chs. 42, 49, 50, 53) to an individual who will do what Israel-as-servant could not. The corporate-to-individual trajectory is the structural backbone of second-Isaiah's servant theology."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The courtroom trial continues as YHWH challenges the idols to testify about the future (vv.21–24). Their silence exposes them as nothing ('ěpěs). The section closes with YHWH announcing that he alone stirred up the one from the north (v.25) — again Cyrus — who will trample rulers like mortar. The polemic against prediction failure is devastating: if the gods cannot declare the future, they cannot be gods. Israel's God, by contrast, announces things before they happen and then brings them to pass."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "41:17-20",
+              "note": "Oswalt reads the transformation-of-the-wilderness language (pools in the desert, cedar and acacia in the wasteland) as explicit new-creation typology. The seven named trees (v.19) deliberately recall Eden's vegetative abundance. The promise is not merely geographical return from Babylon but cosmological restoration; Eden is being recovered along the exiles' road."
+            },
+            {
+              "ref": "41:21-24, 28-29",
+              "note": "The idol-challenge is direct and contemptuous: 'tell us what the future holds, so we may know you are gods.' Oswalt: the inability to predict is the theological disqualification of the idol-gods. Yahweh's prediction-and-fulfilment pattern, which the prophets will document across centuries, is the evidential core of Israel's monotheism."
+            }
+          ]
         }
       }
     }
@@ -222,7 +248,30 @@
         }
       ],
       "note": "Faith peaks at 10: triple fear-not, righteous right hand, worm Jacob held. The idol-trial: YHWH alone foretells. Seven trees in the desert."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 41:8-9",
+        "target": "Rom 8:33; 2 Chr 20:7; Jas 2:23",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You, Israel, my servant, Jacob, whom I have chosen, you descendants of Abraham my friend.' Abraham as 'friend of God' (also 2 Chr 20:7) supplies the language James applies in 2:23, and the elect-servant theology feeds Paul's 'who will bring any charge against those whom God has chosen?'"
+      },
+      {
+        "anchor": "Isa 41:10",
+        "target": "Matt 28:20; Heb 13:5-6",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Do not fear, for I am with you.' The covenant-presence formula reaches NT climax in Jesus' 'I am with you always, to the end of the age' and Hebrews' 'I will never leave you or forsake you' — the fear-not word Yahweh speaks becomes the assurance on which Christian courage rests."
+      },
+      {
+        "anchor": "Isa 41:21-23",
+        "target": "1 Kgs 18:20-40",
+        "type": "Echo",
+        "direction": "back",
+        "text": "The idol-trial motif — 'present your case... tell us what the future holds' — rhymes with Elijah's Mount Carmel contest: gods are known by their ability to act in history. Yahweh's prediction-fulfilment record is the prophetic version of Elijah's fire-from-heaven proof."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/42.json
+++ b/content/isaiah/42.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "The First Servant Song (42:1–9) introduces a mysterious figure: YHWH's chosen one, endowed with the Spirit, who will bring justice to the nations without force or fanfare. The bruised reed and smoldering wick (v.3) signal compassion for the weak. The Servant is appointed as 'covenant for the people, light for the Gentiles' (v.6) — a dual mission to Israel and nations. The identity is deliberately fluid: Israel as collective servant, a righteous remnant, or a future individual. The NT resolves the ambiguity Christologically."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "42:1-4",
+              "note": "Oswalt treats the first Servant Song as the introduction of the figure who will solve the problem corporate-Israel has created. 'He will not shout or cry out' contrasts the servant-king with ancient monarchs who announced themselves with trumpets. His method is quietness and bruised-reed-mercy; his scope is 'justice to the nations.' Matthew quotes this song in full (12:18-21) as Jesus' ministry template."
+            },
+            {
+              "ref": "42:6-7",
+              "note": "'A covenant for the people, a light for the nations.' Oswalt sees this as the decisive widening: the servant is not merely Israel's deliverer but the nations' illuminator. The patriarchal promise that all families of the earth would be blessed in Abraham (Gen 12:3) is now located in a specific person. Gentile inclusion is not a NT innovation; it is Isa 42's explicit commission."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "After the Servant Song comes a hymn of praise for YHWH's warrior-like intervention (vv.10–17), followed by a sharp rebuke of Israel's blindness and deafness (vv.18–25). The irony is bitter: the servant called to open blind eyes is himself blind. This duality — Israel as both servant and failed witness — creates the tension that the later Servant Songs will resolve. The plundered and imprisoned condition (v.22) reflects exilic reality; YHWH gave Jacob to the looters because of covenant unfaithfulness."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "42:10-13",
+              "note": "The 'new song' summons the ends of the earth — explicit universalism. Oswalt notes how second-Isaiah steadily enlarges the worship horizon: the coastlands, the desert, the cities of Kedar, Sela. Yahweh's people are no longer just Judah; the liturgy now requires the nations."
+            },
+            {
+              "ref": "42:18-25",
+              "note": "The paradox: the servant-people are themselves blind and deaf (vv.18-19). Oswalt's resolution: corporate Israel as servant has failed the servant-role; the mission falls to the individual servant of chs. 49-53 who succeeds where the corporate servant could not. The chapter's sharp turn from the servant-idyll (vv.1-9) to the servant-failure (vv.18-25) is not a contradiction but the book's central theological problem."
+            }
+          ]
         }
       }
     }
@@ -217,7 +243,23 @@
         }
       ],
       "note": "Prophecy AND Mission peak at 10: the first Servant Song. Matt 12:18–21; Luke 2:32; Acts 13:47. The servant IS the covenant. Light to the Gentiles. Bruised reed theology. Mercy at 9: tenderness as messianic strategy."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 42:1-4",
+        "target": "Matt 12:18-21",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "The first Servant Song is quoted in full in Matthew 12:18-21 as the programmatic text for Jesus' ministry: 'he will not shout or cry out, or raise his voice in the streets. A bruised reed he will not break.' The Servant's mercy-method is the pattern for Messianic ministry."
+      },
+      {
+        "anchor": "Isa 42:6-7",
+        "target": "Luke 2:32; Acts 13:47; 26:23",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will make you a light for the gentiles, to open eyes that are blind, to free captives.' Simeon quotes in the Nunc Dimittis (Luke 2:32); Paul applies it to his own mission (Acts 13:47); Christ's proclamation is 'a light to Jews and gentiles' (Acts 26:23)."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/43.json
+++ b/content/isaiah/43.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "The salvation oracle (43:1–7) is among the most intimate in the Hebrew Bible. YHWH addresses Israel by name, claims ownership by creation and redemption, and promises presence through water and fire — not exemption from trial but accompaniment through it. The ransom language (v.3) is striking: Egypt, Cush, and Seba are offered as payment for Israel's release. Historically, this may allude to Cyrus's conquest of Egypt (which occurred after his release of the exiles). The chapter establishes that Israel's value is not earned but bestowed."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "43:1-3",
+              "note": "'I have redeemed you; I have called you by name; you are mine.' Oswalt reads this as the covenant formula's most concentrated expression in the OT. The name-knowledge and the ownership-claim are specifically exilic pastoral — the people who think they have lost their identity among the empires are told that Yahweh knows every name."
+            },
+            {
+              "ref": "43:10-13",
+              "note": "'You are my witnesses, declares the LORD, that I am God.' Oswalt on the legal framing: Israel's whole existence is testimony to Yahweh's unique deity. 'Before me no god was formed, nor will there be one after me' (v.10) is one of the OT's strongest monotheistic statements — not just Yahweh-above-other-gods but Yahweh-alone-is."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The famous 'forget the former things' oracle (vv.18–19) announces that the coming exodus will eclipse even the original deliverance from Egypt. Rivers in the desert and water in the wilderness will mark YHWH's new act. Yet the chapter also contains a devastating indictment: Israel has burdened YHWH with sins rather than honoring him with sacrifices (vv.22–24). The juxtaposition is theological whiplash — election and accusation, promise and rebuke. YHWH blots out transgressions for his own sake, not because Israel deserves it (v.25)."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "43:16-21",
+              "note": "'Behold, I am doing a new thing.' Oswalt sees the new-exodus language here at its densest: the chariot-drowning imagery of Exod 14 is deliberately invoked and then superseded. Even the first exodus is relativised: 'forget the former things' — the new exodus will be so astonishing that Red Sea deliverance will look like its prototype."
+            },
+            {
+              "ref": "43:25",
+              "note": "'I, even I, am he who blots out your transgressions, for my own sake, and remembers your sins no more.' Oswalt: the grounding is not 'because you deserve it' but 'for my own sake' — Yahweh's forgiveness is self-motivated, rooted in his character, not contingent on Israel's performance. This is the foundation the servant-work of ch.53 will make effective."
+            }
+          ]
         }
       }
     }
@@ -212,7 +238,30 @@
         }
       ],
       "note": "Mercy peaks at 10: precious, honoured, loved. Waters, rivers, fire. Sins blotted for God’s own sake. Covenant at 9: redeemed, named, mine. The new thing surpasses the Exodus."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 43:1-2",
+        "target": "1 Pet 1:18-19; Rev 5:9",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I have redeemed you; I have summoned you by name; you are mine.' The redemption-and-naming-and-possession formula becomes the NT Church's experience: redeemed by Christ's blood, named (Rev 3:5), and belonging."
+      },
+      {
+        "anchor": "Isa 43:10-13",
+        "target": "John 8:58; Rev 1:17",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I am he' (ani hu) — a key formula Yahweh uses in these chapters — stands behind Jesus' 'I am' claims in John and the risen Christ's 'I am the First and the Last' in Rev 1:17. The absolute-self-designation moves from Yahweh directly to the exalted Son."
+      },
+      {
+        "anchor": "Isa 43:18-19",
+        "target": "2 Cor 5:17; Rev 21:5",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Forget the former things; do not dwell on the past. See, I am doing a new thing!' Paul's 'if anyone is in Christ, the new creation has come' and Revelation's 'I am making everything new' both draw on this new-thing announcement."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/44.json
+++ b/content/isaiah/44.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Isaiah 44:9–20 contains the most extended idol satire in the Hebrew Bible. A craftsman cuts a tree, uses half for fuel to warm himself and roast meat, then carves the other half into a god and bows down to it. The absurdity is deliberate: the same wood that becomes ash also becomes deity. The satire exposes idolatry as category confusion — worshiping what you make rather than the Maker. This is not mere polemic; it addresses exiles surrounded by Babylon's impressive cult, reassuring them that YHWH alone is God (vv.6–8)."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "44:1-5",
+              "note": "Oswalt reads the Spirit-poured-on-offspring promise (v.3) as one of the OT's clearest anticipations of the Pentecostal outpouring. 'I will pour out my Spirit on your descendants' is directly behind Joel 2:28-29 and then Acts 2:17-18. Identity-writing ('one will write on his hand, The LORD's,' v.5) anticipates the NT's seal-of-the-Spirit imagery."
+            },
+            {
+              "ref": "44:6-8",
+              "note": "'I am the first and I am the last; apart from me there is no God.' Oswalt highlights this as Isaiah's most radical monotheistic statement. The first-and-last formula will be applied directly to Christ in Revelation 1:17; 22:13 — a christological identification made possible only by this text's exclusivity."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The chapter concludes with the first explicit naming of Cyrus (v.28), called 'my shepherd' who will authorize Jerusalem's rebuilding and the temple's foundation. This is remarkable: a pagan king is YHWH's agent of restoration. The oracle is set roughly 550–540 BC, when Cyrus was conquering the Median empire and would soon topple Babylon (539 BC). Isaiah's claim that YHWH named Cyrus before his rise is central to the predictive-proof argument running through these chapters: only the true God can declare the end from the beginning."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "44:9-20",
+              "note": "The extended idol-maker parody. Oswalt: the theological point is that idol-making exposes the absurdity of the entire pagan project — the same block of wood cooks your bread and is worshipped as god. The craftsman 'eats its half, roasts meat, warms himself... and from the rest he makes a god.' The parody is not mere mockery; it is an argument from materials: whatever you make cannot save you."
+            },
+            {
+              "ref": "44:24-28",
+              "note": "The Cyrus-naming oracle. Oswalt argues for the predictive-prophecy reading: Cyrus is named by Isaiah more than 150 years before his rise. The oracle climaxes in 'he is my shepherd and will accomplish all that I please' — a covenant-king title (2 Sam 7) applied to a pagan Persian who does not know Yahweh (45:4). Prediction of specific future events is Isaiah's proof against the idol-gods."
+            }
+          ]
         }
       }
     }
@@ -207,7 +233,30 @@
         }
       ],
       "note": "Prophecy peaks at 10: Cyrus named 150 years before his conquest. \"First and Last\" applied to Christ (Rev 1:17). Mercy at 9: sins swept like clouds. The idol-satire: the most savage and funny in the Bible."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 44:3",
+        "target": "John 7:38-39; Acts 2:17-18",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will pour water on the thirsty land... I will pour out my Spirit on your offspring.' The Spirit-outpouring promise cluster (with Joel 2:28) is cited at Pentecost and drawn on by Jesus at the Feast of Tabernacles for the 'rivers of living water' promise."
+      },
+      {
+        "anchor": "Isa 44:6",
+        "target": "Rev 1:8, 17; 22:13",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I am the first and I am the last; apart from me there is no God.' Revelation applies this formula three times to Christ (1:8, 17; 22:13) — the most explicit christological identification of Jesus with the divine name."
+      },
+      {
+        "anchor": "Isa 44:28",
+        "target": "Ezra 1:1-4; 2 Chr 36:22-23",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Who says of Cyrus, He is my shepherd and will accomplish all that I please; he will say of Jerusalem, Let it be rebuilt.' Fulfilled in Ezra 1:1-4 and 2 Chr 36:22-23 — Cyrus's decree for the temple's rebuilding, issued approximately 150 years after Isaiah's prediction."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/45.json
+++ b/content/isaiah/45.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Chapter 45 contains the most explicit Cyrus oracle in Scripture. YHWH calls Cyrus 'my anointed' (māšîaḥ, v.1) — the only non-Israelite to receive this title. YHWH promises to subdue nations, open doors, and give Cyrus treasures so that he will know there is no God but YHWH (v.3). The theological audacity is stunning: Israel's deliverer will be a Persian who does not acknowledge Israel's God. Yet YHWH uses even those who do not know him (v.4–5). The chapter's monotheistic affirmations ('I am YHWH, there is no other') are among the clearest in the Hebrew Bible."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "45:1-7",
+              "note": "'His anointed, Cyrus.' Oswalt: the shock of the OT's only use of mashiach for a non-Israelite. Cyrus, who does not know Yahweh (v.4, 5), is given the messianic title because Yahweh is commissioning him for a specific covenant-serving task: returning Judah and rebuilding Jerusalem. Yahweh's freedom to anoint outside the covenant community prefigures the universal scope of the servant's own anointing."
+            },
+            {
+              "ref": "45:7",
+              "note": "'I form light and create darkness, I make weal and create woe, I the LORD do all these things.' Oswalt: direct polemic against Zoroastrian dualism that was emerging in the Persian context. One God, not two; cosmos ordered under single sovereignty. The 'create woe' claim is theologically sharp: Yahweh superintends even the hard edges of providence."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The universal-salvation oracle (vv.22–25) is programmatic: 'Turn to me and be saved, all you ends of the earth, for I am God and there is no other.' Every knee will bow, every tongue swear allegiance. This is not merely Israel's restoration but a vision of worldwide worship. The chapter also contains a theodicy-like dialogue (vv.9–13): the potter-and-clay imagery answers those who question YHWH's use of a pagan king. The Creator who formed the earth and gave it meaning does not owe explanations to creatures who are like potsherds among potsherds."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "45:14-17",
+              "note": "'They will make supplication to you... surely God is with you; there is no other.' Oswalt sees the nations-confession as the culmination of the courtroom scenes: gentiles come in chains confessing Yahweh's uniqueness. The pattern is reversed from conquest — not Yahweh's people fighting the nations but the nations voluntarily submitting to Yahweh's name."
+            },
+            {
+              "ref": "45:22-23",
+              "note": "'Turn to me and be saved, all you ends of the earth.' Oswalt: the universal invitation reaches its widest horizon here. 'Every knee shall bow, every tongue confess' becomes Paul's proof-text in Phil 2:10-11 for the exaltation of Christ — with the telling move that what Isaiah says of Yahweh, Paul says of Jesus, a direct christological claim."
+            }
+          ]
         }
       }
     }
@@ -217,7 +243,23 @@
         }
       ],
       "note": "Sovereignty AND Mission peak at 10: Cyrus called Messiah. \"I form light and create darkness.\" \"Every knee will bow\" (Phil 2:10). The universal invitation: all the earth. The most comprehensive sovereignty claim in the Bible."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 45:1-4",
+        "target": "Ezra 1:1-11",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "The Cyrus-as-anointed oracle is historically fulfilled in Ezra 1, with the Cyrus cylinder (540s BC) providing extra-biblical corroboration of Cyrus's policy of funding the rebuilding of local sanctuaries across his empire — including Jerusalem's temple."
+      },
+      {
+        "anchor": "Isa 45:22-23",
+        "target": "Rom 14:11; Phil 2:10-11",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Before me every knee will bow; by me every tongue will swear.' Paul applies this text to God the Father in Rom 14:11 and to the exalted Christ in Phil 2:10-11 — a decisive christological move: what Isaiah says of Yahweh, Paul says of Jesus."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/46.json
+++ b/content/isaiah/46.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "The chapter opens with devastating irony: Bel (Marduk) and Nebo (Nabu), Babylon's chief deities, must be loaded onto weary beasts and carted away when the city falls. The gods who cannot save themselves become burdens rather than bearers. By contrast, YHWH has carried Israel from the womb and will carry them to gray hairs (vv.3–4). The polemic is visual: imagine a New Year's procession where golden idols are paraded on carts, then imagine those same statues being looted and hauled off as plunder. That is Babylon's future."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "46:1-2",
+              "note": "'Bel bows down, Nebo stoops.' Oswalt: the image is of Babylonian gods loaded onto pack-animals as Cyrus enters Babylon — gods who must be carried, who become burdens themselves. The contrast with v.3-4 is the chapter's whole argument: idols must be carried; Yahweh carries his people 'from the womb... even to your old age.'"
+            },
+            {
+              "ref": "46:3-4",
+              "note": "'I have made, and I will bear; I will carry and will save.' Oswalt: one of the OT's tenderest pictures of divine constancy — a God who carries his people from birth through to old age. The covenant is personalised here in generational terms: Yahweh is not just Israel's God but the Israelite's God through the entire span of a life."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The chapter concludes with YHWH's self-identification as the one who declares the end from the beginning (v.10) — the predictive-proof argument that runs through Deutero-Isaiah. My counsel will stand, and I will accomplish all my purpose (v.10). A bird of prey from the east (v.11) is summoned — again Cyrus, swift and unstoppable. The theological point is inescapable: YHWH plans, speaks, and then brings to pass. The idols cannot predict; YHWH alone controls history. This certainty grounds the exiles' hope."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "46:9-10",
+              "note": "'Declaring the end from the beginning.' Oswalt: this is the most concentrated statement of Isaiah's prediction-argument. Yahweh's claim to uniqueness rests on the historical record of announcing what he will do before he does it. This epistemology — monotheism verified by fulfilled prophecy — is the second-Isaiah's apologetic backbone."
+            },
+            {
+              "ref": "46:12-13",
+              "note": "'Listen to me, you stubborn-hearted, who are far from righteousness.' Oswalt notes that the 'far-from-righteousness' addressees are Israel, not Babylon. The comfort-oracles throughout chs.40-48 are not sentimental; they assume a people deeply estranged whose righteousness must be brought to them as a gift. 'My salvation will not delay' — the work is Yahweh's, on Yahweh's timeline."
+            }
+          ]
         }
       }
     }
@@ -228,7 +254,23 @@
         }
       ],
       "note": "Sovereignty peaks at 10: God carries; idols are carried. \"I make known the end from the beginning.\" What I plan, I do."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 46:3-4",
+        "target": "Ps 48:14; Matt 28:20",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I have made, and I will bear; I will carry and will save.' The lifelong-carrying promise to covenant people echoes the psalmist's 'this God is our God forever and ever; he will be our guide even to the end' and Jesus' always-with-you promise."
+      },
+      {
+        "anchor": "Isa 46:9-10",
+        "target": "Eph 1:11",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I make known the end from the beginning, from ancient times, what is still to come. I say, My purpose will stand.' Paul's 'him who works out everything in conformity with the purpose of his will' is Isaiah's divine-purpose theology applied to the cosmic plan in Christ."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/47.json
+++ b/content/isaiah/47.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Chapter 47 is a taunt song against personified Babylon, the 'virgin daughter' (v.1) who must now sit in the dust, stripped of royal robes, grinding grain like a slave. The reversal is complete: the queen becomes servant, the pampered becomes exposed. YHWH was angry with his people and gave them into Babylon's hand, but Babylon showed no mercy (v.6), and for that she will be judged. The chapter draws on the ancient Near Eastern convention of city-as-woman — Babylon's humiliation is personal and total."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "47:1-5",
+              "note": "Oswalt reads the Babylon-oracle as the flip side of the Cyrus announcement: every empire that oppressed the covenant people comes under judgment. 'Virgin daughter of Babylon' is a mocking title — Babylon had never been humbled, never taken, never exposed. The sit-in-the-dust imagery inverts Babylon's self-image as eternal mistress of kingdoms."
+            },
+            {
+              "ref": "47:6",
+              "note": "'I was angry with my people; I profaned my heritage and gave them into your hand.' Oswalt: Babylon was the rod of Yahweh's anger (the same theology he applied to Assyria in 10:5), but their failure was to assume their power was self-generated. The tool of judgment becomes the object of judgment when it exceeds its commission."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The taunt continues with mockery of Babylon's astrologers and stargazers (vv.12–15). Let them save you, YHWH taunts — but they are stubble, fire consumes them, and there is not even a coal to warm oneself. The sorceries and enchantments in which Babylon trusted will prove useless. The merchants who trafficked with her will wander off, each to his own quarter, and no one will save her. The historical reference is the fall of Babylon to Cyrus in 539 BC, accomplished (according to Greek sources) without a major battle — the city fell suddenly, as Isaiah promised."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "47:8-11",
+              "note": "'You said, I am, and there is no one besides me; I shall not sit as a widow.' Oswalt: the self-deification formula Babylon uses is the exact formula Yahweh claims for himself ('I am, and there is no other'). Babylon has usurped the divine name; the judgment restores proper reference."
+            },
+            {
+              "ref": "47:12-15",
+              "note": "The astrologer-and-sorcerer parody. Oswalt notes the historical accuracy: Babylon's culture was famously invested in celestial prognostication and omen-texts. The mockery is targeted at the heart of the empire's religious establishment. 'They cannot save themselves from the power of the flame' — the very arts Babylon used to secure its future fail when the future actually arrives."
+            }
+          ]
         }
       }
     }
@@ -228,7 +254,30 @@
         }
       ],
       "note": "Judgment peaks at 10: queen to millstone. Justice at 9: Babylon showed no mercy. Rev 18 develops this. The empire that claims to be God is destroyed."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 47:1-15",
+        "target": "Jer 50-51; Rev 17-18",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The Babylon-oracle here is one of three major biblical Babylon-downfall cycles (with Jer 50-51 and Rev 17-18). The imagery of Babylon-as-proud-queen seated in splendour, then stripped and widowed, is picked up verbatim in Rev 18:7 — 'as she glorified herself and lived luxuriously, give her a like measure of torment.'"
+      },
+      {
+        "anchor": "Isa 47:8-10",
+        "target": "Rev 18:7",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You said, I am, and there is no one besides me. I will not be a widow or suffer the loss of children.' Revelation 18:7 quotes this directly as the prostitute-Babylon's self-deifying boast that is about to be overturned."
+      },
+      {
+        "anchor": "Isa 47:12-13",
+        "target": "Dan 2:27-28; 5:7-8",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "The astrologer-and-sorcerer mockery is dramatised in Daniel's court narratives: Babylon's magicians cannot interpret Nebuchadnezzar's dreams (Dan 2) or read the writing on Belshazzar's wall (Dan 5). Isaiah's prediction of their impotence lands historically."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/48.json
+++ b/content/isaiah/48.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Chapter 48 is a complex oracle mixing rebuke and promise. Israel is addressed as obstinate (v.4), a people who swear by YHWH's name but not in truth (v.1). The predictive-proof argument returns: YHWH declared things long ago precisely because Israel was stubborn and would credit idols if events seemed spontaneous (vv.3–5). New things are now announced, hidden until this moment (v.6–7). For his own name's sake, YHWH delays his wrath and does not cut Israel off (v.9). The refining-furnace metaphor (v.10) suggests that exile is purification, not annihilation."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "48:1-5",
+              "note": "Oswalt reads ch.48 as the concluding summary of chs.40-47's polemic: Yahweh predicted everything in advance 'lest you should say, My idol did them.' The repeated motif of 'former things' vs 'new things' is pedagogical — Israel is told the old predictions to build trust for the new ones. Theologically, fulfilment is the grammar of faith."
+            },
+            {
+              "ref": "48:9-11",
+              "note": "'For my own name's sake I defer my anger... I refine you, but not as silver; I have tried you in the furnace of affliction.' Oswalt: the justification of the exile is pedagogical, not punitive in the final analysis. 'How should my name be profaned?' is the root-motive — Yahweh's covenant commitment is self-anchored."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The chapter climaxes with the exodus imperative: 'Go out from Babylon! Flee from the Chaldeans!' (v.20). The new exodus motif reaches its narrative turning point: the deliverance YHWH announced is now to be enacted. Proclaim it with shouts of joy to the ends of the earth: YHWH has redeemed his servant Jacob (v.20). The water-from-rock imagery (v.21) recalls the original exodus, assuring the exiles that the same power is available for their journey home. Yet the chapter closes with a warning: there is no peace for the wicked (v.22) — a refrain that will recur at 57:21 and 66:24."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "48:16",
+              "note": "'And now the Lord GOD has sent me, and his Spirit.' Oswalt treats this verse as a quiet trinitarian datum: the speaker (the servant?) is sent by both the Father and the Spirit. The identification of the speaker is deliberately ambiguous, setting up the clearer servant identification in ch.49."
+            },
+            {
+              "ref": "48:20-22",
+              "note": "'Go out from Babylon, flee from Chaldea.' Oswalt: the exodus-imperative closes chs.40-48. The people-who-are-servant (corporate Israel) have been commanded to leave their exile. But v.22's 'there is no peace for the wicked' is a dissonant note: the exodus does not automatically resolve the heart-problem. The stage is set for an individual servant (chs.49-53) who will do what corporate Israel cannot."
+            }
+          ]
         }
       }
     }
@@ -213,7 +239,23 @@
         }
       ],
       "note": "Sovereignty peaks: for my own sake. First and Last again. The exodus-from-Babylon command. \"No peace for the wicked\" divides Second Isaiah."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 48:10-11",
+        "target": "1 Pet 1:6-7; Mal 3:3",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I have refined you, though not as silver; I have tested you in the furnace of affliction.' The refiner's-fire imagery becomes Malachi's (3:3) and Peter's (1 Pet 1:6-7) central metaphor for suffering as purifying discipline, not punitive destruction."
+      },
+      {
+        "anchor": "Isa 48:20-21",
+        "target": "Exod 15; 17:6",
+        "type": "Echo",
+        "direction": "back",
+        "text": "'He did not thirst when he led them through the deserts; he made water flow for them from the rock.' The new-exodus language consciously recalls the Red Sea song and the water-from-the-rock episodes of the first exodus — not as mere analogy but as resource for expectation."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/49.json
+++ b/content/isaiah/49.json
@@ -68,6 +68,19 @@
         },
         "hist": {
           "context": "The Second Servant Song (49:1–13) shifts from third-person introduction to first-person speech. The Servant addresses the coastlands, claiming that YHWH named him from the womb and made his mouth a sharp sword. The mission is twofold: restore Israel and become a light for the Gentiles (v.6). This dual scope resolves the earlier ambiguity — the Servant has a mission to Israel, so he cannot simply be Israel. Yet the mission is also through Israel to the nations. The song ends with a hymn of cosmic rejoicing (v.13) at the comfort YHWH provides."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "49:1-6",
+              "note": "The second Servant Song. Oswalt: the servant is identified with Israel (v.3) but then sent 'to bring Jacob back to him' (v.5) — an individual distinct from the corporate people. This is the key move in the servant theology: the true Israel is a person, and his mission is to restore the people who bear the name. 'A light for the gentiles' (v.6) is Paul's text in Acts 13:47 for gentile mission."
+            },
+            {
+              "ref": "49:5-6",
+              "note": "'It is too small a thing for you to be my servant to restore the tribes of Jacob... I will make you a light for the gentiles.' Oswalt reads this as the widening that exposes the servant-Messiah's cosmic office: covenant-particular work (Israel's restoration) is the instrument of cosmic-universal work (salvation to the ends of the earth)."
+            }
+          ]
         }
       }
     },
@@ -124,6 +137,19 @@
         },
         "hist": {
           "context": "Zion's lament — 'The LORD has forsaken me, my Lord has forgotten me' (v.14) — receives one of Scripture's most tender responses: can a mother forget her nursing child? Even if she could, YHWH will not forget. Jerusalem's name is engraved on his palms (v.16). The passage addresses the exiles' deepest fear: that covenant abandonment is permanent. The answer is categorical: your children will return, your destroyers will depart, you will be too crowded for your inhabitants. Kings and queens will bow to you (vv.22–23). The reversal of exile is total."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "49:14-16",
+              "note": "'Zion said, The LORD has forsaken me.' The answer Oswalt highlights: 'Can a mother forget the baby at her breast? Though she may forget, I will not forget you. See, I have engraved you on the palms of my hands.' The maternal-God imagery (rare in the OT) combined with the graving-on-the-palms creates one of Scripture's most intimate pictures of covenant memory."
+            },
+            {
+              "ref": "49:22-23",
+              "note": "'Kings will be your foster fathers, queens your nursing mothers.' Oswalt: the reversal is complete — Judah was exile-nation, now the nations serve Judah. Not in political imperial sense but in covenant-privilege sense: the nations recognise Zion as the locus of Yahweh's presence and assist rather than oppose the restoration."
+            }
+          ]
         }
       }
     }
@@ -221,7 +247,30 @@
         }
       ],
       "note": "Mercy AND Mission peak at 10: mother-love, palm-engraving, barren mother overwhelmed. Light for the Gentiles (Acts 13:47). Covenant at 9: engraved. Prophecy at 9: second Servant Song."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 49:6",
+        "target": "Luke 2:32; Acts 13:47",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will make you a light for the gentiles, that my salvation may reach to the ends of the earth.' Simeon voices it over the infant Jesus (Luke 2:32); Paul takes it as his apostolic commission (Acts 13:47). The Servant's mission is inherited by the Messiah and the Church."
+      },
+      {
+        "anchor": "Isa 49:8",
+        "target": "2 Cor 6:2",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'In the time of my favor I will answer you, and in the day of salvation I will help you.' Paul quotes this in 2 Cor 6:2 and adds 'now is the time of God's favor, now is the day of salvation' — the eschatological favour Isaiah anticipated has arrived in Christ."
+      },
+      {
+        "anchor": "Isa 49:15-16",
+        "target": "John 10:27-28",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'See, I have engraved you on the palms of my hands.' The name-on-palms imagery feeds the sheep-in-my-hand security of John 10:27-28 — 'no one will snatch them out of my hand.' Possession and protection are both hand-metaphors."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/50.json
+++ b/content/isaiah/50.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The chapter opens with rhetorical questions: where is your mother's divorce certificate? To which creditors was I forced to sell you (v.1)? The implied answer: none. Israel's exile is discipline, not divorce. YHWH's arm is not too short to save (v.2). The passage reframes exile: Israel was sold for her sins, not because YHWH was bankrupt. This legal-metaphor section sets up the Third Servant Song by clearing away the notion that YHWH abandoned his people permanently."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "50:1-3",
+              "note": "'Where is the certificate of your mother's divorce?' Oswalt: Yahweh denies that the exile is a covenant-divorce. The rhetorical question assumes no such certificate exists, because no such divorce happened. Exile was discipline, not rejection. The covenant relationship is interrupted, not terminated."
+            },
+            {
+              "ref": "50:2",
+              "note": "'Is my hand shortened, that it cannot redeem? Or have I no power to deliver?' Oswalt: the question assumes an answer the exiles may have stopped giving. The shortened-hand motif recurs (Num 11:23; Isa 59:1). Power is not the problem; Israel's sin has separated them from the available rescuer (59:2)."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The Third Servant Song (50:4–9) introduces suffering explicitly. The Servant is YHWH's disciple (limmûd), awakened morning by morning to hear and teach. He offers his back to those who beat him, his cheeks to those who pull out his beard, his face to mocking and spitting. Yet he sets his face like flint, confident that YHWH will vindicate him (vv.7–9). This is not passive victimhood but resolute trust. The legal metaphor returns: 'Who will bring charges against me?' The Servant expects acquittal from the heavenly court even as he endures earthly abuse."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "50:4-9",
+              "note": "The third Servant Song. Oswalt: the servant is now explicitly a suffering figure — smitten, spit on, beard plucked out. And yet 'I set my face like flint,' a determination that becomes Luke's explicit echo at 9:51 ('he set his face to go to Jerusalem'). The servant's trust is grounded in vindication-language: 'he who vindicates me is near.'"
+            },
+            {
+              "ref": "50:10-11",
+              "note": "'Who among you fears the LORD and obeys the voice of his servant?' Oswalt: response to the servant becomes the dividing line of the community. Those who walk in darkness without light must 'trust in the name of the LORD and rely on his God' — the servant mediates the relationship. The alternative (v.11) is to light one's own torches and lie down in torment."
+            }
+          ]
         }
       }
     }
@@ -217,7 +243,23 @@
         }
       ],
       "note": "Prophecy peaks at 10: the third Servant Song. Beating, spitting, beard-pulling (Matt 26–27). Face like flint (Luke 9:51). \"Who will condemn?\" (Rom 8:33). Faith at 9: trust in darkness."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 50:6",
+        "target": "Matt 26:67; 27:30",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I offered my back to those who beat me, my cheeks to those who pulled out my beard; I did not hide my face from mocking and spitting.' The passion-narratives describe Jesus undergoing exactly these specific indignities — beard-pulling, spitting, face-mocking — consciously fulfilling this third Servant Song."
+      },
+      {
+        "anchor": "Isa 50:7",
+        "target": "Luke 9:51",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I have set my face like flint, and I know I will not be put to shame.' Luke's Greek — Jesus 'set his face' to go to Jerusalem — is a direct verbal echo of this verse. The Servant's determination is the Messiah's trajectory."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/51.json
+++ b/content/isaiah/51.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Chapter 51 opens with a call to those who pursue righteousness: look to Abraham your father and Sarah who bore you. The barren-rock imagery (v.1) recalls Abraham and Sarah's miraculous fertility — YHWH can make the desert bloom. The comfort motif returns (v.3): YHWH will make Zion's wilderness like Eden, her desert like YHWH's garden. Joy and gladness will be found there. The ransomed-of-the-LORD refrain (v.11) anticipates the return from exile as a second exodus, complete with everlasting joy and the banishment of sorrow."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "51:1-3",
+              "note": "'Look to the rock from which you were cut; look to Abraham your father and Sarah who bore you.' Oswalt: the Abraham-reference is rhetorically pointed — 'when I called him, he was but one.' Yahweh multiplied the one into a nation; he can do it again. Exile-Israel is small; so was the covenant at its founding."
+            },
+            {
+              "ref": "51:9-11",
+              "note": "The 'awake, awake' summons to Yahweh's arm. Oswalt on the poetry: the chaoskampf imagery (Rahab, the dragon, the sea) is deliberately invoked to connect creation-victory, Red Sea deliverance, and the coming new-exodus. Yahweh's past acts are resources for his future acts; the exiles are invited to pray history forward."
+            }
+          ]
         }
       }
     },
@@ -120,6 +133,19 @@
         },
         "hist": {
           "context": "The 'Awake, awake' summons (vv.9, 17) calls YHWH's arm to action as in the days of old — when it cut Rahab to pieces and pierced the dragon (v.9). This is combat-myth language: YHWH's victory over primordial chaos is the paradigm for his victory over Babylon. The sea-drying imagery (v.10) fuses creation and exodus. The chapter climaxes with Zion's arousal: she has drunk YHWH's cup of wrath to the dregs; now that cup will pass to her tormentors (vv.21–23). The reversal of fortunes is complete."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "51:12-16",
+              "note": "'I, I am he who comforts you.' The doubled 'I' pronoun — Oswalt notes — emphasises the exclusivity of Yahweh's comforting role. The rhetorical question 'who are you that you fear mere mortals?' is theological therapy: fear of men is always a displacement of the fear of God."
+            },
+            {
+              "ref": "51:17-23",
+              "note": "'Awake, awake, rise up, O Jerusalem.' The address now reverses from Yahweh's arm (v.9) to Zion's shaking-off the cup of wrath. Oswalt: the cup-of-wrath motif (Jer 25:15-29; Rev 14:10; 16:19) is introduced here as the staple biblical image for divine judgment. The servant of ch.53 will drink the cup Zion has drunk."
+            }
+          ]
         }
       }
     }
@@ -212,7 +238,30 @@
         }
       ],
       "note": "Sovereignty peaks at 9: the Rahab-slaying arm, the cup transferred, salvation that outlasts heaven and earth. Mercy at 8: comfort, the cup removed. The 35:10 refrain returns."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 51:1-2",
+        "target": "Rom 4:16-17; Gal 3:29",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Look to Abraham your father and Sarah who bore you. When I called him, he was but one.' Paul's 'Abraham is the father of us all' (Rom 4:16) and 'if you belong to Christ, then you are Abraham's seed' (Gal 3:29) work out the theological implication: Abraham the one becomes Abraham the many."
+      },
+      {
+        "anchor": "Isa 51:6",
+        "target": "Matt 24:35; Heb 12:26-27",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The heavens will vanish like smoke, the earth will wear out like a garment... but my salvation will last forever.' The cosmic-transience/salvation-permanence contrast feeds Jesus' 'heaven and earth will pass away, but my words will never pass away' and Hebrews' shaking-of-creation theology."
+      },
+      {
+        "anchor": "Isa 51:17-23",
+        "target": "Matt 26:39-42; Rev 14:10",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The cup of his wrath... the goblet that makes people stagger.' The cup-of-wrath image becomes Jesus' Gethsemane prayer ('let this cup pass') — the Servant drinks the cup Zion has drunk. Rev 14:10 applies it back to final judgment."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/52.json
+++ b/content/isaiah/52.json
@@ -68,6 +68,19 @@
         },
         "hist": {
           "context": "Chapter 52 opens with another 'awake, awake' summons, this time to Zion herself. Put on your beautiful garments, holy city — the uncircumcised and unclean will no longer enter (v.1). The beautiful-feet oracle (vv.7–10) celebrates the messenger running over the mountains with good news: your God reigns! The watchmen on Zion's walls see YHWH returning and break into song. The exodus call follows: depart, touch nothing unclean, go out in purity but not in haste (v.11–12). YHWH himself goes before and behind — rearguard and vanguard for the returning exiles."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "52:1-6",
+              "note": "'Awake, awake, O Zion; clothe yourself with strength.' Oswalt: the threefold 'awake' sequence (Yahweh's arm 51:9, Zion 51:17, now Zion again 52:1) builds to the announcement of deliverance. Jerusalem is to dress for a coronation. 'My name is continually blasphemed' — the covenant shame is theological, not merely political."
+            },
+            {
+              "ref": "52:7",
+              "note": "'How beautiful on the mountains are the feet of those who bring good news.' Oswalt notes this is the OT's primary euaggelion-text: 'good news' as technical vocabulary for Yahweh's reign announced. Paul quotes it in Rom 10:15 for gospel preaching; the chain of messengers from Isaiah to the apostles is deliberate."
+            }
+          ]
         }
       }
     },
@@ -124,6 +137,19 @@
         },
         "hist": {
           "context": "The Fourth Servant Song begins at 52:13 (many scholars treat 52:13–53:12 as a unit). The Servant will be raised and highly exalted (v.13), yet his appearance was marred beyond human likeness (v.14). Kings will shut their mouths at him; what they were never told they will see (v.15). This prologue sets up the shocking reversal: the despised figure is the exalted agent of YHWH's salvation. The nations and kings who were horrified will be silenced with awe. The passage is the theological climax of Deutero-Isaiah."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "52:13-15",
+              "note": "The opening stanza of the fourth Servant Song (52:13-53:12). Oswalt: 'he will be high and lifted up and greatly exalted' uses the exact triad of divine-throne language from 6:1 ('high and lifted up'). The servant shares Yahweh's exaltation. But it sits alongside 'his appearance was so disfigured beyond that of any human being' — the paradox of glory-through-suffering the song will unfold."
+            },
+            {
+              "ref": "52:15",
+              "note": "'He will sprinkle many nations; kings will shut their mouths because of him.' Oswalt on the 'sprinkle' verb — priestly language for purification. The servant does what the sacrificial system did, but for nations, not just Israel. Paul quotes v.15 in Rom 15:21 as the rationale for gentile pioneer-preaching: 'those who were not told about him will see.'"
+            }
+          ]
         }
       }
     }
@@ -231,7 +257,30 @@
         }
       ],
       "note": "Prophecy AND Mission peak at 10: beautiful feet (Rom 10:15), the fourth Servant Song begins. \"Your God reigns!\" Nations sprinkled. Kings silenced. The theological climax of the OT approaches."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 52:7",
+        "target": "Rom 10:15; Eph 6:15",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'How beautiful on the mountains are the feet of those who bring good news.' Paul quotes this in Rom 10:15 as the apostolic-mission mandate, and Eph 6:15's 'feet fitted with readiness' of the gospel of peace extends the footwear-imagery."
+      },
+      {
+        "anchor": "Isa 52:11",
+        "target": "2 Cor 6:17; Rev 18:4",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Come out from it and be pure, you who carry the articles of the LORD's house.' Paul's 'come out from them and be separate' (2 Cor 6:17) and Revelation's 'come out of her, my people' (Rev 18:4) both draw on this text — the call to separation from idolatrous systems."
+      },
+      {
+        "anchor": "Isa 52:13-15",
+        "target": "Rom 15:21",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Those who were not told about him will see, and those who have not heard will understand.' Paul quotes v.15 in Rom 15:21 as his rationale for apostolic pioneer-preaching — taking the Servant's news to those who have not heard."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/53.json
+++ b/content/isaiah/53.json
@@ -68,6 +68,19 @@
         },
         "hist": {
           "context": "Isaiah 53:1–6 is the theological heart of the Hebrew Bible's suffering-for-others theology. The servant grew up like a tender shoot, without beauty or majesty (v.2). He was despised, rejected, a man of suffering (v.3). Yet he bore our griefs and carried our sorrows (v.4). He was pierced for our transgressions, crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed (v.5). All we like sheep had gone astray, and YHWH laid on him the iniquity of us all (v.6). The substitutionary logic is explicit: our sins, his suffering, our healing."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "53:1-3",
+              "note": "Oswalt reads 53:1 ('who has believed our message?') as the rhetorical acknowledgment that the servant's appearance contradicts every expectation. 'No beauty or majesty' — not the kind of messiah anyone was looking for. John 12:38 and Rom 10:16 both quote v.1 as the key to unbelief: the servant is rejected because he does not look like what salvation is supposed to look like."
+            },
+            {
+              "ref": "53:4-6",
+              "note": "The substitutionary-atonement climax. Oswalt: 'pierced for our transgressions, crushed for our iniquities' is the OT's most explicit penal-substitution language. 'The LORD has laid on him the iniquity of us all.' The inversions are total: we strayed, he bore; we deserved, he suffered; we were sick, by his wounds we are healed. Peter quotes vv.4-6 in 1 Pet 2:24-25 as the structural content of the cross."
+            }
+          ]
         }
       }
     },
@@ -128,6 +141,19 @@
         },
         "hist": {
           "context": "The servant's suffering culminates in death and burial with the wicked, yet with the rich in his death (v.9). YHWH's will was to crush him and cause him to suffer (v.10), yet through his offspring's flourishing and the LORD's purpose prospering, the servant's suffering is vindicated. He will see the light of life after his anguish (v.11). The 'many' language dominates: he bore the sin of many, made many righteous, made intercession for transgressors. The Fourth Servant Song resolves the Servant's identity crisis: this is not Israel (who sins and needs healing) but someone who heals Israel's wound by bearing it himself."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "53:7-9",
+              "note": "'He was led like a lamb to the slaughter, and as a sheep before its shearers is silent.' Oswalt: the Ethiopian eunuch reads precisely these verses when Philip joins him (Acts 8:32-35), and Philip 'told him the good news about Jesus' — the earliest example of Christian exegesis of Isa 53. The silent-lamb image is the synoptic gospels' template for Jesus before Pilate."
+            },
+            {
+              "ref": "53:10-12",
+              "note": "Oswalt on the song's climax: 'it was the LORD's will to crush him.' The shock is theological — the servant's suffering is not a mistake but a divine intention, a guilt-offering ('asham, v.10). 'He bore the sin of many, and made intercession for the transgressors' — priestly language grafted onto sacrificial language. The servant is simultaneously lamb and priest, offering and offerer."
+            }
+          ]
         }
       }
     }
@@ -224,7 +250,38 @@
         }
       ],
       "note": "Covenant, Mercy, AND Prophecy all peak at 10: THE theological climax of the OT. Every NT author quotes or alludes to this chapter. Substitutionary atonement. The lamb. The guilt offering. Resurrection implied. The most important chapter in Isaiah."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 53:1",
+        "target": "John 12:37-38; Rom 10:16",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Who has believed our message and to whom has the arm of the LORD been revealed?' John 12 and Romans 10 both quote this verse as the theological key to understanding Jewish rejection of the Servant-Messiah."
+      },
+      {
+        "anchor": "Isa 53:4-5",
+        "target": "Matt 8:17; 1 Pet 2:24",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'He took up our pain and bore our suffering... by his wounds we are healed.' Matthew applies v.4 to Jesus' healing ministry; Peter applies v.5 to the cross. The Servant's suffering is dual-dimensional: physical healing and spiritual atonement."
+      },
+      {
+        "anchor": "Isa 53:7-8",
+        "target": "Acts 8:32-35",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "The Ethiopian eunuch is reading precisely these verses when Philip meets him, and Philip 'began with that very passage of Scripture and told him the good news about Jesus.' Acts 8 is the NT's most explicit example of Christian exegesis of Isa 53."
+      },
+      {
+        "anchor": "Isa 53:12",
+        "target": "Luke 22:37",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'He was numbered with the transgressors.' Jesus quotes this verse in Luke 22:37 at the Last Supper, explicitly applying the Servant Song to himself: 'what is written about me is reaching its fulfilment.'"
+      }
+    ],
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Surely he took up our pain and bore our suffering, yet we considered him punished by God, stricken by him, and afflicted.</td></tr><tr><td class=\"t-label\">ESV</td><td>Surely he has borne our griefs and carried our sorrows; yet we esteemed him stricken, smitten by God, and afflicted.</td></tr><tr><td class=\"t-label\">NIV</td><td>But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.</td></tr><tr><td class=\"t-label\">ESV</td><td>But he was pierced for our transgressions; he was crushed for our iniquities; upon him was the chastisement that brought us peace, and with his wounds we are healed.</td></tr><tr><td class=\"t-label\">NIV</td><td>We all, like sheep, have gone astray, each of us has turned to our own way; and the LORD has laid on him the iniquity of us all.</td></tr><tr><td class=\"t-label\">ESV</td><td>All we like sheep have gone astray; we have turned — every one — to his own way; and the LORD has laid on him the iniquity of us all.</td></tr><tr><td class=\"t-label\">NIV</td><td>After he has suffered, he will see the light of life and be satisfied; by his knowledge my righteous servant will justify many, and he will bear their iniquities.</td></tr><tr><td class=\"t-label\">ESV</td><td>Out of the anguish of his soul he shall see and be satisfied; by his knowledge shall the righteous one, my servant, make many to be accounted righteous, and he shall bear their iniquities.</td></tr>"
   },
   "vhl_groups": [
     {

--- a/content/isaiah/54.json
+++ b/content/isaiah/54.json
@@ -68,6 +68,19 @@
         },
         "hist": {
           "context": "After the Fourth Servant Song, the mood shifts to exuberant celebration. The barren woman — Zion in exile — is called to sing because her children will outnumber those of the married woman (v.1). Enlarge your tent, stretch your curtains, lengthen your cords (vv.2–3). The husband-of-your-youth metaphor returns: YHWH abandoned Zion briefly in anger but now gathers her with everlasting compassion (vv.6–8). The flood-oath reference (v.9) grounds the promise: as YHWH swore never to flood the earth again, so he swears never to be angry with Zion again. The covenant is unbreakable."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "54:1-3",
+              "note": "'Sing, barren woman, you who never bore a child.' Oswalt: the imagery is the reversal of exile — Zion who seemed childless will have more children than she could imagine. Paul quotes v.1 in Gal 4:27 as the template for covenant freedom that produces more spiritual descendants than covenant slavery ever did. The post-servant fruitfulness is ecclesiologically enormous."
+            },
+            {
+              "ref": "54:7-10",
+              "note": "'As I swore that the waters of Noah should no more go over the earth, so I have sworn that I will not be angry with you.' Oswalt: the Noahic-covenant parallel makes the post-servant covenant unconditionally stable. 'The mountains may depart, but my steadfast love shall not depart from you.' Cosmic dissolution is conceivable; covenant-chesed dissolution is not."
+            }
+          ]
         }
       }
     },
@@ -124,6 +137,19 @@
         },
         "hist": {
           "context": "The afflicted, storm-tossed city will be rebuilt with precious stones: foundations of sapphires, battlements of rubies, gates of sparkling jewels (vv.11–12). All your children will be taught by YHWH, and great will be their peace (v.13). No weapon forged against you will prevail; every tongue that accuses you will be refuted (v.17). This is the heritage of YHWH's servants — plural, extending the Servant's vindication to those who belong to him. The chapter closes with one of the most sweeping security promises in Scripture: divine teaching, lasting peace, complete protection."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "54:11-17",
+              "note": "The jewelled-city vision. Oswalt: the images (sapphires, rubies, precious stones as foundations and gates) feed directly into the New Jerusalem description of Rev 21:18-21. The post-servant Zion is already eschatological — the church-that-will-be is seen from this height."
+            },
+            {
+              "ref": "54:17",
+              "note": "'No weapon formed against you shall prosper... This is the heritage of the servants of the LORD.' Oswalt: the shift from singular 'servant' (chs.42-53) to plural 'servants' (here and throughout chs.55-66). The individual servant's work produces a community of servants who inherit his vindication — the NT's 'in Christ' ecclesiology has its OT source here."
+            }
+          ]
         }
       }
     }
@@ -221,7 +247,30 @@
         }
       ],
       "note": "Covenant AND Mercy peak at 10: covenant of peace, barren woman sings, brief anger / everlasting kindness. The servant death (ch.53) produces the barren woman children (ch.54). No weapon prevails."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 54:1",
+        "target": "Gal 4:27",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Sing, barren woman, you who never bore a child.' Paul quotes this verse in Gal 4:27 as his warrant for the theology of grace — spiritual children produced by promise (Isaac/Sarah/the Jerusalem above) outnumber those produced by flesh (Ishmael/Hagar/the present Jerusalem)."
+      },
+      {
+        "anchor": "Isa 54:13",
+        "target": "John 6:45",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'All your children will be taught by the LORD.' Jesus cites this in John 6:45 as the basis for his claim that those who come to him are the ones the Father has drawn and taught — the Servant's community is a taught-by-God community."
+      },
+      {
+        "anchor": "Isa 54:17",
+        "target": "Rom 8:31-34",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'No weapon forged against you will prevail, and you will refute every tongue that accuses you.' Paul's 'if God is for us, who can be against us?' and 'who will bring any charge against God's elect?' are Romans-language versions of this servant-community promise."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/55.json
+++ b/content/isaiah/55.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Chapter 55 opens with the most expansive invitation in the Hebrew Bible: come, all who thirst, buy wine and milk without money (v.1). Why spend money on what is not bread? (v.2). The offer is free, universal, and life-giving. YHWH extends to the many the 'everlasting covenant, the sure mercies promised to David' (v.3). David as witness, leader, and commander of peoples (v.4) now becomes a paradigm for nations who will run to Israel because of YHWH's glory. The democratization of the Davidic covenant is striking: what was promised to the king is now offered to all who come."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "55:1-3",
+              "note": "'Come, all you who are thirsty, come to the waters.' Oswalt: the post-servant invitation is universally open and absolutely free. 'You who have no money' — the economy of grace repudiates the merit economy. The 'everlasting covenant, my faithful love promised to David' transfers Davidic-covenant blessings to the servant-community — democratised messianic privilege."
+            },
+            {
+              "ref": "55:3-5",
+              "note": "'I will make an everlasting covenant with you, my faithful love promised to David.' Oswalt: Paul quotes v.3 in Acts 13:34 (the 'sure mercies of David') as proof of the resurrection — the Davidic covenant's permanence requires a permanent Davidic figure. The servant becomes the means by which Davidic promises reach the nations: 'nations that did not know you will come running.'"
+            }
+          ]
         }
       }
     },
@@ -124,6 +137,19 @@
         },
         "hist": {
           "context": "The chapter closes with one of Scripture's most profound statements about divine speech: as rain and snow water the earth and make it bring forth seed, so my word will not return empty but will accomplish what I purpose (vv.10–11). The effectiveness of YHWH's word is guaranteed. The final image is eschatological transformation: mountains and hills will burst into song, trees will clap their hands, cypress will replace thornbush (vv.12–13). This everlasting sign will be for YHWH's renown. The Book of Comfort ends on a note of cosmic rejoicing, nature itself celebrating the redemption announced."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "55:6-9",
+              "note": "'Seek the LORD while he may be found.' Oswalt: the window-of-opportunity language is urgent because the servant's work has actually been accomplished; the response is now. 'My thoughts are not your thoughts' is the epistemological foundation of this whole section — grace operates on a logic humans cannot construct from below."
+            },
+            {
+              "ref": "55:10-13",
+              "note": "'So is my word that goes out from my mouth; it will not return to me empty.' Oswalt: the word-efficacy theology climaxes Second Isaiah's entire argument. The predictions announced in chs.40-48 will definitely land. 'You will go out in joy and be led forth in peace' — the new exodus is now framed as creation-wide joy; thorn-to-cypress reversal recalls Eden's curse being undone."
+            }
+          ]
         }
       }
     }
@@ -216,7 +242,30 @@
         }
       ],
       "note": "Mercy peaks at 10: the great invitation. Free grace. No money. Mission at 9: all who are thirsty, all nations. God word as rain: it accomplishes its purpose. Trees clap their hands."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 55:1",
+        "target": "John 7:37; Rev 22:17",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Come, all you who are thirsty, come to the waters; and you who have no money, come!' Jesus' 'if anyone thirsts, let him come to me and drink' at Tabernacles and Revelation's closing 'let the one who is thirsty come; and let the one who wishes take the free gift of the water of life' both rest on Isa 55:1."
+      },
+      {
+        "anchor": "Isa 55:3",
+        "target": "Acts 13:34",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will make with you an everlasting covenant, my faithful love promised to David.' Paul quotes this verse in Acts 13:34 as proof of the resurrection — the Davidic covenant's permanence requires a perpetual Davidic figure, which only a risen Christ can be."
+      },
+      {
+        "anchor": "Isa 55:10-11",
+        "target": "Heb 4:12; 1 Pet 1:23-25",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'My word that goes out from my mouth will not return to me empty.' The word-efficacy theology feeds Hebrews' 'word of God is living and active' and Peter's 'imperishable seed... the living and enduring word of God.'"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/56.json
+++ b/content/isaiah/56.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Third Isaiah (chapters 56-66) addresses the post-exilic community, likely in the late sixth century BC. The inclusion of foreigners and eunuchs reverses Deuteronomy 23:1-8's exclusions, signaling that the restoration transcends ethnic boundaries. The rebuilt temple must serve its original purpose as a house of prayer for all peoples, not a nationalistic shrine."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "56:1-2",
+              "note": "Oswalt reads chs.56-66 as the third major section of the book: after judgment (1-39) and comfort (40-55), these chapters describe the servant-community's post-restoration life. 'Keep justice, and do righteousness; my salvation is soon to come.' The ethical imperatives flow from the eschatological expectation: servants live as if the kingdom is already near."
+            },
+            {
+              "ref": "56:3-8",
+              "note": "The inclusion of foreigners and eunuchs. Oswalt: both categories had been explicitly excluded from the Deuteronomic assembly (Deut 23:1-8). Isaiah 56 reverses the exclusions — 'a name better than sons and daughters' to the eunuch, 'my house will be called a house of prayer for all nations' (v.7, Jesus' Temple-cleansing text). The servant's universal mission disassembles the old boundary markers."
+            }
+          ]
         }
       }
     },
@@ -108,6 +121,19 @@
         },
         "hist": {
           "context": "The 'blind watchmen' and 'mute dogs' represent post-exilic leadership failures. Despite the return from Babylon, the community faced corrupt priests, economic exploitation, and spiritual lethargy. The accusation that leaders love to sleep and dream echoes pre-exilic prophetic critiques, warning that restoration alone does not guarantee righteousness."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "56:9-12",
+              "note": "The oracle against corrupt leaders. Oswalt: the 'dumb dogs... loving to slumber' are Israel's watchmen who should be warning the people but instead are greedy and self-serving. The ideal-Zion of vv.1-8 sits against the real-Zion of vv.9-12 — the vision and the reality are theologically paired, the gap between them is the work of the rest of the book."
+            },
+            {
+              "ref": "56:10-11",
+              "note": "'They are shepherds who lack understanding.' Oswalt notes the direct echo of Ezekiel 34 (failed shepherds), which becomes the backdrop for John 10's good-shepherd discourse. The leadership-failure theme is dense across the prophets and consistently points to a coming true Shepherd the servant will embody."
+            }
+          ]
         }
       }
     }
@@ -205,7 +231,23 @@
         }
       ],
       "note": "Mission peaks at 10: house of prayer for ALL nations. Foreigners and eunuchs included. Mark 11:17. Acts 8 (Ethiopian eunuch) fulfils. The widest inclusion in the OT."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 56:3-5",
+        "target": "Acts 8:26-39",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Let no foreigner say... let no eunuch say, I am only a dry tree.' Deut 23:1 had excluded eunuchs from the assembly; Isaiah 56 reverses the exclusion. Acts 8's conversion of the Ethiopian eunuch — the first Gentile-convert — concretises this reversal."
+      },
+      {
+        "anchor": "Isa 56:7",
+        "target": "Matt 21:13; Mark 11:17; Luke 19:46",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'My house will be called a house of prayer for all nations.' Jesus quotes this at the Temple cleansing — the all-nations scope of the temple's purpose is the theological ground of his protest against the commercial encroachment of the Court of the Gentiles."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/57.json
+++ b/content/isaiah/57.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The righteous perishing unnoticed reflects the post-exilic community's moral confusion. The idolatrous practices described (child sacrifice in valleys, worship among oaks) suggest that exile had not fully purged Judah of its syncretism. Some returning exiles revived pre-exilic abominations, prompting this harsh prophetic condemnation."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "57:1-2",
+              "note": "'The righteous perish, and no one takes it to heart.' Oswalt: the chapter's opening is a lament for the post-exilic community's moral blindness. The death of the righteous is not tragedy for them ('they enter into peace') but an indictment of the community that does not notice. The righteous are 'taken away from calamity' — death as mercy."
+            },
+            {
+              "ref": "57:3-13",
+              "note": "The idolatry-polemic. Oswalt notes that the specific offenses — sacred trees, valley altars, child sacrifice — are the pre-exilic Canaanite syncretism Israel was never fully purged of. Post-exilic Judah is still dealing with the same heart-idolatries. Return from geographical exile has not produced return from theological exile."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The declaration that God dwells both in the high and holy place and with the contrite represents Isaiah's characteristic both/and theology. The post-exilic community, humbled by exile, is assured that their brokenness is itself the condition for divine presence. The peace promised to those far and near anticipates universal scope even in restoration-era prophecy."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "57:14-19",
+              "note": "'I dwell in a high and holy place, and also with him who is of a contrite and lowly spirit.' Oswalt: this is one of the OT's strongest statements of the divine condescension — the transcendent God's deliberate presence with the broken. 'I will heal them; I will guide them and give them comfort' — the servant-community's ongoing pastoral reality."
+            },
+            {
+              "ref": "57:20-21",
+              "note": "'The wicked are like the tossing sea... there is no peace for the wicked, says my God.' Oswalt: the exact refrain as 48:22, marking the boundary of another major subsection. The book has three 'no peace' refrains (48:22, 57:21, 66:24 equivalent) structuring its final movement."
+            }
+          ]
         }
       }
     }
@@ -224,7 +250,30 @@
         }
       ],
       "note": "Holiness peaks at 9: the high-and-holy God with the contrite. Mercy: peace to far and near (Eph 2:17). The divine paradox: transcendence inhabits lowliness."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 57:15",
+        "target": "Matt 5:3; Jas 4:6",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'I live in a high and holy place, but also with the one who is contrite and lowly in spirit.' The divine presence with the humble feeds Jesus' 'blessed are the poor in spirit' and James's (via Prov 3:34) 'God opposes the proud but shows favor to the humble.'"
+      },
+      {
+        "anchor": "Isa 57:19",
+        "target": "Eph 2:13-17",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Peace, peace, to those far and near.' Paul's 'preached peace to you who were far away and peace to those who were near' in Eph 2:17 is a direct appropriation — Christ is the peace that brings near and far together."
+      },
+      {
+        "anchor": "Isa 57:20-21",
+        "target": "Jude 13",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The wicked are like the tossing sea, which cannot rest, whose waves cast up mire and mud.' Jude 13's 'wild waves of the sea, foaming up their shame' applies the imagery to false teachers within the church."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/58.json
+++ b/content/isaiah/58.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "Post-exilic fasting commemorated Jerusalem's destruction (Zech 7:3-5), but the community observed rituals while perpetuating injustice. Isaiah redefines fasting as social ethics: loosing chains of injustice, freeing the oppressed, sharing food with the hungry. This prophetic tradition influenced later rabbinic interpretation of Yom Kippur."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "58:1-5",
+              "note": "The fasting critique. Oswalt: the post-exilic community is performing the religious rituals but missing the covenant substance. 'Why have we fasted and you have not seen it?' — their question betrays the commercial theology (we did X, God owes Y) the prophets repeatedly reject. True fasting is ethical practice, not cultic performance."
+            },
+            {
+              "ref": "58:6-9",
+              "note": "'Is not this the fast that I choose: to loose the bonds of wickedness... to share your bread with the hungry?' Oswalt: the social-justice content of true fasting is explicitly theological — it mirrors Yahweh's own liberative character (61:1). Jesus' Nazareth-manifesto in Luke 4 quotes the companion-text of Isa 61 in exactly this social-justice mode."
+            }
+          ]
         }
       }
     },
@@ -108,6 +121,19 @@
         },
         "hist": {
           "context": "The titles 'Repairer of Broken Walls' and 'Restorer of Streets with Dwellings' address a devastated Jerusalem still in ruins decades after the exile's end. The sabbath instruction (vv.13-14) gains urgency in a community redefining its identity around Torah observance. Sabbath becomes the visible marker distinguishing Israel from surrounding peoples."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "58:10-12",
+              "note": "'If you pour yourself out for the hungry... then shall your light rise in the darkness.' Oswalt: the light-imagery connects to the servant's mission (49:6) — the community that acts like the servant becomes the servant's continuing embodiment. 'Rebuilder of broken walls' (v.12) is the Nehemiah-shaped vocation of post-exilic restoration."
+            },
+            {
+              "ref": "58:13-14",
+              "note": "The Sabbath promise. Oswalt: 'if you call the Sabbath a delight... then you will find your joy in the LORD.' Sabbath is not a legal burden but an access point to covenant delight. The chapter's entire ethics — fasting, justice, Sabbath — reconfigures religious practice around the question: does this practice actually move you toward Yahweh?"
+            }
+          ]
         }
       }
     }
@@ -195,7 +221,23 @@
         }
       ],
       "note": "Justice peaks at 10: true fasting = social action. Loose chains, feed hungry, clothe naked. Justice produces answered prayer and light. Repairer of walls."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 58:6-7",
+        "target": "Matt 25:34-40; Jas 1:27",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'To loose the chains of injustice... to share your food with the hungry, to provide the poor wanderer with shelter.' The social-justice content of true fasting is directly behind Jesus' sheep-and-goats criteria ('I was hungry and you gave me something to eat') and James's 'pure and faultless religion.'"
+      },
+      {
+        "anchor": "Isa 58:11",
+        "target": "John 7:38",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You will be like a well-watered garden, like a spring whose waters never fail.' The living-water-within-the-believer imagery anticipates Jesus' 'out of his belly shall flow rivers of living water' promise at Tabernacles."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/59.json
+++ b/content/isaiah/59.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The catalogue of sins (lying, violence, injustice) describes post-exilic Judah's moral condition. The legal metaphors (justice, righteousness, truth) suggest covenant lawsuit language. Sin is presented not merely as individual failure but as communal darkness that blinds the nation. The image of groping like the blind at noon captures spiritual disorientation."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "59:1-2",
+              "note": "'The LORD's hand is not shortened that it cannot save, nor his ear too dull to hear. But your iniquities have made a separation.' Oswalt: the diagnosis refuses the deus-absconditus reading of divine silence. Yahweh has not retracted; sin has built a wall. The problem is not absence of power but presence of iniquity."
+            },
+            {
+              "ref": "59:3-15a",
+              "note": "The extended sin-catalogue. Oswalt: Paul-in-Romans quotes v.7-8 in Rom 3:15-17 as part of the universal-human-depravity proof. The diagnosis is comprehensive (lips, tongue, feet, thoughts, works) and culminates in 'truth has stumbled in the public squares, and uprightness cannot enter' — social dissolution traced to personal unrighteousness."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "When no human intercessor appears, YHWH himself arms for battle. The divine warrior imagery draws on ancient Near Eastern combat mythology but redirects it: God fights for his people when they cannot fight for themselves. The Redeemer coming to Zion addresses those who turn from transgression, maintaining the prophetic tension between judgment and hope."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "59:16-17",
+              "note": "'He saw that there was no one... so his own arm brought him salvation.' Oswalt: the divine-warrior imagery is explicit — Yahweh himself puts on righteousness as a breastplate, salvation as a helmet. Paul applies this armour directly to believers in Eph 6:14-17, making the servant-community wear its God's own equipment."
+            },
+            {
+              "ref": "59:20-21",
+              "note": "'A Redeemer will come to Zion, to those in Jacob who repent.' Paul quotes this in Rom 11:26 as the basis for the eschatological salvation of Israel. Oswalt: the chapter closes with the eternal-covenant promise — Spirit and word will not depart from the servant-community 'forever.' The Redeemer-announcement sets up chs.60-62's glory-vision."
+            }
+          ]
         }
       }
     }
@@ -209,7 +235,30 @@
         }
       ],
       "note": "Prophecy peaks at 9: the divine warrior (Eph 6:14-17), the Redeemer coming to Zion (Rom 11:26), the Spirit-and-word covenant forever. Justice and Judgment: sin as barrier, truth stumbled, no one to intervene — so God acts alone."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 59:7-8",
+        "target": "Rom 3:15-17",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Their feet rush into sin; they are swift to shed innocent blood... ruin and destruction mark their ways.' Paul quotes these verses in Rom 3:15-17 as part of his universal-depravity catena — Isaiah's indictment of Israel becomes Paul's proof of universal human sinfulness."
+      },
+      {
+        "anchor": "Isa 59:17",
+        "target": "Eph 6:14-17; 1 Thess 5:8",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'He put on righteousness as his breastplate, and the helmet of salvation on his head.' Paul's armour-of-God passage applies Yahweh's own warrior equipment to believers — the Servant's community wears its God's armour."
+      },
+      {
+        "anchor": "Isa 59:20-21",
+        "target": "Rom 11:26-27",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'The Redeemer will come to Zion, to those in Jacob who repent of their sins.' Paul quotes this in Rom 11:26 as the eschatological foundation for 'all Israel will be saved' — the final salvation of ethnic Israel anchored in Isaiah's promise."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/60.json
+++ b/content/isaiah/60.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "Isaiah 60's vision of nations streaming to Zion reverses Israel's humiliation under empire. The wealth of Midian, Ephah, and Sheba (Arabian trade goods) represents the reversal of Israel's former dependence on foreign powers. The chapter functions as eschatological liturgy, celebrating a restoration that transcends any historical return from exile."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "60:1-3",
+              "note": "'Arise, shine, for your light has come.' Oswalt: the chapter is the vision-peak of third-Isaiah — Zion enthroned, nations streaming in, the glory of the LORD risen as the light of the world. 'Nations will come to your light, kings to the brightness of your dawn' — the nations-to-Zion pattern (2:2-3) reaches its fullest description."
+            },
+            {
+              "ref": "60:10-14",
+              "note": "'Foreigners will rebuild your walls, and their kings will serve you.' Oswalt reads this not as political triumphalism but as the fulfilment of the servant's universal mission: the nations voluntarily resource the Zion-project because they recognise it as their own true destination. Revelation 21:24-26's New Jerusalem draws directly from this vision."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The promise that sun and moon will be unnecessary transforms cosmology into theology. No more mourning, eternal light, and perpetual divine presence describe existence beyond historical time. The 'least becoming a thousand' inverts Israel's diminished state, promising exponential growth. This vision shaped both Jewish messianic expectation and early Christian eschatology."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "60:19-20",
+              "note": "'The sun will no more be your light by day... the LORD will be your everlasting light.' Oswalt: the cosmological image is picked up directly in Rev 21:23 — the New Jerusalem has no need for sun or moon because the glory of God gives it light. Isaiah 60 is the Revelation 21 source-text for the Lamb-as-lamp-of-the-city."
+            },
+            {
+              "ref": "60:21-22",
+              "note": "'Your people will all be righteous; they will possess the land forever.' Oswalt: the post-servant community's definitive character — righteousness is no longer the exception but the rule. 'The least of you will become a thousand, the smallest a mighty nation' — the multiplication of the covenant community mirrors the Abrahamic promise's original scale."
+            }
+          ]
         }
       }
     }
@@ -209,7 +235,30 @@
         }
       ],
       "note": "Prophecy AND Mission peak at 10: Epiphany text, Matt 2:11, Rev 21:23–25. Nations stream to the light. Gates never shut. Everlasting light replaces sun and moon."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 60:1-3",
+        "target": "Matt 4:16; John 8:12",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Arise, shine, for your light has come... nations will come to your light.' The coming-of-light imagery stands behind Matthew's quotation of Isa 9:2 at Jesus' Galilee ministry and Jesus' 'I am the light of the world' claim."
+      },
+      {
+        "anchor": "Isa 60:11",
+        "target": "Rev 21:25-26",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Your gates will always stand open, they will never be shut... the wealth of nations will be brought to you.' Revelation 21:25-26 quotes directly: 'On no day will its gates ever be shut... the glory and honor of the nations will be brought into it.'"
+      },
+      {
+        "anchor": "Isa 60:19-20",
+        "target": "Rev 21:23; 22:5",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'The sun will no more be your light by day... for the LORD will be your everlasting light.' The New Jerusalem of Revelation 21:23 'does not need the sun or the moon to shine on it, for the glory of God gives it light' — direct fulfilment."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/61.json
+++ b/content/isaiah/61.json
@@ -64,6 +64,19 @@
         },
         "hist": {
           "context": "The speaker in Isaiah 61 is anointed by YHWH's Spirit to proclaim jubilee — freedom for captives, release for prisoners. The imagery draws on Leviticus 25's Year of Jubilee, when debts were cancelled and slaves freed. Whether the original speaker was a prophet, the Servant, or an idealized figure, Jesus's appropriation in Luke 4 made this passage central to Christian messianism."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "61:1-3",
+              "note": "'The Spirit of the Sovereign LORD is upon me, because the LORD has anointed me.' Oswalt: Jesus' Nazareth-manifesto text (Luke 4:18-19) — the figure who speaks is the anointed-Spirit-endowed servant, now identified in Jesus' self-announcement. Oil of gladness, garment of praise, oaks of righteousness: the reversal-imagery describes the inside-of-persons restoration the servant's work produces."
+            },
+            {
+              "ref": "61:1-2",
+              "note": "'To proclaim freedom for the captives and release from darkness for the prisoners, to proclaim the year of the LORD's favor.' Oswalt: the 'year of the LORD's favor' is Jubilee language (Lev 25) — debt-cancellation, slave-emancipation, property-restoration, Sabbath-year rest. The servant's ministry is cosmic Jubilee. Jesus stops the reading at v.2a, deliberately cutting 'the day of vengeance' (postponed to the parousia)."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The transformation from mourning to gladness, from ashes to a crown of beauty, employs concrete liturgical imagery. The recipients become 'oaks of righteousness,' reversing the polluted sacred oaks condemned in chapter 57. The priestly designation for all Israel democratizes what was previously limited to Levites, anticipating later concepts of universal priesthood."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "61:4-7",
+              "note": "'You will be called priests of the LORD; you will be named ministers of our God.' Oswalt: the democratisation of priesthood — all servant-community members share priestly identity. 1 Pet 2:9 ('a royal priesthood, a holy nation') draws directly on this and Exod 19:6. The 'double-portion' inheritance (v.7) is the firstborn-share scaled to the whole community."
+            },
+            {
+              "ref": "61:10-11",
+              "note": "'I delight greatly in the LORD... for he has clothed me with garments of salvation and arrayed me in a robe of righteousness.' Oswalt: the individual speaker (likely the servant) is clothed in salvation as a bride dresses for a wedding. The bridal imagery becomes Paul's (Eph 5:27) and John's (Rev 19:7-8) for the eschatological church-bride."
+            }
+          ]
         }
       }
     }
@@ -213,7 +239,30 @@
         }
       ],
       "note": "Prophecy AND Mercy peak at 10: Luke 4:18–21 — Jesus inaugural sermon. The comma between favour and vengeance IS the church age. Priestly nation (1 Pet 2:9). Mission at 9: all nations."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 61:1-2",
+        "target": "Luke 4:18-21",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'The Spirit of the Sovereign LORD is on me, because the LORD has anointed me to proclaim good news to the poor.' Jesus reads precisely this text in the Nazareth synagogue and announces 'today this Scripture is fulfilled in your hearing' — one of the most theologically explicit moments in the gospels."
+      },
+      {
+        "anchor": "Isa 61:2",
+        "target": "Luke 4:19",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'To proclaim the year of the LORD's favor and the day of vengeance of our God.' Jesus stops reading mid-verse, omitting the vengeance clause — a deliberate theological move deferring eschatological judgment to the parousia."
+      },
+      {
+        "anchor": "Isa 61:10",
+        "target": "Rev 19:7-8; 21:2",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'He has clothed me with garments of salvation and arrayed me in a robe of righteousness, as a bridegroom adorns his head like a priest.' The bride-dressed-for-the-wedding imagery reaches its NT climax in Revelation's marriage-supper of the Lamb."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/62.json
+++ b/content/isaiah/62.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The new names — Hephzibah ('my delight is in her') and Beulah ('married') — reverse Azubah ('forsaken') and Shemamah ('desolate'). In ancient thought, naming expressed essence; renaming signaled ontological change. The bridal metaphor portrays restoration as wedding celebration, with YHWH as the rejoicing bridegroom."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "62:1-3",
+              "note": "'For Zion's sake I will not keep silent.' Oswalt: the speaker is Yahweh (or the servant on Yahweh's behalf) announcing persistent intercession for Zion's vindication. 'You will be called by a new name that the mouth of the LORD will bestow' — the name-change follows the servant's work, marking the definitive end of exile-shame identity."
+            },
+            {
+              "ref": "62:4-5",
+              "note": "'No longer will they call you Deserted, or name your land Desolate. But you will be called Hephzibah (My Delight Is in Her), and your land Beulah (Married).' Oswalt: the naming reverses the exile-covenant-divorce question of 50:1. 'As a bridegroom rejoices over his bride, so will your God rejoice over you' — the covenant relationship is recast as marital joy, feeding Paul's Eph 5 marriage-theology."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The watchmen who never keep silent day or night are likely prophetic figures tasked with intercession. 'Giving God no rest' is bold anthropomorphism: human prayer is portrayed as holding God to his promises. The highway preparation and banner-raising recall processional imagery — the exiles' return is envisioned as triumphant parade."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "62:6-9",
+              "note": "The watchmen-on-the-walls who 'never keep silent day or night.' Oswalt: the post-exilic community is summoned to persistent prayer until Zion is established — intercession as a vocational role within the servant-community. 'Take no rest, and give him no rest' — a striking command to prevent God from resting until his promises are completed."
+            },
+            {
+              "ref": "62:10-12",
+              "note": "'Pass through, pass through the gates! Prepare the way for the people.' Oswalt: the new-exodus highway language returns at the closing of chs.60-62, paired with 'your Savior comes!' The servant-community is called 'the Holy People, the Redeemed of the LORD' — the titles that were promised are now bestowed."
+            }
+          ]
         }
       }
     }
@@ -209,7 +235,30 @@
         }
       ],
       "note": "Covenant and Mercy peak at 9: Hephzibah, Beulah — renamed by God. The bridegroom REJOICES. Watchmen who never stop praying. The highway complete."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 62:2",
+        "target": "Rev 2:17; 3:12",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You will be called by a new name that the mouth of the LORD will bestow.' Revelation's 'white stone with a new name written on it' and 'I will write on them my new name' both draw on this Isaianic naming-theology."
+      },
+      {
+        "anchor": "Isa 62:5",
+        "target": "Eph 5:25-27; Rev 19:7",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'As a bridegroom rejoices over his bride, so will your God rejoice over you.' The bridegroom-God imagery feeds Paul's Christ-and-the-church marriage theology and Revelation's marriage of the Lamb."
+      },
+      {
+        "anchor": "Isa 62:11",
+        "target": "Matt 21:5; Rev 22:12",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'Say to Daughter Zion, See, your Savior comes! See, his reward is with him.' Matthew's triumphal-entry formula ('Say to Daughter Zion, See, your king comes') and Revelation's 'my reward is with me' both echo this announcement."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/63.json
+++ b/content/isaiah/63.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The warrior from Edom with garments stained like a grape-treader represents divine judgment on Israel's ancient enemy. Edom's treachery during Jerusalem's fall (Ps 137:7; Obadiah) made it symbolic of all hostile nations. The winepress of wrath became standard apocalyptic imagery, with Isaiah's lone warrior anticipating later christological appropriation."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "63:1-6",
+              "note": "The warrior-from-Edom. Oswalt: the figure 'splendid in his apparel... crimson garments like one treading the winepress' has been christologically read since the early church. Rev 19:13-15 picks up the winepress-warrior image directly. The Edom-origin is paradigmatic — the prototypical enemy (Esau's descendants) becomes representative of all adversaries under divine judgment."
+            },
+            {
+              "ref": "63:5",
+              "note": "'I looked, but there was no one to help; I was appalled that no one gave support. So my own arm achieved salvation for me.' Oswalt: the same 'own arm' motif as 59:16 — salvation is exclusively divine work because human participation has failed. The verse is the OT's theological ground for the uniqueness of redemptive agency, later summarised in Paul's 'no one seeks God.'"
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The shift from judgment (vv.1-6) to lament (vv.7-19) is jarring but theologically coherent: the same God who tramples enemies is invoked as Father and Redeemer. The appeal to Abraham and Israel not recognizing their descendants reflects post-exilic alienation. The cry 'Why do you harden our hearts?' anticipates later debates about divine sovereignty and human responsibility."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "63:7-14",
+              "note": "The historical-covenant review. Oswalt: the prayer rehearses exodus-period grace ('in his love and mercy he redeemed them; he lifted them up and carried them all the days of old') as the basis for current appeal. The Spirit-within-the-midst-of-Israel language (v.11) is a major OT datum for the indwelling Spirit's historic work."
+            },
+            {
+              "ref": "63:16-19",
+              "note": "'You are our Father, though Abraham does not know us.' Oswalt: a remarkable transfer — paternal identity is shifted from the patriarchs to Yahweh directly. The post-exilic community grounds its identity not in biological descent but in divine parentage — a decisive move toward NT adoptive-sonship theology."
+            }
+          ]
         }
       }
     }
@@ -204,7 +230,23 @@
         }
       ],
       "note": "Sovereignty and Prophecy peak at 9: the winepress warrior (Rev 19:13), the Holy Spirit grieved (Eph 4:30), God as Father. Judgment at 8: the vengeance Jesus omitted now arrives."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 63:1-6",
+        "target": "Rev 19:13-15",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Who is this, coming from Edom... with garments stained crimson... I trod the winepress alone.' Revelation 19:13-15 applies this directly to the returning Christ: 'he is dressed in a robe dipped in blood... he treads the winepress of the fury of the wrath of God Almighty.'"
+      },
+      {
+        "anchor": "Isa 63:9",
+        "target": "Heb 4:15; Matt 25:40",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'In all their distress he too was distressed, and the angel of his presence saved them.' The God-with-us-in-suffering theme anticipates Hebrews' sympathetic high priest who empathises with our weaknesses and Jesus' 'whatever you did to the least of these, you did to me.'"
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/64.json
+++ b/content/isaiah/64.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The prayer for God to 'rend the heavens and come down' expresses post-exilic desperation. Despite the return from Babylon, God's presence seemed distant. The appeal to Sinai theophany (mountains trembling, fire kindling) requests that foundational experience. The confession that even righteous acts are like filthy rags represents radical penitence."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "64:1-4",
+              "note": "'Oh, that you would rend the heavens and come down!' Oswalt: the prayer's opening is Advent-theology in raw form — the cry for theophany to pierce the gap between the transcendent God and the struggling community. Paul quotes v.4 ('no eye has seen, no ear has heard') in 1 Cor 2:9 as the eschatological mystery now revealed by the Spirit."
+            },
+            {
+              "ref": "64:6",
+              "note": "'All our righteous acts are like filthy rags.' Oswalt: one of the OT's strongest statements of the inadequacy of human righteousness — specifically of religious performance. The exile-aware community has lost all illusion of covenantal merit; only divine initiative can rescue. Paul's Rom 3:10-18 depravity-argument resonates with this theological posture."
+            }
+          ]
         }
       }
     },
@@ -112,6 +125,19 @@
         },
         "hist": {
           "context": "The potter-clay metaphor expresses total dependence on divine creativity. The ruined temple ('our holy and beautiful house where our ancestors praised you') confirms the post-exilic setting. The final question 'will you keep silent?' challenges divine inaction. This communal lament anticipates the eschatological answer in chapters 65-66."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "64:8-9",
+              "note": "'You, LORD, are our Father. We are the clay, you are the potter; we are all the work of your hand.' Oswalt: the potter-clay image (developed in Jer 18 and then Paul's Rom 9) is used here not for fatalistic submission but for penitent appeal — 'do not be angry beyond measure, O LORD; do not remember our sins forever.' Creaturely dependence is the ground of mercy-appeal."
+            },
+            {
+              "ref": "64:10-12",
+              "note": "'Our holy and glorious temple, where our ancestors praised you, has been burned with fire.' Oswalt: the community's lament is grounded in a specific post-exilic desolation-reality. The prayer ends without divine response recorded — the gap is intentional, filled by the judgement-and-mercy answer of chs.65-66."
+            }
+          ]
         }
       }
     }
@@ -224,7 +250,30 @@
         }
       ],
       "note": "Faith and Prophecy peak: rend the heavens (Mark 1:10), no eye has seen (1 Cor 2:9), the potter and clay (Rom 9:21). The unanswered question that demands chs.65–66."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 64:4",
+        "target": "1 Cor 2:9",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'No eye has seen any God besides you, who acts on behalf of those who wait for him.' Paul quotes this verse in 1 Cor 2:9 ('what no eye has seen, no ear has heard, no human mind has conceived the things God has prepared for those who love him') — the eschatological mystery now unveiled by the Spirit."
+      },
+      {
+        "anchor": "Isa 64:6",
+        "target": "Phil 3:9; Rom 3:10-18",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'All our righteous acts are like filthy rags.' Paul's 'a righteousness of my own that comes from the law' set against the 'righteousness that comes from God' in Phil 3:9 is the theological elaboration of Isa 64:6's despair about self-righteousness."
+      },
+      {
+        "anchor": "Isa 64:8",
+        "target": "Rom 9:20-21; Jer 18:1-6",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'You, LORD, are our Father. We are the clay, you are the potter.' The potter-clay metaphor runs through Jer 18, feeds Rom 9's divine-sovereignty argument, and grounds the creation-theology of dependence throughout Paul."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/65.json
+++ b/content/isaiah/65.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The opening reversal — God found by those who didn't seek him — addresses the paradox of Gentile responsiveness versus Israelite resistance. The syncretistic practices described (gardens, secret places, eating pig flesh) reflect persistent idolatry in the post-exilic community. The 'servants' who receive blessing versus those who forsake God establishes the remnant concept central to Isaiah's theology."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "65:1-7",
+              "note": "'I revealed myself to those who did not ask for me; I was found by those who did not seek me.' Oswalt: Paul quotes v.1 in Rom 10:20 as the OT basis for gentile inclusion — Yahweh found by those not seeking him (gentiles) while Israel refused to come (v.2, quoted Rom 10:21). The servant-narrative's universal reach is rooted in Yahweh's universal availability."
+            },
+            {
+              "ref": "65:8-16",
+              "note": "'My servants' (plural) will eat, drink, rejoice, while 'you' (the idolatrous majority) will hunger, thirst, be put to shame. Oswalt: the binary split of the community — not Jew/gentile but servant/non-servant — foreshadows the NT's remnant-ecclesiology. 'My chosen ones... will be called by a different name.'"
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "The new heavens and new earth represent the most expansive eschatological vision in Isaiah. Former things forgotten, Jerusalem a delight, lifespans extending like trees, wolf and lamb feeding together — these images shaped Jewish and Christian apocalypticism. The reference to 'my holy mountain' (Zion) maintains continuity between present worship and cosmic transformation."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "65:17-19",
+              "note": "'See, I will create new heavens and a new earth.' Oswalt: one of the OT's few explicit new-creation promises, picked up directly in 2 Pet 3:13 and Rev 21:1. 'The former things will not be remembered, nor will they come to mind' — the eschatological healing of covenant trauma."
+            },
+            {
+              "ref": "65:20-25",
+              "note": "The new-creation description — long lives, fruitful labour, children not born to calamity, wolf and lamb feeding together. Oswalt: the imagery deliberately recalls 11:6-9 (the peaceable-kingdom vision), now consolidated in the final new-creation horizon. 'They will neither harm nor destroy on all my holy mountain' — the curse of Gen 3 undone."
+            }
+          ]
         }
       }
     }
@@ -218,7 +244,30 @@
         }
       ],
       "note": "Prophecy peaks at 10: new heavens and new earth (Rev 21:1). Rom 10:20. Wolf and lamb. Before they call, I answer. Sovereignty at 9: God creates entirely new. Mercy at 9: revealed to the unseeking."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 65:1-2",
+        "target": "Rom 10:20-21",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I revealed myself to those who did not ask for me; I was found by those who did not seek me... all day long I have held out my hands to an obstinate people.' Paul quotes both verses in Rom 10:20-21 — v.1 for gentile inclusion, v.2 for Israel's resistance."
+      },
+      {
+        "anchor": "Isa 65:17",
+        "target": "2 Pet 3:13; Rev 21:1",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'See, I will create new heavens and a new earth.' One of the OT's two explicit new-creation promises (with 66:22), fulfilled in 2 Pet 3:13's 'new heavens and a new earth, where righteousness dwells' and Rev 21:1's opening vision."
+      },
+      {
+        "anchor": "Isa 65:25",
+        "target": "Rom 8:19-21; Rev 22:3",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'The wolf and the lamb will feed together, and the lion will eat straw like the ox... they will neither harm nor destroy on all my holy mountain.' The peaceable-kingdom imagery (echoing 11:6-9) feeds the cosmic-reconciliation theology of Rom 8 and the 'no more curse' of Rev 22:3."
+      }
+    ]
   },
   "vhl_groups": [
     {

--- a/content/isaiah/66.json
+++ b/content/isaiah/66.json
@@ -60,6 +60,19 @@
         },
         "hist": {
           "context": "The challenge to temple-building ('what is the house you will build me?') is startling in a book that elsewhere celebrates Zion. The point is not anti-temple but anti-formalism: ritual without humility is rejected. The 'one who trembles at my word' becomes the true temple, anticipating later spiritualization of sacred space."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "66:1-2",
+              "note": "'Heaven is my throne, and the earth is my footstool. Where is the house you will build for me?' Oswalt: Stephen quotes these verses in Acts 7:49-50 against Temple-centred religion. The transcendence-statement is not anti-Temple but anti-presumption: 'this is the one I esteem — he who is humble and contrite in spirit.' The criterion for Yahweh's attention is posture, not architecture."
+            },
+            {
+              "ref": "66:7-14",
+              "note": "The birth-imagery — Zion giving birth before labour, a nation born in a day. Oswalt: the compressed time-scale depicts the suddenness of eschatological restoration. Galatians 4 picks up the maternal-Zion image. The mother-God comforting imagery (v.13) pairs with 49:15 as Scripture's most tender maternal theomorphism."
+            }
+          ]
         }
       }
     },
@@ -116,6 +129,19 @@
         },
         "hist": {
           "context": "Isaiah concludes with all flesh worshipping before YHWH and viewing the corpses of rebels whose 'worm does not die and fire is not quenched.' This harsh juxtaposition of universal worship and eternal judgment became foundational for later Jewish and Christian eschatology. The final verse's graphic imagery was so disturbing that synagogue reading traditionally repeats verse 23 after verse 24 to end on a positive note."
+        },
+        "oswalt": {
+          "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "66:18-21",
+              "note": "The gathering-of-nations climax. Oswalt: 'they will come and see my glory... I will send some of those who survive to the nations... they will proclaim my glory among the nations.' The missionary mandate of the OT finds its clearest statement here. 'I will select some of them also to be priests and Levites, says the LORD' — gentile priesthood within the covenant community."
+            },
+            {
+              "ref": "66:22-24",
+              "note": "The book's final images — new-heavens-and-new-earth endurance paired with eschatological judgment ('their worm will not die, nor will their fire be quenched'). Oswalt: Jesus quotes v.24 in Mark 9:48 as the template for Gehenna. Isaiah ends with the same two-worlds structure that frames the NT: the new creation of the redeemed and the unquenchable fire of the unrepentant, both products of the servant's completed work."
+            }
+          ]
         }
       }
     }
@@ -203,7 +229,37 @@
         }
       ],
       "note": "Mission peaks at 10: all nations gathered, all flesh worships, Gentiles as priests. Worship and Sovereignty at 9: the final vision. Prophecy at 9: Mark 9:48, Acts 7:49. Isaiah closes with both universal worship AND eternal judgment."
-    }
+    },
+    "thread": [
+      {
+        "anchor": "Isa 66:1-2",
+        "target": "Acts 7:49-50",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Heaven is my throne, and the earth is my footstool. Where is the house you will build for me?' Stephen quotes this in Acts 7:49-50 as the OT refutation of Temple-centred religion — God's transcendence relativises every built sanctuary."
+      },
+      {
+        "anchor": "Isa 66:13",
+        "target": "Luke 13:34; Matt 23:37",
+        "type": "Echo",
+        "direction": "forward",
+        "text": "'As a mother comforts her child, so will I comfort you; and you will be comforted over Jerusalem.' The maternal-divine imagery stands alongside Jesus' 'how often I have longed to gather your children together, as a hen gathers her chicks under her wings.'"
+      },
+      {
+        "anchor": "Isa 66:18-19",
+        "target": "Matt 28:19-20; Rom 15:9-12",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'I will send some of those who survive to the nations... they will proclaim my glory among the nations.' The OT's clearest missionary-to-the-nations commission, fulfilled in the Great Commission and Paul's gentile apostolic ministry."
+      },
+      {
+        "anchor": "Isa 66:24",
+        "target": "Mark 9:48",
+        "type": "Fulfilment",
+        "direction": "forward",
+        "text": "'Their worm will not die, nor will their fire be quenched.' Jesus quotes this verse verbatim (three times in Mark 9:48 MSS) as the template for Gehenna's permanence. Isaiah closes with the judgment-scene Jesus uses to close his warnings."
+      }
+    ]
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Closes #1645. Parent epic: #1626. Audit source: #1635.

## Audit delta — Isaiah

Both numbers from `python3 _tools/coverage_auditor.py --book isaiah`.

| Layer | Finding | Before | After |
|---|---|---:|---:|
| L1 | 🔴 Deficient sections | 62 | 0 |
| L1 | 🟡 Thin sections | 0 | 0 |
| L2 | Non-substantive section panels | 0 | 0 |
| L3 | Missing `thread` chapter panels | 44 | 0 |
| L3 | Stub `ppl` (ch 35) | 1 | 0 |
| L3 | Missing `trans` (ch 53) | 1 | 0 |
| **Total** | | **108** | **0** |

Post-state section tiers: 🔴 0 | 🟡 0 | 🟢 63 | ✨ 69 (total 132).
Post-state chapter-panel completeness: 462 expected, 462 substantive, 0 missing, 0 deficient.

Quality scorer (Tier 1): all 66 chapters ≥ 93.2 vs. the 90 floor. Worst 10 are all chapters this PR did not touch (isa1, 4, 10, 14-20, 30) — their scores are pre-existing and not affected.

## L1 remediation — one scholar per section, no new names

Every deficient section in ch 36-66 shared the exact profile `weight=7, cats=4, commentators=1` with only `mac` (MacArthur) on the panel. To clear the `commentator_count ≥ 2` floor I added exactly one Oswalt (NICOT Isaiah) panel to each of the 62 sections:

- `oswalt` is scoped to Isaiah in `COMMENTATOR_SCOPE` (config.py:122).
- Oswalt already appears in 69 of Isaiah's 132 sections today (all in ch 1-35); adding him to ch 36-66 extends an already-established scholarly voice to the second half of the book.
- No new scholars were added to `SCHOLAR_REGISTRY` or `COMMENTATOR_SCOPE`.

Notes paraphrase John N. Oswalt, *Isaiah*, NICOT (2 vols., 1986/1998) — his signature positions: Isaian unity, Christ-as-fulfilment of the Servant Songs, the "Holy One of Israel" motif, the new-exodus structure of chs. 40-55, and the comfort/servant/restoration three-movement structure of chs. 40-66.

## Sample new panel — Isaiah 53 §1 Oswalt

```json
{
  "source": "John N. Oswalt, Isaiah, NICOT (2 vols., 1986/1998) — Scholarly Paraphrase",
  "notes": [
    {
      "ref": "53:1-3",
      "note": "Oswalt reads 53:1 ('who has believed our message?') as the rhetorical acknowledgment that the servant's appearance contradicts every expectation. 'No beauty or majesty' — not the kind of messiah anyone was looking for. John 12:38 and Rom 10:16 both quote v.1 as the key to unbelief: the servant is rejected because he does not look like what salvation is supposed to look like."
    },
    {
      "ref": "53:4-6",
      "note": "The substitutionary-atonement climax. Oswalt: 'pierced for our transgressions, crushed for our iniquities' is the OT's most explicit penal-substitution language. 'The LORD has laid on him the iniquity of us all.' The inversions are total: we strayed, he bore; we deserved, he suffered; we were sick, by his wounds we are healed. Peter quotes vv.4-6 in 1 Pet 2:24-25 as the structural content of the cross."
    }
  ]
}
```

(Combined note text = 782 chars; well above the 100-char substantive floor.)

## Scope confirmation (out-of-scope items per #1645)

- ❌ **No new scholars** introduced. `SCHOLAR_REGISTRY` and `COMMENTATOR_SCOPE` untouched.
- ❌ **No NIV verse-text changes.** The Ch 53 `trans` panel is assembled from existing NIV and ESV verse data for vv. 4, 5, 6, 11.
- ❌ **No section-header rewrites.** All `header`, `verse_start`, `verse_end` fields unchanged.
- ❌ **No app-layer drift.** `app/`, `_tools/`, and workflow files all untouched. Build artifacts (`db-manifest.json`, `explore-images.json`) reverted from local rebuild — CI rebuilds on master post-merge.
- ❌ **No Psalms work** — Phase 1b (#1644).

Patch surface: 44 `content/isaiah/*.json` files modified; +1,855 / -91 lines.

## Pipeline

- ✅ `python3 _tools/schema_validator.py` — 137,950 passed, 77 failed (failure count identical to master; all pre-existing topic / era_config / PLAYBOOK issues, none introduced by this PR).
- ✅ `python3 _tools/build_sqlite.py` — clean build, 100MB.
- ✅ `python3 _tools/validate_sqlite.py` — 101 passed, 0 failed.
- ✅ `python3 _tools/coverage_auditor.py --book isaiah` — **0 findings** (was 108).
- ✅ `python3 _tools/quality_scorer.py --book isaiah` — all 66 chapters ≥ 93.2.

## Pilot template feedback (continuing from #1647)

One Isaiah-specific observation for the template: the 62 L1 findings here were a **single structural pattern** (one scholar short across a 31-chapter block), not a scattered distribution. Future Tier B epic summaries could call that out — "62 findings all clear with one patterned-remediation pass" vs. "62 findings each needing bespoke content" are very different work sizes, and the current issue template does not surface that distinction. Worth including in the audit-report or issue-body generator for subsequent books.

Both prior spec-gaps flagged on #1647 still apply — `--section-detail --format json` silently emits markdown, and `save_chapter()` is a full-rewrite. Same direct-JSON-patch generator pattern that worked on #1651 (Genesis) used here.

## Test plan

- [x] Coverage auditor reports 0 Isaiah findings.
- [x] Quality scorer ≥ 90 on every chapter (min 93.2).
- [x] Schema validator failure count unchanged vs master.
- [x] DB builds and validates clean.
- [x] No scholars added to `SCHOLAR_REGISTRY` or `COMMENTATOR_SCOPE`.
- [ ] On merge: content-pipeline CI green; coverage-audit step (warning-only, #1650 once merged) surfaces zero Isaiah findings on rebuild.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_