### PR TITLE
feat(amicus): harden auth access with RC init wiring (1/3)

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { StyleSheet, View, Text, Text as RNText, ActivityIndicator, AppState } from 'react-native';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Text as RNText,
+  ActivityIndicator,
+  AppState,
+  Platform,
+} from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { useFonts } from 'expo-font';
@@ -20,7 +28,7 @@ import { useSettingsStore, useAuthStore, usePremiumStore } from './src/stores';
 import { pruneEvents } from './src/services/analytics';
 import { checkAndScheduleReengagement } from './src/services/reengagement';
 import { rescheduleIfStale } from './src/services/notifications';
-import { syncPremiumStatus } from './src/services/purchases';
+import { initializePurchases, syncPremiumStatus } from './src/services/purchases';
 import { flushQueue } from './src/services/syncQueue';
 import { RootNavigator } from './src/navigation';
 import type { TabParamList } from './src/navigation/types';
@@ -185,6 +193,26 @@ async function hydrateAppState(): Promise<void> {
   pruneEvents(90); // Clean up old analytics (fire-and-forget)
 }
 
+/**
+ * Resolve the RevenueCat API key from env at call time.
+ * RevenueCat's client-side keys are designed to ship embedded in the app
+ * bundle (unlike a server secret), so `EXPO_PUBLIC_*` is the correct place.
+ * Prefers platform-specific keys, falls back to a shared one, then trims.
+ */
+function getRevenueCatApiKey(): string {
+  return (
+    Platform.select({
+      ios:
+        process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY ??
+        process.env.EXPO_PUBLIC_REVENUECAT_API_KEY,
+      android:
+        process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY ??
+        process.env.EXPO_PUBLIC_REVENUECAT_API_KEY,
+      default: process.env.EXPO_PUBLIC_REVENUECAT_API_KEY,
+    }) ?? ''
+  ).trim();
+}
+
 function App() {
   const [fontsLoaded] = useFonts(FONT_MAP);
   const [dbStatus, setDbStatus] = useState<'loading' | 'needs_download' | 'ready'>('loading');
@@ -206,6 +234,15 @@ function App() {
         }
 
         await hydrateAppState();
+        // Fire-and-forget: RevenueCat configure + syncPremiumStatus hits the
+        // network. Awaiting it here would stall the splash screen for as long
+        // as it takes for the customer-info fetch to resolve (10s+ worst case
+        // on a spotty connection). initializePurchases swallows its own
+        // errors and sets purchasesConfigured internally; syncPremiumStatus
+        // short-circuits until that flag flips. Downstream consumers
+        // (useAmicusAccess, premiumStore) already treat RC as async and
+        // refresh on events, so a delayed-ready RC is fine.
+        void initializePurchases(getRevenueCatApiKey());
         setDbStatus(status);
       } catch (e) {
         console.error('Init error:', e);
@@ -277,6 +314,8 @@ function App() {
                   // app tree, otherwise components can touch stores or
                   // analytics against partially-hydrated state.
                   await hydrateAppState();
+                  // Fire-and-forget — see rationale in the primary init above.
+                  void initializePurchases(getRevenueCatApiKey());
                   setDbStatus('ready');
                 } catch (e) {
                   console.error('Post-download init error:', e);

--- a/app/__tests__/App.providerTree.test.tsx
+++ b/app/__tests__/App.providerTree.test.tsx
@@ -52,6 +52,7 @@ jest.mock('@/services/notifications', () => ({
 }));
 
 jest.mock('@/services/purchases', () => ({
+  initializePurchases: jest.fn().mockResolvedValue(undefined),
   syncPremiumStatus: jest.fn(),
 }));
 

--- a/app/__tests__/services/purchases.test.ts
+++ b/app/__tests__/services/purchases.test.ts
@@ -12,6 +12,7 @@ const mockSDK = {
   purchasePackage: jest.fn(),
   restorePurchases: jest.fn(),
   getCustomerInfo: jest.fn(),
+  getAppUserID: jest.fn(),
 };
 jest.mock('react-native-purchases', () => ({ default: mockSDK }), { virtual: true });
 
@@ -28,6 +29,7 @@ jest.mock('@/stores/premiumStore', () => ({
 }));
 
 import {
+  getPurchasesAppUserID,
   initializePurchases,
   purchasePlan,
   restorePurchases,
@@ -73,6 +75,11 @@ describe('purchases service', () => {
       const { initializePurchases: initFresh } = require('@/services/purchases');
       await initFresh('key');
       // Should not throw, just log and return
+      expect(mockSDK.configure).not.toHaveBeenCalled();
+    });
+
+    it('does not configure when the API key is empty', async () => {
+      await initializePurchases('   ');
       expect(mockSDK.configure).not.toHaveBeenCalled();
     });
   });
@@ -244,9 +251,27 @@ describe('purchases service', () => {
         },
       });
 
+      await initializePurchases('rc_api_key');
+      mockSDK.getCustomerInfo.mockClear();
       await syncPremiumStatus();
       expect(mockSDK.getCustomerInfo).toHaveBeenCalled();
       expect(mockSetPremiumStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPurchasesAppUserID', () => {
+    it('returns null before RevenueCat is configured', async () => {
+      expect(await getPurchasesAppUserID()).toBeNull();
+    });
+
+    it('returns the configured app user id after initialization', async () => {
+      mockSDK.getCustomerInfo.mockResolvedValue({ entitlements: { active: {} } });
+      mockSDK.getAppUserID.mockResolvedValue('rc_app_user_123456789');
+
+      await initializePurchases('rc_api_key');
+
+      await expect(getPurchasesAppUserID()).resolves.toBe('rc_app_user_123456789');
+      expect(mockSDK.getAppUserID).toHaveBeenCalled();
     });
   });
 });

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -5,6 +5,7 @@
  * via getUserDb().
  */
 
+import { emitAmicusUsageChanged } from '../services/amicus/usageEvents';
 import { logger } from '../utils/logger';
 import { nextIntervalAfter } from '../services/guidedStudy/review';
 import type { GuidedStudyStep } from '../types';
@@ -695,6 +696,7 @@ export async function clearAllAmicusData(): Promise<void> {
     await db.runAsync('DELETE FROM amicus_threads');
     await db.runAsync('DELETE FROM amicus_usage');
   });
+  emitAmicusUsageChanged();
   logger.info('Amicus', 'cleared all amicus data');
 }
 
@@ -704,6 +706,7 @@ export async function incrementAmicusUsage(): Promise<void> {
      VALUES (strftime('%Y-%m-%d', 'now'), 1)
      ON CONFLICT(day) DO UPDATE SET query_count = query_count + 1`,
   );
+  emitAmicusUsageChanged();
 }
 
 // ── Amicus daily prompt cache (#1465) ───────────────────────────────

--- a/app/src/hooks/useAmicusAccess.ts
+++ b/app/src/hooks/useAmicusAccess.ts
@@ -5,6 +5,7 @@
  */
 import { useEffect, useState } from 'react';
 import { getAmicusUsageThisMonth } from '../db/userQueries';
+import { subscribeAmicusUsageChanges } from '../services/amicus/usageEvents';
 import { isConnected, onConnectivityChange } from '../services/connectivity';
 import { useSettingsStore } from '../stores';
 import { usePremiumStore } from '../stores/premiumStore';
@@ -53,19 +54,26 @@ export function useAmicusAccess(): AmicusAccessState {
       ? 'partner_plus'
       : 'premium';
 
-  // Fetch monthly usage once per mount and refresh on entitlement changes.
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+
+    const refreshUsage = async (): Promise<void> => {
       try {
         const n = await getAmicusUsageThisMonth();
         if (!cancelled) setUsageThisMonth(n);
       } catch (err) {
         logger.warn('Amicus', 'usage fetch failed', err);
       }
-    })();
+    };
+
+    void refreshUsage();
+    const unsubscribe = subscribeAmicusUsageChanges(() => {
+      void refreshUsage();
+    });
+
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, [entitlement]);
 

--- a/app/src/services/amicus/__tests__/authToken.test.ts
+++ b/app/src/services/amicus/__tests__/authToken.test.ts
@@ -1,0 +1,48 @@
+jest.mock('@/services/purchases', () => ({
+  getPurchasesAppUserID: jest.fn(),
+}));
+
+import { getPurchasesAppUserID } from '@/services/purchases';
+import { getAmicusAuthToken } from '@/services/amicus/authToken';
+
+const mockGetPurchasesAppUserID = jest.mocked(getPurchasesAppUserID);
+
+describe('getAmicusAuthToken', () => {
+  const previousDevToken = process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN;
+  });
+
+  afterAll(() => {
+    process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = previousDevToken;
+  });
+
+  it('prefers the RevenueCat app user id when available', async () => {
+    mockGetPurchasesAppUserID.mockResolvedValue('rc_app_user_123456789');
+    process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'dev_token_123456789';
+
+    await expect(getAmicusAuthToken()).resolves.toBe('rc_app_user_123456789');
+  });
+
+  it('falls back to the dev token when no RevenueCat id is available', async () => {
+    mockGetPurchasesAppUserID.mockResolvedValue(null);
+    process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'dev_token_123456789';
+
+    await expect(getAmicusAuthToken()).resolves.toBe('dev_token_123456789');
+  });
+
+  it('returns null when neither token source is available', async () => {
+    mockGetPurchasesAppUserID.mockResolvedValue(null);
+
+    await expect(getAmicusAuthToken()).resolves.toBeNull();
+  });
+
+  it('can disable the dev fallback explicitly', async () => {
+    mockGetPurchasesAppUserID.mockResolvedValue(null);
+    process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN = 'dev_token_123456789';
+
+    await expect(getAmicusAuthToken({ allowDevFallback: false })).resolves.toBeNull();
+  });
+});

--- a/app/src/services/amicus/authToken.ts
+++ b/app/src/services/amicus/authToken.ts
@@ -1,0 +1,36 @@
+import { getPurchasesAppUserID } from '@/services/purchases';
+import { logger } from '@/utils/logger';
+
+const MIN_TOKEN_LENGTH = 16;
+
+export interface GetAmicusAuthTokenOptions {
+  allowDevFallback?: boolean;
+}
+
+function normalizeToken(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? '';
+  return trimmed.length >= MIN_TOKEN_LENGTH ? trimmed : null;
+}
+
+export async function getAmicusAuthToken(
+  opts: GetAmicusAuthTokenOptions = {},
+): Promise<string | null> {
+  const appUserID = normalizeToken(await getPurchasesAppUserID());
+  if (appUserID) return appUserID;
+
+  if (opts.allowDevFallback === false) return null;
+
+  const devToken = normalizeToken(process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN);
+  if (devToken) {
+    // Only log the dev fallback in development. If EXPO_PUBLIC_AMICUS_DEV_TOKEN
+    // is accidentally set on a production build (EXPO_PUBLIC_* vars are
+    // inlined into the shipped bundle) we still honor the token silently
+    // rather than revealing the fallback in production logs.
+    if (__DEV__) {
+      logger.info('AmicusAuth', 'using dev auth token fallback');
+    }
+    return devToken;
+  }
+
+  return null;
+}

--- a/app/src/services/amicus/usageEvents.ts
+++ b/app/src/services/amicus/usageEvents.ts
@@ -1,0 +1,16 @@
+type UsageListener = () => void;
+
+const listeners = new Set<UsageListener>();
+
+export function subscribeAmicusUsageChanges(listener: UsageListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitAmicusUsageChanged(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}

--- a/app/src/services/purchases.ts
+++ b/app/src/services/purchases.ts
@@ -66,6 +66,7 @@ export const PARTNER_PLUS_PLANS: PlanInfo[] = [
 // Platform-specific native module API - react-native-purchases SDK shape varies
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Purchases: any = null;
+let purchasesConfigured = false;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getSDK(): any {
@@ -91,7 +92,13 @@ export async function initializePurchases(apiKey: string): Promise<void> {
     return;
   }
   try {
-    await sdk.configure({ apiKey });
+    const trimmedKey = apiKey.trim();
+    if (!trimmedKey) {
+      logger.warn('purchases', 'RevenueCat API key missing — purchases not initialized');
+      return;
+    }
+    await sdk.configure({ apiKey: trimmedKey });
+    purchasesConfigured = true;
     logger.info('purchases', 'RevenueCat configured');
     await syncPremiumStatus();
   } catch (err) {
@@ -156,7 +163,7 @@ export async function restorePurchases(): Promise<boolean> {
  */
 export async function syncPremiumStatus(): Promise<void> {
   const sdk = getSDK();
-  if (!sdk) return;
+  if (!sdk || !purchasesConfigured) return;
 
   try {
     const customerInfo = await sdk.getCustomerInfo();
@@ -197,4 +204,19 @@ function getFutureDate(plan: PurchaseType): string {
   if (plan === 'monthly') now.setMonth(now.getMonth() + 1);
   else if (plan === 'annual') now.setFullYear(now.getFullYear() + 1);
   return now.toISOString();
+}
+
+export async function getPurchasesAppUserID(): Promise<string | null> {
+  const sdk = getSDK();
+  if (!sdk || !purchasesConfigured) return null;
+
+  try {
+    const appUserID = await sdk.getAppUserID();
+    return typeof appUserID === 'string' && appUserID.trim().length > 0
+      ? appUserID.trim()
+      : null;
+  } catch (err) {
+    logger.warn('purchases', 'Failed to read RevenueCat app user id', err);
+    return null;
+  }
 }


### PR DESCRIPTION
## Part 1 of 3 — salvaging codex/amicus-auth-access-hardening

This is the first of three PRs that split up the `codex/amicus-auth-access-hardening` branch. That branch bundled 10+ distinct Amicus features under a name that describes only one of them, with no PR opened for review. After a senior-dev review we're splitting it into focused PRs to preserve rollback granularity.

**This PR ships only the auth/access work the codex branch name promised.** PR 2 covers DB + services foundation; PR 3 covers UI wiring.

## Why it matters

On current master, `initializePurchases()` exists in `services/purchases.ts` but is **never called from production code** — only from tests. RevenueCat is effectively uninitialized in the shipped app, which means:

- `syncPremiumStatus()` is a no-op (the SDK was never configured)
- Premium status is driven entirely by local state in `premiumStore`
- There is no canonical user identifier for the Amicus Cloudflare Worker proxy to authenticate against

This PR is the first time production actually hits RevenueCat.

## What's in

### Auth layer
- **`services/amicus/authToken.ts`** (new) — `getAmicusAuthToken()` returns the token Amicus sends to the Worker. Prefers `getPurchasesAppUserID()` (the RevenueCat appUserID); falls back to `EXPO_PUBLIC_AMICUS_DEV_TOKEN` in dev. Accepts `{ allowDevFallback: false }` so production call sites can explicitly forbid the dev path. 16-char min-length sanity guard on both token sources.
- **`services/amicus/__tests__/authToken.test.ts`** — covers the RC-preferred / dev-fallback / no-token / explicit-disable paths.

### RevenueCat init
- **`services/purchases.ts`** — `purchasesConfigured` flag guards `syncPremiumStatus` and the new `getPurchasesAppUserID()` so they short-circuit until `configure()` completes. Empty/whitespace API keys are rejected with a warn-and-skip instead of reaching the SDK. `getPurchasesAppUserID()` is the new export `authToken.ts` consumes.
- **`App.tsx`** — `getRevenueCatApiKey()` helper reads `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY` / `_ANDROID_API_KEY` with a generic `_API_KEY` fallback. Wired into both the primary init path and the post-download init path.
- **`__tests__/services/purchases.test.ts`** — coverage for the `purchasesConfigured` gate + `getPurchasesAppUserID` happy/error paths.

### Usage event bus
- **`services/amicus/usageEvents.ts`** (new) — 16-line pub/sub. `emitAmicusUsageChanged()` fires on usage writes; `subscribeAmicusUsageChanges()` returns an unsubscribe.
- **`hooks/useAmicusAccess.ts`** — subscribes on mount, refreshes `usageThisMonth` on every emit. Previously only refreshed on entitlement change, so the monthly counter could lag behind the user's actual usage within a session.
- **`db/userMutations.ts`** — two-line isolated change: fire `emitAmicusUsageChanged()` from `incrementAmicusUsage` and `clearAllAmicusData`. Kept surgical so PR 2's larger `userMutations.ts` changes don't conflict.

## Tier 2 fixes included

1. **RC init is fire-and-forget.** The naïve wiring would `await initializePurchases(...)` before `setDbStatus('ready')`, which stalls the splash screen on `sdk.configure()` + `syncPremiumStatus()` (a customer-info network call — 10+ seconds worst case on flaky networks). Changed to `void initializePurchases(...)` with a comment explaining the rationale. The SDK swallows its own errors and `purchasesConfigured` guards downstream access, so delayed RC readiness is safe.
2. **Dev-fallback log gated with `__DEV__`.** `EXPO_PUBLIC_*` env vars get inlined into the shipped JS bundle. If `EXPO_PUBLIC_AMICUS_DEV_TOKEN` accidentally leaks into a production build the token still works, but we don't announce the fallback in production logs.

## Out of scope (moving to PR 2 / PR 3)

- DB migrations 22/23 (thread context + summaries tables), `PRAGMA foreign_keys = ON`, and all the new thread-context queries/mutations → **PR 2**
- `context.ts`, `trust.ts`, `threadIntelligence.ts`, `studyActions.ts`, `studyLaunch.ts` services and their types → **PR 2**
- `TrustFooter`, `StudyActionRow`, thread/screen/hook wiring → **PR 3**
- `StudySessionScreen.tsx` changes (the codex branch reverts #1654's `useRef` bounce-back guard — conflict resolution deferred to PR 3 which will preserve the guard)
- `MyStudyScreen.tsx` changes (deferred until #1652's re-plan per standing direction)

## Test plan

- `npx tsc --noEmit` + `npx jest` via CI
- Manual (rentamac simulator):
  1. Fresh install → splash screen completes promptly even with airplane mode on (fire-and-forget proven)
  2. Re-enable network, verify RC configures in background, premium status reflects entitlement within a few seconds
  3. Make a few Amicus queries, watch `usageThisMonth` in the access hook update in real time without a remount
  4. Set `EXPO_PUBLIC_AMICUS_DEV_TOKEN` on a dev build, confirm log line appears; verify a prod build with the same env does NOT log (would require a release build — spot check is fine)

## Rollback

Single-commit revert. App.tsx goes back to the pre-init state (RC stays uninitialized — pre-existing no-op). `getAmicusAuthToken` disappears but has no callers in this PR. The `emitAmicusUsageChanged` calls stop firing — the subscription in `useAmicusAccess` becomes inert but the hook falls back to its original mount-only refresh, still functional.

Stacks with PR 2 and PR 3 (to follow).