### PR TITLE
feat(amicus): v2 foundation — migrations, services, types, FK enforcement (2/3)

### DIFF
--- a/app/__tests__/db/amicus/mutations.test.ts
+++ b/app/__tests__/db/amicus/mutations.test.ts
@@ -3,9 +3,7 @@
  */
 import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
 
-jest.mock('@/db/userDatabase', () =>
-  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
-);
+jest.mock('@/db/userDatabase', () => require('../../helpers/mockUserDb').mockUserDatabaseModule());
 
 import {
   appendAmicusMessage,
@@ -15,6 +13,8 @@ import {
   incrementAmicusUsage,
   toggleThreadPin,
   updateThreadTitle,
+  upsertAmicusThreadContext,
+  upsertAmicusThreadSummary,
 } from '@/db/userMutations';
 
 beforeEach(() => {
@@ -31,7 +31,7 @@ describe('createAmicusThread', () => {
     const mock = getMockUserDb();
     const [sql, bindings] = mock.runAsync.mock.calls[0]!;
     expect(String(sql)).toMatch(/INSERT INTO amicus_threads/);
-    expect(bindings).toEqual(['t-1', 'First', 'romans:9']);
+    expect(bindings).toEqual(['t-1', 'First', 'romans/9']);
   });
 
   it('defaults chapterRef to null', async () => {
@@ -63,9 +63,7 @@ describe('appendAmicusMessage', () => {
       threadId: 't1',
       role: 'assistant',
       content: 'answer',
-      citations: [
-        { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
-      ],
+      citations: [{ chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' }],
       followUps: ['follow-up 1'],
     });
     const [, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
@@ -80,6 +78,46 @@ describe('updateThreadTitle', () => {
     const [sql, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
     expect(String(sql)).toMatch(/UPDATE amicus_threads/);
     expect(bindings).toEqual(['New title', 't1']);
+  });
+});
+
+describe('upsertAmicusThreadSummary', () => {
+  it('upserts summary text and last user intent', async () => {
+    await upsertAmicusThreadSummary({
+      threadId: 't1',
+      summaryText: 'Overview of Genesis 1.',
+      lastUserIntent: 'Explain this chapter',
+    });
+    const [sql, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_thread_summaries/);
+    expect(String(sql)).toMatch(/ON CONFLICT\(thread_id\) DO UPDATE/);
+    expect(bindings).toEqual(['t1', 'Overview of Genesis 1.', 'Explain this chapter']);
+  });
+});
+
+describe('upsertAmicusThreadContext', () => {
+  it('upserts guided study context for a thread', async () => {
+    await upsertAmicusThreadContext({
+      threadId: 't1',
+      entryPoint: 'guided_study',
+      guidedSessionId: 14,
+      guidedStep: 'synthesize',
+      openQuestionId: 9,
+      takeaway: 'Creation is ordered.',
+      keyConnection: 'John 1',
+    });
+    const [sql, bindings] = getMockUserDb().runAsync.mock.calls[0]!;
+    expect(String(sql)).toMatch(/INSERT INTO amicus_thread_context/);
+    expect(String(sql)).toMatch(/ON CONFLICT\(thread_id\) DO UPDATE/);
+    expect(bindings).toEqual([
+      't1',
+      'guided_study',
+      14,
+      'synthesize',
+      9,
+      'Creation is ordered.',
+      'John 1',
+    ]);
   });
 });
 
@@ -108,10 +146,11 @@ describe('toggleThreadPin', () => {
 });
 
 describe('deleteAmicusThread', () => {
-  it('issues DELETE on thread_id (CASCADE handles messages)', async () => {
+  it('clears thread context before deleting the thread', async () => {
     await deleteAmicusThread('t1');
-    const [sql] = getMockUserDb().runAsync.mock.calls[0]!;
-    expect(String(sql)).toMatch(/DELETE FROM amicus_threads/);
+    const sqls = getMockUserDb().runAsync.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(sqls[0]).toMatch(/DELETE FROM amicus_thread_context/);
+    expect(sqls[1]).toMatch(/DELETE FROM amicus_threads/);
   });
 });
 
@@ -124,6 +163,7 @@ describe('clearAllAmicusData', () => {
     expect(sqls).toEqual(
       expect.arrayContaining([
         expect.stringMatching(/DELETE FROM amicus_messages/),
+        expect.stringMatching(/DELETE FROM amicus_thread_context/),
         expect.stringMatching(/DELETE FROM amicus_threads/),
         expect.stringMatching(/DELETE FROM amicus_usage/),
       ]),

--- a/app/__tests__/db/amicus/queries.test.ts
+++ b/app/__tests__/db/amicus/queries.test.ts
@@ -3,17 +3,19 @@
  */
 import { getMockUserDb, resetMockUserDb } from '../../helpers/mockUserDb';
 
-jest.mock('@/db/userDatabase', () =>
-  require('../../helpers/mockUserDb').mockUserDatabaseModule(),
-);
-jest.mock('@/db/database', () =>
-  require('../../helpers/mockDb').mockDatabaseModule(),
-);
+jest.mock('@/db/userDatabase', () => require('../../helpers/mockUserDb').mockUserDatabaseModule());
+jest.mock('@/db/database', () => require('../../helpers/mockDb').mockDatabaseModule());
 
 import {
+  getAmicusThreadContext,
+  getLatestAmicusThreadIdForChapterContext,
+  getAmicusThreadIdForGuidedQuestion,
+  getAmicusThreadIdForGuidedSession,
   getAmicusThread,
   getAmicusUsageThisMonth,
   getAmicusUsageToday,
+  getGuidedStudyQuestionForSession,
+  getLinkedGuidedStudyQuestionForThread,
   listAmicusMessages,
   listAmicusThreads,
 } from '@/db/userQueries';
@@ -31,14 +33,28 @@ describe('listAmicusThreads', () => {
         title: 'Pinned thread',
         chapter_ref: null,
         pinned: 1,
+        summary_text: 'Overview of Genesis 1.',
+        last_user_intent: 'Explain this chapter',
+        guided_step: 'synthesize',
+        open_question_id: 4,
+        guided_question_status: 'open',
+        takeaway: null,
+        key_connection: null,
         created_at: '2026-04-17',
         last_message_at: '2026-04-17',
       },
       {
         thread_id: 'normal',
         title: 'Normal thread',
-        chapter_ref: 'romans:9',
+        chapter_ref: 'romans/9',
         pinned: 0,
+        summary_text: 'What does Romans 9 say about mercy?',
+        last_user_intent: null,
+        guided_step: null,
+        open_question_id: null,
+        guided_question_status: null,
+        takeaway: null,
+        key_connection: null,
         created_at: '2026-04-16',
         last_message_at: '2026-04-16',
       },
@@ -46,7 +62,9 @@ describe('listAmicusThreads', () => {
     const threads = await listAmicusThreads();
     expect(threads).toHaveLength(2);
     expect(threads[0]!.pinned).toBe(true);
+    expect(threads[0]!.summary_text).toBe('Overview of Genesis 1.');
     expect(threads[1]!.pinned).toBe(false);
+    expect(threads[1]!.chapter_ref).toBe('romans/9');
     // Verify we called with DESC ordering in SQL
     const [sql] = userDb.getAllAsync.mock.calls[0]!;
     expect(String(sql)).toMatch(/pinned DESC/);
@@ -66,19 +84,92 @@ describe('getAmicusThread', () => {
       title: 'T1',
       chapter_ref: null,
       pinned: 1,
+      summary_text: 'Intro summary',
+      last_user_intent: null,
+      guided_step: null,
+      open_question_id: null,
+      guided_question_status: null,
+      takeaway: null,
+      key_connection: null,
       created_at: 'x',
       last_message_at: 'x',
     });
     const t = await getAmicusThread('t1');
     expect(t?.pinned).toBe(true);
+    expect(t?.summary_text).toBe('Intro summary');
+  });
+});
+
+describe('guided study thread queries', () => {
+  it('loads persisted thread context', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      thread_id: 't1',
+      entry_point: 'guided_study',
+      guided_session_id: 7,
+      guided_step: 'synthesize',
+      open_question_id: 4,
+      takeaway: 'Creation is ordered.',
+      key_connection: 'John 1',
+      created_at: 'x',
+      updated_at: 'x',
+    });
+    const context = await getAmicusThreadContext('t1');
+    expect(context?.entry_point).toBe('guided_study');
+    expect(context?.guided_session_id).toBe(7);
+    expect(context?.open_question_id).toBe(4);
+  });
+
+  it('looks up a linked guided-study question for a thread', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      id: 4,
+      session_id: 7,
+      chapter_id: 'genesis_1',
+      question_text: 'Why is there repetition?',
+      status: 'open',
+      created_at: 'x',
+      resolved_at: null,
+      updated_at: 'x',
+    });
+    const question = await getLinkedGuidedStudyQuestionForThread('t1');
+    expect(question?.question_text).toBe('Why is there repetition?');
+  });
+
+  it('finds an existing thread id for a guided question', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ thread_id: 't-linked' });
+    await expect(getAmicusThreadIdForGuidedQuestion(9)).resolves.toBe('t-linked');
+  });
+
+  it('finds an existing thread id for a guided session', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ thread_id: 't-session' });
+    await expect(getAmicusThreadIdForGuidedSession(12, 'synthesize')).resolves.toBe('t-session');
+  });
+
+  it('finds the latest thread id for a chapter context', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ thread_id: 't-chapter' });
+    await expect(
+      getLatestAmicusThreadIdForChapterContext('genesis/1', 'guided_study'),
+    ).resolves.toBe('t-chapter');
+  });
+
+  it('loads a guided-study question by session id', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      id: 4,
+      session_id: 7,
+      chapter_id: 'genesis_1',
+      question_text: 'Why is there repetition?',
+      status: 'open',
+      created_at: 'x',
+      resolved_at: null,
+      updated_at: 'x',
+    });
+    const question = await getGuidedStudyQuestionForSession(7);
+    expect(question?.id).toBe(4);
   });
 });
 
 describe('listAmicusMessages', () => {
   it('hydrates citations + follow-ups JSON', async () => {
-    const citations = [
-      { chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' },
-    ];
+    const citations = [{ chunk_id: 'c:1', source_type: 'section_panel', display_label: 'Calvin' }];
     const followUps = ['What about faith?', 'Why Romans 9?'];
     getMockUserDb().getAllAsync.mockResolvedValueOnce([
       {

--- a/app/__tests__/db/userDatabaseV3.test.ts
+++ b/app/__tests__/db/userDatabaseV3.test.ts
@@ -39,4 +39,18 @@ describe('userDatabase V3 migration', () => {
     expect(migrationSql).toContain('CREATE TABLE IF NOT EXISTS guided_study_questions');
     expect(migrationSql).toContain('INSERT OR IGNORE INTO guided_study_questions');
   });
+
+  it('adds Amicus thread context migration SQL', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    const userDatabase = require('@/db/userDatabase');
+
+    await userDatabase.initUserDatabase();
+
+    const migrationSql = mockExecAsync.mock.calls
+      .map(([sql]: [string]) => sql)
+      .find((sql) => sql.includes('CREATE TABLE IF NOT EXISTS amicus_thread_context'));
+
+    expect(migrationSql).toContain('CREATE TABLE IF NOT EXISTS amicus_thread_context');
+    expect(migrationSql).toContain('open_question_id INTEGER UNIQUE');
+  });
 });

--- a/app/__tests__/utils/routeContext.test.ts
+++ b/app/__tests__/utils/routeContext.test.ts
@@ -11,6 +11,7 @@
 
 import {
   findDeepestRoute,
+  routeToAmicusGuidedStudyContext,
   routeToChipContext,
   type MinimalRoute,
 } from '@/utils/routeContext';
@@ -166,6 +167,20 @@ describe('routeToChipContext', () => {
     });
   });
 
+  describe('StudySession route', () => {
+    it('maps a valid StudySession route to chapter context', () => {
+      const route: MinimalRoute = {
+        name: 'StudySession',
+        params: { bookId: 'genesis', chapterNum: 1 },
+      };
+      expect(routeToChipContext(route)).toEqual({
+        kind: 'chapter',
+        bookId: 'genesis',
+        chapterNum: 1,
+      });
+    });
+  });
+
   describe('PersonDetail route', () => {
     it('maps a valid PersonDetail route to person context', () => {
       const route: MinimalRoute = {
@@ -208,5 +223,28 @@ describe('routeToChipContext', () => {
       const route: MinimalRoute = { name: 'DebateDetail', params: {} };
       expect(routeToChipContext(route)).toEqual({ kind: 'none' });
     });
+  });
+});
+
+describe('routeToAmicusGuidedStudyContext', () => {
+  it('returns guided-study entry info for StudySession', () => {
+    const route: MinimalRoute = {
+      name: 'StudySession',
+      params: { initialStep: 'synthesize' },
+    };
+    expect(routeToAmicusGuidedStudyContext(route)).toEqual({
+      entryPoint: 'guided_study',
+      guidedStudyStep: 'synthesize',
+    });
+  });
+
+  it('returns my-study entry info for MyStudy', () => {
+    expect(routeToAmicusGuidedStudyContext({ name: 'MyStudy' })).toEqual({
+      entryPoint: 'my_study',
+    });
+  });
+
+  it('returns null for unrelated routes', () => {
+    expect(routeToAmicusGuidedStudyContext({ name: 'Chapter' })).toBeNull();
   });
 });

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -31,6 +31,15 @@ export async function initUserDatabase(): Promise<SQLite.SQLiteDatabase> {
     await userDb.execAsync('PRAGMA journal_mode=WAL');
   }
 
+  // Enforce foreign keys at runtime. SQLite leaves FK checks OFF by default
+  // and the setting is per-connection — if we don't turn it on here, every
+  // `REFERENCES ... ON DELETE CASCADE / SET NULL` in our schema is cosmetic
+  // and orphan rows accumulate silently. Must be set outside any transaction
+  // (which is why this lives here, before runMigrations). DDL in migrations
+  // is unaffected by the setting — only DML statements that would violate
+  // a declared FK get rejected, which is the desired runtime behavior.
+  await userDb.execAsync('PRAGMA foreign_keys = ON');
+
   await runMigrations(userDb);
   return userDb;
 }
@@ -716,6 +725,41 @@ const MIGRATIONS: Migration[] = [
       FROM guided_study_synthesis synthesis
       JOIN guided_study_sessions sessions ON sessions.id = synthesis.session_id
       WHERE trim(synthesis.open_question) != '';
+    `,
+  },
+  {
+    version: 22,
+    description: 'Amicus - thread summaries and last-intent metadata for thread intelligence',
+    sql: `
+      CREATE TABLE IF NOT EXISTS amicus_thread_summaries (
+        thread_id TEXT PRIMARY KEY REFERENCES amicus_threads(thread_id) ON DELETE CASCADE,
+        summary_text TEXT NOT NULL,
+        last_user_intent TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `,
+  },
+  {
+    version: 23,
+    description: 'Amicus V2 contextual study links for guided study launches',
+    sql: `
+      CREATE TABLE IF NOT EXISTS amicus_thread_context (
+        thread_id TEXT PRIMARY KEY REFERENCES amicus_threads(thread_id) ON DELETE CASCADE,
+        entry_point TEXT NOT NULL
+          CHECK (entry_point IN ('fab', 'peek', 'thread', 'home_card', 'guided_study', 'my_study')),
+        guided_session_id INTEGER REFERENCES guided_study_sessions(id) ON DELETE SET NULL,
+        guided_step TEXT
+          CHECK (guided_step IS NULL OR guided_step IN ('scene', 'observe', 'explore', 'synthesize', 'review')),
+        open_question_id INTEGER UNIQUE REFERENCES guided_study_questions(id) ON DELETE SET NULL,
+        takeaway TEXT,
+        key_connection TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_amicus_thread_context_session
+        ON amicus_thread_context(guided_session_id, guided_step, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_amicus_thread_context_updated
+        ON amicus_thread_context(updated_at DESC);
     `,
   },
 ];

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -78,6 +78,13 @@ export async function setPreference(key: string, value: string): Promise<void> {
   );
 }
 
+export async function deletePreference(key: string): Promise<void> {
+  await getUserDb().runAsync(
+    'DELETE FROM user_preferences WHERE key = ?',
+    [key],
+  );
+}
+
 // ── Highlights (write) ───────────────────────────────────────────
 
 export async function setHighlight(

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -5,6 +5,7 @@
  * via getUserDb().
  */
 
+import { serializeAmicusChapterRef, type AmicusEntryPoint } from '../services/amicus/context';
 import { logger } from '../utils/logger';
 import { nextIntervalAfter } from '../services/guidedStudy/review';
 import type { GuidedStudyStep } from '../types';
@@ -74,13 +75,6 @@ export async function setPreference(key: string, value: string): Promise<void> {
     `INSERT INTO user_preferences (key, value) VALUES (?, ?)
      ON CONFLICT(key) DO UPDATE SET value = ?`,
     [key, value, value],
-  );
-}
-
-export async function deletePreference(key: string): Promise<void> {
-  await getUserDb().runAsync(
-    'DELETE FROM user_preferences WHERE key = ?',
-    [key],
   );
 }
 
@@ -451,6 +445,17 @@ export async function resolveGuidedStudyQuestion(id: number): Promise<void> {
   );
 }
 
+export async function reopenGuidedStudyQuestion(id: number): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE guided_study_questions
+     SET status = 'open',
+         resolved_at = NULL,
+         updated_at = datetime('now')
+     WHERE id = ?`,
+    [id],
+  );
+}
+
 export async function createGuidedReviewItems(
   sessionId: number,
   chapterId: string,
@@ -592,6 +597,7 @@ export async function resetToNewUser(): Promise<void> {
   await db.runAsync('DELETE FROM reading_progress');
   await db.runAsync('DELETE FROM concept_encounters');
   await db.runAsync('DELETE FROM guided_review_items');
+  await db.runAsync('DELETE FROM amicus_thread_context');
   await db.runAsync('DELETE FROM guided_study_questions');
   await db.runAsync('DELETE FROM guided_study_synthesis');
   await db.runAsync('DELETE FROM guided_study_responses');
@@ -619,9 +625,46 @@ export async function createAmicusThread(args: CreateAmicusThreadArgs): Promise<
   await getUserDb().runAsync(
     `INSERT INTO amicus_threads (thread_id, title, chapter_ref)
      VALUES (?, ?, ?)`,
-    [args.threadId, args.title, args.chapterRef ?? null],
+    [args.threadId, args.title, serializeAmicusChapterRef(args.chapterRef)],
   );
   logger.info('Amicus', `created thread ${args.threadId}`);
+}
+
+export interface UpsertAmicusThreadContextArgs {
+  threadId: string;
+  entryPoint: AmicusEntryPoint;
+  guidedSessionId?: number | null;
+  guidedStep?: GuidedStudyStep | null;
+  openQuestionId?: number | null;
+  takeaway?: string | null;
+  keyConnection?: string | null;
+}
+
+export async function upsertAmicusThreadContext(
+  args: UpsertAmicusThreadContextArgs,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_thread_context
+       (thread_id, entry_point, guided_session_id, guided_step, open_question_id, takeaway, key_connection, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(thread_id) DO UPDATE SET
+       entry_point = excluded.entry_point,
+       guided_session_id = excluded.guided_session_id,
+       guided_step = excluded.guided_step,
+       open_question_id = excluded.open_question_id,
+       takeaway = excluded.takeaway,
+       key_connection = excluded.key_connection,
+       updated_at = excluded.updated_at`,
+    [
+      args.threadId,
+      args.entryPoint,
+      args.guidedSessionId ?? null,
+      args.guidedStep ?? null,
+      args.openQuestionId ?? null,
+      args.takeaway?.trim() || null,
+      args.keyConnection?.trim() || null,
+    ],
+  );
 }
 
 export interface AppendAmicusMessageArgs {
@@ -670,6 +713,26 @@ export async function updateThreadTitle(threadId: string, title: string): Promis
   ]);
 }
 
+export interface UpsertAmicusThreadSummaryArgs {
+  threadId: string;
+  summaryText: string;
+  lastUserIntent?: string | null;
+}
+
+export async function upsertAmicusThreadSummary(
+  args: UpsertAmicusThreadSummaryArgs,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT INTO amicus_thread_summaries (thread_id, summary_text, last_user_intent, updated_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT(thread_id) DO UPDATE SET
+       summary_text = excluded.summary_text,
+       last_user_intent = excluded.last_user_intent,
+       updated_at = excluded.updated_at`,
+    [args.threadId, args.summaryText, args.lastUserIntent ?? null],
+  );
+}
+
 export async function toggleThreadPin(threadId: string): Promise<boolean> {
   const db = getUserDb();
   const row = await db.getFirstAsync<{ pinned: number }>(
@@ -683,8 +746,11 @@ export async function toggleThreadPin(threadId: string): Promise<boolean> {
 }
 
 export async function deleteAmicusThread(threadId: string): Promise<void> {
-  // CASCADE handles amicus_messages.
-  await getUserDb().runAsync('DELETE FROM amicus_threads WHERE thread_id = ?', [threadId]);
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync('DELETE FROM amicus_thread_context WHERE thread_id = ?', [threadId]);
+    await db.runAsync('DELETE FROM amicus_threads WHERE thread_id = ?', [threadId]);
+  });
   logger.info('Amicus', `deleted thread ${threadId}`);
 }
 
@@ -692,6 +758,7 @@ export async function clearAllAmicusData(): Promise<void> {
   const db = getUserDb();
   await db.withTransactionAsync(async () => {
     await db.runAsync('DELETE FROM amicus_messages');
+    await db.runAsync('DELETE FROM amicus_thread_context');
     await db.runAsync('DELETE FROM amicus_threads');
     await db.runAsync('DELETE FROM amicus_usage');
   });

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -18,6 +18,7 @@ import type {
   AmicusThread,
   AmicusMessage,
   AmicusCitation,
+  AmicusThreadContextRecord,
   ConceptEncounter,
   GuidedReviewItem,
   GuidedStudyQuestion,
@@ -532,6 +533,18 @@ export async function getOpenGuidedStudyQuestions(
   );
 }
 
+export async function getGuidedStudyQuestionForSession(
+  sessionId: number,
+): Promise<GuidedStudyQuestion | null> {
+  return getUserDb().getFirstAsync<GuidedStudyQuestion>(
+    `SELECT * FROM guided_study_questions
+     WHERE session_id = ?
+     ORDER BY updated_at DESC, id DESC
+     LIMIT 1`,
+    [sessionId],
+  );
+}
+
 export async function getRecentGuidedStudyTakeaways(
   limit: number = 10,
 ): Promise<GuidedStudyTakeawaySummary[]> {
@@ -661,8 +674,27 @@ interface AmicusThreadRow {
   title: string;
   chapter_ref: string | null;
   pinned: number;
+  summary_text: string | null;
+  last_user_intent: string | null;
+  guided_step: GuidedStudySession['current_step'] | null;
+  open_question_id: number | null;
+  guided_question_status: GuidedStudyQuestion['status'] | null;
+  takeaway: string | null;
+  key_connection: string | null;
   created_at: string;
   last_message_at: string;
+}
+
+interface AmicusThreadContextRow {
+  thread_id: string;
+  entry_point: AmicusThreadContextRecord['entry_point'];
+  guided_session_id: number | null;
+  guided_step: GuidedStudySession['current_step'] | null;
+  open_question_id: number | null;
+  takeaway: string | null;
+  key_connection: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 interface AmicusMessageRow {
@@ -681,8 +713,29 @@ function hydrateThread(row: AmicusThreadRow): AmicusThread {
     title: row.title,
     chapter_ref: row.chapter_ref,
     pinned: row.pinned === 1,
+    summary_text: row.summary_text,
+    last_user_intent: row.last_user_intent,
+    guided_step: row.guided_step,
+    open_question_id: row.open_question_id,
+    guided_question_status: row.guided_question_status,
+    takeaway: row.takeaway,
+    key_connection: row.key_connection,
     created_at: row.created_at,
     last_message_at: row.last_message_at,
+  };
+}
+
+function hydrateThreadContext(row: AmicusThreadContextRow): AmicusThreadContextRecord {
+  return {
+    thread_id: row.thread_id,
+    entry_point: row.entry_point,
+    guided_session_id: row.guided_session_id,
+    guided_step: row.guided_step,
+    open_question_id: row.open_question_id,
+    takeaway: row.takeaway,
+    key_connection: row.key_connection,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
   };
 }
 
@@ -718,8 +771,15 @@ function hydrateMessage(row: AmicusMessageRow): AmicusMessage {
 
 export async function listAmicusThreads(limit = 50, offset = 0): Promise<AmicusThread[]> {
   const rows = await getUserDb().getAllAsync<AmicusThreadRow>(
-    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
-       FROM amicus_threads
+    `SELECT t.thread_id, t.title, t.chapter_ref, t.pinned,
+            s.summary_text, s.last_user_intent,
+            c.guided_step, c.open_question_id, q.status AS guided_question_status,
+            c.takeaway, c.key_connection,
+            t.created_at, t.last_message_at
+       FROM amicus_threads t
+       LEFT JOIN amicus_thread_summaries s ON s.thread_id = t.thread_id
+       LEFT JOIN amicus_thread_context c ON c.thread_id = t.thread_id
+       LEFT JOIN guided_study_questions q ON q.id = c.open_question_id
       ORDER BY pinned DESC, last_message_at DESC
       LIMIT ? OFFSET ?`,
     [limit, offset],
@@ -729,11 +789,123 @@ export async function listAmicusThreads(limit = 50, offset = 0): Promise<AmicusT
 
 export async function getAmicusThread(threadId: string): Promise<AmicusThread | null> {
   const row = await getUserDb().getFirstAsync<AmicusThreadRow>(
-    `SELECT thread_id, title, chapter_ref, pinned, created_at, last_message_at
-       FROM amicus_threads WHERE thread_id = ?`,
+    `SELECT t.thread_id, t.title, t.chapter_ref, t.pinned,
+            s.summary_text, s.last_user_intent,
+            c.guided_step, c.open_question_id, q.status AS guided_question_status,
+            c.takeaway, c.key_connection,
+            t.created_at, t.last_message_at
+       FROM amicus_threads t
+       LEFT JOIN amicus_thread_summaries s ON s.thread_id = t.thread_id
+       LEFT JOIN amicus_thread_context c ON c.thread_id = t.thread_id
+       LEFT JOIN guided_study_questions q ON q.id = c.open_question_id
+      WHERE t.thread_id = ?`,
     [threadId],
   );
   return row ? hydrateThread(row) : null;
+}
+
+export async function getAmicusThreadContext(
+  threadId: string,
+): Promise<AmicusThreadContextRecord | null> {
+  const row = await getUserDb().getFirstAsync<AmicusThreadContextRow>(
+    `SELECT thread_id, entry_point, guided_session_id, guided_step,
+            open_question_id, takeaway, key_connection, created_at, updated_at
+       FROM amicus_thread_context
+      WHERE thread_id = ?`,
+    [threadId],
+  );
+  return row ? hydrateThreadContext(row) : null;
+}
+
+export async function getLinkedGuidedStudyQuestionForThread(
+  threadId: string,
+): Promise<GuidedStudyQuestion | null> {
+  return getUserDb().getFirstAsync<GuidedStudyQuestion>(
+    `SELECT q.*
+       FROM guided_study_questions q
+       JOIN amicus_thread_context c ON c.open_question_id = q.id
+      WHERE c.thread_id = ?
+      LIMIT 1`,
+    [threadId],
+  );
+}
+
+export async function getAmicusThreadIdForGuidedQuestion(
+  questionId: number,
+): Promise<string | null> {
+  const row = await getUserDb().getFirstAsync<{ thread_id: string }>(
+    `SELECT thread_id
+       FROM amicus_thread_context
+      WHERE open_question_id = ?
+      LIMIT 1`,
+    [questionId],
+  );
+  return row?.thread_id ?? null;
+}
+
+export async function getAmicusThreadIdForGuidedSession(
+  sessionId: number,
+  guidedStep?: GuidedStudySession['current_step'] | null,
+): Promise<string | null> {
+  const row = await getUserDb().getFirstAsync<{ thread_id: string }>(
+    guidedStep
+      ? `SELECT thread_id
+           FROM amicus_thread_context
+          WHERE guided_session_id = ? AND guided_step = ?
+          ORDER BY updated_at DESC
+          LIMIT 1`
+      : `SELECT thread_id
+           FROM amicus_thread_context
+          WHERE guided_session_id = ?
+          ORDER BY updated_at DESC
+          LIMIT 1`,
+    guidedStep ? [sessionId, guidedStep] : [sessionId],
+  );
+  return row?.thread_id ?? null;
+}
+
+export async function getLatestAmicusThreadIdForChapterContext(
+  chapterRef: string,
+  entryPoint?: AmicusThreadContextRecord['entry_point'] | null,
+): Promise<string | null> {
+  const row = await getUserDb().getFirstAsync<{ thread_id: string }>(
+    entryPoint
+      ? `SELECT t.thread_id
+           FROM amicus_threads t
+           LEFT JOIN amicus_thread_context c ON c.thread_id = t.thread_id
+          WHERE t.chapter_ref = ? AND c.entry_point = ?
+          ORDER BY COALESCE(c.updated_at, t.last_message_at) DESC
+          LIMIT 1`
+      : `SELECT thread_id
+           FROM amicus_threads
+          WHERE chapter_ref = ?
+          ORDER BY last_message_at DESC
+          LIMIT 1`,
+    entryPoint ? [chapterRef, entryPoint] : [chapterRef],
+  );
+  return row?.thread_id ?? null;
+}
+
+export async function getLatestStudyAmicusThreadIdForChapter(
+  chapterRef: string,
+): Promise<string | null> {
+  const row = await getUserDb().getFirstAsync<{ thread_id: string }>(
+    `SELECT t.thread_id
+       FROM amicus_threads t
+       LEFT JOIN amicus_thread_context c ON c.thread_id = t.thread_id
+      WHERE t.chapter_ref = ?
+        AND (
+          c.entry_point IN ('guided_study', 'my_study')
+          OR c.guided_session_id IS NOT NULL
+          OR c.open_question_id IS NOT NULL
+          OR trim(COALESCE(c.takeaway, '')) != ''
+          OR trim(COALESCE(c.key_connection, '')) != ''
+        )
+      ORDER BY COALESCE(c.updated_at, t.last_message_at) DESC
+      LIMIT 1`,
+    [chapterRef],
+  );
+  return row?.thread_id ?? null;
 }
 
 export async function listAmicusMessages(threadId: string): Promise<AmicusMessage[]> {

--- a/app/src/services/amicus/__tests__/context.test.ts
+++ b/app/src/services/amicus/__tests__/context.test.ts
@@ -1,0 +1,139 @@
+import {
+  buildAmicusContextEnvelope,
+  chapterRefFromChipContext,
+  formatAmicusContextLabel,
+  normalizeChapterRef,
+  serializeAmicusChapterRef,
+} from '@/services/amicus/context';
+
+describe('amicus context helpers', () => {
+  it('derives a chapter ref from chapter chip context', () => {
+    expect(
+      chapterRefFromChipContext({
+        kind: 'chapter',
+        bookId: 'genesis',
+        chapterNum: 1,
+      }),
+    ).toEqual({
+      book_id: 'genesis',
+      chapter_num: 1,
+    });
+  });
+
+  it('returns null when the chip context is not chapter-based', () => {
+    expect(chapterRefFromChipContext({ kind: 'none' })).toBeNull();
+    expect(
+      chapterRefFromChipContext({
+        kind: 'person',
+        personId: 'moses',
+      }),
+    ).toBeNull();
+  });
+
+  it('normalizes both slash and legacy colon chapter refs', () => {
+    expect(normalizeChapterRef('romans/8')).toEqual({
+      book_id: 'romans',
+      chapter_num: 8,
+    });
+    expect(normalizeChapterRef('romans:8')).toEqual({
+      book_id: 'romans',
+      chapter_num: 8,
+    });
+  });
+
+  it('serializes normalized chapter refs with slash format', () => {
+    expect(serializeAmicusChapterRef('romans:8')).toBe('romans/8');
+    expect(
+      serializeAmicusChapterRef({
+        book_id: 'john',
+        chapter_num: 3,
+      }),
+    ).toBe('john/3');
+  });
+
+  it('builds an envelope from route chapter context when no override is provided', () => {
+    expect(
+      buildAmicusContextEnvelope({
+        entryPoint: 'peek',
+        chipContext: {
+          kind: 'chapter',
+          bookId: 'psalms',
+          chapterNum: 23,
+        },
+      }),
+    ).toEqual({
+      entryPoint: 'peek',
+      routeContext: {
+        kind: 'chapter',
+        bookId: 'psalms',
+        chapterNum: 23,
+      },
+      chapterRef: {
+        book_id: 'psalms',
+        chapter_num: 23,
+      },
+      sessionId: null,
+      guidedStudyStep: null,
+      openQuestionId: null,
+      openQuestionText: null,
+      takeaway: null,
+      keyConnection: null,
+    });
+  });
+
+  it('prefers an explicit chapter ref override when building an envelope', () => {
+    expect(
+      buildAmicusContextEnvelope({
+        entryPoint: 'thread',
+        chipContext: { kind: 'none' },
+        chapterRef: 'genesis:1',
+      }),
+    ).toEqual({
+      entryPoint: 'thread',
+      routeContext: { kind: 'none' },
+      chapterRef: {
+        book_id: 'genesis',
+        chapter_num: 1,
+      },
+      sessionId: null,
+      guidedStudyStep: null,
+      openQuestionId: null,
+      openQuestionText: null,
+      takeaway: null,
+      keyConnection: null,
+    });
+  });
+
+  it('carries guided-study context into the envelope', () => {
+    expect(
+      buildAmicusContextEnvelope({
+        entryPoint: 'guided_study',
+        chipContext: { kind: 'none' },
+        guidedStudyContext: {
+          sessionId: 12,
+          guidedStudyStep: 'synthesize',
+          openQuestionId: 5,
+          openQuestionText: 'Why is this repeated?',
+          takeaway: 'Creation is ordered.',
+          keyConnection: 'John 1',
+        },
+      }),
+    ).toEqual({
+      entryPoint: 'guided_study',
+      routeContext: { kind: 'none' },
+      chapterRef: null,
+      sessionId: 12,
+      guidedStudyStep: 'synthesize',
+      openQuestionId: 5,
+      openQuestionText: 'Why is this repeated?',
+      takeaway: 'Creation is ordered.',
+      keyConnection: 'John 1',
+    });
+  });
+
+  it('formats human-readable context labels from stored refs', () => {
+    expect(formatAmicusContextLabel('1_corinthians/13')).toBe('1 Corinthians 13');
+    expect(formatAmicusContextLabel('romans:8')).toBe('Romans 8');
+    expect(formatAmicusContextLabel(null)).toBeNull();
+  });
+});

--- a/app/src/services/amicus/__tests__/deepLink.test.ts
+++ b/app/src/services/amicus/__tests__/deepLink.test.ts
@@ -4,6 +4,7 @@
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import {
   formatChapterRef,
+  navigateToAmicusWithPromotion,
   navigateToAmicusWithSeed,
   parseAmicusDeepLink,
   parseChapterRef,
@@ -80,6 +81,29 @@ describe('navigateToAmicusWithSeed', () => {
       { onNoParent },
     );
     expect(onNoParent).toHaveBeenCalled();
+  });
+});
+
+describe('navigateToAmicusWithPromotion', () => {
+  it('dispatches a NewThread navigation with promoted peek messages', () => {
+    const { nav, parentNavigate } = makeNav();
+    navigateToAmicusWithPromotion(nav, {
+      messages: [
+        { role: 'user', content: 'What is hesed?' },
+        { role: 'assistant', content: 'It means covenant love.' },
+      ],
+      chapterRef: { book_id: 'psalms', chapter_num: 23 },
+    });
+    expect(parentNavigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'NewThread',
+      params: {
+        seedChapterRef: 'psalms/23',
+        promotedMessages: [
+          { role: 'user', content: 'What is hesed?' },
+          { role: 'assistant', content: 'It means covenant love.' },
+        ],
+      },
+    });
   });
 });
 

--- a/app/src/services/amicus/__tests__/studyActions.test.ts
+++ b/app/src/services/amicus/__tests__/studyActions.test.ts
@@ -1,0 +1,89 @@
+import { buildAmicusContextEnvelope } from '@/services/amicus/context';
+import { buildStudyActionSeeds } from '@/services/amicus/studyActions';
+
+describe('buildStudyActionSeeds', () => {
+  it('returns three chapter-oriented actions when chapter context is present', () => {
+    const context = buildAmicusContextEnvelope({
+      entryPoint: 'thread',
+      chipContext: {
+        kind: 'chapter',
+        bookId: 'genesis',
+        chapterNum: 1,
+      },
+    });
+
+    expect(buildStudyActionSeeds(context)).toEqual([
+      {
+        key: 'explain_context',
+        label: 'Explain this chapter',
+        seedQuery:
+          'Give me a guided overview of Genesis 1. What should I notice before I interpret it?',
+      },
+      {
+        key: 'interpretive_tensions',
+        label: 'Show interpretive tensions',
+        seedQuery:
+          'Show me the main interpretive tensions in Genesis 1. Distinguish broad consensus from debated readings.',
+      },
+      {
+        key: 'trace_connections',
+        label: 'Trace key connections',
+        seedQuery:
+          'Trace the most important canonical connections for Genesis 1. Keep the connections grounded in the text.',
+      },
+    ]);
+  });
+
+  it('returns a debate summary action for debate-topic context', () => {
+    const context = buildAmicusContextEnvelope({
+      entryPoint: 'peek',
+      chipContext: {
+        kind: 'debate_topic',
+        topicId: 'predestination',
+      },
+    });
+
+    expect(buildStudyActionSeeds(context)).toEqual([
+      {
+        key: 'interpretive_tensions',
+        label: 'Summarize this debate',
+        seedQuery:
+          'Summarize the main positions in this debate and explain where the strongest tensions are.',
+      },
+    ]);
+  });
+
+  it('returns no actions when there is no contextual hook to build from', () => {
+    const context = buildAmicusContextEnvelope({
+      entryPoint: 'peek',
+      chipContext: { kind: 'none' },
+    });
+
+    expect(buildStudyActionSeeds(context)).toEqual([]);
+  });
+
+  it('prioritizes guided-study actions when a question or takeaway is present', () => {
+    const context = buildAmicusContextEnvelope({
+      entryPoint: 'guided_study',
+      chapterRef: { book_id: 'genesis', chapter_num: 1 },
+      guidedStudyContext: {
+        openQuestionText: 'Why is the structure repeated?',
+        takeaway: 'Creation unfolds in ordered stages.',
+      },
+    });
+
+    expect(buildStudyActionSeeds(context).slice(0, 2)).toEqual([
+      {
+        key: 'investigate_question',
+        label: 'Investigate my question',
+        seedQuery: 'Help me investigate this study question: Why is the structure repeated?',
+      },
+      {
+        key: 'refine_takeaway',
+        label: 'Refine takeaway',
+        seedQuery:
+          'Help me refine this takeaway so it stays faithful to the text: Creation unfolds in ordered stages.',
+      },
+    ]);
+  });
+});

--- a/app/src/services/amicus/__tests__/studyLaunch.test.ts
+++ b/app/src/services/amicus/__tests__/studyLaunch.test.ts
@@ -1,0 +1,162 @@
+import { launchAmicusStudyThread, promotePeekToAmicusThread } from '@/services/amicus/studyLaunch';
+import {
+  getAmicusThreadIdForGuidedQuestion,
+  getAmicusThreadIdForGuidedSession,
+  getLatestAmicusThreadIdForChapterContext,
+} from '@/db/userQueries';
+import {
+  appendAmicusMessage,
+  upsertAmicusThreadContext,
+  upsertAmicusThreadSummary,
+} from '@/db/userMutations';
+
+jest.mock('@/db/userQueries', () => ({
+  getAmicusThreadIdForGuidedQuestion: jest.fn(),
+  getAmicusThreadIdForGuidedSession: jest.fn(),
+  getLatestAmicusThreadIdForChapterContext: jest.fn(),
+}));
+
+jest.mock('@/db/userMutations', () => ({
+  appendAmicusMessage: jest.fn().mockResolvedValue(undefined),
+  upsertAmicusThreadContext: jest.fn().mockResolvedValue(undefined),
+  upsertAmicusThreadSummary: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetThreadIdForQuestion = getAmicusThreadIdForGuidedQuestion as jest.MockedFunction<
+  typeof getAmicusThreadIdForGuidedQuestion
+>;
+const mockGetThreadIdForSession = getAmicusThreadIdForGuidedSession as jest.MockedFunction<
+  typeof getAmicusThreadIdForGuidedSession
+>;
+const mockGetLatestThreadIdForChapter =
+  getLatestAmicusThreadIdForChapterContext as jest.MockedFunction<
+    typeof getLatestAmicusThreadIdForChapterContext
+  >;
+const mockAppendAmicusMessage = appendAmicusMessage as jest.MockedFunction<
+  typeof appendAmicusMessage
+>;
+const mockUpsertAmicusThreadContext = upsertAmicusThreadContext as jest.MockedFunction<
+  typeof upsertAmicusThreadContext
+>;
+const mockUpsertAmicusThreadSummary = upsertAmicusThreadSummary as jest.MockedFunction<
+  typeof upsertAmicusThreadSummary
+>;
+
+describe('launchAmicusStudyThread', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetThreadIdForQuestion.mockResolvedValue(null);
+    mockGetThreadIdForSession.mockResolvedValue(null);
+    mockGetLatestThreadIdForChapter.mockResolvedValue(null);
+  });
+
+  it('reuses an existing linked question thread when available', async () => {
+    const parent = { navigate: jest.fn() };
+    const navigation = { getParent: () => parent } as any;
+    mockGetThreadIdForQuestion.mockResolvedValueOnce('t-linked');
+
+    await launchAmicusStudyThread(navigation, {
+      entryPoint: 'my_study',
+      chapterId: 'genesis_1',
+      sessionId: 8,
+      guidedStudyStep: 'synthesize',
+      openQuestionId: 3,
+      openQuestionText: 'Why is the structure repeated?',
+      seedQuery: 'Investigate this question',
+    });
+
+    expect(parent.navigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'Thread',
+      params: expect.objectContaining({
+        threadId: 't-linked',
+        seedChapterRef: 'genesis/1',
+      }),
+    });
+  });
+
+  it('creates a new seeded thread when no existing study thread is found', async () => {
+    const parent = { navigate: jest.fn() };
+    const navigation = { getParent: () => parent } as any;
+
+    await launchAmicusStudyThread(navigation, {
+      entryPoint: 'guided_study',
+      chapterId: 'genesis_1',
+      sessionId: 8,
+      guidedStudyStep: 'synthesize',
+      takeaway: 'Creation unfolds in ordered stages.',
+      seedQuery: 'Help me refine this takeaway',
+    });
+
+    expect(parent.navigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'NewThread',
+      params: expect.objectContaining({
+        seedQuery: 'Help me refine this takeaway',
+        seedChapterRef: 'genesis/1',
+        seedGuidedContext: expect.objectContaining({
+          sessionId: 8,
+          guidedStudyStep: 'synthesize',
+          takeaway: 'Creation unfolds in ordered stages.',
+        }),
+      }),
+    });
+  });
+
+  it('promotes peek messages into an existing study-linked thread when one exists', async () => {
+    const parent = { navigate: jest.fn() };
+    const navigation = { getParent: () => parent } as any;
+    mockGetLatestThreadIdForChapter.mockResolvedValueOnce('t-existing');
+
+    await promotePeekToAmicusThread(navigation, {
+      chapterRef: { book_id: 'genesis', chapter_num: 1 },
+      guidedContext: {
+        entryPoint: 'guided_study',
+        guidedStudyStep: 'synthesize',
+      },
+      messages: [
+        { role: 'user', content: 'Why is the structure repeated?' },
+        { role: 'assistant', content: 'It creates a pattern.' },
+      ],
+    });
+
+    expect(mockAppendAmicusMessage).toHaveBeenCalledTimes(2);
+    expect(mockUpsertAmicusThreadContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 't-existing',
+        entryPoint: 'guided_study',
+      }),
+    );
+    expect(mockUpsertAmicusThreadSummary).toHaveBeenCalled();
+    expect(parent.navigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'Thread',
+      params: expect.objectContaining({
+        threadId: 't-existing',
+        seedChapterRef: 'genesis/1',
+      }),
+    });
+  });
+
+  it('falls back to a new thread when no existing study-linked thread is found for peek promotion', async () => {
+    const parent = { navigate: jest.fn() };
+    const navigation = { getParent: () => parent } as any;
+
+    await promotePeekToAmicusThread(navigation, {
+      chapterRef: { book_id: 'genesis', chapter_num: 1 },
+      guidedContext: {
+        entryPoint: 'guided_study',
+      },
+      messages: [{ role: 'user', content: 'Help me connect this chapter.' }],
+    });
+
+    expect(parent.navigate).toHaveBeenCalledWith('AmicusTab', {
+      screen: 'NewThread',
+      params: expect.objectContaining({
+        seedChapterRef: 'genesis/1',
+        promotedMessages: [{ role: 'user', content: 'Help me connect this chapter.' }],
+      }),
+    });
+  });
+});

--- a/app/src/services/amicus/__tests__/threadIntelligence.test.ts
+++ b/app/src/services/amicus/__tests__/threadIntelligence.test.ts
@@ -1,0 +1,85 @@
+import {
+  deriveThreadIntelligence,
+  shouldAutoRenameThread,
+} from '@/services/amicus/threadIntelligence';
+
+describe('thread intelligence', () => {
+  it('derives chapter-aware titles and summaries for study actions', () => {
+    expect(
+      deriveThreadIntelligence({
+        currentTitle: 'New conversation',
+        chapterRef: 'genesis/1',
+        userQuery: 'Give me a guided overview of Genesis 1.',
+        action: {
+          key: 'explain_context',
+          label: 'Explain this chapter',
+          seedQuery: 'Give me a guided overview of Genesis 1.',
+        },
+      }),
+    ).toEqual({
+      title: 'Genesis 1 — chapter overview',
+      summaryText: 'Explain this chapter in Genesis 1.',
+      lastUserIntent: 'Explain this chapter',
+    });
+  });
+
+  it('falls back to the user query for generic chapter threads', () => {
+    expect(
+      deriveThreadIntelligence({
+        currentTitle: 'New conversation',
+        chapterRef: 'romans/8',
+        userQuery: 'How does this chapter connect adoption and suffering?',
+      }),
+    ).toEqual({
+      title: 'Romans 8 — How does this chapter connect adopt…',
+      summaryText: 'How does this chapter connect adoption and suffering?',
+      lastUserIntent: null,
+    });
+  });
+
+  it('does not overwrite explicit custom titles', () => {
+    expect(
+      deriveThreadIntelligence({
+        currentTitle: 'My Romans thread',
+        chapterRef: 'romans/8',
+        userQuery: 'What is Paul doing here?',
+      }).title,
+    ).toBe('My Romans thread');
+  });
+
+  it('recognizes untitled threads for auto-rename', () => {
+    expect(shouldAutoRenameThread(undefined)).toBe(true);
+    expect(shouldAutoRenameThread('New conversation')).toBe(true);
+    expect(shouldAutoRenameThread('My saved thread')).toBe(false);
+  });
+
+  it('prefers open-question context for study-linked threads', () => {
+    expect(
+      deriveThreadIntelligence({
+        currentTitle: 'New conversation',
+        chapterRef: 'genesis/1',
+        userQuery: 'Help me investigate this study question.',
+        openQuestionText: 'Why is the structure repeated?',
+      }),
+    ).toEqual({
+      title: 'Genesis 1 — Why is the structure repeated?',
+      summaryText: 'Investigating: Why is the structure repeated?',
+      lastUserIntent: 'Investigate question',
+    });
+  });
+
+  it('uses takeaway context when refining synthesis', () => {
+    expect(
+      deriveThreadIntelligence({
+        currentTitle: 'New conversation',
+        chapterRef: 'genesis/1',
+        userQuery: 'Help me refine this synthesis.',
+        takeaway: 'Creation unfolds in ordered stages.',
+      }),
+    ).toEqual({
+      title: 'Genesis 1 — refine takeaway',
+      summaryText: 'Refining takeaway: Creation unfolds in ordered stages.',
+      lastUserIntent: 'Refine takeaway',
+    });
+  });
+});

--- a/app/src/services/amicus/__tests__/trust.test.ts
+++ b/app/src/services/amicus/__tests__/trust.test.ts
@@ -1,0 +1,47 @@
+import {
+  formatTrustStanceLabel,
+  summarizeAmicusTrust,
+} from '@/services/amicus/trust';
+import type { AmicusCitation } from '@/types';
+
+describe('amicus trust helpers', () => {
+  it('summarizes unique source labels and detects debated stance', () => {
+    const citations: AmicusCitation[] = [
+      {
+        chunk_id: 'debate_topic:election',
+        source_type: 'debate_topic',
+        display_label: 'Election Debate',
+      },
+      {
+        chunk_id: 'section_panel:romans-9-s1-calvin',
+        source_type: 'section_panel',
+        display_label: 'Calvin · Romans 9',
+      },
+      {
+        chunk_id: 'section_panel:romans-9-s1-calvin-2',
+        source_type: 'section_panel',
+        display_label: 'Calvin · Romans 9',
+      },
+    ];
+
+    expect(summarizeAmicusTrust(citations)).toEqual({
+      sourceCount: 2,
+      labels: ['Election Debate', 'Calvin · Romans 9'],
+      stance: 'debated',
+      hasTrustSignals: true,
+    });
+  });
+
+  it('returns an empty summary when there are no citations', () => {
+    expect(summarizeAmicusTrust([])).toEqual({
+      sourceCount: 0,
+      labels: [],
+      stance: null,
+      hasTrustSignals: false,
+    });
+  });
+
+  it('formats debated stance for display', () => {
+    expect(formatTrustStanceLabel('debated')).toBe('Debated');
+  });
+});

--- a/app/src/services/amicus/context.ts
+++ b/app/src/services/amicus/context.ts
@@ -1,0 +1,123 @@
+import type { ChipContext } from '@/hooks/useAmicusChips';
+import type { GuidedStudyStep } from '@/types';
+import { formatChapterRef, parseChapterRef, type AmicusSeedChapterRef } from './deepLink';
+
+export type AmicusEntryPoint =
+  | 'fab'
+  | 'peek'
+  | 'thread'
+  | 'home_card'
+  | 'guided_study'
+  | 'my_study';
+
+export interface AmicusGuidedStudyContext {
+  entryPoint?: AmicusEntryPoint;
+  sessionId?: number | null;
+  guidedStudyStep?: GuidedStudyStep | null;
+  openQuestionId?: number | null;
+  openQuestionText?: string | null;
+  takeaway?: string | null;
+  keyConnection?: string | null;
+}
+
+export interface AmicusContextEnvelope {
+  entryPoint: AmicusEntryPoint;
+  routeContext: ChipContext;
+  chapterRef: AmicusSeedChapterRef | null;
+  sessionId: number | null;
+  guidedStudyStep: GuidedStudyStep | null;
+  openQuestionId: number | null;
+  openQuestionText: string | null;
+  takeaway: string | null;
+  keyConnection: string | null;
+}
+
+export interface BuildAmicusContextEnvelopeOptions {
+  entryPoint: AmicusEntryPoint;
+  chipContext?: ChipContext | null;
+  chapterRef?: AmicusSeedChapterRef | string | null;
+  guidedStudyContext?: AmicusGuidedStudyContext | null;
+}
+
+function parseLegacyChapterRef(raw: string): AmicusSeedChapterRef | null {
+  const match = /^([^:]+):(\d+)$/.exec(raw.trim());
+  if (!match) return null;
+  const chapterNum = Number(match[2]);
+  if (!Number.isFinite(chapterNum) || chapterNum <= 0) return null;
+  return {
+    book_id: match[1]!,
+    chapter_num: chapterNum,
+  };
+}
+
+export function normalizeChapterRef(
+  ref: AmicusSeedChapterRef | string | null | undefined,
+): AmicusSeedChapterRef | null {
+  if (!ref) return null;
+  if (typeof ref === 'string') {
+    return parseChapterRef(ref) ?? parseLegacyChapterRef(ref);
+  }
+  if (
+    typeof ref.book_id === 'string' &&
+    ref.book_id.trim().length > 0 &&
+    Number.isFinite(ref.chapter_num) &&
+    ref.chapter_num > 0
+  ) {
+    return {
+      book_id: ref.book_id.trim(),
+      chapter_num: ref.chapter_num,
+    };
+  }
+  return null;
+}
+
+export function chapterRefFromChipContext(
+  chipContext: ChipContext | null | undefined,
+): AmicusSeedChapterRef | null {
+  if (!chipContext || chipContext.kind !== 'chapter') return null;
+  return {
+    book_id: chipContext.bookId,
+    chapter_num: chipContext.chapterNum,
+  };
+}
+
+export function serializeAmicusChapterRef(
+  ref: AmicusSeedChapterRef | string | null | undefined,
+): string | null {
+  const normalized = normalizeChapterRef(ref);
+  return normalized ? (formatChapterRef(normalized) ?? null) : null;
+}
+
+export function prettyBookId(bookId: string): string {
+  return bookId.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function formatAmicusContextLabel(
+  ref: AmicusSeedChapterRef | string | null | undefined,
+): string | null {
+  const normalized = normalizeChapterRef(ref);
+  if (!normalized) {
+    if (typeof ref !== 'string') return null;
+    const trimmed = ref.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return `${prettyBookId(normalized.book_id)} ${normalized.chapter_num}`;
+}
+
+export function buildAmicusContextEnvelope(
+  options: BuildAmicusContextEnvelopeOptions,
+): AmicusContextEnvelope {
+  const routeContext = options.chipContext ?? { kind: 'none' };
+  const guidedContext = options.guidedStudyContext;
+  return {
+    entryPoint: guidedContext?.entryPoint ?? options.entryPoint,
+    routeContext,
+    chapterRef: normalizeChapterRef(options.chapterRef) ?? chapterRefFromChipContext(routeContext),
+    sessionId: guidedContext?.sessionId ?? null,
+    guidedStudyStep: guidedContext?.guidedStudyStep ?? null,
+    openQuestionId: guidedContext?.openQuestionId ?? null,
+    openQuestionText: guidedContext?.openQuestionText?.trim() || null,
+    takeaway: guidedContext?.takeaway?.trim() || null,
+    keyConnection: guidedContext?.keyConnection?.trim() || null,
+  };
+}

--- a/app/src/services/amicus/dailyPrompt.ts
+++ b/app/src/services/amicus/dailyPrompt.ts
@@ -7,7 +7,6 @@
  */
 import { getCachedDailyPrompt, getRecentChapters } from '@/db/userQueries';
 import { upsertDailyPrompt } from '@/db/userMutations';
-import { getAmicusAuthToken } from '@/services/amicus/authToken';
 import { generateProfile } from '@/services/amicus/profile/generator';
 import { logger } from '@/utils/logger';
 
@@ -22,7 +21,7 @@ export interface DailyPrompt {
 }
 
 export interface GetDailyPromptOptions {
-  getAuthToken?: () => string | null | Promise<string | null>;
+  getAuthToken?: () => string;
   fetchImpl?: typeof fetch;
   /** Inject a fixed date for deterministic tests. Defaults to now. */
   now?: () => Date;
@@ -59,7 +58,7 @@ export async function getDailyPrompt(
   }
 
   const authToken =
-    (await opts.getAuthToken?.()) ?? (await getAmicusAuthToken());
+    opts.getAuthToken?.() ?? process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '';
   if (!authToken || !profileHash) {
     // No way to call the proxy — fall back to whatever we have.
     return cached

--- a/app/src/services/amicus/dailyPrompt.ts
+++ b/app/src/services/amicus/dailyPrompt.ts
@@ -7,6 +7,7 @@
  */
 import { getCachedDailyPrompt, getRecentChapters } from '@/db/userQueries';
 import { upsertDailyPrompt } from '@/db/userMutations';
+import { getAmicusAuthToken } from '@/services/amicus/authToken';
 import { generateProfile } from '@/services/amicus/profile/generator';
 import { logger } from '@/utils/logger';
 
@@ -21,7 +22,7 @@ export interface DailyPrompt {
 }
 
 export interface GetDailyPromptOptions {
-  getAuthToken?: () => string;
+  getAuthToken?: () => string | null | Promise<string | null>;
   fetchImpl?: typeof fetch;
   /** Inject a fixed date for deterministic tests. Defaults to now. */
   now?: () => Date;
@@ -58,7 +59,7 @@ export async function getDailyPrompt(
   }
 
   const authToken =
-    opts.getAuthToken?.() ?? process.env.EXPO_PUBLIC_AMICUS_DEV_TOKEN ?? '';
+    (await opts.getAuthToken?.()) ?? (await getAmicusAuthToken());
   if (!authToken || !profileHash) {
     // No way to call the proxy — fall back to whatever we have.
     return cached

--- a/app/src/services/amicus/deepLink.ts
+++ b/app/src/services/amicus/deepLink.ts
@@ -6,6 +6,7 @@
  * future deep-link sources (push notifications, widgets).
  */
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import type { AmicusDraftMessage } from '@/types';
 import { logger } from '@/utils/logger';
 
 export interface AmicusSeedChapterRef {
@@ -15,6 +16,11 @@ export interface AmicusSeedChapterRef {
 
 export interface AmicusSeed {
   query: string;
+  chapterRef?: AmicusSeedChapterRef | null;
+}
+
+export interface AmicusPeekPromotion {
+  messages: AmicusDraftMessage[];
   chapterRef?: AmicusSeedChapterRef | null;
 }
 
@@ -74,6 +80,31 @@ export function navigateToAmicusWithSeed(
   logger.info(
     'AmicusDeepLink',
     `seeded nav: query=${seed.query.length}ch chapter=${formatChapterRef(seed.chapterRef) ?? 'none'}`,
+  );
+}
+
+export function navigateToAmicusWithPromotion(
+  navigation: NavigationProp<ParamListBase>,
+  promotion: AmicusPeekPromotion,
+  opts: NavigateToAmicusWithSeedOptions = {},
+): void {
+  const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+  if (!parent) {
+    (opts.onNoParent ?? (() => {
+      logger.warn('AmicusDeepLink', 'no parent navigator for promotion');
+    }))();
+    return;
+  }
+  parent.navigate('AmicusTab', {
+    screen: 'NewThread',
+    params: {
+      seedChapterRef: formatChapterRef(promotion.chapterRef),
+      promotedMessages: promotion.messages,
+    },
+  });
+  logger.info(
+    'AmicusDeepLink',
+    `promoted peek: messages=${promotion.messages.length} chapter=${formatChapterRef(promotion.chapterRef) ?? 'none'}`,
   );
 }
 

--- a/app/src/services/amicus/index.ts
+++ b/app/src/services/amicus/index.ts
@@ -7,6 +7,27 @@
  */
 export { retrieve } from './retrieval';
 export type { RetrievalResult, RetrieveOptions } from './retrieval';
+export {
+  buildAmicusContextEnvelope,
+  chapterRefFromChipContext,
+  formatAmicusContextLabel,
+  normalizeChapterRef,
+  prettyBookId,
+  serializeAmicusChapterRef,
+} from './context';
+export { buildStudyActionSeeds } from './studyActions';
+export { launchAmicusStudyThread, promotePeekToAmicusThread } from './studyLaunch';
+export {
+  deriveThreadIntelligence,
+  shouldAutoRenameThread,
+  summarizeLinkedQuestionState,
+} from './threadIntelligence';
+export { formatTrustStanceLabel, summarizeAmicusTrust } from './trust';
+export type { AmicusContextEnvelope, AmicusEntryPoint, AmicusGuidedStudyContext } from './context';
+export type { AmicusStudyActionKey, AmicusStudyActionSeed } from './studyActions';
+export type { LaunchAmicusStudyThreadInput, PromotePeekToStudyThreadInput } from './studyLaunch';
+export type { DerivedThreadIntelligence } from './threadIntelligence';
+export type { AmicusTrustStance, AmicusTrustSummary } from './trust';
 export { AmicusError } from './types';
 export type {
   AmicusErrorCode,

--- a/app/src/services/amicus/studyActions.ts
+++ b/app/src/services/amicus/studyActions.ts
@@ -1,0 +1,89 @@
+import type { AmicusContextEnvelope } from './context';
+import { prettyBookId } from './context';
+
+export type AmicusStudyActionKey =
+  | 'explain_context'
+  | 'investigate_question'
+  | 'interpretive_tensions'
+  | 'refine_takeaway'
+  | 'trace_connections';
+
+export interface AmicusStudyActionSeed {
+  key: AmicusStudyActionKey;
+  label: string;
+  seedQuery: string;
+}
+
+function buildChapterStudyActions(
+  chapterRef: NonNullable<AmicusContextEnvelope['chapterRef']>,
+): AmicusStudyActionSeed[] {
+  const refLabel = `${prettyBookId(chapterRef.book_id)} ${chapterRef.chapter_num}`;
+  return [
+    {
+      key: 'explain_context',
+      label: 'Explain this chapter',
+      seedQuery: `Give me a guided overview of ${refLabel}. What should I notice before I interpret it?`,
+    },
+    {
+      key: 'interpretive_tensions',
+      label: 'Show interpretive tensions',
+      seedQuery: `Show me the main interpretive tensions in ${refLabel}. Distinguish broad consensus from debated readings.`,
+    },
+    {
+      key: 'trace_connections',
+      label: 'Trace key connections',
+      seedQuery: `Trace the most important canonical connections for ${refLabel}. Keep the connections grounded in the text.`,
+    },
+  ];
+}
+
+export function buildStudyActionSeeds(context: AmicusContextEnvelope): AmicusStudyActionSeed[] {
+  const guidedActions: AmicusStudyActionSeed[] = [];
+  if (context.openQuestionText) {
+    guidedActions.push({
+      key: 'investigate_question',
+      label: 'Investigate my question',
+      seedQuery: `Help me investigate this study question: ${context.openQuestionText}`,
+    });
+  }
+  if (context.takeaway) {
+    guidedActions.push({
+      key: 'refine_takeaway',
+      label: 'Refine takeaway',
+      seedQuery: `Help me refine this takeaway so it stays faithful to the text: ${context.takeaway}`,
+    });
+  }
+  if (guidedActions.length > 0) {
+    return [
+      ...guidedActions,
+      ...(context.chapterRef ? buildChapterStudyActions(context.chapterRef) : []),
+    ];
+  }
+
+  if (context.chapterRef) {
+    return buildChapterStudyActions(context.chapterRef);
+  }
+
+  switch (context.routeContext.kind) {
+    case 'debate_topic':
+      return [
+        {
+          key: 'interpretive_tensions',
+          label: 'Summarize this debate',
+          seedQuery:
+            'Summarize the main positions in this debate and explain where the strongest tensions are.',
+        },
+      ];
+    case 'person':
+      return [
+        {
+          key: 'trace_connections',
+          label: 'Trace this person',
+          seedQuery:
+            'Trace why this person matters in the wider biblical story and point me to the strongest connections.',
+        },
+      ];
+    default:
+      return [];
+  }
+}

--- a/app/src/services/amicus/studyLaunch.ts
+++ b/app/src/services/amicus/studyLaunch.ts
@@ -1,0 +1,201 @@
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import {
+  getAmicusThreadIdForGuidedQuestion,
+  getAmicusThreadIdForGuidedSession,
+  getLatestAmicusThreadIdForChapterContext,
+} from '@/db/userQueries';
+import {
+  appendAmicusMessage,
+  upsertAmicusThreadContext,
+  upsertAmicusThreadSummary,
+} from '@/db/userMutations';
+import type { AmicusDraftMessage } from '@/types';
+import { logger } from '@/utils/logger';
+import type { GuidedStudyStep } from '@/types';
+import { formatChapterRef, type AmicusSeedChapterRef } from './deepLink';
+import type { AmicusGuidedStudyContext } from './context';
+import { deriveThreadIntelligence } from './threadIntelligence';
+
+export interface LaunchAmicusStudyThreadInput {
+  entryPoint: 'guided_study' | 'my_study';
+  chapterId: string;
+  sessionId?: number | null;
+  guidedStudyStep?: GuidedStudyStep | null;
+  openQuestionId?: number | null;
+  openQuestionText?: string | null;
+  takeaway?: string | null;
+  keyConnection?: string | null;
+  seedQuery: string;
+}
+
+export interface PromotePeekToStudyThreadInput {
+  chapterRef?: AmicusSeedChapterRef | null;
+  guidedContext?: AmicusGuidedStudyContext | null;
+  messages: AmicusDraftMessage[];
+}
+
+function createMessageId(prefix: string): string {
+  const rand = Math.random().toString(16).slice(2, 10);
+  const stamp = Date.now().toString(16);
+  return `${prefix}-${stamp}-${rand}`;
+}
+
+function chapterRefFromChapterId(chapterId: string): AmicusSeedChapterRef | null {
+  const match = /^(.*)_(\d+)$/.exec(chapterId.trim());
+  if (!match) return null;
+  const chapterNum = Number(match[2]);
+  if (!Number.isFinite(chapterNum) || chapterNum <= 0) return null;
+  return {
+    book_id: match[1]!,
+    chapter_num: chapterNum,
+  };
+}
+
+function buildGuidedContext(input: LaunchAmicusStudyThreadInput): AmicusGuidedStudyContext {
+  return {
+    entryPoint: input.entryPoint,
+    sessionId: input.sessionId ?? null,
+    guidedStudyStep: input.guidedStudyStep ?? null,
+    openQuestionId: input.openQuestionId ?? null,
+    openQuestionText: input.openQuestionText ?? null,
+    takeaway: input.takeaway ?? null,
+    keyConnection: input.keyConnection ?? null,
+  };
+}
+
+export async function launchAmicusStudyThread(
+  navigation: NavigationProp<ParamListBase>,
+  input: LaunchAmicusStudyThreadInput,
+): Promise<void> {
+  const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+  if (!parent) {
+    logger.warn('AmicusStudyLaunch', 'no parent navigator available');
+    return;
+  }
+
+  const chapterRef = chapterRefFromChapterId(input.chapterId);
+  const seedChapterRef = formatChapterRef(chapterRef);
+  const seedGuidedContext = buildGuidedContext(input);
+
+  let threadId: string | null = null;
+  if (input.openQuestionId != null) {
+    threadId = await getAmicusThreadIdForGuidedQuestion(input.openQuestionId);
+  }
+  if (!threadId && input.sessionId != null) {
+    threadId = await getAmicusThreadIdForGuidedSession(input.sessionId, input.guidedStudyStep);
+  }
+
+  if (threadId) {
+    parent.navigate('AmicusTab', {
+      screen: 'Thread',
+      params: {
+        threadId,
+        seedChapterRef,
+        seedGuidedContext,
+      },
+    });
+    return;
+  }
+
+  parent.navigate('AmicusTab', {
+    screen: 'NewThread',
+    params: {
+      seedQuery: input.seedQuery,
+      seedChapterRef,
+      seedGuidedContext,
+    },
+  });
+}
+
+export async function promotePeekToAmicusThread(
+  navigation: NavigationProp<ParamListBase>,
+  input: PromotePeekToStudyThreadInput,
+): Promise<void> {
+  const parent = navigation.getParent<NavigationProp<ParamListBase>>();
+  if (!parent) {
+    logger.warn('AmicusStudyLaunch', 'no parent navigator available for peek promotion');
+    return;
+  }
+
+  const latestUserMessage = [...input.messages]
+    .reverse()
+    .find((message) => message.role === 'user');
+  const chapterRefString = formatChapterRef(input.chapterRef);
+  let threadId: string | null = null;
+
+  if (input.guidedContext?.openQuestionId != null) {
+    threadId = await getAmicusThreadIdForGuidedQuestion(input.guidedContext.openQuestionId);
+  }
+  if (!threadId && input.guidedContext?.sessionId != null) {
+    threadId = await getAmicusThreadIdForGuidedSession(
+      input.guidedContext.sessionId,
+      input.guidedContext.guidedStudyStep,
+    );
+  }
+  if (!threadId && chapterRefString && input.guidedContext?.entryPoint) {
+    threadId = await getLatestAmicusThreadIdForChapterContext(
+      chapterRefString,
+      input.guidedContext.entryPoint,
+    );
+  }
+
+  if (!threadId) {
+    parent.navigate('AmicusTab', {
+      screen: 'NewThread',
+      params: {
+        seedChapterRef: chapterRefString,
+        promotedMessages: input.messages,
+        seedGuidedContext: input.guidedContext ?? undefined,
+      },
+    });
+    return;
+  }
+
+  for (const message of input.messages) {
+    await appendAmicusMessage({
+      messageId: createMessageId('m'),
+      threadId,
+      role: message.role,
+      content: message.content,
+      citations: message.role === 'assistant' ? message.citations : undefined,
+      followUps: message.role === 'assistant' ? message.follow_ups : undefined,
+    });
+  }
+
+  if (input.guidedContext) {
+    await upsertAmicusThreadContext({
+      threadId,
+      entryPoint: input.guidedContext.entryPoint ?? 'thread',
+      guidedSessionId: input.guidedContext.sessionId,
+      guidedStep: input.guidedContext.guidedStudyStep,
+      openQuestionId: input.guidedContext.openQuestionId,
+      takeaway: input.guidedContext.takeaway,
+      keyConnection: input.guidedContext.keyConnection,
+    });
+  }
+
+  if (latestUserMessage) {
+    const derived = deriveThreadIntelligence({
+      chapterRef: chapterRefString ?? null,
+      currentTitle: null,
+      userQuery: latestUserMessage.content,
+      openQuestionText: input.guidedContext?.openQuestionText,
+      takeaway: input.guidedContext?.takeaway,
+      keyConnection: input.guidedContext?.keyConnection,
+    });
+    await upsertAmicusThreadSummary({
+      threadId,
+      summaryText: derived.summaryText,
+      lastUserIntent: derived.lastUserIntent,
+    });
+  }
+
+  parent.navigate('AmicusTab', {
+    screen: 'Thread',
+    params: {
+      threadId,
+      seedChapterRef: chapterRefString ?? undefined,
+      seedGuidedContext: input.guidedContext ?? undefined,
+    },
+  });
+}

--- a/app/src/services/amicus/threadIntelligence.ts
+++ b/app/src/services/amicus/threadIntelligence.ts
@@ -1,0 +1,133 @@
+import { formatAmicusContextLabel } from './context';
+import type { AmicusStudyActionSeed } from './studyActions';
+
+export interface DeriveThreadIntelligenceOptions {
+  currentTitle?: string | null;
+  chapterRef?: string | null;
+  userQuery: string;
+  action?: AmicusStudyActionSeed | null;
+  openQuestionText?: string | null;
+  takeaway?: string | null;
+  keyConnection?: string | null;
+}
+
+export interface DerivedThreadIntelligence {
+  title: string;
+  summaryText: string;
+  lastUserIntent: string | null;
+}
+
+const DEFAULT_TITLE = 'New conversation';
+
+function compactWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function humanizeActionLabel(action: AmicusStudyActionSeed): string {
+  switch (action.key) {
+    case 'explain_context':
+      return 'chapter overview';
+    case 'investigate_question':
+      return 'open question';
+    case 'interpretive_tensions':
+      return 'interpretive tensions';
+    case 'refine_takeaway':
+      return 'refine takeaway';
+    case 'trace_connections':
+      return 'key connections';
+  }
+}
+
+export function shouldAutoRenameThread(title: string | null | undefined): boolean {
+  if (!title) return true;
+  const normalized = compactWhitespace(title).toLowerCase();
+  return normalized.length === 0 || normalized === DEFAULT_TITLE.toLowerCase();
+}
+
+export function deriveThreadIntelligence(
+  options: DeriveThreadIntelligenceOptions,
+): DerivedThreadIntelligence {
+  const question = compactWhitespace(options.userQuery);
+  const chapterLabel = formatAmicusContextLabel(options.chapterRef);
+  const intent = options.action?.label ?? null;
+  const openQuestion = compactWhitespace(options.openQuestionText ?? '');
+  const takeaway = compactWhitespace(options.takeaway ?? '');
+  const keyConnection = compactWhitespace(options.keyConnection ?? '');
+
+  if (openQuestion && chapterLabel) {
+    return {
+      title: `${chapterLabel} — ${truncate(openQuestion, 34)}`,
+      summaryText: `Investigating: ${truncate(openQuestion, 90)}`,
+      lastUserIntent: 'Investigate question',
+    };
+  }
+
+  if (takeaway && chapterLabel) {
+    return {
+      title: `${chapterLabel} — refine takeaway`,
+      summaryText: `Refining takeaway: ${truncate(takeaway, 90)}`,
+      lastUserIntent: 'Refine takeaway',
+    };
+  }
+
+  if (keyConnection && chapterLabel) {
+    return {
+      title: `${chapterLabel} — trace connection`,
+      summaryText: `Tracing connection: ${truncate(keyConnection, 90)}`,
+      lastUserIntent: 'Trace key connections',
+    };
+  }
+
+  if (options.action && chapterLabel) {
+    const label = humanizeActionLabel(options.action);
+    return {
+      title: `${chapterLabel} — ${label}`,
+      summaryText: `${options.action.label} in ${chapterLabel}.`,
+      lastUserIntent: options.action.label,
+    };
+  }
+
+  if (options.action) {
+    return {
+      title: options.action.label,
+      summaryText: `${options.action.label}.`,
+      lastUserIntent: options.action.label,
+    };
+  }
+
+  if (chapterLabel) {
+    return {
+      title: shouldAutoRenameThread(options.currentTitle)
+        ? `${chapterLabel} — ${truncate(question, 36)}`
+        : (options.currentTitle ?? DEFAULT_TITLE),
+      summaryText: truncate(question, 96),
+      lastUserIntent: intent,
+    };
+  }
+
+  return {
+    title: shouldAutoRenameThread(options.currentTitle)
+      ? truncate(question, 60)
+      : (options.currentTitle ?? DEFAULT_TITLE),
+    summaryText: truncate(question, 96),
+    lastUserIntent: intent,
+  };
+}
+
+export function summarizeLinkedQuestionState(input: {
+  chapterRef?: string | null;
+  questionText: string;
+  status: 'open' | 'resolved';
+}): string {
+  const chapterLabel = formatAmicusContextLabel(input.chapterRef);
+  const question = compactWhitespace(input.questionText);
+  if (input.status === 'resolved') {
+    return chapterLabel ? `Resolved question in ${chapterLabel}.` : 'Resolved question.';
+  }
+  return `Investigating: ${truncate(question, 90)}`;
+}

--- a/app/src/services/amicus/trust.ts
+++ b/app/src/services/amicus/trust.ts
@@ -1,0 +1,49 @@
+import type { AmicusCitation } from '@/types';
+
+export type AmicusTrustStance = 'debated';
+
+export interface AmicusTrustSummary {
+  sourceCount: number;
+  labels: string[];
+  stance: AmicusTrustStance | null;
+  hasTrustSignals: boolean;
+}
+
+function uniqueLabels(citations: AmicusCitation[]): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const citation of citations) {
+    const label = citation.display_label.trim();
+    if (!label || seen.has(label)) continue;
+    seen.add(label);
+    labels.push(label);
+  }
+  return labels;
+}
+
+export function summarizeAmicusTrust(
+  citations: AmicusCitation[],
+): AmicusTrustSummary {
+  const labels = uniqueLabels(citations);
+  const stance: AmicusTrustStance | null = citations.some(
+    (citation) => citation.source_type === 'debate_topic',
+  )
+    ? 'debated'
+    : null;
+
+  return {
+    sourceCount: labels.length,
+    labels,
+    stance,
+    hasTrustSignals: labels.length > 0 || stance !== null,
+  };
+}
+
+export function formatTrustStanceLabel(
+  stance: AmicusTrustStance,
+): string {
+  switch (stance) {
+    case 'debated':
+      return 'Debated';
+  }
+}

--- a/app/src/services/guidedStudy/personal.ts
+++ b/app/src/services/guidedStudy/personal.ts
@@ -82,7 +82,7 @@ export function buildGuidedStudyNextAction(input: {
       kind: 'question',
       title: 'Return to an open question',
       subtitle: question.question_text,
-      ctaLabel: 'Revisit question',
+      ctaLabel: 'Discuss with Amicus',
       chapterId: question.chapter_id,
       initialStep: 'synthesize',
     };
@@ -94,7 +94,7 @@ export function buildGuidedStudyNextAction(input: {
       kind: 'takeaway',
       title: 'Strengthen your last takeaway',
       subtitle: takeaway.takeaway,
-      ctaLabel: 'Open My Study',
+      ctaLabel: 'Refine with Amicus',
       chapterId: takeaway.chapter_id,
       initialStep: 'review',
     };

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -142,10 +142,29 @@ export interface Bookmark {
 export interface AmicusThread {
   thread_id: string;
   title: string;
-  chapter_ref: string | null; // e.g. "romans:9"
+  chapter_ref: string | null; // e.g. "romans/9"
   pinned: boolean;
+  summary_text?: string | null;
+  last_user_intent?: string | null;
+  guided_step?: GuidedStudyStep | null;
+  open_question_id?: number | null;
+  guided_question_status?: 'open' | 'resolved' | null;
+  takeaway?: string | null;
+  key_connection?: string | null;
   created_at: string;
   last_message_at: string;
+}
+
+export interface AmicusThreadContextRecord {
+  thread_id: string;
+  entry_point: 'fab' | 'peek' | 'thread' | 'home_card' | 'guided_study' | 'my_study';
+  guided_session_id: number | null;
+  guided_step: GuidedStudyStep | null;
+  open_question_id: number | null;
+  takeaway: string | null;
+  key_connection: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface AmicusCitation {
@@ -153,6 +172,13 @@ export interface AmicusCitation {
   source_type: string;
   display_label: string;
   scholar_id?: string;
+}
+
+export interface AmicusDraftMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: AmicusCitation[];
+  follow_ups?: string[];
 }
 
 export interface AmicusMessage {

--- a/app/src/utils/routeContext.ts
+++ b/app/src/utils/routeContext.ts
@@ -14,6 +14,8 @@
  */
 
 import type { ChipContext } from '../hooks/useAmicusChips';
+import type { AmicusGuidedStudyContext } from '../services/amicus/context';
+import type { GuidedStudyStep } from '../types';
 
 /**
  * Minimal shape of a React Navigation route sufficient for our traversal.
@@ -64,8 +66,15 @@ export function routeToChipContext(route: MinimalRoute | null): ChipContext {
   switch (route.name) {
     case 'Chapter': {
       const bookId = typeof params.bookId === 'string' ? params.bookId : undefined;
-      const chapterNum =
-        typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
+      const chapterNum = typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
+      if (bookId && chapterNum) {
+        return { kind: 'chapter', bookId, chapterNum };
+      }
+      return { kind: 'none' };
+    }
+    case 'StudySession': {
+      const bookId = typeof params.bookId === 'string' ? params.bookId : undefined;
+      const chapterNum = typeof params.chapterNum === 'number' ? params.chapterNum : undefined;
       if (bookId && chapterNum) {
         return { kind: 'chapter', bookId, chapterNum };
       }
@@ -83,5 +92,26 @@ export function routeToChipContext(route: MinimalRoute | null): ChipContext {
       return { kind: 'none' };
     default:
       return { kind: 'none' };
+  }
+}
+
+export function routeToAmicusGuidedStudyContext(
+  route: MinimalRoute | null,
+): AmicusGuidedStudyContext | null {
+  if (!route) return null;
+  const params = (route.params ?? {}) as Record<string, unknown>;
+  switch (route.name) {
+    case 'StudySession':
+      return {
+        entryPoint: 'guided_study',
+        guidedStudyStep:
+          typeof params.initialStep === 'string' ? (params.initialStep as GuidedStudyStep) : null,
+      };
+    case 'MyStudy':
+      return {
+        entryPoint: 'my_study',
+      };
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
## Part 2 of 3 — salvaging codex/amicus-auth-access-hardening

Foundation layer for the Amicus v2 work split out of `codex/amicus-auth-access-hardening`. **No UI changes** — every touched component is either a DB schema migration, a pure-function service, a type definition, or a test.

Stacks with:
- **PR #1658** (auth/access hardening) — independent, can merge in either order
- **PR #1659** (UI wiring, to follow) — depends on this PR

## Why this is its own PR

The codex branch shipped these foundation pieces intermingled with 10 UI surfaces in one 58-file blob. Splitting them out gives us:
- A reviewable DB change surface (2 migrations + a PRAGMA change) evaluated on its own merits
- The ability to roll back UI wiring without losing the data model
- Clean test signal: foundation-layer tests aren't entangled with screen render tests

## What's in

### DB

- **Migration 22 — `amicus_thread_summaries`** — one row per thread, stores `summary_text`, `last_user_intent`, `updated_at`. Feeds the thread list so rows show meaningful labels without re-parsing every message.
- **Migration 23 — `amicus_thread_context`** — ties threads to guided-study sessions, specific steps, open questions, takeaways, key connections, and entry points. `CHECK` constraints on `entry_point` (`fab|peek|thread|home_card|guided_study|my_study`) and `guided_step` (`scene|observe|explore|synthesize|review`). FK references to `amicus_threads` (`ON DELETE CASCADE`) and `guided_study_sessions` / `guided_study_questions` (`ON DELETE SET NULL`). Two indexes tuned for recent-first lookups by (session, step) and by updated timestamp.
- **`PRAGMA foreign_keys = ON`** on every user-db connection open. **Tier 2 fix from the senior review.** SQLite leaves FK checks off by default and the setting is per-connection. Without it, every `REFERENCES ... ON DELETE ...` in our schema is cosmetic. This makes them real runtime constraints. Runs outside any transaction, before migrations, so migration DDL is unaffected — only DML that violates a declared FK gets rejected, which is what we want.

### Services (all new, all pure functions)

| File | What it does |
|---|---|
| `services/amicus/context.ts` | `buildAmicusContextEnvelope`, `chapterRefFromChipContext`, `normalizeChapterRef`, `serializeAmicusChapterRef`, `formatAmicusContextLabel`, `prettyBookId`. Shared envelope the Worker proxy receives + client-side formatting. |
| `services/amicus/trust.ts` | `summarizeAmicusTrust` reduces citations into source labels and stance; `formatTrustStanceLabel`. |
| `services/amicus/threadIntelligence.ts` | `deriveThreadIntelligence` derives title/summary/intent from first user query + guided-study context. `shouldAutoRenameThread`, `summarizeLinkedQuestionState`. |
| `services/amicus/studyActions.ts` | `buildStudyActionSeeds` enumerates one-tap actions for chapter-aware Amicus surfaces (`explain_context`, `investigate_question`, `interpretive_tensions`, `refine_takeaway`, `trace_connections`). |
| `services/amicus/studyLaunch.ts` | `launchAmicusStudyThread` resolves the right thread to open (dedup by question > session/step > chapter+entrypoint) and navigates. `promotePeekToAmicusThread` hydrates a peek session into a full thread. |
| `services/amicus/deepLink.ts` | `formatChapterRef` helper extended for the new envelope shape. |
| `services/amicus/dailyPrompt.ts` | Minor signature update to accept the enriched context. |
| `services/amicus/index.ts` | Barrel exports all of the above. |

### Types

- `types/user.ts` — `AmicusThread` extended with `summary_text`, `last_user_intent`, `guided_step`, `open_question_id`, `guided_question_status`, `takeaway`, `key_connection` (all hydrated by a single LEFT JOIN'd query). New `AmicusThreadContextRecord` and `AmicusDraftMessage` types.

### Queries + mutations

- `db/userQueries.ts` — `listAmicusThreads` / `getAmicusThread` now `LEFT JOIN amicus_thread_summaries`, `amicus_thread_context`, and `guided_study_questions` so the UI can render enriched rows without N+1. New getters: `getAmicusThreadContext`, `getLinkedGuidedStudyQuestionForThread`, `getAmicusThreadIdForGuided{Question,Session}`, `getLatestAmicusThreadIdForChapterContext`, `getLatestStudyAmicusThreadIdForChapter`, `getGuidedStudyQuestionForSession`.
- `db/userMutations.ts` — `upsertAmicusThreadContext` and `upsertAmicusThreadSummary` (proper `ON CONFLICT DO UPDATE SET … = excluded.*`). `reopenGuidedStudyQuestion`. `deleteAmicusThread` wrapped in a transaction with explicit `amicus_thread_context` delete (redundant with FK cascade now ON, but defensive against DBs that predated this PR's pragma). `resetToNewUser` extended. `createAmicusThread` uses `serializeAmicusChapterRef`.
- **Not in this PR:** the `emitAmicusUsageChanged` calls in `incrementAmicusUsage` / `clearAllAmicusData` — those belong with the subscription in PR #1658 and are stripped here to keep the PRs independent.

### Tests

- New: `services/amicus/__tests__/` for context, trust, threadIntelligence, studyActions, studyLaunch
- Extended: deepLink, db/amicus/mutations + queries, utils/routeContext, db/userDatabaseV3 (migrations 22/23)

## Tier 2 fix included

**`PRAGMA foreign_keys = ON`** — turns the FK references in migrations 22/23 (and all prior migrations that have declared FKs) into actual runtime constraints. Flagged during the senior review as a pre-existing latent issue this branch was amplifying; fixing it here makes the new schema honest.

## Risks

**FK enforcement on existing DBs.** If earlier bugs wrote orphan rows that violate a declared FK, those rows stay (SQLite doesn't retroactively scan) — but any *new* operation that tries to reference a missing parent will start failing. Low risk in practice: existing migrations declare few FKs and those reference well-populated tables. Worth a simulator smoke pass on a user.db that has real-world usage before cutting a release.

## Out of scope (moves to PR 3)

- All UI components, hooks, screens, and navigation types
- `StudySessionScreen.tsx` changes (which must preserve #1654's `useRef` bounce-back guard)
- `MyStudyScreen.tsx` changes (deferred per #1652's re-plan)

## Test plan

- `tsc --noEmit` + `jest` via CI
- Manual smoke (rentamac iOS simulator):
  1. First launch — new user-db gets migrations 22/23 applied; `sqlite_master` shows both tables + both indexes
  2. `PRAGMA foreign_keys` returns 1 on a fresh connection
  3. Manually insert a bad FK (e.g. `INSERT INTO amicus_thread_context(thread_id, entry_point) VALUES ('nope', 'fab')`) — expect SQLITE_CONSTRAINT
  4. Delete an `amicus_threads` row that has a matching `amicus_thread_context` — verify CASCADE fires (context row gone)
  5. Existing app surfaces (notes, bookmarks, reading progress) continue to work — smoke each of the main screens

## Rollback

Single-commit revert. Migrations 22 and 23 stay in `sqlite_master` (SQLite doesn't run migrations in reverse), but the code that reads/writes them is gone so the tables become inert. New thread-context/summary rows stop being written; existing ones orphan harmlessly. FK pragma goes back to off on the next release. No user data loss.