### PR TITLE
fix(lint): resolve 15 eslint warnings from amicus v2 merge

### DIFF
--- a/app/src/components/guidedStudy/EvidenceTrailRow.tsx
+++ b/app/src/components/guidedStudy/EvidenceTrailRow.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ChevronRight } from 'lucide-react-native';
-import { ConfidenceBadge } from './ConfidenceBadge';
 import { fontFamily, MIN_TOUCH_TARGET, radii, spacing, useTheme } from '../../theme';
 import type { GuidedEvidenceTrailItem } from '../../services/guidedStudy';
+import { ConfidenceBadge } from './ConfidenceBadge';
 
 interface Props {
   item: GuidedEvidenceTrailItem;

--- a/app/src/hooks/useAmicusChapterStudyThread.ts
+++ b/app/src/hooks/useAmicusChapterStudyThread.ts
@@ -7,12 +7,11 @@ export function useAmicusChapterStudyThread(chapterRef: string | null) {
 
   useEffect(() => {
     let cancelled = false;
-    if (!chapterRef) {
-      setThreadId(null);
-      return;
-    }
-
     void (async () => {
+      if (!chapterRef) {
+        if (!cancelled) setThreadId(null);
+        return;
+      }
       try {
         const next = await getLatestStudyAmicusThreadIdForChapter(chapterRef);
         if (!cancelled) setThreadId(next);

--- a/app/src/hooks/useAmicusContext.ts
+++ b/app/src/hooks/useAmicusContext.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useAmicusChipContext } from './useAmicusChipContext';
 import type { ChipContext } from '@/hooks/useAmicusChips';
 import {
   buildAmicusContextEnvelope,
@@ -7,7 +8,6 @@ import {
   type AmicusGuidedStudyContext,
 } from '@/services/amicus/context';
 import type { AmicusSeedChapterRef } from '@/services/amicus/deepLink';
-import { useAmicusChipContext } from './useAmicusChipContext';
 
 export interface UseAmicusContextOptions {
   entryPoint: AmicusEntryPoint;

--- a/app/src/screens/AmicusThreadScreen.tsx
+++ b/app/src/screens/AmicusThreadScreen.tsx
@@ -117,34 +117,6 @@ export default function AmicusThreadScreen(): React.ReactElement {
     };
   }, [threadId]);
 
-  const handleSend = useCallback(
-    async (text: string) => {
-      // Pre-flight access check (#1460).
-      if (access.reason === 'not_premium') {
-        navigation.navigate('Paywall');
-        return;
-      }
-      if (access.reason === 'monthly_cap_reached' || access.reason === 'offline') {
-        logger.info('Amicus', `send blocked: ${access.reason}`);
-        return;
-      }
-
-      const authToken = await getAmicusAuthToken();
-      if (!authToken) {
-        logger.warn('Amicus', 'no auth token — aborting send');
-        return;
-      }
-      // Gate on one-time privacy acknowledgement (#1458).
-      const accepted = await requestAmicusConsent();
-      if (!accepted) {
-        logger.info('Amicus', 'opt-in declined — not sending');
-        return;
-      }
-      await sendMessage(text, authToken);
-    },
-    [sendMessage, requestAmicusConsent, access.reason, navigation],
-  );
-
   const persistThreadIntelligence = useCallback(
     async (text: string, action?: AmicusStudyActionSeed) => {
       const derived = deriveThreadIntelligence({
@@ -184,7 +156,6 @@ export default function AmicusThreadScreen(): React.ReactElement {
       }
     },
     [
-      linkedQuestion?.question_text,
       questionText,
       seedChapterRef,
       seedGuidedContext?.keyConnection,
@@ -192,7 +163,6 @@ export default function AmicusThreadScreen(): React.ReactElement {
       seedGuidedContext?.takeaway,
       thread,
       threadContext?.key_connection,
-      threadContext?.open_question_id,
       threadContext?.takeaway,
       threadId,
     ],
@@ -227,7 +197,9 @@ export default function AmicusThreadScreen(): React.ReactElement {
 
   // Auto-send the seed query once per mount when navigated in from the
   // home card / deep-link handoff (#1467). Guarded by a ref so rapid
-  // re-renders don't re-dispatch.
+  // re-renders don't re-dispatch. Deferred with queueMicrotask so the
+  // setState calls sendWithContext performs don't run synchronously
+  // within the effect body (react-hooks/set-state-in-effect).
   const autoSentRef = useRef(false);
   useEffect(() => {
     if (autoSentRef.current) return;
@@ -235,7 +207,9 @@ export default function AmicusThreadScreen(): React.ReactElement {
     if (messages.length > 0) return;
     if (isStreaming) return;
     autoSentRef.current = true;
-    void sendWithContext(initialQuery);
+    queueMicrotask(() => {
+      void sendWithContext(initialQuery);
+    });
   }, [initialQuery, messages.length, isStreaming, sendWithContext]);
 
   const handleExport = useCallback(async () => {
@@ -316,7 +290,7 @@ export default function AmicusThreadScreen(): React.ReactElement {
     } catch (err) {
       logger.warn('Amicus', 'failed to update linked question status', err);
     }
-  }, [linkedQuestion, seedChapterRef, thread?.chapter_ref, threadId]);
+  }, [linkedQuestion, seedChapterRef, thread, threadId]);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>

--- a/app/src/services/amicus/__tests__/studyLaunch.test.ts
+++ b/app/src/services/amicus/__tests__/studyLaunch.test.ts
@@ -1,3 +1,4 @@
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { launchAmicusStudyThread, promotePeekToAmicusThread } from '@/services/amicus/studyLaunch';
 import {
   getAmicusThreadIdForGuidedQuestion,
@@ -56,7 +57,7 @@ describe('launchAmicusStudyThread', () => {
 
   it('reuses an existing linked question thread when available', async () => {
     const parent = { navigate: jest.fn() };
-    const navigation = { getParent: () => parent } as any;
+    const navigation = { getParent: () => parent } as unknown as NavigationProp<ParamListBase>;
     mockGetThreadIdForQuestion.mockResolvedValueOnce('t-linked');
 
     await launchAmicusStudyThread(navigation, {
@@ -80,7 +81,7 @@ describe('launchAmicusStudyThread', () => {
 
   it('creates a new seeded thread when no existing study thread is found', async () => {
     const parent = { navigate: jest.fn() };
-    const navigation = { getParent: () => parent } as any;
+    const navigation = { getParent: () => parent } as unknown as NavigationProp<ParamListBase>;
 
     await launchAmicusStudyThread(navigation, {
       entryPoint: 'guided_study',
@@ -107,7 +108,7 @@ describe('launchAmicusStudyThread', () => {
 
   it('promotes peek messages into an existing study-linked thread when one exists', async () => {
     const parent = { navigate: jest.fn() };
-    const navigation = { getParent: () => parent } as any;
+    const navigation = { getParent: () => parent } as unknown as NavigationProp<ParamListBase>;
     mockGetLatestThreadIdForChapter.mockResolvedValueOnce('t-existing');
 
     await promotePeekToAmicusThread(navigation, {
@@ -141,7 +142,7 @@ describe('launchAmicusStudyThread', () => {
 
   it('falls back to a new thread when no existing study-linked thread is found for peek promotion', async () => {
     const parent = { navigate: jest.fn() };
-    const navigation = { getParent: () => parent } as any;
+    const navigation = { getParent: () => parent } as unknown as NavigationProp<ParamListBase>;
 
     await promotePeekToAmicusThread(navigation, {
       chapterRef: { book_id: 'genesis', chapter_num: 1 },

--- a/app/src/services/amicus/context.ts
+++ b/app/src/services/amicus/context.ts
@@ -1,6 +1,6 @@
+import { formatChapterRef, parseChapterRef, type AmicusSeedChapterRef } from './deepLink';
 import type { ChipContext } from '@/hooks/useAmicusChips';
 import type { GuidedStudyStep } from '@/types';
-import { formatChapterRef, parseChapterRef, type AmicusSeedChapterRef } from './deepLink';
 
 export type AmicusEntryPoint =
   | 'fab'

--- a/app/src/services/amicus/studyLaunch.ts
+++ b/app/src/services/amicus/studyLaunch.ts
@@ -1,4 +1,7 @@
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { formatChapterRef, type AmicusSeedChapterRef } from './deepLink';
+import type { AmicusGuidedStudyContext } from './context';
+import { deriveThreadIntelligence } from './threadIntelligence';
 import {
   getAmicusThreadIdForGuidedQuestion,
   getAmicusThreadIdForGuidedSession,
@@ -12,9 +15,6 @@ import {
 import type { AmicusDraftMessage } from '@/types';
 import { logger } from '@/utils/logger';
 import type { GuidedStudyStep } from '@/types';
-import { formatChapterRef, type AmicusSeedChapterRef } from './deepLink';
-import type { AmicusGuidedStudyContext } from './context';
-import { deriveThreadIntelligence } from './threadIntelligence';
 
 export interface LaunchAmicusStudyThreadInput {
   entryPoint: 'guided_study' | 'my_study';


### PR DESCRIPTION
Master lint CI (`eslint src/ --max-warnings 0`) went red after the amicus v2 foundation (#1660) and UI (#1661) merges. This PR takes it back to zero warnings.

## Auto-fixable (6)

Ran `eslint --fix` on the files with `import/order` warnings:
- `components/guidedStudy/EvidenceTrailRow.tsx`
- `hooks/useAmicusContext.ts`
- `services/amicus/context.ts`
- `services/amicus/studyLaunch.ts` (3 issues)

## Manual fixes (9)

### `screens/AmicusThreadScreen.tsx`

| Warning | Fix |
|---|---|
| `handleSend is assigned a value but never used` | Removed — dead code superseded by `sendWithContext`, which adds thread-intelligence persistence |
| `useCallback has unnecessary dependencies: linkedQuestion.question_text and threadContext.open_question_id` (on `persistThreadIntelligence`) | Dropped both — `linkedQuestion?.question_text` is already captured via the derived `questionText` value on line 91; `threadContext?.open_question_id` is never referenced in the body |
| `preserve-manual-memoization` on `toggleQuestionStatus` (inferred `thread`, source `thread?.chapter_ref`) | Changed dep from `thread?.chapter_ref` to `thread` to match React Compiler’s inferred dep |
| `set-state-in-effect` on `void sendWithContext(initialQuery)` in the auto-send effect | Wrapped call in `queueMicrotask(...)` so the cascading setState in `sendWithContext` doesn’t run synchronously inside the effect body |

### `hooks/useAmicusChapterStudyThread.ts`

| Warning | Fix |
|---|---|
| `set-state-in-effect` on `setThreadId(null)` | Moved the null-reset into the async IIFE branch so setState isn’t called synchronously in the effect body |

### `services/amicus/__tests__/studyLaunch.test.ts`

| Warning | Fix |
|---|---|
| 4x `no-explicit-any` on `{ getParent: () => parent } as any` navigation stubs | Replaced with `as unknown as NavigationProp<ParamListBase>` and added the type import from `@react-navigation/native` |

## Verification

```bash
npx eslint <7 touched files> --max-warnings 0
# Exit: 0
```

Full-repo `eslint src/` timed out locally at 240s without finishing, so relying on CI for end-to-end lint verification.