### PR TITLE
content(micah): coverage enrichment — 1 finding to zero

### DIFF
--- a/content/micah/6.json
+++ b/content/micah/6.json
@@ -484,22 +484,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 6:3",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The verb hel'etikha ('I have burdened/wearied you') uses the Hiphil of la'ah ('to be weary'). The question implies that Israel has grown tired of God'…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads What Does the LORD Require? Act Justly, Love Mercy within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "Micah 6:8 ('do justice, love mercy, walk humbly'): summary of true religion, critique of sacrifice, or covenant formula?",
+        "positions": [
+          {
+            "name": "Programmatic summary of Torah ethics",
+            "proponents": "Waltke (NICOT), Allen, Stuart",
+            "argument": "Micah 6:8 compresses the covenant's ethical core into three verbal commitments — doing mishpat (just legal-social action), loving hesed (covenant-loyal kindness), and walking humbly with God. This is not a replacement for Torah but its essence. Jesus's summary of the law (Matt 22:37-40 — love God and neighbor) stands in the same tradition; Paul's 'faith working through love' (Gal 5:6) is the NT echo. The verse is the OT's cleanest statement of covenantal ethics."
+          },
+          {
+            "name": "Anti-sacrificial polemic continuous with Amos-Hosea",
+            "proponents": "Mays (OTL), Andersen-Freedman (AB)",
+            "argument": "The verse's rhetorical setting (vv.6-7 — rhetorical questions about extravagant sacrifices and firstborn offerings, rejected in favor of v.8's ethics) places it in the 8th-century prophetic critique tradition (Amos 5:21-24; Hos 6:6; Isa 1:11-17). The prophets collectively target hollow cultic performance disconnected from covenantal ethics. Micah 6:8 is the most concentrated expression of this anti-formalism."
+          },
+          {
+            "name": "Covenant lawsuit verdict-summary",
+            "proponents": "Waltke, Allen",
+            "argument": "Micah 6 opens with a covenant-lawsuit form (vv.1-2 — 'hear what the LORD is saying: Stand up, plead your case before the mountains'). Verse 8 is the verdict: this is what the LORD requires. Reading the verse within this legal-covenantal frame grounds it in covenant history rather than general ethics. The 'He has shown you, O mortal, what is good' (v.8a) refers back to the Mosaic revelation — the requirement was never obscure."
+          }
+        ]
+      }
     ],
     "thread": [
       {


### PR DESCRIPTION
Refs #1626. Audit source #1635.

## Audit delta — Micah: 1 finding → 0

Ch 6's templated debate replaced with substantive positions on Micah 6:8 — programmatic Torah summary (Waltke, Allen, Stuart) / anti-sacrificial polemic (Mays, Andersen-Freedman) / covenant lawsuit verdict (Waltke, Allen).

No new scholars, no NIV / section-header / app-layer changes. 1 file; +21 / -17.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_