### PR TITLE
content(mark): coverage enrichment — 1 finding to zero

### DIFF
--- a/content/mark/9.json
+++ b/content/mark/9.json
@@ -395,6 +395,23 @@
         },
         "hist": {
           "context": "The failed exorcism at the foot of the mountain contrasts with the Transfiguration glory above. The disciples’ failure provokes Jesus’s rebuke of an unbelieving generation. The second passion prediction follows (9:31), and the disciples’ immediate argument about greatness reveals complete misunderstanding. Jesus’s response — a child in the arms — redefines greatness as servitude."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "9:38-41",
+              "note": "The disciple John's concern about the outside exorcist — 'he was not one of us' — displays the same sectarian spirit Jesus will rebuke throughout the passage. Jesus's answer ('whoever is not against us is for us') is balanced by its Matt 12:30 counterpart ('whoever is not with me is against me'); the two sayings are not contradictory but cover different scenarios — one about actions, one about ultimate allegiance. A cup of water 'because you bear the name of Christ' (v.41) dignifies small acts of kindness toward believers as eternally weighted service."
+            },
+            {
+              "ref": "9:42-48",
+              "note": "The most severe warning in Jesus's teaching against leading 'little ones' (new or weak believers) astray. The millstone imagery — a large donkey-driven grindstone weighted around the neck — is not hyperbole but graphic judgment language. Verses 43-48 use progressively severe self-denial imagery (hand, foot, eye) as the answer: whatever part of life causes sin must be decisively severed. 'Gehenna' (the Valley of Hinnom, Jerusalem's burning refuse site) is the consistent NT word for final judgment, not metaphor. The threefold repetition of 'where their worm does not die and the fire is not quenched' (v.48, echoing Isa 66:24) emphasises the permanence of the alternative to radical discipleship."
+            },
+            {
+              "ref": "9:49-50",
+              "note": "'Everyone will be salted with fire.' The difficult saying connects the Gehenna-fire imagery (vv.43-48) with the purifying-fire imagery of covenantal testing (cf. Mal 3:2-3; 1 Pet 1:7). Salt in Lev 2:13 was required on every grain offering — the 'salt of the covenant.' Disciples must retain their saltiness (covenantal distinctiveness) and 'be at peace with one another' (v.50) — a direct rebuke of the sectarian spirit John displayed in v.38. The chapter's final command ties back to its opening concern."
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Refs #1626. Audit source #1635.

## Audit delta — Mark: 1 finding → 0

Mark 9 §4 (vv.38-50) was L1 🔴 Deficient (commentators=1, only calvin). MacArthur already appears on §1-3 of the same chapter; adding his voice to §4 brings commentator_count to 2, clearing the floor.

Post-state: 0 🔴 / 0 🟡 / 3 🟢 / 47 ✨.

No new scholars in `SCHOLAR_REGISTRY`; `mac` was already scoped to Mark. No NIV / section-header / app-layer changes. 1 file; +18 / -1.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_