### PR TITLE
content(ecclesiastes): coverage enrichment — 1 finding to zero

### DIFF
--- a/content/ecclesiastes/12.json
+++ b/content/ecclesiastes/12.json
@@ -408,7 +408,8 @@
         }
       ],
       "note": "Worship peaks at 9: \"fear God\" is the wisdom tradition’s shared climax (Prov 1:7, Job 28:28, Eccl 12:13). Judgment at 8: every deed brought before God. Faith at 8: remember your Creator. Prophecy at 8: universal judgment anticipates Revelation 20:12. The theological capstone."
-    }
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Remember your Creator in the days of your youth, before the days of trouble come and the years approach when you will say, “I find no pleasure in them”—</td></tr><tr><td class=\"t-label\">ESV</td><td>Remember also your Creator in the days of your youth, before the evil days come and the years draw near of which you will say, “I have no pleasure in them”;</td></tr><tr><td class=\"t-label\">NIV</td><td>and the dust returns to the ground it came from, and the spirit returns to God who gave it.</td></tr><tr><td class=\"t-label\">ESV</td><td>and the dust returns to the earth as it was, and the spirit returns to God who gave it.</td></tr><tr><td class=\"t-label\">NIV</td><td>Now all has been heard; here is the conclusion of the matter: Fear God and keep his commandments, for this is the duty of all mankind.</td></tr><tr><td class=\"t-label\">ESV</td><td>The end of the matter; all has been heard. Fear God and keep his commandments, for this is the whole duty of man.</td></tr><tr><td class=\"t-label\">NIV</td><td>For God will bring every deed into judgment, including every hidden thing, whether it is good or evil.</td></tr><tr><td class=\"t-label\">ESV</td><td>For God will bring every deed into judgment, with every secret thing, whether good or evil.</td></tr>"
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Refs #1626. Ecclesiastes ch 12 `trans` panel added with NIV+ESV comparison of vv.1, 7, 13, 14 (the chapter's key "remember your Creator" + dust-returns + fear-God conclusion verses). 1 finding → 0. No NIV text modified — pulled verbatim from `content/verses/`. 1 file; +3 / -2.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_