### PR TITLE
content(zephaniah): coverage enrichment — 2 findings to zero

### DIFF
--- a/content/zephaniah/1.json
+++ b/content/zephaniah/1.json
@@ -492,38 +492,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 1:5",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The identity of Molek (Hebrew malkam) is debated: it could refer to the Ammonite deity Molek or to 'their king' (malkam) as a title for Baal. Either r…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Day of the LORD Against Judah within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 1:9",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'those who avoid stepping on the threshold' is debated. It may refer to the Philistine custom described in 1 Samuel 5:5 or to a superstitio…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Day of the LORD Against Judah within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "The 'day of the LORD' in Zephaniah 1:14-18: near-term or eschatological?",
+        "positions": [
+          {
+            "name": "Near-historical: 586 BCE Jerusalem fall",
+            "proponents": "Baker (TOTC), Stuart (WBC)",
+            "argument": "Zephaniah ministers during Josiah's reign (1:1 — c. 640-609 BCE). The 'day of the LORD' (yom YHWH) imagery targets the imminent Babylonian destruction of Jerusalem in 586 BCE. The specific targets — Judah's leaders, syncretistic worshipers, complacent merchants — fit the pre-exilic historical moment rather than eschatological projection."
+          },
+          {
+            "name": "Eschatological day-of-judgment",
+            "proponents": "Robertson (NICOT), MacArthur",
+            "argument": "The cosmic-scale language ('I will sweep everything from the face of the earth,' 1:2; 'in the fire of his jealousy the whole earth will be consumed,' 1:18) reaches beyond any single historical event. Zephaniah's day-of-the-LORD telescopes from 586 BCE through the eschatological final-day (echoing Joel 2; 2 Pet 3:10)."
+          },
+          {
+            "name": "Telescoped — both at once",
+            "proponents": "Bruckner (NIVAC), Barker-Bailey (NAC)",
+            "argument": "OT prophetic 'day of the LORD' language regularly operates on multiple horizons simultaneously. Zephaniah's near-historical targets (Judah's 586 fall, Assyria's 612 fall) are genuine; so is the cosmic-eschatological horizon into which they merge. Reading either horizon without the other impoverishes the text."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/zephaniah/3.json
+++ b/content/zephaniah/3.json
@@ -486,38 +486,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 3:3",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The image of officials as 'evening wolves' (zeʼevei ʼerev) who 'leave nothing for the morning' describes complete consumption: the predatory elite dev…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Woe, Purification, and Restoration within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 3:17",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The Hebrew yacharish beʼahavato is debated: 'he will quiet you with his love' (reading charash, 'to be silent') or 'he will renew you in his love' (re…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Woe, Purification, and Restoration within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "Zephaniah 3:9-20: full-eschatological fulfilment, or first-exilic-return fulfilment?",
+        "positions": [
+          {
+            "name": "Fulfilled in the post-exilic return",
+            "proponents": "Baker, Stuart",
+            "argument": "Verses 14-20's joyful restoration ('Sing, Daughter Zion; shout aloud, Israel! Be glad and rejoice with all your heart') were substantially fulfilled in the Ezra-Nehemiah return and community re-establishment. The 'shame' removed and the 'remnant restored' have clear post-exilic historical referents."
+          },
+          {
+            "name": "Messianic / eschatological",
+            "proponents": "Robertson, MacArthur",
+            "argument": "The universal-language ('on that day... I will gather you,' 3:20) and the inner-transformation promise ('I will purify the lips of the peoples, that all of them may call on the name of the LORD,' 3:9) exceed the post-exilic return. These promises await Christ's work and final consummation. Particular emphasis: 3:17's 'the LORD your God is with you... he will take great delight in you; he will rejoice over you with singing' is quoted in patristic and contemporary devotional theology as Christ's posture toward the church."
+          },
+          {
+            "name": "Inaugurated-awaiting-consummation",
+            "proponents": "Bruckner, Wright",
+            "argument": "The promises begin in the post-exile, climax in Christ's first coming (universal gospel-language of 3:9-10 fulfilled in Pentecost/mission), and await full consummation in the New Jerusalem (3:11-20's complete shame-removal and joyful presence). The arc is real, not either-or."
+          }
+        ]
+      }
     ],
     "thread": [
       {


### PR DESCRIPTION
Refs #1626. Zephaniah ch 1 + ch 3 templated debates rewritten with substantive positions on day-of-the-LORD near/eschatological/telescoped and on post-exilic vs messianic fulfilment of 3:9-20. 2 findings → 0. 2 files; +42 / -66.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_