### PR TITLE
content(ruth): coverage enrichment — 4 findings to zero

### DIFF
--- a/content/ruth/1.json
+++ b/content/ruth/1.json
@@ -510,8 +510,33 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
+      "scores": [
+        {
+          "label": "Hesed (Covenant Loyalty) Across Ethnic Lines",
+          "score": 10
+        },
+        {
+          "label": "Emptiness and Return (the Naomi Arc)",
+          "score": 10
+        },
+        {
+          "label": "Providence Working Through Tragedy",
+          "score": 9
+        },
+        {
+          "label": "Famine, Migration, and Exile",
+          "score": 8
+        },
+        {
+          "label": "Conversion Confession (Ruth 1:16-17)",
+          "score": 10
+        },
+        {
+          "label": "Gentile Inclusion in Israel",
+          "score": 9
+        }
+      ],
+      "note": "Ruth 1 establishes the book's central theological framework through the Naomi-Ruth relationship. The famine-migration-bereavement arc compresses decades of loss into twenty verses, then pivots on Ruth's unparalleled confession: 'Where you go I will go, your people my people, your God my God, where you die I will die' (vv.16-17). This is the OT's clearest pre-exilic conversion-confession from a foreigner, and critically it is made to Naomi (not directly to Yahweh) — covenant membership comes through covenant belonging. The chapter closes with Naomi's 'call me Mara' — the theological problem the rest of the book must resolve: how does the God who emptied her restore her?"
     }
   },
   "vhl_groups": [

--- a/content/ruth/2.json
+++ b/content/ruth/2.json
@@ -475,8 +475,33 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
+      "scores": [
+        {
+          "label": "Hesed Exchanged: Boaz and Ruth",
+          "score": 10
+        },
+        {
+          "label": "Gleaning Laws (Lev 19:9-10; Deut 24:19-22)",
+          "score": 9
+        },
+        {
+          "label": "Providence Disguised as Chance ('she happened')",
+          "score": 10
+        },
+        {
+          "label": "Kinsman-Redeemer (Go'el) Introduced",
+          "score": 9
+        },
+        {
+          "label": "Protection of the Vulnerable Foreigner",
+          "score": 8
+        },
+        {
+          "label": "Covenant Welcome ('under whose wings')",
+          "score": 9
+        }
+      ],
+      "note": "Ruth 2's theological genius is the narrator's note that Ruth 'happened to come to the part of the field belonging to Boaz' (v.3). The Hebrew idiom (miqreh) is deliberate understatement — what reads as chance is providence disguised. The chapter introduces the go'el (kinsman-redeemer) institution that will structure chs.3-4 and drives the book's typological connection to Christ. Boaz's blessing — 'may you be richly rewarded by the LORD, under whose wings you have come to take refuge' (v.12) — uses covenant-protection imagery (Ps 91:4) to welcome the Moabite woman into Yahweh's people. Gleaning, a Mosaic provision for the poor, becomes the concrete mechanism of that welcome."
     }
   },
   "vhl_groups": [

--- a/content/ruth/3.json
+++ b/content/ruth/3.json
@@ -483,8 +483,33 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
+      "scores": [
+        {
+          "label": "Naomi's Initiative and Strategic Providence",
+          "score": 9
+        },
+        {
+          "label": "The Threshing-Floor Encounter",
+          "score": 10
+        },
+        {
+          "label": "Levirate-Related Redemption",
+          "score": 9
+        },
+        {
+          "label": "Boaz's Honour Under Pressure",
+          "score": 10
+        },
+        {
+          "label": "Ruth as 'Eshet Hayil (Woman of Valour)",
+          "score": 10
+        },
+        {
+          "label": "Nearer-Kinsman Complication Introduced",
+          "score": 8
+        }
+      ],
+      "note": "Ruth 3 stages one of the OT's most intentionally ambiguous scenes — Ruth uncovers Boaz's feet at the threshing floor at night, and asks him to 'spread the corner of your garment over me, since you are a guardian-redeemer' (v.9). The request parallels Ezek 16:8 (Yahweh's marriage-covenant with Jerusalem) and combines levirate marriage with go'el redemption. The scene's sexual undercurrent is real; Boaz's response is honorable under pressure ('all my fellow townsmen know that you are a woman of noble character,' v.11 — the same 'eshet hayil phrase of Prov 31:10). The nearer-kinsman problem introduced at v.12 creates the chapter's cliffhanger and drives the legal resolution of ch.4."
     }
   },
   "vhl_groups": [

--- a/content/ruth/4.json
+++ b/content/ruth/4.json
@@ -498,8 +498,33 @@
       }
     ],
     "themes": {
-      "scores": [],
-      "note": ""
+      "scores": [
+        {
+          "label": "Legal Redemption at the City Gate",
+          "score": 10
+        },
+        {
+          "label": "Boaz as Kinsman-Redeemer (Go'el)",
+          "score": 10
+        },
+        {
+          "label": "Obed, Jesse, David — Royal Genealogy",
+          "score": 10
+        },
+        {
+          "label": "From Emptiness to Fullness (Naomi's Arc)",
+          "score": 9
+        },
+        {
+          "label": "Foreign Ancestress of the Davidic Line",
+          "score": 10
+        },
+        {
+          "label": "Typology: Go'el as Christ-Figure",
+          "score": 9
+        }
+      ],
+      "note": "Ruth 4 resolves every thread the book has opened. The legal ceremony at the city gate (vv.1-12) dispatches the nearer-kinsman problem through the sandal-exchange custom preserved in Deut 25:9. The women's blessing on Naomi (vv.14-15) inverts ch.1's 'call me Mara': the empty matriarch is restored by the foreign daughter-in-law 'who is better to you than seven sons.' The genealogical close (vv.18-22 — Perez to David) reveals the book's canonical shape: the Moabite outsider Ruth is David's great-grandmother and (per Matt 1:5) Christ's foremother. The book closes having answered Naomi's bitter question of ch.1 — the God who emptied her has restored her in a line that reaches the throne of David and, beyond, the throne of heaven."
     }
   },
   "vhl_groups": [


### PR DESCRIPTION
Refs #1626. Ruth's 4 stub themes panels rewritten — chapter-specific 6-score palettes + substantive notes (hesed / emptiness-and-return / threshing-floor / go'el-redemption-to-David). 4 findings → 0. 4 files; +112 / -12.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_