### PR TITLE
content(1_thessalonians): coverage enrichment — 4 findings to zero

### DIFF
--- a/content/1_thessalonians/2.json
+++ b/content/1_thessalonians/2.json
@@ -524,22 +524,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 2:16",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'the wrath has come upon them at last' (eis telos) is debated. Does Paul refer to a recent event (perhaps Claudius's expulsion of Jews from…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Paul's Ministry and Longing to Return within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Thessalonians 2:14-16's judgment on Judeans: authentically Pauline or later interpolation?",
+        "positions": [
+          {
+            "name": "Pauline — consistent with his diaspora-mission context",
+            "proponents": "Wanamaker (NIGTC), Fee (NICNT)",
+            "argument": "The passage is found in all extant manuscripts of 1 Thessalonians with no textual evidence for interpolation. Paul's harsh language against 'the Jews who... oppose all people' reflects his specific frustration with synagogue-based opposition to his gentile mission (Acts 17:5-9's Thessalonian mob). The language is consistent with Paul's Romans-9 wrestling and reflects prophetic in-house critique, not generic anti-Semitism."
+          },
+          {
+            "name": "Post-70 CE interpolation",
+            "proponents": "Pearson, Schmidt (minority critical)",
+            "argument": "A minority critical reading argues the passage reflects post-70 CE Christian anti-Judaism imported into Paul's text. 'Wrath has come upon them at last' (v.16) is read as post-Temple-destruction retrospective. The uncharacteristic harshness is claimed to fit later editorial layering. Most scholars reject this view for lack of textual evidence."
+          },
+          {
+            "name": "Authentic but pastorally difficult",
+            "proponents": "Bruce (WBC), Green (Pillar)",
+            "argument": "The passage is authentically Pauline but belongs to the NT's handful of theologically-difficult texts requiring careful contextual reading. Paul, himself a Jew, targets specific opposition he has personally experienced, not Judeans as a population. The text must be read alongside Rom 9-11's affirmation of God's ongoing purposes for Israel; neither passage negates the other."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_thessalonians/4.json
+++ b/content/1_thessalonians/4.json
@@ -562,38 +562,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 4:4",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'control his own body' translates skeuos, literally 'vessel.' Some interpret this as 'acquire a wife' (cf. 1 Pet 3:7), but most modern tran…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Holy Living and the Dead in Christ within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 4:15",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'by the word of the Lord' (en logō kyriou) indicates authoritative dominical teaching. Whether this is a saying of Jesus, apostolic traditi…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Holy Living and the Dead in Christ within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Thess 4:13-18's 'caught up in the clouds' — pretribulational rapture or general resurrection?",
+        "positions": [
+          {
+            "name": "Pretribulational rapture",
+            "proponents": "MacArthur, Walvoord, classical dispensationalism",
+            "argument": "Paul describes a distinct event — the Lord descending from heaven, believers caught up (harpazō, whence 'rapture') 'to meet the Lord in the air' — which dispensational eschatology distinguishes from the second coming in glory. The church is removed before the tribulation begins; 1 Thess 5:1-11's day-of-the-LORD imagery immediately follows to describe the subsequent tribulation."
+          },
+          {
+            "name": "Single parousia event (post-tribulational / amillennial)",
+            "proponents": "Fee (NICNT), Wright, mainstream evangelical",
+            "argument": "Paul describes a single parousia event combining resurrection of the dead, transformation of the living, and meeting Christ. The 'meeting' (apantēsis) is the technical term for a city-delegation going out to welcome an arriving dignitary then escorting him in — the church goes up to meet Christ descending, and accompanies him back. No separate rapture-event distinct from the second coming is in view."
+          },
+          {
+            "name": "Rapture real but chronologically ambiguous",
+            "proponents": "Marshall (NIGTC)",
+            "argument": "Paul affirms that believers will be 'caught up' to meet the returning Christ — this is genuine rapture-language. But Paul gives no chronological detail on its relationship to tribulation. Reading in the pretribulational gap is an inference from other passages, not from 1 Thess 4 itself. The text's pastoral aim (comfort those grieving departed believers) does not require chronological resolution."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_thessalonians/5.json
+++ b/content/1_thessalonians/5.json
@@ -532,22 +532,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 5:23",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'spirit, soul, and body' has generated debate about Paul's anthropology. Most scholars see this as rhetorical emphasis (the whole person) r…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Day of the Lord and Final Instructions within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Thess 5:2's 'day of the LORD comes like a thief in the night' — apocalyptic certainty or divine surprise?",
+        "positions": [
+          {
+            "name": "Warning to the unwatchful",
+            "proponents": "Fee, Wanamaker",
+            "argument": "The thief-metaphor targets those who are 'in darkness' (v.4) — unprepared. For believers, the day will not surprise them because they are 'children of the light.' The metaphor's force is ethical: stay awake, live as people of the day, so that the coming is not catastrophic intrusion."
+          },
+          {
+            "name": "Certain chronological uncertainty for all",
+            "proponents": "Green, Morris",
+            "argument": "The metaphor emphasises that no one — not even believers — knows when the day will come. 'Times and dates' (v.1) are not given. Paul's pastoral comfort is that the day's uncertainty is not abandonment: it is God's sovereignty over timing. Even the well-prepared believer does not know the hour, but the believer is nonetheless safe because their relationship to the day is light-to-light, not dark-to-light."
+          },
+          {
+            "name": "Both: different aspects of the same reality",
+            "proponents": "Bruce, Shogren (BECNT)",
+            "argument": "The day is chronologically unknown to all (including believers) but not equally-surprising to all. The ethical-ecclesial application (light vs darkness) does not erase the literal unknowability; it transforms its meaning. Believers cannot predict but can prepare; unbelievers cannot prepare."
+          }
+        ]
+      }
     ],
     "thread": [
       {
@@ -619,7 +623,8 @@
         }
       ],
       "note": "The rapid-fire exhortations (5:16-22) are among the most quoted ethical summaries in Paul."
-    }
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>for you know very well that the day of the Lord will come like a thief in the night.</td></tr><tr><td class=\"t-label\">KJV</td><td>For yourselves know perfectly that the day of the Lord so cometh as a thief in the night.</td></tr><tr><td class=\"t-label\">NIV</td><td>While people are saying, “Peace and safety,” destruction will come on them suddenly, as labor pains on a pregnant woman, and they will not escape.</td></tr><tr><td class=\"t-label\">KJV</td><td>For when they shall say, Peace and safety; then sudden destruction cometh upon them, as travail upon a woman with child; and they shall not escape.</td></tr><tr><td class=\"t-label\">NIV</td><td>For God did not appoint us to suffer wrath but to receive salvation through our Lord Jesus Christ.</td></tr><tr><td class=\"t-label\">KJV</td><td>For God hath not appointed us to wrath, but to obtain salvation by our Lord Jesus Christ,</td></tr><tr><td class=\"t-label\">NIV</td><td>Rejoice always,</td></tr><tr><td class=\"t-label\">KJV</td><td>Rejoice evermore.</td></tr><tr><td class=\"t-label\">NIV</td><td>pray continually,</td></tr><tr><td class=\"t-label\">KJV</td><td>Pray without ceasing.</td></tr><tr><td class=\"t-label\">NIV</td><td>give thanks in all circumstances; for this is God’s will for you in Christ Jesus.</td></tr><tr><td class=\"t-label\">KJV</td><td>In every thing give thanks: for this is the will of God in Christ Jesus concerning you.</td></tr><tr><td class=\"t-label\">NIV</td><td>May God himself, the God of peace, sanctify you through and through. May your whole spirit, soul and body be kept blameless at the coming of our Lord Jesus Christ.</td></tr><tr><td class=\"t-label\">KJV</td><td>And the very God of peace sanctify you wholly; and I pray God your whole spirit and soul and body be preserved blameless unto the coming of our Lord Jesus Christ.</td></tr>"
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Refs #1626. 1 Thess ch 2/4/5 debates rewritten (anti-Jewish passage authenticity; rapture hermeneutics; thief-in-the-night) + ch 5 `trans` added (NIV+KJV). 4 findings → 0. 3 files; +65 / -68.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_