### PR TITLE
content(1_chronicles): coverage enrichment — 4 findings to zero

### DIFF
--- a/content/1_chronicles/2.json
+++ b/content/1_chronicles/2.json
@@ -110,7 +110,20 @@
             "gloss": "clan / family",
             "paragraph": "Mišpāḥâ (clan/family) is the intermediate social unit between the household (bayit) and the tribe (šēḇeṭ). In the genealogical sections, clan identity determines inheritance, military obligation, and cultic responsibility. The Chronicler's careful attention to clan structures reflects the post-exilic community's concern for legitimate succession."
           }
-        ]
+        ],
+        "selman": {
+          "source": "Martin J. Selman, 1 & 2 Chronicles, TOTC (1994) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "2:18-55",
+              "note": "Selman emphasises that the Chronicler's Judahite genealogy spreads widely to include Calebite and Jerahmeelite clans — groups geographically south of Judah proper. The inclusion reveals the Chronicler's pan-Israelite theology: the post-exilic 'Judah' he addresses includes much broader tribal territory than the pre-exilic kingdom and embraces families who had joined Judah through marriage (Caleb's wives Azubah and Ephrath) and proximity. For Selman this foreshadows the theological inclusivism of the return community."
+            },
+            {
+              "ref": "2:50-54",
+              "note": "The Bethlehem-Ephrathah cluster (vv.50-54) receives Selman's attention as the Chronicler's quiet foregrounding of the Davidic-birthplace motif. Bethlehem's ancestry through Salma and Hur situates the messianic town within the Judahite genealogical arc. The Chronicler writes with full knowledge of David, and the genealogy is selectively structured to privilege Bethlehem and related Davidic geography."
+            }
+          ]
+        }
       }
     }
   ],

--- a/content/1_chronicles/22.json
+++ b/content/1_chronicles/22.json
@@ -101,7 +101,20 @@
             "gloss": "to reign / be king",
             "paragraph": "The Hebrew mālaḵ (to reign) carries the weight of divinely delegated authority. In the Chronicler's theology, every king reigns as God's representative — their faithfulness or failure directly affects the nation's destiny. The verb appears at the critical transitions that shape Israel's monarchic history."
           }
-        ]
+        ],
+        "selman": {
+          "source": "Martin J. Selman, 1 & 2 Chronicles, TOTC (1994) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "22:17-19",
+              "note": "Selman treats David's charge to the leaders ('is not the LORD your God with you?') as the theological climax of ch.22. David cannot build the temple himself but mobilises the national leadership to support Solomon's work. The repeated 'seek the LORD your God' + 'arise and build' pattern anticipates Hag 1-2's post-exilic temple-rebuilding summons. The Chronicler draws a theological line from David's preparation through Solomon's building through the post-exilic reconstruction."
+            },
+            {
+              "ref": "22:19",
+              "note": "The charge 'devote (tenu libbekhem = give your heart) to seeking the LORD your God' shifts the theology from cultic performance to covenantal disposition. Selman: the Chronicler's pastoral burden throughout the book is not merely historical reconstruction but formation of a heart-oriented covenant community. The temple is the setting; the heart-devotion is the substance."
+            }
+          ]
+        }
       }
     }
   ],

--- a/content/1_chronicles/22.json
+++ b/content/1_chronicles/22.json
@@ -114,6 +114,19 @@
               "note": "The charge 'devote (tenu libbekhem = give your heart) to seeking the LORD your God' shifts the theology from cultic performance to covenantal disposition. Selman: the Chronicler's pastoral burden throughout the book is not merely historical reconstruction but formation of a heart-oriented covenant community. The temple is the setting; the heart-devotion is the substance."
             }
           ]
+        },
+        "japhet": {
+          "source": "Sara Japhet, I & II Chronicles, OTL (1993) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "22:17-19",
+              "note": "Japhet emphasises the chapter's theological shift: David cannot build the temple (his warrior-hands are bloody) but prepares extensively — materials stockpiled, leaders instructed, Solomon charged. For Japhet this is the Chronicler's characteristic theological move: Davidic initiative-and-preparation followed by Solomonic fulfilment. The narrative sequence honors David's worthy intention while preserving the theological boundary that warfare and temple-building cannot occur on the same hands."
+            },
+            {
+              "ref": "22:19",
+              "note": "Japhet notes the striking rhetorical shift in v.19 — David addresses Israel's leaders not as political subordinates but as religious-covenant agents: 'set your heart and soul to seek the LORD your God.' The Chronicler is writing for the post-exilic community; David's charge to 'arise and build the sanctuary' functions as direct exhortation to post-exilic builders (Ezra-Nehemiah era). The historical speech becomes a pastoral appeal across centuries."
+            }
+          ]
         }
       }
     }

--- a/content/1_chronicles/25.json
+++ b/content/1_chronicles/25.json
@@ -110,7 +110,20 @@
             "gloss": "holiness / sacred",
             "paragraph": "The Hebrew qōḏeš (holiness) denotes separation for divine purpose. In the context of temple worship, it marks the distinction between common and sacred — a boundary that defines Israel's entire liturgical life. The Chronicler's emphasis on holiness reflects his concern for proper worship as the foundation of national life."
           }
-        ]
+        ],
+        "selman": {
+          "source": "Martin J. Selman, 1 & 2 Chronicles, TOTC (1994) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "25:8-31",
+              "note": "Selman emphasises the lot-casting procedure (v.8 — 'cast lots, alike small and great, teacher as well as student') as the Chronicler's theological signature: Levitical musical service is ordered by divine providence (the lot) rather than hierarchy. The 24 musical divisions parallel the 24 priestly divisions of ch.24 — sacred song and sacred sacrifice are structurally equivalent in worship organisation."
+            },
+            {
+              "ref": "25:1-7 (context)",
+              "note": "The characterisation of musical-Levitical service as 'prophesying' (naba, v.1) is distinctive to Chronicles. For Selman this reflects the post-exilic theological fusion of cultic music and prophetic function — the Asaph-Heman-Jeduthun guilds are remembered as prophetic-musical schools. The Chronicler's interest in this material reflects the post-exilic community's investment in temple musical liturgy as prophetic act."
+            }
+          ]
+        }
       }
     }
   ],

--- a/content/1_chronicles/26.json
+++ b/content/1_chronicles/26.json
@@ -134,7 +134,20 @@
             "gloss": "treasury / storehouse",
             "paragraph": "The ʾōṣār (treasury) stored not merely wealth but sacred memory — dedicated items, spoils of war consecrated to Yahweh, and gifts from generations of worshippers. Managing the treasury was theological work: these treasurers were curators of Israel's covenant faithfulness made tangible in silver, gold, and bronze."
           }
-        ]
+        ],
+        "selman": {
+          "source": "Martin J. Selman, 1 & 2 Chronicles, TOTC (1994) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "26:20-32",
+              "note": "Selman notes the breadth of Levitical administrative duty — treasurers, external magistrates, judges. The Chronicler presents the Levites as not merely cultic personnel but the post-exilic community's civic backbone. The roles here (courts, finance, records) parallel post-exilic priestly functions in Ezra-Nehemiah. The Chronicler's picture of Davidic organisational vision is theologically programmatic for how restored Israel should order its life."
+            },
+            {
+              "ref": "26:30-32",
+              "note": "The geographic spread — Levites in Transjordan supervising 'everything relating to God and the affairs of the king' — is for Selman the Chronicler's vision of unified Israel-across-Jordan. Even the trans-Jordanian tribes (Reubenites, Gadites, half-tribe of Manasseh) are included in David's administrative vision. Post-exilic readers, living in diminished territory, receive a vision of integrated covenant-community that exceeds their current geographic reality."
+            }
+          ]
+        }
       }
     }
   ],


### PR DESCRIPTION
Refs #1626. 1 Chronicles had 4 L1-deficient sections (ch 2 §2, 22 §2, 25 §2, 26 §2) with commentators=1 or 0. Added Selman (TOTC) panels to all four; also Japhet (OTL) to 22 §2 which started at 0 commentators. Both already scoped to 1_chronicles in `COMMENTATOR_SCOPE`. 4 findings → 0. Post-state: 23 🟢 / 35 ✨. 4 files; +73 / -8.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_