### PR TITLE
content(john): coverage enrichment — 5 findings to zero

### DIFF
--- a/content/john/1.json
+++ b/content/john/1.json
@@ -354,6 +354,32 @@
         },
         "hist": {
           "context": "The Baptist's Testimony\nJohn structures the Baptist's witness as a series of \"next day\" scenes (vv.29, 35, 43) — a week of escalating testimony building toward Jesus's first sign at Cana (ch.2). The Baptist's triple denial (\"I am not the Messiah / Elijah / the Prophet\") mirrors the triple denial that will characterise Peter later — but in an ironic positive direction: the Baptist's denials all serve to magnify Jesus. His self-description (\"voice of one calling in the wilderness\") deliberately positions him as the fulfilment of Isaiah 40:3.\n\n\"Come and See\"\nThe phrase \"come and see\" (vv.39, 46) is John's characteristic invitation throughout the Gospel — an experiential epistemology: discipleship begins not with arguments but with encounter. Jesus's first words in John's Gospel are a question: \"What do you want?\" (v.38). The disciples answer with a question: \"Where are you staying?\" Jesus's response sets the tone for the entire Gospel: \"Come and see.\""
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "1:35-42",
+              "note": "The calling pattern — John points, Andrew follows, Andrew brings Peter — models the evangelistic chain Jesus commissions in 17:18 ('as you sent me into the world, I have sent them'). Jesus's renaming of Simon to Cephas/Peter ('rock') at first meeting prophecies his future ecclesial role (Matt 16:18). The chapter's rapid shift from John's witness to Jesus's direct discipleship shows John's purpose: pointing away from himself to Christ."
+            },
+            {
+              "ref": "1:43-51",
+              "note": "Nathanael's conversion scene is Johannine theology in miniature: skepticism ('can anything good come from Nazareth?'), Jesus's prophetic insight ('I saw you under the fig tree'), and confession ('Rabbi, you are the Son of God, the King of Israel'). The 'greater things' promise of v.50 — angels ascending and descending on the Son of Man — identifies Jesus as the ladder of Gen 28:12, the true Bethel where heaven touches earth."
+            }
+          ]
+        },
+        "catena": {
+          "source": "Thomas Aquinas, Catena Aurea on John — Patristic Chain",
+          "notes": [
+            {
+              "ref": "1:35-42",
+              "note": "Chrysostom: John the Baptist's 'behold the Lamb of God' is the shepherd handing the flock over to its true shepherd. Augustine: Andrew's response — 'we have found the Messiah' — is the first apostolic confession, preceding even Peter's at Caesarea Philippi. The naming of Peter (v.42) is prospective: Christ names what Peter will become."
+            },
+            {
+              "ref": "1:47-51",
+              "note": "Augustine on 'an Israelite indeed, in whom there is no guile' (v.47): Jesus praises Nathanael for being unlike Jacob the deceiver, yet promises him the same vision Jacob received — the ladder/angels. Chrysostom: the 'greater things' (v.50) reaches to the crucifixion and resurrection; Nathanael's first-meeting confession anticipates the fullness of glory to come."
+            }
+          ]
         }
       }
     }

--- a/content/john/11.json
+++ b/content/john/11.json
@@ -332,6 +332,32 @@
         },
         "hist": {
           "context": "Caiaphas's Unwitting Prophecy\nJohn explicitly identifies Caiaphas's statement as prophecy (v.51) — not despite its cynical political motivation but through it. Caiaphas intends a piece of political pragmatism: sacrifice one troublemaker to preserve the nation's peace with Rome. God speaks through this cynicism the deepest truth of the atonement: the one dies for the many. John's double-level narrative reaches its apex here: the very words used to condemn Jesus proclaim the gospel."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "11:45-53",
+              "note": "The raising of Lazarus triggers the final plot to kill Jesus — one of the Johannine ironies at full intensity. Caiaphas's cynical political calculation ('better that one man die for the people than that the whole nation perish,' v.50) is narrated by John as unwitting prophecy (v.51-52): Caiaphas speaks gospel truth by divine providence while intending murder. The prophecy explicitly extends the substitutionary death to 'the scattered children of God' — gentile inclusion."
+            },
+            {
+              "ref": "11:54-57",
+              "note": "Jesus's withdrawal to Ephraim marks a deliberate Passover-crowd avoidance until the appointed hour. The chapter closes with the religious authorities' public arrest-warrant (v.57) — the final Passover week is set up institutionally. The Gospel's precise time-markers (v.55 — 'Jewish Passover was near'; compare 12:1, 13:1) frame the passion narrative's deliberate Passover-lamb typology."
+            }
+          ]
+        },
+        "catena": {
+          "source": "Thomas Aquinas, Catena Aurea on John — Patristic Chain",
+          "notes": [
+            {
+              "ref": "11:50-52",
+              "note": "Augustine: Caiaphas spoke better than he knew. The high priestly office carried prophetic authority (Num 27:21's Urim and Thummim precedent); God uses even the office occupied by a murderer to speak the salvific truth of the cross. Chrysostom: the narrator's clarification (v.51) protects the reader from reading Caiaphas as a hero — the prophecy is providential, not personal."
+            },
+            {
+              "ref": "11:54",
+              "note": "Chrysostom on Jesus's withdrawal to Ephraim: not from fear but from sovereign control over the appointed hour. Jesus orchestrates the timing of his arrest; he is not overtaken by events. The withdrawal is the last in John's series of strategic disappearances (6:15, 7:10, 10:39-40) before the passion begins."
+            }
+          ]
         }
       }
     }

--- a/content/john/3.json
+++ b/content/john/3.json
@@ -324,6 +324,32 @@
         },
         "hist": {
           "context": "The Bridegroom Motif\nThe OT consistently used the bridegroom/bride image for God's relationship with Israel (Hos 2:19-20; Isa 62:5; Jer 2:2). Jesus applying this imagery to himself (and John using it of himself as \"friend of the bridegroom\") is an implicit claim to be YHWH in relation to his people — the divine bridegroom come to claim his bride. This becomes explicit in Revelation 19:7-9 and 21:2.\n\nJohn and Jesus Baptising Simultaneously\nThe picture of John and Jesus both baptising in Judea simultaneously (3:22-24) is unique to John and historically specific. John's disciples' concern (\"everyone is going to him\") reveals the transition underway: the forerunner's movement is being absorbed into the movement it pointed toward."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "3:31-34",
+              "note": "The passage's uncertain speaker (John the Baptist or the evangelist's commentary) reflects the Gospel's characteristic interpretive layering. Either way, the content is Christological: the one from above is above all; his testimony is accepted only by those whom the Father gives. God 'gives the Spirit without limit' (v.34) to him — the Spirit's full-indwelling distinguishes Christ from every other prophet."
+            },
+            {
+              "ref": "3:35-36",
+              "note": "The Father's love for the Son and delegation of 'all things' to him (v.35) reaches its application in v.36's binary: whoever believes has eternal life; whoever rejects the Son experiences divine wrath. John's Gospel does not soften this division — eternal outcomes turn on response to Christ, understood in the Gospel's characteristic 'already' framework (believing now, life now; rejecting now, wrath now)."
+            }
+          ]
+        },
+        "catena": {
+          "source": "Thomas Aquinas, Catena Aurea on John — Patristic Chain",
+          "notes": [
+            {
+              "ref": "3:31",
+              "note": "Augustine: 'he who comes from above is above all' refers to Christ's divine origin. The contrast 'he who is of the earth is earthly' applies to John the Baptist's subordinate role. Chrysostom: 'from the earth' does not deny John's spiritual gifts but locates his office as creaturely compared to the Son's."
+            },
+            {
+              "ref": "3:36",
+              "note": "Chrysostom on the wrath-remains formulation: the verb 'remains' (menei) suggests wrath as the default state apart from Christ; believing in the Son lifts the wrath already resting on humanity. Augustine extends: whoever rejects the Son rejects the Father who sent him, and inherits the judgment pronounced on rejection."
+            }
+          ]
         }
       }
     }

--- a/content/john/6.json
+++ b/content/john/6.json
@@ -366,6 +366,32 @@
         },
         "hist": {
           "context": "The Manna Typology\nThe crowd quotes Ps 78:24 (\"He gave them bread from heaven to eat,\" v.31) to demand a sign like Moses's manna. Jesus corrects two assumptions: (1) Moses did not give the manna — the Father did; (2) the manna was not the true bread from heaven — that is what the Father is now giving. The typological argument is that manna was a shadow pointing to Christ, who is the substance. Those who ate manna died; those who eat this bread live forever (v.49-51).\n\nDivision and Departure\nThe discourse produces the most dramatic departure in the Gospel: \"many of his disciples turned back and no longer followed him\" (v.66). This is not the crowd — it is disciples. The hard teaching about eating his flesh and drinking his blood functions as a sifting: those who cannot accept the claim that Jesus is himself the life-giving gift depart. Peter's confession (v.68-69) stands in sharp contrast as the model of perseverant faith."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "6:60-66",
+              "note": "The 'hard teaching' (v.60) is the eating-my-flesh-and-drinking-my-blood discourse. Jesus's response ('the words I have spoken are spirit and life,' v.63) clarifies: the teaching is not cannibalistic literalism but spiritual participation in his atoning death. Many turn back — not because they misunderstand literally, but because they understand substantively and reject the substitutionary demand. The Gospel's theology of divine drawing (v.65) explains both the rejection and Peter's confession that follows."
+            },
+            {
+              "ref": "6:67-71",
+              "note": "Peter's confession — 'Lord, to whom shall we go? You have the words of eternal life' — is the Johannine parallel to the Caesarea Philippi confession of the Synoptics, here framed in staying-language rather than identifying-language. Jesus's dark word in response ('one of you is a devil,' v.70) introduces Judas's betrayal into the narrative, preventing triumphalist readings of the Twelve's loyalty."
+            }
+          ]
+        },
+        "catena": {
+          "source": "Thomas Aquinas, Catena Aurea on John — Patristic Chain",
+          "notes": [
+            {
+              "ref": "6:60-63",
+              "note": "Augustine: the words are 'spirit and life' because the flesh of Christ must be understood through the Spirit, not carnally. Chrysostom: the Capernaum audience fails precisely by refusing to trust; their offense at the hard saying is offense at the cross itself, which Jesus is prophesying."
+            },
+            {
+              "ref": "6:67-69",
+              "note": "Chrysostom on 'will you also go away?' — Jesus does not compel; he invites testing of loyalty. Peter's 'you have the words of eternal life' is one of the patristic tradition's favorite confessions, often read as the foundation-stone of ecclesial allegiance built on the Word incarnate."
+            }
+          ]
         }
       }
     }

--- a/content/john/8.json
+++ b/content/john/8.json
@@ -325,6 +325,32 @@
         },
         "hist": {
           "context": "\"The Truth Will Set You Free\"\nOne of the most quoted statements of Jesus, usually detached from its context. The freedom Jesus offers is freedom from slavery to sin (v.34), not freedom as general autonomy or self-realisation. The context is a debate about whether Abraham's physical descendants are spiritually free — Jesus insists that ethnic or religious heritage provides no exemption from sin's bondage. Only the Son can grant genuine freedom (v.36).\n\n\"Abraham Rejoiced to See My Day\"\nJesus's claim in v.56 — that Abraham saw and rejoiced at \"my day\" — is one of the most provocative statements in ch.8. The Jewish tradition included various accounts of Abraham being shown the future (cf. Gen 15 Covenant of the Pieces; the Apocalypse of Abraham). Jesus claims Abraham's joy was specifically anticipatory joy at the Messiah's coming. The \"day\" he saw was the day of Jesus."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "8:48-58",
+              "note": "The exchange escalates from 'Abraham is our father' (v.39) through 'you have a demon' (v.48) to the climactic 'before Abraham was, I AM' (v.58). The unambiguous divine self-designation (the Exodus 3:14 'I AM') prompts the immediate attempted stoning (v.59) — Jesus's audience understood the claim as blasphemy requiring execution under Lev 24:16. This is the Gospel's clearest pre-passion claim to divinity."
+            },
+            {
+              "ref": "8:58-59",
+              "note": "'Before Abraham was, I AM' (prin Abraam genesthai, ego eimi) uses the present-tense ego eimi against Abraham's past-tense genesthai. The grammatical shift asserts eternal pre-existence rather than merely prior existence. The stoning attempt confirms the Jewish audience's understanding: this is not a Messianic claim (they would argue, not stone) but a divine-identity claim."
+            }
+          ]
+        },
+        "catena": {
+          "source": "Thomas Aquinas, Catena Aurea on John — Patristic Chain",
+          "notes": [
+            {
+              "ref": "8:56",
+              "note": "Augustine: Abraham 'saw Christ's day and rejoiced' refers to Abraham's prophetic anticipation of the Messianic age — perhaps through the Isaac-binding (Gen 22) or the 'seed' promise (Gen 15). The joy is faith-anticipation, not literal vision."
+            },
+            {
+              "ref": "8:58",
+              "note": "Chrysostom: the careful grammatical difference (genesthai for Abraham, ego eimi for Christ) communicates two kinds of existence — creaturely becoming and divine being. Augustine extends: 'I AM' is the eternal name revealed at the bush; Jesus claims identity with the one who spoke to Moses. The stoning response confirms the audience understood the claim."
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Refs #1626. John's 5 L1-deficient §4 sections (1/3/6/8/11) had commentators=0. Added `mac` (MacArthur) and `catena` (Catena Aurea patristic chain) panels to each; both scholars already used widely in John. 5 findings → 0. Post-state: 5 🟢 / 58 ✨. No new scholars in `SCHOLAR_REGISTRY`. 5 files; +135 / -5.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_