### PR TITLE
content(colossians): coverage enrichment — 5 findings to zero

### DIFF
--- a/content/colossians/1.json
+++ b/content/colossians/1.json
@@ -531,38 +531,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 1:7",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase kathōs emathete apo Epaphra (just as you learned from Epaphras) establishes Epaphras as the authoritative teacher. The preposition apo indi…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Supremacy of Christ over All Creation within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 1:13",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The noun exousia (authority, domain, dominion) applied to darkness personifies it as a ruling power. The transfer from darkness’s domain to the Son’s …",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Supremacy of Christ over All Creation within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "Colossians 1:15-20 (the Christ Hymn): pre-Pauline hymn or Pauline composition?",
+        "positions": [
+          {
+            "name": "Pre-Pauline hymn adapted by Paul",
+            "proponents": "Wright (NTfE), Dunn, Lohse (Hermeneia)",
+            "argument": "The passage's elevated vocabulary ('firstborn,' 'image,' 'thrones and powers'), parallel structure (creation in vv.15-17, redemption in vv.18-20), and distinct theological emphasis suggest a pre-Pauline hymn Paul adapts for his Colossian argument. Wright particularly emphasises the Wisdom-tradition parallels (Prov 8; Sirach 24) as the hymn's background."
+          },
+          {
+            "name": "Pauline composition for Colossian context",
+            "proponents": "Moo (Pillar), Beale (BECNT)",
+            "argument": "The passage fits Paul's theological vocabulary and addresses Colossians' specific Christological crisis directly. The 'hymn' label overdetermines the genre; structured-Christological prose is within Paul's range (cf. Rom 11:33-36; 1 Tim 3:16). No external evidence of a pre-existing hymn exists; the suggestion is conjectural."
+          },
+          {
+            "name": "Pauline composition drawing on pre-existing Christological material",
+            "proponents": "Pao (ZECNT)",
+            "argument": "Paul may have composed the passage while drawing on early Christian confessional language already in liturgical use. The either/or is too sharp; Paul's Christology developed in conversation with early Christian worship, and his writing participates in its patterns."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/colossians/2.json
+++ b/content/colossians/2.json
@@ -485,22 +485,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 2:18",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase thelōn en tapeinophrosynē kai thrēskeia tōn aggelōn (delighting in false humility and the worship of angels) is debated: does it mean worsh…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Fullness in Christ, Freedom from False Teaching within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "What was the 'Colossian heresy'? Jewish-ascetic, Gnostic proto-philosophy, or Phrygian syncretism?",
+        "positions": [
+          {
+            "name": "Jewish-ascetic practice (circumcision, food laws, festivals)",
+            "proponents": "Dunn (NIGTC), Moo (Pillar)",
+            "argument": "Paul's explicit targets — circumcision (2:11), food-and-drink regulations (2:16), new moon and sabbath (2:16), 'self-imposed worship, asceticism, severe treatment of the body' (2:23) — map to Jewish Torah-observance pressed on Gentile believers. The 'Colossian heresy' is a Judaizing variant specific to the region's diaspora synagogue context."
+          },
+          {
+            "name": "Proto-Gnostic philosophical speculation",
+            "proponents": "Lightfoot (older), some commentators",
+            "argument": "The 'philosophy and empty deceit' (2:8), 'worship of angels' (2:18), and 'principalities and powers' language suggest Gnostic-style speculation about intermediary spiritual beings. Paul's Christological centrality response (1:15-20; 2:9-10) is the doctrinal corrective to dualist emanation-theology."
+          },
+          {
+            "name": "Phrygian-regional syncretism blending multiple strands",
+            "proponents": "Arnold (Colossian Syncretism), mainstream contemporary",
+            "argument": "Arnold's detailed study of regional Phrygian religion argues for a syncretistic blend of Jewish ascetic practice, local magical-angelic speculation, and mystery-religion elements. This accounts for Paul's otherwise varied targets (Torah-observance plus angel-worship plus ascetic visions) without requiring one unified system."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/colossians/3.json
+++ b/content/colossians/3.json
@@ -446,22 +446,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 3:14",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase syndesmos tēs teleiotētos (bond of perfection/unity) is debated: does love bind the community together, or does love bind the virtues toget…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The New Self and the Christian Household within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "Colossians 3:18-4:1's household code: transformed or endorsed slave-master structure?",
+        "positions": [
+          {
+            "name": "Countercultural transformation through Christ-submission framework",
+            "proponents": "Moo (Pillar), Wright",
+            "argument": "Paul's Christianisation of the Haustafel (household code) is transformative — every party, including masters, receives ethical demand ('Masters, provide your slaves with what is right and fair, because you know that you also have a Master in heaven,' 4:1). The Christ-framework ('as to the Lord,' 3:23) radically reframes every relationship, not simply legitimating existing structures but reconstituting them under Christ's lordship."
+          },
+          {
+            "name": "Conservative endorsement of Roman household-structure",
+            "proponents": "Some critical / feminist readings",
+            "argument": "Paul's instructions to slaves (obey masters, work heartily) reinforce the Roman slavery structure without demanding systemic change. Whatever theological reframing Paul offers, the practical effect is to legitimise continued slavery and hierarchical marriage. The text has been used historically to justify oppressive structures."
+          },
+          {
+            "name": "Transformative-within-given-structure",
+            "proponents": "Pao (ZECNT), Thompson (Two Horizons)",
+            "argument": "Paul transforms relationships within existing structures without directly demanding structural change. The theological seed planted (masters are themselves under a Master) created space for later Christian abolitionist readings while not demanding immediate institutional overthrow. The text's complex reception history reflects its internal tension between transformation and accommodation."
+          }
+        ]
+      }
     ],
     "thread": [
       {
@@ -535,7 +539,8 @@
           "text": "Wives, submit to husbands. Husbands, love your wives. Children, obey parents. Fathers, do not provoke children. Bondservants, obey in everything — work heartily as for the Lord. Masters, treat bondservants justly."
         }
       ]
-    }
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Since, then, you have been raised with Christ, set your hearts on things above, where Christ is, seated at the right hand of God.</td></tr><tr><td class=\"t-label\">KJV</td><td>If ye then be risen with Christ, seek those things which are above, where Christ sitteth on the right hand of God.</td></tr><tr><td class=\"t-label\">NIV</td><td>Set your minds on things above, not on earthly things.</td></tr><tr><td class=\"t-label\">KJV</td><td>Set your affection on things above, not on things on the earth.</td></tr><tr><td class=\"t-label\">NIV</td><td>Here there is no Gentile or Jew, circumcised or uncircumcised, barbarian, Scythian, slave or free, but Christ is all, and is in all.</td></tr><tr><td class=\"t-label\">KJV</td><td>Where there is neither Greek nor Jew, circumcision nor uncircumcision, Barbarian, Scythian, bond nor free: but Christ is all, and in all.</td></tr><tr><td class=\"t-label\">NIV</td><td>Let the message of Christ dwell among you richly as you teach and admonish one another with all wisdom through psalms, hymns, and songs from the Spirit, singing to God with gratitude in your hearts.</td></tr><tr><td class=\"t-label\">KJV</td><td>Let the word of Christ dwell in you richly in all wisdom; teaching and admonishing one another in psalms and hymns and spiritual songs, singing with grace in your hearts to the Lord.</td></tr><tr><td class=\"t-label\">NIV</td><td>And whatever you do, whether in word or deed, do it all in the name of the Lord Jesus, giving thanks to God the Father through him.</td></tr><tr><td class=\"t-label\">KJV</td><td>And whatsoever ye do in word or deed, do all in the name of the Lord Jesus, giving thanks to God and the Father by him.</td></tr><tr><td class=\"t-label\">NIV</td><td>Whatever you do, work at it with all your heart, as working for the Lord, not for human masters,</td></tr><tr><td class=\"t-label\">KJV</td><td>And whatsoever ye do, do it heartily, as to the Lord, and not unto men;</td></tr>"
   },
   "vhl_groups": [
     {

--- a/content/colossians/4.json
+++ b/content/colossians/4.json
@@ -415,7 +415,8 @@
           "text": "Greet the brothers at Laodicea and Nympha's house church. Have this letter read in Laodicea; read the Laodicean letter also. Tell Archippus: fulfill the ministry you received. Paul's greeting by his own hand — remember his chains. Grace be with you."
         }
       ]
-    }
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>Devote yourselves to prayer, being watchful and thankful.</td></tr><tr><td class=\"t-label\">KJV</td><td>Continue in prayer, and watch in the same with thanksgiving;</td></tr><tr><td class=\"t-label\">NIV</td><td>Be wise in the way you act toward outsiders; make the most of every opportunity.</td></tr><tr><td class=\"t-label\">KJV</td><td>Walk in wisdom toward them that are without, redeeming the time.</td></tr><tr><td class=\"t-label\">NIV</td><td>Let your conversation be always full of grace, seasoned with salt, so that you may know how to answer everyone.</td></tr><tr><td class=\"t-label\">KJV</td><td>Let your speech be alway with grace, seasoned with salt, that ye may know how ye ought to answer every man.</td></tr><tr><td class=\"t-label\">NIV</td><td>Epaphras, who is one of you and a servant of Christ Jesus, sends greetings. He is always wrestling in prayer for you, that you may stand firm in all the will of God, mature and fully assured.</td></tr><tr><td class=\"t-label\">KJV</td><td>Epaphras, who is one of you, a servant of Christ, saluteth you, always labouring fervently for you in prayers, that ye may stand perfect and complete in all the will of God.</td></tr><tr><td class=\"t-label\">NIV</td><td>Our dear friend Luke, the doctor, and Demas send greetings.</td></tr><tr><td class=\"t-label\">KJV</td><td>Luke, the beloved physician, and Demas, greet you.</td></tr>"
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Refs #1626. Colossians ch 1/2/3 debates rewritten (1:15-20 hymn authorship; Colossian heresy; 3:18-4:1 household code) + ch 3/4 `trans` added (NIV+KJV). 5 findings → 0. 4 files; +68 / -70.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_