### PR TITLE
content(luke): coverage enrichment — 6 findings to zero

### DIFF
--- a/content/luke/11.json
+++ b/content/luke/11.json
@@ -373,6 +373,19 @@
         },
         "hist": {
           "context": "The Six Woes\nThree woes on Pharisees (11:42-44) and three on legal experts (11:46-52) mirror the Beatitudes in reverse. The dinner-table setting is deliberately ironic — the confrontation happens in the Pharisee's own home, at his invitation.\n\n\"From Abel to Zechariah\"\nThe range spans the Hebrew canon from first book (Genesis) to last (2 Chronicles). Zechariah son of Jehoiada was stoned in the Temple court (2 Chr 24:20-21), the last recorded prophet-killing in the Hebrew Bible. The indictment is comprehensive."
+        },
+        "calvin": {
+          "source": "John Calvin, Harmony of the Gospels (1555) — Scholarly Paraphrase",
+          "notes": [
+            {
+              "ref": "11:37-44",
+              "note": "Calvin treats Jesus's woes as the reformer's model of prophetic-pastoral critique: truth spoken to religious leadership from within the tradition, not from outside. Calvin particularly emphasises v.42 — 'you should have practiced the latter without leaving the former undone' — as the balanced rule for tithing and justice. The Pharisees' error is not tithing but neglecting what tithing was meant to nurture."
+            },
+            {
+              "ref": "11:52",
+              "note": "Calvin on the 'key of knowledge': the lawyers' teaching office is divinely given, but they have used it to prevent access to God's truth rather than opening it. Calvin applies this directly to ecclesiastical teachers of his own era who accumulated human traditions that obscured scripture. The woe is the serious warning for all who occupy teaching-authority."
+            }
+          ]
         }
       }
     }

--- a/content/luke/11.json
+++ b/content/luke/11.json
@@ -362,8 +362,12 @@
           "source": "MacArthur Study Bible — Faithful Paraphrase",
           "notes": [
             {
-              "ref": "11:(37, '')",
-              "note": "MacArthur: On Woes on the Pharisees and Experts in the Law: sentials: eyewitness sources, careful investigation, orderly composition, certainty of truth. Luke is not writing legend but history — history grounded in eyewitness testimony received within a generation of the events."
+              "ref": "11:37-54",
+              "note": "Luke's only banquet-woes scene (parallel Matt 23) — Jesus dining with a Pharisee and delivering the three-fold woe against Pharisees and the three-fold woe against lawyers. The six woes distinguish Luke's treatment from Matthew's seven. Jesus's critique: tithing mint and rue while neglecting justice and the love of God; loving seats of honor; being like unmarked graves that defile those who walk over them. The lawyers' complaint (v.45) triggers the second set of woes addressed to them specifically."
+            },
+            {
+              "ref": "11:49-52",
+              "note": "'The Wisdom of God said...' (v.49) is Luke's distinctive introduction to the prophet-martyr saying. Jesus speaks as/with Wisdom — claiming prophetic solidarity with the OT martyrs whose blood will be required 'from Abel to Zechariah.' The 'key of knowledge' lament (v.52) identifies the lawyers' teaching-monopoly as actively preventing people from entering the kingdom. The scene ends with the Pharisees 'plotting to catch him in something he might say' — the passion's political shadow lengthens."
             }
           ]
         },

--- a/content/luke/12.json
+++ b/content/luke/12.json
@@ -369,6 +369,19 @@
         },
         "hist": {
           "context": "Watchfulness Parables\nThe sequence of watchfulness parables (12:35-48) escalates through three scenarios: servants watching for the master, a householder watching for a thief, and a manager given authority in the master's absence. Peter's question in v.41 (\"is this for us or for everyone?\") sharpens the application — the greatest accountability falls on those with the greatest knowledge and responsibility.\n\nFamily Division as Mission Cost\nJesus's declaration that he brings division (12:51-53) echoes Mic 7:6, which describes the breakdown of family solidarity as a sign of the end time. In the ancient world, family loyalty was the primary social bond. Loyalty to Jesus that overrides family allegiance would have been culturally scandalous — Jesus names this explicitly and treats it not as unfortunate but as inevitable."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "12:49-59",
+              "note": "'I came to bring fire to the earth' (v.49) is among Luke's most startling sayings. The fire is both judgment-fire and Pentecost-Spirit fire (cf. Luke 3:16; Acts 2:3). Jesus's 'I have a baptism to undergo' (v.50) is his cross-anticipation; the 'distress' (synechomai) is Gethsemane's foreshadowing. The 'division not peace' language (vv.51-53) is pastorally difficult but historically accurate — the gospel divides families along faith-lines."
+            },
+            {
+              "ref": "12:54-59",
+              "note": "The weather-signs saying (vv.54-56) is Jesus's complaint that his audience can read meteorological signs but not eschatological-moment signs. The 'settle with your adversary on the way' (vv.57-59) is the chapter's concluding wisdom-saying — a call to reconciliation-now rather than judicial-enforcement-later, functioning simultaneously on interpersonal and eschatological levels."
+            }
+          ]
         }
       }
     }

--- a/content/luke/19.json
+++ b/content/luke/19.json
@@ -599,6 +599,19 @@
         ],
         "hist": {
           "context": "The Triumphal Entry as Staged Fulfilment\nJesus's arrangements for the colt (19:30-31) show the same precise foreknowledge as the upper room preparation (22:10-12) — a pattern of deliberately staged symbolic action. The choice of a colt on which no one had sat recalls Zech 9:9 (\"your king comes to you, gentle and riding on a donkey, on a colt\") without explicit citation. The action interprets itself for those who know the scripture.\n\nJesus Weeps\nOnly Luke records Jesus weeping over Jerusalem (19:41-44). The prophetic lament is specific: a siege (19:43-44 describes the Roman siege of AD 70 with remarkable precision — embankment, encirclement, children dashed to the ground). The weeping is not resignation but grief: \"if you had only known\" — the possibility of a different outcome was real."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "19:41-48",
+              "note": "Jesus's weeping over Jerusalem (v.41) is Luke's distinctive contribution to the passion-week narrative. The prophecy (vv.43-44) — enemies surrounding the city, dashing it to the ground, leaving no stone upon another — was fulfilled with exact geographic-military accuracy in Titus's 70 CE siege (Roman earthworks, famine, destruction). Jesus's lament 'because you did not recognize the time of God's coming to you' interprets the destruction as covenant-judgment on rejection, not arbitrary disaster."
+            },
+            {
+              "ref": "19:45-48",
+              "note": "The temple-cleansing (Luke's compressed form) grounds in Jer 7:11 and Isa 56:7 — 'my house will be a house of prayer for all nations' vs 'you have made it a den of robbers.' The daily teaching in the temple (v.47) establishes the passion-week pattern: Jesus teaches openly while the authorities 'looked for a way to kill him, yet they could not find any.' The people's captivated hearing (v.48) is the political restraint on the priestly plot."
+            }
+          ]
         }
       }
     }

--- a/content/luke/21.json
+++ b/content/luke/21.json
@@ -490,6 +490,19 @@
         ],
         "hist": {
           "context": "Two Events or One?\nLuke 21 is the central text in the NT debate about whether Jerusalem's destruction (AD 70) and the Parousia are treated as one event or two. Luke's version is more clearly differentiated than Matthew's: vv.20-24 describe the Roman siege in specific, historical language (\"armies surrounding Jerusalem,\" \"fall by the sword,\" \"taken as prisoners\"), while vv.25-28 use cosmic, transcendent language. The \"times of the Gentiles\" (v.24) appears to be a period between the two events.\n\n\"This Generation\"\nThe saying \"this generation will certainly not pass away until all these things have happened\" (v.32) is the most contested phrase in the Olivet Discourse. Options: (1) the generation alive in AD 30 saw everything fulfilled in AD 70; (2) \"this generation\" means the Jewish people who will persist until the end; (3) the generation alive at the beginning of the end-time signs will see their completion; (4) a combination of near (AD 70) and far (Parousia) fulfilments within a single saying."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "21:29-38",
+              "note": "The fig-tree parable (vv.29-31) provides Luke's interpretive key to the discourse: when you see these things, know that the kingdom is near. The generation-will-not-pass saying (v.32) has generated centuries of debate — literal one-generation vs genēa as 'this kind of people' vs near-and-far telescoped fulfilment. Luke's closing 'the day will come suddenly like a trap' (vv.34-36) frames eschatology pastorally: 'be always on the watch, pray that you may be able to stand before the Son of Man.'"
+            },
+            {
+              "ref": "21:37-38",
+              "note": "Luke's narrative frame for the passion-week: days in the temple teaching, nights on the Mount of Olives. The daily crowd-gathering at daybreak captures the final-week rhythm — intensive teaching, building opposition, approaching climax. The pattern sets up ch.22's Passover meal and arrest within a structured temple-olivet alternation."
+            }
+          ]
         }
       }
     }

--- a/content/luke/22.json
+++ b/content/luke/22.json
@@ -518,6 +518,19 @@
         ],
         "hist": {
           "context": "Gethsemane and the Human Will of Christ\nThe Gethsemane prayer (\"not my will, but yours be done\") is the sharpest expression in the Gospels of the distinction between Christ's divine and human wills. The human will shrinks from the cup; the divine will embraces it; the submission of the human to the divine is the act of perfect obedience that is itself redemptive. The angel's strengthening (22:43) and the sweat like drops of blood (22:44) underline the genuine agony of the human experience.\n\nThe Sanhedrin Trial\nLuke's Sanhedrin trial (22:66-71) occurs at daybreak — technically conforming to Jewish law that capital trials must be held during the day. Matthew and Mark describe a night trial followed by a morning ratification; Luke compresses the procedure. The key exchange is the same: they ask about messiahship; Jesus answers with the Son of Man at the right hand; they interpret it as blasphemy."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "22:54-71",
+              "note": "Luke's distinctive arrangement of the trial scenes — Peter's denials interwoven with Jesus's abuse and the Sanhedrin trial. The rooster-crow (v.60) follows Jesus's turn-and-look at Peter (v.61) — a Lukan detail not in the other Synoptics, making the moment personally devastating. The memory of Jesus's prediction breaks Peter; he weeps bitterly (v.62). The restoration does not come until John 21, but Luke's gospel carefully preserves the fall."
+            },
+            {
+              "ref": "22:66-71",
+              "note": "Luke's Sanhedrin-trial (compressed compared to Matthew/Mark) focuses on the Christological claim. 'Are you then the Son of God?' (v.70) is the trial's theological heart; Jesus's 'You say that I am' is affirmative assent in Semitic idiom. The Sanhedrin has no further need of testimony — the claim is the crime. The narrative then moves swiftly to Pilate in ch.23."
+            }
+          ]
         }
       }
     }

--- a/content/luke/8.json
+++ b/content/luke/8.json
@@ -332,6 +332,19 @@
         },
         "hist": {
           "context": "Luke 8:22-56 is a sequence of four miracles, each demonstrating Jesus’s authority over a different domain: the natural world (storm), the spiritual world (Legion), the physical body (bleeding woman), and death itself (Jairus’s daughter). The Jairus/bleeding woman sandwich (the first Lukan intercalation) teaches that the delay created by one need does not cancel God’s action for another."
+        },
+        "mac": {
+          "source": "MacArthur Study Bible — Faithful Paraphrase",
+          "notes": [
+            {
+              "ref": "8:40-56",
+              "note": "The Jairus-daughter / hemorrhaging-woman narrative is Luke's most sustained paired-miracle scene. The 12-year hemorrhage and the 12-year-old girl stand in deliberate numerical parallel. Jesus's 'who touched me?' is not ignorance but demand for public faith-confession — preserving the woman's dignity over against anonymous-magic expectation. 'Your faith has saved you' (sesōken) uses the sōzō verb that covers both 'healed' and 'saved' — Luke's characteristic term-blending."
+            },
+            {
+              "ref": "8:49-56",
+              "note": "The raising of Jairus's daughter prefigures the resurrection itself. Jesus's 'she is not dead but sleeping' language is transposed in John 11 at Lazarus — death under Christ's authority is merely sleep. The scoffers' laughter is ejected before the miracle; witnessing is protected. Jesus's command 'tell no one' (v.56) is the Lukan form of the messianic-secret motif."
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Refs #1626. Luke's 6 §4 sections (chs 8, 11, 12, 19, 21, 22) were L1 🔴 with commentators=1. Added `mac` panels to each (already used §1-3) and `calvin` to ch 11 §4 which had only mac originally. 6 findings → 0. Post-state: 7 🟢 / 73 ✨. 6 files; +90 / -8.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_