### PR TITLE
content(2_timothy): coverage enrichment — 7 findings to zero

### DIFF
--- a/content/2_timothy/1.json
+++ b/content/2_timothy/1.json
@@ -516,38 +516,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 1:9",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The creedal fragment has a pre-Pauline character, using vocabulary uncommon in the undisputed letters.…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Fan into Flame the Gift of God within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 1:18",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The prayer for mercy 'on that day' has been debated: some take it as evidence Onesiphorus had died; others argue he was still alive.…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Fan into Flame the Gift of God within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "2 Tim 1:9's 'purpose and grace given us in Christ Jesus before the ages began': eternal decree or timeless divine intention?",
+        "positions": [
+          {
+            "name": "Unconditional eternal election",
+            "proponents": "Mounce (WBC), Knight (NIGTC), Reformed tradition",
+            "argument": "Paul's 'before the ages' (pro chronōn aiōniōn) locates God's electing purpose in eternity past — grace given in Christ before time began. This is one of Paul's most explicit pre-temporal election texts, parallel to Eph 1:4. The verse grounds salvation in God's unconditional eternal decision, not in foreseen human response."
+          },
+          {
+            "name": "Timeless divine character manifested in time",
+            "proponents": "Witherington, Mounce (alternate emphasis)",
+            "argument": "'Before the ages' need not specify chronological pre-temporality but rather the timeless character of God's gracious purpose. The emphasis is on grace as God's essential disposition, now 'manifested through the appearing of our Savior Christ Jesus.' The reading softens the strict decretal frame while preserving divine initiative."
+          },
+          {
+            "name": "Election-in-Christ rather than election-to-Christ",
+            "proponents": "Marshall (ICC), Wright",
+            "argument": "'In Christ Jesus' qualifies 'grace given' — grace is given in Christ as the electing mediator, not prior to Christ. The pre-temporal language locates the purpose in God's eternal intention to save through Christ; humans participate in election by union with Christ. This reading connects Paul's pre-temporal election language with his characteristic 'in Christ' theology."
+          }
+        ]
+      }
     ],
     "thread": [
       {
@@ -592,7 +580,29 @@
         "type": "Echo",
         "text": "The pre-temporal election language parallels the creedal fragment's 'before the beginning of time.'"
       }
-    ]
+    ],
+    "discourse": {
+      "title": "2 Timothy 1 — Paul's Last Charge: Guard the Deposit",
+      "thesis": "Paul, awaiting execution, charges Timothy to fan into flame the Spirit-gift, to share in suffering for the gospel, and to guard the good deposit with the Holy Spirit's help.",
+      "nodes": [
+        {
+          "label": "Greeting and thanksgiving (1:1-7)",
+          "text": "Paul, apostle by God's will, to Timothy, beloved child. Grace, mercy, peace. Paul thanks God, remembering Timothy constantly in prayer, longing to see him, recalling Timothy's sincere faith which lived first in his grandmother Lois and mother Eunice. Paul reminds him to fan into flame the gift of God received through laying-on-of-hands. God gave us a spirit not of fear but of power, love, and self-control.",
+          "type": "thesis"
+        },
+        {
+          "label": "Share in suffering for the gospel (1:8-12)",
+          "text": "Do not be ashamed of the Lord's testimony or of Paul's imprisonment, but share in suffering for the gospel by the power of God, who saved and called us to a holy calling — not because of our works but because of his own purpose and grace given in Christ Jesus before the ages began. Now manifested through the appearance of Christ Jesus, who abolished death and brought life and immortality to light. Paul was appointed preacher, apostle, and teacher — suffering for this reason but not ashamed.",
+          "type": "evidence"
+        },
+        {
+          "label": "Guard the deposit (1:13-18)",
+          "text": "Follow the pattern of sound words heard from me, in faith and love in Christ Jesus. Guard (phylaxon) the good deposit (parathēkēn) entrusted to you — with the Holy Spirit dwelling in us. Paul notes that all in Asia have turned away (including Phygelus and Hermogenes); Onesiphorus's household, however, showed mercy by seeking Paul in Rome and not being ashamed of his chain.",
+          "type": "conclusion"
+        }
+      ],
+      "note": "The chapter establishes 2 Timothy's dominant theme: the apostolic faith as deposit (parathēkē) that Timothy must guard and transmit in a setting where many are defecting. The Onesiphorus note is both practical thanksgiving and pastoral example."
+    }
   },
   "vhl_groups": [
     {

--- a/content/2_timothy/2.json
+++ b/content/2_timothy/2.json
@@ -456,7 +456,29 @@
         "type": "Connection",
         "text": "The 'firm foundation of God' draws on the Isaianic foundation-stone tradition."
       }
-    ]
+    ],
+    "discourse": {
+      "title": "2 Timothy 2 — Entrust Faithful Men; Avoid Useless Controversy",
+      "thesis": "The faith passes through faithful teachers to successive generations. Timothy must endure hardship, avoid foolish controversies, and pursue righteousness with those who call on the Lord from a pure heart.",
+      "nodes": [
+        {
+          "label": "Entrust to faithful men (2:1-7)",
+          "text": "Be strong in grace in Christ Jesus. What you have heard from me in the presence of many witnesses, entrust to faithful men who will be able to teach others also. Share in suffering as a good soldier of Christ Jesus. Three images: soldier (not entangled in civilian affairs), athlete (competing according to rules), farmer (the hard-working farmer first shares in the fruit).",
+          "type": "thesis"
+        },
+        {
+          "label": "Remember Jesus Christ / trustworthy saying (2:8-13)",
+          "text": "Remember Jesus Christ, risen from the dead, descended from David, according to my gospel — for which I am suffering, bound in chains as a criminal. But the word of God is not bound. I endure all for the elect, that they may obtain salvation with eternal glory. Trustworthy saying: if we died with him, we will also live with him; if we endure, we will also reign with him; if we deny him, he will deny us; if we are faithless, he remains faithful — for he cannot deny himself.",
+          "type": "evidence"
+        },
+        {
+          "label": "Avoid foolish controversies (2:14-26)",
+          "text": "Warn before God not to quarrel about words — it ruins hearers. Be diligent to present yourself approved to God, workman unashamed, rightly handling the word of truth. Avoid irreverent babble (leading to more ungodliness — like Hymenaeus and Philetus whose talk spread like gangrene, saying the resurrection already happened). Yet God's firm foundation stands, bearing this seal: 'The Lord knows those who are his.' Flee youthful passions; pursue righteousness, faith, love, peace with those who call on the Lord from a pure heart. The Lord's servant must not be quarrelsome but kind, correcting opponents with gentleness — God may grant them repentance.",
+          "type": "conclusion"
+        }
+      ],
+      "note": "The chapter gives 2 Timothy its most densely practical teaching on pastoral conduct: succession (faithful-men principle), endurance, rightly handling the word, avoiding speculative theology, combining firm correction with gentleness."
+    }
   },
   "vhl_groups": [
     {

--- a/content/2_timothy/3.json
+++ b/content/2_timothy/3.json
@@ -114,15 +114,37 @@
         "st2": {
           "header": "Jannes and Jambres: Naming Pharaoh's Magicians",
           "body": "Exodus 7:11–12 tells us that when Moses performed the staff-to-serpent sign before Pharaoh, 'Pharaoh summoned his wise men and sorcerers — and the magicians of Egypt also did the same by their secret arts.' The magicians are unnamed. Exodus mentions them again several times through the first plagues without ever giving names; they finally fail at the gnats (8:18–19) and disappear from the narrative entirely after the boils (9:11). The Hebrew Bible nowhere names them.\n\nPaul does. At 2 Timothy 3:8 he writes: 'Just as Jannes and Jambres opposed Moses, so these people also oppose the truth' (antestēsan Iannēs kai Iambrēs). He uses the names without explanation — they are assumed to be familiar to Timothy and, presumably, to the wider Christian community in Ephesus. This is possible because the names had long since entered broader Jewish interpretive tradition.\n\nThe earliest attested naming appears in the Dead Sea Scrolls: the Damascus Document (CD 5:17–19) mentions 'Jannes and his brother' who 'Belial raised up against Moses and Aaron.' The Qumran community knew the tradition by the late 2nd or early 1st century BC. Targum Pseudo-Jonathan on Exodus 1:15 and 7:11 names them (Yohané and Mamré in the Aramaic), as does the Zadokite Fragments and later rabbinic literature (b. Menahot 85a, Exodus Rabbah 9:7). Pliny the Elder (Natural History 30.11) and Apuleius (Apology 90) both mention 'Iannes' among famous magicians of antiquity, suggesting the names had diffused beyond Jewish circles by the 1st century AD. A fragmentary pseudepigraphon known as the Book of Jannes and Jambres survives in small Greek and Ethiopic fragments; Origen (Commentary on Matthew 27:9) cites it, and the Decretum Gelasianum (6th century) lists it among rejected apocrypha. Whatever its exact relationship to Paul's source, the tradition about these two magicians was ancient, broadly diffused, and required no explanation by Paul's day.\n\nThe interpretive question Paul's usage raises is the same as for Jude and 2 Peter: does naming extra-biblical figures imply endorsing an extra-biblical book? Evangelical commentators (Mounce, Towner, Knight) consistently argue that it does not. Paul draws on an oral-literary tradition that Timothy shares; the reliability of 'Jannes and Jambres' as the magicians' names is not Paul's theological claim but his assumed cultural shorthand. The same logic governs Paul's citations of Greek poets (Aratus in Acts 17:28; Epimenides in Titus 1:12; Menander in 1 Corinthians 15:33) — he draws on culturally available tradition without canonizing its source.\n\nWhat Paul's naming does document is the permeability of Scripture's boundary with respected Jewish interpretive tradition at the moment the NT was being written. Extra-biblical tradition here functions as midrash — supplementary narrative that fills gaps in the Hebrew text without replacing or competing with it.",
-          "extrabiblical_ids": ["damascus_document"],
+          "extrabiblical_ids": [
+            "damascus_document"
+          ],
           "citation_refs": [
-            {"nt": "2 Timothy 3:8", "source": "Damascus Document (CD) 5:17-19; Targum Pseudo-Jonathan Exodus 1:15, 7:11; Book of Jannes and Jambres (fragmentary)", "type": "allusion"}
+            {
+              "nt": "2 Timothy 3:8",
+              "source": "Damascus Document (CD) 5:17-19; Targum Pseudo-Jonathan Exodus 1:15, 7:11; Book of Jannes and Jambres (fragmentary)",
+              "type": "allusion"
+            }
           ],
           "scholar_voices": [
-            {"scholar_id": "mounce", "tradition": "Evangelical Pastorals", "note": "Mounce (Word Biblical Commentary) treats Paul's naming as a straightforward appeal to shared Jewish tradition. The names were well established by the 1st century — the Damascus Document and the Targums show us why Timothy and the Ephesian community would recognize them without explanation — and Paul is neither endorsing a specific extra-biblical book nor making a claim about the historical accuracy of 'Jannes and Jambres' as birth names."},
-            {"scholar_id": "towner", "tradition": "Evangelical Pastorals", "note": "Towner (NICNT) sees Paul's typology as the primary point: the contemporary opponents are to Timothy what Jannes and Jambres were to Moses — resourceful impostors whose 'secret arts' ultimately fail before God's work. The naming is rhetorical, drawing on a cultural reservoir that reinforces the comparison."},
-            {"scholar_id": "vanderkam", "tradition": "Critical (DSS / Second Temple)", "note": "VanderKam's work on the Damascus Document places the Jannes-and-his-brother tradition in the Qumran community's reading of Exodus. The community read the biblical text through an interpretive framework that named anonymous figures and explained their opposition in terms of Belial's cosmic hostility — a framework Paul inherits and deploys in his typology."},
-            {"scholar_id": "nickelsburg", "tradition": "Critical (Second Temple)", "note": "Nickelsburg documents the Jannes and Jambres tradition as part of the broader Second Temple practice of filling biblical narrative gaps with named figures. The fragmentary Book of Jannes and Jambres (attested by Origen and Decretum Gelasianum) shows the tradition had sufficient weight to generate a dedicated pseudepigraphon by the late Second Temple period."}
+            {
+              "scholar_id": "mounce",
+              "tradition": "Evangelical Pastorals",
+              "note": "Mounce (Word Biblical Commentary) treats Paul's naming as a straightforward appeal to shared Jewish tradition. The names were well established by the 1st century — the Damascus Document and the Targums show us why Timothy and the Ephesian community would recognize them without explanation — and Paul is neither endorsing a specific extra-biblical book nor making a claim about the historical accuracy of 'Jannes and Jambres' as birth names."
+            },
+            {
+              "scholar_id": "towner",
+              "tradition": "Evangelical Pastorals",
+              "note": "Towner (NICNT) sees Paul's typology as the primary point: the contemporary opponents are to Timothy what Jannes and Jambres were to Moses — resourceful impostors whose 'secret arts' ultimately fail before God's work. The naming is rhetorical, drawing on a cultural reservoir that reinforces the comparison."
+            },
+            {
+              "scholar_id": "vanderkam",
+              "tradition": "Critical (DSS / Second Temple)",
+              "note": "VanderKam's work on the Damascus Document places the Jannes-and-his-brother tradition in the Qumran community's reading of Exodus. The community read the biblical text through an interpretive framework that named anonymous figures and explained their opposition in terms of Belial's cosmic hostility — a framework Paul inherits and deploys in his typology."
+            },
+            {
+              "scholar_id": "nickelsburg",
+              "tradition": "Critical (Second Temple)",
+              "note": "Nickelsburg documents the Jannes and Jambres tradition as part of the broader Second Temple practice of filling biblical narrative gaps with named figures. The fragmentary Book of Jannes and Jambres (attested by Origen and Decretum Gelasianum) shows the tradition had sufficient weight to generate a dedicated pseudepigraphon by the late Second Temple period."
+            }
           ],
           "takeaway": "Paul names Exodus's anonymous Egyptian magicians using a Jewish interpretive tradition already two centuries old by his day (Damascus Document, Targums, Jannes and Jambres pseudepigraphon). The names come from extra-biblical literature; the theological point — false teachers ultimately fail before God's truth — comes from typological reading of Scripture. NT citation of such tradition reflects the lived culture of 1st-century Jewish-Christian interpretation, not canonization of the source."
         }
@@ -423,7 +445,30 @@
         "type": "Connection",
         "text": "The persecutions at Antioch, Iconium, and Lystra are narrated in Acts and provide the historical referent for Paul's autobiographical reminder in v. 11."
       }
-    ]
+    ],
+    "discourse": {
+      "title": "2 Timothy 3 — Last-Days Apostasy; All Scripture Is God-Breathed",
+      "thesis": "In the last days difficult times will come because of widespread moral decay; but Timothy's foundation — the Scriptures breathed out by God — equips him for every good work.",
+      "nodes": [
+        {
+          "label": "Character catalog of the last days (3:1-9)",
+          "text": "In the last days there will be terrible times. People will be lovers of self, money, proud, arrogant, abusive, disobedient to parents, ungrateful, unholy, heartless, unappeasable, slanderous, without self-control, brutal, not loving good, treacherous, reckless, swollen with conceit, lovers of pleasure rather than lovers of God — having the appearance of godliness but denying its power. Avoid such people. They creep into households, capture weak women laden with sins, always learning, never arriving at knowledge of truth. As Jannes and Jambres opposed Moses, so these men oppose the truth — disqualified regarding the faith. But they will not get far; their folly will be plain to all.",
+          "type": "thesis"
+        },
+        {
+          "label": "Paul's example and Timothy's formation (3:10-15)",
+          "text": "You have followed my teaching, conduct, aim in life, faith, patience, love, steadfastness, persecutions, sufferings — what happened in Antioch, Iconium, Lystra — and from all the Lord rescued me. Indeed all who desire to live godly in Christ Jesus will be persecuted. Evil people will go on from bad to worse. But continue in what you have learned and firmly believed, knowing from whom you learned it and how from childhood you have known the sacred writings, which are able to make you wise for salvation through faith in Christ Jesus.",
+          "type": "evidence"
+        },
+        {
+          "label": "All Scripture God-breathed (3:16-17)",
+          "text": "All Scripture is breathed out by God (theopneustos) and profitable for teaching, for reproof, for correction, for training in righteousness — that the man of God may be complete, equipped for every good work.",
+          "type": "conclusion"
+        }
+      ],
+      "note": "v.16's theopneustos (only NT occurrence of the term) supplies the foundational vocabulary for Christian doctrine of Scripture's inspiration. The verse has anchored every major discussion of biblical authority from the patristic era through the Reformation to contemporary evangelical theology."
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>In fact, everyone who wants to live a godly life in Christ Jesus will be persecuted,</td></tr><tr><td class=\"t-label\">KJV</td><td>Yea, and all that will live godly in Christ Jesus shall suffer persecution.</td></tr><tr><td class=\"t-label\">NIV</td><td>But as for you, continue in what you have learned and have become convinced of, because you know those from whom you learned it,</td></tr><tr><td class=\"t-label\">KJV</td><td>But continue thou in the things which thou hast learned and hast been assured of, knowing of whom thou hast learned them;</td></tr><tr><td class=\"t-label\">NIV</td><td>and how from infancy you have known the Holy Scriptures, which are able to make you wise for salvation through faith in Christ Jesus.</td></tr><tr><td class=\"t-label\">KJV</td><td>And that from a child thou hast known the holy scriptures, which are able to make thee wise unto salvation through faith which is in Christ Jesus.</td></tr><tr><td class=\"t-label\">NIV</td><td>All Scripture is God-breathed and is useful for teaching, rebuking, correcting and training in righteousness,</td></tr><tr><td class=\"t-label\">KJV</td><td>All scripture is given by inspiration of God, and is profitable for doctrine, for reproof, for correction, for instruction in righteousness:</td></tr><tr><td class=\"t-label\">NIV</td><td>so that the servant of God may be thoroughly equipped for every good work.</td></tr><tr><td class=\"t-label\">KJV</td><td>That the man of God may be perfect, throughly furnished unto all good works.</td></tr>"
   },
   "vhl_groups": [
     {

--- a/content/2_timothy/4.json
+++ b/content/2_timothy/4.json
@@ -449,7 +449,30 @@
         "type": "Connection",
         "text": "Mark's earlier abandonment of Paul (during the first missionary journey) and Paul's subsequent refusal to take him on the second journey make Paul's request for Mark here (v. 11) a notable reconciliation."
       }
-    ]
+    ],
+    "discourse": {
+      "title": "2 Timothy 4 — Preach the Word; Paul's Farewell",
+      "thesis": "Paul charges Timothy solemnly to preach the word in season and out, then recounts his imminent departure, his fight finished, the crown of righteousness reserved for him.",
+      "nodes": [
+        {
+          "label": "Solemn charge to preach (4:1-5)",
+          "text": "In the presence of God and Christ Jesus who will judge the living and the dead, and by his appearing and kingdom, I solemnly charge you: preach the word. Be ready in season and out. Reprove, rebuke, exhort with complete patience and teaching. For the time is coming when people will not endure sound teaching but will gather teachers to suit their own passions, turning away from truth to myths. As for you, always be sober-minded, endure suffering, do the work of an evangelist, fulfill your ministry.",
+          "type": "thesis"
+        },
+        {
+          "label": "Paul's finished fight (4:6-8)",
+          "text": "I am already being poured out as a drink offering, and the time of my departure has come. I have fought the good fight, I have finished the race, I have kept the faith. Henceforth there is laid up for me the crown of righteousness, which the Lord, the righteous judge, will award to me on that day — and not only to me but to all who have loved his appearing.",
+          "type": "evidence"
+        },
+        {
+          "label": "Personal requests and final warnings (4:9-22)",
+          "text": "Come to me quickly; Demas has deserted me (loving this present world), Crescens gone to Galatia, Titus to Dalmatia. Only Luke is with me. Bring Mark — he is useful for ministry. Tychicus sent to Ephesus. Bring the cloak left at Troas, and the books, especially the parchments. Alexander did me great harm — the Lord will repay him. At my first defense no one came to my support; all deserted me. But the Lord stood by me and strengthened me, so that the message might be fully proclaimed and all the Gentiles might hear. The Lord will rescue me from every evil deed and bring me safely to his heavenly kingdom. To him be glory forever. Greet Prisca and Aquila, Onesiphorus's household. Do your best to come before winter. Grace be with you.",
+          "type": "conclusion"
+        }
+      ],
+      "note": "Paul's last surviving letter. The valedictory self-assessment ('I have fought the good fight...') is among the NT's most moving personal passages. The final practical requests — cloak, books, parchments, specifically Mark — humanise the apostolic figure in his final days."
+    },
+    "trans": "<tr><th>Version</th><th>Translation</th></tr><tr><td class=\"t-label\">NIV</td><td>In the presence of God and of Christ Jesus, who will judge the living and the dead, and in view of his appearing and his kingdom, I give you this charge:</td></tr><tr><td class=\"t-label\">KJV</td><td>I charge thee therefore before God, and the Lord Jesus Christ, who shall judge the quick and the dead at his appearing and his kingdom;</td></tr><tr><td class=\"t-label\">NIV</td><td>Preach the word; be prepared in season and out of season; correct, rebuke and encourage—with great patience and careful instruction.</td></tr><tr><td class=\"t-label\">KJV</td><td>Preach the word; be instant in season, out of season; reprove, rebuke, exhort with all longsuffering and doctrine.</td></tr><tr><td class=\"t-label\">NIV</td><td>For the time will come when people will not put up with sound doctrine. Instead, to suit their own desires, they will gather around them a great number of teachers to say what their itching ears want to hear.</td></tr><tr><td class=\"t-label\">KJV</td><td>For the time will come when they will not endure sound doctrine; but after their own lusts shall they heap to themselves teachers, having itching ears;</td></tr><tr><td class=\"t-label\">NIV</td><td>I have fought the good fight, I have finished the race, I have kept the faith.</td></tr><tr><td class=\"t-label\">KJV</td><td>I have fought a good fight, I have finished my course, I have kept the faith:</td></tr><tr><td class=\"t-label\">NIV</td><td>Now there is in store for me the crown of righteousness, which the Lord, the righteous Judge, will award to me on that day—and not only to me, but also to all who have longed for his appearing.</td></tr><tr><td class=\"t-label\">KJV</td><td>Henceforth there is laid up for me a crown of righteousness, which the Lord, the righteous judge, shall give me at that day: and not to me only, but unto all them also that love his appearing.</td></tr><tr><td class=\"t-label\">NIV</td><td>But the Lord stood at my side and gave me strength, so that through me the message might be fully proclaimed and all the Gentiles might hear it. And I was delivered from the lion’s mouth.</td></tr><tr><td class=\"t-label\">KJV</td><td>Notwithstanding the Lord stood with me, and strengthened me; that by me the preaching might be fully known, and that all the Gentiles might hear: and I was delivered out of the mouth of the lion.</td></tr>"
   },
   "vhl_groups": [
     {


### PR DESCRIPTION
Refs #1626. 2 Timothy 4 missing discourse panels added (one per chapter) + ch 1 templated debate rewritten (eternal election) + ch 3+4 `trans` added. 7 findings → 0. 4 files; +146 / -46.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_