### PR TITLE
content(1_corinthians): coverage enrichment — 15 findings to zero

### DIFF
--- a/content/1_corinthians/1.json
+++ b/content/1_corinthians/1.json
@@ -646,22 +646,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 1:12",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The ‘Christ party’ (egō de Christou) is debated: some scholars see a genuine faction claiming direct Christ-authority; others view it as Paul’s own po…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Wisdom of the Cross and the Folly of Divisions within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 1:18-25's 'foolishness of the cross': rhetorical strategy or fundamental epistemological claim?",
+        "positions": [
+          {
+            "name": "Fundamental epistemological claim",
+            "proponents": "Thiselton (NIGTC), Fee (NICNT)",
+            "argument": "Paul sets out an epistemological reversal — God's wisdom appears foolishness to human wisdom-criteria, and human wisdom is folly before God. The cross discloses a divine knowledge-pattern that contradicts the world's. This is not rhetorical posture but theological-philosophical foundation. Paul will return to this throughout the letter."
+          },
+          {
+            "name": "Rhetorical strategy against Corinthian factionalism",
+            "proponents": "Witherington, Mitchell",
+            "argument": "Paul's wisdom-vs-foolishness rhetoric counters specific Corinthian rhetorical-philosophical pretensions. The Corinthians prized eloquent-philosophical-rhetoric; Paul deconstructs that prestige-economy by elevating the cross's apparent foolishness. The argument is targeted-rhetorical, not abstract-epistemological."
+          },
+          {
+            "name": "Both: targeted rhetoric grounded in genuine epistemology",
+            "proponents": "Garland (BECNT), Hays",
+            "argument": "Paul's rhetorical move addresses Corinthian-specific factionalism while articulating genuinely-foundational claims about how God's wisdom works. The two readings name complementary aspects: targeted polemic and durable theological-epistemology. The chapter's force depends on both being real."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/10.json
+++ b/content/1_corinthians/10.json
@@ -501,38 +501,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 10:4",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note discusses the Jewish tradition of a 'following rock' (based on the rock appearing at two different locations in Exodus 17 and Numbers 20)…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Warnings from Israel's History within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 10:29b–30",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note addresses the interpretive puzzle of vv. 29b–30: 'Why should my freedom be judged by another's conscience?' Some commentators read this a…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Warnings from Israel's History within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 10:1-13's wilderness-Israel typology: warning-only or also believers' identity-formation?",
+        "positions": [
+          {
+            "name": "Warning-only function",
+            "proponents": "Some popular readings",
+            "argument": "The wilderness-narrative serves as warning-example: 'these things happened as examples for us, that we should not desire evil as they did' (vv.6, 11). The point is moral-cautionary; do not repeat their mistakes. The chapter functions as ethical-warning."
+          },
+          {
+            "name": "Identity-formation through typological participation",
+            "proponents": "Hays, Wright",
+            "argument": "Paul's 'they were our fathers' / 'Christ was the rock' / 'these things happened as examples for us' creates typological-identity continuity. Believers participate in Israel's wilderness-experience by canonical-covenantal incorporation. The chapter forms believer-identity, not just warning. NT readers understand themselves as wilderness-Israel's continuation."
+          },
+          {
+            "name": "Both: identity-formation grounds the warning's force",
+            "proponents": "Fee, Garland",
+            "argument": "The warning's force depends on identity-continuity. Because believers are typologically continuous with wilderness-Israel, what happened to them is genuinely warning to us. Pure-warning without identity-continuity is rhetoric; pure-identity without warning lacks the chapter's ethical-urgency. Paul integrates both."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/11.json
+++ b/content/1_corinthians/11.json
@@ -483,38 +483,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 11:3",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note on kephalē provides an extensive discussion of the 'authority' vs. 'source' debate. The note favours 'authority over' as the primary mean…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Proper Worship within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 11:10",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note addresses the crux interpretum: 'a woman ought to have authority (exousia) on her head.' The note explains that exousia is active ('a sig…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Proper Worship within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 11:2-16's head-covering: cultural practice with timeless principle, timeless-universal command, or contextual response?",
+        "positions": [
+          {
+            "name": "Cultural-practice expressing timeless principle",
+            "proponents": "Mainstream evangelical; Garland, Fee",
+            "argument": "The head-covering is the 1st-century cultural-form of the timeless principle — distinction-in-equality between men and women (and recognition of created-order). Modern Christians honor the principle (sex-distinction within unity, gender-particular dignity) without literally requiring head-coverings, which were that era's expression of the principle."
+          },
+          {
+            "name": "Timeless-universal command",
+            "proponents": "Some Reformed and Anabaptist traditions",
+            "argument": "Paul grounds the practice in creation-order (vv.7-9, 11-12) and angelic witnesses (v.10) — universals that transcend culture. The instruction therefore remains binding. Several Christian traditions (Mennonite, conservative Brethren) have maintained literal head-covering practice on this reading."
+          },
+          {
+            "name": "Context-specific Corinthian response",
+            "proponents": "Witherington, some critical readings",
+            "argument": "The instruction targets specific Corinthian-cultural-religious dynamics (perhaps women's prophetic activity confused with pagan-cultic conduct). Paul's response is context-pastoral. The general-creation-order grounding is rhetorical-supportive of context-specific advice rather than establishing universal Christian practice."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/12.json
+++ b/content/1_corinthians/12.json
@@ -469,22 +469,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 12:31",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note discusses the imperative vs. indicative debate for zēloute. The NET translators opt for the imperative reading ('eagerly desire the great…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Spiritual Gifts and the Body of Christ within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 12-14's spiritual gifts: cessationist or continuationist? Tongues, prophecy still operative?",
+        "positions": [
+          {
+            "name": "Cessationist: sign-gifts ceased with apostolic age",
+            "proponents": "MacArthur, classical Reformed",
+            "argument": "Sign-gifts (tongues, prophecy, miraculous healing) functioned to authenticate apostolic-foundation; with NT-canonical-completion, they have fulfilled their purpose and ceased. Heb 2:3-4's framework shows sign-gifts as authenticating 'the salvation announced by the Lord.' Once Scripture is closed, they are no longer needed."
+          },
+          {
+            "name": "Continuationist: gifts remain operative throughout church age",
+            "proponents": "Pentecostal/Charismatic; Fee, Carson, Storms",
+            "argument": "Paul gives no expiration date; the gifts continue 'until the perfect comes' (1 Cor 13:10), which most continuationists identify with the parousia, not canonical-completion. Acts 2:17's 'last days' Spirit-outpouring covers the entire church-age. Gifts continue, though their operation may vary by historical-circumstances."
+          },
+          {
+            "name": "Cautious-continuationist: gifts continue but require careful discernment",
+            "proponents": "Grudem, Schreiner",
+            "argument": "The gifts continue but operate differently than apostolic-era — particularly NT prophecy is non-authoritative-revelation that supplements but never overrides Scripture. This 'open but cautious' position has been influential in Reformed evangelical circles, distinguishing it from both strict cessationism and uncritical-charismatic practice."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/13.json
+++ b/content/1_corinthians/13.json
@@ -459,22 +459,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 13:10",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note evaluates four major interpretations and favours the eschatological reading, arguing that 'face to face' imagery is most naturally unders…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Way of Love within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 13's love-chapter: spontaneous insertion or integral to Paul's gifts-argument?",
+        "positions": [
+          {
+            "name": "Integral to gifts-argument",
+            "proponents": "Mainstream evangelical; Fee, Garland",
+            "argument": "Ch 13 is not interruption but the heart of chs 12-14 — Paul argues that any gift-exercise without love is empty. Love is the more-excellent-way (12:31) chs 12 and 14 require. Removing ch 13 loses the trilogy's coherence; Paul carefully positions the love-passage to govern gift-discussion."
+          },
+          {
+            "name": "Originally-independent rhetorical insertion",
+            "proponents": "Some critical readings",
+            "argument": "Ch 13's stylistic elevation and rhetorical structure suggest pre-existing material Paul incorporated. The chapter could function independently as poem-on-love. Whether Paul composed it specifically for 1 Cor or imported a pre-existing piece, its standalone-character is plausible."
+          },
+          {
+            "name": "Paul's composition with rhetorical-self-containment",
+            "proponents": "Witherington, Thiselton",
+            "argument": "Paul composed ch 13 specifically for this letter while crafting it with rhetorical-self-containment. The result is a chapter that serves the letter's argument while standing as one of NT's most-quotable rhetorical achievements. The two readings are not opposed; the chapter is both contextually-integral and standalone-quotable."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/14.json
+++ b/content/1_corinthians/14.json
@@ -480,22 +480,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 14:2",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note clarifies that 'speaks to God' emphasises the limitation of uninterpreted tongues, not their superiority: only God understands the tongue…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Prophecy and Tongues in Worship within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 14:34-35's 'women should be silent in churches': Paul's instruction, later interpolation, or specific-context advice?",
+        "positions": [
+          {
+            "name": "Authentic Paul, contextual to specific Corinthian situation",
+            "proponents": "Mainstream evangelical (Fee, Garland, Schreiner)",
+            "argument": "The verses are textually well-attested; calling them interpolation is not text-critically defensible. They address specific Corinthian-contextual issue — perhaps women's disorderly questioning during prophetic-evaluation (1 Cor 14's specific concern). Paul is not silencing women's prayer/prophecy (which 11:5 explicitly permits) but addressing specific-disruptive behavior."
+          },
+          {
+            "name": "Later interpolation (textual-critical argument)",
+            "proponents": "Fee (NICNT, position changed over editions); Payne",
+            "argument": "Some manuscripts place vv.34-35 after v.40 rather than after v.33, suggesting unstable text. Some critical scholars (notably Fee in his NICNT) argue the verses are post-Pauline interpolation reflecting later Pastoral-Epistles concerns. The internal tension with 11:5 supports interpolation reading."
+          },
+          {
+            "name": "Apostolic command to all churches (universal)",
+            "proponents": "Conservative complementarian readings",
+            "argument": "v.33b 'as in all the churches of the saints' indicates universal apostolic instruction, not local advice. The verses establish ongoing-Christian principle of women's silence in formal church-teaching contexts (compatible with Paul's permission of prayer/prophecy in 11:5 — different speech-categories). The text remains universally binding."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/15.json
+++ b/content/1_corinthians/15.json
@@ -767,22 +767,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 15:29",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The NET note surveys major options and leaves the question open, noting Paul's argument works regardless of which interpretation is correct.…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Resurrection of the Dead within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 15:29's 'baptism for the dead': Mormon-style proxy baptism, generic vicarious practice, or rhetorical observation?",
+        "positions": [
+          {
+            "name": "Rhetorical observation, not endorsement",
+            "proponents": "Mainstream evangelical; Garland, Fee",
+            "argument": "Paul's 'they' (third person) about baptism-for-the-dead distances Paul from the practice. He uses the practice (whatever it was) as ad-hominem argument against resurrection-deniers: even those who practice this are inconsistent if they deny resurrection. Paul does not endorse the practice; he uses it argumentatively. Christian theology has not generally adopted proxy-baptism."
+          },
+          {
+            "name": "Mormon proxy-baptism (LDS reading)",
+            "proponents": "Latter-day Saints theology",
+            "argument": "LDS theology reads the verse as Paul's reference to a real, divinely-sanctioned proxy-baptism practice for deceased relatives. The LDS Temple practice of baptism-for-the-dead is grounded in this verse. Paul's ad-hominem use is read as implicit endorsement."
+          },
+          {
+            "name": "Some early Christian practice Paul tolerated but did not commend",
+            "proponents": "Critical mainstream",
+            "argument": "Some 1st-century Christians (perhaps Corinthian sub-group) practiced baptism-for-deceased catechumens or recently-converted-but-died-before-baptism family members. Paul mentions the practice without explicit endorsement. The practice did not become broadly-Christian; the verse remains evidence of a now-lost early-Christian practice."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/2.json
+++ b/content/1_corinthians/2.json
@@ -391,22 +391,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 2:13",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase pneumatikois pneumatika synkrinontes is ambiguous: it may mean ‘interpreting spiritual things to spiritual people’ or ‘combining spiritual …",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Wisdom from the Spirit within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 2:6-16's 'wisdom for the mature' / 'natural vs spiritual person': two-class Christianity or one-class with growth?",
+        "positions": [
+          {
+            "name": "Two-class Christianity (mature vs ordinary)",
+            "proponents": "Some patristic readings; some Pentecostal traditions",
+            "argument": "Paul speaks 'wisdom for the mature' (teleioi) distinct from elementary teaching given the immature. The verses suggest tiered Christian-formation: some believers attain spiritual-wisdom levels others do not reach. Reading supports two-tier ecclesiology with differentiated spiritual-knowledge access."
+          },
+          {
+            "name": "One-class Christianity with growth-stages",
+            "proponents": "Fee, Garland, mainstream evangelical",
+            "argument": "Paul's contrast is not between two categories of Christians but between believers (any maturity-level) and unbelievers (the natural-soulish person). The 'mature' refers to Christians vs. non-Christians, not advanced-Christians vs. ordinary-ones. All believers receive the Spirit; growth is real but the basic-categorical line is between Spirit-having and Spirit-lacking."
+          },
+          {
+            "name": "Both: real maturity-distinctions within unified believer-category",
+            "proponents": "Thiselton",
+            "argument": "Paul recognizes both the believer/unbeliever foundational distinction and real maturity-development within Christian community. The two readings are not exclusive: there is one Christian category (Spirit-indwelled) with genuine growth-stages within it."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/3.json
+++ b/content/1_corinthians/3.json
@@ -486,22 +486,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 3:16",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The question ouk oidate (‘don’t you know?’) appears ten times in 1 Corinthians and consistently introduces truths the Corinthians should know but are …",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Foundation and the Temple within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 3:10-15's 'fire that tests each one's work': believers' final judgment, purgatory-doctrine, or Christian-pastoral teaching?",
+        "positions": [
+          {
+            "name": "Believers' rewards-judgment (post-salvation)",
+            "proponents": "Reformed mainstream; Schreiner, Garland",
+            "argument": "Paul describes believers being saved 'as through fire' — already-saved persons whose works are tested for reward purposes. The judgment-of-works does not concern salvation (which is secured by Christ) but reward-quality. The text supports the doctrine of differentiated heavenly-rewards based on faithful-service."
+          },
+          {
+            "name": "Purgatory doctrine (post-mortem purification)",
+            "proponents": "Roman Catholic tradition (citing this text)",
+            "argument": "Catholic theology has historically read 'saved through fire' as suggesting post-mortem purification from sins. The believer is saved but undergoes fire-purification before final beatitude. This reading became one of the central proof-texts for purgatory doctrine in medieval Catholic theology."
+          },
+          {
+            "name": "Pastoral-corporate teaching about ministry-quality",
+            "proponents": "Fee, Witherington",
+            "argument": "The immediate context (Corinthian factionalism over apostolic-leaders) addresses ministry-quality, not individual-believers' afterlife. Paul targets specifically the Corinthian apostles/teachers ('let each one take care how he builds') warning against shoddy ecclesiastical-construction. The 'fire' tests teachers' work-quality; the 'saved through fire' refers to faithful-but-faulty teachers themselves being preserved."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/4.json
+++ b/content/1_corinthians/4.json
@@ -489,22 +489,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 4:6",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase to mē hyper ha gegraptai (‘not beyond what is written’) is one of the most debated phrases in 1 Corinthians. Options include: (a) a general…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads The Apostles as Servants of Christ within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 4:14-21's 'reign with Christ' irony: critique of over-realized eschatology or affirmation of present-kingdom reality?",
+        "positions": [
+          {
+            "name": "Critique of over-realized eschatology",
+            "proponents": "Mainstream evangelical; Thiselton, Fee",
+            "argument": "Paul's 'already you have become rich, already you reign as kings' (v.8) is irony — the Corinthians have collapsed eschatological-future into present-experience, treating themselves as already-glorified. Paul's rebuke (he and apostles still suffer 'last of all... a spectacle') restores the not-yet eschatological tension. The chapter critiques realized-eschatology gone wrong."
+          },
+          {
+            "name": "Affirmation of inaugurated reign",
+            "proponents": "Some charismatic readings",
+            "argument": "Paul's irony does not deny believers' present-reign-with-Christ but corrects its misuse. Believers do reign with Christ already (Eph 2:6), but with cruciform-suffering, not triumphalism. The chapter's apostolic-suffering example demonstrates how present-reign actually operates."
+          },
+          {
+            "name": "Both: present-reign reality requires cruciform-shape",
+            "proponents": "Garland, Hays",
+            "argument": "The two readings are not opposed. Paul corrects the Corinthian misappropriation of inaugurated-eschatology while preserving its substance. Present-reign with Christ is real but operates in suffering-and-service mode until the parousia. The chapter combines critique-of-misuse with affirmation-of-genuine-reign."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/5.json
+++ b/content/1_corinthians/5.json
@@ -377,22 +377,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 5:5",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase eis olethron tēs sarkos (‘for the destruction of the flesh’) is debated: sarx may mean the physical body (implying illness or death) or the…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Expel the Immoral Brother within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 5's church-discipline of incestuous man: 'hand him over to Satan' — physical-death excommunication or restorative-purpose discipline?",
+        "positions": [
+          {
+            "name": "Restorative-purpose discipline",
+            "proponents": "Mainstream evangelical; Garland, Fee",
+            "argument": "v.5's 'so that his spirit may be saved on the day of the Lord' shows the discipline's restorative aim. The exclusion from community puts the offender in 'Satan's domain' (outside the church-of-Christ's-protection) so that the suffering produces repentance and eventual restoration. The 2 Cor 2:5-11 sequel suggests this man (or similar offender) was indeed restored."
+          },
+          {
+            "name": "Physical-death-resulting excommunication",
+            "proponents": "Some critical readings",
+            "argument": "'Destruction of the flesh' (v.5) may indicate physical death as result of excommunication. The Corinthian discipline involves removing the offender from divine-protection that covenant-community provides; without that protection, physical death may result. The verse is theologically severe but coherent within Paul's framework."
+          },
+          {
+            "name": "Both: severe discipline with restorative aim",
+            "proponents": "Thiselton, Hays",
+            "argument": "The discipline is genuinely severe (potentially deadly) while its purpose is salvific. Paul does not soften the consequences but holds them within restorative-pastoral aim. The disciplinary act may produce physical-suffering or death; its goal is the offender's eventual salvation. The text resists both sentimentalization and severity-without-purpose."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/6.json
+++ b/content/1_corinthians/6.json
@@ -391,38 +391,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 6:9",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The compound term arsenokoitai (v. 9) combines arsenos (‘male’) and koitē (‘bed’), likely coined from the LXX of Lev 18:22 and 20:13. Its precise scop…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Lawsuits Among Believers and the Body as Temple within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 6:12",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase panta moi exestin (‘I have the right to do anything’ or ‘all things are lawful for me’) is probably a Corinthian slogan that Paul quotes an…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Lawsuits Among Believers and the Body as Temple within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 6:1-11's 'saints will judge the world / angels': eschatological-future judgment role or symbolic-spiritual authority?",
+        "positions": [
+          {
+            "name": "Future eschatological judgment-role",
+            "proponents": "Schreiner, Garland",
+            "argument": "Paul appeals to a future role believers will play in eschatological judgment (Matt 19:28; Rev 20:4) — they will participate in Christ's judgment of the world and angels. The argument: if you will exercise that future-eschatological judgment, surely you can handle present trivial-disputes. The verses presume a real future-judicial role."
+          },
+          {
+            "name": "Symbolic-spiritual authority",
+            "proponents": "Fee, Thiselton",
+            "argument": "The 'judging' is symbolic-spiritual authority believers possess in Christ rather than literal-future-courtroom role. Paul's argument uses the language hyperbolically to motivate Corinthians to handle disputes internally. The future-judgment scene is not literal courtroom-process but reflects believers' identity in Christ."
+          },
+          {
+            "name": "Both: real eschatological role experienced symbolically now",
+            "proponents": "Witherington",
+            "argument": "Paul holds both: a genuine future-eschatological judging-role + present-symbolic authority through union with Christ. The two are continuous — present spiritual-authority anticipates future-eschatological function. The argument's force depends on real-future-role being theologically operative now."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/7.json
+++ b/content/1_corinthians/7.json
@@ -587,38 +587,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 7:26",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase tēn enestōsan anankēn (‘the present crisis’ or ‘the impending distress’) is debated: does enestōsan mean ‘present’ (already here) or ‘impen…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Marriage, Singleness, and the Present Crisis within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 7:36",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The identity of the ‘man’ (tis) and his ‘virgin’ (parthenos) is the most debated interpretive question in the chapter. The NIV translates as ‘the virg…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Marriage, Singleness, and the Present Crisis within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 7's marriage / celibacy / divorce instruction: timeless principle or context-specific advice for impending-crisis?",
+        "positions": [
+          {
+            "name": "Context-specific 'present distress' advice",
+            "proponents": "Fee, Garland",
+            "argument": "v.26 explicitly grounds Paul's advice in 'the present distress' (eschatological-imminent crisis) — likely persecution, social upheaval, or eschatological-tension. Paul's celibacy-preference is pragmatic counsel for crisis-conditions, not timeless devaluation of marriage. The chapter must be read as context-bound."
+          },
+          {
+            "name": "Timeless principles with situational application",
+            "proponents": "Schreiner, MacArthur",
+            "argument": "Paul articulates lasting Christian-marriage principles (mutual-conjugal-rights, divorce-prohibitions, mixed-marriage guidance) that transcend the specific Corinthian context. The 'present distress' affects emphasis but not substance. Paul's instructions remain theologically-binding across Christian history."
+          },
+          {
+            "name": "Layered: timeless principles within context-specific advice",
+            "proponents": "Thiselton, Witherington",
+            "argument": "The chapter combines genuine timeless-principles (Christian marriage-ethics) with context-specific applications (celibacy-preference for the imminent crisis). Reading at one register without the other distorts: pure-timelessness misreads the explicit context-markers; pure-contextualism dismisses durable Christian-ethical content."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/8.json
+++ b/content/1_corinthians/8.json
@@ -367,22 +367,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 8:6",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The bipartite formula (one God, one Lord) adapts the Jewish Shema (Deut 6:4), splitting the divine identity between the Father and Christ. The preposi…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Food Offered to Idols within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 8's idol-meat: relativism, accommodation, or the 'stronger conscience' principle?",
+        "positions": [
+          {
+            "name": "Stronger-conscience principle (limit-rights for weaker)",
+            "proponents": "Mainstream evangelical; Fee, Garland",
+            "argument": "Paul establishes that idols are nothing (vv.4-6) and meat is morally indifferent. But knowledge-confident believers must limit their freedom for the sake of weaker-conscience brothers who would be wounded. Christian liberty is real but bounded by love. The principle extends widely in Christian ethics."
+          },
+          {
+            "name": "Anti-syncretism boundary (some idol-meat is dangerous)",
+            "proponents": "Witherington (with 1 Cor 10:14-22)",
+            "argument": "Paul does not blanket-permit idol-meat. Ch 10:14-22 prohibits temple-feast-participation as actual demonic-fellowship. Ch 8's 'idols are nothing' coexists with ch 10's 'do not participate in demonic-table.' The boundary preserves both Christian-liberty and worship-purity."
+          },
+          {
+            "name": "Both: liberty respected in private; boundary maintained in cultic contexts",
+            "proponents": "Thiselton, Hays",
+            "argument": "Paul holds both: idol-meat eaten privately is morally indifferent (ch 8 + 10:25-30); temple-cultic participation is forbidden (10:14-22). The two contexts require different responses. The 'weaker-conscience' principle operates within the moral-indifference cases; the cultic-boundary is non-negotiable."
+          }
+        ]
+      }
     ],
     "thread": [
       {

--- a/content/1_corinthians/9.json
+++ b/content/1_corinthians/9.json
@@ -600,38 +600,26 @@
       }
     ],
     "debate": [
-      [
-        "Interpretive Question: 9:5",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The phrase 'a believing wife' (adelphēn gynaika) is literally 'a sister wife'—a woman who is a fellow believer. The NET note observes that some interp…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Paul's Rights as an Apostle within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ],
-      [
-        "Interpretive Question: 9:9–10",
-        [
-          [
-            "Critical/Analytical scholarship",
-            "The interpretive crux is Paul's question: 'Is it about oxen that God is concerned?' The NET note clarifies that Paul is not denying God's care for ani…",
-            "Emphasises historical-critical, literary, or text-critical analysis."
-          ],
-          [
-            "Traditional/Confessional reading",
-            "Reads Paul's Rights as an Apostle within the canonical framework of fulfilled prophecy and covenant theology.",
-            "Represented by Calvin, MacArthur, and the evangelical tradition."
-          ]
-        ],
-        "Both readings engage the text seriously; they differ primarily in their hermeneutical starting points and assumptions about authorship and historical context."
-      ]
+      {
+        "title": "1 Cor 9's apostolic rights and Paul's voluntary renunciation: model for vocational-ministry or unique apostolic-stance?",
+        "positions": [
+          {
+            "name": "Model for all Christian vocational-ministry",
+            "proponents": "Mainstream evangelical",
+            "argument": "Paul's principles (the laborer is worthy of pay; nevertheless, willingness to forgo rights for gospel-mission) extend to all gospel-workers. The chapter has historically grounded Christian financial-support practices for missionaries and pastors — the right to be supported + freedom to forgo support for strategic-missional reasons."
+          },
+          {
+            "name": "Specifically apostolic stance (not generalisable)",
+            "proponents": "Some critical readings",
+            "argument": "Paul writes about specifically apostolic-rights and apostolic-renunciations within the unique mission to Corinth. The principles are context-bound to apostolic mission-strategy and do not necessarily extend to ordinary-ministerial situations. The chapter's force is specifically Pauline-apostolic, not generally-ministerial."
+          },
+          {
+            "name": "Apostolic example with paradigmatic implications",
+            "proponents": "Fee, Garland",
+            "argument": "Paul's specific apostolic situation provides the paradigm for ministry-financial-ethics that extends beyond apostles to all gospel-workers. The principle (right to support + freedom to renounce) generalises while the specific applications vary. NT and church-history have rightly drawn lessons from Paul's example for broader ministerial-economic life."
+          }
+        ]
+      }
     ],
     "thread": [
       {


### PR DESCRIPTION
Refs #1626. 1 Corinthians 15 templated debates rewritten across all 15 chapters (cross/wisdom, mature/spiritual person, fire-judgment, reign-with-Christ, church-discipline, judging-angels, marriage/celibacy, idol-meat, apostolic rights, wilderness typology, head-coverings, gifts cessation/continuation, love-chapter, women's silence, baptism-for-dead). 15 findings → 0. 15 files; +315 / -335.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JCmWA2JW579hcQNncKDc4)_