### PR TITLE
chore: remove stale DB commit-back step from content-pipeline

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -93,21 +93,6 @@ jobs:
           pip install boto3
           python3 _tools/upload_to_r2.py
 
-      # ── Commit rebuilt assets back to repo ───────────────────
-
-      - name: Commit rebuilt DB and manifest
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add app/assets/scripture.db app/assets/db-manifest.json scripture.db
-          if git diff --cached --quiet; then
-            echo "No asset changes to commit"
-          else
-            git commit -m "Rebuild scripture.db [content-pipeline]"
-            git push
-          fi
-
       # ── Stage 2: Detect changed chapters ─────────────────────
 
       - name: Detect changed content


### PR DESCRIPTION
## Problem

The `Commit rebuilt DB and manifest` step in `.github/workflows/content-pipeline.yml` is failing on every master push:

```
The following paths are ignored by one of your .gitignore files:
app/assets/scripture.db
scripture.db
hint: Use -f if you really want to add them.
Error: Process completed with exit code 1.
```

## Root Cause

The step is a fossil from the pre-R2 era when `scripture.db` was committed back to the repo by CI. Since commit 93d0267b, the DB is gitignored and delivered via CloudFlare R2. The preceding `Upload to CloudFlare R2` step is now the publication mechanism — committing the binary back to git would actively undo the architecture change.

`git add` (without `-f`) errors out when explicitly given an ignored path, hence the failure.

## Fix

Delete the stale step entirely. R2 is the source of truth.

## What is *not* changing

- `app/assets/db-manifest.json` is still tracked. It is no longer auto-updated by CI, but it is also not the source of truth — the app reads `db/manifest.json` from R2. The in-tree copy becomes a one-time historical snapshot and is harmless if stale.
- The R2 upload step is unchanged.
- No application code paths are affected.

## Rollback

Revert this commit. The workflow will resume failing on master pushes (the original behavior we are fixing).

## Verification

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Diff is a pure deletion — no other steps touched.
- Next master merge that touches `content/**` or `_tools/**` will exercise the change.