### PR TITLE
feat: chapter mode tiers (read/study/deep) — refactor + onboarding gate

### DIFF
--- a/app/__tests__/screens/ChapterScreen.test.tsx
+++ b/app/__tests__/screens/ChapterScreen.test.tsx
@@ -112,7 +112,7 @@ jest.mock('@/stores', () => ({
       setTranslation: jest.fn(),
       gettingStartedDone: new Set(),
     }),
-    { getState: () => ({ markGettingStartedDone: jest.fn(), focusMode: false, gettingStartedDone: new Set() }) },
+    { getState: () => ({ markGettingStartedDone: jest.fn(), chapterMode: 'study', gettingStartedDone: new Set() }) },
   ),
   useReaderStore: (sel: any) => sel({
     activePanel: null,

--- a/app/__tests__/stores/settingsStore.test.ts
+++ b/app/__tests__/stores/settingsStore.test.ts
@@ -101,13 +101,13 @@ describe('settingsStore', () => {
       expect(useSettingsStore.getState().isHydrated).toBe(true);
     });
 
-    it('hydrates ttsVoice, comparisonTranslation, redLetterEnabled, focusMode', async () => {
+    it('hydrates ttsVoice, comparisonTranslation, redLetterEnabled, chapterMode', async () => {
       getPreference.mockImplementation((key: string) => {
         const map: Record<string, string> = {
           ttsVoice: 'en-US-voice-1',
           comparisonTranslation: 'asv',
           redLetterEnabled: '0',
-          focusMode: '1',
+          chapter_mode: 'deep',
         };
         return Promise.resolve(map[key] ?? null);
       });
@@ -117,7 +117,7 @@ describe('settingsStore', () => {
       expect(state.ttsVoice).toBe('en-US-voice-1');
       expect(state.comparisonTranslation).toBe('asv');
       expect(state.redLetterEnabled).toBe(false);
-      expect(state.focusMode).toBe(true);
+      expect(state.chapterMode).toBe('deep');
     });
 
     it('hydrates gettingStartedDone from JSON', async () => {
@@ -196,16 +196,60 @@ describe('settingsStore', () => {
     });
   });
 
-  describe('toggleFocusMode', () => {
-    it('toggles focusMode and persists', () => {
-      useSettingsStore.setState({ focusMode: false });
-      useSettingsStore.getState().toggleFocusMode();
-      expect(useSettingsStore.getState().focusMode).toBe(true);
-      expect(setPreference).toHaveBeenCalledWith('focusMode', '1');
+  describe('chapterMode', () => {
+    it('starts as "study" before hydrate', () => {
+      useSettingsStore.setState({ chapterMode: 'study' });
+      expect(useSettingsStore.getState().chapterMode).toBe('study');
+    });
 
-      useSettingsStore.getState().toggleFocusMode();
-      expect(useSettingsStore.getState().focusMode).toBe(false);
-      expect(setPreference).toHaveBeenCalledWith('focusMode', '0');
+    it('setChapterMode("read") updates state and persists chapter_mode', () => {
+      useSettingsStore.getState().setChapterMode('read');
+      expect(useSettingsStore.getState().chapterMode).toBe('read');
+      expect(setPreference).toHaveBeenCalledWith('chapter_mode', 'read');
+    });
+
+    it('setChapterMode("deep") updates state and persists chapter_mode', () => {
+      useSettingsStore.getState().setChapterMode('deep');
+      expect(useSettingsStore.getState().chapterMode).toBe('deep');
+      expect(setPreference).toHaveBeenCalledWith('chapter_mode', 'deep');
+    });
+
+    it('hydrate reads chapter_mode="read"', async () => {
+      getPreference.mockImplementation((key: string) =>
+        Promise.resolve(key === 'chapter_mode' ? 'read' : null),
+      );
+      await useSettingsStore.getState().hydrate();
+      expect(useSettingsStore.getState().chapterMode).toBe('read');
+    });
+
+    it('hydrate reads chapter_mode="study"', async () => {
+      getPreference.mockImplementation((key: string) =>
+        Promise.resolve(key === 'chapter_mode' ? 'study' : null),
+      );
+      await useSettingsStore.getState().hydrate();
+      expect(useSettingsStore.getState().chapterMode).toBe('study');
+    });
+
+    it('hydrate reads chapter_mode="deep"', async () => {
+      getPreference.mockImplementation((key: string) =>
+        Promise.resolve(key === 'chapter_mode' ? 'deep' : null),
+      );
+      await useSettingsStore.getState().hydrate();
+      expect(useSettingsStore.getState().chapterMode).toBe('deep');
+    });
+
+    it('hydrate falls back to "study" when chapter_mode is absent', async () => {
+      getPreference.mockResolvedValue(null);
+      await useSettingsStore.getState().hydrate();
+      expect(useSettingsStore.getState().chapterMode).toBe('study');
+    });
+
+    it('hydrate falls back to "study" when chapter_mode is invalid', async () => {
+      getPreference.mockImplementation((key: string) =>
+        Promise.resolve(key === 'chapter_mode' ? 'garbage' : null),
+      );
+      await useSettingsStore.getState().hydrate();
+      expect(useSettingsStore.getState().chapterMode).toBe('study');
     });
   });
 

--- a/app/src/components/ChapterModePicker.tsx
+++ b/app/src/components/ChapterModePicker.tsx
@@ -1,0 +1,93 @@
+/**
+ * ChapterModePicker — Bottom sheet for switching the chapter reading mode
+ * from the chapter nav bar. Mirrors the AuthorshipSheet structure.
+ *
+ * Tap a mode to persist via settingsStore.setChapterMode and close. No
+ * "Recommended" pip — onboarding owns that affordance.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, Modal, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useSettingsStore, type ChapterMode } from '../stores/settingsStore';
+import { MODE_META, ModeChoiceCard } from './onboarding/ModeChoiceCard';
+
+interface Props {
+  visible: boolean;
+  currentMode: ChapterMode;
+  onClose: () => void;
+}
+
+export function ChapterModePicker({ visible, currentMode, onClose }: Props) {
+  const { base } = useTheme();
+  const setChapterMode = useSettingsStore((s) => s.setChapterMode);
+
+  const handlePick = (mode: ChapterMode) => {
+    if (mode !== currentMode) {
+      setChapterMode(mode);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <TouchableOpacity
+        style={styles.backdrop}
+        activeOpacity={1}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Close mode picker"
+      />
+      <SafeAreaView
+        style={[
+          styles.sheet,
+          { backgroundColor: base.bgElevated, borderColor: base.border },
+        ]}
+      >
+        <View style={styles.content}>
+          <View style={[styles.handle, { backgroundColor: base.textMuted }]} />
+
+          <Text style={[styles.title, { color: base.gold }]}>
+            Chapter Reading Mode
+          </Text>
+
+          {MODE_META.map((meta) => (
+            <ModeChoiceCard
+              key={meta.mode}
+              mode={meta.mode}
+              selected={meta.mode === currentMode}
+              onPress={() => handlePick(meta.mode)}
+            />
+          ))}
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+  },
+  sheet: {
+    borderTopLeftRadius: radii.lg,
+    borderTopRightRadius: radii.lg,
+    borderTopWidth: 1,
+  },
+  content: {
+    padding: spacing.md,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 16,
+    marginBottom: spacing.md,
+  },
+});

--- a/app/src/components/ChapterNavBar.tsx
+++ b/app/src/components/ChapterNavBar.tsx
@@ -12,10 +12,11 @@
 import React, { useCallback, useState } from 'react';
 import { View, Text, TouchableOpacity, Modal, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ArrowLeft, ChevronLeft, ChevronRight, Info, Volume2, Check, BookOpen, Eye } from 'lucide-react-native';
+import { ArrowLeft, ChevronLeft, ChevronRight, Info, Volume2, Check, Layers } from 'lucide-react-native';
 import { lightImpact, selectionFeedback } from '../utils/haptics';
 import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
 import { TRANSLATIONS } from '../db/translationRegistry';
+import type { ChapterMode } from '../stores/settingsStore';
 import { CompactDropdown, type DropdownOption } from './CompactDropdown';
 
 const TRANSLATION_OPTIONS: DropdownOption[] = TRANSLATIONS.map((t) => ({
@@ -40,8 +41,8 @@ interface Props {
   comparisonTranslation: string | null;
   onCompareStart: (t: string) => void;
   onCompareEnd: () => void;
-  focusMode?: boolean;
-  onFocusToggle?: () => void;
+  chapterMode?: ChapterMode;
+  onModePress?: () => void;
 }
 
 export function ChapterNavBar({
@@ -49,7 +50,7 @@ export function ChapterNavBar({
   onPrev, onNext, onQnav, onBack, onIntroPress, onTTSPress, ttsActive,
   translation, onTranslationChange,
   comparisonTranslation, onCompareStart, onCompareEnd,
-  focusMode, onFocusToggle,
+  chapterMode, onModePress,
 }: Props) {
   const { base } = useTheme();
   const [comparePicker, setComparePicker] = useState(false);
@@ -148,18 +149,16 @@ export function ChapterNavBar({
           </TouchableOpacity>
         </View>
 
-        {/* Right: Focus + TTS + ⓘ */}
+        {/* Right: Mode picker + TTS + ⓘ */}
         <View style={[styles.sideSection, styles.sideSectionRight]}>
-          {onFocusToggle ? (
+          {onModePress ? (
             <TouchableOpacity
-              onPress={onFocusToggle}
-              accessibilityLabel={focusMode ? 'Exit reading mode' : 'Enter reading mode'}
+              onPress={onModePress}
+              accessibilityLabel={chapterMode ? `Chapter reading mode: ${chapterMode}. Tap to change.` : 'Chapter reading mode'}
               accessibilityRole="button"
               style={styles.actionButton}
             >
-              {focusMode
-                ? <BookOpen size={18} color={base.gold} />
-                : <Eye size={18} color={base.textMuted} />}
+              <Layers size={18} color={base.textMuted} />
             </TouchableOpacity>
           ) : null}
           {onTTSPress ? (

--- a/app/src/components/ChapterReaderContext.tsx
+++ b/app/src/components/ChapterReaderContext.tsx
@@ -8,6 +8,7 @@
 import React, { createContext, useContext, type ReactNode } from 'react';
 import type { Verse, VHLGroup, CoachingTip, ChapterCoaching } from '../types';
 import type { OpenPanelParam } from '../navigation/types';
+import type { ChapterMode } from '../stores/settingsStore';
 
 // ── Verse rendering state ──
 interface VerseState {
@@ -61,7 +62,7 @@ interface CoachingState {
 
 // ── Display state ──
 interface DisplayState {
-  focusMode: boolean;
+  tier: ChapterMode;
 }
 
 export interface ChapterReaderContextValue {

--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -52,6 +52,10 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
 }: Props) {
   const { base } = useTheme();
   const { verse, panel, callbacks, layout, coaching, display } = useChapterReader();
+  // PR 1 parity bridge: `isFocus` mirrors the prior boolean focusMode
+  // behavior. PR 2 replaces these checks with helper calls from
+  // utils/chapterMode.ts that distinguish 'study' vs 'deep'.
+  const isFocus = display.tier === 'read';
   const relatedItems = useRelatedContent(chapterMeta, chapterPanels);
   const { chipData } = useMapChipData(chapterMeta?.map_story_link_id);
   const navigation = useNavigation();
@@ -102,8 +106,8 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
             onVerseLongPress={callbacks.onVerseLongPress}
             onVerseNumPress={callbacks.onInterlinearPress}
             activeVerseNum={verse.activeVerseNum}
-            depthExplored={display.focusMode ? undefined : panel.depthMap.get(sec.id)?.explored}
-            depthTotal={display.focusMode ? undefined : panel.depthMap.get(sec.id)?.total}
+            depthExplored={isFocus ? undefined : panel.depthMap.get(sec.id)?.explored}
+            depthTotal={isFocus ? undefined : panel.depthMap.get(sec.id)?.total}
             onDepthRecord={callbacks.recordOpen}
             comparisonVerses={verse.comparisonVerses}
             comparisonLabel={verse.comparisonLabel}
@@ -113,7 +117,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
             onVerseLayout={(verseNum, y, sectionId) => {
               layout.onVerseLayout(verseNum, y, sectionId);
             }}
-            renderButtonRow={display.focusMode ? undefined : (panels, sectionId) => (
+            renderButtonRow={isFocus ? undefined : (panels, sectionId) => (
               <View onLayout={(e) => {
                 layout.onBtnRowLayout(sectionId, 0, e.nativeEvent.layout.y);
               }}>
@@ -129,7 +133,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
                 />
               </View>
             )}
-            renderPanel={display.focusMode ? undefined : (p) => (
+            renderPanel={isFocus ? undefined : (p) => (
               <PanelContainer
                 panelType={p.panel_type}
                 contentJson={p.content_json}
@@ -148,7 +152,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
       );
 
       // Inject coaching card after this section if applicable (hidden in focus mode)
-      if (!display.focusMode && coaching.studyCoachEnabled && coaching.coachingTips.length > 0) {
+      if (!isFocus && coaching.studyCoachEnabled && coaching.coachingTips.length > 0) {
         const tip = coaching.coachingTips.find((t) => t.after_section === sec.section_num);
         if (tip && !coaching.dismissedTips.has(tip.after_section)) {
           elements.push(
@@ -164,14 +168,14 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
 
       return elements;
     });
-  }, [sections, verse, panel, callbacks, layout, coaching, display, handlePanelLongPress]);
+  }, [sections, verse, panel, callbacks, layout, coaching, isFocus, handlePanelLongPress]);
 
   return (
     <>
       {sectionElements}
 
       {/* Chapter-level scholarly block (hidden in focus mode) */}
-      {!display.focusMode && (
+      {!isFocus && (
         <ScholarlyBlock
           chapterPanels={chapterPanels}
           activePanel={panel.activeChapterPanelType}
@@ -188,14 +192,14 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
       )}
 
       {/* Scholar disclaimer */}
-      {!display.focusMode && (
+      {!isFocus && (
         <Text style={[styles.scholarDisclaimer, { color: base.textMuted }]}>
           Scholar commentary panels present paraphrased summaries of positions found in published works and are not direct quotations. For exact wording, consult the original sources cited.
         </Text>
       )}
 
       {/* Chapter-level coaching (study guide) */}
-      {!display.focusMode && coaching.studyCoachEnabled && coaching.chapterCoaching ? (
+      {!isFocus && coaching.studyCoachEnabled && coaching.chapterCoaching ? (
         <ChapterCoachingCard coaching={coaching.chapterCoaching} />
       ) : null}
 
@@ -206,7 +210,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
       {prayerPrompt ? <PrayerPromptCard prompt={prayerPrompt} /> : null}
 
       {/* Inline map chip for chapters with a map_story_link (#1322). */}
-      {!display.focusMode && chipData ? (
+      {!isFocus && chipData ? (
         <MapChip
           story={chipData.story}
           places={chipData.places}
@@ -221,7 +225,7 @@ const ChapterVerseList = React.memo(function ChapterVerseList({
       ) : null}
 
       {/* Related Content carousel (hidden in focus mode) */}
-      {!display.focusMode && <RelatedContentCarousel items={relatedItems} />}
+      {!isFocus && <RelatedContentCarousel items={relatedItems} />}
 
       {/* Panel info tooltip (long-press) */}
       <PanelInfoSheet

--- a/app/src/components/RelatedContentCarousel.tsx
+++ b/app/src/components/RelatedContentCarousel.tsx
@@ -3,7 +3,7 @@
  * linking to related Explore features for the current chapter.
  *
  * Replaces ContinueExploringFooter with content_images support.
- * Hidden when focusMode is active or no related content exists.
+ * Hidden in Read mode or when no related content exists.
  *
  * Part of Epic #1130.
  */

--- a/app/src/components/onboarding/ModeChoiceCard.tsx
+++ b/app/src/components/onboarding/ModeChoiceCard.tsx
@@ -1,0 +1,121 @@
+/**
+ * ModeChoiceCard — Shared row for choosing a chapter reading mode.
+ *
+ * Used by the onboarding mode-choice page and the in-app ChapterModePicker
+ * sheet. The "Recommended" pip is opt-in via the `recommended` prop —
+ * onboarding shows it, the in-app picker omits it.
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Check } from 'lucide-react-native';
+import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import type { ChapterMode } from '../../stores/settingsStore';
+
+export interface ModeMeta {
+  mode: ChapterMode;
+  label: string;
+  description: string;
+}
+
+export const MODE_META: ReadonlyArray<ModeMeta> = [
+  {
+    mode: 'read',
+    label: 'Read',
+    description: 'Just the words. Verse text, notes, prayer.',
+  },
+  {
+    mode: 'study',
+    label: 'Study',
+    description: 'Guided reading with context, journeys, and coach.',
+  },
+  {
+    mode: 'deep',
+    label: 'Deep Dive',
+    description: 'Adds scholar commentary, Hebrew/Greek, manuscripts, debates.',
+  },
+];
+
+export const RECOMMENDED_MODE: ChapterMode = 'study';
+
+interface Props {
+  mode: ChapterMode;
+  selected: boolean;
+  recommended?: boolean;
+  onPress: () => void;
+}
+
+export function ModeChoiceCard({ mode, selected, recommended, onPress }: Props) {
+  const { base } = useTheme();
+  const meta = MODE_META.find((m) => m.mode === mode);
+  if (!meta) return null;
+
+  const borderColor = selected ? base.gold : base.border;
+  const backgroundColor = selected ? base.gold + '15' : base.bgSurface;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.8}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      accessibilityLabel={`${meta.label}. ${meta.description}${recommended ? '. Recommended.' : ''}`}
+      style={[styles.card, { borderColor, backgroundColor }]}
+    >
+      <View style={styles.headerRow}>
+        <Text style={[styles.label, { color: base.text }]}>{meta.label}</Text>
+        <View style={styles.headerRight}>
+          {recommended ? (
+            <View style={[styles.pip, { backgroundColor: base.gold + '25', borderColor: base.gold + '60' }]}>
+              <Text style={[styles.pipText, { color: base.gold }]}>Recommended</Text>
+            </View>
+          ) : null}
+          {selected ? <Check size={18} color={base.gold} /> : null}
+        </View>
+      </View>
+      <Text style={[styles.description, { color: base.textDim }]}>{meta.description}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  label: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 16,
+    letterSpacing: 0.3,
+  },
+  description: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  pip: {
+    borderWidth: 1,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  pipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+});

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -613,7 +613,7 @@ export async function resetToNewUser(): Promise<void> {
   await db.runAsync('DELETE FROM study_session_events');
   await db.runAsync('DELETE FROM study_sessions');
   await db.runAsync(
-    "DELETE FROM user_preferences WHERE key IN ('onboarding_complete', 'focusMode', 'getting_started', 'startHereDismissed', 'lastStreakDate', 'currentStreak', 'longestStreak', 'studyMaturityOverride', 'panelOpenSet', 'lastSeenLevel')",
+    "DELETE FROM user_preferences WHERE key IN ('onboarding_complete', 'chapter_mode', 'getting_started', 'startHereDismissed', 'lastStreakDate', 'currentStreak', 'longestStreak', 'studyMaturityOverride', 'panelOpenSet', 'lastSeenLevel')",
   );
   await db.runAsync('DELETE FROM plan_progress');
   await db.runAsync(

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -53,6 +53,7 @@ import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import { ChapterVerseList } from '../components/ChapterVerseList';
 import { ChapterReaderProvider } from '../components/ChapterReaderContext';
 import { ChapterPanelSheet } from '../components/ChapterPanelSheet';
+import { ChapterModePicker } from '../components/ChapterModePicker';
 import { useChapterTTS } from '../hooks/chapter/useChapterTTS';
 import { useChapterHighlights } from '../hooks/chapter/useChapterHighlights';
 import { useChapterCoaching } from '../hooks/chapter/useChapterCoaching';
@@ -102,8 +103,11 @@ function ChapterScreen() {
   const { checkAndPrompt } = useStoreReview();
   const studyCoachEnabled = useSettingsStore((s) => s.studyCoachEnabled);
   const vhlEnabled = useSettingsStore((s) => s.vhlEnabled);
-  const focusMode = useSettingsStore((s) => s.focusMode);
-  const toggleFocusMode = useSettingsStore((s) => s.toggleFocusMode);
+  const chapterMode = useSettingsStore((s) => s.chapterMode);
+  // PR 1 parity bridge: `isFocus` mirrors the prior boolean focusMode
+  // behavior. PR 2 replaces these checks with helper calls from
+  // utils/chapterMode.ts that distinguish 'study' vs 'deep'.
+  const isFocus = chapterMode === 'read';
   const qnavOpen = useReaderStore((s) => s.qnavOpen);
   const toggleQnav = useReaderStore((s) => s.toggleQnav);
   const notesOverlayOpen = useReaderStore((s) => s.notesOverlayOpen);
@@ -115,6 +119,7 @@ function ChapterScreen() {
   const [activeLens, setActiveLens] = useState<string | null>(null);
   const [bookData, setBookData] = useState<Book | null>(null);
   const [showBreadcrumb, setShowBreadcrumb] = useState(!!openPanel);
+  const [modePickerOpen, setModePickerOpen] = useState(false);
 
   const {
     chapter,
@@ -233,8 +238,8 @@ function ChapterScreen() {
 
   // Clear active panels when focus mode is enabled
   useEffect(() => {
-    if (focusMode) panels.clearActivePanel();
-  }, [focusMode]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (isFocus) panels.clearActivePanel();
+  }, [isFocus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reset breadcrumb + lens on chapter change
   useEffect(() => {
@@ -259,8 +264,8 @@ function ChapterScreen() {
 
   // VHL highlights — controlled by Settings toggle; disabled in focus mode
   const activeVhlGroups = useMemo(
-    () => (vhlEnabled && !focusMode ? vhlGroups.map((g) => g.group_name) : []),
-    [vhlGroups, vhlEnabled, focusMode],
+    () => (vhlEnabled && !isFocus ? vhlGroups.map((g) => g.group_name) : []),
+    [vhlGroups, vhlEnabled, isFocus],
   );
 
   // Callbacks
@@ -337,8 +342,8 @@ function ChapterScreen() {
         comparisonTranslation={comparisonTranslation}
         onCompareStart={setComparisonTranslation}
         onCompareEnd={() => setComparisonTranslation(null)}
-        focusMode={focusMode}
-        onFocusToggle={toggleFocusMode}
+        chapterMode={chapterMode}
+        onModePress={() => setModePickerOpen(true)}
       />
 
       {showBreadcrumb && openPanel && (
@@ -354,7 +359,7 @@ function ChapterScreen() {
         </TouchableOpacity>
       )}
 
-      {!focusMode && availableLenses.length > 0 && (
+      {!isFocus && availableLenses.length > 0 && (
         <LensToggleBar
           lenses={availableLenses}
           activeLensId={activeLens}
@@ -362,7 +367,7 @@ function ChapterScreen() {
         />
       )}
 
-      {!focusMode && comparisonTranslation && (
+      {!isFocus && comparisonTranslation && (
         <CompareBar
           primaryLabel={TRANSLATION_MAP.get(translation)?.label ?? translation.toUpperCase()}
           comparisonLabel={
@@ -444,7 +449,7 @@ function ChapterScreen() {
           }
         />
 
-        {!focusMode && proofTextGuard ? (
+        {!isFocus && proofTextGuard ? (
           <ContextGuardBanner
             guard={proofTextGuard}
             onReadContext={() =>
@@ -456,7 +461,7 @@ function ChapterScreen() {
           />
         ) : null}
 
-        {!focusMode ? (
+        {!isFocus ? (
           <StudySessionCTA
             estimate={studyEstimate}
             mode={guidedStudyState.mode}
@@ -473,7 +478,7 @@ function ChapterScreen() {
           />
         ) : null}
 
-        {!focusMode && bookData?.genre_label && bookData?.genre_guidance ? (
+        {!isFocus && bookData?.genre_label && bookData?.genre_guidance ? (
           <GenreBanner genreLabel={bookData.genre_label} genreGuidance={bookData.genre_guidance} />
         ) : null}
 
@@ -520,7 +525,7 @@ function ChapterScreen() {
             dismissedTips,
             onDismissTip: handleDismissTip,
           }}
-          display={{ focusMode }}
+          display={{ tier: chapterMode }}
         >
           <ChapterVerseList
             sections={sections}
@@ -613,6 +618,12 @@ function ChapterScreen() {
         loadHighlights={loadHighlights}
         upgradeRequest={upgradeRequest}
         dismissUpgrade={dismissUpgrade}
+      />
+
+      <ChapterModePicker
+        visible={modePickerOpen}
+        currentMode={chapterMode}
+        onClose={() => setModePickerOpen(false)}
       />
     </View>
   );

--- a/app/src/screens/OnboardingScreen.tsx
+++ b/app/src/screens/OnboardingScreen.tsx
@@ -1,12 +1,13 @@
 /**
- * OnboardingScreen — 3-page carousel shown on first launch only.
+ * OnboardingScreen — 4-page carousel shown on first launch only.
  *
  * Page 1: App thesis
  * Page 2: Chapter reading experience (panel buttons demo)
  * Page 3: Explore tools overview
+ * Page 4: Mode choice — required tap before "Get Started"
  *
- * After completing or skipping, marks onboarding done and navigates
- * to Genesis 1 to start the user's reading journey.
+ * After completing or skipping (skip is hidden on the final page), marks
+ * onboarding done and navigates to Genesis 1.
  */
 
 import React, { useState, useRef, useMemo, useCallback } from 'react';
@@ -24,8 +25,16 @@ import { BookOpen, Layers, Map, Clock, Users, Search } from 'lucide-react-native
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { OnboardingDemo } from '../components/OnboardingDemo';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { useSettingsStore, type ChapterMode } from '../stores/settingsStore';
+import {
+  ModeChoiceCard,
+  MODE_META,
+  RECOMMENDED_MODE,
+} from '../components/onboarding/ModeChoiceCard';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+const MODE_CHOICE_KEY = 'modeChoice';
 
 interface Props {
   onComplete: () => void;
@@ -77,7 +86,7 @@ const PAGES: PageData[] = [
     key: 'explore',
     title: 'Explore Tools',
     subtitle: 'Tools that connect the dots across Scripture.',
-    body: 'Follow Abraham\u2019s journey on a map. Trace a Hebrew word through every book. See how an Old Testament promise finds its fulfillment. All offline, all free.',
+    body: 'Follow Abraham’s journey on a map. Trace a Hebrew word through every book. See how an Old Testament promise finds its fulfillment. All offline, all free.',
     renderContent: (base) => (
       <View style={styles.toolGrid}>
         <ToolIcon Icon={Users} label="People" base={base} />
@@ -89,13 +98,23 @@ const PAGES: PageData[] = [
       </View>
     ),
   },
+  {
+    key: MODE_CHOICE_KEY,
+    title: 'Choose how you read.',
+    subtitle: 'You can change this any time from the chapter screen.',
+    body: '',
+    renderContent: () => null,
+  },
 ];
 
 function OnboardingScreen({ onComplete }: Props) {
   const { base } = useTheme();
   const [currentPage, setCurrentPage] = useState(0);
+  const [selectedMode, setSelectedMode] = useState<ChapterMode | null>(null);
+  const setChapterMode = useSettingsStore((s) => s.setChapterMode);
   const flatListRef = useRef<FlatList>(null);
   const isLastPage = currentPage === PAGES.length - 1;
+  const ctaDisabled = isLastPage && selectedMode === null;
 
   const onViewableItemsChanged = useCallback(
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
@@ -108,7 +127,16 @@ function OnboardingScreen({ onComplete }: Props) {
 
   const viewabilityConfig = useMemo(() => ({ viewAreaCoveragePercentThreshold: 50 }), []);
 
+  const handleSelectMode = useCallback(
+    (mode: ChapterMode) => {
+      setSelectedMode(mode);
+      setChapterMode(mode);
+    },
+    [setChapterMode],
+  );
+
   const handleNext = () => {
+    if (ctaDisabled) return;
     if (isLastPage) {
       onComplete();
     } else {
@@ -116,27 +144,53 @@ function OnboardingScreen({ onComplete }: Props) {
     }
   };
 
-  const renderPage = ({ item }: { item: PageData }) => (
-    <View style={[styles.page, { width: SCREEN_WIDTH }]}>
-      {item.renderContent(base)}
-      <Text style={[styles.pageTitle, { color: base.gold }]}>{item.title}</Text>
-      <Text style={[styles.pageSubtitle, { color: base.text }]}>{item.subtitle}</Text>
-      <Text style={[styles.pageBody, { color: base.textDim }]}>{item.body}</Text>
-    </View>
-  );
+  const renderPage = ({ item }: { item: PageData }) => {
+    if (item.key === MODE_CHOICE_KEY) {
+      return (
+        <View style={[styles.page, { width: SCREEN_WIDTH }]}>
+          <Text style={[styles.pageTitle, { color: base.gold }]}>{item.title}</Text>
+          <Text style={[styles.pageSubtitle, { color: base.text }]}>{item.subtitle}</Text>
+          <View style={styles.modeList}>
+            {MODE_META.map((meta) => (
+              <ModeChoiceCard
+                key={meta.mode}
+                mode={meta.mode}
+                selected={selectedMode === meta.mode}
+                recommended={meta.mode === RECOMMENDED_MODE}
+                onPress={() => handleSelectMode(meta.mode)}
+              />
+            ))}
+          </View>
+        </View>
+      );
+    }
+    return (
+      <View style={[styles.page, { width: SCREEN_WIDTH }]}>
+        {item.renderContent(base)}
+        <Text style={[styles.pageTitle, { color: base.gold }]}>{item.title}</Text>
+        <Text style={[styles.pageSubtitle, { color: base.text }]}>{item.subtitle}</Text>
+        <Text style={[styles.pageBody, { color: base.textDim }]}>{item.body}</Text>
+      </View>
+    );
+  };
+
+  const ctaBg = ctaDisabled ? base.bgSurface : base.gold;
+  const ctaColor = ctaDisabled ? base.textMuted : base.bg;
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
-      {/* Skip button */}
+      {/* Skip button — hidden on the final mode-choice page */}
       <View style={styles.skipRow}>
-        <TouchableOpacity
-          onPress={onComplete}
-          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-          accessibilityLabel="Skip onboarding"
-          accessibilityRole="button"
-        >
-          <Text style={[styles.skipText, { color: base.textMuted }]}>Skip</Text>
-        </TouchableOpacity>
+        {!isLastPage ? (
+          <TouchableOpacity
+            onPress={onComplete}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            accessibilityLabel="Skip onboarding"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.skipText, { color: base.textMuted }]}>Skip</Text>
+          </TouchableOpacity>
+        ) : null}
       </View>
 
       {/* Carousel */}
@@ -173,11 +227,13 @@ function OnboardingScreen({ onComplete }: Props) {
 
         <TouchableOpacity
           onPress={handleNext}
-          style={[styles.ctaButton, { backgroundColor: base.gold }]}
+          disabled={ctaDisabled}
+          style={[styles.ctaButton, { backgroundColor: ctaBg }]}
           accessibilityLabel={isLastPage ? 'Get Started' : 'Next'}
           accessibilityRole="button"
+          accessibilityState={{ disabled: ctaDisabled }}
         >
-          <Text style={[styles.ctaText, { color: base.bg }]}>
+          <Text style={[styles.ctaText, { color: ctaColor }]}>
             {isLastPage ? 'Get Started' : 'Next'}
           </Text>
         </TouchableOpacity>
@@ -195,6 +251,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     paddingHorizontal: spacing.md,
     paddingTop: spacing.sm,
+    minHeight: 32,
   },
   skipText: {
     fontFamily: fontFamily.uiMedium,
@@ -276,6 +333,10 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.ui,
     fontSize: 10,
     textAlign: 'center',
+  },
+  modeList: {
+    width: '100%',
+    marginTop: spacing.lg,
   },
   footer: {
     alignItems: 'center',

--- a/app/src/screens/SettingsScreen.tsx
+++ b/app/src/screens/SettingsScreen.tsx
@@ -53,8 +53,8 @@ function SettingsScreen() {
   const setRedLetterEnabled = useSettingsStore((s) => s.setRedLetterEnabled);
   const studyCoachEnabled = useSettingsStore((s) => s.studyCoachEnabled);
   const setStudyCoachEnabled = useSettingsStore((s) => s.setStudyCoachEnabled);
-  const focusMode = useSettingsStore((s) => s.focusMode);
-  const toggleFocusMode = useSettingsStore((s) => s.toggleFocusMode);
+  const chapterMode = useSettingsStore((s) => s.chapterMode);
+  const setChapterMode = useSettingsStore((s) => s.setChapterMode);
   const theme = useSettingsStore((s) => s.theme);
   const setTheme = useSettingsStore((s) => s.setTheme);
   const amicusEnabled = useSettingsStore((s) => s.amicusEnabled);
@@ -98,8 +98,8 @@ function SettingsScreen() {
           setRedLetterEnabled={setRedLetterEnabled}
           studyCoachEnabled={studyCoachEnabled}
           setStudyCoachEnabled={setStudyCoachEnabled}
-          focusMode={focusMode}
-          toggleFocusMode={toggleFocusMode}
+          chapterMode={chapterMode}
+          setChapterMode={setChapterMode}
         />
 
         <VoicePicker base={base} />

--- a/app/src/screens/settings/PreferencesSection.tsx
+++ b/app/src/screens/settings/PreferencesSection.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Switch } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Switch } from 'react-native';
 import type { BaseColors } from '../../theme/palettes';
 import type { DropdownOption } from '../../components/CompactDropdown';
 import { CompactDropdown } from '../../components/CompactDropdown';
 import { ThemePicker } from '../../components/ThemePicker';
 import { ReadingScaleEditor } from '../../components/settings/ReadingScaleEditor';
+import { spacing, radii, fontFamily } from '../../theme';
+import type { ChapterMode } from '../../stores/settingsStore';
+import { MODE_META } from '../../components/onboarding/ModeChoiceCard';
 import { SectionLabel } from './SectionLabel';
 import { SettingsRow } from './SettingsRow';
 
@@ -23,8 +26,8 @@ interface PreferencesSectionProps {
   setRedLetterEnabled: (v: boolean) => void;
   studyCoachEnabled: boolean;
   setStudyCoachEnabled: (v: boolean) => void;
-  focusMode: boolean;
-  toggleFocusMode: () => void;
+  chapterMode: ChapterMode;
+  setChapterMode: (mode: ChapterMode) => void;
 }
 
 export function PreferencesSection({
@@ -40,8 +43,8 @@ export function PreferencesSection({
   setRedLetterEnabled,
   studyCoachEnabled,
   setStudyCoachEnabled,
-  focusMode,
-  toggleFocusMode,
+  chapterMode,
+  setChapterMode,
 }: PreferencesSectionProps) {
   return (
     <>
@@ -92,15 +95,66 @@ export function PreferencesSection({
         />
       </SettingsRow>
 
-      {/* Focus / Reading Mode */}
-      <SettingsRow label="Focus Mode" base={base}>
-        <Switch
-          value={focusMode}
-          onValueChange={toggleFocusMode}
-          trackColor={{ false: base.bgSurface, true: base.gold + '60' }}
-          thumbColor={focusMode ? base.gold : base.textMuted}
-        />
-      </SettingsRow>
+      {/* Chapter Reading Mode — 3-segment control */}
+      <View style={[styles.modeBlock, { borderBottomColor: base.border + '40' }]}>
+        <Text style={[styles.modeLabel, { color: base.text }]}>Chapter Reading Mode</Text>
+        <View style={[styles.segments, { borderColor: base.border, backgroundColor: base.bgSurface }]}>
+          {MODE_META.map((meta) => {
+            const active = meta.mode === chapterMode;
+            return (
+              <TouchableOpacity
+                key={meta.mode}
+                onPress={() => setChapterMode(meta.mode)}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={meta.label}
+                style={[
+                  styles.segment,
+                  active && { backgroundColor: base.gold + '25' },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.segmentText,
+                    { color: active ? base.gold : base.textMuted },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {meta.label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
     </>
   );
 }
+
+const styles = StyleSheet.create({
+  modeBlock: {
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+  },
+  modeLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 14,
+    marginBottom: spacing.sm,
+  },
+  segments: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    overflow: 'hidden',
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  segmentText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/stores/settingsStore.ts
+++ b/app/src/stores/settingsStore.ts
@@ -22,6 +22,10 @@ type ThemePreference = 'dark' | 'sepia' | 'light' | 'system';
 
 const VALID_THEMES: ThemePreference[] = ['dark', 'sepia', 'light', 'system'];
 
+export type ChapterMode = 'read' | 'study' | 'deep';
+
+const VALID_CHAPTER_MODES: ChapterMode[] = ['read', 'study', 'deep'];
+
 interface SettingsState {
   translation: string;
   readingScale: number;
@@ -32,7 +36,7 @@ interface SettingsState {
   ttsVoice: string;
   comparisonTranslation: string | null;
   redLetterEnabled: boolean;
-  focusMode: boolean;
+  chapterMode: ChapterMode;
   amicusEnabled: boolean;
   gettingStartedDone: Set<string>;
   isHydrated: boolean;
@@ -47,7 +51,7 @@ interface SettingsState {
   setComparisonTranslation: (t: string | null) => void;
   setRedLetterEnabled: (v: boolean) => void;
   setAmicusEnabled: (v: boolean) => void;
-  toggleFocusMode: () => void;
+  setChapterMode: (mode: ChapterMode) => void;
   markGettingStartedDone: (key: string) => void;
   hydrate: () => Promise<void>;
 }
@@ -62,7 +66,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   ttsVoice: '',
   comparisonTranslation: null,
   redLetterEnabled: true,
-  focusMode: false,
+  chapterMode: 'study',
   amicusEnabled: true,
   gettingStartedDone: new Set<string>(),
   isHydrated: false,
@@ -113,10 +117,9 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     setPreference('amicusEnabled', v ? '1' : '0').catch((err) => { logger.warn('settingsStore', 'Failed to persist amicusEnabled', err); });
   },
 
-  toggleFocusMode: () => {
-    const next = !useSettingsStore.getState().focusMode;
-    set({ focusMode: next });
-    setPreference('focusMode', next ? '1' : '0').catch((err) => { logger.warn('settingsStore', 'Failed to persist focusMode', err); });
+  setChapterMode: (mode) => {
+    set({ chapterMode: mode });
+    setPreference('chapter_mode', mode).catch((err) => { logger.warn('settingsStore', 'Failed to persist chapter_mode', err); });
   },
 
   markGettingStartedDone: (key: string) => {
@@ -145,7 +148,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       const voice = await getPreference('ttsVoice');
       const comp = await getPreference('comparisonTranslation');
       const rl = await getPreference('redLetterEnabled');
-      const fm = await getPreference('focusMode');
+      const cm = await getPreference('chapter_mode');
       const amicus = await getPreference('amicusEnabled');
       const gs = await getPreference('getting_started');
 
@@ -191,7 +194,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
         ttsVoice: voice ?? '',
         comparisonTranslation: (comp && TRANSLATION_MAP.has(comp)) ? comp : null,
         redLetterEnabled: rl !== '0',
-        focusMode: fm === '1',
+        chapterMode: (VALID_CHAPTER_MODES.includes(cm as ChapterMode) ? cm : 'study') as ChapterMode,
         amicusEnabled: amicus !== '0',
         gettingStartedDone: gsDone,
         isHydrated: true,


### PR DESCRIPTION
## Summary

Splits the current binary chapter display (Read vs everything-else) into a three-tier model: **Read**, **Study**, **Deep Dive**. Ships the data model, picker UI, settings UI, and onboarding gate. Allocation between Study and Deep Dive is deferred to PR 2.

## Why two PRs

- **PR 1 (this one):** mechanical refactor + new UI scaffolding. `chapterMode='read'` mirrors today's `focusMode=true`. `chapterMode='study'` and `'deep'` both mirror today's `focusMode=false`. Behavior-parity guarantee for existing rendering paths.
- **PR 2 (next):** introduces `app/src/utils/chapterMode.ts` with `isPanelVisibleInMode` / `isElementVisibleInMode` helpers and replaces the `isFocus` parity bridges. That's where Study and Deep Dive actually diverge.

Independently revertable. PR 1 revert restores the boolean; PR 2 revert restores the parity behavior.

## Allocation table (for PR 2 — not implemented here)

**Always shown:** verse text, highlights, notes, TTS, prayer prompt, related life topics, content library breadcrumb.

**Study tier adds:** lens toggle bar, compare bar, genre banner, study session CTA, study coach, map chip, related content carousel, VHL groups, context guard banner, depth tracking. Section panels: `ctx`, `cross`, `hist`. Chapter panels: `ppl`, `themes`.

**Deep Dive tier adds:** all remaining section panels (`heb`, `mac`, scholar commentary) and chapter panels (`trans`, `src`, `rec`, `lit`, `hebtext`, `thread`, `tx`, `debate`), plus scholar disclaimer text.

Existing premium gates on `debate` and `secondTemple` are unchanged — they fire within Deep Dive.

## Onboarding flow

- Page 4 added: "Choose how you read."
- Skip button hidden on page 4 only.
- "Get Started" CTA disabled until a mode is selected (visually muted, `accessibilityState.disabled`).
- Selection persists to `chapter_mode` immediately on tap so backgrounding doesn't lose it.
- Study has the "Recommended" pip; in-app picker omits it.

## Migration

No legacy users — app is pre-launch. Hydrate falls back to `'study'` when `chapter_mode` is absent. The legacy `focusMode` SQLite key is no longer read or written; it'll persist as orphan data on dev devices but is harmless. Data reset clears `chapter_mode` (key swap in `userMutations.ts`).

## Acceptance

- [x] `git grep focusMode app/src/` returns only parity-bridge comments
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` passes; new `settingsStore.test.ts` cases included (3686 tests, 502 suites — all green)
- [x] `npx eslint src/ --max-warnings=0` clean
- [ ] Onboarding flow manually verified — **untested in this branch** (no dev client available); see Notes for review

## Notes for review

This branch was rebuilt end-to-end from the PR description rather than verified against any prior in-progress work, so please spot-check more carefully than usual:

- **Theme keys** in new files (`ModeChoiceCard.tsx`, `ChapterModePicker.tsx`, `PreferencesSection.tsx` segmented-control block) — used `base.bg/bgSurface/bgElevated/border/borderLight/text/textDim/textMuted/gold` and `spacing.{xs,sm,md,lg,xl}`, `radii.{md,lg,pill}`, `fontFamily.{ui,uiMedium,uiSemiBold,body,displayMedium,bodyItalic}` per the existing palette and theme barrel. No new tokens introduced.
- **Parity-bridge placement.** `isFocus = chapterMode === 'read'` lives in `ChapterScreen.tsx:108` and `ChapterVerseList.tsx:55`, both with the comment flagging them for PR 2 replacement.
- **Segmented control** styling (label-on-top + 3-segment row in `PreferencesSection.tsx`) — chose a custom block rather than forcing into `SettingsRow` because three labels don't fit inline. Active segment uses `base.gold + '25'` tint with `base.gold` text; inactive uses `base.textMuted`.
- **Nav bar icon swap.** `BookOpen` and `Eye` removed from imports; single `Layers` button added (`base.textMuted`, no per-mode swap).
- **`RelatedContentCarousel.tsx`** — only change is a stale comment ("Hidden when focusMode is active" → "Hidden in Read mode") so the grep audit comes back clean.

## Rollback

Single revert. The `chapter_mode` SQLite key remains harmless if the revert lands; nothing reads it on the rolled-back code path.

https://claude.ai/code/session_01AhTz2nckLFsKJYsXAJm8Kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhTz2nckLFsKJYsXAJm8Kf)_