### PR TITLE
feat(premium): self-contained gating for SecondTemplePanel + HWGTB FEATURE_DESCRIPTIONS (#1555)

### DIFF
--- a/app/__tests__/components/panels/SecondTemplePanel.test.tsx
+++ b/app/__tests__/components/panels/SecondTemplePanel.test.tsx
@@ -1,13 +1,23 @@
 /**
  * SecondTemplePanel.test.tsx — Tests for the Second Temple Context panel
- * (HWGTB-P2-01 / #1546).
+ * (HWGTB-P2-01 / #1546). Premium gating is self-contained as of HWGTB-P5-01
+ * (#1555); these tests mock `usePremiumStore` rather than passing props.
  */
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { renderWithProviders } from '../../helpers/renderWithProviders';
-import { SecondTemplePanel } from '@/components/panels/SecondTemplePanel';
 import type { SecondTemplePanelPayload } from '@/types';
+
+let mockIsPremium = true;
+
+jest.mock('@/stores/premiumStore', () => ({
+  usePremiumStore: (selector: (s: any) => any) => selector({ isPremium: mockIsPremium }),
+}));
+
+// Import after the mock so the panel picks up the mocked store.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { SecondTemplePanel } = require('@/components/panels/SecondTemplePanel');
 
 const PAYLOAD: SecondTemplePanelPayload = {
   header: "Jude's Use of Second Temple Literature",
@@ -34,12 +44,13 @@ const PAYLOAD: SecondTemplePanelPayload = {
 };
 
 describe('SecondTemplePanel', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsPremium = true;
+  });
 
   it('renders header and body when premium', () => {
-    const { getByText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium />,
-    );
+    const { getByText } = renderWithProviders(<SecondTemplePanel data={PAYLOAD} />);
     expect(getByText("Jude's Use of Second Temple Literature")).toBeTruthy();
     expect(
       getByText(/In the twelve verses of this section Jude/),
@@ -47,9 +58,7 @@ describe('SecondTemplePanel', () => {
   });
 
   it('renders citation badges with NT ref + source + type', () => {
-    const { getByText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium />,
-    );
+    const { getByText } = renderWithProviders(<SecondTemplePanel data={PAYLOAD} />);
     expect(getByText('Jude 14-15')).toBeTruthy();
     expect(getByText('1 Enoch 1:9')).toBeTruthy();
     expect(getByText('Direct quotation')).toBeTruthy();
@@ -61,7 +70,6 @@ describe('SecondTemplePanel', () => {
     const { getByLabelText } = renderWithProviders(
       <SecondTemplePanel
         data={PAYLOAD}
-        isPremium
         onExtraBiblicalPress={onExtraBiblicalPress}
       />,
     );
@@ -74,7 +82,6 @@ describe('SecondTemplePanel', () => {
     const { getByLabelText } = renderWithProviders(
       <SecondTemplePanel
         data={PAYLOAD}
-        isPremium
         onExtraBiblicalPress={onExtraBiblicalPress}
       />,
     );
@@ -85,26 +92,21 @@ describe('SecondTemplePanel', () => {
   it('fires onScholarPress with the scholar_id on scholar tap', () => {
     const onScholarPress = jest.fn();
     const { getByLabelText } = renderWithProviders(
-      <SecondTemplePanel
-        data={PAYLOAD}
-        isPremium
-        onScholarPress={onScholarPress}
-      />,
+      <SecondTemplePanel data={PAYLOAD} onScholarPress={onScholarPress} />,
     );
     fireEvent.press(getByLabelText('Scholar: tertullian'));
     expect(onScholarPress).toHaveBeenCalledWith('tertullian');
   });
 
   it('renders takeaway text in italicized block', () => {
-    const { getByText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium />,
-    );
+    const { getByText } = renderWithProviders(<SecondTemplePanel data={PAYLOAD} />);
     expect(getByText(/NT citation does not equal canonicity/)).toBeTruthy();
   });
 
   it('free tier shows upgrade CTA and does not render full body / chips / voices / takeaway', () => {
+    mockIsPremium = false;
     const { getByText, queryByText, queryByLabelText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium={false} />,
+      <SecondTemplePanel data={PAYLOAD} />,
     );
     // Header always visible
     expect(getByText("Jude's Use of Second Temple Literature")).toBeTruthy();
@@ -117,22 +119,21 @@ describe('SecondTemplePanel', () => {
     expect(queryByText(/NT citation does not equal canonicity/)).toBeNull();
   });
 
-  it('free tier tap on teaser fires onUpgradePress', () => {
-    const onUpgradePress = jest.fn();
-    const { getByLabelText } = renderWithProviders(
-      <SecondTemplePanel
-        data={PAYLOAD}
-        isPremium={false}
-        onUpgradePress={onUpgradePress}
-      />,
+  it('free tier tap on teaser opens UpgradePrompt with Second Temple Context feature description', () => {
+    mockIsPremium = false;
+    const { getByLabelText, getByText } = renderWithProviders(
+      <SecondTemplePanel data={PAYLOAD} />,
     );
     fireEvent.press(getByLabelText('Unlock Second Temple Context'));
-    expect(onUpgradePress).toHaveBeenCalledTimes(1);
+    // UpgradePrompt is now rendered internally. The modal description is keyed
+    // off the feature name passed to showUpgrade(), so asserting the FEATURE_DESCRIPTIONS
+    // copy proves the correct key ('Second Temple Context') was used.
+    expect(getByText(/Intertestamental literature background/)).toBeTruthy();
   });
 
   it('collapses to hide body on header tap', () => {
     const { getByLabelText, queryByText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium />,
+      <SecondTemplePanel data={PAYLOAD} />,
     );
     expect(queryByText(/In the twelve verses of this section Jude/)).toBeTruthy();
     fireEvent.press(getByLabelText('Collapse Second Temple Context'));
@@ -140,9 +141,7 @@ describe('SecondTemplePanel', () => {
   });
 
   it('does not render extrabiblical chips when no onExtraBiblicalPress is provided', () => {
-    const { queryByLabelText } = renderWithProviders(
-      <SecondTemplePanel data={PAYLOAD} isPremium />,
-    );
+    const { queryByLabelText } = renderWithProviders(<SecondTemplePanel data={PAYLOAD} />);
     expect(queryByLabelText('Open 1_enoch detail')).toBeNull();
   });
 });

--- a/app/src/components/UpgradePrompt.tsx
+++ b/app/src/components/UpgradePrompt.tsx
@@ -49,6 +49,10 @@ const FEATURE_DESCRIPTIONS: Record<string, string> = {
   'The Story of the Bible': 'Trace the 8-act redemptive narrative from Creation to Restoration — see how every chapter fits into God\'s story.',
   'Person Journey': 'Follow key biblical figures across multiple books — see their full arc from calling to legacy.',
   'Guided Study Review': 'Save your synthesis, build concept vocabulary, and revisit key insights with spaced review.',
+  'Extra-Biblical Literature': 'Scholarly entries on 1 Enoch, Jubilees, the Apocrypha, Dead Sea Scrolls — what they are, what they contain, and why traditions treated them differently.',
+  'Canon Comparison': 'Side-by-side Protestant, Catholic, Orthodox, and Ethiopian canons — see what each includes and why.',
+  'How We Got The Bible': 'Two deep journeys tracing canon formation and textual transmission, from oral tradition to modern English translations.',
+  'Second Temple Context': 'Intertestamental literature background on NT passages that cite or allude to 1 Enoch, Jubilees, and other extra-biblical sources.',
 };
 
 export function UpgradePrompt({ visible, onClose, variant, featureName }: Props) {

--- a/app/src/components/panels/SecondTemplePanel.tsx
+++ b/app/src/components/panels/SecondTemplePanel.tsx
@@ -8,9 +8,11 @@
  * background rather than mainstream commentary.
  *
  * Schema: HWGTB-P1-03 (#1540). Content: HWGTB-P1-06 (#1543).
- * Premium gating follows the DebatePanel.tsx convention — props-based,
- * parent (ChapterScreen) wires `isPremium` + `onUpgradePress` from the
- * `usePremium()` hook. The panel stays decoupled from the premium store.
+ *
+ * Premium gating is self-contained (HWGTB-P5-01 / #1555): the panel calls
+ * `usePremium()` directly and renders its own `UpgradePrompt` rather than
+ * relying on parent prop-drilling. Upgrade variant: 'explore' (matches
+ * the rest of the HWGTB content surfaces — ExtraBiblicalIndex/Detail).
  */
 
 import React, { useCallback, useState } from 'react';
@@ -25,6 +27,8 @@ import {
 import { ChevronDown, ChevronRight, ScrollText } from 'lucide-react-native';
 import { useTheme, spacing, radii, fontFamily } from '../../theme';
 import { TappableReference } from '../TappableReference';
+import { UpgradePrompt } from '../UpgradePrompt';
+import { usePremium } from '../../hooks/usePremium';
 import type {
   ParsedRef,
   SecondTemplePanelPayload,
@@ -37,9 +41,6 @@ interface Props {
   onRefPress?: (ref: ParsedRef) => void;
   onScholarPress?: (scholarId: string) => void;
   onExtraBiblicalPress?: (extrabiblicalId: string) => void;
-  /** Free-tier sees header + 2-line body teaser with a fade overlay. */
-  isPremium?: boolean;
-  onUpgradePress?: () => void;
 }
 
 export function SecondTemplePanel({
@@ -47,12 +48,11 @@ export function SecondTemplePanel({
   onRefPress,
   onScholarPress,
   onExtraBiblicalPress,
-  isPremium = true,
-  onUpgradePress,
 }: Props) {
   const { base, getPanelColors } = useTheme();
   const colors = getPanelColors('st2');
   const [expanded, setExpanded] = useState(true);
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
 
   const toggleExpand = useCallback(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -62,60 +62,70 @@ export function SecondTemplePanel({
   const locked = !isPremium;
 
   const handleUpgradeTap = useCallback(() => {
-    onUpgradePress?.();
-  }, [onUpgradePress]);
+    showUpgrade('explore', 'Second Temple Context');
+  }, [showUpgrade]);
 
   return (
-    <View
-      style={[
-        styles.container,
-        { backgroundColor: colors.bg, borderColor: colors.border },
-      ]}
-    >
-      <TouchableOpacity
-        onPress={toggleExpand}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={
-          expanded ? 'Collapse Second Temple Context' : 'Expand Second Temple Context'
-        }
-        style={styles.header}
+    <>
+      <View
+        style={[
+          styles.container,
+          { backgroundColor: colors.bg, borderColor: colors.border },
+        ]}
       >
-        <ScrollText size={16} color={colors.accent} />
-        <Text style={[styles.headerTitle, { color: colors.accent }]} numberOfLines={1}>
-          {data.header}
-        </Text>
-        {expanded ? (
-          <ChevronDown size={14} color={base.textMuted} />
-        ) : (
-          <ChevronRight size={14} color={base.textMuted} />
-        )}
-      </TouchableOpacity>
+        <TouchableOpacity
+          onPress={toggleExpand}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={
+            expanded ? 'Collapse Second Temple Context' : 'Expand Second Temple Context'
+          }
+          style={styles.header}
+        >
+          <ScrollText size={16} color={colors.accent} />
+          <Text style={[styles.headerTitle, { color: colors.accent }]} numberOfLines={1}>
+            {data.header}
+          </Text>
+          {expanded ? (
+            <ChevronDown size={14} color={base.textMuted} />
+          ) : (
+            <ChevronRight size={14} color={base.textMuted} />
+          )}
+        </TouchableOpacity>
 
-      {expanded ? (
-        locked ? (
-          <LockedBody
-            text={data.body}
-            onPress={handleUpgradeTap}
-            accent={colors.accent}
-            bg={colors.bg}
-            textColor={base.textDim}
-            mutedColor={base.textMuted}
-          />
-        ) : (
-          <UnlockedBody
-            data={data}
-            accent={colors.accent}
-            textColor={base.textDim}
-            mutedColor={base.textMuted}
-            goldColor={base.gold}
-            onRefPress={onRefPress}
-            onScholarPress={onScholarPress}
-            onExtraBiblicalPress={onExtraBiblicalPress}
-          />
-        )
+        {expanded ? (
+          locked ? (
+            <LockedBody
+              text={data.body}
+              onPress={handleUpgradeTap}
+              accent={colors.accent}
+              bg={colors.bg}
+              textColor={base.textDim}
+              mutedColor={base.textMuted}
+            />
+          ) : (
+            <UnlockedBody
+              data={data}
+              accent={colors.accent}
+              textColor={base.textDim}
+              mutedColor={base.textMuted}
+              goldColor={base.gold}
+              onRefPress={onRefPress}
+              onScholarPress={onScholarPress}
+              onExtraBiblicalPress={onExtraBiblicalPress}
+            />
+          )
+        ) : null}
+      </View>
+      {upgradeRequest ? (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
       ) : null}
-    </View>
+    </>
   );
 }
 


### PR DESCRIPTION
## Closes #1555

Final remaining work for the **How We Got The Bible** epic (#1536) — premium gating wire-up for Canon content.

## Problem

Investigation showed two real gaps:

1. **`UpgradePrompt.tsx`** — none of the four `FEATURE_DESCRIPTIONS` entries from the spec existed. The four feature names (`Extra-Biblical Literature`, `Canon Comparison`, `How We Got The Bible`, `Second Temple Context`) were already being passed to `showUpgrade()` from various screens, but with no matching key in `FEATURE_DESCRIPTIONS`, the modal was silently falling back to the generic `Unlock ${featureName} and other premium study tools.` placeholder.

2. **`SecondTemplePanel.tsx`** had `isPremium` / `onUpgradePress` props correctly implemented, but `PanelRenderer.tsx` never passed them. Default `isPremium = true` meant **free users were seeing fully-unlocked Second Temple panels** — a real premium content leak.

The other items from the spec (`ExtraBiblicalIndexScreen`, `ExtraBiblicalDetailScreen`, `CanonComparisonScreen`) were already correctly wired in earlier HWGTB PRs.

## Approach: self-contained gating

Rather than prop-drill premium state through `PanelRenderer` → section/chapter renderers → individual panels (and risk the same omission the next time a gated panel is added), the panel now calls `usePremium()` directly and renders its own `UpgradePrompt`. Trade-off:

- **Lose:** small amount of store coupling at the panel layer
- **Gain:** true encapsulated gating that can't be silently broken by an upstream renderer change

This is the new pattern for any future panel-level gates.

## Changes

- **`UpgradePrompt.tsx`** — add 4 `FEATURE_DESCRIPTIONS` entries (verbatim from spec).
- **`SecondTemplePanel.tsx`** — drop `isPremium` / `onUpgradePress` props; call `usePremium()` internally; render `UpgradePrompt` next to the panel View. Lock-tap fires `showUpgrade('explore', 'Second Temple Context')` matching the variant used by the other HWGTB content surfaces. Updated jsdoc.
- **`SecondTemplePanel.test.tsx`** — rewrite to mock `@/stores/premiumStore` with a `mockIsPremium` toggle. The lock-tap test asserts the rendered feature-description copy, which proves the correct `showUpgrade` key was passed.

## Out of scope (follow-up issue)

`DebatePanel` has the identical prop-shape gap (`isPremium` / `onUpgradePress` declared, `PanelRenderer` doesn't pass them). Same self-contained refactor needed but it's outside the HWGTB epic. I'll file a separate issue once this merges.

## Verification

- `git diff` reviewed — pure refactor of one panel, four added strings, one rewritten test.
- Confirmed `PanelRenderer.tsx` is the only call site of `SecondTemplePanel` and never passed the now-removed props.
- Couldn't run `tsc`/`jest` in this sandbox (npm install didn't complete); CI will verify.

## Rollback

Revert this commit. Free users go back to seeing unlocked Second Temple panels (the pre-existing leak); the four `FEATURE_DESCRIPTIONS` entries fall back to the generic placeholder. Clean reset.

## After merge

- Close #1555 (this PR closes it)
- Close epic #1536 — every other child issue is already closed; this is the last one
- File `DebatePanel` follow-up issue
