### PR TITLE
feat: define ModeDefinition types and MODE_DEFINITIONS table (#1726)

### DIFF
--- a/app/src/services/guidedStudy/index.ts
+++ b/app/src/services/guidedStudy/index.ts
@@ -1,4 +1,5 @@
 export { getStudyDepthEstimate } from './estimate';
+export { MODE_DEFINITIONS, getModeDefinition } from './modes/definitions';
 export { buildGuidedStudyPlan } from './plan';
 export { buildGuidedStudyNextAction, formatChapterRef, getGuidedStudyStepLabel } from './personal';
 export { buildReviewItemsFromSynthesis, nextIntervalAfter, REVIEW_INTERVAL_DAYS } from './review';
@@ -21,4 +22,11 @@ export type {
   GuidedStudyStep,
   StudyDepthEstimate,
 } from './types';
+export type {
+  EvidenceTrailKind,
+  ModeDefinition,
+  ModeStepConfig,
+  ReviewArtifactType,
+  SynthesisTemplateKind,
+} from './modes/types';
 export type { GuidedStudyNextAction } from './personal';

--- a/app/src/services/guidedStudy/modes/__tests__/definitions.test.ts
+++ b/app/src/services/guidedStudy/modes/__tests__/definitions.test.ts
@@ -1,0 +1,74 @@
+import { GUIDED_STUDY_MODES, type GuidedStudyMode } from '../../types';
+import { MODE_DEFINITIONS, getModeDefinition } from '../definitions';
+
+// Hardcoded current-behavior values (Phase 1 parity). If you change these, you
+// are changing observable behavior — make sure that is intentional.
+const EXPECTED_RECOMMENDATION_LIMIT: Record<GuidedStudyMode, number> = {
+  quick: 3,
+  deep: 5,
+  teaching: 5,
+  devotional: 3,
+};
+
+const EXPECTED_TRAIL_ORDER: Record<GuidedStudyMode, readonly string[]> = {
+  quick: ['context', 'language', 'scripture'],
+  deep: ['context', 'language', 'scripture', 'debate'],
+  teaching: ['context', 'structure', 'scripture', 'debate'],
+  devotional: ['context', 'scripture', 'language'],
+};
+
+describe('MODE_DEFINITIONS', () => {
+  it('covers exactly the four GUIDED_STUDY_MODES keys', () => {
+    const keys = Object.keys(MODE_DEFINITIONS).sort();
+    const expected = [...GUIDED_STUDY_MODES].sort();
+    expect(keys).toEqual(expected);
+  });
+
+  it.each(GUIDED_STUDY_MODES)(
+    '%s recommendationLimit matches current MODE_RECOMMENDATION_LIMIT',
+    (mode) => {
+      expect(MODE_DEFINITIONS[mode].recommendationLimit).toBe(
+        EXPECTED_RECOMMENDATION_LIMIT[mode],
+      );
+    },
+  );
+
+  it.each(GUIDED_STUDY_MODES)(
+    '%s trailOrder matches current MODE_TRAIL_ORDER',
+    (mode) => {
+      expect([...MODE_DEFINITIONS[mode].trailOrder]).toEqual(EXPECTED_TRAIL_ORDER[mode]);
+    },
+  );
+
+  it.each(GUIDED_STUDY_MODES)('%s has a non-empty marketingPromise', (mode) => {
+    expect(MODE_DEFINITIONS[mode].marketingPromise.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each(GUIDED_STUDY_MODES)(
+    '%s has empty panelWeights and empty step prompts in Phase 1',
+    (mode) => {
+      const def = MODE_DEFINITIONS[mode];
+      expect(def.panelWeights).toEqual({});
+      for (const step of Object.values(def.steps)) {
+        expect(step.prompts).toEqual([]);
+      }
+    },
+  );
+
+  it('exposes all five guided-study steps per mode', () => {
+    const expectedSteps = ['scene', 'observe', 'explore', 'synthesize', 'review'].sort();
+    for (const mode of GUIDED_STUDY_MODES) {
+      expect(Object.keys(MODE_DEFINITIONS[mode].steps).sort()).toEqual(expectedSteps);
+    }
+  });
+});
+
+describe('getModeDefinition', () => {
+  it.each(GUIDED_STUDY_MODES)('returns the definition for %s', (mode) => {
+    expect(getModeDefinition(mode)).toBe(MODE_DEFINITIONS[mode]);
+  });
+
+  it('falls back to deep for unknown keys (matches normalizeMode behavior)', () => {
+    expect(getModeDefinition('garbage' as GuidedStudyMode)).toBe(MODE_DEFINITIONS.deep);
+  });
+});

--- a/app/src/services/guidedStudy/modes/deep.ts
+++ b/app/src/services/guidedStudy/modes/deep.ts
@@ -1,0 +1,22 @@
+import type { ModeDefinition } from './types';
+
+export const DEEP_MODE: ModeDefinition = {
+  key: 'deep',
+  label: 'Deep study',
+  shortLabel: 'Deep',
+  estimatedMinutes: 25,
+  blurb: 'A fuller trail through context, language, Scripture, and debate.',
+  marketingPromise: 'A structured analysis you can reason from.',
+  steps: {
+    scene: { prompts: [] },
+    observe: { prompts: [] },
+    explore: { prompts: [] },
+    synthesize: { prompts: [] },
+    review: { prompts: [] },
+  },
+  trailOrder: ['context', 'language', 'scripture', 'debate'],
+  recommendationLimit: 5,
+  panelWeights: {},
+  synthesisTemplate: 'claim_evidence_tension',
+  reviewArtifact: 'analytical_claim',
+};

--- a/app/src/services/guidedStudy/modes/definitions.ts
+++ b/app/src/services/guidedStudy/modes/definitions.ts
@@ -1,0 +1,17 @@
+import type { GuidedStudyMode } from '../types';
+import { DEEP_MODE } from './deep';
+import { DEVOTIONAL_MODE } from './devotional';
+import { QUICK_MODE } from './quick';
+import { TEACHING_MODE } from './teaching';
+import type { ModeDefinition } from './types';
+
+export const MODE_DEFINITIONS: Record<GuidedStudyMode, ModeDefinition> = {
+  quick: QUICK_MODE,
+  deep: DEEP_MODE,
+  teaching: TEACHING_MODE,
+  devotional: DEVOTIONAL_MODE,
+};
+
+export function getModeDefinition(key: GuidedStudyMode): ModeDefinition {
+  return MODE_DEFINITIONS[key] ?? MODE_DEFINITIONS.deep;
+}

--- a/app/src/services/guidedStudy/modes/devotional.ts
+++ b/app/src/services/guidedStudy/modes/devotional.ts
@@ -1,0 +1,22 @@
+import type { ModeDefinition } from './types';
+
+export const DEVOTIONAL_MODE: ModeDefinition = {
+  key: 'devotional',
+  label: 'Devotional',
+  shortLabel: 'Devotional',
+  estimatedMinutes: 12,
+  blurb: 'Observe the text carefully before moving toward prayerful response.',
+  marketingPromise: "A prayer in the chapter's own language.",
+  steps: {
+    scene: { prompts: [] },
+    observe: { prompts: [] },
+    explore: { prompts: [] },
+    synthesize: { prompts: [] },
+    review: { prompts: [] },
+  },
+  trailOrder: ['context', 'scripture', 'language'],
+  recommendationLimit: 3,
+  panelWeights: {},
+  synthesisTemplate: 'prayer_and_carry',
+  reviewArtifact: 'returning_prayer',
+};

--- a/app/src/services/guidedStudy/modes/quick.ts
+++ b/app/src/services/guidedStudy/modes/quick.ts
@@ -1,0 +1,22 @@
+import type { ModeDefinition } from './types';
+
+export const QUICK_MODE: ModeDefinition = {
+  key: 'quick',
+  label: 'Quick pass',
+  shortLabel: 'Quick',
+  estimatedMinutes: 9,
+  blurb: 'Context, one key observation, and a short takeaway.',
+  marketingPromise: "A short pass that lands one takeaway you'll remember.",
+  steps: {
+    scene: { prompts: [] },
+    observe: { prompts: [] },
+    explore: { prompts: [] },
+    synthesize: { prompts: [] },
+    review: { prompts: [] },
+  },
+  trailOrder: ['context', 'language', 'scripture'],
+  recommendationLimit: 3,
+  panelWeights: {},
+  synthesisTemplate: 'paragraph_plus_verse',
+  reviewArtifact: 'memory_verse',
+};

--- a/app/src/services/guidedStudy/modes/teaching.ts
+++ b/app/src/services/guidedStudy/modes/teaching.ts
@@ -1,0 +1,22 @@
+import type { ModeDefinition } from './types';
+
+export const TEACHING_MODE: ModeDefinition = {
+  key: 'teaching',
+  label: 'Teaching prep',
+  shortLabel: 'Teaching',
+  estimatedMinutes: 25,
+  blurb: 'Structure, claims, and what someone else will need clarified.',
+  marketingPromise: 'An outline you can teach from confidently.',
+  steps: {
+    scene: { prompts: [] },
+    observe: { prompts: [] },
+    explore: { prompts: [] },
+    synthesize: { prompts: [] },
+    review: { prompts: [] },
+  },
+  trailOrder: ['context', 'structure', 'scripture', 'debate'],
+  recommendationLimit: 5,
+  panelWeights: {},
+  synthesisTemplate: 'teaching_outline',
+  reviewArtifact: 'teaching_outline',
+};

--- a/app/src/services/guidedStudy/modes/types.ts
+++ b/app/src/services/guidedStudy/modes/types.ts
@@ -1,0 +1,36 @@
+import type { GuidedPrompt, GuidedStudyMode, GuidedStudyStep } from '../types';
+
+export type EvidenceTrailKind = 'context' | 'structure' | 'language' | 'scripture' | 'debate';
+
+export interface ModeStepConfig {
+  prompts: GuidedPrompt[];
+  helperText?: string;
+  carryForward?: ReadonlyArray<'scene' | 'observe' | 'explore' | 'synthesize'>;
+}
+
+export type SynthesisTemplateKind =
+  | 'paragraph_plus_verse'
+  | 'claim_evidence_tension'
+  | 'teaching_outline'
+  | 'prayer_and_carry';
+
+export type ReviewArtifactType =
+  | 'memory_verse'
+  | 'analytical_claim'
+  | 'teaching_outline'
+  | 'returning_prayer';
+
+export interface ModeDefinition {
+  key: GuidedStudyMode;
+  label: string;
+  shortLabel: string;
+  estimatedMinutes: number;
+  blurb: string;
+  marketingPromise: string;
+  steps: Record<GuidedStudyStep, ModeStepConfig>;
+  trailOrder: ReadonlyArray<EvidenceTrailKind>;
+  recommendationLimit: number;
+  panelWeights: Readonly<Record<string, number>>;
+  synthesisTemplate: SynthesisTemplateKind;
+  reviewArtifact: ReviewArtifactType;
+}


### PR DESCRIPTION
Closes #1726. Phase 1.1 of epic #1725.

## Why
Every subsequent card in the *From Reading to Understanding* epic reads from a single mode-as-data table. This card lays that table down and encodes **current** behavior (recommendation limit + trail order) into it so later phases can extend cleanly without changing what the user sees today.

## What
New `app/src/services/guidedStudy/modes/` directory:
- `types.ts` — `ModeDefinition`, `ModeStepConfig`, `EvidenceTrailKind`, `SynthesisTemplateKind`, `ReviewArtifactType`
- `quick.ts` / `deep.ts` / `teaching.ts` / `devotional.ts` — per-mode definitions
- `definitions.ts` — `MODE_DEFINITIONS` table + `getModeDefinition(key)` helper with deep-mode fallback (matches `normalizeMode` in `plan.ts`)
- `__tests__/definitions.test.ts` — parity tests

`index.ts` re-exports the table, helper, and new types. **No other file modified** — this card is structurally inert by design.

Phase 1 placeholders, intentionally empty:
- `panelWeights: {}` for every mode (filled by #1733)
- `steps[*].prompts: []` for every mode (filled by #1730)

`synthesisTemplate` and `reviewArtifact` are declared per the epic table; they're not consumed yet (Phase 3 dispatches on them).

## Acceptance criteria
- [x] `MODE_DEFINITIONS` exported from `modes/definitions.ts`
- [x] `getModeDefinition(key)` helper exported, falls back to `deep` for unknown keys
- [x] Re-exports added to `services/guidedStudy/index.ts`
- [x] `recommendationLimit` and `trailOrder` exactly match current `MODE_RECOMMENDATION_LIMIT` and `MODE_TRAIL_ORDER` in `plan.ts`
- [x] All four `marketingPromise` strings non-empty
- [x] Tests pass (23 new + 71 existing guidedStudy tests green)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] No file outside `services/guidedStudy/modes/` modified except `index.ts`

## Rollback
Revert the PR. No DB migration, no flag, no consumer wired up — purely additive.

## Notes for Craig
- Kanban move to **In Progress** / **Done** must be done manually (no GraphQL access from this session).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_