### PR TITLE
refactor: plan.ts reads from MODE_DEFINITIONS (#1727)

### DIFF
--- a/app/__tests__/services/guidedStudy.test.ts
+++ b/app/__tests__/services/guidedStudy.test.ts
@@ -141,7 +141,7 @@ describe('guided study services', () => {
     expect(plan.conceptChips.map((chip) => chip.label)).toContain('Theological Narrative');
   });
 
-  it('adapts recommendation depth and better questions by study mode', () => {
+  it('adapts recommendation depth by study mode', () => {
     const quick = buildGuidedStudyPlan({
       book,
       chapter,
@@ -171,11 +171,10 @@ describe('guided study services', () => {
     });
 
     expect(quick.recommendations).toHaveLength(3);
-    expect(quick.betterQuestionPrompt).toContain('one question');
-    expect(teaching.betterQuestionPrompt).toContain('teach this passage');
-    expect(devotional.betterQuestionPrompt).toBe(
-      'What does the chapter emphasize before you ask how it applies to me?',
-    );
+    expect(teaching.recommendations.length).toBeLessThanOrEqual(5);
+    expect(devotional.recommendations).toHaveLength(3);
+    // Mode-specific betterQuestionPrompt strings move to MODE_DEFINITIONS in
+    // #1730 (Phase 2.1). After Phase 1.2 the prompt is mode-agnostic.
   });
 
   it('schedules one row per populated synthesis field at the first interval', () => {

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,6 +1,6 @@
 import type { SectionPanel } from '../../types';
+import { getModeDefinition } from './modes/definitions';
 import {
-  GUIDED_STUDY_MODE_OPTIONS,
   type ConfidenceLevel,
   type GuidedConceptChip,
   type GuidedEvidenceTrailItem,
@@ -10,8 +10,6 @@ import {
   type GuidedStudyPlan,
   type GuidedStudyPlanInput,
 } from './types';
-
-const DEFAULT_MODE: GuidedStudyMode = 'deep';
 
 const RECOMMENDATION_ORDER = [
   'hist',
@@ -40,13 +38,6 @@ const PANEL_LABELS: Record<string, string> = {
   lit: 'Literary Structure',
   thread: 'Intertextual Threading',
   discourse: 'Argument Flow',
-};
-
-const MODE_RECOMMENDATION_LIMIT: Record<GuidedStudyMode, number> = {
-  quick: 3,
-  deep: 5,
-  teaching: 5,
-  devotional: 3,
 };
 
 // TODO(#1584): Replace with labels from content/meta/concepts.json via
@@ -140,13 +131,6 @@ const EVIDENCE_TRAIL_DEFINITIONS: Record<EvidenceTrailKind, EvidenceTrailDefinit
   },
 };
 
-const MODE_TRAIL_ORDER: Record<GuidedStudyMode, EvidenceTrailKind[]> = {
-  quick: ['context', 'language', 'scripture'],
-  deep: ['context', 'language', 'scripture', 'debate'],
-  teaching: ['context', 'structure', 'scripture', 'debate'],
-  devotional: ['context', 'scripture', 'language'],
-};
-
 function compact(value: string | null | undefined): string | null {
   if (!value) return null;
   const cleaned = value.replace(/\s+/g, ' ').trim();
@@ -166,13 +150,11 @@ function displayChapter(input: GuidedStudyPlanInput): string {
 }
 
 function normalizeMode(mode?: GuidedStudyMode): GuidedStudyMode {
-  return GUIDED_STUDY_MODE_OPTIONS.some((option) => option.key === mode)
-    ? mode ?? DEFAULT_MODE
-    : DEFAULT_MODE;
+  return getModeDefinition((mode ?? 'deep') as GuidedStudyMode).key;
 }
 
 function modeLabel(mode: GuidedStudyMode): string {
-  return GUIDED_STUDY_MODE_OPTIONS.find((option) => option.key === mode)?.label ?? 'Deep study';
+  return getModeDefinition(mode).label;
 }
 
 function genrePrompt(genreLabel?: string): string {
@@ -185,17 +167,10 @@ function genrePrompt(genreLabel?: string): string {
   );
 }
 
-function betterQuestionPrompt(input: GuidedStudyPlanInput, mode: GuidedStudyMode): string {
+// Mode-specific better-question prompts move into MODE_DEFINITIONS in #1730
+// (Phase 2.1). For Phase 1 this is intentionally not mode-aware.
+function betterQuestionPrompt(input: GuidedStudyPlanInput): string {
   const first = input.sections[0];
-  if (mode === 'quick') {
-    return 'What is the one question you should answer before moving on?';
-  }
-  if (mode === 'teaching') {
-    return 'What would someone need clarified before they could teach this passage responsibly?';
-  }
-  if (mode === 'devotional') {
-    return 'What does the chapter emphasize before you ask how it applies to me?';
-  }
   if (!first) return 'What question would help you understand this chapter on its own terms?';
   return `What do verses ${first.verse_start}-${first.verse_end} ask you to notice about the original audience, not just yourself?`;
 }
@@ -204,7 +179,13 @@ function recommendationSubtitle(panel: SectionPanel, sectionHeader: string): str
   return sectionHeader ? `From ${sectionHeader}` : `Section ${panel.section_id}`;
 }
 
-function buildRecommendations(input: GuidedStudyPlanInput): GuidedPanelRecommendation[] {
+function buildRecommendations(
+  input: GuidedStudyPlanInput,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  panelWeights: Readonly<Record<string, number>> = {},
+): GuidedPanelRecommendation[] {
+  // panelWeights is plumbed through but not yet applied — Phase 2.4 (#1733)
+  // wires the bias logic. Phase 1 keeps RECOMMENDATION_ORDER as the sort key.
   const recs: GuidedPanelRecommendation[] = [];
   const used = new Set<string>();
 
@@ -251,7 +232,7 @@ function buildEvidenceTrail(
 ): GuidedEvidenceTrailItem[] {
   const items: GuidedEvidenceTrailItem[] = [];
 
-  for (const kind of MODE_TRAIL_ORDER[mode]) {
+  for (const kind of getModeDefinition(mode).trailOrder) {
     const definition = EVIDENCE_TRAIL_DEFINITIONS[kind];
     const recommendation = recommendations.find((rec) =>
       definition.candidatePanelTypes.includes(rec.panelType),
@@ -314,8 +295,9 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
   const guidance = compact(input.book?.genre_guidance);
   const audienceContext =
     compact(input.bookIntro?.era) ?? compact(input.bookIntro?.at_a_glance?.chapters?.toString());
-  const allRecommendations = buildRecommendations(input);
-  const betterQuestion = betterQuestionPrompt(input, mode);
+  const def = getModeDefinition(mode);
+  const allRecommendations = buildRecommendations(input, def.panelWeights);
+  const betterQuestion = betterQuestionPrompt(input);
 
   const prompts: GuidedPrompt[] = [
     {
@@ -345,7 +327,7 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
       },
     ],
     prompts,
-    recommendations: allRecommendations.slice(0, MODE_RECOMMENDATION_LIMIT[mode]),
+    recommendations: allRecommendations.slice(0, def.recommendationLimit),
     evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
     betterQuestionPrompt: betterQuestion,
     conceptChips: buildConceptChips(input),


### PR DESCRIPTION
Closes #1727. Phase 1.2 of epic #1725.

## Why
`plan.ts` had its own copies of mode-shaped constants (`MODE_RECOMMENDATION_LIMIT`, `MODE_TRAIL_ORDER`) and inline mode switches. With `MODE_DEFINITIONS` landed in #1726, this card collapses those duplicates so every mode-shaped value comes from one place. Sets up Phase 2 cards to add behavior by editing the table, not the planner.

## What
`app/src/services/guidedStudy/plan.ts`:
- Drop `DEFAULT_MODE`, `MODE_RECOMMENDATION_LIMIT`, `MODE_TRAIL_ORDER`
- `normalizeMode` / `modeLabel` become thin shims over `getModeDefinition`
- `buildEvidenceTrail` iterates `getModeDefinition(mode).trailOrder`
- `buildGuidedStudyPlan` uses `def.recommendationLimit` and passes `def.panelWeights` into `buildRecommendations`
- `buildRecommendations` gains a `panelWeights` parameter (default `{}`) — plumbed but not yet applied (Phase 2.4 / #1733 wires the bias logic)
- `betterQuestionPrompt` drops its mode switch — mode-specific prompts return via `MODE_DEFINITIONS` in Phase 2.1 (#1730), per the card's "make it pure-of-mode for now" instruction

`app/__tests__/services/guidedStudy.test.ts`:
- The assertion `quick.betterQuestionPrompt`-by-mode is removed with an inline note pointing to #1730 where mode-specific prompts return
- Replaced with a benign recommendation-depth check that's robust to fixture size

## Acceptance criteria
- [x] `MODE_RECOMMENDATION_LIMIT` and `MODE_TRAIL_ORDER` constants deleted
- [x] `plan.ts` references `getModeDefinition` exclusively for mode-shaped values
- [x] `buildRecommendations` accepts a `panelWeights` parameter with `{}` default
- [x] `tsc`, `lint`, full `npm test` (3709 tests) all clean
- [x] No file outside `plan.ts` modified except the one existing test that depended on the removed mode switch

## Rollback
Revert the PR. No DB migration, no flag, no consumer surface change beyond the planner.

## Notes for Craig
- Kanban (In Progress / Done) requires manual move — no project-board GraphQL access from this session.
- The Phase 1.2 betterQuestionPrompt regression is expected per the card and is fully restored by #1730.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_