### PR TITLE
feat: apply panelWeights stable sort in buildRecommendations (#1728)

### DIFF
--- a/app/src/services/guidedStudy/__tests__/panelWeights.test.ts
+++ b/app/src/services/guidedStudy/__tests__/panelWeights.test.ts
@@ -1,0 +1,95 @@
+import { buildRecommendations } from '../plan';
+import type { Chapter, ChapterPanel, Section, SectionPanel, Verse } from '../../../types';
+import type { GuidedStudyPlanInput } from '../types';
+
+const chapter: Chapter = {
+  id: 'genesis_1',
+  book_id: 'genesis',
+  chapter_num: 1,
+  title: 'Creation',
+  subtitle: null,
+  timeline_link_event: null,
+  timeline_link_text: null,
+  map_story_link_id: null,
+  map_story_link_text: null,
+  coaching_json: null,
+  difficulty: null,
+};
+
+const verses: Verse[] = [
+  {
+    id: 1,
+    book_id: 'genesis',
+    chapter_num: 1,
+    verse_num: 1,
+    translation: 'kjv',
+    text: 'In the beginning.',
+  },
+];
+
+function panel(id: number, sectionId: string, panel_type: string): SectionPanel {
+  return { id, section_id: sectionId, panel_type, content_json: '{}' };
+}
+
+const sections: Array<Section & { panels: SectionPanel[] }> = [
+  {
+    id: 'genesis_1_1',
+    chapter_id: 'genesis_1',
+    section_num: 1,
+    header: 'Light',
+    verse_start: 1,
+    verse_end: 5,
+    panels: [
+      panel(1, 'genesis_1_1', 'ctx'),
+      panel(2, 'genesis_1_1', 'heb'),
+      panel(3, 'genesis_1_1', 'cross'),
+      panel(4, 'genesis_1_1', 'debate'),
+      panel(5, 'genesis_1_1', 'com'),
+    ],
+  },
+];
+
+const chapterPanels: ChapterPanel[] = [];
+
+const baseInput: GuidedStudyPlanInput = {
+  book: null,
+  chapter,
+  sections,
+  chapterPanels,
+  verses,
+};
+
+describe('buildRecommendations panelWeights', () => {
+  it('with empty weights, output matches the canonical RECOMMENDATION_ORDER', () => {
+    const recs = buildRecommendations(baseInput);
+    expect(recs.map((r) => r.panelType)).toEqual(['ctx', 'heb', 'cross', 'com', 'debate']);
+  });
+
+  it('with empty weights, output is identical to the explicit-{} call', () => {
+    const implicit = buildRecommendations(baseInput).map((r) => r.panelType);
+    const explicit = buildRecommendations(baseInput, {}).map((r) => r.panelType);
+    expect(explicit).toEqual(implicit);
+  });
+
+  it('promotes a panelType to the front when its weight is positive', () => {
+    const recs = buildRecommendations(baseInput, { heb: 10 });
+    expect(recs[0].panelType).toBe('heb');
+  });
+
+  it('demotes a panelType to the back when its weight is negative', () => {
+    const recs = buildRecommendations(baseInput, { debate: -10 });
+    expect(recs[recs.length - 1].panelType).toBe('debate');
+  });
+
+  it('orders multiple weighted types by their weight, descending', () => {
+    const recs = buildRecommendations(baseInput, { debate: 5, heb: 10, cross: 1 });
+    const order = recs.map((r) => r.panelType);
+    expect(order.slice(0, 3)).toEqual(['heb', 'debate', 'cross']);
+  });
+
+  it('preserves the relative order of equal-weight items (stable sort)', () => {
+    // Every type maps to weight 0, so the array should be untouched.
+    const recs = buildRecommendations(baseInput, { unknown: 0 });
+    expect(recs.map((r) => r.panelType)).toEqual(['ctx', 'heb', 'cross', 'com', 'debate']);
+  });
+});

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -179,13 +179,10 @@ function recommendationSubtitle(panel: SectionPanel, sectionHeader: string): str
   return sectionHeader ? `From ${sectionHeader}` : `Section ${panel.section_id}`;
 }
 
-function buildRecommendations(
+export function buildRecommendations(
   input: GuidedStudyPlanInput,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   panelWeights: Readonly<Record<string, number>> = {},
 ): GuidedPanelRecommendation[] {
-  // panelWeights is plumbed through but not yet applied — Phase 2.4 (#1733)
-  // wires the bias logic. Phase 1 keeps RECOMMENDATION_ORDER as the sort key.
   const recs: GuidedPanelRecommendation[] = [];
   const used = new Set<string>();
 
@@ -221,6 +218,10 @@ function buildRecommendations(
       confidence: chapterPanel.panel_type === 'debate' ? 'debated' : undefined,
     });
     used.add(`chapter:${chapterPanel.panel_type}`);
+  }
+
+  if (Object.keys(panelWeights).length > 0) {
+    recs.sort((a, b) => (panelWeights[b.panelType] ?? 0) - (panelWeights[a.panelType] ?? 0));
   }
 
   return recs;


### PR DESCRIPTION
Closes #1728. Phase 1.3 of epic #1725.

## Why
#1727 added a `panelWeights` parameter to `buildRecommendations` but the body did nothing with it. This card adds the actual sort behavior, gated so the empty-weights default remains a behavior-identical no-op.

## What
`app/src/services/guidedStudy/plan.ts` — single change inside `buildRecommendations`:

```ts
if (Object.keys(panelWeights).length > 0) {
  recs.sort((a, b) => (panelWeights[b.panelType] ?? 0) - (panelWeights[a.panelType] ?? 0));
}
```

`Array.prototype.sort` is stable since ES2019, so equal-weight items retain their `RECOMMENDATION_ORDER`-derived order.

`buildRecommendations` is exported so the new unit tests can call it directly without round-tripping through `buildGuidedStudyPlan` + a mock `MODE_DEFINITIONS`.

`app/src/services/guidedStudy/__tests__/panelWeights.test.ts` — covers all four spec cases:
- Empty weights → output identical to current behavior
- `{ heb: 10 }` → `heb` at index 0
- `{ debate: -10 }` → `debate` at the end
- Multi-key ordering by weight, descending
- Equal-weight items preserve relative order (stable sort)

## Acceptance criteria
- [x] `panelWeights` behavior matches the four test cases
- [x] With `panelWeights = {}`, no observable change anywhere
- [x] tsc / lint / 77 guidedStudy tests clean

## Rollback
Revert the PR. Per-mode weights are still `{}` so consumers see no change either way.

## Notes for Craig
- Kanban move (In Progress / Done) requires manual action — no project-board GraphQL access from this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_