### PR TITLE
test: snapshot Phase 1 plan output across 4 modes x 5 chapters (#1729)

### DIFF
--- a/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
+++ b/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
@@ -1,0 +1,2239 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plan parity for mode=deep chapter gen_1 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "gen_1",
+  "conceptChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:debate",
+      "panelType": "debate",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What tension, movement, or turning point do you notice in this scene?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Theological Narrative: Read for who and why before how and when.",
+    },
+    {
+      "label": "Moment",
+      "value": "Creation ordered by speech",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Primeval",
+    },
+    {
+      "label": "Purpose",
+      "value": "Explain beginnings and covenant hope.",
+    },
+  ],
+  "title": "The Creation of the Heaven and the Earth",
+}
+`;
+
+exports[`plan parity for mode=deep chapter isa_53 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "isa_53",
+  "conceptChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:debate",
+      "panelType": "debate",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What covenant problem is the prophet confronting?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:ctx",
+      "panelType": "ctx",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "From Vindication",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:src",
+      "panelType": "src",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Cross-Testament Echoes",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Prophecy: Listen for the covenant lawsuit.",
+    },
+    {
+      "label": "Moment",
+      "value": "Stricken for the people",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Divided monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Comfort and confront a covenant people facing judgment.",
+    },
+  ],
+  "title": "The Suffering Servant",
+}
+`;
+
+exports[`plan parity for mode=deep chapter prov_3 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "prov_3",
+  "conceptChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "wisdom",
+      "label": "Wisdom",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What pattern of wise or foolish living is being exposed?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Wisdom’s worth",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Wisdom: Read as observed regularities, not iron promises.",
+    },
+    {
+      "label": "Moment",
+      "value": "Wisdom’s value and ways",
+    },
+    {
+      "label": "Original audience context",
+      "value": "United monarchy onward",
+    },
+    {
+      "label": "Purpose",
+      "value": "Form covenant character through observed wisdom.",
+    },
+  ],
+  "title": "Trust in the LORD",
+}
+`;
+
+exports[`plan parity for mode=deep chapter psa_23 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "psa_23",
+  "conceptChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:com",
+      "panelType": "com",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What emotional movement do you notice from the opening line to the close?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Valley",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:com",
+      "panelType": "com",
+      "subtitle": "Chapter-level study",
+      "title": "Scholar Commentary",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Psalm: Trace the emotional arc.",
+    },
+    {
+      "label": "Moment",
+      "value": "Trust through the valley",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Anthology of Israel’s prayer and praise.",
+    },
+  ],
+  "title": "The LORD Is My Shepherd",
+}
+`;
+
+exports[`plan parity for mode=deep chapter rom_8 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "rom_8",
+  "conceptChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:rom_8_2:com",
+      "panelType": "com",
+      "sectionNum": 2,
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What problem or question is this paragraph answering?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": "majority",
+      "key": "rom_8_2:com",
+      "panelType": "com",
+      "sectionNum": 2,
+      "subtitle": "From Children and heirs",
+      "title": "Scholar Commentary",
+    },
+    {
+      "confidence": "debated",
+      "key": "rom_8_2:debate",
+      "panelType": "debate",
+      "sectionNum": 2,
+      "subtitle": "From Children and heirs",
+      "title": "Scholar Debate",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Letter: Trace the argument paragraph by paragraph.",
+    },
+    {
+      "label": "Moment",
+      "value": "No condemnation, no separation",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Apostolic",
+    },
+    {
+      "label": "Purpose",
+      "value": "Defend the gospel for Jew and Gentile alike.",
+    },
+  ],
+  "title": "Life in the Spirit",
+}
+`;
+
+exports[`plan parity for mode=devotional chapter gen_1 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "gen_1",
+  "conceptChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+  ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What tension, movement, or turning point do you notice in this scene?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Original-Language Study",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Theological Narrative: Read for who and why before how and when.",
+    },
+    {
+      "label": "Moment",
+      "value": "Creation ordered by speech",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Primeval",
+    },
+    {
+      "label": "Purpose",
+      "value": "Explain beginnings and covenant hope.",
+    },
+  ],
+  "title": "The Creation of the Heaven and the Earth",
+}
+`;
+
+exports[`plan parity for mode=devotional chapter isa_53 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "isa_53",
+  "conceptChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+  ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What covenant problem is the prophet confronting?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:ctx",
+      "panelType": "ctx",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Original-Language Study",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Prophecy: Listen for the covenant lawsuit.",
+    },
+    {
+      "label": "Moment",
+      "value": "Stricken for the people",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Divided monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Comfort and confront a covenant people facing judgment.",
+    },
+  ],
+  "title": "The Suffering Servant",
+}
+`;
+
+exports[`plan parity for mode=devotional chapter prov_3 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "prov_3",
+  "conceptChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "wisdom",
+      "label": "Wisdom",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+  ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What pattern of wise or foolish living is being exposed?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Wisdom’s worth",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Wisdom: Read as observed regularities, not iron promises.",
+    },
+    {
+      "label": "Moment",
+      "value": "Wisdom’s value and ways",
+    },
+    {
+      "label": "Original audience context",
+      "value": "United monarchy onward",
+    },
+    {
+      "label": "Purpose",
+      "value": "Form covenant character through observed wisdom.",
+    },
+  ],
+  "title": "Trust in the LORD",
+}
+`;
+
+exports[`plan parity for mode=devotional chapter psa_23 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "psa_23",
+  "conceptChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+  ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What emotional movement do you notice from the opening line to the close?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Valley",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Psalm: Trace the emotional arc.",
+    },
+    {
+      "label": "Moment",
+      "value": "Trust through the valley",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Anthology of Israel’s prayer and praise.",
+    },
+  ],
+  "title": "The LORD Is My Shepherd",
+}
+`;
+
+exports[`plan parity for mode=devotional chapter rom_8 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "rom_8",
+  "conceptChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+  ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What problem or question is this paragraph answering?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Letter: Trace the argument paragraph by paragraph.",
+    },
+    {
+      "label": "Moment",
+      "value": "No condemnation, no separation",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Apostolic",
+    },
+    {
+      "label": "Purpose",
+      "value": "Defend the gospel for Jew and Gentile alike.",
+    },
+  ],
+  "title": "Life in the Spirit",
+}
+`;
+
+exports[`plan parity for mode=quick chapter gen_1 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "gen_1",
+  "conceptChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What tension, movement, or turning point do you notice in this scene?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Original-Language Study",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Theological Narrative: Read for who and why before how and when.",
+    },
+    {
+      "label": "Moment",
+      "value": "Creation ordered by speech",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Primeval",
+    },
+    {
+      "label": "Purpose",
+      "value": "Explain beginnings and covenant hope.",
+    },
+  ],
+  "title": "The Creation of the Heaven and the Earth",
+}
+`;
+
+exports[`plan parity for mode=quick chapter isa_53 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "isa_53",
+  "conceptChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What covenant problem is the prophet confronting?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:ctx",
+      "panelType": "ctx",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Original-Language Study",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Prophecy: Listen for the covenant lawsuit.",
+    },
+    {
+      "label": "Moment",
+      "value": "Stricken for the people",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Divided monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Comfort and confront a covenant people facing judgment.",
+    },
+  ],
+  "title": "The Suffering Servant",
+}
+`;
+
+exports[`plan parity for mode=quick chapter prov_3 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "prov_3",
+  "conceptChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "wisdom",
+      "label": "Wisdom",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What pattern of wise or foolish living is being exposed?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Wisdom’s worth",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Wisdom: Read as observed regularities, not iron promises.",
+    },
+    {
+      "label": "Moment",
+      "value": "Wisdom’s value and ways",
+    },
+    {
+      "label": "Original audience context",
+      "value": "United monarchy onward",
+    },
+    {
+      "label": "Purpose",
+      "value": "Form covenant character through observed wisdom.",
+    },
+  ],
+  "title": "Trust in the LORD",
+}
+`;
+
+exports[`plan parity for mode=quick chapter psa_23 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "psa_23",
+  "conceptChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What emotional movement do you notice from the opening line to the close?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Valley",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Psalm: Trace the emotional arc.",
+    },
+    {
+      "label": "Moment",
+      "value": "Trust through the valley",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Anthology of Israel’s prayer and praise.",
+    },
+  ],
+  "title": "The LORD Is My Shepherd",
+}
+`;
+
+exports[`plan parity for mode=quick chapter rom_8 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "rom_8",
+  "conceptChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "language:rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "Key words, translation choices, and repeated phrases",
+      "title": "Check the language",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What problem or question is this paragraph answering?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Cross-References",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Letter: Trace the argument paragraph by paragraph.",
+    },
+    {
+      "label": "Moment",
+      "value": "No condemnation, no separation",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Apostolic",
+    },
+    {
+      "label": "Purpose",
+      "value": "Defend the gospel for Jew and Gentile alike.",
+    },
+  ],
+  "title": "Life in the Spirit",
+}
+`;
+
+exports[`plan parity for mode=teaching chapter gen_1 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "gen_1",
+  "conceptChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "structure:chapter:lit",
+      "panelType": "lit",
+      "subtitle": "How the chapter is arranged and argued",
+      "title": "Trace the structure",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:debate",
+      "panelType": "debate",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What tension, movement, or turning point do you notice in this scene?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "gen_1_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From Light",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Theological Narrative: Read for who and why before how and when.",
+    },
+    {
+      "label": "Moment",
+      "value": "Creation ordered by speech",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Primeval",
+    },
+    {
+      "label": "Purpose",
+      "value": "Explain beginnings and covenant hope.",
+    },
+  ],
+  "title": "The Creation of the Heaven and the Earth",
+}
+`;
+
+exports[`plan parity for mode=teaching chapter isa_53 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "isa_53",
+  "conceptChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:debate",
+      "panelType": "debate",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What covenant problem is the prophet confronting?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:hist",
+      "panelType": "hist",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Historical Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:ctx",
+      "panelType": "ctx",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From No form or comeliness",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_3:cross",
+      "panelType": "cross",
+      "sectionNum": 3,
+      "subtitle": "From Vindication",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "isa_53_2:src",
+      "panelType": "src",
+      "sectionNum": 2,
+      "subtitle": "From Stricken",
+      "title": "Cross-Testament Echoes",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Prophecy: Listen for the covenant lawsuit.",
+    },
+    {
+      "label": "Moment",
+      "value": "Stricken for the people",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Divided monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Comfort and confront a covenant people facing judgment.",
+    },
+  ],
+  "title": "The Suffering Servant",
+}
+`;
+
+exports[`plan parity for mode=teaching chapter prov_3 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "prov_3",
+  "conceptChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "wisdom",
+      "label": "Wisdom",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "structure:chapter:lit",
+      "panelType": "lit",
+      "subtitle": "How the chapter is arranged and argued",
+      "title": "Trace the structure",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+  ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What pattern of wise or foolish living is being exposed?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Trust",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "prov_3_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Wisdom’s worth",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Wisdom: Read as observed regularities, not iron promises.",
+    },
+    {
+      "label": "Moment",
+      "value": "Wisdom’s value and ways",
+    },
+    {
+      "label": "Original audience context",
+      "value": "United monarchy onward",
+    },
+    {
+      "label": "Purpose",
+      "value": "Form covenant character through observed wisdom.",
+    },
+  ],
+  "title": "Trust in the LORD",
+}
+`;
+
+exports[`plan parity for mode=teaching chapter psa_23 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "psa_23",
+  "conceptChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "structure:chapter:lit",
+      "panelType": "lit",
+      "subtitle": "How the chapter is arranged and argued",
+      "title": "Trace the structure",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:chapter:com",
+      "panelType": "com",
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What emotional movement do you notice from the opening line to the close?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_1:heb",
+      "panelType": "heb",
+      "sectionNum": 1,
+      "subtitle": "From Shepherd",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "psa_23_2:cross",
+      "panelType": "cross",
+      "sectionNum": 2,
+      "subtitle": "From Valley",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:lit",
+      "panelType": "lit",
+      "subtitle": "Chapter-level study",
+      "title": "Literary Structure",
+    },
+    {
+      "confidence": undefined,
+      "key": "chapter:com",
+      "panelType": "com",
+      "subtitle": "Chapter-level study",
+      "title": "Scholar Commentary",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Psalm: Trace the emotional arc.",
+    },
+    {
+      "label": "Moment",
+      "value": "Trust through the valley",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Monarchy",
+    },
+    {
+      "label": "Purpose",
+      "value": "Anthology of Israel’s prayer and praise.",
+    },
+  ],
+  "title": "The LORD Is My Shepherd",
+}
+`;
+
+exports[`plan parity for mode=teaching chapter rom_8 1`] = `
+{
+  "betterQuestionPrompt": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+  "chapterId": "rom_8",
+  "conceptChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
+  "evidenceTrail": [
+    {
+      "badge": "Required",
+      "key": "context:rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "Ancient audience, genre, and setting",
+      "title": "Start with context",
+    },
+    {
+      "badge": "Helpful",
+      "key": "structure:chapter:discourse",
+      "panelType": "discourse",
+      "subtitle": "How the chapter is arranged and argued",
+      "title": "Trace the structure",
+    },
+    {
+      "badge": "Helpful",
+      "key": "scripture:rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "Echoes, cross-references, and canonical connections",
+      "title": "Compare Scripture",
+    },
+    {
+      "badge": "Debated",
+      "confidence": "debated",
+      "key": "debate:rom_8_2:com",
+      "panelType": "com",
+      "sectionNum": 2,
+      "subtitle": "Where careful interpreters differ",
+      "title": "If unclear, weigh debate",
+    },
+  ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
+  "prompts": [
+    {
+      "key": "genre-observation",
+      "text": "What problem or question is this paragraph answering?",
+    },
+    {
+      "key": "better-question",
+      "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
+    },
+  ],
+  "recommendations": [
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:ctx",
+      "panelType": "ctx",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Context",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:greek",
+      "panelType": "greek",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Original-Language Study",
+    },
+    {
+      "confidence": undefined,
+      "key": "rom_8_1:cross",
+      "panelType": "cross",
+      "sectionNum": 1,
+      "subtitle": "From No condemnation",
+      "title": "Cross-References",
+    },
+    {
+      "confidence": "majority",
+      "key": "rom_8_2:com",
+      "panelType": "com",
+      "sectionNum": 2,
+      "subtitle": "From Children and heirs",
+      "title": "Scholar Commentary",
+    },
+    {
+      "confidence": "debated",
+      "key": "rom_8_2:debate",
+      "panelType": "debate",
+      "sectionNum": 2,
+      "subtitle": "From Children and heirs",
+      "title": "Scholar Debate",
+    },
+  ],
+  "sceneRows": [
+    {
+      "label": "Genre",
+      "value": "Letter: Trace the argument paragraph by paragraph.",
+    },
+    {
+      "label": "Moment",
+      "value": "No condemnation, no separation",
+    },
+    {
+      "label": "Original audience context",
+      "value": "Apostolic",
+    },
+    {
+      "label": "Purpose",
+      "value": "Defend the gospel for Jew and Gentile alike.",
+    },
+  ],
+  "title": "Life in the Spirit",
+}
+`;

--- a/app/src/services/guidedStudy/__tests__/fixtures/sampleChapters.ts
+++ b/app/src/services/guidedStudy/__tests__/fixtures/sampleChapters.ts
@@ -1,0 +1,442 @@
+import type {
+  Book,
+  Chapter,
+  ChapterPanel,
+  ParsedBookIntro,
+  Section,
+  SectionPanel,
+  Verse,
+} from '../../../../types';
+import type { GuidedStudyMode, GuidedStudyPlanInput } from '../../types';
+
+export const SAMPLE_CHAPTER_IDS = [
+  'gen_1',
+  'psa_23',
+  'isa_53',
+  'rom_8',
+  'prov_3',
+] as const;
+
+export type SampleChapterId = (typeof SAMPLE_CHAPTER_IDS)[number];
+
+interface ChapterFixture {
+  book: Book;
+  chapter: Chapter;
+  sections: Array<Section & { panels: SectionPanel[] }>;
+  chapterPanels: ChapterPanel[];
+  verses: Verse[];
+  bookIntro: ParsedBookIntro;
+}
+
+function panel(id: number, sectionId: string, type: string, note: string): SectionPanel {
+  return { id, section_id: sectionId, panel_type: type, content_json: JSON.stringify({ note }) };
+}
+
+function chapterPanel(id: number, chapterId: string, type: string, note: string): ChapterPanel {
+  return { id, chapter_id: chapterId, panel_type: type, content_json: JSON.stringify({ note }) };
+}
+
+const GEN_1: ChapterFixture = {
+  book: {
+    id: 'gen',
+    name: 'Genesis',
+    testament: 'ot',
+    total_chapters: 50,
+    book_order: 1,
+    is_live: true,
+    genre: 'theological_narrative',
+    genre_label: 'Theological Narrative',
+    genre_guidance: 'Read for who and why before how and when.',
+  },
+  chapter: {
+    id: 'gen_1',
+    book_id: 'gen',
+    chapter_num: 1,
+    title: 'The Creation of the Heaven and the Earth',
+    subtitle: 'Creation ordered by speech',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+  },
+  sections: [
+    {
+      id: 'gen_1_1',
+      chapter_id: 'gen_1',
+      section_num: 1,
+      header: 'Light',
+      verse_start: 1,
+      verse_end: 5,
+      panels: [
+        panel(1, 'gen_1_1', 'hist', 'ANE creation backdrop'),
+        panel(2, 'gen_1_1', 'ctx', 'Function-oriented opening'),
+        panel(3, 'gen_1_1', 'heb', 'bara — to create'),
+        panel(4, 'gen_1_1', 'cross', 'John 1:1-3 echo'),
+      ],
+    },
+    {
+      id: 'gen_1_2',
+      chapter_id: 'gen_1',
+      section_num: 2,
+      header: 'Sky and seas',
+      verse_start: 6,
+      verse_end: 13,
+      panels: [
+        panel(5, 'gen_1_2', 'ctx', 'Separating the waters'),
+        panel(6, 'gen_1_2', 'lit', 'Day pairings 1-3 / 4-6'),
+      ],
+    },
+  ],
+  chapterPanels: [
+    chapterPanel(101, 'gen_1', 'lit', 'Six-day frame, sabbath crown'),
+    chapterPanel(102, 'gen_1', 'debate', 'Days: literal vs framework'),
+  ],
+  verses: [
+    { id: 1, book_id: 'gen', chapter_num: 1, verse_num: 1, translation: 'kjv', text: 'In the beginning God created the heaven and the earth.' },
+    { id: 2, book_id: 'gen', chapter_num: 1, verse_num: 2, translation: 'kjv', text: 'And the earth was without form, and void.' },
+  ],
+  bookIntro: {
+    era: 'Primeval',
+    purpose: 'Explain beginnings and covenant hope.',
+    at_a_glance: {
+      author: 'Moses (traditional)',
+      date: '~1446-1406 BC',
+      chapters: 50,
+      genre: 'Theological Narrative',
+      key_theme: 'Creation, fall, and covenant promise',
+      key_word: 'beginning',
+    },
+  },
+};
+
+const PSA_23: ChapterFixture = {
+  book: {
+    id: 'psa',
+    name: 'Psalms',
+    testament: 'ot',
+    total_chapters: 150,
+    book_order: 19,
+    is_live: true,
+    genre: 'poetry',
+    genre_label: 'Psalm',
+    genre_guidance: 'Trace the emotional arc.',
+  },
+  chapter: {
+    id: 'psa_23',
+    book_id: 'psa',
+    chapter_num: 23,
+    title: 'The LORD Is My Shepherd',
+    subtitle: 'Trust through the valley',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+  },
+  sections: [
+    {
+      id: 'psa_23_1',
+      chapter_id: 'psa_23',
+      section_num: 1,
+      header: 'Shepherd',
+      verse_start: 1,
+      verse_end: 3,
+      panels: [
+        panel(1, 'psa_23_1', 'heb', 'roi — my shepherd'),
+        panel(2, 'psa_23_1', 'ctx', 'Pastoral imagery in ancient Israel'),
+      ],
+    },
+    {
+      id: 'psa_23_2',
+      chapter_id: 'psa_23',
+      section_num: 2,
+      header: 'Valley',
+      verse_start: 4,
+      verse_end: 6,
+      panels: [
+        panel(3, 'psa_23_2', 'cross', 'John 10 — good shepherd'),
+        panel(4, 'psa_23_2', 'ctx', 'Banquet imagery in covenant context'),
+      ],
+    },
+  ],
+  chapterPanels: [
+    chapterPanel(201, 'psa_23', 'lit', 'Shift from third to second person at v.4'),
+    chapterPanel(202, 'psa_23', 'com', 'Calvin: comfort in the shadow'),
+  ],
+  verses: [
+    { id: 1, book_id: 'psa', chapter_num: 23, verse_num: 1, translation: 'kjv', text: 'The LORD is my shepherd; I shall not want.' },
+  ],
+  bookIntro: {
+    era: 'Monarchy',
+    purpose: 'Anthology of Israel’s prayer and praise.',
+    at_a_glance: {
+      author: 'David and others',
+      date: '~1000-400 BC',
+      chapters: 150,
+      genre: 'Poetry',
+      key_theme: 'Worship in every season',
+      key_word: 'praise',
+    },
+  },
+};
+
+const ISA_53: ChapterFixture = {
+  book: {
+    id: 'isa',
+    name: 'Isaiah',
+    testament: 'ot',
+    total_chapters: 66,
+    book_order: 23,
+    is_live: true,
+    genre: 'prophecy',
+    genre_label: 'Prophecy',
+    genre_guidance: 'Listen for the covenant lawsuit.',
+  },
+  chapter: {
+    id: 'isa_53',
+    book_id: 'isa',
+    chapter_num: 53,
+    title: 'The Suffering Servant',
+    subtitle: 'Stricken for the people',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+  },
+  sections: [
+    {
+      id: 'isa_53_1',
+      chapter_id: 'isa_53',
+      section_num: 1,
+      header: 'No form or comeliness',
+      verse_start: 1,
+      verse_end: 3,
+      panels: [
+        panel(1, 'isa_53_1', 'hist', '8th-century context'),
+        panel(2, 'isa_53_1', 'heb', 'mareh — appearance'),
+      ],
+    },
+    {
+      id: 'isa_53_2',
+      chapter_id: 'isa_53',
+      section_num: 2,
+      header: 'Stricken',
+      verse_start: 4,
+      verse_end: 6,
+      panels: [
+        panel(3, 'isa_53_2', 'ctx', 'Substitutionary motif'),
+        panel(4, 'isa_53_2', 'src', 'Acts 8 — Ethiopian eunuch reads'),
+      ],
+    },
+    {
+      id: 'isa_53_3',
+      chapter_id: 'isa_53',
+      section_num: 3,
+      header: 'Vindication',
+      verse_start: 7,
+      verse_end: 12,
+      panels: [
+        panel(5, 'isa_53_3', 'cross', '1 Peter 2:24'),
+      ],
+    },
+  ],
+  chapterPanels: [
+    chapterPanel(301, 'isa_53', 'debate', 'Servant identity: Israel vs Messiah'),
+    chapterPanel(302, 'isa_53', 'com', 'Calvin / Moo on imputation'),
+  ],
+  verses: [
+    { id: 1, book_id: 'isa', chapter_num: 53, verse_num: 1, translation: 'kjv', text: 'Who hath believed our report?' },
+  ],
+  bookIntro: {
+    era: 'Divided monarchy',
+    purpose: 'Comfort and confront a covenant people facing judgment.',
+    at_a_glance: {
+      author: 'Isaiah of Jerusalem',
+      date: '~740-680 BC',
+      chapters: 66,
+      genre: 'Prophecy',
+      key_theme: 'The Holy One of Israel',
+      key_word: 'comfort',
+    },
+  },
+};
+
+const ROM_8: ChapterFixture = {
+  book: {
+    id: 'rom',
+    name: 'Romans',
+    testament: 'nt',
+    total_chapters: 16,
+    book_order: 45,
+    is_live: true,
+    genre: 'epistle',
+    genre_label: 'Letter',
+    genre_guidance: 'Trace the argument paragraph by paragraph.',
+  },
+  chapter: {
+    id: 'rom_8',
+    book_id: 'rom',
+    chapter_num: 8,
+    title: 'Life in the Spirit',
+    subtitle: 'No condemnation, no separation',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+  },
+  sections: [
+    {
+      id: 'rom_8_1',
+      chapter_id: 'rom_8',
+      section_num: 1,
+      header: 'No condemnation',
+      verse_start: 1,
+      verse_end: 11,
+      panels: [
+        panel(1, 'rom_8_1', 'greek', 'katakrima — condemnation'),
+        panel(2, 'rom_8_1', 'ctx', 'Forensic vs participatory framing'),
+        panel(3, 'rom_8_1', 'cross', 'Galatians 5 echo'),
+      ],
+    },
+    {
+      id: 'rom_8_2',
+      chapter_id: 'rom_8',
+      section_num: 2,
+      header: 'Children and heirs',
+      verse_start: 12,
+      verse_end: 17,
+      panels: [
+        panel(4, 'rom_8_2', 'com', 'Moo: adoption as legal status'),
+        panel(5, 'rom_8_2', 'debate', 'Suffering: necessary or consequential?'),
+      ],
+    },
+    {
+      id: 'rom_8_3',
+      chapter_id: 'rom_8',
+      section_num: 3,
+      header: 'No separation',
+      verse_start: 31,
+      verse_end: 39,
+      panels: [
+        panel(6, 'rom_8_3', 'cross', 'Psalm 44 quoted'),
+      ],
+    },
+  ],
+  chapterPanels: [
+    chapterPanel(401, 'rom_8', 'discourse', 'Climax of chs 5-8'),
+    chapterPanel(402, 'rom_8', 'debate', 'Predestination scope'),
+  ],
+  verses: [
+    { id: 1, book_id: 'rom', chapter_num: 8, verse_num: 1, translation: 'kjv', text: 'There is therefore now no condemnation to them which are in Christ Jesus.' },
+  ],
+  bookIntro: {
+    era: 'Apostolic',
+    purpose: 'Defend the gospel for Jew and Gentile alike.',
+    at_a_glance: {
+      author: 'Paul',
+      date: '~57 AD',
+      chapters: 16,
+      genre: 'Letter',
+      key_theme: 'Righteousness from God',
+      key_word: 'gospel',
+    },
+  },
+};
+
+const PROV_3: ChapterFixture = {
+  book: {
+    id: 'prov',
+    name: 'Proverbs',
+    testament: 'ot',
+    total_chapters: 31,
+    book_order: 20,
+    is_live: true,
+    genre: 'wisdom',
+    genre_label: 'Wisdom',
+    genre_guidance: 'Read as observed regularities, not iron promises.',
+  },
+  chapter: {
+    id: 'prov_3',
+    book_id: 'prov',
+    chapter_num: 3,
+    title: 'Trust in the LORD',
+    subtitle: 'Wisdom’s value and ways',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+  },
+  sections: [
+    {
+      id: 'prov_3_1',
+      chapter_id: 'prov_3',
+      section_num: 1,
+      header: 'Trust',
+      verse_start: 1,
+      verse_end: 12,
+      panels: [
+        panel(1, 'prov_3_1', 'heb', 'batach — trust'),
+        panel(2, 'prov_3_1', 'ctx', 'Father-to-son didactic frame'),
+      ],
+    },
+    {
+      id: 'prov_3_2',
+      chapter_id: 'prov_3',
+      section_num: 2,
+      header: 'Wisdom’s worth',
+      verse_start: 13,
+      verse_end: 35,
+      panels: [
+        panel(3, 'prov_3_2', 'cross', 'Job 28 — wisdom’s mine'),
+      ],
+    },
+  ],
+  chapterPanels: [
+    chapterPanel(501, 'prov_3', 'lit', 'Three-strand: trust / honor / discipline'),
+  ],
+  verses: [
+    { id: 1, book_id: 'prov', chapter_num: 3, verse_num: 5, translation: 'kjv', text: 'Trust in the LORD with all thine heart.' },
+  ],
+  bookIntro: {
+    era: 'United monarchy onward',
+    purpose: 'Form covenant character through observed wisdom.',
+    at_a_glance: {
+      author: 'Solomon and others',
+      date: '~970-700 BC',
+      chapters: 31,
+      genre: 'Wisdom',
+      key_theme: 'Fear of the LORD',
+      key_word: 'wisdom',
+    },
+  },
+};
+
+const FIXTURES: Record<SampleChapterId, ChapterFixture> = {
+  gen_1: GEN_1,
+  psa_23: PSA_23,
+  isa_53: ISA_53,
+  rom_8: ROM_8,
+  prov_3: PROV_3,
+};
+
+export function loadFixture(id: SampleChapterId, mode: GuidedStudyMode): GuidedStudyPlanInput {
+  const f = FIXTURES[id];
+  return {
+    book: f.book,
+    chapter: f.chapter,
+    sections: f.sections,
+    chapterPanels: f.chapterPanels,
+    verses: f.verses,
+    bookIntro: f.bookIntro,
+    mode,
+  };
+}

--- a/app/src/services/guidedStudy/__tests__/plan.parity.test.ts
+++ b/app/src/services/guidedStudy/__tests__/plan.parity.test.ts
@@ -1,0 +1,11 @@
+import { buildGuidedStudyPlan } from '../plan';
+import { GUIDED_STUDY_MODES } from '../types';
+import { SAMPLE_CHAPTER_IDS, loadFixture } from './fixtures/sampleChapters';
+
+describe.each(GUIDED_STUDY_MODES)('plan parity for mode=%s', (mode) => {
+  it.each(SAMPLE_CHAPTER_IDS)('chapter %s', (chId) => {
+    const input = loadFixture(chId, mode);
+    const plan = buildGuidedStudyPlan(input);
+    expect(plan).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Closes #1729. Phase 1.4 of epic #1725 — **the Phase 1 capstone.**

## Why
The Phase 1 refactor (#1726–#1728) moves mode behavior into `MODE_DEFINITIONS` and reroutes `plan.ts` through `getModeDefinition`. The objective was zero visible behavior change. This card writes that promise down as 20 snapshots so the next regression breaks the build, not the user experience.

## What
Three new files, no production-code changes:

- `__tests__/fixtures/sampleChapters.ts` — five deterministic in-memory chapters spanning the canonical genres:
  - `gen_1` (Theological Narrative)
  - `psa_23` (Psalm / Poetry)
  - `isa_53` (Prophecy)
  - `rom_8` (Letter / debate-heavy)
  - `prov_3` (Wisdom)
  Each fixture has 2–3 sections, varied panel types (`hist`/`ctx`/`heb`/`greek`/`cross`/`src`/`debate`/`com`/`lit`/`discourse`), populated `bookIntro`. No `scripture.db` access.
- `__tests__/plan.parity.test.ts` — `describe.each(GUIDED_STUDY_MODES)` × `it.each(SAMPLE_CHAPTER_IDS)` → 20 `toMatchSnapshot()` calls.
- `__tests__/__snapshots__/plan.parity.test.ts.snap` — 20 snapshots, all generated against post-refactor `plan.ts`.

## Acceptance criteria
- [x] 20 snapshots committed
- [x] Tests run green on first commit (and idempotent re-run)
- [x] Snapshots reflect post-refactor output (the parity that #1726–#1728 promised). Phase 2 cards that change plan output will need to update them — that's the design.
- [x] tsc / lint / 97 guidedStudy tests clean

## Rollback
Revert the PR. Pure tests + fixtures, zero runtime impact.

## Notes for Craig
- Kanban move (In Progress → Done) requires manual action — no project-board GraphQL access from this session.
- This closes Phase 1. I'll post the phase-completion comment on epic #1725 once this merges, then wait for go-ahead before starting Phase 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_