### PR TITLE
feat: mode-specific prompts per step (#1730)

### DIFF
--- a/app/__tests__/services/guidedStudy.test.ts
+++ b/app/__tests__/services/guidedStudy.test.ts
@@ -125,7 +125,7 @@ describe('guided study services', () => {
       'Original audience context',
       'Purpose',
     ]);
-    expect(plan.prompts).toHaveLength(2);
+    expect(plan.legacyPrompts).toHaveLength(2);
     expect(plan.recommendations.map((rec) => rec.panelType)).toEqual([
       'ctx',
       'heb',
@@ -217,7 +217,7 @@ describe('guided study services', () => {
       chapterPanels,
       verses,
     });
-    const genrePromptText = plan.prompts.find((p) => p.key === 'genre-observation')?.text ?? '';
+    const genrePromptText = plan.legacyPrompts.find((p) => p.key === 'genre-observation')?.text ?? '';
     expect(genrePromptText).toBe(
       'What does the passage emphasize before you open any study panels?',
     );
@@ -230,7 +230,7 @@ describe('guided study services', () => {
       chapterPanels,
       verses,
     });
-    expect(plan2.prompts.find((p) => p.key === 'genre-observation')?.text).toBe(
+    expect(plan2.legacyPrompts.find((p) => p.key === 'genre-observation')?.text).toBe(
       'What does the passage emphasize before you open any study panels?',
     );
   });
@@ -251,7 +251,7 @@ describe('guided study services', () => {
         chapterPanels,
         verses,
       });
-      expect(plan.prompts.find((p) => p.key === 'genre-observation')?.text).toBe(expected);
+      expect(plan.legacyPrompts.find((p) => p.key === 'genre-observation')?.text).toBe(expected);
     }
   });
 
@@ -319,7 +319,7 @@ describe('guided study services', () => {
     expect(plan.title).toBe('The Creation of the Heaven and the Earth');
     expect(plan.recommendations).toHaveLength(0);
     // Section prompt falls back to the generic chapter-level prompt
-    expect(plan.prompts.some((p) => p.text.includes('chapter on its own terms'))).toBe(true);
+    expect(plan.legacyPrompts.some((p) => p.text.includes('chapter on its own terms'))).toBe(true);
   });
 
   it('reads concept haystack from bookIntro fields (purpose, key_theme, key_word)', () => {

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -170,7 +170,7 @@ function StudySessionScreen() {
   const savePromptDrafts = useCallback(async () => {
     if (!plan) return;
     await Promise.all(
-      plan.prompts.map((prompt) =>
+      plan.legacyPrompts.map((prompt) =>
         session.saveResponse(prompt.key, prompt.text, responseDrafts[prompt.key] ?? ''),
       ),
     );
@@ -291,7 +291,7 @@ function StudySessionScreen() {
         {session.currentStep === 'observe' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Observe</Text>
-            {plan.prompts.map((prompt) => (
+            {plan.legacyPrompts.map((prompt) => (
               <View key={prompt.key} style={styles.promptBlock}>
                 <Text style={[styles.promptText, { color: base.text }]}>{prompt.text}</Text>
                 <TextInput

--- a/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
+++ b/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
@@ -52,9 +52,7 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "deep",
-  "modeLabel": "Deep study",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What tension, movement, or turning point do you notice in this scene?",
@@ -64,6 +62,8 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
       "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
   "recommendations": [
     {
       "confidence": undefined,
@@ -123,6 +123,46 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
       "value": "Explain beginnings and covenant hope.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "deep-explore-evidence",
+        "text": "Which panels speak to what you noticed above?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "deep-observe-surprise",
+        "text": "What surprises you in this chapter?",
+      },
+      {
+        "key": "deep-observe-confusion",
+        "text": "What confuses you or feels unresolved?",
+      },
+      {
+        "key": "deep-observe-repetition",
+        "text": "What words, phrases, or ideas seem to repeat?",
+      },
+    ],
+    "review": [
+      {
+        "key": "deep-review-connection",
+        "text": "Which connection is worth carrying into your next study?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "deep-scene-tensions",
+        "text": "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "deep-synthesize-claim",
+        "text": "State your claim. What's the evidence? What tension remains?",
+      },
+    ],
+  },
   "title": "The Creation of the Heaven and the Earth",
 }
 `;
@@ -183,9 +223,7 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "deep",
-  "modeLabel": "Deep study",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What covenant problem is the prophet confronting?",
@@ -195,6 +233,8 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
   "recommendations": [
     {
       "confidence": undefined,
@@ -255,6 +295,46 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
       "value": "Comfort and confront a covenant people facing judgment.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "deep-explore-evidence",
+        "text": "Which panels speak to what you noticed above?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "deep-observe-surprise",
+        "text": "What surprises you in this chapter?",
+      },
+      {
+        "key": "deep-observe-confusion",
+        "text": "What confuses you or feels unresolved?",
+      },
+      {
+        "key": "deep-observe-repetition",
+        "text": "What words, phrases, or ideas seem to repeat?",
+      },
+    ],
+    "review": [
+      {
+        "key": "deep-review-connection",
+        "text": "Which connection is worth carrying into your next study?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "deep-scene-tensions",
+        "text": "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "deep-synthesize-claim",
+        "text": "State your claim. What's the evidence? What tension remains?",
+      },
+    ],
+  },
   "title": "The Suffering Servant",
 }
 `;
@@ -303,9 +383,7 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "deep",
-  "modeLabel": "Deep study",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What pattern of wise or foolish living is being exposed?",
@@ -315,6 +393,8 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
       "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
   "recommendations": [
     {
       "confidence": undefined,
@@ -366,6 +446,46 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
       "value": "Form covenant character through observed wisdom.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "deep-explore-evidence",
+        "text": "Which panels speak to what you noticed above?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "deep-observe-surprise",
+        "text": "What surprises you in this chapter?",
+      },
+      {
+        "key": "deep-observe-confusion",
+        "text": "What confuses you or feels unresolved?",
+      },
+      {
+        "key": "deep-observe-repetition",
+        "text": "What words, phrases, or ideas seem to repeat?",
+      },
+    ],
+    "review": [
+      {
+        "key": "deep-review-connection",
+        "text": "Which connection is worth carrying into your next study?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "deep-scene-tensions",
+        "text": "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "deep-synthesize-claim",
+        "text": "State your claim. What's the evidence? What tension remains?",
+      },
+    ],
+  },
   "title": "Trust in the LORD",
 }
 `;
@@ -414,9 +534,7 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "deep",
-  "modeLabel": "Deep study",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What emotional movement do you notice from the opening line to the close?",
@@ -426,6 +544,8 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
   "recommendations": [
     {
       "confidence": undefined,
@@ -484,6 +604,46 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
       "value": "Anthology of Israel’s prayer and praise.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "deep-explore-evidence",
+        "text": "Which panels speak to what you noticed above?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "deep-observe-surprise",
+        "text": "What surprises you in this chapter?",
+      },
+      {
+        "key": "deep-observe-confusion",
+        "text": "What confuses you or feels unresolved?",
+      },
+      {
+        "key": "deep-observe-repetition",
+        "text": "What words, phrases, or ideas seem to repeat?",
+      },
+    ],
+    "review": [
+      {
+        "key": "deep-review-connection",
+        "text": "Which connection is worth carrying into your next study?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "deep-scene-tensions",
+        "text": "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "deep-synthesize-claim",
+        "text": "State your claim. What's the evidence? What tension remains?",
+      },
+    ],
+  },
   "title": "The LORD Is My Shepherd",
 }
 `;
@@ -537,9 +697,7 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "deep",
-  "modeLabel": "Deep study",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What problem or question is this paragraph answering?",
@@ -549,6 +707,8 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
       "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "deep",
+  "modeLabel": "Deep study",
   "recommendations": [
     {
       "confidence": undefined,
@@ -609,6 +769,46 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
       "value": "Defend the gospel for Jew and Gentile alike.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "deep-explore-evidence",
+        "text": "Which panels speak to what you noticed above?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "deep-observe-surprise",
+        "text": "What surprises you in this chapter?",
+      },
+      {
+        "key": "deep-observe-confusion",
+        "text": "What confuses you or feels unresolved?",
+      },
+      {
+        "key": "deep-observe-repetition",
+        "text": "What words, phrases, or ideas seem to repeat?",
+      },
+    ],
+    "review": [
+      {
+        "key": "deep-review-connection",
+        "text": "Which connection is worth carrying into your next study?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "deep-scene-tensions",
+        "text": "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "deep-synthesize-claim",
+        "text": "State your claim. What's the evidence? What tension remains?",
+      },
+    ],
+  },
   "title": "Life in the Spirit",
 }
 `;
@@ -657,9 +857,7 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
       "title": "Check the language",
     },
   ],
-  "mode": "devotional",
-  "modeLabel": "Devotional",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What tension, movement, or turning point do you notice in this scene?",
@@ -669,6 +867,8 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
       "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
   "recommendations": [
     {
       "confidence": undefined,
@@ -713,6 +913,38 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
       "value": "Explain beginnings and covenant hope.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "devotional-explore-deepen",
+        "text": "Which panel deepens what's meeting you?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "devotional-observe-meeting",
+        "text": "What word, phrase, or image is meeting you in this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "devotional-review-carry",
+        "text": "What will you carry into the rest of your day?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "devotional-scene-arrival",
+        "text": "How did you arrive at this chapter today? What are you bringing with you?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "devotional-synthesize-prayer",
+        "text": "What might God be saying? Pray it back in your own words.",
+      },
+    ],
+  },
   "title": "The Creation of the Heaven and the Earth",
 }
 `;
@@ -765,9 +997,7 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
       "title": "Check the language",
     },
   ],
-  "mode": "devotional",
-  "modeLabel": "Devotional",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What covenant problem is the prophet confronting?",
@@ -777,6 +1007,8 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
   "recommendations": [
     {
       "confidence": undefined,
@@ -821,6 +1053,38 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
       "value": "Comfort and confront a covenant people facing judgment.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "devotional-explore-deepen",
+        "text": "Which panel deepens what's meeting you?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "devotional-observe-meeting",
+        "text": "What word, phrase, or image is meeting you in this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "devotional-review-carry",
+        "text": "What will you carry into the rest of your day?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "devotional-scene-arrival",
+        "text": "How did you arrive at this chapter today? What are you bringing with you?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "devotional-synthesize-prayer",
+        "text": "What might God be saying? Pray it back in your own words.",
+      },
+    ],
+  },
   "title": "The Suffering Servant",
 }
 `;
@@ -869,9 +1133,7 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
       "title": "Check the language",
     },
   ],
-  "mode": "devotional",
-  "modeLabel": "Devotional",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What pattern of wise or foolish living is being exposed?",
@@ -881,6 +1143,8 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
       "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
   "recommendations": [
     {
       "confidence": undefined,
@@ -925,6 +1189,38 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
       "value": "Form covenant character through observed wisdom.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "devotional-explore-deepen",
+        "text": "Which panel deepens what's meeting you?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "devotional-observe-meeting",
+        "text": "What word, phrase, or image is meeting you in this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "devotional-review-carry",
+        "text": "What will you carry into the rest of your day?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "devotional-scene-arrival",
+        "text": "How did you arrive at this chapter today? What are you bringing with you?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "devotional-synthesize-prayer",
+        "text": "What might God be saying? Pray it back in your own words.",
+      },
+    ],
+  },
   "title": "Trust in the LORD",
 }
 `;
@@ -965,9 +1261,7 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
       "title": "Check the language",
     },
   ],
-  "mode": "devotional",
-  "modeLabel": "Devotional",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What emotional movement do you notice from the opening line to the close?",
@@ -977,6 +1271,8 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1021,6 +1317,38 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
       "value": "Anthology of Israel’s prayer and praise.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "devotional-explore-deepen",
+        "text": "Which panel deepens what's meeting you?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "devotional-observe-meeting",
+        "text": "What word, phrase, or image is meeting you in this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "devotional-review-carry",
+        "text": "What will you carry into the rest of your day?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "devotional-scene-arrival",
+        "text": "How did you arrive at this chapter today? What are you bringing with you?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "devotional-synthesize-prayer",
+        "text": "What might God be saying? Pray it back in your own words.",
+      },
+    ],
+  },
   "title": "The LORD Is My Shepherd",
 }
 `;
@@ -1065,9 +1393,7 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
       "title": "Check the language",
     },
   ],
-  "mode": "devotional",
-  "modeLabel": "Devotional",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What problem or question is this paragraph answering?",
@@ -1077,6 +1403,8 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
       "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "devotional",
+  "modeLabel": "Devotional",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1121,6 +1449,38 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
       "value": "Defend the gospel for Jew and Gentile alike.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "devotional-explore-deepen",
+        "text": "Which panel deepens what's meeting you?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "devotional-observe-meeting",
+        "text": "What word, phrase, or image is meeting you in this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "devotional-review-carry",
+        "text": "What will you carry into the rest of your day?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "devotional-scene-arrival",
+        "text": "How did you arrive at this chapter today? What are you bringing with you?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "devotional-synthesize-prayer",
+        "text": "What might God be saying? Pray it back in your own words.",
+      },
+    ],
+  },
   "title": "Life in the Spirit",
 }
 `;
@@ -1169,9 +1529,7 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "quick",
-  "modeLabel": "Quick pass",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What tension, movement, or turning point do you notice in this scene?",
@@ -1181,6 +1539,8 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
       "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1225,6 +1585,38 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
       "value": "Explain beginnings and covenant hope.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "quick-explore-priority",
+        "text": "Which of these will help you most in 5 minutes?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "quick-observe-takeaway",
+        "text": "What's the one thing you'd want to remember from this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "quick-review-carry",
+        "text": "What verse or phrase will you carry with you today?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "quick-scene-genre",
+        "text": "What kind of writing is this, and what's happening in this chapter?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "quick-synthesize-summary",
+        "text": "In one sentence: what does this chapter say?",
+      },
+    ],
+  },
   "title": "The Creation of the Heaven and the Earth",
 }
 `;
@@ -1277,9 +1669,7 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "quick",
-  "modeLabel": "Quick pass",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What covenant problem is the prophet confronting?",
@@ -1289,6 +1679,8 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1333,6 +1725,38 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
       "value": "Comfort and confront a covenant people facing judgment.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "quick-explore-priority",
+        "text": "Which of these will help you most in 5 minutes?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "quick-observe-takeaway",
+        "text": "What's the one thing you'd want to remember from this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "quick-review-carry",
+        "text": "What verse or phrase will you carry with you today?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "quick-scene-genre",
+        "text": "What kind of writing is this, and what's happening in this chapter?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "quick-synthesize-summary",
+        "text": "In one sentence: what does this chapter say?",
+      },
+    ],
+  },
   "title": "The Suffering Servant",
 }
 `;
@@ -1381,9 +1805,7 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "quick",
-  "modeLabel": "Quick pass",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What pattern of wise or foolish living is being exposed?",
@@ -1393,6 +1815,8 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
       "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1437,6 +1861,38 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
       "value": "Form covenant character through observed wisdom.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "quick-explore-priority",
+        "text": "Which of these will help you most in 5 minutes?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "quick-observe-takeaway",
+        "text": "What's the one thing you'd want to remember from this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "quick-review-carry",
+        "text": "What verse or phrase will you carry with you today?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "quick-scene-genre",
+        "text": "What kind of writing is this, and what's happening in this chapter?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "quick-synthesize-summary",
+        "text": "In one sentence: what does this chapter say?",
+      },
+    ],
+  },
   "title": "Trust in the LORD",
 }
 `;
@@ -1477,9 +1933,7 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "quick",
-  "modeLabel": "Quick pass",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What emotional movement do you notice from the opening line to the close?",
@@ -1489,6 +1943,8 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1533,6 +1989,38 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
       "value": "Anthology of Israel’s prayer and praise.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "quick-explore-priority",
+        "text": "Which of these will help you most in 5 minutes?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "quick-observe-takeaway",
+        "text": "What's the one thing you'd want to remember from this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "quick-review-carry",
+        "text": "What verse or phrase will you carry with you today?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "quick-scene-genre",
+        "text": "What kind of writing is this, and what's happening in this chapter?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "quick-synthesize-summary",
+        "text": "In one sentence: what does this chapter say?",
+      },
+    ],
+  },
   "title": "The LORD Is My Shepherd",
 }
 `;
@@ -1577,9 +2065,7 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "quick",
-  "modeLabel": "Quick pass",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What problem or question is this paragraph answering?",
@@ -1589,6 +2075,8 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
       "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "quick",
+  "modeLabel": "Quick pass",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1633,6 +2121,38 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
       "value": "Defend the gospel for Jew and Gentile alike.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "quick-explore-priority",
+        "text": "Which of these will help you most in 5 minutes?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "quick-observe-takeaway",
+        "text": "What's the one thing you'd want to remember from this chapter?",
+      },
+    ],
+    "review": [
+      {
+        "key": "quick-review-carry",
+        "text": "What verse or phrase will you carry with you today?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "quick-scene-genre",
+        "text": "What kind of writing is this, and what's happening in this chapter?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "quick-synthesize-summary",
+        "text": "In one sentence: what does this chapter say?",
+      },
+    ],
+  },
   "title": "Life in the Spirit",
 }
 `;
@@ -1688,9 +2208,7 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "teaching",
-  "modeLabel": "Teaching prep",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What tension, movement, or turning point do you notice in this scene?",
@@ -1700,6 +2218,8 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
       "text": "What do verses 1-5 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1759,6 +2279,46 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
       "value": "Explain beginnings and covenant hope.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "teaching-explore-supports",
+        "text": "Which structural and contextual panels support your main point?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "teaching-observe-main-point",
+        "text": "What's the main point you'd want a listener to leave with?",
+      },
+      {
+        "key": "teaching-observe-misread",
+        "text": "What would they get wrong if you didn't clarify it?",
+      },
+    ],
+    "review": [
+      {
+        "key": "teaching-review-check",
+        "text": "What's one question you'll ask your audience to check understanding?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "teaching-scene-audience",
+        "text": "Who are you teaching? What do they already know about this passage?",
+      },
+      {
+        "key": "teaching-scene-setting",
+        "text": "What's the setting — sermon, small group, classroom, one-on-one?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "teaching-synthesize-outline",
+        "text": "Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.",
+      },
+    ],
+  },
   "title": "The Creation of the Heaven and the Earth",
 }
 `;
@@ -1811,9 +2371,7 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "teaching",
-  "modeLabel": "Teaching prep",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What covenant problem is the prophet confronting?",
@@ -1823,6 +2381,8 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1883,6 +2443,46 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
       "value": "Comfort and confront a covenant people facing judgment.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "teaching-explore-supports",
+        "text": "Which structural and contextual panels support your main point?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "teaching-observe-main-point",
+        "text": "What's the main point you'd want a listener to leave with?",
+      },
+      {
+        "key": "teaching-observe-misread",
+        "text": "What would they get wrong if you didn't clarify it?",
+      },
+    ],
+    "review": [
+      {
+        "key": "teaching-review-check",
+        "text": "What's one question you'll ask your audience to check understanding?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "teaching-scene-audience",
+        "text": "Who are you teaching? What do they already know about this passage?",
+      },
+      {
+        "key": "teaching-scene-setting",
+        "text": "What's the setting — sermon, small group, classroom, one-on-one?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "teaching-synthesize-outline",
+        "text": "Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.",
+      },
+    ],
+  },
   "title": "The Suffering Servant",
 }
 `;
@@ -1930,9 +2530,7 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
       "title": "Compare Scripture",
     },
   ],
-  "mode": "teaching",
-  "modeLabel": "Teaching prep",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What pattern of wise or foolish living is being exposed?",
@@ -1942,6 +2540,8 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
       "text": "What do verses 1-12 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
   "recommendations": [
     {
       "confidence": undefined,
@@ -1993,6 +2593,46 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
       "value": "Form covenant character through observed wisdom.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "teaching-explore-supports",
+        "text": "Which structural and contextual panels support your main point?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "teaching-observe-main-point",
+        "text": "What's the main point you'd want a listener to leave with?",
+      },
+      {
+        "key": "teaching-observe-misread",
+        "text": "What would they get wrong if you didn't clarify it?",
+      },
+    ],
+    "review": [
+      {
+        "key": "teaching-review-check",
+        "text": "What's one question you'll ask your audience to check understanding?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "teaching-scene-audience",
+        "text": "Who are you teaching? What do they already know about this passage?",
+      },
+      {
+        "key": "teaching-scene-setting",
+        "text": "What's the setting — sermon, small group, classroom, one-on-one?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "teaching-synthesize-outline",
+        "text": "Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.",
+      },
+    ],
+  },
   "title": "Trust in the LORD",
 }
 `;
@@ -2040,9 +2680,7 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "teaching",
-  "modeLabel": "Teaching prep",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What emotional movement do you notice from the opening line to the close?",
@@ -2052,6 +2690,8 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
       "text": "What do verses 1-3 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
   "recommendations": [
     {
       "confidence": undefined,
@@ -2110,6 +2750,46 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
       "value": "Anthology of Israel’s prayer and praise.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "teaching-explore-supports",
+        "text": "Which structural and contextual panels support your main point?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "teaching-observe-main-point",
+        "text": "What's the main point you'd want a listener to leave with?",
+      },
+      {
+        "key": "teaching-observe-misread",
+        "text": "What would they get wrong if you didn't clarify it?",
+      },
+    ],
+    "review": [
+      {
+        "key": "teaching-review-check",
+        "text": "What's one question you'll ask your audience to check understanding?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "teaching-scene-audience",
+        "text": "Who are you teaching? What do they already know about this passage?",
+      },
+      {
+        "key": "teaching-scene-setting",
+        "text": "What's the setting — sermon, small group, classroom, one-on-one?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "teaching-synthesize-outline",
+        "text": "Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.",
+      },
+    ],
+  },
   "title": "The LORD Is My Shepherd",
 }
 `;
@@ -2162,9 +2842,7 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
       "title": "If unclear, weigh debate",
     },
   ],
-  "mode": "teaching",
-  "modeLabel": "Teaching prep",
-  "prompts": [
+  "legacyPrompts": [
     {
       "key": "genre-observation",
       "text": "What problem or question is this paragraph answering?",
@@ -2174,6 +2852,8 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
       "text": "What do verses 1-11 ask you to notice about the original audience, not just yourself?",
     },
   ],
+  "mode": "teaching",
+  "modeLabel": "Teaching prep",
   "recommendations": [
     {
       "confidence": undefined,
@@ -2234,6 +2914,46 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
       "value": "Defend the gospel for Jew and Gentile alike.",
     },
   ],
+  "stepPrompts": {
+    "explore": [
+      {
+        "key": "teaching-explore-supports",
+        "text": "Which structural and contextual panels support your main point?",
+      },
+    ],
+    "observe": [
+      {
+        "key": "teaching-observe-main-point",
+        "text": "What's the main point you'd want a listener to leave with?",
+      },
+      {
+        "key": "teaching-observe-misread",
+        "text": "What would they get wrong if you didn't clarify it?",
+      },
+    ],
+    "review": [
+      {
+        "key": "teaching-review-check",
+        "text": "What's one question you'll ask your audience to check understanding?",
+      },
+    ],
+    "scene": [
+      {
+        "key": "teaching-scene-audience",
+        "text": "Who are you teaching? What do they already know about this passage?",
+      },
+      {
+        "key": "teaching-scene-setting",
+        "text": "What's the setting — sermon, small group, classroom, one-on-one?",
+      },
+    ],
+    "synthesize": [
+      {
+        "key": "teaching-synthesize-outline",
+        "text": "Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.",
+      },
+    ],
+  },
   "title": "Life in the Spirit",
 }
 `;

--- a/app/src/services/guidedStudy/__tests__/stepPrompts.test.ts
+++ b/app/src/services/guidedStudy/__tests__/stepPrompts.test.ts
@@ -1,0 +1,87 @@
+import { buildGuidedStudyPlan } from '../plan';
+import { GUIDED_STUDY_MODES, GUIDED_STUDY_STEPS } from '../types';
+import { MODE_DEFINITIONS } from '../modes/definitions';
+import { loadFixture } from './fixtures/sampleChapters';
+
+describe('GuidedStudyPlan.stepPrompts', () => {
+  it.each(GUIDED_STUDY_MODES)(
+    '%s plan exposes all five steps with prompts identical to MODE_DEFINITIONS',
+    (mode) => {
+      const plan = buildGuidedStudyPlan(loadFixture('gen_1', mode));
+      const def = MODE_DEFINITIONS[mode];
+
+      for (const step of GUIDED_STUDY_STEPS) {
+        expect(plan.stepPrompts[step]).toEqual(def.steps[step].prompts);
+      }
+    },
+  );
+
+  it('quick mode carries the verbatim prompt copy', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('gen_1', 'quick'));
+    expect(plan.stepPrompts.scene.map((p) => p.text)).toEqual([
+      "What kind of writing is this, and what's happening in this chapter?",
+    ]);
+    expect(plan.stepPrompts.observe.map((p) => p.text)).toEqual([
+      "What's the one thing you'd want to remember from this chapter?",
+    ]);
+    expect(plan.stepPrompts.review.map((p) => p.text)).toEqual([
+      'What verse or phrase will you carry with you today?',
+    ]);
+  });
+
+  it('deep mode supplies three observe prompts (surprise, confusion, repetition)', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('gen_1', 'deep'));
+    expect(plan.stepPrompts.observe).toHaveLength(3);
+    expect(plan.stepPrompts.observe.map((p) => p.text)).toEqual([
+      'What surprises you in this chapter?',
+      'What confuses you or feels unresolved?',
+      'What words, phrases, or ideas seem to repeat?',
+    ]);
+  });
+
+  it('teaching mode supplies two scene prompts (audience + setting)', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('rom_8', 'teaching'));
+    expect(plan.stepPrompts.scene).toHaveLength(2);
+    expect(plan.stepPrompts.scene.map((p) => p.text)).toEqual([
+      'Who are you teaching? What do they already know about this passage?',
+      "What's the setting — sermon, small group, classroom, one-on-one?",
+    ]);
+  });
+
+  it('teaching mode supplies two observe prompts (main point + clarification)', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('rom_8', 'teaching'));
+    expect(plan.stepPrompts.observe).toHaveLength(2);
+    expect(plan.stepPrompts.observe.map((p) => p.text)).toEqual([
+      "What's the main point you'd want a listener to leave with?",
+      "What would they get wrong if you didn't clarify it?",
+    ]);
+  });
+
+  it('devotional mode prayer prompt appears at synthesize', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('psa_23', 'devotional'));
+    expect(plan.stepPrompts.synthesize.map((p) => p.text)).toEqual([
+      'What might God be saying? Pray it back in your own words.',
+    ]);
+  });
+
+  it('legacyPrompts retains the genre + better-question pair', () => {
+    const plan = buildGuidedStudyPlan(loadFixture('gen_1', 'quick'));
+    expect(plan.legacyPrompts).toHaveLength(2);
+    expect(plan.legacyPrompts.map((p) => p.key)).toEqual([
+      'genre-observation',
+      'better-question',
+    ]);
+  });
+
+  it('every prompt key is unique across all (mode, step) combinations', () => {
+    const seen = new Set<string>();
+    for (const mode of GUIDED_STUDY_MODES) {
+      for (const step of GUIDED_STUDY_STEPS) {
+        for (const prompt of MODE_DEFINITIONS[mode].steps[step].prompts) {
+          expect(seen.has(prompt.key)).toBe(false);
+          seen.add(prompt.key);
+        }
+      }
+    }
+  });
+});

--- a/app/src/services/guidedStudy/modes/__tests__/definitions.test.ts
+++ b/app/src/services/guidedStudy/modes/__tests__/definitions.test.ts
@@ -45,12 +45,22 @@ describe('MODE_DEFINITIONS', () => {
   });
 
   it.each(GUIDED_STUDY_MODES)(
-    '%s has empty panelWeights and empty step prompts in Phase 1',
+    '%s has empty panelWeights through Phase 2.1 (filled in #1733)',
+    (mode) => {
+      expect(MODE_DEFINITIONS[mode].panelWeights).toEqual({});
+    },
+  );
+
+  it.each(GUIDED_STUDY_MODES)(
+    '%s has at least one prompt at every step after Phase 2.1',
     (mode) => {
       const def = MODE_DEFINITIONS[mode];
-      expect(def.panelWeights).toEqual({});
-      for (const step of Object.values(def.steps)) {
-        expect(step.prompts).toEqual([]);
+      for (const [stepKey, step] of Object.entries(def.steps)) {
+        expect(step.prompts.length).toBeGreaterThan(0);
+        for (const prompt of step.prompts) {
+          expect(prompt.key).toMatch(new RegExp(`^${mode}-${stepKey}-`));
+          expect(prompt.text.trim().length).toBeGreaterThan(0);
+        }
       }
     },
   );

--- a/app/src/services/guidedStudy/modes/deep.ts
+++ b/app/src/services/guidedStudy/modes/deep.ts
@@ -8,11 +8,51 @@ export const DEEP_MODE: ModeDefinition = {
   blurb: 'A fuller trail through context, language, Scripture, and debate.',
   marketingPromise: 'A structured analysis you can reason from.',
   steps: {
-    scene: { prompts: [] },
-    observe: { prompts: [] },
-    explore: { prompts: [] },
-    synthesize: { prompts: [] },
-    review: { prompts: [] },
+    scene: {
+      prompts: [
+        {
+          key: 'deep-scene-tensions',
+          text: "What tensions or movements do you expect from this genre and this chapter's place in the book?",
+        },
+      ],
+    },
+    observe: {
+      prompts: [
+        { key: 'deep-observe-surprise', text: 'What surprises you in this chapter?' },
+        {
+          key: 'deep-observe-confusion',
+          text: 'What confuses you or feels unresolved?',
+        },
+        {
+          key: 'deep-observe-repetition',
+          text: 'What words, phrases, or ideas seem to repeat?',
+        },
+      ],
+    },
+    explore: {
+      prompts: [
+        {
+          key: 'deep-explore-evidence',
+          text: 'Which panels speak to what you noticed above?',
+        },
+      ],
+    },
+    synthesize: {
+      prompts: [
+        {
+          key: 'deep-synthesize-claim',
+          text: "State your claim. What's the evidence? What tension remains?",
+        },
+      ],
+    },
+    review: {
+      prompts: [
+        {
+          key: 'deep-review-connection',
+          text: 'Which connection is worth carrying into your next study?',
+        },
+      ],
+    },
   },
   trailOrder: ['context', 'language', 'scripture', 'debate'],
   recommendationLimit: 5,

--- a/app/src/services/guidedStudy/modes/devotional.ts
+++ b/app/src/services/guidedStudy/modes/devotional.ts
@@ -8,11 +8,46 @@ export const DEVOTIONAL_MODE: ModeDefinition = {
   blurb: 'Observe the text carefully before moving toward prayerful response.',
   marketingPromise: "A prayer in the chapter's own language.",
   steps: {
-    scene: { prompts: [] },
-    observe: { prompts: [] },
-    explore: { prompts: [] },
-    synthesize: { prompts: [] },
-    review: { prompts: [] },
+    scene: {
+      prompts: [
+        {
+          key: 'devotional-scene-arrival',
+          text: 'How did you arrive at this chapter today? What are you bringing with you?',
+        },
+      ],
+    },
+    observe: {
+      prompts: [
+        {
+          key: 'devotional-observe-meeting',
+          text: 'What word, phrase, or image is meeting you in this chapter?',
+        },
+      ],
+    },
+    explore: {
+      prompts: [
+        {
+          key: 'devotional-explore-deepen',
+          text: "Which panel deepens what's meeting you?",
+        },
+      ],
+    },
+    synthesize: {
+      prompts: [
+        {
+          key: 'devotional-synthesize-prayer',
+          text: 'What might God be saying? Pray it back in your own words.',
+        },
+      ],
+    },
+    review: {
+      prompts: [
+        {
+          key: 'devotional-review-carry',
+          text: 'What will you carry into the rest of your day?',
+        },
+      ],
+    },
   },
   trailOrder: ['context', 'scripture', 'language'],
   recommendationLimit: 3,

--- a/app/src/services/guidedStudy/modes/quick.ts
+++ b/app/src/services/guidedStudy/modes/quick.ts
@@ -8,11 +8,46 @@ export const QUICK_MODE: ModeDefinition = {
   blurb: 'Context, one key observation, and a short takeaway.',
   marketingPromise: "A short pass that lands one takeaway you'll remember.",
   steps: {
-    scene: { prompts: [] },
-    observe: { prompts: [] },
-    explore: { prompts: [] },
-    synthesize: { prompts: [] },
-    review: { prompts: [] },
+    scene: {
+      prompts: [
+        {
+          key: 'quick-scene-genre',
+          text: "What kind of writing is this, and what's happening in this chapter?",
+        },
+      ],
+    },
+    observe: {
+      prompts: [
+        {
+          key: 'quick-observe-takeaway',
+          text: "What's the one thing you'd want to remember from this chapter?",
+        },
+      ],
+    },
+    explore: {
+      prompts: [
+        {
+          key: 'quick-explore-priority',
+          text: 'Which of these will help you most in 5 minutes?',
+        },
+      ],
+    },
+    synthesize: {
+      prompts: [
+        {
+          key: 'quick-synthesize-summary',
+          text: 'In one sentence: what does this chapter say?',
+        },
+      ],
+    },
+    review: {
+      prompts: [
+        {
+          key: 'quick-review-carry',
+          text: 'What verse or phrase will you carry with you today?',
+        },
+      ],
+    },
   },
   trailOrder: ['context', 'language', 'scripture'],
   recommendationLimit: 3,

--- a/app/src/services/guidedStudy/modes/teaching.ts
+++ b/app/src/services/guidedStudy/modes/teaching.ts
@@ -8,11 +8,54 @@ export const TEACHING_MODE: ModeDefinition = {
   blurb: 'Structure, claims, and what someone else will need clarified.',
   marketingPromise: 'An outline you can teach from confidently.',
   steps: {
-    scene: { prompts: [] },
-    observe: { prompts: [] },
-    explore: { prompts: [] },
-    synthesize: { prompts: [] },
-    review: { prompts: [] },
+    scene: {
+      prompts: [
+        {
+          key: 'teaching-scene-audience',
+          text: 'Who are you teaching? What do they already know about this passage?',
+        },
+        {
+          key: 'teaching-scene-setting',
+          text: "What's the setting — sermon, small group, classroom, one-on-one?",
+        },
+      ],
+    },
+    observe: {
+      prompts: [
+        {
+          key: 'teaching-observe-main-point',
+          text: "What's the main point you'd want a listener to leave with?",
+        },
+        {
+          key: 'teaching-observe-misread',
+          text: "What would they get wrong if you didn't clarify it?",
+        },
+      ],
+    },
+    explore: {
+      prompts: [
+        {
+          key: 'teaching-explore-supports',
+          text: 'Which structural and contextual panels support your main point?',
+        },
+      ],
+    },
+    synthesize: {
+      prompts: [
+        {
+          key: 'teaching-synthesize-outline',
+          text: 'Build the outline: hook, main point, two or three moves, application, a clarifying question for discussion.',
+        },
+      ],
+    },
+    review: {
+      prompts: [
+        {
+          key: 'teaching-review-check',
+          text: "What's one question you'll ask your audience to check understanding?",
+        },
+      ],
+    },
   },
   trailOrder: ['context', 'structure', 'scripture', 'debate'],
   recommendationLimit: 5,

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,6 +1,7 @@
 import type { SectionPanel } from '../../types';
 import { getModeDefinition } from './modes/definitions';
 import {
+  GUIDED_STUDY_STEPS,
   type ConfidenceLevel,
   type GuidedConceptChip,
   type GuidedEvidenceTrailItem,
@@ -9,6 +10,7 @@ import {
   type GuidedStudyMode,
   type GuidedStudyPlan,
   type GuidedStudyPlanInput,
+  type GuidedStudyStep,
 } from './types';
 
 const RECOMMENDATION_ORDER = [
@@ -300,13 +302,21 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
   const allRecommendations = buildRecommendations(input, def.panelWeights);
   const betterQuestion = betterQuestionPrompt(input);
 
-  const prompts: GuidedPrompt[] = [
+  const legacyPrompts: GuidedPrompt[] = [
     {
       key: 'genre-observation',
       text: genrePrompt(input.book?.genre_label ?? input.bookIntro?.at_a_glance?.genre),
     },
     { key: 'better-question', text: betterQuestion },
   ];
+
+  const stepPrompts = GUIDED_STUDY_STEPS.reduce<Record<GuidedStudyStep, GuidedPrompt[]>>(
+    (acc, step) => {
+      acc[step] = def.steps[step].prompts;
+      return acc;
+    },
+    {} as Record<GuidedStudyStep, GuidedPrompt[]>,
+  );
 
   return {
     chapterId: input.chapter.id,
@@ -327,7 +337,8 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
         value: purpose ?? 'Read the chapter first, then let the study panels sharpen the context.',
       },
     ],
-    prompts,
+    stepPrompts,
+    legacyPrompts,
     recommendations: allRecommendations.slice(0, def.recommendationLimit),
     evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
     betterQuestionPrompt: betterQuestion,

--- a/app/src/services/guidedStudy/types.ts
+++ b/app/src/services/guidedStudy/types.ts
@@ -100,7 +100,16 @@ export interface GuidedStudyPlan {
   mode: GuidedStudyMode;
   modeLabel: string;
   sceneRows: GuidedSceneRow[];
-  prompts: GuidedPrompt[];
+  /**
+   * Mode-specific prompts keyed by step. Filled from
+   * `MODE_DEFINITIONS[mode].steps[step].prompts`.
+   */
+  stepPrompts: Record<GuidedStudyStep, GuidedPrompt[]>;
+  /**
+   * Pre-Phase-2 genre-observation + better-question pair. Retired by
+   * #1736 (Phase 2.7) once the screen consumes `stepPrompts` directly.
+   */
+  legacyPrompts: GuidedPrompt[];
   recommendations: GuidedPanelRecommendation[];
   evidenceTrail: GuidedEvidenceTrailItem[];
   betterQuestionPrompt: string;


### PR DESCRIPTION
Closes #1730. Phase 2.1 of epic #1725.

## Why
Phase 1 set up the table; this card fills it with the prompts that actually make modes feel different. After this PR, Quick / Deep / Teaching / Devotional each ask a different set of questions at every step. UI wiring for those prompts comes in #1735 — they're loaded into `plan.stepPrompts` here so the screen has data to render.

## What
**Verbatim prompt copy from the issue, in `app/src/services/guidedStudy/modes/{quick,deep,teaching,devotional}.ts`:**
- **Quick** — 1 prompt per step (5 total)
- **Deep** — 3 observe prompts (surprise / confusion / repetition); 1 per other step (7 total)
- **Teaching** — 2 scene (audience + setting); 2 observe (main point + clarification); 1 per other (7 total)
- **Devotional** — 1 per step (5 total)

Prompt keys follow the stable scheme `{mode}-{step}-{slug}` so #1731 can reference them as the keyspace for `CapturedInputs`.

**`app/src/services/guidedStudy/types.ts`** — `GuidedStudyPlan` gets:
```ts
stepPrompts: Record<GuidedStudyStep, GuidedPrompt[]>;
legacyPrompts: GuidedPrompt[]; // was `prompts`; retired by #1736
```

**`plan.ts`** — populates `stepPrompts` from `getModeDefinition(mode).steps[step].prompts`; `legacyPrompts` retains the existing genre-observation + better-question pair so the screen keeps rendering until #1735 migrates it.

**`StudySessionScreen.tsx`** — two surgical reads renamed `plan.prompts` → `plan.legacyPrompts` (UI continues showing the same content; nothing rendered from `stepPrompts` yet — that's #1735).

**Tests:**
- New `stepPrompts.test.ts` — verifies plan exposes all five steps, spot-checks verbatim copy for each mode, asserts global key uniqueness across the 24 prompts
- `definitions.test.ts` — Phase 1's "empty prompts" assertion replaced with namespacing + non-empty checks
- Existing `guidedStudy.test.ts` — `plan.prompts` references renamed to `plan.legacyPrompts`
- 20 `plan.parity` snapshots intentionally refreshed (the spec calls this out as the first card that legitimately changes plan output)

## Acceptance criteria
- [x] Each mode's `steps[*].prompts` contains the verbatim text from the issue
- [x] `GuidedStudyPlan.stepPrompts` populated correctly across all modes (verified by `stepPrompts.test.ts` `it.each`)
- [x] Phase 1.4 snapshots updated to capture the new field
- [x] tsc / lint / full app suite (3750 tests) clean

## Rollback
Revert the PR. The screen still consumed the same data (now via `legacyPrompts`), so user-visible behavior is identical to pre-PR before the rollback completes.

## Notes for Craig
- Kanban move requires manual action (no project-board GraphQL access).
- `panelWeights` still `{}` in MODE_DEFINITIONS; #1733 fills them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_