### PR TITLE
feat: CapturedInputs shape + db migration v24 (#1731)

### DIFF
--- a/app/__tests__/db/guidedStudyCapturedInputs.test.ts
+++ b/app/__tests__/db/guidedStudyCapturedInputs.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Phase 2.2 (#1731) DB-helper tests for the captured_inputs_json /
+ * mode_artifact_json / synthesis_strategy columns appended in migration
+ * v24. Verifies that pre-migration rows (NULL in the new columns) round
+ * trip safely through the readers.
+ */
+import { getMockUserDb, resetMockUserDb } from '../helpers/mockUserDb';
+import {
+  getCapturedInputs,
+  getModeArtifact,
+  getSynthesisStrategy,
+} from '@/db/userQueries';
+import {
+  setCapturedInputs,
+  setModeArtifact,
+  setSynthesisStrategy,
+} from '@/db/userMutations';
+import type { CapturedInputs } from '@/services/guidedStudy/capturedInputs';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('getCapturedInputs', () => {
+  it('returns empty when the session row has NULL in the column (pre-migration shape)', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ captured_inputs_json: null });
+    expect(await getCapturedInputs(42)).toEqual({});
+  });
+
+  it('returns empty when the session row is missing entirely', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce(null);
+    expect(await getCapturedInputs(42)).toEqual({});
+  });
+
+  it('parses a populated captured_inputs_json column', async () => {
+    const inputs: CapturedInputs = { observe: { primary: 'shepherd' } };
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      captured_inputs_json: JSON.stringify(inputs),
+    });
+    expect(await getCapturedInputs(42)).toEqual(inputs);
+  });
+});
+
+describe('setCapturedInputs', () => {
+  it('serializes inputs and updates the session row', async () => {
+    const inputs: CapturedInputs = { synthesize: { takeaway: 'a', open_question: '', key_connection: '' } };
+    await setCapturedInputs(7, inputs);
+    expect(getMockUserDb().runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE guided_study_sessions'),
+      [JSON.stringify(inputs), 7],
+    );
+  });
+});
+
+describe('getModeArtifact', () => {
+  it('returns null when the column is NULL', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ mode_artifact_json: null });
+    expect(await getModeArtifact(42)).toBeNull();
+  });
+
+  it('parses a populated artifact column', async () => {
+    const artifact = { kind: 'memory_verse', text: 'Trust in the LORD' };
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      mode_artifact_json: JSON.stringify(artifact),
+    });
+    expect(await getModeArtifact(42)).toEqual(artifact);
+  });
+
+  it('returns null on parse error', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ mode_artifact_json: '{not json' });
+    expect(await getModeArtifact(42)).toBeNull();
+  });
+});
+
+describe('setModeArtifact', () => {
+  it('JSON-stringifies an artifact', async () => {
+    const artifact = { kind: 'memory_verse' };
+    await setModeArtifact(7, artifact);
+    expect(getMockUserDb().runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('mode_artifact_json'),
+      [JSON.stringify(artifact), 7],
+    );
+  });
+
+  it('writes NULL when the artifact is null', async () => {
+    await setModeArtifact(7, null);
+    expect(getMockUserDb().runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('mode_artifact_json'),
+      [null, 7],
+    );
+  });
+});
+
+describe('getSynthesisStrategy', () => {
+  it('returns null when the column is NULL', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ synthesis_strategy: null });
+    expect(await getSynthesisStrategy(42)).toBeNull();
+  });
+
+  it.each(['free', 'premium_structured', 'premium_amicus'] as const)(
+    'returns %s when the column carries the canonical value',
+    async (kind) => {
+      getMockUserDb().getFirstAsync.mockResolvedValueOnce({ synthesis_strategy: kind });
+      expect(await getSynthesisStrategy(42)).toBe(kind);
+    },
+  );
+
+  it('returns null for an unknown strategy value (defensive against schema drift)', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ synthesis_strategy: 'garbage' });
+    expect(await getSynthesisStrategy(42)).toBeNull();
+  });
+});
+
+describe('setSynthesisStrategy', () => {
+  it('writes the kind to the session row', async () => {
+    await setSynthesisStrategy(7, 'premium_amicus');
+    expect(getMockUserDb().runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('synthesis_strategy'),
+      ['premium_amicus', 7],
+    );
+  });
+});

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -762,6 +762,16 @@ const MIGRATIONS: Migration[] = [
         ON amicus_thread_context(updated_at DESC);
     `,
   },
+  {
+    version: 24,
+    description:
+      'Guided study captured inputs — append captured_inputs_json + mode_artifact_json + synthesis_strategy to guided_study_sessions',
+    sql: `
+      ALTER TABLE guided_study_sessions ADD COLUMN captured_inputs_json TEXT;
+      ALTER TABLE guided_study_sessions ADD COLUMN mode_artifact_json TEXT;
+      ALTER TABLE guided_study_sessions ADD COLUMN synthesis_strategy TEXT;
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -7,6 +7,11 @@
 
 import { serializeAmicusChapterRef, type AmicusEntryPoint } from '../services/amicus/context';
 import { emitAmicusUsageChanged } from '../services/amicus/usageEvents';
+import {
+  serializeCapturedInputs,
+  type CapturedInputs,
+  type SynthesisStrategyKind,
+} from '../services/guidedStudy/capturedInputs';
 import { logger } from '../utils/logger';
 import { nextIntervalAfter } from '../services/guidedStudy/review';
 import type { GuidedStudyStep } from '../types';
@@ -365,6 +370,40 @@ export async function completeGuidedStudySession(sessionId: number): Promise<voi
          updated_at = datetime('now')
      WHERE id = ?`,
     [sessionId],
+  );
+}
+
+export async function setCapturedInputs(
+  sessionId: number,
+  inputs: CapturedInputs,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE guided_study_sessions
+     SET captured_inputs_json = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+    [serializeCapturedInputs(inputs), sessionId],
+  );
+}
+
+export async function setModeArtifact(sessionId: number, artifact: unknown): Promise<void> {
+  const serialized = artifact == null ? null : JSON.stringify(artifact);
+  await getUserDb().runAsync(
+    `UPDATE guided_study_sessions
+     SET mode_artifact_json = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+    [serialized, sessionId],
+  );
+}
+
+export async function setSynthesisStrategy(
+  sessionId: number,
+  kind: SynthesisStrategyKind,
+): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE guided_study_sessions
+     SET synthesis_strategy = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+    [kind, sessionId],
   );
 }
 

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -7,6 +7,7 @@
 
 import { chapterPrefix, formatVerseRef } from '../utils/verseRef';
 import { escapeLike } from '../utils/escapeLike';
+import { logger } from '../utils/logger';
 import type {
   UserNote,
   ReadingProgress,
@@ -27,6 +28,12 @@ import type {
   GuidedStudySynthesis,
   GuidedStudyTakeawaySummary,
 } from '../types';
+import {
+  emptyCapturedInputs,
+  safeParseCapturedInputs,
+  type CapturedInputs,
+  type SynthesisStrategyKind,
+} from '../services/guidedStudy/capturedInputs';
 import { getDb } from './database';
 import { getUserDb } from './userDatabase';
 
@@ -479,6 +486,43 @@ export async function getGuidedStudySynthesis(
     'SELECT * FROM guided_study_synthesis WHERE session_id = ?',
     [sessionId],
   );
+}
+
+export async function getCapturedInputs(sessionId: number): Promise<CapturedInputs> {
+  const row = await getUserDb().getFirstAsync<{ captured_inputs_json: string | null }>(
+    'SELECT captured_inputs_json FROM guided_study_sessions WHERE id = ?',
+    [sessionId],
+  );
+  if (!row) return emptyCapturedInputs();
+  return safeParseCapturedInputs(row.captured_inputs_json);
+}
+
+export async function getModeArtifact(sessionId: number): Promise<unknown> {
+  const row = await getUserDb().getFirstAsync<{ mode_artifact_json: string | null }>(
+    'SELECT mode_artifact_json FROM guided_study_sessions WHERE id = ?',
+    [sessionId],
+  );
+  if (!row || row.mode_artifact_json == null) return null;
+  try {
+    return JSON.parse(row.mode_artifact_json) as unknown;
+  } catch (err) {
+    logger.warn('GuidedStudy', 'modeArtifact JSON parse failed', err);
+    return null;
+  }
+}
+
+export async function getSynthesisStrategy(
+  sessionId: number,
+): Promise<SynthesisStrategyKind | null> {
+  const row = await getUserDb().getFirstAsync<{ synthesis_strategy: string | null }>(
+    'SELECT synthesis_strategy FROM guided_study_sessions WHERE id = ?',
+    [sessionId],
+  );
+  const value = row?.synthesis_strategy;
+  if (value === 'free' || value === 'premium_structured' || value === 'premium_amicus') {
+    return value;
+  }
+  return null;
 }
 
 export async function getDueGuidedReviewItems(limit: number = 20): Promise<GuidedReviewItem[]> {

--- a/app/src/services/guidedStudy/__tests__/capturedInputs.test.ts
+++ b/app/src/services/guidedStudy/__tests__/capturedInputs.test.ts
@@ -1,0 +1,108 @@
+import {
+  emptyCapturedInputs,
+  safeParseCapturedInputs,
+  serializeCapturedInputs,
+  type CapturedInputs,
+} from '../capturedInputs';
+import { logger } from '@/utils/logger';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const warnMock = logger.warn as jest.Mock;
+
+beforeEach(() => {
+  warnMock.mockClear();
+});
+
+describe('emptyCapturedInputs', () => {
+  it('returns a fresh empty object each call', () => {
+    const a = emptyCapturedInputs();
+    const b = emptyCapturedInputs();
+    expect(a).toEqual({});
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('serializeCapturedInputs / safeParseCapturedInputs round-trip', () => {
+  it('empty object round-trips to empty', () => {
+    const empty = emptyCapturedInputs();
+    expect(safeParseCapturedInputs(serializeCapturedInputs(empty))).toEqual(empty);
+  });
+
+  it('fully populated CapturedInputs survives round-trip', () => {
+    const populated: CapturedInputs = {
+      scene: {
+        genre_response: 'Theological narrative; creation arc.',
+        audience: 'College small group',
+        setting: 'small group',
+        arrival: 'Anxious about a hard week.',
+        concepts: ['creation', 'covenant'],
+      },
+      observe: {
+        primary: 'Light from speech.',
+        surprises: 'God evaluates the work as good.',
+        confusions: 'What is the firmament exactly?',
+        repetitions: '"And God said" / "and it was so".',
+        main_point: 'Order from chaos by speech.',
+        clarification: "It isn't a science manual.",
+        questions: ['What is the role of the Spirit here?'],
+      },
+      explore: {
+        panels_opened: [
+          { panel_type: 'hist', section_num: 1, opened_at_ms: 1735000000000 },
+          { panel_type: 'cross', opened_at_ms: 1735000005000 },
+        ],
+        most_helpful_panel_type: 'hist',
+      },
+      synthesize: {
+        takeaway: 'Creation is ordered by speech.',
+        open_question: 'How does this frame John 1?',
+        key_connection: 'John 1 echoes Genesis 1.',
+      },
+      review: {
+        artifact_generated: true,
+        next_chapter_accepted: false,
+      },
+    };
+    const back = safeParseCapturedInputs(serializeCapturedInputs(populated));
+    expect(back).toEqual(populated);
+  });
+
+  it('partial CapturedInputs round-trips with only the populated keys', () => {
+    const partial: CapturedInputs = {
+      observe: { primary: 'shepherd' },
+    };
+    expect(safeParseCapturedInputs(serializeCapturedInputs(partial))).toEqual(partial);
+  });
+});
+
+describe('safeParseCapturedInputs error handling', () => {
+  it('returns empty for null without warning', () => {
+    expect(safeParseCapturedInputs(null)).toEqual({});
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty for undefined without warning', () => {
+    expect(safeParseCapturedInputs(undefined)).toEqual({});
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty for empty string without warning', () => {
+    expect(safeParseCapturedInputs('')).toEqual({});
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty + logs a warning on malformed JSON', () => {
+    expect(safeParseCapturedInputs('{not valid')).toEqual({});
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith('GuidedStudy', 'parse failed', expect.anything());
+  });
+
+  it('returns empty + logs a warning when JSON parses to a non-object', () => {
+    expect(safeParseCapturedInputs('"a string"')).toEqual({});
+    expect(safeParseCapturedInputs('[1,2,3]')).toEqual({});
+    expect(warnMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/services/guidedStudy/capturedInputs.ts
+++ b/app/src/services/guidedStudy/capturedInputs.ts
@@ -1,0 +1,76 @@
+import { logger } from '@/utils/logger';
+
+export interface SynthesisDraft {
+  takeaway: string;
+  open_question: string;
+  key_connection: string;
+}
+
+export interface PanelOpenedRecord {
+  panel_type: string;
+  section_num?: number;
+  opened_at_ms: number;
+}
+
+export interface CapturedInputs {
+  scene?: {
+    genre_response?: string;
+    /** Teaching mode: who you're teaching. */
+    audience?: string;
+    /** Teaching mode: sermon / small group / classroom / one-on-one. */
+    setting?: string;
+    /** Devotional mode: what the user brought into the chapter. */
+    arrival?: string;
+    concepts?: string[];
+  };
+  observe?: {
+    /** Quick mode "one thing"; devotional mode "word/phrase/image". */
+    primary?: string;
+    /** Deep mode. */
+    surprises?: string;
+    /** Deep mode. */
+    confusions?: string;
+    /** Deep mode. */
+    repetitions?: string;
+    /** Teaching mode. */
+    main_point?: string;
+    /** Teaching mode. */
+    clarification?: string;
+    /** Any mode — free-form additional questions. */
+    questions?: string[];
+  };
+  explore?: {
+    panels_opened: PanelOpenedRecord[];
+    most_helpful_panel_type?: string;
+  };
+  synthesize?: SynthesisDraft;
+  review?: {
+    artifact_generated?: boolean;
+    next_chapter_accepted?: boolean;
+  };
+}
+
+export function emptyCapturedInputs(): CapturedInputs {
+  return {};
+}
+
+export function safeParseCapturedInputs(json: string | null | undefined): CapturedInputs {
+  if (json == null || json === '') return emptyCapturedInputs();
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as CapturedInputs;
+    }
+    logger.warn('GuidedStudy', 'CapturedInputs JSON is not an object', { json });
+    return emptyCapturedInputs();
+  } catch (err) {
+    logger.warn('GuidedStudy', 'parse failed', err);
+    return emptyCapturedInputs();
+  }
+}
+
+export function serializeCapturedInputs(inputs: CapturedInputs): string {
+  return JSON.stringify(inputs);
+}
+
+export type SynthesisStrategyKind = 'free' | 'premium_structured' | 'premium_amicus';

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -61,6 +61,12 @@ export interface GuidedStudySession {
   started_at: string;
   completed_at: string | null;
   updated_at: string;
+  /** Phase 2.2 (#1731). NULL for pre-migration rows. */
+  captured_inputs_json?: string | null;
+  /** Phase 2.2 (#1731). NULL for pre-migration rows. */
+  mode_artifact_json?: string | null;
+  /** Phase 2.2 (#1731). NULL for pre-migration rows. */
+  synthesis_strategy?: string | null;
 }
 
 export interface GuidedStudyResponse {


### PR DESCRIPTION
Closes #1731. Phase 2.2 of epic #1725.

## Why
The compounding-step UX needs a place to put input from each step that later steps can reference. This card adds the in-memory shape (`CapturedInputs`), the JSON serializer, and the user-DB columns to persist it. Append-only migration; existing sessions keep working with NULLs.

## What
**`app/src/services/guidedStudy/capturedInputs.ts` (new)** — the type tree per the spec:
- `CapturedInputs` covers every step (`scene` / `observe` / `explore` / `synthesize` / `review`) with mode-shaped optional fields
- `PanelOpenedRecord`, `SynthesisDraft` (shape lifted from `useGuidedStudySession`), `SynthesisStrategyKind` (`free` / `premium_structured` / `premium_amicus`)
- `emptyCapturedInputs()`, `safeParseCapturedInputs(json)` (returns empty + `logger.warn` on malformed JSON or non-object), `serializeCapturedInputs(inputs)`

**`app/src/db/userDatabase.ts` (modify, append-only)** — migration **v24**:
```sql
ALTER TABLE guided_study_sessions ADD COLUMN captured_inputs_json TEXT;
ALTER TABLE guided_study_sessions ADD COLUMN mode_artifact_json TEXT;
ALTER TABLE guided_study_sessions ADD COLUMN synthesis_strategy TEXT;
```
Three nullable TEXT columns. No backfill; readers tolerate NULL.

**`app/src/db/userQueries.ts`** — `getCapturedInputs(sessionId)`, `getModeArtifact(sessionId)`, `getSynthesisStrategy(sessionId)`. The strategy reader is defensive: returns `null` for any value outside the canonical union, so future schema drift can't crash callers.

**`app/src/db/userMutations.ts`** — `setCapturedInputs`, `setModeArtifact`, `setSynthesisStrategy`. All bump `updated_at`.

**`app/src/types/user.ts`** — `GuidedStudySession` documents the three new optional columns (NULL for pre-migration rows).

## Tests
- `services/guidedStudy/__tests__/capturedInputs.test.ts` — empty round-trip; fully populated round-trip (every field set); partial round-trip; null/undefined/empty-string return empty silently; malformed JSON returns empty + warns; non-object JSON (string / array) returns empty + warns.
- `__tests__/db/guidedStudyCapturedInputs.test.ts` — covers the migration's NULL-tolerance contract: `getCapturedInputs` returns empty when the row's column is NULL or the row is absent; setters round-trip the right SQL with the right args; `getSynthesisStrategy` returns null for unknown strategy values.

## Acceptance criteria
- [x] Migration v24 applied cleanly. Existing sessions continue to work — readers return empty for NULL columns.
- [x] `getCapturedInputs(sessionId)` returns `emptyCapturedInputs()` for legacy rows (test: `'returns empty when the session row has NULL in the column'`).
- [x] `setCapturedInputs` round-trips through SQLite (test: serializes via `serializeCapturedInputs`, runs the right UPDATE).
- [x] tsc / lint / full suite (3774 tests) clean.

## Rollback
Revert the PR. Migration v24 is append-only and nullable — leftover columns on rolled-back installs are inert. No code path relies on the columns yet (wiring lands in #1735).

## Notes for Craig
- Out of scope per spec: screen wiring to populate the fields (Phase 2.6 / #1735) and premium gating on persistence (Phase 3).
- Kanban move requires manual action (no project-board GraphQL access).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_