### PR TITLE
feat: CarriedForwardBanner component (#1732)

### DIFF
--- a/app/src/components/guidedStudy/CarriedForwardBanner.tsx
+++ b/app/src/components/guidedStudy/CarriedForwardBanner.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useState } from 'react';
+import {
+  LayoutAnimation,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  UIManager,
+  View,
+} from 'react-native';
+import { ChevronDown, ChevronUp } from 'lucide-react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { GuidedStudyStep } from '../../types';
+
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const COLLAPSED_PREVIEW_CHARS = 80;
+
+export interface CarriedForwardItem {
+  sourceStep: GuidedStudyStep;
+  label: string;
+  content: string;
+}
+
+interface CarriedForwardBannerProps {
+  items: CarriedForwardItem[];
+  defaultCollapsed?: boolean;
+}
+
+function previewOf(content: string): string {
+  if (content.length <= COLLAPSED_PREVIEW_CHARS) return content;
+  return `${content.slice(0, COLLAPSED_PREVIEW_CHARS).trimEnd()}…`;
+}
+
+export function CarriedForwardBanner({
+  items,
+  defaultCollapsed = true,
+}: CarriedForwardBannerProps) {
+  const { base } = useTheme();
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  const toggle = useCallback(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setCollapsed((prev) => !prev);
+  }, []);
+
+  if (items.length === 0) return null;
+
+  return (
+    <TouchableOpacity
+      onPress={toggle}
+      activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: !collapsed }}
+      accessibilityLabel={`Carried forward from earlier steps, ${
+        collapsed ? 'collapsed' : 'expanded'
+      }`}
+      style={[
+        styles.outer,
+        { backgroundColor: base.bgElevated, borderColor: `${base.gold}20` },
+      ]}
+    >
+      <View style={styles.headerRow}>
+        <Text style={[styles.headerLabel, { color: base.textMuted }]}>CARRIED FORWARD</Text>
+        {collapsed ? (
+          <ChevronDown size={14} color={base.textMuted} />
+        ) : (
+          <ChevronUp size={14} color={base.textMuted} />
+        )}
+      </View>
+      {items.map((item, idx) => (
+        <View
+          key={`${item.sourceStep}-${idx}`}
+          style={idx > 0 ? styles.itemSpacing : undefined}
+        >
+          <Text style={[styles.itemLabel, { color: base.textMuted }]}>
+            {item.label.toUpperCase()}
+          </Text>
+          <Text style={[styles.itemContent, { color: base.textDim }]}>
+            {collapsed ? previewOf(item.content) : item.content}
+          </Text>
+        </View>
+      ))}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.sm,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  headerLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 10,
+    letterSpacing: 1,
+  },
+  itemSpacing: {
+    marginTop: spacing.xs,
+  },
+  itemLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 10,
+    letterSpacing: 1,
+    marginBottom: 2,
+  },
+  itemContent: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 20,
+  },
+});

--- a/app/src/components/guidedStudy/__tests__/CarriedForwardBanner.test.tsx
+++ b/app/src/components/guidedStudy/__tests__/CarriedForwardBanner.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
+import {
+  CarriedForwardBanner,
+  type CarriedForwardItem,
+} from '../CarriedForwardBanner';
+
+const sceneItem: CarriedForwardItem = {
+  sourceStep: 'scene',
+  label: 'What you brought today',
+  content:
+    "Anxious about a hard week and looking for steadiness — came in tired but wanting to listen.",
+};
+
+const observeItem: CarriedForwardItem = {
+  sourceStep: 'observe',
+  label: 'What met you',
+  content: 'The valley language — God is with me, not above me.',
+};
+
+describe('CarriedForwardBanner', () => {
+  it('renders null when items is empty', () => {
+    const { toJSON } = renderWithProviders(<CarriedForwardBanner items={[]} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the CARRIED FORWARD header and the item label and content', () => {
+    const { getByText } = renderWithProviders(
+      <CarriedForwardBanner items={[observeItem]} />,
+    );
+    expect(getByText('CARRIED FORWARD')).toBeTruthy();
+    expect(getByText('WHAT MET YOU')).toBeTruthy();
+    expect(getByText(observeItem.content)).toBeTruthy();
+  });
+
+  it('truncates long content with an ellipsis when collapsed', () => {
+    const { getByText, queryByText } = renderWithProviders(
+      <CarriedForwardBanner items={[sceneItem]} />,
+    );
+    // Full content is hidden when collapsed
+    expect(queryByText(sceneItem.content)).toBeNull();
+    // Some preview ending in ellipsis is shown
+    expect(getByText(/…$/)).toBeTruthy();
+  });
+
+  it('expands to full content when tapped', () => {
+    const { getByLabelText, getByText, queryByText } = renderWithProviders(
+      <CarriedForwardBanner items={[sceneItem]} />,
+    );
+    expect(queryByText(sceneItem.content)).toBeNull();
+    fireEvent.press(getByLabelText(/Carried forward from earlier steps, collapsed/));
+    expect(getByText(sceneItem.content)).toBeTruthy();
+  });
+
+  it('renders multiple items in the order given', () => {
+    const { getAllByText } = renderWithProviders(
+      <CarriedForwardBanner items={[sceneItem, observeItem]} defaultCollapsed={false} />,
+    );
+    const labels = getAllByText(/WHAT (?:YOU BROUGHT TODAY|MET YOU)/);
+    expect(labels[0].props.children).toBe('WHAT YOU BROUGHT TODAY');
+    expect(labels[1].props.children).toBe('WHAT MET YOU');
+  });
+
+  it('reports its expanded state via accessibilityState (button role)', () => {
+    const collapsed = renderWithProviders(<CarriedForwardBanner items={[observeItem]} />);
+    expect(collapsed.getByRole('button').props.accessibilityState.expanded).toBe(false);
+
+    const expanded = renderWithProviders(
+      <CarriedForwardBanner items={[observeItem]} defaultCollapsed={false} />,
+    );
+    expect(expanded.getByRole('button').props.accessibilityState.expanded).toBe(true);
+  });
+
+  it('honors defaultCollapsed=false (renders full content immediately)', () => {
+    const { getByText } = renderWithProviders(
+      <CarriedForwardBanner items={[sceneItem]} defaultCollapsed={false} />,
+    );
+    expect(getByText(sceneItem.content)).toBeTruthy();
+  });
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -1,3 +1,5 @@
+export { CarriedForwardBanner } from './CarriedForwardBanner';
+export type { CarriedForwardItem } from './CarriedForwardBanner';
 export { ConfidenceBadge } from './ConfidenceBadge';
 export { ContextGuardBanner } from './ContextGuardBanner';
 export { EvidenceTrailRow } from './EvidenceTrailRow';


### PR DESCRIPTION
Closes #1732. Phase 2.3 of epic #1725.

## Why
The presentational primitive that makes the *compounding* concept visible. At the top of each step that has prior-step content to surface, the screen will render this banner with what was captured earlier. This card delivers only the component — wiring lives in #1735 (Phase 2.6).

## What
**`app/src/components/guidedStudy/CarriedForwardBanner.tsx` (new)**:
- Tappable banner that takes `items: CarriedForwardItem[]` (`{ sourceStep, label, content }`)
- `defaultCollapsed?: boolean` prop (defaults `true`)
- Empty array → renders `null`
- Collapsed: 80-char preview + ellipsis per item
- Tap to expand → full content; `LayoutAnimation.easeInEaseOut`
- `ChevronDown` / `ChevronUp` indicator from `lucide-react-native`
- Visual: `base.bgElevated` background, `base.gold` 20%-alpha border, radius `radii.md`, padding `spacing.sm`
- Label `base.textMuted` 10pt 1px-letter-spacing small caps; content `base.textDim` 13pt 20pt line-height
- A11y: container is `accessibilityRole="button"` with `accessibilityState={{ expanded }}` and a localized `accessibilityLabel`

**`app/src/components/guidedStudy/index.ts`** — exports the component + the `CarriedForwardItem` type.

**`app/src/components/guidedStudy/__tests__/CarriedForwardBanner.test.tsx`** — covers all the spec test cases:
- Empty `items` → `toJSON()` is null
- Header copy + label + content render
- Long content truncated with `…` when collapsed
- Tap expands to full content
- Multiple items render in order
- `accessibilityState.expanded` reflects collapse state (button role)
- `defaultCollapsed={false}` renders full content immediately

## Acceptance criteria
- [x] Component renders correctly in all states
- [x] No screen changes — purely a new component
- [x] tsc / lint / full suite (3781 tests) clean

## Rollback
Revert the PR. No consumers; pure addition.

## Notes for Craig
- Mode→step→carry-forward-source mapping (the table in the issue) is consumed in #1735 from `MODE_DEFINITIONS[mode].steps[step].carryForward`. This card just delivers the renderer.
- Kanban move requires manual action (no project-board GraphQL access).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_