### PR TITLE
test: Phase 2 integration coverage — mode differentiation, captured inputs, panel ordering, migration v24 (#1737)

### DIFF
--- a/app/__tests__/db/migrationV24.test.ts
+++ b/app/__tests__/db/migrationV24.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Phase 2.8 (#1737) — focused idempotency test for migration v24
+ * (Phase 2.2, captured_inputs_json + mode_artifact_json + synthesis_
+ * strategy on guided_study_sessions).
+ *
+ * Mirrors the structural pattern of __tests__/db/userDatabase.test.ts so
+ * the existing migration runner mocks are reused. NOT mocking
+ * @/db/userDatabase here because we want to exercise the real migration
+ * loop — that's the whole point of the idempotency check.
+ */
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  mockOpenDatabaseAsync.mockResolvedValue({
+    execAsync: mockExecAsync,
+    getAllAsync: mockGetAllAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  });
+});
+
+describe('migration v24 — captured_inputs columns on guided_study_sessions', () => {
+  it('the migration count includes v24 (proves the migration was added)', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT } = require('@/db/userDatabase');
+    expect(MIGRATION_COUNT).toBeGreaterThanOrEqual(24);
+  });
+
+  it('skips every migration when v24 (and all earlier versions) are already applied', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: MIGRATION_COUNT }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  it('applies exactly one transaction when only versions 1..23 have run (v24 is the only pending one)', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 23 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("v24's SQL adds the three captured-inputs columns to guided_study_sessions", async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 23 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    // execAsync receives every migration's SQL plus the WAL/_migrations
+    // prep statements. Find the call that ALTERs guided_study_sessions.
+    const allSql = mockExecAsync.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN captured_inputs_json');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN mode_artifact_json');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN synthesis_strategy');
+  });
+});

--- a/app/src/services/guidedStudy/__tests__/capturedInputsPersistence.test.ts
+++ b/app/src/services/guidedStudy/__tests__/capturedInputsPersistence.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Phase 2.8 (#1737) integration test — proves CapturedInputs persistence
+ * survives the SQLite layer added in #1731.
+ *
+ * SQLite is mocked because Jest runs in node; the test focuses on the
+ * round-trip contract between setCapturedInputs / getCapturedInputs.
+ * Migration v24 idempotency lives in migrationV24.test.ts (separate file
+ * because that test pattern requires NOT mocking @/db/userDatabase).
+ */
+import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
+import {
+  getCapturedInputs,
+  getModeArtifact,
+  getSynthesisStrategy,
+} from '@/db/userQueries';
+import {
+  setCapturedInputs,
+  setModeArtifact,
+  setSynthesisStrategy,
+} from '@/db/userMutations';
+import type { CapturedInputs } from '@/services/guidedStudy/capturedInputs';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('CapturedInputs round-trip through SQLite', () => {
+  it('full populated payload round-trips through set + get', async () => {
+    const inputs: CapturedInputs = {
+      scene: { audience: 'College small group', setting: 'small group' },
+      observe: { surprises: 'God evaluates the work as good.', main_point: 'Order from chaos.' },
+      explore: {
+        panels_opened: [{ panel_type: 'hist', section_num: 1, opened_at_ms: 1735000000000 }],
+        most_helpful_panel_type: 'hist',
+      },
+      synthesize: {
+        takeaway: 'Creation is ordered by speech.',
+        open_question: 'How does this frame John 1?',
+        key_connection: 'John 1 echoes Genesis 1.',
+      },
+      review: { artifact_generated: true, next_chapter_accepted: false },
+    };
+
+    await setCapturedInputs(42, inputs);
+    const writtenJson = (getMockUserDb().runAsync.mock.calls[0] as unknown[][])[1] as [
+      string,
+      number,
+    ];
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      captured_inputs_json: writtenJson[0],
+    });
+    expect(await getCapturedInputs(42)).toEqual(inputs);
+  });
+
+  it('partial inputs (only scene) preserve the partial shape — other steps stay undefined', async () => {
+    const partial: CapturedInputs = {
+      scene: { audience: 'mid-week group' },
+    };
+
+    await setCapturedInputs(42, partial);
+    const writtenJson = (getMockUserDb().runAsync.mock.calls[0] as unknown[][])[1] as [
+      string,
+      number,
+    ];
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({
+      captured_inputs_json: writtenJson[0],
+    });
+    const fetched = await getCapturedInputs(42);
+    expect(fetched).toEqual(partial);
+    expect(fetched.observe).toBeUndefined();
+    expect(fetched.explore).toBeUndefined();
+    expect(fetched.synthesize).toBeUndefined();
+    expect(fetched.review).toBeUndefined();
+  });
+
+  it('mode artifact round-trips through set + get', async () => {
+    const artifact = { kind: 'memory_verse', text: 'Trust in the LORD.' };
+    await setModeArtifact(7, artifact);
+    const args = (getMockUserDb().runAsync.mock.calls[0] as unknown[][])[1] as [
+      string | null,
+      number,
+    ];
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ mode_artifact_json: args[0] });
+    expect(await getModeArtifact(7)).toEqual(artifact);
+  });
+
+  it.each(['free', 'premium_structured', 'premium_amicus'] as const)(
+    'synthesis strategy %s round-trips through set + get',
+    async (kind) => {
+      await setSynthesisStrategy(7, kind);
+      const args = (getMockUserDb().runAsync.mock.calls[0] as unknown[][])[1] as [
+        string,
+        number,
+      ];
+      getMockUserDb().getFirstAsync.mockResolvedValueOnce({ synthesis_strategy: args[0] });
+      expect(await getSynthesisStrategy(7)).toBe(kind);
+    },
+  );
+});
+

--- a/app/src/services/guidedStudy/__tests__/modeDifferentiation.test.ts
+++ b/app/src/services/guidedStudy/__tests__/modeDifferentiation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Phase 2.8 (#1737) integration test — proves each mode produces a
+ * recognisably different plan against the same chapter fixture.
+ */
+import { buildGuidedStudyPlan } from '../plan';
+import { GUIDED_STUDY_MODES, type GuidedStudyMode, type GuidedStudyStep } from '../types';
+import { loadFixture } from './fixtures/sampleChapters';
+
+const STEPS: GuidedStudyStep[] = ['scene', 'observe', 'explore', 'synthesize', 'review'];
+
+function plansByMode() {
+  return Object.fromEntries(
+    GUIDED_STUDY_MODES.map((mode) => [mode, buildGuidedStudyPlan(loadFixture('rom_8', mode))]),
+  ) as Record<GuidedStudyMode, ReturnType<typeof buildGuidedStudyPlan>>;
+}
+
+function promptKeySignature(prompts: { key: string }[]): string {
+  return prompts
+    .map((p) => p.key)
+    .sort()
+    .join(',');
+}
+
+describe('mode differentiation on Romans 8', () => {
+  const plans = plansByMode();
+
+  it('each mode emits a non-empty stepPrompts array at every step', () => {
+    for (const mode of GUIDED_STUDY_MODES) {
+      for (const step of STEPS) {
+        expect(plans[mode].stepPrompts[step].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('every (mode, step) pair has a distinct prompt-key signature from at least one other mode', () => {
+    let stepsWithDifferentiation = 0;
+    for (const step of STEPS) {
+      const signatures = new Set(
+        GUIDED_STUDY_MODES.map((mode) => promptKeySignature(plans[mode].stepPrompts[step])),
+      );
+      if (signatures.size > 1) stepsWithDifferentiation += 1;
+    }
+    // Spec acceptance: at least 4 of 5 steps must differ.
+    expect(stepsWithDifferentiation).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each([
+    ['quick', ['hist', 'ctx']],
+    ['deep', ['heb', 'greek']],
+    ['teaching', ['lit', 'discourse', 'hist']],
+    ['devotional', ['ctx']],
+  ] as const)(
+    '%s mode leads with %s (panelWeights table)',
+    (mode, allowed) => {
+      const first = plans[mode].recommendations[0]?.panelType;
+      expect(allowed).toContain(first);
+    },
+  );
+
+  it('teaching adds two scene input rows; devotional adds one; quick + deep add none', () => {
+    const inputCount = (mode: GuidedStudyMode) =>
+      plans[mode].sceneRows.filter((r) => r.kind === 'input').length;
+    expect(inputCount('teaching')).toBe(2);
+    expect(inputCount('devotional')).toBe(1);
+    expect(inputCount('quick')).toBe(0);
+    expect(inputCount('deep')).toBe(0);
+  });
+
+  it('all four modes still expose the four standard display scene rows', () => {
+    for (const mode of GUIDED_STUDY_MODES) {
+      const displayRows = plans[mode].sceneRows.filter((r) => r.kind === 'display');
+      expect(displayRows.map((r) => r.label)).toEqual([
+        'Genre',
+        'Moment',
+        'Original audience context',
+        'Purpose',
+      ]);
+    }
+  });
+});

--- a/app/src/services/guidedStudy/__tests__/panelOrdering.test.ts
+++ b/app/src/services/guidedStudy/__tests__/panelOrdering.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Phase 2.8 (#1737) integration test — locks the per-mode panel
+ * ordering produced by buildGuidedStudyPlan against a chapter that
+ * contains every major panel type. Phase 1.4 fixtures are intentionally
+ * narrower; this fixture is purpose-built for Phase 2.4's panelWeights.
+ */
+import { buildGuidedStudyPlan } from '../plan';
+import type { GuidedStudyMode, GuidedStudyPlanInput } from '../types';
+import type {
+  Book,
+  Chapter,
+  ChapterPanel,
+  Section,
+  SectionPanel,
+  Verse,
+} from '../../../types';
+
+function panel(id: number, sectionId: string, type: string): SectionPanel {
+  return { id, section_id: sectionId, panel_type: type, content_json: '{}' };
+}
+
+function chapterPanel(id: number, chapterId: string, type: string): ChapterPanel {
+  return { id, chapter_id: chapterId, panel_type: type, content_json: '{}' };
+}
+
+const book: Book = {
+  id: 'rom',
+  name: 'Romans',
+  testament: 'nt',
+  total_chapters: 16,
+  book_order: 45,
+  is_live: true,
+  genre_label: 'Letter',
+};
+
+const chapter: Chapter = {
+  id: 'rom_8',
+  book_id: 'rom',
+  chapter_num: 8,
+  title: 'Life in the Spirit',
+  subtitle: null,
+  timeline_link_event: null,
+  timeline_link_text: null,
+  map_story_link_id: null,
+  map_story_link_text: null,
+  coaching_json: null,
+  difficulty: null,
+};
+
+// One section carrying every major section-level panel type. Limited to
+// six entries so buildRecommendations' 7-rec cap leaves room for at least
+// one chapter-level panel (lit) — without that headroom the teaching
+// "lit at index 0" assertion can't hold.
+const sections: Array<Section & { panels: SectionPanel[] }> = [
+  {
+    id: 'rom_8_1',
+    chapter_id: 'rom_8',
+    section_num: 1,
+    header: 'No condemnation',
+    verse_start: 1,
+    verse_end: 11,
+    panels: [
+      panel(1, 'rom_8_1', 'hist'),
+      panel(2, 'rom_8_1', 'ctx'),
+      panel(3, 'rom_8_1', 'heb'),
+      panel(4, 'rom_8_1', 'greek'),
+      panel(5, 'rom_8_1', 'cross'),
+      panel(6, 'rom_8_1', 'debate'),
+    ],
+  },
+];
+
+// Chapter-level panels for lit + discourse.
+const chapterPanels: ChapterPanel[] = [
+  chapterPanel(101, 'rom_8', 'lit'),
+  chapterPanel(102, 'rom_8', 'discourse'),
+];
+
+const verses: Verse[] = [
+  {
+    id: 1,
+    book_id: 'rom',
+    chapter_num: 8,
+    verse_num: 1,
+    translation: 'kjv',
+    text: 'There is therefore now no condemnation to them which are in Christ Jesus.',
+  },
+];
+
+function planFor(mode: GuidedStudyMode) {
+  const input: GuidedStudyPlanInput = { book, chapter, sections, chapterPanels, verses, mode };
+  return buildGuidedStudyPlan(input);
+}
+
+function indexOf(plan: ReturnType<typeof buildGuidedStudyPlan>, panelType: string): number {
+  return plan.recommendations.findIndex((r) => r.panelType === panelType);
+}
+
+describe('panel ordering — fixture has every major panel type present', () => {
+  it('deep mode leads with heb or greek', () => {
+    const first = planFor('deep').recommendations[0]?.panelType;
+    expect(first === 'heb' || first === 'greek').toBe(true);
+  });
+
+  it('teaching mode leads with lit', () => {
+    expect(planFor('teaching').recommendations[0]?.panelType).toBe('lit');
+  });
+
+  it('devotional mode leads with ctx and excludes heb/greek from the limited set', () => {
+    const plan = planFor('devotional');
+    expect(plan.recommendations[0]?.panelType).toBe('ctx');
+    // Devotional caps at 3 recommendations and pushes heb/greek to weight -3,
+    // so neither should make the cut.
+    const types = plan.recommendations.map((r) => r.panelType);
+    expect(types).not.toContain('heb');
+    expect(types).not.toContain('greek');
+  });
+
+  it('quick mode leads with hist or ctx and deprioritizes heb/greek', () => {
+    const plan = planFor('quick');
+    const first = plan.recommendations[0]?.panelType;
+    expect(first === 'hist' || first === 'ctx').toBe(true);
+    // Quick also caps at 3 recs with negative-weighted technical panels —
+    // heb/greek/debate should not make the cut.
+    const types = plan.recommendations.map((r) => r.panelType);
+    expect(types).not.toContain('heb');
+    expect(types).not.toContain('greek');
+    expect(types).not.toContain('debate');
+  });
+
+  it('teaching keeps debate in the recommendations (positive weight)', () => {
+    expect(indexOf(planFor('teaching'), 'debate')).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Closes #1737. Phase 2.8 of epic #1725 — **the Phase 2 capstone.**

## Why
Phase 2 made the four modes feel different at every step and persisted captured input across sessions. This card writes that contract down as integration tests so future regressions surface in CI.

## What
Four new test files, no production code changes:

**`modeDifferentiation.test.ts`** — against the Romans 8 fixture:
- Each (mode, step) pair has a non-empty `stepPrompts` array.
- At least 4 of 5 steps produce distinct prompt-key signatures across modes (spec acceptance: 4/5 minimum).
- `recommendations[0].panelType` matches the panelWeights table — quick → hist/ctx, deep → heb/greek, teaching → lit/discourse/hist, devotional → ctx.
- Teaching adds 2 input scene rows; devotional adds 1; quick + deep add 0.
- All four modes still expose the four standard display scene rows.

**`capturedInputsPersistence.test.ts`** — through mock-SQLite:
- Fully populated `CapturedInputs` round-trips through `setCapturedInputs` → `getCapturedInputs`.
- Partial inputs (only `scene`) preserve the partial shape — other steps stay `undefined`.
- Mode artifact JSON round-trips.
- All three canonical synthesis strategy kinds (`free` / `premium_structured` / `premium_amicus`) round-trip.

**`panelOrdering.test.ts`** — synthetic fixture with hist/ctx/heb/greek/cross/debate (section) + lit/discourse (chapter):
- Deep → heb or greek at index 0.
- Teaching → lit at index 0; debate present in recommendations.
- Devotional → ctx at index 0; heb/greek excluded entirely (negative weight + 3-rec cap).
- Quick → hist or ctx at index 0; heb/greek/debate excluded (negative weights + 3-rec cap).

**`__tests__/db/migrationV24.test.ts`** — dedicated file (no `@/db/userDatabase` mock; mirrors the existing `userDatabase.test.ts` pattern):
- `MIGRATION_COUNT >= 24` (proves v24 was added).
- Runner skips every migration when v24 + earlier are already recorded.
- Exactly one `withTransactionAsync` call when only versions 1..23 are recorded (v24 is the only pending one).
- The v24 SQL contains all three `ALTER TABLE guided_study_sessions ADD COLUMN ...` statements.

## Acceptance criteria
- [x] All tests pass on first commit (23 new tests; 3848 in the full suite)
- [x] Each test file is self-contained
- [x] tsc / lint clean

## Rollback
Pure tests. Revert the PR; no runtime impact.

## Notes for Craig
- The migration idempotency block ended up in its own file (`__tests__/db/migrationV24.test.ts`) because the file-level `jest.mock('@/db/userDatabase', ...)` used by the persistence round-trip tests can't co-exist with exercising the real migration runner.
- This closes Phase 2. I'll post the phase-completion comment on epic #1725 once this merges, then wait for go-ahead before starting Phase 3 (#1738).
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_