### PR TITLE
feat: feature flags module + GUIDED_STUDY_AMICUS_SYNTHESIS flag (#1738)

### DIFF
--- a/app/src/components/guidedStudy/SynthesisFreeRecap.tsx
+++ b/app/src/components/guidedStudy/SynthesisFreeRecap.tsx
@@ -5,16 +5,12 @@ import * as Sharing from 'expo-sharing';
 import * as FileSystem from 'expo-file-system/legacy';
 import { ChevronRight, Copy, Share2 } from 'lucide-react-native';
 import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import { isFlagEnabled } from '../../config/featureFlags';
 import type { CapturedInputs } from '../../services/guidedStudy/capturedInputs';
 import type { CapturedTextRef } from '../../services/guidedStudy/stepBindings';
 import { getCapturedText } from '../../services/guidedStudy/stepBindings';
 import type { GuidedStudyMode } from '../../services/guidedStudy/types';
 import { logger } from '../../utils/logger';
-
-// Phase 3.1 (#1738) replaces this inline constant with an import from a
-// dedicated feature-flags module. Until then the flag stays off so the
-// premium-nudge footer copy reflects the structured (non-Amicus) path.
-const GUIDED_STUDY_AMICUS_SYNTHESIS = false;
 
 interface RecapSection {
   label: string;
@@ -152,7 +148,7 @@ export function SynthesisFreeRecap({
 
   if (sections.length === 0) return null;
 
-  const footerCopy = GUIDED_STUDY_AMICUS_SYNTHESIS
+  const footerCopy = isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')
     ? PREMIUM_FOOTER_AMICUS_ON
     : PREMIUM_FOOTER_AMICUS_OFF;
 

--- a/app/src/config/__tests__/featureFlags.test.ts
+++ b/app/src/config/__tests__/featureFlags.test.ts
@@ -1,0 +1,27 @@
+import { FEATURE_FLAGS, isFlagEnabled, type FeatureFlag } from '../featureFlags';
+
+describe('featureFlags', () => {
+  it('GUIDED_STUDY_AMICUS_SYNTHESIS defaults to false', () => {
+    expect(FEATURE_FLAGS.GUIDED_STUDY_AMICUS_SYNTHESIS).toBe(false);
+    expect(isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')).toBe(false);
+  });
+
+  it('FEATURE_FLAGS is exhaustively typed by FeatureFlag', () => {
+    // Round-trip through FeatureFlag — caller can iterate via a typed
+    // narrowing. If a flag is added to FEATURE_FLAGS without updating the
+    // type, tsc fails on this assignment.
+    const keys = Object.keys(FEATURE_FLAGS) as FeatureFlag[];
+    expect(keys).toContain('GUIDED_STUDY_AMICUS_SYNTHESIS');
+    for (const key of keys) {
+      expect(typeof FEATURE_FLAGS[key]).toBe('boolean');
+    }
+  });
+
+  it('isFlagEnabled returns the stored boolean', () => {
+    // Spot-check the helper actually reads from FEATURE_FLAGS rather than
+    // hardcoding a value.
+    expect(isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')).toBe(
+      FEATURE_FLAGS.GUIDED_STUDY_AMICUS_SYNTHESIS,
+    );
+  });
+});

--- a/app/src/config/featureFlags.ts
+++ b/app/src/config/featureFlags.ts
@@ -1,0 +1,28 @@
+/**
+ * Feature flags for in-flight work that needs to ship behind a switch.
+ *
+ * These are compile-time constants on purpose — no remote config in this
+ * codebase yet. Flipping a flag is a single-line PR + EAS Update.
+ *
+ * Add a comment per flag explaining what to verify before flipping.
+ */
+export const FEATURE_FLAGS = {
+  /**
+   * Enables Amicus-drafted synthesis at the end of guided study sessions.
+   * Before flipping true, verify:
+   *   - Epic #1446 (Amicus AI Study Partner) is past Phase 3 (chat working
+   *     against the production worker).
+   *   - The mode-specific system prompts in app/src/services/amicus/prompts/
+   *     guidedStudy.ts have been reviewed.
+   *   - Anthropic prompt caching is hitting on the system prompt (>80% cache
+   *     rate observed in dev for at least 100 calls).
+   * When false, premium users get the structured-form synthesis path.
+   */
+  GUIDED_STUDY_AMICUS_SYNTHESIS: false,
+} as const;
+
+export type FeatureFlag = keyof typeof FEATURE_FLAGS;
+
+export function isFlagEnabled(flag: FeatureFlag): boolean {
+  return FEATURE_FLAGS[flag];
+}


### PR DESCRIPTION
Closes #1738. Phase 3.1 of epic #1725 — opens Phase 3.

## Why
The Amicus-drafted synthesis path needs to ship behind a flag so the structured premium path can land first while #1446 catches up. This card creates the tiny compile-time feature-flag table + helper, and resolves the inline-constant placeholder I left in #1736.

## What
- **`app/src/config/featureFlags.ts`** — `FEATURE_FLAGS` const, `FeatureFlag` type, `isFlagEnabled(flag)` helper. `GUIDED_STUDY_AMICUS_SYNTHESIS` defaults `false`. Per-flag JSDoc lists what to verify before flipping (Epic #1446 status, prompts review, prompt-cache hit rate).
- **`app/src/config/__tests__/featureFlags.test.ts`** — default-off assertion, exhaustive-shape check (every flag is a boolean), helper round-trip.
- **`app/src/components/guidedStudy/SynthesisFreeRecap.tsx`** — replace the inline Phase 2.7 placeholder `const GUIDED_STUDY_AMICUS_SYNTHESIS = false` with `isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')`. Resolves the deferred item I flagged in the #1736 PR description.

## Acceptance criteria
- [x] Module exists and exports flags + helper
- [x] Default for `GUIDED_STUDY_AMICUS_SYNTHESIS` is `false`
- [x] `isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')` returns `false`
- [x] `isFlagEnabled('garbage')` is a compile error (`FeatureFlag` keyof typed)
- [x] tsc / lint / full suite (3851 tests) clean

## Rollback
Revert the PR. The `SynthesisFreeRecap` consumer falls back to importing… nothing — clean revert.

## Notes for Craig
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_