### PR TITLE
feat: SynthesisStrategy interface + freeStrategy (#1739)

### DIFF
--- a/app/src/components/guidedStudy/SynthesisFreeRecap.tsx
+++ b/app/src/components/guidedStudy/SynthesisFreeRecap.tsx
@@ -5,118 +5,51 @@ import * as Sharing from 'expo-sharing';
 import * as FileSystem from 'expo-file-system/legacy';
 import { ChevronRight, Copy, Share2 } from 'lucide-react-native';
 import { fontFamily, radii, spacing, useTheme } from '../../theme';
-import { isFlagEnabled } from '../../config/featureFlags';
-import type { CapturedInputs } from '../../services/guidedStudy/capturedInputs';
-import type { CapturedTextRef } from '../../services/guidedStudy/stepBindings';
-import { getCapturedText } from '../../services/guidedStudy/stepBindings';
-import type { GuidedStudyMode } from '../../services/guidedStudy/types';
+import type { SynthesisOutputBlock } from '../../services/guidedStudy/synthesis/strategy';
 import { logger } from '../../utils/logger';
 
-interface RecapSection {
-  label: string;
-  ref: CapturedTextRef;
-}
-
-interface RecapConfig {
+export interface SynthesisFreeRecapProps {
+  /** Card heading — e.g. 'Your Quick Pass'. Free path is mode-shaped. */
   title: string;
-  sections: RecapSection[];
-}
-
-const RECAP_BY_MODE: Record<GuidedStudyMode, RecapConfig> = {
-  quick: {
-    title: 'Your Quick Pass',
-    sections: [
-      { label: 'Takeaway', ref: { step: 'synthesize', key: 'takeaway' } },
-      { label: 'Verse to remember', ref: { step: 'synthesize', key: 'key_connection' } },
-    ],
-  },
-  deep: {
-    title: 'Your Deep Study',
-    sections: [
-      { label: 'Claim', ref: { step: 'synthesize', key: 'takeaway' } },
-      { label: 'Evidence', ref: { step: 'synthesize', key: 'key_connection' } },
-      { label: 'Tension still unresolved', ref: { step: 'synthesize', key: 'open_question' } },
-    ],
-  },
-  teaching: {
-    title: 'Your Teaching Outline',
-    sections: [
-      { label: 'Audience', ref: { step: 'scene', key: 'audience' } },
-      { label: 'Setting', ref: { step: 'scene', key: 'setting' } },
-      { label: 'Main point', ref: { step: 'observe', key: 'main_point' } },
-      { label: 'Clarification', ref: { step: 'observe', key: 'clarification' } },
-      { label: 'Outline', ref: { step: 'synthesize', key: 'takeaway' } },
-      { label: 'Discussion question', ref: { step: 'synthesize', key: 'open_question' } },
-    ],
-  },
-  devotional: {
-    title: 'Your Devotional',
-    sections: [
-      { label: 'What met you', ref: { step: 'observe', key: 'primary' } },
-      { label: 'Your prayer', ref: { step: 'synthesize', key: 'takeaway' } },
-      { label: 'Carrying forward', ref: { step: 'synthesize', key: 'key_connection' } },
-    ],
-  },
-};
-
-interface PopulatedSection {
-  label: string;
-  content: string;
-}
-
-function populatedSections(
-  mode: GuidedStudyMode,
-  captured: CapturedInputs,
-): { title: string; sections: PopulatedSection[] } {
-  const cfg = RECAP_BY_MODE[mode];
-  const sections: PopulatedSection[] = [];
-  for (const section of cfg.sections) {
-    const content = getCapturedText(captured, section.ref).trim();
-    if (!content) continue;
-    sections.push({ label: section.label, content });
-  }
-  return { title: cfg.title, sections };
+  /** Renderable descriptors from a SynthesisStrategy.run() result. */
+  blocks: SynthesisOutputBlock[];
+  /** Plain-text label for the source — included in clipboard/share output. */
+  chapterTitle: string;
+  /** Fired when a cta_button with action='upgrade' is tapped, OR when the
+   *  flag-aware footer note is tapped. */
+  onUpgradeNudgePress?: () => void;
 }
 
 function buildPlainText(
   chapterTitle: string,
-  modeTitle: string,
-  sections: PopulatedSection[],
+  title: string,
+  recapSections: { label: string; content: string }[],
 ): string {
-  const header = `${chapterTitle} — ${modeTitle}`;
-  const body = sections.map((s) => `${s.label}:\n${s.content}`).join('\n\n');
+  const header = `${chapterTitle} — ${title}`;
+  const body = recapSections.map((s) => `${s.label}:\n${s.content}`).join('\n\n');
   return `${header}\n\n${body}`;
 }
 
-const PREMIUM_FOOTER_AMICUS_ON =
-  'Companion+ drafts this for you and saves it for spaced review.';
-const PREMIUM_FOOTER_AMICUS_OFF =
-  'Companion+ saves this for spaced review and brings it back when it matters.';
-
-export interface SynthesisFreeRecapProps {
-  mode: GuidedStudyMode;
-  chapterTitle: string;
-  capturedInputs: CapturedInputs;
-  onUpgradeNudgePress?: () => void;
-}
-
 export function SynthesisFreeRecap({
-  mode,
+  title,
+  blocks,
   chapterTitle,
-  capturedInputs,
   onUpgradeNudgePress,
 }: SynthesisFreeRecapProps) {
   const { base } = useTheme();
   const [copied, setCopied] = useState(false);
 
-  const { title, sections } = useMemo(
-    () => populatedSections(mode, capturedInputs),
-    [mode, capturedInputs],
+  const recapSections = useMemo(
+    () =>
+      blocks.flatMap((b) =>
+        b.type === 'recap_section' ? [{ label: b.label, content: b.content }] : [],
+      ),
+    [blocks],
   );
 
   const plainText = useMemo(
-    () => buildPlainText(chapterTitle, title, sections),
-    [chapterTitle, title, sections],
+    () => buildPlainText(chapterTitle, title, recapSections),
+    [chapterTitle, title, recapSections],
   );
 
   const onCopy = useCallback(async () => {
@@ -146,52 +79,77 @@ export function SynthesisFreeRecap({
     }
   }, [plainText]);
 
-  if (sections.length === 0) return null;
+  const handleAction = useCallback(
+    (action: 'copy' | 'share' | 'upgrade') => {
+      if (action === 'copy') void onCopy();
+      else if (action === 'share') void onShare();
+      else onUpgradeNudgePress?.();
+    },
+    [onCopy, onShare, onUpgradeNudgePress],
+  );
 
-  const footerCopy = isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')
-    ? PREMIUM_FOOTER_AMICUS_ON
-    : PREMIUM_FOOTER_AMICUS_OFF;
+  if (blocks.length === 0) return null;
 
   return (
     <View style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}>
       <Text style={[styles.title, { color: base.gold }]}>{title}</Text>
-      {sections.map((s) => (
-        <View key={s.label} style={styles.section}>
-          <Text style={[styles.label, { color: base.textMuted }]}>{s.label.toUpperCase()}</Text>
-          <Text style={[styles.body, { color: base.text }]}>{s.content}</Text>
-        </View>
-      ))}
-      <View style={styles.actionRow}>
-        <TouchableOpacity
-          onPress={onCopy}
-          accessibilityRole="button"
-          accessibilityLabel={copied ? 'Copied to clipboard' : 'Copy recap to clipboard'}
-          style={[styles.actionButton, { borderColor: base.border }]}
-        >
-          <Copy size={14} color={base.text} />
-          <Text style={[styles.actionLabel, { color: base.text }]}>
-            {copied ? 'Copied' : 'Copy'}
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={onShare}
-          accessibilityRole="button"
-          accessibilityLabel="Share recap"
-          style={[styles.actionButton, { borderColor: base.border }]}
-        >
-          <Share2 size={14} color={base.text} />
-          <Text style={[styles.actionLabel, { color: base.text }]}>Share</Text>
-        </TouchableOpacity>
-      </View>
-      <TouchableOpacity
-        onPress={onUpgradeNudgePress}
-        accessibilityRole="button"
-        accessibilityLabel="Learn about Companion Study Partner"
-        style={[styles.footer, { borderTopColor: `${base.gold}25` }]}
-      >
-        <Text style={[styles.footerText, { color: base.gold }]}>{footerCopy}</Text>
-        <ChevronRight size={14} color={base.gold} />
-      </TouchableOpacity>
+      {blocks.map((block, idx) => {
+        switch (block.type) {
+          case 'recap_section':
+            return (
+              <View key={`${block.label}-${idx}`} style={styles.section}>
+                <Text style={[styles.label, { color: base.textMuted }]}>
+                  {block.label.toUpperCase()}
+                </Text>
+                <Text style={[styles.body, { color: base.text }]}>{block.content}</Text>
+              </View>
+            );
+          case 'cta_button': {
+            const Icon = block.action === 'copy' ? Copy : Share2;
+            const label =
+              block.action === 'copy' && copied ? 'Copied' : block.label;
+            return (
+              <TouchableOpacity
+                key={`${block.action}-${idx}`}
+                onPress={() => handleAction(block.action)}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  block.action === 'copy'
+                    ? copied
+                      ? 'Copied to clipboard'
+                      : 'Copy recap to clipboard'
+                    : block.action === 'share'
+                      ? 'Share recap'
+                      : 'Upgrade'
+                }
+                style={[styles.actionButton, { borderColor: base.border }]}
+              >
+                {block.action !== 'upgrade' ? <Icon size={14} color={base.text} /> : null}
+                <Text style={[styles.actionLabel, { color: base.text }]}>{label}</Text>
+              </TouchableOpacity>
+            );
+          }
+          case 'footer_note':
+            return (
+              <TouchableOpacity
+                key={`footer-${idx}`}
+                onPress={onUpgradeNudgePress}
+                accessibilityRole="button"
+                accessibilityLabel="Learn about Companion Study Partner"
+                style={[styles.footer, { borderTopColor: `${base.gold}25` }]}
+              >
+                <Text style={[styles.footerText, { color: base.gold }]}>{block.text}</Text>
+                <ChevronRight size={14} color={base.gold} />
+              </TouchableOpacity>
+            );
+          case 'streaming_placeholder':
+          case 'amicus_text':
+            // Phase 4 (#1745) renders these. Skip in the free path.
+            return null;
+          default:
+            return null;
+        }
+      })}
     </View>
   );
 }
@@ -222,14 +180,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 21,
   },
-  actionRow: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-    marginTop: spacing.xs,
-  },
   actionButton: {
     flexDirection: 'row',
     alignItems: 'center',
+    alignSelf: 'flex-start',
     gap: 6,
     borderWidth: 1,
     borderRadius: radii.sm,

--- a/app/src/components/guidedStudy/__tests__/SynthesisFreeRecap.test.tsx
+++ b/app/src/components/guidedStudy/__tests__/SynthesisFreeRecap.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import * as Clipboard from 'expo-clipboard';
 import { renderWithProviders } from '../../../../__tests__/helpers/renderWithProviders';
 import { SynthesisFreeRecap } from '../SynthesisFreeRecap';
-import type { CapturedInputs } from '../../../services/guidedStudy/capturedInputs';
+import type { SynthesisOutputBlock } from '../../../services/guidedStudy/synthesis/strategy';
 
 const setStringAsync = Clipboard.setStringAsync as jest.Mock;
 
@@ -11,105 +11,45 @@ beforeEach(() => {
   setStringAsync.mockReset();
 });
 
-describe('SynthesisFreeRecap', () => {
-  it('renders null when nothing has been captured', () => {
+const sampleBlocks: SynthesisOutputBlock[] = [
+  { type: 'recap_section', label: 'Takeaway', content: 'Creation is ordered by speech.' },
+  { type: 'recap_section', label: 'Verse to remember', content: 'In the beginning, God.' },
+  { type: 'cta_button', label: 'Copy to clipboard', action: 'copy' },
+  { type: 'cta_button', label: 'Share', action: 'share' },
+  {
+    type: 'footer_note',
+    text: 'Companion+ saves this for spaced review and brings it back when it matters.',
+  },
+];
+
+describe('SynthesisFreeRecap (block-driven)', () => {
+  it('renders null when blocks is empty', () => {
     const { toJSON } = renderWithProviders(
-      <SynthesisFreeRecap
-        mode="quick"
-        chapterTitle="Genesis 1"
-        capturedInputs={{}}
-      />,
+      <SynthesisFreeRecap title="Your Quick Pass" chapterTitle="Genesis 1" blocks={[]} />,
     );
     expect(toJSON()).toBeNull();
   });
 
-  it('quick mode shows takeaway + verse-to-remember sections', () => {
-    const captured: CapturedInputs = {
-      synthesize: {
-        takeaway: 'Creation is ordered by speech.',
-        key_connection: 'In the beginning, God.',
-        open_question: '',
-      },
-    };
+  it('renders title and recap_section blocks with uppercase labels', () => {
     const { getByText } = renderWithProviders(
-      <SynthesisFreeRecap mode="quick" chapterTitle="Genesis 1" capturedInputs={captured} />,
+      <SynthesisFreeRecap
+        title="Your Quick Pass"
+        chapterTitle="Genesis 1"
+        blocks={sampleBlocks}
+      />,
     );
     expect(getByText('Your Quick Pass')).toBeTruthy();
     expect(getByText('TAKEAWAY')).toBeTruthy();
     expect(getByText('Creation is ordered by speech.')).toBeTruthy();
     expect(getByText('VERSE TO REMEMBER')).toBeTruthy();
-    expect(getByText('In the beginning, God.')).toBeTruthy();
   });
 
-  it('hides empty sections — partial sessions only show populated fields', () => {
-    const captured: CapturedInputs = {
-      synthesize: { takeaway: 'Creation is ordered.', open_question: '', key_connection: '' },
-    };
-    const { getByText, queryByText } = renderWithProviders(
-      <SynthesisFreeRecap mode="quick" chapterTitle="Genesis 1" capturedInputs={captured} />,
-    );
-    expect(getByText('TAKEAWAY')).toBeTruthy();
-    expect(queryByText('VERSE TO REMEMBER')).toBeNull();
-  });
-
-  it('teaching mode renders six labeled outline sections', () => {
-    const captured: CapturedInputs = {
-      scene: { audience: 'College small group', setting: 'small group' },
-      observe: { main_point: 'Order from chaos.', clarification: 'Not a science manual.' },
-      synthesize: {
-        takeaway: 'Hook → main point → moves → application.',
-        open_question: 'How does this frame John 1?',
-        key_connection: '',
-      },
-    };
-    const { getByText } = renderWithProviders(
-      <SynthesisFreeRecap
-        mode="teaching"
-        chapterTitle="Genesis 1"
-        capturedInputs={captured}
-      />,
-    );
-    expect(getByText('Your Teaching Outline')).toBeTruthy();
-    for (const label of [
-      'AUDIENCE',
-      'SETTING',
-      'MAIN POINT',
-      'CLARIFICATION',
-      'OUTLINE',
-      'DISCUSSION QUESTION',
-    ]) {
-      expect(getByText(label)).toBeTruthy();
-    }
-  });
-
-  it('devotional mode title and prayer label appear', () => {
-    const captured: CapturedInputs = {
-      synthesize: {
-        takeaway: 'Lord, you walk with me.',
-        open_question: '',
-        key_connection: '',
-      },
-    };
-    const { getByText } = renderWithProviders(
-      <SynthesisFreeRecap
-        mode="devotional"
-        chapterTitle="Psalm 23"
-        capturedInputs={captured}
-      />,
-    );
-    expect(getByText('Your Devotional')).toBeTruthy();
-    expect(getByText('YOUR PRAYER')).toBeTruthy();
-  });
-
-  it('Copy button writes the plain-text recap to the clipboard', async () => {
-    const captured: CapturedInputs = {
-      synthesize: { takeaway: 'A.', key_connection: 'B.', open_question: '' },
-    };
+  it('Copy CTA writes the plain-text recap to the clipboard', async () => {
     const { getByLabelText } = renderWithProviders(
       <SynthesisFreeRecap
-        mode="quick"
+        title="Your Quick Pass"
         chapterTitle="Genesis 1"
-        capturedInputs={captured}
+        blocks={sampleBlocks}
       />,
     );
     fireEvent.press(getByLabelText('Copy recap to clipboard'));
@@ -117,41 +57,35 @@ describe('SynthesisFreeRecap', () => {
     const arg = setStringAsync.mock.calls[0][0] as string;
     expect(arg).toContain('Genesis 1 — Your Quick Pass');
     expect(arg).toContain('Takeaway:');
-    expect(arg).toContain('A.');
-    expect(arg).toContain('Verse to remember:');
-    expect(arg).toContain('B.');
+    expect(arg).toContain('Creation is ordered by speech.');
   });
 
-  it('renders the flag-off footer copy when GUIDED_STUDY_AMICUS_SYNTHESIS=false', () => {
-    const captured: CapturedInputs = {
-      synthesize: { takeaway: 'A.', open_question: '', key_connection: '' },
-    };
-    const { getByText } = renderWithProviders(
+  it('renders the footer_note text and fires onUpgradeNudgePress on tap', () => {
+    const onUpgradeNudgePress = jest.fn();
+    const { getByLabelText, getByText } = renderWithProviders(
       <SynthesisFreeRecap
-        mode="quick"
+        title="Your Quick Pass"
         chapterTitle="Genesis 1"
-        capturedInputs={captured}
+        blocks={sampleBlocks}
+        onUpgradeNudgePress={onUpgradeNudgePress}
       />,
     );
     expect(
       getByText('Companion+ saves this for spaced review and brings it back when it matters.'),
     ).toBeTruthy();
-  });
-
-  it('fires onUpgradeNudgePress when the footer is tapped', () => {
-    const onUpgradeNudgePress = jest.fn();
-    const captured: CapturedInputs = {
-      synthesize: { takeaway: 'A.', open_question: '', key_connection: '' },
-    };
-    const { getByLabelText } = renderWithProviders(
-      <SynthesisFreeRecap
-        mode="quick"
-        chapterTitle="Genesis 1"
-        capturedInputs={captured}
-        onUpgradeNudgePress={onUpgradeNudgePress}
-      />,
-    );
     fireEvent.press(getByLabelText('Learn about Companion Study Partner'));
     expect(onUpgradeNudgePress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders each cta_button block with its label', () => {
+    const { getByLabelText } = renderWithProviders(
+      <SynthesisFreeRecap
+        title="Your Quick Pass"
+        chapterTitle="Genesis 1"
+        blocks={sampleBlocks}
+      />,
+    );
+    expect(getByLabelText('Copy recap to clipboard')).toBeTruthy();
+    expect(getByLabelText('Share recap')).toBeTruthy();
   });
 });

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -53,6 +53,14 @@ import {
   type GuidedStudyStep,
   type SceneInputKey,
 } from '../services/guidedStudy';
+import { chooseStrategy } from '../services/guidedStudy/synthesis/strategy';
+import { recapTitleFor } from '../services/guidedStudy/synthesis/freeStrategy';
+import type {
+  SynthesisOutputBlock,
+  SynthesisRunResult,
+} from '../services/guidedStudy/synthesis/strategy';
+import { isFlagEnabled } from '../config/featureFlags';
+import { useAmicusAccess } from '../hooks/useAmicusAccess';
 import type { CapturedInputs } from '../services/guidedStudy/capturedInputs';
 import { launchAmicusStudyThread } from '../services/amicus';
 import { useSettingsStore } from '../stores';
@@ -66,7 +74,7 @@ import type {
   SectionPanel,
   Verse,
 } from '../types';
-import { safeParse } from '../utils/logger';
+import { logger, safeParse } from '../utils/logger';
 
 interface RouteParams {
   bookId: string;
@@ -83,6 +91,7 @@ function StudySessionScreen() {
   const translation = useSettingsStore((s) => s.translation);
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const { liveBooks } = useBooks();
+  const amicusAccess = useAmicusAccess();
 
   const [book, setBook] = useState<Book | null>(null);
   const [chapter, setChapter] = useState<Chapter | null>(null);
@@ -229,6 +238,44 @@ function StudySessionScreen() {
       mode: studyMode,
     });
   }, [book, chapter, sections, chapterPanels, verses, bookIntro, studyMode]);
+
+  const synthesisStrategy = useMemo(
+    () =>
+      chooseStrategy({
+        isPremium,
+        amicusFlagEnabled: isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS'),
+        amicusCanUse: amicusAccess.canUse,
+      }),
+    [isPremium, amicusAccess.canUse],
+  );
+
+  const [synthesisResult, setSynthesisResult] = useState<SynthesisRunResult | null>(null);
+  useEffect(() => {
+    if (!plan || synthesisStrategy.kind !== 'free') {
+      // Premium paths plug in starting at #1740. Until then the screen
+      // only renders the free path's output.
+      setSynthesisResult(null);
+      return;
+    }
+    let cancelled = false;
+    void synthesisStrategy
+      .run({
+        plan,
+        captured: capturedInputs,
+        sessionId,
+        bookId,
+        chapterNum,
+      })
+      .then((r) => {
+        if (!cancelled) setSynthesisResult(r);
+      })
+      .catch((err) => logger.warn('StudySessionScreen', 'synthesis run failed', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [synthesisStrategy, plan, capturedInputs, sessionId, bookId, chapterNum]);
+
+  const synthesisBlocks: SynthesisOutputBlock[] = synthesisResult?.output ?? [];
 
   const savePromptDrafts = useCallback(async () => {
     if (!plan) return;
@@ -488,9 +535,9 @@ function StudySessionScreen() {
             </TouchableOpacity>
             <PrimaryButton label="Save to My Study" onPress={saveToMyStudy} />
             <SynthesisFreeRecap
-              mode={plan.mode}
+              title={recapTitleFor(plan.mode)}
               chapterTitle={plan.title}
-              capturedInputs={capturedInputs}
+              blocks={synthesisBlocks}
               onUpgradeNudgePress={() =>
                 showUpgrade('feature', 'Companion Study Partner')
               }

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
@@ -1,0 +1,192 @@
+import { chooseStrategy } from '../strategy';
+import { freeStrategy, buildFreeSynthesisBlocks, recapTitleFor } from '../freeStrategy';
+import { premiumStructuredStrategy } from '../premiumStructuredStrategy';
+import { premiumAmicusStrategy } from '../premiumAmicusStrategy';
+import type { CapturedInputs } from '../../capturedInputs';
+import type { GuidedStudyMode, GuidedStudyPlan } from '../../types';
+
+function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
+  return {
+    chapterId: 'gen_1',
+    title: 'Genesis 1',
+    mode,
+    modeLabel: 'Mode',
+    sceneRows: [],
+    stepPrompts: { scene: [], observe: [], explore: [], synthesize: [], review: [] },
+    legacyPrompts: [],
+    recommendations: [],
+    evidenceTrail: [],
+    betterQuestionPrompt: '',
+    conceptChips: [],
+  };
+}
+
+describe('chooseStrategy', () => {
+  it('returns the free strategy when isPremium is false', () => {
+    const s = chooseStrategy({
+      isPremium: false,
+      amicusFlagEnabled: true,
+      amicusCanUse: true,
+    });
+    expect(s).toBe(freeStrategy);
+  });
+
+  it('returns premium_amicus when premium + flag on + amicus access available', () => {
+    const s = chooseStrategy({
+      isPremium: true,
+      amicusFlagEnabled: true,
+      amicusCanUse: true,
+    });
+    expect(s).toBe(premiumAmicusStrategy);
+  });
+
+  it('falls back to premium_structured when the flag is off', () => {
+    const s = chooseStrategy({
+      isPremium: true,
+      amicusFlagEnabled: false,
+      amicusCanUse: true,
+    });
+    expect(s).toBe(premiumStructuredStrategy);
+  });
+
+  it('falls back to premium_structured when amicus access is unavailable', () => {
+    const s = chooseStrategy({
+      isPremium: true,
+      amicusFlagEnabled: true,
+      amicusCanUse: false,
+    });
+    expect(s).toBe(premiumStructuredStrategy);
+  });
+});
+
+describe('freeStrategy.run', () => {
+  it('returns kind=free with artifact=null', async () => {
+    const result = await freeStrategy.run({
+      plan: planFor('quick'),
+      captured: {},
+      sessionId: null,
+      bookId: 'gen',
+      chapterNum: 1,
+    });
+    expect(result.kind).toBe('free');
+    expect(result.artifact).toBeNull();
+  });
+
+  it('emits an empty output array when nothing is captured', async () => {
+    const result = await freeStrategy.run({
+      plan: planFor('quick'),
+      captured: {},
+      sessionId: null,
+      bookId: 'gen',
+      chapterNum: 1,
+    });
+    expect(result.output).toEqual([]);
+  });
+
+  it('emits recap_section + cta + footer blocks in the expected order when captured', async () => {
+    const captured: CapturedInputs = {
+      synthesize: { takeaway: 'A.', key_connection: 'B.', open_question: '' },
+    };
+    const result = await freeStrategy.run({
+      plan: planFor('quick'),
+      captured,
+      sessionId: null,
+      bookId: 'gen',
+      chapterNum: 1,
+    });
+    const types = result.output.map((b) => b.type);
+    // recap_sections come first, then both cta_buttons, then the footer note.
+    expect(types).toEqual([
+      'recap_section',
+      'recap_section',
+      'cta_button',
+      'cta_button',
+      'footer_note',
+    ]);
+  });
+
+  it('hides recap_section blocks when their captured field is empty', async () => {
+    const captured: CapturedInputs = {
+      synthesize: { takeaway: 'A.', key_connection: '', open_question: '' },
+    };
+    const result = await freeStrategy.run({
+      plan: planFor('quick'),
+      captured,
+      sessionId: null,
+      bookId: 'gen',
+      chapterNum: 1,
+    });
+    const recapSections = result.output.filter((b) => b.type === 'recap_section');
+    expect(recapSections).toHaveLength(1);
+  });
+});
+
+describe('buildFreeSynthesisBlocks per mode', () => {
+  it.each(['quick', 'deep', 'teaching', 'devotional'] as const)(
+    '%s mode renders the mode-shaped recap title',
+    (mode) => {
+      const expected: Record<GuidedStudyMode, string> = {
+        quick: 'Your Quick Pass',
+        deep: 'Your Deep Study',
+        teaching: 'Your Teaching Outline',
+        devotional: 'Your Devotional',
+      };
+      expect(recapTitleFor(mode)).toBe(expected[mode]);
+    },
+  );
+
+  it('teaching pulls from scene + observe + synthesize buckets', () => {
+    const captured: CapturedInputs = {
+      scene: { audience: 'small group', setting: 'small group' },
+      observe: { main_point: 'main', clarification: 'clarify' },
+      synthesize: {
+        takeaway: 'outline',
+        open_question: 'discuss?',
+        key_connection: '',
+      },
+    };
+    const blocks = buildFreeSynthesisBlocks('teaching', captured);
+    const labels = blocks
+      .filter((b): b is { type: 'recap_section'; label: string; content: string } => b.type === 'recap_section')
+      .map((b) => b.label);
+    expect(labels).toEqual([
+      'Audience',
+      'Setting',
+      'Main point',
+      'Clarification',
+      'Outline',
+      'Discussion question',
+    ]);
+  });
+});
+
+describe('premium strategy stubs', () => {
+  it('premium_structured throws not-implemented (filled in by #1740)', async () => {
+    await expect(
+      premiumStructuredStrategy.run({
+        plan: planFor('deep'),
+        captured: {},
+        sessionId: null,
+        bookId: 'gen',
+        chapterNum: 1,
+      }),
+    ).rejects.toThrow(/not implemented/);
+  });
+
+  it('premium_amicus throws not-implemented (filled in by #1745)', async () => {
+    await expect(
+      premiumAmicusStrategy.run({
+        plan: planFor('deep'),
+        captured: {},
+        sessionId: null,
+        bookId: 'gen',
+        chapterNum: 1,
+      }),
+    ).rejects.toThrow(/not implemented/);
+  });
+
+  it('premium stubs report their kind correctly', () => {
+    expect(premiumStructuredStrategy.kind).toBe('premium_structured');
+    expect(premiumAmicusStrategy.kind).toBe('premium_amicus');
+  });
+});

--- a/app/src/services/guidedStudy/synthesis/freeStrategy.ts
+++ b/app/src/services/guidedStudy/synthesis/freeStrategy.ts
@@ -1,0 +1,110 @@
+/**
+ * Free synthesis strategy — Phase 3.2 (#1739).
+ *
+ * Reads CapturedInputs and the current mode, returns the mode-shaped
+ * recap + clipboard/share/upgrade CTAs as SynthesisOutputBlock[]. No
+ * persistence, no Amicus call, no streaming.
+ */
+
+import type { CapturedInputs } from '../capturedInputs';
+import { getCapturedText, type CapturedTextRef } from '../stepBindings';
+import type { GuidedStudyMode } from '../types';
+import type {
+  SynthesisOutputBlock,
+  SynthesisRunResult,
+  SynthesisStrategy,
+} from './strategy';
+
+interface RecapSection {
+  label: string;
+  ref: CapturedTextRef;
+}
+
+interface RecapConfig {
+  /** Mode-specific card title (e.g. 'Your Quick Pass'). */
+  title: string;
+  sections: RecapSection[];
+}
+
+const RECAP_BY_MODE: Record<GuidedStudyMode, RecapConfig> = {
+  quick: {
+    title: 'Your Quick Pass',
+    sections: [
+      { label: 'Takeaway', ref: { step: 'synthesize', key: 'takeaway' } },
+      { label: 'Verse to remember', ref: { step: 'synthesize', key: 'key_connection' } },
+    ],
+  },
+  deep: {
+    title: 'Your Deep Study',
+    sections: [
+      { label: 'Claim', ref: { step: 'synthesize', key: 'takeaway' } },
+      { label: 'Evidence', ref: { step: 'synthesize', key: 'key_connection' } },
+      { label: 'Tension still unresolved', ref: { step: 'synthesize', key: 'open_question' } },
+    ],
+  },
+  teaching: {
+    title: 'Your Teaching Outline',
+    sections: [
+      { label: 'Audience', ref: { step: 'scene', key: 'audience' } },
+      { label: 'Setting', ref: { step: 'scene', key: 'setting' } },
+      { label: 'Main point', ref: { step: 'observe', key: 'main_point' } },
+      { label: 'Clarification', ref: { step: 'observe', key: 'clarification' } },
+      { label: 'Outline', ref: { step: 'synthesize', key: 'takeaway' } },
+      { label: 'Discussion question', ref: { step: 'synthesize', key: 'open_question' } },
+    ],
+  },
+  devotional: {
+    title: 'Your Devotional',
+    sections: [
+      { label: 'What met you', ref: { step: 'observe', key: 'primary' } },
+      { label: 'Your prayer', ref: { step: 'synthesize', key: 'takeaway' } },
+      { label: 'Carrying forward', ref: { step: 'synthesize', key: 'key_connection' } },
+    ],
+  },
+};
+
+/**
+ * Mode-specific recap-card title (e.g. for use as the card heading
+ * the renderer chooses to display). Exposed so the screen can title
+ * the rendered card without re-deriving it.
+ */
+export function recapTitleFor(mode: GuidedStudyMode): string {
+  return RECAP_BY_MODE[mode].title;
+}
+
+export function buildFreeSynthesisBlocks(
+  mode: GuidedStudyMode,
+  captured: CapturedInputs,
+): SynthesisOutputBlock[] {
+  const cfg = RECAP_BY_MODE[mode];
+  const blocks: SynthesisOutputBlock[] = [];
+
+  for (const section of cfg.sections) {
+    const content = getCapturedText(captured, section.ref).trim();
+    if (!content) continue;
+    blocks.push({ type: 'recap_section', label: section.label, content });
+  }
+
+  // No recap content yet → return an empty descriptor list. The renderer
+  // hides the card entirely in that case.
+  if (blocks.length === 0) return [];
+
+  blocks.push({ type: 'cta_button', label: 'Copy to clipboard', action: 'copy' });
+  blocks.push({ type: 'cta_button', label: 'Share', action: 'share' });
+  blocks.push({
+    type: 'footer_note',
+    text: 'Companion+ saves this for spaced review and brings it back when it matters.',
+  });
+  return blocks;
+}
+
+export const freeStrategy: SynthesisStrategy = {
+  kind: 'free',
+  async run(ctx): Promise<SynthesisRunResult> {
+    return {
+      kind: 'free',
+      output: buildFreeSynthesisBlocks(ctx.plan.mode, ctx.captured),
+      artifact: null,
+    };
+  },
+};

--- a/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
+++ b/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
@@ -1,0 +1,15 @@
+/**
+ * Premium Amicus synthesis strategy — stub.
+ *
+ * Filled in by Phase 4 (#1745). Behind GUIDED_STUDY_AMICUS_SYNTHESIS;
+ * the chooseStrategy factory only routes here when the flag is on AND
+ * useAmicusAccess.canUse is true.
+ */
+import type { SynthesisStrategy } from './strategy';
+
+export const premiumAmicusStrategy: SynthesisStrategy = {
+  kind: 'premium_amicus',
+  async run() {
+    throw new Error('premiumAmicusStrategy: not implemented (lands in #1745)');
+  },
+};

--- a/app/src/services/guidedStudy/synthesis/premiumStructuredStrategy.ts
+++ b/app/src/services/guidedStudy/synthesis/premiumStructuredStrategy.ts
@@ -1,0 +1,15 @@
+/**
+ * Premium structured synthesis strategy — stub.
+ *
+ * Filled in by Phase 3.3 (#1740): mode-shaped form with persistent save
+ * + spaced review queue entry. This is the path premium users get when
+ * the GUIDED_STUDY_AMICUS_SYNTHESIS flag is OFF.
+ */
+import type { SynthesisStrategy } from './strategy';
+
+export const premiumStructuredStrategy: SynthesisStrategy = {
+  kind: 'premium_structured',
+  async run() {
+    throw new Error('premiumStructuredStrategy: not implemented (lands in #1740)');
+  },
+};

--- a/app/src/services/guidedStudy/synthesis/strategy.ts
+++ b/app/src/services/guidedStudy/synthesis/strategy.ts
@@ -1,0 +1,90 @@
+/**
+ * Synthesis strategy abstraction — Phase 3.2 (#1739).
+ *
+ * The screen needs a synthesis output without knowing which tier or
+ * feature flag the user is on. Three concrete strategies hide behind
+ * this interface:
+ *   - free                 (this card, freeStrategy.ts)
+ *   - premium_structured   (#1740 / Phase 3.3)
+ *   - premium_amicus       (Phase 4 / #1745)
+ *
+ * Strategies return *descriptors* of the UI (SynthesisOutputBlock[])
+ * rather than JSX so the renderer + tests + a future preview tool can
+ * consume them without React-Native rendering machinery.
+ */
+
+import type { CapturedInputs } from '../capturedInputs';
+import type { GuidedStudyPlan } from '../types';
+import { freeStrategy } from './freeStrategy';
+import { premiumAmicusStrategy } from './premiumAmicusStrategy';
+import { premiumStructuredStrategy } from './premiumStructuredStrategy';
+
+export type SynthesisStrategyKind = 'free' | 'premium_structured' | 'premium_amicus';
+
+export interface SynthesisRunContext {
+  plan: GuidedStudyPlan;
+  captured: CapturedInputs;
+  sessionId: number | null;
+  bookId: string;
+  chapterNum: number;
+}
+
+export interface CitationRef {
+  /** Panel type that was opened during the explore step (e.g. 'hist'). */
+  panelType: string;
+  /** Optional short snippet/quote drawn from the panel. */
+  snippet?: string;
+}
+
+export interface ReviewArtifact {
+  kind: 'memory_verse' | 'analytical_claim' | 'teaching_outline' | 'returning_prayer';
+  title: string;
+  body: string;
+}
+
+export type SynthesisOutputBlock =
+  | { type: 'recap_section'; label: string; content: string }
+  | { type: 'cta_button'; label: string; action: 'copy' | 'share' | 'upgrade' }
+  | { type: 'streaming_placeholder' }
+  | { type: 'amicus_text'; html: string; citations: CitationRef[] }
+  | { type: 'footer_note'; text: string };
+
+export interface SynthesisRunResult {
+  kind: SynthesisStrategyKind;
+  output: SynthesisOutputBlock[];
+  artifact: ReviewArtifact | null;
+}
+
+export interface SynthesisStrategyCallbacks {
+  onAmicusDelta?: (token: string) => void;
+  onAmicusComplete?: () => void;
+  onError?: (err: Error) => void;
+}
+
+export interface SynthesisStrategy {
+  kind: SynthesisStrategyKind;
+  run(
+    ctx: SynthesisRunContext,
+    callbacks?: SynthesisStrategyCallbacks,
+  ): Promise<SynthesisRunResult>;
+}
+
+export interface ChooseStrategyArgs {
+  isPremium: boolean;
+  amicusFlagEnabled: boolean;
+  /** Result of useAmicusAccess.canUse. */
+  amicusCanUse: boolean;
+}
+
+/**
+ * Pick a strategy without looking at the rendered UI.
+ *
+ *   - non-premium                                 → free
+ *   - premium + flag on + amicus access available → premium_amicus
+ *   - premium otherwise                           → premium_structured
+ */
+export function chooseStrategy(args: ChooseStrategyArgs): SynthesisStrategy {
+  if (!args.isPremium) return freeStrategy;
+  if (args.amicusFlagEnabled && args.amicusCanUse) return premiumAmicusStrategy;
+  return premiumStructuredStrategy;
+}


### PR DESCRIPTION
Closes #1739. Phase 3.2 of epic #1725.

## Why
The synthesize step needs to render different things for free / premium-structured / premium-Amicus users without the screen having to branch on tier or flag state. This card lays down the strategy abstraction, ships the free implementation, and stubs the two premium ones so #1740 / #1745 can fill them in by replacing a single file.

## What

**`services/guidedStudy/synthesis/strategy.ts`** — interface + factory:
- Types: `SynthesisStrategyKind`, `SynthesisRunContext`, `SynthesisRunResult`, `SynthesisOutputBlock` (`recap_section` | `cta_button` | `streaming_placeholder` | `amicus_text` | `footer_note`), `ReviewArtifact`, `CitationRef`, `SynthesisStrategyCallbacks`, `SynthesisStrategy`.
- `chooseStrategy({ isPremium, amicusFlagEnabled, amicusCanUse })`:
  - `!isPremium` → `freeStrategy`
  - premium + flag on + `amicusCanUse` → `premiumAmicusStrategy`
  - otherwise → `premiumStructuredStrategy`

**`freeStrategy.ts`** — `run()` builds mode-shaped recap + clipboard/share CTAs + flag-aware footer note. Returns `artifact: null` (free path doesn't persist). Exposes `recapTitleFor(mode)` so the screen can title the rendered card.

**`premiumStructuredStrategy.ts`** / **`premiumAmicusStrategy.ts`** — stubs that throw `not implemented` and report their `kind`. Filled in by #1740 and #1745.

**`SynthesisFreeRecap.tsx`** — refactored to consume `SynthesisOutputBlock[]` (per spec: "unify the two paths"). The component now renders generically: `recap_section` → labeled body, `cta_button` → owned clipboard/share/upgrade handler, `footer_note` → tappable upgrade nudge. `streaming_placeholder` and `amicus_text` are accepted-but-skipped here; #1745 wires the renderer for those.

**`StudySessionScreen.tsx`** — `useAmicusAccess` + `isFlagEnabled('GUIDED_STUDY_AMICUS_SYNTHESIS')` feed `chooseStrategy`. An effect runs the strategy when its `kind === 'free'` (premium paths plug in starting #1740) and stores the result; blocks flow into `<SynthesisFreeRecap blocks={...} title={recapTitleFor(mode)} />`.

## Tests
- New `synthesis/__tests__/strategy.test.ts` — 13 tests:
  - `chooseStrategy` routing across all four cases.
  - `freeStrategy.run` shape: `kind=free`, `artifact=null`, empty when nothing captured, expected block order when captured (recap_section × N → cta_button × 2 → footer_note), hides empty recap_sections.
  - `recapTitleFor` per mode; teaching's six recap labels.
  - Premium stubs throw `not implemented` and report their `kind`.
- Existing `SynthesisFreeRecap.test.tsx` rewritten for the block-driven API.

## Acceptance criteria
- [x] `freeStrategy` produces correct `SynthesisOutputBlock[]` for each mode (verified in `strategy.test.ts`)
- [x] `SynthesisFreeRecap` from #1736 refactored to consume blocks
- [x] `chooseStrategy` returns `freeStrategy` for non-premium; throws "not implemented" for premium paths until #1740 / #1745 land
- [x] tsc / lint / full suite (3864 tests) clean

## Rollback
Revert the PR. The strategy module + freeStrategy are leaf imports; the screen falls back to its previous render path (still functional via the legacy `synthesisDraft` form).

## Notes for Craig
- Out of scope per spec: `premiumStructured` (#1740) and `premiumAmicus` (#1745).
- Synthesize step still also renders the legacy 3 `SynthesisInput` fields below the strategy-driven recap. Phase 3.3 (#1740) will rationalize this duplication when the structured premium form lands.
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_