### PR TITLE
feat: rename gate to 'Companion Study Partner' (#1741)

### DIFF
--- a/app/src/components/UpgradePrompt.tsx
+++ b/app/src/components/UpgradePrompt.tsx
@@ -48,7 +48,13 @@ const FEATURE_DESCRIPTIONS: Record<string, string> = {
   'Bible Periods': 'Explore all 12 eras of biblical history with key people, books, themes, and the redemptive thread connecting each period.',
   'The Story of the Bible': 'Trace the 8-act redemptive narrative from Creation to Restoration — see how every chapter fits into God\'s story.',
   'Person Journey': 'Follow key biblical figures across multiple books — see their full arc from calling to legacy.',
-  'Guided Study Review': 'Save your synthesis, build concept vocabulary, and revisit key insights with spaced review.',
+  // TODO(#1749): when GUIDED_STUDY_AMICUS_SYNTHESIS flips to true, swap
+  // the description for the Amicus-aware copy:
+  //   'Companion Study Partner': 'Your study partner. Amicus drafts your
+  //    takeaway, outline, or prayer from what you discovered, saves it for
+  //    spaced review, and brings it back when it matters most.'
+  'Companion Study Partner':
+    'Your study, captured. We save your synthesis, build a spaced review queue, and bring insights back when they matter most.',
   'Extra-Biblical Literature': 'Scholarly entries on 1 Enoch, Jubilees, the Apocrypha, Dead Sea Scrolls — what they are, what they contain, and why traditions treated them differently.',
   'Canon Comparison': 'Side-by-side Protestant, Catholic, Orthodox, and Ethiopian canons — see what each includes and why.',
   'How We Got The Bible': 'Two deep journeys tracing canon formation and textual transmission, from oral tradition to modern English translations.',

--- a/app/src/screens/MyStudyScreen.tsx
+++ b/app/src/screens/MyStudyScreen.tsx
@@ -46,7 +46,7 @@ function MyStudyScreen() {
 
   async function openQuestionWithAmicus(question: GuidedStudyQuestion) {
     if (locked) {
-      showUpgrade('feature', 'Guided Study Review');
+      showUpgrade('feature', 'Companion Study Partner');
       return;
     }
     await launchAmicusStudyThread(navigation, {
@@ -62,7 +62,7 @@ function MyStudyScreen() {
 
   async function refineTakeawayWithAmicus(takeaway: GuidedStudyTakeawaySummary) {
     if (locked) {
-      showUpgrade('feature', 'Guided Study Review');
+      showUpgrade('feature', 'Companion Study Partner');
       return;
     }
     await launchAmicusStudyThread(navigation, {
@@ -81,7 +81,7 @@ function MyStudyScreen() {
     takeaway?: GuidedStudyTakeawaySummary | null,
   ) {
     if (locked) {
-      showUpgrade('feature', 'Guided Study Review');
+      showUpgrade('feature', 'Companion Study Partner');
       return;
     }
     await launchAmicusStudyThread(navigation, {
@@ -125,7 +125,7 @@ function MyStudyScreen() {
               Companion+.
             </Text>
             <TouchableOpacity
-              onPress={() => showUpgrade('feature', 'Guided Study Review')}
+              onPress={() => showUpgrade('feature', 'Companion Study Partner')}
               style={[styles.primaryButton, { backgroundColor: base.gold }]}
             >
               <Text style={styles.primaryText}>Unlock My Study</Text>

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -308,7 +308,7 @@ function StudySessionScreen() {
 
   const askAmicus = useCallback(async () => {
     if (!isPremium) {
-      showUpgrade('feature', 'Guided Study Review');
+      showUpgrade('feature', 'Companion Study Partner');
       return;
     }
     await session.saveSynthesis(synthesisDraft);
@@ -343,7 +343,7 @@ function StudySessionScreen() {
   const saveToMyStudy = useCallback(async () => {
     if (!plan) return;
     if (!isPremium) {
-      showUpgrade('feature', 'Guided Study Review');
+      showUpgrade('feature', 'Companion Study Partner');
       return;
     }
     await savePromptDrafts();


### PR DESCRIPTION
Closes #1741. Phase 3.4 of epic #1725.

## Why
Bring the older premium surfaces (`MyStudyScreen`, the legacy `StudySessionScreen` upgrade calls) in line with the partner positioning that #1736 / #1740 already used for the new synthesis surfaces.

## What
- **`components/UpgradePrompt.tsx`** — `FEATURE_DESCRIPTIONS` swaps the `'Guided Study Review'` key for `'Companion Study Partner'`:
  > Your study, captured. We save your synthesis, build a spaced review queue, and bring insights back when they matter most.
  
  TODO comment notes the Amicus-aware copy swap that #1749 will land when the flag flips.
- **`screens/MyStudyScreen.tsx`** (4 sites) + **`screens/StudySessionScreen.tsx`** (2 legacy sites) — `showUpgrade('feature', 'Guided Study Review')` → `'Companion Study Partner'`.

The newer surfaces (`SynthesisFreeRecap` footer, `onViewMyStudy` CTA) already used `'Companion Study Partner'` from #1736 / #1740, so they're unchanged here.

## Acceptance criteria
- [x] `grep -rn "Guided Study Review" app/src` returns zero results
- [x] Upgrade prompt renders for the new key (FEATURE_DESCRIPTIONS lookup hits)
- [x] TODO comment present for the flag-flip copy update
- [x] tsc / lint / full suite (3881 tests) clean

## Rollback
Revert the PR. Pure rename + copy swap; no data shape changes.

## Notes for Craig
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_