### PR TITLE
feat: soft 'after 3 sessions' upgrade prompt (#1742)

### DIFF
--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -525,6 +525,18 @@ export async function getSynthesisStrategy(
   return null;
 }
 
+/**
+ * Number of guided study sessions the user has marked completed. Used by
+ * the soft "after 3 sessions" upgrade prompt (#1742). Counts every
+ * session ever completed regardless of mode or chapter.
+ */
+export async function getCompletedGuidedSessionCount(): Promise<number> {
+  const row = await getUserDb().getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM guided_study_sessions WHERE status = 'completed'",
+  );
+  return row?.count ?? 0;
+}
+
 export async function getDueGuidedReviewItems(limit: number = 20): Promise<GuidedReviewItem[]> {
   return getUserDb().getAllAsync<GuidedReviewItem>(
     `SELECT * FROM guided_review_items

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -59,6 +59,7 @@ import type {
   SynthesisOutputBlock,
   SynthesisRunResult,
 } from '../services/guidedStudy/synthesis/strategy';
+import { markSoftPromptSeen, shouldShowSoftPrompt } from '../services/guidedStudy/softPrompt';
 import { isFlagEnabled } from '../config/featureFlags';
 import { useAmicusAccess } from '../hooks/useAmicusAccess';
 import type { CapturedInputs } from '../services/guidedStudy/capturedInputs';
@@ -225,6 +226,23 @@ function StudySessionScreen() {
       void setSessionStep(initialStep);
     }
   }, [currentStep, initialStep, sessionId, setSessionStep]);
+
+  // Soft "after 3 sessions" upgrade nudge (#1742). Fires once per device
+  // for free users who reach the review step with >= 3 completed sessions.
+  // markSoftPromptSeen runs before the modal so re-entering the review step
+  // can't double-fire.
+  useEffect(() => {
+    if (currentStep !== 'review') return;
+    let cancelled = false;
+    void shouldShowSoftPrompt({ isPremium }).then((show) => {
+      if (cancelled || !show) return;
+      void markSoftPromptSeen();
+      showUpgrade('feature', 'Companion Study Partner');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentStep, isPremium, showUpgrade]);
 
   const plan = useMemo(() => {
     if (!chapter) return null;

--- a/app/src/services/guidedStudy/__tests__/softPrompt.test.ts
+++ b/app/src/services/guidedStudy/__tests__/softPrompt.test.ts
@@ -1,0 +1,66 @@
+import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
+import {
+  SOFT_PROMPT_PREF_KEY,
+  markSoftPromptSeen,
+  shouldShowSoftPrompt,
+} from '../softPrompt';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+describe('shouldShowSoftPrompt', () => {
+  it('returns false for premium users (no DB calls needed)', async () => {
+    expect(await shouldShowSoftPrompt({ isPremium: true })).toBe(false);
+    expect(getMockUserDb().getFirstAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the seen flag is already 1', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ value: '1' });
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(false);
+    // Stops at the preference check; no count query needed.
+    expect(getMockUserDb().getFirstAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the user has fewer than 3 completed sessions', async () => {
+    getMockUserDb().getFirstAsync
+      .mockResolvedValueOnce(null) // preference unset
+      .mockResolvedValueOnce({ count: 2 });
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(false);
+  });
+
+  it('returns true when free user has completed 3 sessions and never seen the prompt', async () => {
+    getMockUserDb().getFirstAsync
+      .mockResolvedValueOnce(null) // preference unset
+      .mockResolvedValueOnce({ count: 3 });
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(true);
+  });
+
+  it('returns true at higher session counts (threshold is a floor)', async () => {
+    getMockUserDb().getFirstAsync
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 27 });
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(true);
+  });
+
+  it('returns false when COUNT(*) row is missing entirely', async () => {
+    getMockUserDb().getFirstAsync
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(false);
+  });
+});
+
+describe('markSoftPromptSeen', () => {
+  it('writes the canonical preference value', async () => {
+    await markSoftPromptSeen();
+    expect(getMockUserDb().runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('user_preferences'),
+      expect.arrayContaining([SOFT_PROMPT_PREF_KEY, '1']),
+    );
+  });
+});

--- a/app/src/services/guidedStudy/softPrompt.ts
+++ b/app/src/services/guidedStudy/softPrompt.ts
@@ -1,0 +1,28 @@
+/**
+ * Soft "after 3 sessions" upgrade prompt — Phase 3.5 (#1742).
+ *
+ * The only soft-prompt timing logic added in epic #1725. Free users who
+ * have completed 3 or more guided study sessions see the Companion Study
+ * Partner upgrade modal once at the end of their next review step. Once
+ * dismissed (or shown), it is never shown again.
+ *
+ * Storage: existing user_preferences row, no migration needed.
+ */
+
+import { getCompletedGuidedSessionCount, getPreference } from '../../db/userQueries';
+import { setPreference } from '../../db/userMutations';
+
+export const SOFT_PROMPT_PREF_KEY = 'softPromptSeen.companionPartner';
+export const SOFT_PROMPT_SESSION_THRESHOLD = 3;
+
+export async function shouldShowSoftPrompt(args: { isPremium: boolean }): Promise<boolean> {
+  if (args.isPremium) return false;
+  const seen = await getPreference(SOFT_PROMPT_PREF_KEY);
+  if (seen === '1') return false;
+  const count = await getCompletedGuidedSessionCount();
+  return count >= SOFT_PROMPT_SESSION_THRESHOLD;
+}
+
+export async function markSoftPromptSeen(): Promise<void> {
+  await setPreference(SOFT_PROMPT_PREF_KEY, '1');
+}


### PR DESCRIPTION
Closes #1742. Phase 3.5 of epic #1725.

## Why
The only new soft-prompt timing logic added in epic #1725. Free users who have completed 3 or more guided study sessions earn a single, dismissable nudge at the end of their next review step. Premium users never see it.

## What
- **`db/userQueries.ts`** — new `getCompletedGuidedSessionCount()`: single `COUNT(*)` over `guided_study_sessions WHERE status = 'completed'`.
- **`services/guidedStudy/softPrompt.ts` (new)**:
  - `shouldShowSoftPrompt({ isPremium })`: false for premium → false if seen → false if count < 3 → true otherwise. Short-circuits early for performance (premium = zero DB calls, seen = one).
  - `markSoftPromptSeen()`: persists `softPromptSeen.companionPartner = '1'` via the existing `user_preferences` table. **No migration needed.**
- **`screens/StudySessionScreen.tsx`** — `useEffect` watching `currentStep`. When the user lands on `review` and the conditions hold, the effect calls `markSoftPromptSeen()` before `showUpgrade('feature', 'Companion Study Partner')` so re-entering the step can't double-fire.

## Tests
- New `softPrompt.test.ts` (7 tests): premium short-circuit (zero DB calls); seen-flag short-circuit (one DB call); count < 3 false; count = 3 true; high-count true (threshold is a floor); missing `COUNT(*)` row defensive; `markSoftPromptSeen` writes `[key, '1', '1']` to `user_preferences`.

## Acceptance criteria
- [x] After 3 completions, free user sees the prompt once at end of review on the 3rd
- [x] Dismissal never fires it again (`markSoftPromptSeen` runs before `showUpgrade`, persisted in `user_preferences`)
- [x] Premium users never see it (early return)
- [x] tsc / lint / full suite (3888 tests) clean

## Rollback
Revert the PR. The preference row stays inert if anyone wrote it before revert.

## Notes for Craig
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_