### PR TITLE
test: Phase 3 integration coverage — strategy dispatch + free/premium divergence + soft prompt (#1743)

### DIFF
--- a/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
+++ b/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Phase 3.6 (#1743) — Phase 3 integration tests.
+ *
+ * Walks the same end-to-end surfaces a session would touch in production
+ * (synthesis strategy + spaced review queue + soft upgrade nudge) but
+ * against the mock-SQLite layer used elsewhere in the suite.
+ */
+import { getMockUserDb, resetMockUserDb } from '../../../../__tests__/helpers/mockUserDb';
+import { freeStrategy } from '../synthesis/freeStrategy';
+import { premiumStructuredStrategy } from '../synthesis/premiumStructuredStrategy';
+import { shouldShowSoftPrompt } from '../softPrompt';
+import type { CapturedInputs } from '../capturedInputs';
+import type { GuidedStudyMode, GuidedStudyPlan } from '../types';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+});
+
+function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
+  return {
+    chapterId: 'rom_8',
+    title: 'Romans 8',
+    mode,
+    modeLabel: 'Mode',
+    sceneRows: [],
+    stepPrompts: { scene: [], observe: [], explore: [], synthesize: [], review: [] },
+    legacyPrompts: [],
+    recommendations: [],
+    evidenceTrail: [],
+    betterQuestionPrompt: '',
+    conceptChips: [],
+  };
+}
+
+const SAMPLE_CAPTURED: CapturedInputs = {
+  synthesize: { takeaway: 'No condemnation.', key_connection: 'Rom 8:1', open_question: 'How?' },
+};
+
+function sqlFromRunCalls(): string {
+  return getMockUserDb()
+    .runAsync.mock.calls.map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+    .join('\n');
+}
+
+describe('Free user — completes session, no review-queue persistence', () => {
+  it('freeStrategy.run touches no DB, returns artifact=null', async () => {
+    const result = await freeStrategy.run({
+      plan: planFor('quick'),
+      captured: SAMPLE_CAPTURED,
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+    expect(result.artifact).toBeNull();
+    expect(getMockUserDb().runAsync).not.toHaveBeenCalled();
+    // No INSERT into guided_review_items either
+    expect(sqlFromRunCalls()).not.toContain('guided_review_items');
+  });
+});
+
+describe('Premium user (flag off) — completes session, queue row written with artifact JSON', () => {
+  it('premiumStructured.run writes mode_artifact_json + an INSERT into guided_review_items', async () => {
+    const result = await premiumStructuredStrategy.run({
+      plan: planFor('quick'),
+      captured: SAMPLE_CAPTURED,
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+    const sql = sqlFromRunCalls();
+
+    // Artifact persisted on the session
+    expect(sql).toContain('SET mode_artifact_json');
+    // Session-level strategy marker recorded
+    expect(sql).toContain('SET synthesis_strategy');
+    // Review queue actually populated
+    expect(sql).toContain('INSERT INTO guided_review_items');
+
+    // The exact JSON payload that landed in mode_artifact_json should be
+    // the typed artifact returned by run(). Find that runAsync call and
+    // assert the args contain the serialised artifact.
+    const artifactCall = getMockUserDb().runAsync.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('mode_artifact_json'),
+    );
+    expect(artifactCall).toBeTruthy();
+    const args = (artifactCall as unknown[][])?.[1] as [string | null, number];
+    expect(args[0]).toBe(JSON.stringify(result.artifact));
+  });
+});
+
+describe('Premium re-runs — existing rows are replaced, not duplicated', () => {
+  it('a second run on the same sessionId fires a DELETE before re-INSERTing', async () => {
+    await premiumStructuredStrategy.run({
+      plan: planFor('deep'),
+      captured: SAMPLE_CAPTURED,
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+    await premiumStructuredStrategy.run({
+      plan: planFor('deep'),
+      captured: SAMPLE_CAPTURED,
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+    const deletes = getMockUserDb().runAsync.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].startsWith('DELETE FROM guided_review_items'),
+    );
+    expect(deletes).toHaveLength(2);
+  });
+});
+
+describe('Soft "after 3 sessions" prompt timing', () => {
+  it('fires for a free user with exactly 3 completed sessions (none seen yet)', async () => {
+    getMockUserDb().getFirstAsync
+      .mockResolvedValueOnce(null) // softPromptSeen.companionPartner unset
+      .mockResolvedValueOnce({ count: 3 });
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(true);
+  });
+
+  it('does NOT fire on the 4th completion if the prompt has already been seen', async () => {
+    getMockUserDb().getFirstAsync.mockResolvedValueOnce({ value: '1' }); // seen
+    expect(await shouldShowSoftPrompt({ isPremium: false })).toBe(false);
+  });
+
+  it('does not fire for premium users regardless of count', async () => {
+    expect(await shouldShowSoftPrompt({ isPremium: true })).toBe(false);
+    expect(getMockUserDb().getFirstAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategyDispatch.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategyDispatch.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Phase 3.6 (#1743) — focused dispatch matrix for chooseStrategy. The
+ * underlying logic is tiny, but locking the routing table down means
+ * future flag/cap interactions never silently change the experience for
+ * free/premium/amicus users.
+ */
+import { chooseStrategy } from '../strategy';
+import { freeStrategy } from '../freeStrategy';
+import { premiumStructuredStrategy } from '../premiumStructuredStrategy';
+import { premiumAmicusStrategy } from '../premiumAmicusStrategy';
+
+describe('chooseStrategy dispatch matrix', () => {
+  it('non-premium + flag off + cap reached → free', () => {
+    expect(
+      chooseStrategy({ isPremium: false, amicusFlagEnabled: false, amicusCanUse: false }),
+    ).toBe(freeStrategy);
+  });
+
+  it('non-premium + flag ON + cap available → still free (premium status wins)', () => {
+    expect(
+      chooseStrategy({ isPremium: false, amicusFlagEnabled: true, amicusCanUse: true }),
+    ).toBe(freeStrategy);
+  });
+
+  it('premium + flag off → premium_structured', () => {
+    expect(
+      chooseStrategy({ isPremium: true, amicusFlagEnabled: false, amicusCanUse: true }),
+    ).toBe(premiumStructuredStrategy);
+  });
+
+  it('premium + flag ON + cap reached → premium_structured (graceful fallback)', () => {
+    expect(
+      chooseStrategy({ isPremium: true, amicusFlagEnabled: true, amicusCanUse: false }),
+    ).toBe(premiumStructuredStrategy);
+  });
+
+  it('premium + flag ON + cap available → premium_amicus', () => {
+    expect(
+      chooseStrategy({ isPremium: true, amicusFlagEnabled: true, amicusCanUse: true }),
+    ).toBe(premiumAmicusStrategy);
+  });
+});


### PR DESCRIPTION
Closes #1743. Phase 3.6 of epic #1725 — **the Phase 3 capstone.**

## Why
Phase 3 introduced the strategy abstraction (#1739), the structured premium path with persistence (#1740), the gate rename (#1741), and the soft 3-sessions prompt (#1742). This card writes the Phase 3 gating contract down as integration tests so future regressions surface in CI.

## What
Two new test files, no production-code changes:

**`synthesis/__tests__/strategyDispatch.test.ts`** — full `chooseStrategy` routing matrix:
| `isPremium` | `amicusFlagEnabled` | `amicusCanUse` | → strategy |
|---|---|---|---|
| false | false | false | free |
| false | true | true | free *(premium status wins)* |
| true | false | true | premium_structured |
| true | true | false | premium_structured *(graceful cap fallback)* |
| true | true | true | premium_amicus |

**`__tests__/phase3Integration.test.ts`** — end-to-end on the mock-SQLite layer:
- **Free** path: `freeStrategy.run()` touches no DB; `artifact: null`; no `guided_review_items` SQL fired.
- **Premium structured (flag off)**: writes `SET mode_artifact_json` + `SET synthesis_strategy` + `INSERT INTO guided_review_items`. The serialised JSON in `mode_artifact_json` equals the artifact returned by `run()`.
- **Premium re-run idempotency**: two `run()` calls on the same `sessionId` fire two `DELETE FROM guided_review_items WHERE source_session_id = ?` calls before re-inserting — no duplicate queue rows.
- **Soft prompt timing**: fires for a 3-session free user with the seen flag unset; does not fire on the 4th if the seen flag is `'1'`; never fires (and never queries) for premium.

## Acceptance criteria
- [x] All tests pass on first commit (11 new tests, 3899 in the full suite)
- [x] tsc / lint clean

## Rollback
Pure tests. Revert the PR; no runtime impact.

## Notes for Craig
- This closes Phase 3. I'll post the phase-completion comment on epic #1725 once this merges, then wait for go-ahead before starting Phase 4 (#1744). The epic prompt notes Phase 4 cards #1744–#1748 can ship without #1446's Phase 3 dependency; only #1749 (the flag-flip) gates on it.
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_