### PR TITLE
feat: mode-specific Amicus system prompts (#1744)

### DIFF
--- a/app/src/services/amicus/prompts/__tests__/__snapshots__/guidedStudy.test.ts.snap
+++ b/app/src/services/amicus/prompts/__tests__/__snapshots__/guidedStudy.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot stability per mode deep prompt snapshot 1`] = `
+"You are Amicus, a study partner helping the user complete a Deep Study of Romans 8.
+
+The user studied for 45+ minutes. They wrote:
+- Surprises: God evaluates the work as good.
+- Confusions: What does "groaning" mean?
+- Repetitions noticed: "In Christ" / "the Spirit".
+
+They opened these panels: hist (section 1), cross, debate.
+
+Draft a structured analytical summary with:
+1. CLAIM — the central interpretive claim, in the user's voice.
+2. EVIDENCE — 2-3 supporting points, citing the specific panels they opened.
+3. TENSION — what remains genuinely unresolved or contested.
+4. UNRESOLVED — questions worth holding for next study.
+
+Use scholar attribution from the panels actually opened. Do not introduce scholars or panels the user did not engage with. Where the panels showed multiple positions, present the disagreement honestly. Cite panel types (e.g., "the historical context panel notes...") rather than claiming knowledge."
+`;
+
+exports[`snapshot stability per mode devotional prompt snapshot 1`] = `
+"You are Amicus, a contemplative study partner helping the user complete a Devotional reading of Romans 8.
+
+The user came to this chapter today carrying: Anxious about a hard week.
+A word, phrase, or image meeting them: No condemnation language.
+
+Draft three short, gentle elements:
+1. WHAT GOD MAY BE SAYING — a tentative listening-prompt rooted in the chapter's own language. Not a sermon. Not a teaching. A sentence the user could sit with.
+2. PRAYER — a 2-3 sentence prayer in the user's voice, using vocabulary from the chapter itself wherever possible.
+3. CARRY-FORWARD — one phrase or image to carry into the rest of their day.
+
+This is contemplative work. No analysis. No scholar attribution unless the user explicitly opened a scholar reflection panel. Match the tone of the chapter — Psalm prayers feel different from Pauline ones. Always lowercase first letter on the prayer to soften it."
+`;
+
+exports[`snapshot stability per mode quick prompt snapshot 1`] = `
+"You are Amicus, a study partner helping the user complete a Quick Pass through Romans 8.
+
+The user just finished a 15-minute study. They wrote:
+- "What's happening": A theological climax of the Romans argument.
+- "One thing to remember": No condemnation language.
+
+They opened these study panels: hist (section 1), cross, debate.
+
+Write a 60-word takeaway in the user's voice that:
+1. Captures what the chapter said in one sentence.
+2. Names the one thing they most want to remember.
+3. Suggests one verse or phrase to carry into their day.
+
+Do not introduce material the user did not engage with. Cite the panels they opened where relevant. Do not preach. Do not embellish."
+`;
+
+exports[`snapshot stability per mode teaching prompt snapshot 1`] = `
+"You are Amicus, a study partner helping the user prepare to teach Romans 8.
+
+The user is teaching to: College small group
+Setting: small group
+Their main point: Order from chaos by speech.
+What listeners might get wrong: It isn't a science manual.
+
+They opened these panels: hist (section 1), cross, debate.
+
+Build a teaching outline that the user can deliver:
+1. HOOK — a way into the passage that lands for this audience.
+2. MAIN POINT — the thesis, in the user's own framing.
+3. SUPPORTING MOVES — 2-3 textual moves through the chapter, each citing the specific panel that supports it.
+4. APPLICATION — concrete and contextual to the audience.
+5. DISCUSSION QUESTION — one open question to check understanding.
+
+Match the formality of the setting. Sermon = more rhetorical; small group = more invitational. Use scholar attribution from panels opened. Do not preach the user's position; present it as the user would."
+`;

--- a/app/src/services/amicus/prompts/__tests__/guidedStudy.test.ts
+++ b/app/src/services/amicus/prompts/__tests__/guidedStudy.test.ts
@@ -1,0 +1,169 @@
+import { buildGuidedStudySystemPrompt } from '../guidedStudy';
+import type { GuidedStudyMode } from '../../../guidedStudy/types';
+
+const MODES: GuidedStudyMode[] = ['quick', 'deep', 'teaching', 'devotional'];
+
+const FULL_INPUT = {
+  chapterRef: 'Romans 8',
+  captured: {
+    scene: {
+      genre_response: 'A theological climax of the Romans argument.',
+      audience: 'College small group',
+      setting: 'small group',
+      arrival: 'Anxious about a hard week.',
+    },
+    observe: {
+      primary: 'No condemnation language.',
+      surprises: 'God evaluates the work as good.',
+      confusions: 'What does "groaning" mean?',
+      repetitions: '"In Christ" / "the Spirit".',
+      main_point: 'Order from chaos by speech.',
+      clarification: "It isn't a science manual.",
+    },
+  },
+  panelsOpened: [
+    { panel_type: 'hist', section_num: 1, opened_at_ms: 1735000000000 },
+    { panel_type: 'cross', opened_at_ms: 1735000005000 },
+    { panel_type: 'debate', opened_at_ms: 1735000010000 },
+    { panel_type: 'hist', section_num: 1, opened_at_ms: 1735000020000 },
+  ],
+  modeSpecificContext: {
+    audience: 'College small group',
+    setting: 'small group',
+    arrival: 'Anxious about a hard week.',
+  },
+};
+
+describe('buildGuidedStudySystemPrompt — per-mode shape', () => {
+  it.each(MODES)('%s prompt names the mode in the opening line', (mode) => {
+    const prompt = buildGuidedStudySystemPrompt({ mode, ...FULL_INPUT });
+    const expectedTitle: Record<GuidedStudyMode, string> = {
+      quick: 'Quick Pass',
+      deep: 'Deep Study',
+      teaching: 'prepare to teach',
+      devotional: 'Devotional reading',
+    };
+    expect(prompt).toContain(expectedTitle[mode]);
+    expect(prompt).toContain('Romans 8');
+  });
+
+  it('quick interpolates scene.genre_response and observe.primary', () => {
+    const prompt = buildGuidedStudySystemPrompt({ mode: 'quick', ...FULL_INPUT });
+    expect(prompt).toContain('A theological climax of the Romans argument.');
+    expect(prompt).toContain('No condemnation language.');
+  });
+
+  it('deep interpolates surprises / confusions / repetitions', () => {
+    const prompt = buildGuidedStudySystemPrompt({ mode: 'deep', ...FULL_INPUT });
+    expect(prompt).toContain('Surprises: God evaluates the work as good.');
+    expect(prompt).toContain('Confusions: What does "groaning" mean?');
+    expect(prompt).toContain('Repetitions noticed: "In Christ" / "the Spirit".');
+  });
+
+  it('teaching interpolates audience / setting / main point / clarification', () => {
+    const prompt = buildGuidedStudySystemPrompt({ mode: 'teaching', ...FULL_INPUT });
+    expect(prompt).toContain('teaching to: College small group');
+    expect(prompt).toContain('Setting: small group');
+    expect(prompt).toContain('main point: Order from chaos by speech.');
+    expect(prompt).toContain("might get wrong: It isn't a science manual.");
+  });
+
+  it('devotional interpolates arrival + word/phrase meeting them', () => {
+    const prompt = buildGuidedStudySystemPrompt({ mode: 'devotional', ...FULL_INPUT });
+    expect(prompt).toContain('carrying: Anxious about a hard week.');
+    expect(prompt).toContain('meeting them: No condemnation language.');
+  });
+
+  it('every mode produces a distinct prompt string', () => {
+    const set = new Set(
+      MODES.map((mode) => buildGuidedStudySystemPrompt({ mode, ...FULL_INPUT })),
+    );
+    expect(set.size).toBe(MODES.length);
+  });
+});
+
+describe('buildGuidedStudySystemPrompt — graceful empty handling', () => {
+  it.each(MODES)(
+    '%s never leaks "undefined" when captured fields are absent',
+    (mode) => {
+      const prompt = buildGuidedStudySystemPrompt({
+        mode,
+        chapterRef: 'Genesis 1',
+        captured: {},
+        panelsOpened: [],
+        modeSpecificContext: {},
+      });
+      expect(prompt).not.toContain('undefined');
+      expect(prompt).not.toContain('null');
+      // Empty fields render as the canonical placeholder
+      expect(prompt).toContain('(not provided)');
+    },
+  );
+
+  // Quick / deep / teaching include a panels-opened line; devotional
+  // intentionally does not (no scholar attribution by default).
+  it.each(['quick', 'deep', 'teaching'] as const)(
+    '%s renders the canonical placeholder when no panels were opened',
+    (mode) => {
+      const prompt = buildGuidedStudySystemPrompt({
+        mode,
+        chapterRef: 'Genesis 1',
+        captured: {},
+        panelsOpened: [],
+        modeSpecificContext: {},
+      });
+      expect(prompt).toContain('(no panels opened)');
+    },
+  );
+
+  it('devotional has no panels-opened line at all (contemplative path)', () => {
+    const prompt = buildGuidedStudySystemPrompt({
+      mode: 'devotional',
+      chapterRef: 'Psalm 23',
+      captured: {},
+      panelsOpened: [
+        { panel_type: 'hist', section_num: 1, opened_at_ms: 100 },
+      ],
+      modeSpecificContext: {},
+    });
+    expect(prompt).not.toMatch(/panels(?: opened)?:/i);
+  });
+
+  it('whitespace-only fields are treated as empty', () => {
+    const prompt = buildGuidedStudySystemPrompt({
+      mode: 'quick',
+      chapterRef: 'Genesis 1',
+      captured: { scene: { genre_response: '   ' }, observe: { primary: '\n\t' } },
+      panelsOpened: [],
+      modeSpecificContext: {},
+    });
+    expect(prompt).toContain('"What\'s happening": (not provided)');
+    expect(prompt).toContain('"One thing to remember": (not provided)');
+  });
+});
+
+describe('panel summary formatting', () => {
+  it('deduplicates same-section/same-type opens; preserves first-open ordering', () => {
+    const prompt = buildGuidedStudySystemPrompt({
+      mode: 'deep',
+      chapterRef: 'Romans 8',
+      captured: {},
+      panelsOpened: [
+        { panel_type: 'hist', section_num: 1, opened_at_ms: 100 },
+        { panel_type: 'cross', opened_at_ms: 200 },
+        { panel_type: 'hist', section_num: 1, opened_at_ms: 300 },
+        { panel_type: 'debate', opened_at_ms: 50 },
+      ],
+      modeSpecificContext: {},
+    });
+    // Sorted by opened_at_ms ascending: debate (50), hist@1 (100), cross (200),
+    // then dedup of hist@1.
+    expect(prompt).toContain('debate, hist (section 1), cross');
+  });
+});
+
+describe('snapshot stability per mode', () => {
+  it.each(MODES)('%s prompt snapshot', (mode) => {
+    expect(buildGuidedStudySystemPrompt({ mode, ...FULL_INPUT })).toMatchSnapshot();
+  });
+});

--- a/app/src/services/amicus/prompts/guidedStudy.ts
+++ b/app/src/services/amicus/prompts/guidedStudy.ts
@@ -1,0 +1,140 @@
+/**
+ * Mode-specific Amicus system prompts — Phase 4.1 (#1744).
+ *
+ * Each builder returns the system instruction Amicus reads when drafting
+ * synthesis for a guided study session. Templates are mode-shaped and
+ * pull from CapturedInputs + the explore-step panel-open record.
+ *
+ * Pure: no I/O, no API calls. The streaming wiring lands in #1745
+ * (Phase 4.2).
+ */
+
+import type {
+  CapturedInputs,
+  PanelOpenedRecord,
+} from '../../guidedStudy/capturedInputs';
+import type { GuidedStudyMode } from '../../guidedStudy/types';
+
+export interface GuidedStudyPromptInput {
+  mode: GuidedStudyMode;
+  /** Human-readable chapter ref, e.g. "Romans 8". */
+  chapterRef: string;
+  captured: CapturedInputs;
+  panelsOpened: PanelOpenedRecord[];
+  /** Mode-specific bits the user typed in scene (audience, arrival, …). */
+  modeSpecificContext: Record<string, string>;
+}
+
+const MISSING = '(not provided)';
+
+function show(value: string | undefined | null): string {
+  if (typeof value !== 'string') return MISSING;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : MISSING;
+}
+
+/**
+ * Compact human-readable summary of which panels the user opened during
+ * the explore step. Deduplicated by panel type, ordered by first-open
+ * timestamp so the listing reflects how the user actually moved.
+ */
+function summarizePanels(panels: PanelOpenedRecord[]): string {
+  if (panels.length === 0) return '(no panels opened)';
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  const sorted = [...panels].sort((a, b) => a.opened_at_ms - b.opened_at_ms);
+  for (const p of sorted) {
+    const key = p.section_num != null ? `${p.panel_type}@${p.section_num}` : p.panel_type;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parts.push(p.section_num != null ? `${p.panel_type} (section ${p.section_num})` : p.panel_type);
+  }
+  return parts.join(', ');
+}
+
+function buildQuickPrompt(input: GuidedStudyPromptInput): string {
+  const { chapterRef, captured } = input;
+  return `You are Amicus, a study partner helping the user complete a Quick Pass through ${chapterRef}.
+
+The user just finished a 15-minute study. They wrote:
+- "What's happening": ${show(captured.scene?.genre_response)}
+- "One thing to remember": ${show(captured.observe?.primary)}
+
+They opened these study panels: ${summarizePanels(input.panelsOpened)}.
+
+Write a 60-word takeaway in the user's voice that:
+1. Captures what the chapter said in one sentence.
+2. Names the one thing they most want to remember.
+3. Suggests one verse or phrase to carry into their day.
+
+Do not introduce material the user did not engage with. Cite the panels they opened where relevant. Do not preach. Do not embellish.`;
+}
+
+function buildDeepPrompt(input: GuidedStudyPromptInput): string {
+  const { chapterRef, captured } = input;
+  return `You are Amicus, a study partner helping the user complete a Deep Study of ${chapterRef}.
+
+The user studied for 45+ minutes. They wrote:
+- Surprises: ${show(captured.observe?.surprises)}
+- Confusions: ${show(captured.observe?.confusions)}
+- Repetitions noticed: ${show(captured.observe?.repetitions)}
+
+They opened these panels: ${summarizePanels(input.panelsOpened)}.
+
+Draft a structured analytical summary with:
+1. CLAIM — the central interpretive claim, in the user's voice.
+2. EVIDENCE — 2-3 supporting points, citing the specific panels they opened.
+3. TENSION — what remains genuinely unresolved or contested.
+4. UNRESOLVED — questions worth holding for next study.
+
+Use scholar attribution from the panels actually opened. Do not introduce scholars or panels the user did not engage with. Where the panels showed multiple positions, present the disagreement honestly. Cite panel types (e.g., "the historical context panel notes...") rather than claiming knowledge.`;
+}
+
+function buildTeachingPrompt(input: GuidedStudyPromptInput): string {
+  const { chapterRef, captured, modeSpecificContext } = input;
+  return `You are Amicus, a study partner helping the user prepare to teach ${chapterRef}.
+
+The user is teaching to: ${show(modeSpecificContext.audience)}
+Setting: ${show(modeSpecificContext.setting)}
+Their main point: ${show(captured.observe?.main_point)}
+What listeners might get wrong: ${show(captured.observe?.clarification)}
+
+They opened these panels: ${summarizePanels(input.panelsOpened)}.
+
+Build a teaching outline that the user can deliver:
+1. HOOK — a way into the passage that lands for this audience.
+2. MAIN POINT — the thesis, in the user's own framing.
+3. SUPPORTING MOVES — 2-3 textual moves through the chapter, each citing the specific panel that supports it.
+4. APPLICATION — concrete and contextual to the audience.
+5. DISCUSSION QUESTION — one open question to check understanding.
+
+Match the formality of the setting. Sermon = more rhetorical; small group = more invitational. Use scholar attribution from panels opened. Do not preach the user's position; present it as the user would.`;
+}
+
+function buildDevotionalPrompt(input: GuidedStudyPromptInput): string {
+  const { chapterRef, captured, modeSpecificContext } = input;
+  return `You are Amicus, a contemplative study partner helping the user complete a Devotional reading of ${chapterRef}.
+
+The user came to this chapter today carrying: ${show(modeSpecificContext.arrival)}
+A word, phrase, or image meeting them: ${show(captured.observe?.primary)}
+
+Draft three short, gentle elements:
+1. WHAT GOD MAY BE SAYING — a tentative listening-prompt rooted in the chapter's own language. Not a sermon. Not a teaching. A sentence the user could sit with.
+2. PRAYER — a 2-3 sentence prayer in the user's voice, using vocabulary from the chapter itself wherever possible.
+3. CARRY-FORWARD — one phrase or image to carry into the rest of their day.
+
+This is contemplative work. No analysis. No scholar attribution unless the user explicitly opened a scholar reflection panel. Match the tone of the chapter — Psalm prayers feel different from Pauline ones. Always lowercase first letter on the prayer to soften it.`;
+}
+
+export function buildGuidedStudySystemPrompt(input: GuidedStudyPromptInput): string {
+  switch (input.mode) {
+    case 'quick':
+      return buildQuickPrompt(input);
+    case 'deep':
+      return buildDeepPrompt(input);
+    case 'teaching':
+      return buildTeachingPrompt(input);
+    case 'devotional':
+      return buildDevotionalPrompt(input);
+  }
+}


### PR DESCRIPTION
Closes #1744. Phase 4.1 of epic #1725 — opens Phase 4.

## Why
The four product-defining Amicus system prompts that draft synthesis per mode. Pure templating + tests this card; #1745 wires the streaming call.

## What
**`services/amicus/prompts/guidedStudy.ts` (new)** — `GuidedStudyPromptInput` interface + `buildGuidedStudySystemPrompt(input)`. Per-mode template strings landed verbatim from the spec.

- `summarizePanels(panels)` — dedupes by `panel_type[+section]`, sorts by first-open timestamp so the listing reflects how the user actually moved through the explore step.
- `show(value)` — renders `'(not provided)'` for missing or whitespace-only fields. Prompt never leaks `'undefined'` or `'null'`.
- Quick / Deep / Teaching include a panels-opened summary line. **Devotional intentionally omits it** (contemplative path; no scholar attribution by default — verbatim with the spec).

**Tests** (`__tests__/guidedStudy.test.ts`, 23 tests + 4 snapshots):
- Per-mode opening line + chapter ref interpolation.
- Quick: scene.genre_response + observe.primary interpolated.
- Deep: surprises / confusions / repetitions interpolated.
- Teaching: audience / setting / main point / clarification interpolated.
- Devotional: arrival + word/phrase meeting them interpolated.
- Every mode produces a distinct prompt string.
- Empty captured fields → `(not provided)` placeholder, never `'undefined'`.
- Whitespace-only fields → also `(not provided)`.
- Empty `panelsOpened` → `(no panels opened)` for quick/deep/teaching; **no panels line at all** for devotional even when panels were opened.
- Panel summary deduplicates same-section/same-type opens; preserves first-open ordering.
- Snapshot stability per mode.

## Acceptance criteria
- [x] Four mode-specific prompts exist verbatim
- [x] Tests pass (23 new tests + 4 snapshots)
- [x] tsc / lint / full suite (3922 tests) clean

## Rollback
Revert the PR. Pure leaf module; no consumers in this card. The streaming caller (#1745) imports it.

## Notes for Craig
- Out of scope per spec: calling Amicus with these prompts (#1745).
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_