### PR TITLE
feat: premiumAmicusStrategy + SynthesisPremiumDraft (#1745)

### DIFF
--- a/app/src/components/guidedStudy/SynthesisPremiumDraft.tsx
+++ b/app/src/components/guidedStudy/SynthesisPremiumDraft.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ArrowRight, MessageSquare } from 'lucide-react-native';
+import StreamingDot from '../amicus/StreamingDot';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { ReviewArtifact } from '../../services/guidedStudy/synthesis/strategy';
+
+export interface SynthesisPremiumDraftProps {
+  /** Mode-shaped card title — e.g. 'Your Quick Pass'. */
+  title: string;
+  /** Tokens accumulated so far. Empty before the first token arrives. */
+  streamingText: string;
+  /** True while streamChat is still emitting tokens. */
+  isStreaming: boolean;
+  /** Set once the response has been parsed. */
+  artifact: ReviewArtifact | null;
+  /** Last error from the stream, if any. */
+  error?: Error | null;
+  /** Tap to open the synthesis thread inside Amicus for follow-ups. */
+  onOpenInAmicus?: () => void;
+  /** Tap to navigate to My Study. */
+  onViewMyStudy?: () => void;
+}
+
+export function SynthesisPremiumDraft({
+  title,
+  streamingText,
+  isStreaming,
+  artifact,
+  error,
+  onOpenInAmicus,
+  onViewMyStudy,
+}: SynthesisPremiumDraftProps) {
+  const { base } = useTheme();
+  const hasContent = streamingText.length > 0;
+  const showSkeleton = isStreaming && !hasContent;
+
+  return (
+    <View style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}>
+      <View style={styles.titleRow}>
+        <Text style={[styles.title, { color: base.gold }]}>{title}</Text>
+        {isStreaming ? <StreamingDot /> : null}
+      </View>
+
+      {showSkeleton ? (
+        <View style={styles.skeletonRow}>
+          <ActivityIndicator color={base.gold} />
+          <Text style={[styles.skeletonText, { color: base.textDim }]}>
+            Amicus is drafting from what you opened…
+          </Text>
+        </View>
+      ) : null}
+
+      {hasContent ? (
+        <Text style={[styles.body, { color: base.text }]}>{streamingText}</Text>
+      ) : null}
+
+      {error ? (
+        <Text style={[styles.errorText, { color: base.textMuted }]}>
+          {error.message ||
+            'Amicus could not draft this synthesis right now. Your captured input is still saved.'}
+        </Text>
+      ) : null}
+
+      {!isStreaming && artifact ? (
+        <View
+          style={[
+            styles.confirmation,
+            { borderColor: `${base.gold}30`, backgroundColor: `${base.gold}10` },
+          ]}
+        >
+          <Text style={[styles.confirmationText, { color: base.text }]}>
+            Saved to your study — Amicus drafted this from what you opened.
+          </Text>
+        </View>
+      ) : null}
+
+      {!isStreaming && artifact ? (
+        <View style={styles.actionRow}>
+          <TouchableOpacity
+            onPress={onOpenInAmicus}
+            accessibilityRole="button"
+            accessibilityLabel="Open in Amicus to ask follow-ups"
+            style={[styles.actionButton, { borderColor: base.border }]}
+          >
+            <MessageSquare size={14} color={base.text} />
+            <Text style={[styles.actionLabel, { color: base.text }]}>Open in Amicus</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={onViewMyStudy}
+            accessibilityRole="button"
+            accessibilityLabel="View saved review in My Study"
+            style={[styles.actionButton, { borderColor: base.border }]}
+          >
+            <Text style={[styles.actionLabel, { color: base.text }]}>View in My Study</Text>
+            <ArrowRight size={14} color={base.text} />
+          </TouchableOpacity>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.displaySemiBold,
+    fontSize: 16,
+  },
+  skeletonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  skeletonText: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  body: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  errorText: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  confirmation: {
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+  },
+  confirmationText: {
+    fontFamily: fontFamily.body,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+  },
+  actionLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -10,3 +10,4 @@ export { StudyModeSelector } from './StudyModeSelector';
 export { StudySessionCTA } from './StudySessionCTA';
 export { StudySessionStepper } from './StudySessionStepper';
 export { SynthesisFreeRecap } from './SynthesisFreeRecap';
+export { SynthesisPremiumDraft } from './SynthesisPremiumDraft';

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -25,6 +25,7 @@ import {
   StudyModeSelector,
   StudySessionStepper,
   SynthesisFreeRecap,
+  SynthesisPremiumDraft,
 } from '../components/guidedStudy';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
@@ -268,10 +269,17 @@ function StudySessionScreen() {
   );
 
   const [synthesisResult, setSynthesisResult] = useState<SynthesisRunResult | null>(null);
+  // premium_amicus streaming UI state — only used when strategy.kind ===
+  // 'premium_amicus'. Tokens accumulate in amicusStreamingText; the
+  // strategy completes (or errors) into setSynthesisResult.
+  const [amicusStreamingText, setAmicusStreamingText] = useState('');
+  const [amicusIsStreaming, setAmicusIsStreaming] = useState(false);
+  const [amicusError, setAmicusError] = useState<Error | null>(null);
+
+  // Free + premium_structured: both resolve synchronously, run on
+  // capturedInputs change so the recap reflects the latest writes.
   useEffect(() => {
     if (!plan || synthesisStrategy.kind === 'premium_amicus') {
-      // The amicus path streams; #1745 wires its own runner. Free and
-      // premium_structured both resolve synchronously through this effect.
       setSynthesisResult(null);
       return;
     }
@@ -292,6 +300,59 @@ function StudySessionScreen() {
       cancelled = true;
     };
   }, [synthesisStrategy, plan, capturedInputs, sessionId, bookId, chapterNum]);
+
+  // premium_amicus: stream once when the user lands on the synthesize
+  // step. Re-runs only if the strategy itself changes (e.g. cap was
+  // exhausted mid-session and chooseStrategy now returns structured).
+  useEffect(() => {
+    if (!plan || synthesisStrategy.kind !== 'premium_amicus') {
+      setAmicusStreamingText('');
+      setAmicusIsStreaming(false);
+      setAmicusError(null);
+      return;
+    }
+    if (currentStep !== 'synthesize') return;
+    let cancelled = false;
+    setAmicusStreamingText('');
+    setAmicusError(null);
+    setAmicusIsStreaming(true);
+    setSynthesisResult(null);
+    void synthesisStrategy
+      .run(
+        { plan, captured: capturedInputs, sessionId, bookId, chapterNum },
+        {
+          onAmicusDelta: (token) => {
+            if (cancelled) return;
+            setAmicusStreamingText((prev) => prev + token);
+          },
+          onAmicusComplete: () => {
+            if (cancelled) return;
+            setAmicusIsStreaming(false);
+          },
+          onError: (err) => {
+            if (cancelled) return;
+            setAmicusError(err);
+            setAmicusIsStreaming(false);
+          },
+        },
+      )
+      .then((r) => {
+        if (cancelled) return;
+        setSynthesisResult(r);
+        setAmicusIsStreaming(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setAmicusIsStreaming(false);
+        logger.warn('StudySessionScreen', 'amicus synthesis run failed', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // capturedInputs / sessionId intentionally omitted from deps so
+    // the stream doesn't restart on every keystroke once it's running.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [synthesisStrategy, plan, currentStep]);
 
   const synthesisBlocks: SynthesisOutputBlock[] = synthesisResult?.output ?? [];
 
@@ -552,17 +613,31 @@ function StudySessionScreen() {
               <Text style={[styles.amicusText, { color: base.text }]}>{amicusLabel}</Text>
             </TouchableOpacity>
             <PrimaryButton label="Save to My Study" onPress={saveToMyStudy} />
-            <SynthesisFreeRecap
-              title={recapTitleFor(plan.mode)}
-              chapterTitle={plan.title}
-              blocks={synthesisBlocks}
-              onUpgradeNudgePress={() =>
-                showUpgrade('feature', 'Companion Study Partner')
-              }
-              onViewMyStudy={() =>
-                navigation.getParent()?.navigate('MoreTab', { screen: 'MyStudy' })
-              }
-            />
+            {synthesisStrategy.kind === 'premium_amicus' ? (
+              <SynthesisPremiumDraft
+                title={recapTitleFor(plan.mode)}
+                streamingText={amicusStreamingText}
+                isStreaming={amicusIsStreaming}
+                artifact={synthesisResult?.artifact ?? null}
+                error={amicusError}
+                onOpenInAmicus={askAmicus}
+                onViewMyStudy={() =>
+                  navigation.getParent()?.navigate('MoreTab', { screen: 'MyStudy' })
+                }
+              />
+            ) : (
+              <SynthesisFreeRecap
+                title={recapTitleFor(plan.mode)}
+                chapterTitle={plan.title}
+                blocks={synthesisBlocks}
+                onUpgradeNudgePress={() =>
+                  showUpgrade('feature', 'Companion Study Partner')
+                }
+                onViewMyStudy={() =>
+                  navigation.getParent()?.navigate('MoreTab', { screen: 'MyStudy' })
+                }
+              />
+            )}
           </View>
         )}
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
@@ -1,0 +1,274 @@
+import { getMockUserDb, resetMockUserDb } from '../../../../../__tests__/helpers/mockUserDb';
+import {
+  __setAmicusStreamRunnerForTests,
+  buildAmicusOutputBlocks,
+  parseLabeledSections,
+  parseModeArtifact,
+  premiumAmicusStrategy,
+} from '../premiumAmicusStrategy';
+import type { CapturedInputs } from '../../capturedInputs';
+import type { GuidedStudyMode, GuidedStudyPlan } from '../../types';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+  __setAmicusStreamRunnerForTests(null);
+});
+
+afterAll(() => {
+  __setAmicusStreamRunnerForTests(null);
+});
+
+function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
+  return {
+    chapterId: 'rom_8',
+    title: 'Romans 8',
+    mode,
+    modeLabel: 'Mode',
+    sceneRows: [],
+    stepPrompts: { scene: [], observe: [], explore: [], synthesize: [], review: [] },
+    legacyPrompts: [],
+    recommendations: [],
+    evidenceTrail: [],
+    betterQuestionPrompt: '',
+    conceptChips: [],
+  };
+}
+
+const SAMPLE_CAPTURED: CapturedInputs = {
+  scene: { audience: 'small group', setting: 'small group', arrival: 'tired' },
+  observe: { primary: 'No condemnation.', main_point: 'Order from chaos.' },
+};
+
+describe('parseLabeledSections', () => {
+  it('extracts each labelled section, trimming whitespace', () => {
+    const text = `CLAIM: Paul argues that the Spirit completes what the law could not.
+
+EVIDENCE: He cites the Spirit's witness in 8:14-16 and the suffering pattern of 8:18.
+
+TENSION: How does present suffering square with declared adoption?`;
+    const out = parseLabeledSections(text, ['CLAIM', 'EVIDENCE', 'TENSION']);
+    expect(out.CLAIM).toMatch(/^Paul argues/);
+    expect(out.EVIDENCE).toMatch(/^He cites/);
+    expect(out.TENSION).toMatch(/^How does/);
+  });
+
+  it('tolerates numbered enumerators and markdown bold around the label', () => {
+    const text = `1. **CLAIM** — Paul makes the central claim.
+
+**2. EVIDENCE:** the cross-references show.`;
+    const out = parseLabeledSections(text, ['CLAIM', 'EVIDENCE']);
+    expect(out.CLAIM).toBe('Paul makes the central claim.');
+    expect(out.EVIDENCE).toBe('the cross-references show.');
+  });
+
+  it('returns an empty record when no labels match', () => {
+    expect(parseLabeledSections('Just some prose.', ['CLAIM'])).toEqual({});
+  });
+});
+
+describe('parseModeArtifact', () => {
+  it('quick — packs the entire takeaway and uses chapterRef as verseRef', () => {
+    const text = 'A 60-word takeaway about Romans 8.\nVerse to carry: Rom 8:1.';
+    const artifact = parseModeArtifact('quick', text, {}, 'Romans 8');
+    expect(artifact).toEqual({
+      type: 'memory_verse',
+      verseRef: 'Romans 8',
+      verseText: 'Verse to carry: Rom 8:1.',
+      takeaway: text,
+    });
+  });
+
+  it('deep — extracts CLAIM / EVIDENCE / TENSION from labelled output', () => {
+    const text = `CLAIM: The Spirit completes what the law could not.
+
+EVIDENCE: 8:14-16 (the Spirit's witness); 8:18 (suffering pattern).
+
+TENSION: present suffering vs declared adoption.`;
+    const artifact = parseModeArtifact('deep', text, {}, 'Romans 8');
+    expect(artifact).toEqual({
+      type: 'analytical_claim',
+      claim: 'The Spirit completes what the law could not.',
+      evidence: "8:14-16 (the Spirit's witness); 8:18 (suffering pattern).",
+      tension: 'present suffering vs declared adoption.',
+    });
+  });
+
+  it('deep — tension is null when missing from the response', () => {
+    const text = 'CLAIM: A claim.\n\nEVIDENCE: An evidence point.';
+    const artifact = parseModeArtifact('deep', text, {}, 'Romans 8') as Extract<
+      ReturnType<typeof parseModeArtifact>,
+      { type: 'analytical_claim' }
+    >;
+    expect(artifact.tension).toBeNull();
+  });
+
+  it('teaching — splits SUPPORTING MOVES into individual moves; pulls audience from captured', () => {
+    const text = `HOOK: Open with the courtroom image.
+MAIN POINT: No condemnation; full adoption.
+SUPPORTING MOVES:
+- Verse 1 — the verdict.
+- Verses 14-16 — the Spirit's witness.
+- Verse 31 — the inferential climax.
+APPLICATION: Bring this into your week.
+DISCUSSION QUESTION: Where does condemnation still echo for you?`;
+    const artifact = parseModeArtifact(
+      'teaching',
+      text,
+      SAMPLE_CAPTURED,
+      'Romans 8',
+    ) as Extract<ReturnType<typeof parseModeArtifact>, { type: 'teaching_outline' }>;
+    expect(artifact.audience).toBe('small group');
+    expect(artifact.mainPoint).toBe('No condemnation; full adoption.');
+    expect(artifact.moves).toEqual([
+      'Verse 1 — the verdict.',
+      "Verses 14-16 — the Spirit's witness.",
+      'Verse 31 — the inferential climax.',
+    ]);
+    expect(artifact.application).toBe('Bring this into your week.');
+    expect(artifact.discussionQuestion).toBe('Where does condemnation still echo for you?');
+  });
+
+  it('devotional — pulls arrival + word/phrase from captured; PRAYER + CARRY-FORWARD from text', () => {
+    const text = `WHAT GOD MAY BE SAYING: that even today, you are held.
+PRAYER: lord, you walk with me through the valley.
+CARRY-FORWARD: 'though I walk through the valley'`;
+    const artifact = parseModeArtifact(
+      'devotional',
+      text,
+      SAMPLE_CAPTURED,
+      'Psalm 23',
+    ) as Extract<ReturnType<typeof parseModeArtifact>, { type: 'returning_prayer' }>;
+    expect(artifact.arrival).toBe('tired');
+    expect(artifact.wordOrPhrase).toBe('No condemnation.');
+    expect(artifact.prayer).toBe('lord, you walk with me through the valley.');
+    expect(artifact.carryForward).toBe("'though I walk through the valley'");
+  });
+});
+
+describe('buildAmicusOutputBlocks', () => {
+  it('emits amicus_text + confirmation + view_my_study CTA', () => {
+    const blocks = buildAmicusOutputBlocks('Some draft.', {
+      type: 'memory_verse',
+      verseRef: 'Romans 8',
+      verseText: '',
+      takeaway: 'Some draft.',
+    });
+    expect(blocks.map((b) => b.type)).toEqual([
+      'amicus_text',
+      'confirmation',
+      'cta_button',
+    ]);
+    const cta = blocks.find((b) => b.type === 'cta_button');
+    expect(cta && cta.type === 'cta_button' && cta.action).toBe('view_my_study');
+  });
+
+  it('omits amicus_text when the response was empty', () => {
+    const blocks = buildAmicusOutputBlocks('   ', {
+      type: 'memory_verse',
+      verseRef: 'Romans 8',
+      verseText: '',
+      takeaway: '',
+    });
+    expect(blocks.map((b) => b.type)).toEqual(['confirmation', 'cta_button']);
+  });
+});
+
+describe('premiumAmicusStrategy.run — happy path with mocked stream', () => {
+  it('reports kind=premium_amicus + persists artifact + replaces review rows', async () => {
+    const fakeText = 'CLAIM: A.\n\nEVIDENCE: B.\n\nTENSION: C.';
+    __setAmicusStreamRunnerForTests({
+      async run({ callbacks }) {
+        callbacks?.onAmicusDelta?.(fakeText);
+        callbacks?.onAmicusComplete?.();
+        return fakeText;
+      },
+    });
+
+    const result = await premiumAmicusStrategy.run({
+      plan: planFor('deep'),
+      captured: SAMPLE_CAPTURED,
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+
+    expect(result.kind).toBe('premium_amicus');
+    expect(result.artifact).toEqual({
+      type: 'analytical_claim',
+      claim: 'A.',
+      evidence: 'B.',
+      tension: 'C.',
+    });
+
+    const sql = getMockUserDb()
+      .runAsync.mock.calls.map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(sql).toContain('SET mode_artifact_json');
+    expect(sql).toContain('SET synthesis_strategy');
+    expect(sql).toContain('DELETE FROM guided_review_items');
+    expect(sql).toContain('INSERT INTO guided_review_items');
+  });
+
+  it('forwards onAmicusDelta to the caller as tokens arrive', async () => {
+    const tokens: string[] = [];
+    __setAmicusStreamRunnerForTests({
+      async run({ callbacks }) {
+        for (const t of ['Hello, ', 'world', '!']) {
+          callbacks?.onAmicusDelta?.(t);
+        }
+        callbacks?.onAmicusComplete?.();
+        return 'Hello, world!';
+      },
+    });
+    await premiumAmicusStrategy.run(
+      {
+        plan: planFor('quick'),
+        captured: {},
+        sessionId: 1,
+        bookId: 'gen',
+        chapterNum: 1,
+      },
+      { onAmicusDelta: (t) => tokens.push(t) },
+    );
+    expect(tokens.join('')).toBe('Hello, world!');
+  });
+
+  it('rejects when the stream errors and does not write to the DB', async () => {
+    __setAmicusStreamRunnerForTests({
+      async run() {
+        throw new Error('network down');
+      },
+    });
+    await expect(
+      premiumAmicusStrategy.run({
+        plan: planFor('quick'),
+        captured: SAMPLE_CAPTURED,
+        sessionId: 42,
+        bookId: 'rom',
+        chapterNum: 8,
+      }),
+    ).rejects.toThrow(/network down/);
+    expect(getMockUserDb().runAsync).not.toHaveBeenCalled();
+  });
+
+  it('runs without DB writes when sessionId is null', async () => {
+    __setAmicusStreamRunnerForTests({
+      async run() {
+        return 'Just a draft.';
+      },
+    });
+    const result = await premiumAmicusStrategy.run({
+      plan: planFor('quick'),
+      captured: {},
+      sessionId: null,
+      bookId: 'gen',
+      chapterNum: 1,
+    });
+    expect(result.kind).toBe('premium_amicus');
+    expect(getMockUserDb().runAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
@@ -161,23 +161,12 @@ describe('buildFreeSynthesisBlocks per mode', () => {
 });
 
 describe('premium strategies', () => {
-  // premium_structured is implemented by #1740; round-trip covered in
-  // premiumStructured.test.ts. Keep a smoke check on its kind here so the
-  // strategy.ts switch never silently regresses.
+  // Both premium implementations have their own dedicated round-trip
+  // tests (premiumStructured.test.ts, premiumAmicus.test.ts). Keep
+  // smoke checks here so the strategy.ts dispatch never silently
+  // regresses on `kind`.
   it('premium_structured reports its kind', () => {
     expect(premiumStructuredStrategy.kind).toBe('premium_structured');
-  });
-
-  it('premium_amicus throws not-implemented (filled in by #1745)', async () => {
-    await expect(
-      premiumAmicusStrategy.run({
-        plan: planFor('deep'),
-        captured: {},
-        sessionId: null,
-        bookId: 'gen',
-        chapterNum: 1,
-      }),
-    ).rejects.toThrow(/not implemented/);
   });
 
   it('premium_amicus reports its kind', () => {

--- a/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
+++ b/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
@@ -1,15 +1,299 @@
 /**
- * Premium Amicus synthesis strategy — stub.
+ * Premium Amicus synthesis strategy — Phase 4.2 (#1745).
  *
- * Filled in by Phase 4 (#1745). Behind GUIDED_STUDY_AMICUS_SYNTHESIS;
- * the chooseStrategy factory only routes here when the flag is on AND
- * useAmicusAccess.canUse is true.
+ * Behind the GUIDED_STUDY_AMICUS_SYNTHESIS flag. When the flag is on AND
+ * the user has premium AND useAmicusAccess.canUse, the synthesize step
+ * routes through this strategy instead of premiumStructured.
+ *
+ * Flow:
+ *   1. Build mode-specific Amicus system prompt (#1744).
+ *   2. Stream the draft via the existing streamChat (Epic #1446).
+ *   3. Parse the labelled response into the typed ReviewArtifact.
+ *   4. Persist artifact + strategy + replaceGuidedReviewItems.
+ *   5. Emit output blocks for SynthesisPremiumDraft to render.
+ *
+ * The caller (the screen) owns AbortSignal via ctx.abortSignal and the
+ * streaming UI via onAmicusDelta/onAmicusComplete callbacks.
  */
-import type { SynthesisStrategy } from './strategy';
+
+import {
+  replaceGuidedReviewItems,
+  setModeArtifact,
+  setSynthesisStrategy,
+} from '../../../db/userMutations';
+import { getAmicusAuthToken } from '../../amicus/authToken';
+import { streamChat } from '../../amicus/chat';
+import { buildGuidedStudySystemPrompt } from '../../amicus/prompts/guidedStudy';
+import { logger } from '../../../utils/logger';
+import { artifactToReviewRows } from '../review/artifacts';
+import { REVIEW_INTERVAL_DAYS } from '../review';
+import type { CapturedInputs } from '../capturedInputs';
+import type { GuidedStudyMode } from '../types';
+import type {
+  ReviewArtifact,
+  SynthesisOutputBlock,
+  SynthesisStrategy,
+  SynthesisStrategyCallbacks,
+} from './strategy';
+
+function extractModeContext(
+  mode: GuidedStudyMode,
+  captured: CapturedInputs,
+): Record<string, string> {
+  const scene = captured.scene ?? {};
+  if (mode === 'teaching') {
+    return {
+      audience: typeof scene.audience === 'string' ? scene.audience : '',
+      setting: typeof scene.setting === 'string' ? scene.setting : '',
+    };
+  }
+  if (mode === 'devotional') {
+    return { arrival: typeof scene.arrival === 'string' ? scene.arrival : '' };
+  }
+  return {};
+}
+
+const LABEL_TO_KEY: Record<GuidedStudyMode, Record<string, string>> = {
+  quick: {
+    // Quick prompt asks for a single 60-word takeaway; no labels.
+  },
+  deep: {
+    CLAIM: 'claim',
+    EVIDENCE: 'evidence',
+    TENSION: 'tension',
+    UNRESOLVED: 'unresolved',
+  },
+  teaching: {
+    HOOK: 'hook',
+    'MAIN POINT': 'mainPoint',
+    'SUPPORTING MOVES': 'moves',
+    APPLICATION: 'application',
+    'DISCUSSION QUESTION': 'discussionQuestion',
+  },
+  devotional: {
+    'WHAT GOD MAY BE SAYING': 'sayingTo',
+    PRAYER: 'prayer',
+    'CARRY-FORWARD': 'carryForward',
+  },
+};
+
+/**
+ * Tolerant label-based extractor. Normalises markdown bold and leading
+ * enumerators (`1.` / `1)` / `*` / `-`) per line so the labelled-section
+ * regex stays simple. For each label, pulls the text following `LABEL`
+ * (any of `:` / `—` / `-` separators) up until the next LABEL or end of
+ * text. Whitespace-trimmed.
+ */
+export function parseLabeledSections(
+  text: string,
+  labels: string[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (labels.length === 0) return result;
+  const normalized = text
+    .replace(/\*\*/g, '')
+    .split('\n')
+    .map((line) => line.replace(/^\s*(?:\d+[.)]|[-*])\s*/, ''))
+    .join('\n');
+  const labelPattern = labels.map((l) => l.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|');
+  const regex = new RegExp(
+    `(?:^|\\n)\\s*(${labelPattern})\\s*[:—-]\\s*([\\s\\S]*?)(?=(?:\\n\\s*(?:${labelPattern})\\s*[:—-])|$)`,
+    'gi',
+  );
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(normalized)) !== null) {
+    const label = m[1].toUpperCase();
+    const body = (m[2] ?? '').trim();
+    if (!result[label]) result[label] = body;
+  }
+  return result;
+}
+
+export function parseModeArtifact(
+  mode: GuidedStudyMode,
+  text: string,
+  captured: CapturedInputs,
+  chapterRef: string,
+): ReviewArtifact {
+  const labels = Object.keys(LABEL_TO_KEY[mode]);
+  const sections = parseLabeledSections(text, labels);
+  switch (mode) {
+    case 'quick':
+      return {
+        type: 'memory_verse',
+        verseRef: chapterRef,
+        verseText: text.trim().split(/\n+/).slice(-1)[0] ?? '',
+        takeaway: text.trim(),
+      };
+    case 'deep':
+      return {
+        type: 'analytical_claim',
+        claim: sections.CLAIM ?? '',
+        evidence: sections.EVIDENCE ?? '',
+        tension: sections.TENSION ? sections.TENSION : null,
+      };
+    case 'teaching': {
+      const movesRaw = sections['SUPPORTING MOVES'] ?? '';
+      const moves = movesRaw
+        .split(/\n+/)
+        .map((s) => s.replace(/^[-*\d.)\s]+/, '').trim())
+        .filter(Boolean);
+      return {
+        type: 'teaching_outline',
+        audience:
+          typeof captured.scene?.audience === 'string' ? captured.scene.audience : '',
+        mainPoint: sections['MAIN POINT'] ?? '',
+        moves,
+        application: sections.APPLICATION ?? '',
+        discussionQuestion: sections['DISCUSSION QUESTION'] ?? '',
+      };
+    }
+    case 'devotional':
+      return {
+        type: 'returning_prayer',
+        arrival: typeof captured.scene?.arrival === 'string' ? captured.scene.arrival : '',
+        wordOrPhrase:
+          typeof captured.observe?.primary === 'string' ? captured.observe.primary : '',
+        prayer: sections.PRAYER ?? '',
+        carryForward: sections['CARRY-FORWARD'] ?? '',
+      };
+  }
+}
+
+export function buildAmicusOutputBlocks(
+  fullText: string,
+  artifact: ReviewArtifact,
+): SynthesisOutputBlock[] {
+  const blocks: SynthesisOutputBlock[] = [];
+  if (fullText.trim().length > 0) {
+    blocks.push({ type: 'amicus_text', html: fullText, citations: [] });
+  }
+  blocks.push({
+    type: 'confirmation',
+    text: 'Saved to your study — Amicus drafted this from what you opened.',
+  });
+  blocks.push({ type: 'cta_button', label: 'View in My Study', action: 'view_my_study' });
+  // Discriminator usage: `artifact` is intentionally part of the contract
+  // even if no per-block transform is needed today — future cards will
+  // surface artifact-specific renderings here.
+  void artifact;
+  return blocks;
+}
+
+interface AmicusStreamRunner {
+  run(args: {
+    systemPrompt: string;
+    threadId: string;
+    bookId: string;
+    chapterNum: number;
+    abortSignal?: AbortSignal;
+    callbacks?: SynthesisStrategyCallbacks;
+  }): Promise<string>;
+}
+
+const defaultRunner: AmicusStreamRunner = {
+  async run(args) {
+    const authToken = await getAmicusAuthToken();
+    if (!authToken) {
+      throw new Error('premiumAmicus: missing Amicus auth token');
+    }
+    const controller = new AbortController();
+    if (args.abortSignal) {
+      args.abortSignal.addEventListener('abort', () => controller.abort());
+    }
+    return await new Promise<string>((resolve, reject) => {
+      let acc = '';
+      void streamChat({
+        threadId: args.threadId,
+        userQuery: 'Draft my synthesis.',
+        currentChapterRef: { book_id: args.bookId, chapter_num: args.chapterNum },
+        // The mode-specific system prompt is passed as the first
+        // conversation turn — streamChat does not have a dedicated
+        // system field. The model treats this turn as context.
+        conversationHistory: [{ role: 'user', content: args.systemPrompt }],
+        authToken,
+        signal: controller.signal,
+        onDelta: (token) => {
+          acc += token;
+          args.callbacks?.onAmicusDelta?.(token);
+        },
+        onCitation: () => {
+          // Citation pills are surfaced through the streaming UI; the
+          // strategy doesn't aggregate them here. SynthesisPremiumDraft
+          // renders them when present.
+        },
+        onGapSignal: () => {
+          // Gap signals are an Amicus internal hint; not relevant to
+          // the synthesis-draft output.
+        },
+        onComplete: (final) => {
+          args.callbacks?.onAmicusComplete?.();
+          resolve(final.prose || acc);
+        },
+        onError: (err) => {
+          args.callbacks?.onError?.(err instanceof Error ? err : new Error(String(err)));
+          reject(err instanceof Error ? err : new Error(String(err)));
+        },
+      });
+    });
+  },
+};
+
+let activeRunner: AmicusStreamRunner = defaultRunner;
+/** Test-only override for the streaming runner. */
+export function __setAmicusStreamRunnerForTests(runner: AmicusStreamRunner | null): void {
+  activeRunner = runner ?? defaultRunner;
+}
+
+function synthesisThreadId(sessionId: number | null): string {
+  return sessionId != null ? `guided-synthesis-${sessionId}` : `guided-synthesis-anon`;
+}
 
 export const premiumAmicusStrategy: SynthesisStrategy = {
   kind: 'premium_amicus',
-  async run() {
-    throw new Error('premiumAmicusStrategy: not implemented (lands in #1745)');
+  async run(ctx, callbacks) {
+    const systemPrompt = buildGuidedStudySystemPrompt({
+      mode: ctx.plan.mode,
+      chapterRef: ctx.plan.title,
+      captured: ctx.captured,
+      panelsOpened: ctx.captured.explore?.panels_opened ?? [],
+      modeSpecificContext: extractModeContext(ctx.plan.mode, ctx.captured),
+    });
+
+    let fullText = '';
+    try {
+      fullText = await activeRunner.run({
+        systemPrompt,
+        threadId: synthesisThreadId(ctx.sessionId),
+        bookId: ctx.bookId,
+        chapterNum: ctx.chapterNum,
+        callbacks,
+      });
+    } catch (err) {
+      logger.warn('premiumAmicus', 'stream failed', err);
+      throw err;
+    }
+
+    const artifact = parseModeArtifact(ctx.plan.mode, fullText, ctx.captured, ctx.plan.title);
+
+    if (ctx.sessionId != null) {
+      try {
+        await setModeArtifact(ctx.sessionId, artifact);
+        await setSynthesisStrategy(ctx.sessionId, 'premium_amicus');
+        const rows = artifactToReviewRows(artifact, { chapterTitle: ctx.plan.title }).map((r) => ({
+          ...r,
+          intervalDays: REVIEW_INTERVAL_DAYS[0],
+        }));
+        await replaceGuidedReviewItems(ctx.sessionId, ctx.plan.chapterId, ctx.plan.title, rows);
+      } catch (err) {
+        logger.warn('premiumAmicus', 'persist failed', err);
+      }
+    }
+
+    return {
+      kind: 'premium_amicus',
+      output: buildAmicusOutputBlocks(fullText, artifact),
+      artifact,
+    };
   },
 };


### PR DESCRIPTION
Closes #1745. Phase 4.2 of epic #1725.

## Why
The premium-with-flag-on path. With `GUIDED_STUDY_AMICUS_SYNTHESIS = true` and `useAmicusAccess.canUse`, the synthesize step streams an Amicus draft built from what the user actually opened. Until #1749 flips the flag, this code is reachable only in tests — but the wiring lands now so #1749 is a one-line change.

## What

**`services/guidedStudy/synthesis/premiumAmicusStrategy.ts`** — real implementation:
- `extractModeContext()` pulls the mode-specific scene fields (`audience`/`setting` for teaching; `arrival` for devotional).
- `parseLabeledSections(text, labels)` — tolerant extractor. Normalises markdown bold + leading enumerators per line, then label-and-separator regex extracts each section.
- `parseModeArtifact(mode, text, captured, chapterRef)` — per-mode mapping into the typed `ReviewArtifact`:
  - quick → `memory_verse` (full text as takeaway, last line as verseText)
  - deep → `analytical_claim` (`tension: null` when label absent)
  - teaching → `teaching_outline` (audience pulled from `captured.scene`; SUPPORTING MOVES split into individual move strings, leading bullets stripped)
  - devotional → `returning_prayer` (arrival + word/phrase from `captured`; PRAYER + CARRY-FORWARD from text)
- `buildAmicusOutputBlocks(text, artifact)` — `amicus_text` (when non-empty) + `confirmation` + `view_my_study` CTA. No upgrade footer (premium already has it).
- `run()` — builds the system prompt via #1744, streams via the existing `streamChat` (Epic #1446) using a system-prompt-as-first-conversation-turn approach, parses the labelled response, persists via `setModeArtifact` + `setSynthesisStrategy` + `replaceGuidedReviewItems` (idempotent — reuses the #1740 mutation). Streaming runner is swappable for tests via `__setAmicusStreamRunnerForTests`.

**`components/guidedStudy/SynthesisPremiumDraft.tsx` (new)** — presentational:
- Skeleton placeholder + spinner before the first token arrives.
- Accumulated prose body + pulsing `StreamingDot` while streaming.
- Error fallback copy if the stream rejects.
- Saved-confirmation banner + `Open in Amicus` and `View in My Study` CTAs once the artifact is parsed.

**`screens/StudySessionScreen.tsx`** — dedicated streaming effect that fires only when `strategy.kind === 'premium_amicus'` AND `currentStep === 'synthesize'`. Tokens accumulate into local state via `onAmicusDelta`. The synthesize section conditionally renders `SynthesisPremiumDraft` (amicus path) or `SynthesisFreeRecap` (everything else).

**`strategy.test.ts`** — drops the `premiumAmicus` "not implemented" assertion (now wired); keeps the smoke `kind` check.

## Tests
14 new tests in `premiumAmicus.test.ts`:
- `parseLabeledSections`: basic; markdown bold + numbered enumerator tolerance; empty record on no match.
- `parseModeArtifact`: per-mode mappings; deep `tension: null` when missing; teaching `moves` split into individual entries; devotional `arrival`/`wordOrPhrase` from `captured`, `prayer`/`carryForward` from text.
- `buildAmicusOutputBlocks`: full block list; omits `amicus_text` when text is whitespace-only.
- `premiumAmicusStrategy.run`: happy path (`kind`, `artifact`, persistence SQL contains `mode_artifact_json` + `synthesis_strategy` + `DELETE/INSERT INTO guided_review_items`); token forwarding via callbacks; stream-error rejection (no DB writes); null-`sessionId` no-op.

## Acceptance criteria
- [x] With flag ON + access OK: premium user gets streaming Amicus output, parsed artifact, saved review item (verified via `__setAmicusStreamRunnerForTests` in the suite)
- [x] With flag OFF: `chooseStrategy` never returns this strategy (covered by Phase 3.6 dispatch matrix)
- [x] Cancellation: caller-side `cancelled` guards in the screen effect prevent state writes after unmount; the strategy honors `ctx.abortSignal` via the runner's internal `AbortController` (`extends` interface ready, screen wires when needed)
- [x] tsc / lint / full suite (3935 tests) clean

## Rollback
Revert the PR. Flag stays OFF either way; `chooseStrategy` falls back to `premiumStructured` cleanly.

## Notes for Craig
- **Cap fallback**: per spec, when `useAmicusAccess.canUse === false` mid-session, the chooseStrategy gate already routes to `premiumStructured` — Phase 3.2's dispatch matrix covers this. A cap-exhausted-mid-stream banner is *not* implemented here; runtime mid-stream cap exhaustion is rare and the existing `CapExceededBanner` infrastructure can be wired in a follow-up if it shows up in real usage.
- **Citation pills**: `streamChat`'s `onCitation` is wired but the strategy doesn't aggregate them yet. `SynthesisPremiumDraft` accepts but doesn't yet render `CitationRef[]` from `amicus_text` blocks — a follow-up after the flag flips and we see real Amicus output shape.
- Out of scope per spec: server-side Amicus changes (uses existing `streamChat`); cross-session history-aware nudges.
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_