### PR TITLE
feat: tagline rollout — From reading to understanding (#1747)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Companion Study
 
-*Don't just read the Bible. Learn to read it the way it was written.*
+*From reading to understanding.*
 
 **The only Bible app that bridges the gap between reading scripture and understanding ancient literature.** 70+ scholars, interlinear Hebrew & Greek, and features no other app offers — seminary-level depth, entirely offline, and free.
 

--- a/app/store-metadata/APP_STORE_GUIDE.md
+++ b/app/store-metadata/APP_STORE_GUIDE.md
@@ -206,7 +206,7 @@ Same verification steps as iPhone.
 In App Store Connect, on your app's page:
 
 **App Information tab:**
-- Subtitle: `Scholarly Bible Study`
+- Subtitle: `From reading to understanding.`
 - Category: `Reference` → subcategory: leave blank (no Bible Study subcategory — Reference is correct)
 - Content Rights: "This app does not contain third-party content" → select and acknowledge
 
@@ -237,7 +237,7 @@ bible study,commentary,hebrew,greek,word study,devotional,NIV,ESV,genealogy,map,
 
 **Promotional Text:**
 ```
-Explore the Bible with 40+ scholars, Hebrew & Greek word studies, an interactive family tree, a biblical world map, and verse-by-verse commentary. Offline. Free.
+Four guided study modes. Scholar-attributed depth. A study partner that remembers what you have learned and brings it back when it matters.
 ```
 
 **Support URL:** `https://github.com/CraigBuckmaster/ScriptureDeepDive/issues`
@@ -284,7 +284,7 @@ Complete the questionnaire:
 
 Go to **Grow → Store presence → Main store listing:**
 
-- **Short description:** `Scholarly Bible study with 40+ commentators, word studies, maps, and timelines.`
+- **Short description:** `From reading to understanding. Scholarly Bible study, free and offline.`
 - **Full description:** Copy from `app/store-metadata/android.md` → Full Description section
 - **App icon:** Upload `app/assets/images/icon-512.png` (Google requires 512×512)
 - **Feature graphic:** You'll need to create a 1024×500 banner image (see Phase 7)
@@ -351,7 +351,7 @@ You need a 1024×500 banner image. Create one using:
 - [Canva](https://canva.com) (free)
 - Dark background `#0c0a07`
 - App name "Companion Study" in gold
-- Tagline "Scholarly Bible Study"
+- Tagline "From reading to understanding."
 - Optional: small screenshots or the app icon
 
 ---

--- a/app/store-metadata/android.md
+++ b/app/store-metadata/android.md
@@ -4,10 +4,10 @@
 Companion Study — Bible Study
 
 ## Short Description (80 chars)
-Don't just read the Bible. Learn to read it the way it was written. Free.
+From reading to understanding. Scholarly Bible study, free and offline.
 
 ## Full Description
-Don't just read the Bible. Learn to read it the way it was written.
+Companion Study is a Bible study app for people who want to go from reading to understanding.
 
 Companion Study is the only Bible app that bridges the gap between reading scripture and understanding ancient literature. It's free, offline, and delivers seminary-level depth without requiring you to know how to use academic tools.
 

--- a/app/store-metadata/ios.md
+++ b/app/store-metadata/ios.md
@@ -4,13 +4,13 @@
 Companion Study
 
 ## Subtitle (30 chars)
-Logos & Letters, Deep Study
+From reading to understanding.
 
 ## Promotional Text (170 chars)
-Don't just read the Bible. Learn to read it the way it was written. 45+ scholars, Hebrew & Greek interlinear, and 8 features no other app offers. Free.
+Four guided study modes. Scholar-attributed depth. A study partner that remembers what you have learned and brings it back when it matters.
 
 ## Description
-Don't just read the Bible. Learn to read it the way it was written.
+Companion Study is a Bible study app for people who want to go from reading to understanding.
 
 Companion Study is the only Bible app that bridges the gap between reading scripture and understanding ancient literature. It's free, offline, and delivers seminary-level depth without requiring you to know how to use academic tools.
 


### PR DESCRIPTION
Closes #1747. Phase 4.4 of epic #1725.

## Why
Carry the *From reading to understanding* tagline through every in-repo new-user-perception surface so the partner positioning lands consistently from app store discovery to install to subscribe.

## What
Copy-only pass; zero functionality change.

- **`store-metadata/ios.md`**:
  - Subtitle: `Logos & Letters, Deep Study` → `From reading to understanding.` (29 chars, fits the 30-char App Store limit).
  - Promotional Text replaced with the spec's "Four guided study modes. Scholar-attributed depth. A study partner that remembers what you have learned and brings it back when it matters."
  - Description first line: `Companion Study is a Bible study app for people who want to go from reading to understanding.`
- **`store-metadata/android.md`**:
  - Short description (80 chars): `From reading to understanding. Scholarly Bible study, free and offline.`
  - Full description first line replaced per spec.
- **`store-metadata/APP_STORE_GUIDE.md`** — the instruction values Craig pastes into App Store Connect / Google Play Console all updated so they don't go stale: subtitle, promotional text, Google Play short description, feature graphic tagline.
- **`README.md`** — hero italic line: `Don't just read the Bible. Learn to read it the way it was written.` → `From reading to understanding.`

**Out of repo / not present:**
- Marketing site is a separate deploy (per spec, "separate PR if web is a different deploy").
- `app/app.json` has no `description` or `slogan` field today; per spec ("if present"), skipped.
- No onboarding screens exist (verified via `find`); skipped per spec.

## Acceptance criteria
- [x] Tagline appears in: Subscription hero (#1746), app store metadata (`ios.md` + `android.md`), in-repo doc surfaces (`README.md`, `APP_STORE_GUIDE.md`)
- [x] No remaining instances of *Every Perspective. Every Tool.* anywhere in the repo (grep returns zero)
- [x] tsc / lint / full suite (3944 tests) clean

## Rollback
Pure copy revert; no runtime risk.

## Notes for Craig
- The marketing site (separate deploy) and the App Store / Play Console listing values are external — once the next release builds, you'll need to paste the new ios.md / android.md values into App Store Connect / Google Play Console manually. The updated `APP_STORE_GUIDE.md` walks the new values.
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_