### PR TITLE
test: Phase 4 integration coverage — Amicus flow + flag-aware Subscription (#1748)

### DIFF
--- a/app/__tests__/screens/SubscriptionScreen.flagToggle.test.tsx
+++ b/app/__tests__/screens/SubscriptionScreen.flagToggle.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Phase 4.5 (#1748) — verifies the flag-aware Captures vs Drafts copy on
+ * the second partner-capability row, and confirms the tagline holds in
+ * both flag states. Uses a getter-backed mock so the same compiled
+ * SubscriptionScreen reads the flag through `isFlagEnabled` per render.
+ */
+import React from 'react';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+
+let mockFlagState = false;
+
+jest.mock('@/config/featureFlags', () => ({
+  FEATURE_FLAGS: {
+    get GUIDED_STUDY_AMICUS_SYNTHESIS() {
+      return mockFlagState;
+    },
+  },
+  isFlagEnabled: (flag: string) =>
+    flag === 'GUIDED_STUDY_AMICUS_SYNTHESIS' && mockFlagState,
+}));
+
+jest.mock('@/stores/premiumStore', () => ({
+  usePremiumStore: jest.fn((selector) =>
+    selector({ isPremium: false, purchaseType: null }),
+  ),
+}));
+
+jest.mock('@/services/purchases', () => ({
+  PLANS: [
+    { id: 'monthly', name: 'Monthly', price: '$4.99' },
+    { id: 'annual', name: 'Annual', price: '$29.99' },
+    { id: 'lifetime', name: 'Lifetime', price: '$79.99' },
+  ],
+  PARTNER_PLUS_PLANS: [
+    { id: 'partner_plus_monthly', productId: 'p_m', label: 'Monthly', price: '$9.99', detail: '/month' },
+    { id: 'partner_plus_annual', productId: 'p_a', label: 'Annual', price: '$99.99', detail: '/year' },
+  ],
+  purchasePlan: jest.fn().mockResolvedValue(false),
+  restorePurchases: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('@/components/ScreenHeader', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const RN = require('react-native');
+    return <RN.Text>{title}</RN.Text>;
+  },
+}));
+
+jest.mock('@/components/ScreenErrorBoundary', () => ({
+  withErrorBoundary: (C: React.ComponentType) => C,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const SubscriptionScreen = require('@/screens/SubscriptionScreen').default;
+
+afterEach(() => {
+  mockFlagState = false;
+});
+
+describe('SubscriptionScreen flag-aware partner row (#1748)', () => {
+  it('flag OFF → "Captures what you discovered"', () => {
+    mockFlagState = false;
+    const { getByText, queryByText } = renderWithProviders(<SubscriptionScreen />);
+    expect(getByText('Captures what you discovered')).toBeTruthy();
+    expect(queryByText('Drafts what you discovered')).toBeNull();
+  });
+
+  it('flag ON → "Drafts what you discovered"', () => {
+    mockFlagState = true;
+    const { getByText, queryByText } = renderWithProviders(<SubscriptionScreen />);
+    expect(getByText('Drafts what you discovered')).toBeTruthy();
+    expect(queryByText('Captures what you discovered')).toBeNull();
+  });
+
+  it('hero subtitle stays "From reading to understanding." in both states', () => {
+    mockFlagState = false;
+    const off = renderWithProviders(<SubscriptionScreen />);
+    expect(off.getByText('From reading to understanding.')).toBeTruthy();
+    mockFlagState = true;
+    const on = renderWithProviders(<SubscriptionScreen />);
+    expect(on.getByText('From reading to understanding.')).toBeTruthy();
+  });
+});

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Phase 4.5 (#1748) — end-to-end integration tests for the
+ * premium_amicus path. Uses the swappable runner override so the suite
+ * exercises real prompt construction + parser behaviour without
+ * touching the network.
+ */
+import { getMockUserDb, resetMockUserDb } from '../../../../../__tests__/helpers/mockUserDb';
+import {
+  __setAmicusStreamRunnerForTests,
+  premiumAmicusStrategy,
+} from '../premiumAmicusStrategy';
+import { chooseStrategy } from '../strategy';
+import { freeStrategy } from '../freeStrategy';
+import { premiumStructuredStrategy } from '../premiumStructuredStrategy';
+import { buildGuidedStudySystemPrompt } from '../../../amicus/prompts/guidedStudy';
+import type { CapturedInputs } from '../../capturedInputs';
+import type { GuidedStudyMode, GuidedStudyPlan } from '../../types';
+import type { CitationRef } from '../strategy';
+
+jest.mock('@/db/userDatabase', () =>
+  require('../../../../../__tests__/helpers/mockUserDb').mockUserDatabaseModule(),
+);
+
+beforeEach(() => {
+  resetMockUserDb();
+  __setAmicusStreamRunnerForTests(null);
+});
+
+afterAll(() => {
+  __setAmicusStreamRunnerForTests(null);
+});
+
+function planFor(mode: GuidedStudyMode, title = 'Romans 8'): GuidedStudyPlan {
+  return {
+    chapterId: 'rom_8',
+    title,
+    mode,
+    modeLabel: 'Mode',
+    sceneRows: [],
+    stepPrompts: { scene: [], observe: [], explore: [], synthesize: [], review: [] },
+    legacyPrompts: [],
+    recommendations: [],
+    evidenceTrail: [],
+    betterQuestionPrompt: '',
+    conceptChips: [],
+  };
+}
+
+const MODE_FAKE_RESPONSES: Record<GuidedStudyMode, string> = {
+  quick: 'A 60-word takeaway about the chapter.\nVerse to carry: Rom 8:1.',
+  deep: `CLAIM: Paul argues no condemnation.
+
+EVIDENCE: 8:1, the Spirit's witness in 8:14-16.
+
+TENSION: present suffering vs declared adoption.`,
+  teaching: `HOOK: courtroom imagery.
+MAIN POINT: No condemnation; full adoption.
+SUPPORTING MOVES:
+- Verse 1.
+- Verses 14-16.
+APPLICATION: bring this into your week.
+DISCUSSION QUESTION: where does condemnation still echo for you?`,
+  devotional: `WHAT GOD MAY BE SAYING: that even today, you are held.
+PRAYER: lord, you walk with me.
+CARRY-FORWARD: 'no condemnation'`,
+};
+
+const MODE_EXPECTED_TYPES: Record<GuidedStudyMode, string> = {
+  quick: 'memory_verse',
+  deep: 'analytical_claim',
+  teaching: 'teaching_outline',
+  devotional: 'returning_prayer',
+};
+
+describe('premium_amicus end-to-end per mode', () => {
+  it.each<GuidedStudyMode>(['quick', 'deep', 'teaching', 'devotional'])(
+    '%s: prompt builds, runner streams, parser produces the right artifact shape',
+    async (mode) => {
+      // Capture the system prompt the strategy hands to the runner.
+      let receivedPrompt = '';
+      __setAmicusStreamRunnerForTests({
+        async run(args) {
+          receivedPrompt = args.systemPrompt;
+          args.callbacks?.onAmicusDelta?.(MODE_FAKE_RESPONSES[mode]);
+          args.callbacks?.onAmicusComplete?.();
+          return MODE_FAKE_RESPONSES[mode];
+        },
+      });
+
+      const captured: CapturedInputs = {
+        scene: { audience: 'small group', setting: 'small group', arrival: 'tired' },
+        observe: { primary: 'meeting word', main_point: 'No condemnation.' },
+      };
+
+      const result = await premiumAmicusStrategy.run({
+        plan: planFor(mode),
+        captured,
+        sessionId: 42,
+        bookId: 'rom',
+        chapterNum: 8,
+      });
+
+      // Prompt is the same one the prompts module produces — proves the
+      // strategy doesn't drift from #1744.
+      expect(receivedPrompt).toBe(
+        buildGuidedStudySystemPrompt({
+          mode,
+          chapterRef: 'Romans 8',
+          captured,
+          panelsOpened: [],
+          modeSpecificContext:
+            mode === 'teaching'
+              ? { audience: 'small group', setting: 'small group' }
+              : mode === 'devotional'
+                ? { arrival: 'tired' }
+                : {},
+        }),
+      );
+
+      // Artifact is the right discriminated shape.
+      expect(result.artifact?.type).toBe(MODE_EXPECTED_TYPES[mode]);
+      expect(result.kind).toBe('premium_amicus');
+    },
+  );
+});
+
+describe('cap fallback at the chooseStrategy gate', () => {
+  it('isPremium + flag on + canUse=false → premium_structured (NOT premium_amicus)', () => {
+    const strategy = chooseStrategy({
+      isPremium: true,
+      amicusFlagEnabled: true,
+      amicusCanUse: false,
+    });
+    expect(strategy).toBe(premiumStructuredStrategy);
+    expect(strategy).not.toBe(premiumAmicusStrategy);
+  });
+
+  it('isPremium + flag on + canUse=true → premium_amicus', () => {
+    expect(
+      chooseStrategy({ isPremium: true, amicusFlagEnabled: true, amicusCanUse: true }),
+    ).toBe(premiumAmicusStrategy);
+  });
+
+  it('non-premium short-circuits to free regardless of flag/cap', () => {
+    expect(
+      chooseStrategy({ isPremium: false, amicusFlagEnabled: true, amicusCanUse: true }),
+    ).toBe(freeStrategy);
+  });
+});
+
+describe('cancellation mid-stream', () => {
+  it('rejects without persisting when ctx.abortSignal aborts before the stream resolves', async () => {
+    const controller = new AbortController();
+    __setAmicusStreamRunnerForTests({
+      async run({ abortSignal }) {
+        // Simulate the runner respecting the caller's abort signal.
+        await new Promise<void>((_resolve, reject) => {
+          if (abortSignal?.aborted) return reject(new Error('aborted'));
+          abortSignal?.addEventListener('abort', () => reject(new Error('aborted')));
+        });
+        return 'should not happen';
+      },
+    });
+
+    const promise = premiumAmicusStrategy.run({
+      plan: planFor('deep'),
+      captured: {},
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+      abortSignal: controller.signal,
+    });
+    controller.abort();
+    await expect(promise).rejects.toThrow();
+
+    // No persistence calls landed.
+    expect(getMockUserDb().runAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the canonical aborted error when abort fires after stream resolution', async () => {
+    const controller = new AbortController();
+    __setAmicusStreamRunnerForTests({
+      async run() {
+        controller.abort();
+        return 'CLAIM: A.';
+      },
+    });
+    await expect(
+      premiumAmicusStrategy.run({
+        plan: planFor('deep'),
+        captured: {},
+        sessionId: 42,
+        bookId: 'rom',
+        chapterNum: 8,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+    // No persistence after the abort check.
+    expect(getMockUserDb().runAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('citation parsing into the amicus_text block', () => {
+  it('citations forwarded by the runner land on the amicus_text output block', async () => {
+    const expectedCitations: CitationRef[] = [
+      { panelType: 'panel', snippet: 'Romans 8 — historical context' },
+      { panelType: 'panel', snippet: 'Romans 8 — cross references' },
+    ];
+    __setAmicusStreamRunnerForTests({
+      async run({ callbacks, onCitation }) {
+        callbacks?.onAmicusDelta?.('CLAIM: A.\n\nEVIDENCE: B.');
+        for (const c of expectedCitations) onCitation?.(c);
+        callbacks?.onAmicusComplete?.();
+        return 'CLAIM: A.\n\nEVIDENCE: B.';
+      },
+    });
+    const result = await premiumAmicusStrategy.run({
+      plan: planFor('deep'),
+      captured: {},
+      sessionId: 42,
+      bookId: 'rom',
+      chapterNum: 8,
+    });
+    const amicusBlock = result.output.find((b) => b.type === 'amicus_text');
+    expect(amicusBlock).toBeTruthy();
+    if (amicusBlock && amicusBlock.type === 'amicus_text') {
+      expect(amicusBlock.citations).toEqual(expectedCitations);
+    }
+  });
+});

--- a/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
+++ b/app/src/services/guidedStudy/synthesis/premiumAmicusStrategy.ts
@@ -30,6 +30,7 @@ import { REVIEW_INTERVAL_DAYS } from '../review';
 import type { CapturedInputs } from '../capturedInputs';
 import type { GuidedStudyMode } from '../types';
 import type {
+  CitationRef,
   ReviewArtifact,
   SynthesisOutputBlock,
   SynthesisStrategy,
@@ -163,10 +164,11 @@ export function parseModeArtifact(
 export function buildAmicusOutputBlocks(
   fullText: string,
   artifact: ReviewArtifact,
+  citations: CitationRef[] = [],
 ): SynthesisOutputBlock[] {
   const blocks: SynthesisOutputBlock[] = [];
   if (fullText.trim().length > 0) {
-    blocks.push({ type: 'amicus_text', html: fullText, citations: [] });
+    blocks.push({ type: 'amicus_text', html: fullText, citations });
   }
   blocks.push({
     type: 'confirmation',
@@ -188,6 +190,7 @@ interface AmicusStreamRunner {
     chapterNum: number;
     abortSignal?: AbortSignal;
     callbacks?: SynthesisStrategyCallbacks;
+    onCitation?: (citation: CitationRef) => void;
   }): Promise<string>;
 }
 
@@ -199,7 +202,8 @@ const defaultRunner: AmicusStreamRunner = {
     }
     const controller = new AbortController();
     if (args.abortSignal) {
-      args.abortSignal.addEventListener('abort', () => controller.abort());
+      if (args.abortSignal.aborted) controller.abort();
+      else args.abortSignal.addEventListener('abort', () => controller.abort());
     }
     return await new Promise<string>((resolve, reject) => {
       let acc = '';
@@ -217,10 +221,13 @@ const defaultRunner: AmicusStreamRunner = {
           acc += token;
           args.callbacks?.onAmicusDelta?.(token);
         },
-        onCitation: () => {
-          // Citation pills are surfaced through the streaming UI; the
-          // strategy doesn't aggregate them here. SynthesisPremiumDraft
-          // renders them when present.
+        onCitation: (pill) => {
+          // Map the streaming-pill shape onto our typed CitationRef so
+          // downstream blocks stay decoupled from streamParser internals.
+          args.onCitation?.({
+            panelType: pill.source_type,
+            snippet: pill.display_label,
+          });
         },
         onGapSignal: () => {
           // Gap signals are an Amicus internal hint; not relevant to
@@ -260,6 +267,8 @@ export const premiumAmicusStrategy: SynthesisStrategy = {
       modeSpecificContext: extractModeContext(ctx.plan.mode, ctx.captured),
     });
 
+
+    const citations: CitationRef[] = [];
     let fullText = '';
     try {
       fullText = await activeRunner.run({
@@ -267,11 +276,21 @@ export const premiumAmicusStrategy: SynthesisStrategy = {
         threadId: synthesisThreadId(ctx.sessionId),
         bookId: ctx.bookId,
         chapterNum: ctx.chapterNum,
+        abortSignal: ctx.abortSignal,
         callbacks,
+        onCitation: (citation) => {
+          citations.push(citation);
+        },
       });
     } catch (err) {
       logger.warn('premiumAmicus', 'stream failed', err);
       throw err;
+    }
+
+    if (ctx.abortSignal?.aborted) {
+      // Caller cancelled mid-stream. Do not persist anything; surface the
+      // abort to the caller via a rejection so state stays consistent.
+      throw new Error('premiumAmicus: aborted');
     }
 
     const artifact = parseModeArtifact(ctx.plan.mode, fullText, ctx.captured, ctx.plan.title);
@@ -292,7 +311,7 @@ export const premiumAmicusStrategy: SynthesisStrategy = {
 
     return {
       kind: 'premium_amicus',
-      output: buildAmicusOutputBlocks(fullText, artifact),
+      output: buildAmicusOutputBlocks(fullText, artifact, citations),
       artifact,
     };
   },

--- a/app/src/services/guidedStudy/synthesis/strategy.ts
+++ b/app/src/services/guidedStudy/synthesis/strategy.ts
@@ -27,6 +27,12 @@ export interface SynthesisRunContext {
   sessionId: number | null;
   bookId: string;
   chapterNum: number;
+  /**
+   * Optional abort signal for streaming strategies (premium_amicus).
+   * When the signal aborts mid-stream, the strategy should reject without
+   * persisting any artifact (#1748).
+   */
+  abortSignal?: AbortSignal;
 }
 
 export interface CitationRef {


### PR DESCRIPTION
Closes #1748. Phase 4.5 of epic #1725.

## Why
Phase 4 introduced the Amicus prompts (#1744), the streaming strategy + draft component (#1745), the partner-led Subscription rewrite (#1746), and the tagline rollout (#1747). This card writes the Phase 4 contracts down as integration tests so the flag-flip in #1749 can ship with confidence.

## What
**Production support (needed to make the cancellation + citation tests testable):**
- **`services/guidedStudy/synthesis/strategy.ts`** — `SynthesisRunContext` gains optional `abortSignal?: AbortSignal`. `premium_amicus` is the only current consumer; the other strategies ignore.
- **`services/guidedStudy/synthesis/premiumAmicusStrategy.ts`**:
  - `AmicusStreamRunner.run` accepts `abortSignal` + `onCitation`.
  - Default runner forwards `streamChat`'s `onCitation` as a typed `CitationRef` (`source_type` → `panelType`, `display_label` → `snippet`), and uses the caller's signal to drive the internal `AbortController`.
  - Strategy aggregates citations locally; passes them into `buildAmicusOutputBlocks` so the `amicus_text` block carries the accumulated `CitationRef[]` for `SynthesisPremiumDraft`.
  - Post-stream guard: if `ctx.abortSignal` aborted, throw before persisting anything.

**New tests:**

`synthesis/__tests__/premiumAmicusFlow.test.ts` (10 tests):
- **Per-mode end-to-end**: the system prompt the strategy hands to the runner is byte-for-byte the same one `buildGuidedStudySystemPrompt` (#1744) produces; the parser emits the expected discriminated artifact (`memory_verse` / `analytical_claim` / `teaching_outline` / `returning_prayer`).
- **Cap fallback**: `chooseStrategy({ isPremium: true, amicusFlagEnabled: true, amicusCanUse: false })` returns `premium_structured` (not `premium_amicus`); flag-on + canUse-true → `premium_amicus`; non-premium → `free` regardless of flag.
- **Cancellation**: `abortSignal` aborting before the stream resolves → rejects with no DB writes; abort *after* stream resolves but before persistence → strategy still throws and skips persistence.
- **Citation parsing**: runner-fired `CitationRef`s land on the `amicus_text` output block.

`__tests__/screens/SubscriptionScreen.flagToggle.test.tsx` (3 tests):
- Getter-backed `jest.mock` of `@/config/featureFlags` so the same compiled screen reads the live flag state per render. `mockFlagState = false` → "Captures what you discovered" (and "Drafts" absent); `mockFlagState = true` → "Drafts what you discovered" (and "Captures" absent); tagline `From reading to understanding.` renders in both states.

## Acceptance criteria
- [x] All tests pass (13 new tests; 3957 in the full suite)
- [x] tsc / lint clean

## Rollback
Revert the PR. The new `abortSignal` field on `SynthesisRunContext` is optional, so reverting just removes a feature; the citation aggregation falls back to an empty array (already the default).

## Notes for Craig
- Out of scope per spec: E2E tests against the real Amicus production endpoint — that's a manual smoke test before flipping the flag in #1749.
- This closes Phase 4 development cards #1744–#1748. **#1749 is the flag-flip PR — gated on you confirming Epic #1446 Phase 3 is production-ready.** I'll wait for your go-ahead before opening it.
- Kanban move requires manual action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnhJaVDXTsUe3WPixutJBN)_