### PR TITLE
feat: per-chapter genre overrides for sub-genre shifts (#1724)

### DIFF
--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -238,8 +238,8 @@ def populate_chapters(cur):
                 'INSERT INTO chapters (id, book_id, chapter_num, title, subtitle, '
                 'timeline_link_event, timeline_link_text, '
                 'map_story_link_id, map_story_link_text, coaching_json, prayer_prompt, '
-                'redemptive_act) '
-                'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                'redemptive_act, chapter_genre_label, chapter_genre_guidance) '
+                'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                 (chapter_id, book_id, ch_num,
                  data.get('title'), data.get('subtitle'),
                  tl['event_id'] if tl else None,
@@ -248,7 +248,9 @@ def populate_chapters(cur):
                  ms['text'] if ms else None,
                  coaching_str,
                  data.get('prayer_prompt'),
-                 ra_chapter_map.get(chapter_id))
+                 ra_chapter_map.get(chapter_id),
+                 data.get('chapter_genre_label'),
+                 data.get('chapter_genre_guidance'))
             )
             chapter_count += 1
 

--- a/_tools/build_sqlite_schema.py
+++ b/_tools/build_sqlite_schema.py
@@ -38,7 +38,12 @@ CREATE TABLE chapters (
   difficulty INTEGER,
   prayer_prompt TEXT,
   related_life_topics TEXT,
-  redemptive_act TEXT
+  redemptive_act TEXT,
+  -- Per-chapter genre overrides (#1724). Atomic: both fields populated, or
+  -- both null. When present, override book-level genre_label/genre_guidance
+  -- in the GenreBanner and Guided Study mode prompts.
+  chapter_genre_label TEXT,
+  chapter_genre_guidance TEXT
 );
 
 CREATE TABLE sections (

--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -199,6 +199,23 @@ def main():
             if sv != CURRENT_SCHEMA_VERSION:
                 stale_schema_count += 1
 
+            # Per-chapter genre override (#1724) — atomic both-or-neither.
+            # If a chapter sets one of (chapter_genre_label, chapter_genre_guidance)
+            # it must set the other; otherwise the resolver in app code falls
+            # through to book-level entirely (mismatched mixing is forbidden).
+            has_label = 'chapter_genre_label' in data
+            has_guidance = 'chapter_genre_guidance' in data
+            if has_label != has_guidance:
+                check(f"{json_file.name} chapter genre fields paired", False,
+                      "must set both chapter_genre_label and chapter_genre_guidance, or neither")
+            elif has_label and has_guidance:
+                lbl = data['chapter_genre_label']
+                gdc = data['chapter_genre_guidance']
+                if not isinstance(lbl, str) or not lbl.strip():
+                    check(f"{json_file.name} chapter_genre_label non-empty string", False)
+                if not isinstance(gdc, str) or not gdc.strip():
+                    check(f"{json_file.name} chapter_genre_guidance non-empty string", False)
+
             sections = data.get('sections', [])
             check(f"{json_file.name} has sections", len(sections) >= 1,
                   f"got {len(sections)}")

--- a/app/__tests__/utils/genre.test.ts
+++ b/app/__tests__/utils/genre.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for utils/genre.ts — per-chapter genre override resolution (#1724).
+ */
+import { resolveGenre } from '@/utils/genre';
+import type { Book, Chapter } from '@/types';
+
+const BOOK: Pick<Book, 'genre_label' | 'genre_guidance'> = {
+  genre_label: 'Apocalyptic',
+  genre_guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+};
+
+const CHAPTER_WITH_OVERRIDE: Pick<Chapter, 'chapter_genre_label' | 'chapter_genre_guidance'> = {
+  chapter_genre_label: 'Apocalyptic Vision',
+  chapter_genre_guidance: 'Symbolic beasts encode empires · Vision-then-interpretation form',
+};
+
+const CHAPTER_NO_OVERRIDE: Pick<Chapter, 'chapter_genre_label' | 'chapter_genre_guidance'> = {
+  chapter_genre_label: null,
+  chapter_genre_guidance: null,
+};
+
+describe('resolveGenre', () => {
+  it('returns the chapter override when both chapter fields are present', () => {
+    expect(resolveGenre(BOOK, CHAPTER_WITH_OVERRIDE)).toEqual({
+      label: 'Apocalyptic Vision',
+      guidance: 'Symbolic beasts encode empires · Vision-then-interpretation form',
+    });
+  });
+
+  it('falls back to book-level when the chapter has no override', () => {
+    expect(resolveGenre(BOOK, CHAPTER_NO_OVERRIDE)).toEqual({
+      label: 'Apocalyptic',
+      guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+    });
+  });
+
+  it('returns null when neither chapter nor book carries genre data', () => {
+    expect(resolveGenre({}, CHAPTER_NO_OVERRIDE)).toBeNull();
+    expect(resolveGenre(null, null)).toBeNull();
+    expect(resolveGenre(undefined, undefined)).toBeNull();
+  });
+
+  it('falls through to book entirely when the chapter sets only the label (no mixing)', () => {
+    // Defensive case: schema validator would reject this content, but if a
+    // malformed row reaches the runtime, we must NOT mix sources.
+    const halfOverride = {
+      chapter_genre_label: 'Apocalyptic Vision',
+      chapter_genre_guidance: null,
+    };
+    expect(resolveGenre(BOOK, halfOverride)).toEqual({
+      label: 'Apocalyptic',
+      guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+    });
+  });
+
+  it('falls through to book entirely when the chapter sets only the guidance (no mixing)', () => {
+    const halfOverride = {
+      chapter_genre_label: null,
+      chapter_genre_guidance: 'Symbolic beasts encode empires',
+    };
+    expect(resolveGenre(BOOK, halfOverride)).toEqual({
+      label: 'Apocalyptic',
+      guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+    });
+  });
+
+  it('returns null if book has only label (book-level half-state)', () => {
+    expect(resolveGenre({ genre_label: 'Prophecy' }, CHAPTER_NO_OVERRIDE)).toBeNull();
+    expect(resolveGenre({ genre_guidance: 'something' }, CHAPTER_NO_OVERRIDE)).toBeNull();
+  });
+
+  it('treats empty strings as missing (truthy guard)', () => {
+    expect(
+      resolveGenre(BOOK, { chapter_genre_label: '', chapter_genre_guidance: '' }),
+    ).toEqual({
+      label: 'Apocalyptic',
+      guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+    });
+  });
+});

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "20ffe66a867071df",
-  "build_time": "2026-04-23T19:34:01.367823Z"
+  "content_hash": "f48d278bb65b8590",
+  "build_time": "2026-04-27T17:34:11.255976Z"
 }

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -30,6 +30,7 @@ import { useNotedVerses } from '../hooks/useNotedVerses';
 import { useSettingsStore, useReaderStore } from '../stores';
 import { recordVisit } from '../db/user';
 import { GenreBanner } from '../components/GenreBanner';
+import { resolveGenre } from '../utils/genre';
 import { useTranslationSwitch } from '../hooks/useTranslationSwitch';
 import { useStoreReview } from '../hooks/useStoreReview';
 import { logEvent } from '../services/analytics';
@@ -478,9 +479,13 @@ function ChapterScreen() {
           />
         ) : null}
 
-        {!isFocus && bookData?.genre_label && bookData?.genre_guidance ? (
-          <GenreBanner genreLabel={bookData.genre_label} genreGuidance={bookData.genre_guidance} />
-        ) : null}
+        {(() => {
+          if (isFocus) return null;
+          const genre = resolveGenre(bookData, chapter);
+          return genre ? (
+            <GenreBanner genreLabel={genre.label} genreGuidance={genre.guidance} />
+          ) : null;
+        })()}
 
         <ChapterReaderProvider
           verse={{

--- a/app/src/services/guidedStudy/__tests__/genreOverride.test.ts
+++ b/app/src/services/guidedStudy/__tests__/genreOverride.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for #1724 — per-chapter genre override threading through
+ * buildGuidedStudyPlan and buildConceptChips. Asserts that when a
+ * chapter sets both chapter_genre_label and chapter_genre_guidance,
+ * those values appear in the plan output instead of book-level genre.
+ */
+import { buildGuidedStudyPlan } from '../plan';
+import type { GuidedStudyPlanInput } from '../types';
+import type { Book, Chapter, Verse } from '../../../types';
+
+const BOOK: Book = {
+  id: 'dan',
+  name: 'Daniel',
+  testament: 'ot',
+  total_chapters: 12,
+  book_order: 27,
+  is_live: true,
+  genre_label: 'Apocalyptic',
+  genre_guidance: 'Court tales (1-6) + apocalyptic visions (7-12) · Symbolic numbers and beasts',
+};
+
+const VERSES: Verse[] = [
+  { id: 1, book_id: 'dan', chapter_num: 7, verse_num: 1, translation: 'niv', text: 'In the first year of Belshazzar...' },
+];
+
+function makeChapter(overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id: 'dan_7',
+    book_id: 'dan',
+    chapter_num: 7,
+    title: "Daniel's Dream of Four Beasts",
+    subtitle: 'Vision of the Ancient of Days',
+    timeline_link_event: null,
+    timeline_link_text: null,
+    map_story_link_id: null,
+    map_story_link_text: null,
+    coaching_json: null,
+    difficulty: null,
+    ...overrides,
+  };
+}
+
+function makeInput(chapter: Chapter): GuidedStudyPlanInput {
+  return {
+    book: BOOK,
+    chapter,
+    sections: [],
+    chapterPanels: [],
+    verses: VERSES,
+  };
+}
+
+function findGenreValue(plan: ReturnType<typeof buildGuidedStudyPlan>): string {
+  const row = plan.sceneRows.find(
+    (r): r is Extract<typeof r, { kind: 'display' }> =>
+      r.kind === 'display' && r.label === 'Genre',
+  );
+  if (!row) throw new Error('No "Genre" display row found in sceneRows');
+  return row.value;
+}
+
+describe('buildGuidedStudyPlan — per-chapter genre overrides (#1724)', () => {
+  it('uses chapter override label/guidance when both are set', () => {
+    const chapter = makeChapter({
+      chapter_genre_label: 'Apocalyptic Vision',
+      chapter_genre_guidance: 'Symbolic beasts encode empires · Vision-then-interpretation form',
+    });
+
+    const value = findGenreValue(buildGuidedStudyPlan(makeInput(chapter)));
+
+    expect(value).toContain('Apocalyptic Vision');
+    expect(value).toContain('Symbolic beasts encode empires');
+    // Book-level "Court tales" guidance must NOT leak through.
+    expect(value).not.toContain('Court tales');
+  });
+
+  it('falls back to book-level genre when chapter has no override', () => {
+    const chapter = makeChapter();
+
+    const value = findGenreValue(buildGuidedStudyPlan(makeInput(chapter)));
+
+    expect(value).toContain('Apocalyptic');
+    expect(value).toContain('Court tales');
+  });
+
+  it('produces a chapter-level concept chip from the override label', () => {
+    const chapter = makeChapter({
+      chapter_genre_label: 'Apocalyptic Vision',
+      chapter_genre_guidance: 'Symbolic beasts encode empires',
+    });
+
+    const plan = buildGuidedStudyPlan(makeInput(chapter));
+
+    const genreChip = plan.conceptChips.find((c) => c.id.startsWith('genre:'));
+    expect(genreChip?.label).toBe('Apocalyptic Vision');
+    expect(genreChip?.id).toBe('genre:apocalyptic-vision');
+  });
+
+  it('does not mix sources when only one chapter field is populated', () => {
+    // Defensive: schema validator rejects this, but if it sneaks through
+    // we fall through to book-level entirely rather than mix.
+    const chapter = makeChapter({
+      chapter_genre_label: 'Apocalyptic Vision',
+      chapter_genre_guidance: null,
+    });
+
+    const value = findGenreValue(buildGuidedStudyPlan(makeInput(chapter)));
+
+    expect(value).toContain('Apocalyptic');
+    expect(value).toContain('Court tales');
+    expect(value).not.toContain('Apocalyptic Vision');
+  });
+});

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,4 +1,5 @@
 import type { SectionPanel } from '../../types';
+import { resolveGenre } from '../../utils/genre';
 import { getModeDefinition } from './modes/definitions';
 import {
   GUIDED_STUDY_STEPS,
@@ -260,7 +261,9 @@ function buildEvidenceTrail(
 
 function buildConceptChips(input: GuidedStudyPlanInput): GuidedConceptChip[] {
   const chips: GuidedConceptChip[] = [];
-  const genre = compact(input.book?.genre_label) ?? compact(input.bookIntro?.at_a_glance?.genre);
+  // #1724 — chapter override wins, then book-level, then bookIntro fallback.
+  const resolved = resolveGenre(input.book, input.chapter);
+  const genre = resolved?.label ?? compact(input.bookIntro?.at_a_glance?.genre);
   if (genre) {
     chips.push({ id: `genre:${genre.toLowerCase().replace(/\s+/g, '-')}`, label: genre });
   }
@@ -292,11 +295,13 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
   const purpose = firstSentence(input.bookIntro?.purpose);
   const moment =
     compact(input.chapter.subtitle) ?? compact(input.chapter.title) ?? displayChapter(input);
+  // #1724 — chapter override wins, then book-level, then bookIntro fallback.
+  const resolvedGenre = resolveGenre(input.book, input.chapter);
   const genre =
-    compact(input.book?.genre_label) ??
+    resolvedGenre?.label ??
     compact(input.bookIntro?.at_a_glance?.genre) ??
     'Biblical literature';
-  const guidance = compact(input.book?.genre_guidance);
+  const guidance = resolvedGenre?.guidance;
   const audienceContext =
     compact(input.bookIntro?.era) ?? compact(input.bookIntro?.at_a_glance?.chapters?.toString());
   const def = getModeDefinition(mode);
@@ -306,7 +311,7 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
   const legacyPrompts: GuidedPrompt[] = [
     {
       key: 'genre-observation',
-      text: genrePrompt(input.book?.genre_label ?? input.bookIntro?.at_a_glance?.genre),
+      text: genrePrompt(resolvedGenre?.label ?? input.bookIntro?.at_a_glance?.genre),
     },
     { key: 'better-question', text: betterQuestion },
   ];

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -30,6 +30,16 @@ export interface Chapter {
   prayer_prompt?: string | null;
   related_life_topics_json?: string | null;
   redemptive_act?: string | null;
+  /**
+   * Per-chapter genre override (#1724). Atomic with `chapter_genre_guidance`:
+   * both populated, or both null. When present, overrides book-level
+   * `genre_label` / `genre_guidance` in the GenreBanner and Guided Study
+   * mode prompts. Use `resolveGenre()` from `utils/genre.ts` rather than
+   * reading these directly so the both-or-neither rule is honored.
+   */
+  chapter_genre_label?: string | null;
+  /** See `chapter_genre_label`. Atomic pair — both or neither. */
+  chapter_genre_guidance?: string | null;
 }
 
 export interface CoachingTip {

--- a/app/src/utils/genre.ts
+++ b/app/src/utils/genre.ts
@@ -1,0 +1,60 @@
+/**
+ * utils/genre.ts — Genre label + guidance resolution (#1724).
+ *
+ * The chapter row may carry per-chapter genre overrides
+ * (`chapter_genre_label`, `chapter_genre_guidance`) for books with
+ * sharply different sub-genres across chapter ranges (e.g. Daniel 1–6
+ * court tales vs 7–12 apocalyptic visions, Genesis 1–11 primeval history
+ * vs 12–50 patriarchal narrative).
+ *
+ * Resolution is atomic per level: a chapter override only takes effect
+ * when BOTH fields are populated. The schema validator enforces this at
+ * authoring time (see `_tools/schema_validator.py`). The runtime check
+ * here defends against any malformed row that slips through — we'd
+ * rather hide the banner than mix sources (chapter label + book guidance
+ * would prime the reader incorrectly).
+ *
+ * Consumers:
+ *   - `<GenreBanner>` via `ChapterScreen`
+ *   - `buildGuidedStudyPlan` and `buildConceptChips` in
+ *     `services/guidedStudy/plan.ts`
+ *
+ * Note: `useExploreRecommendations` deliberately stays on book-level —
+ * exploration recs are a book-aggregate concern, not chapter-orientation.
+ */
+
+import type { Book, Chapter } from '../types';
+
+export interface ResolvedGenre {
+  label: string;
+  guidance: string;
+}
+
+type GenreBookFields = Pick<Book, 'genre_label' | 'genre_guidance'>;
+type GenreChapterFields = Pick<Chapter, 'chapter_genre_label' | 'chapter_genre_guidance'>;
+
+/**
+ * Returns the chapter-override genre when both fields are populated,
+ * otherwise the book-level genre when both are populated, otherwise null.
+ *
+ * Mixed sources (chapter label + book guidance, or vice versa) are never
+ * returned — this is intentional, see file header.
+ */
+export function resolveGenre(
+  book: GenreBookFields | null | undefined,
+  chapter: GenreChapterFields | null | undefined,
+): ResolvedGenre | null {
+  const chapterLabel = chapter?.chapter_genre_label;
+  const chapterGuidance = chapter?.chapter_genre_guidance;
+  if (chapterLabel && chapterGuidance) {
+    return { label: chapterLabel, guidance: chapterGuidance };
+  }
+
+  const bookLabel = book?.genre_label;
+  const bookGuidance = book?.genre_guidance;
+  if (bookLabel && bookGuidance) {
+    return { label: bookLabel, guidance: bookGuidance };
+  }
+
+  return null;
+}

--- a/content/daniel/1.json
+++ b/content/daniel/1.json
@@ -5,6 +5,8 @@
   "chapter_num": 1,
   "title": "Daniel 1",
   "subtitle": "Daniel’s Resolve in Babylon",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "first-deportation",
     "text": "See on Timeline — First Deportation"

--- a/content/daniel/10.json
+++ b/content/daniel/10.json
@@ -5,6 +5,8 @@
   "chapter_num": 10,
   "title": "Daniel 10",
   "subtitle": "The Heavenly Messenger",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/daniel/11.json
+++ b/content/daniel/11.json
@@ -5,6 +5,8 @@
   "chapter_num": 11,
   "title": "Daniel 11",
   "subtitle": "The Kings of the North and South",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/daniel/12.json
+++ b/content/daniel/12.json
@@ -5,6 +5,8 @@
   "chapter_num": 12,
   "title": "Daniel 12",
   "subtitle": "The Resurrection and the Time of the End",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/daniel/2.json
+++ b/content/daniel/2.json
@@ -5,6 +5,8 @@
   "chapter_num": 2,
   "title": "Daniel 2",
   "subtitle": "Nebuchadnezzar’s Dream: The Statue of Four Kingdoms",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "daniel-statue-dream",
     "text": "See on Timeline — Nebuchadnezzar's Dream"

--- a/content/daniel/3.json
+++ b/content/daniel/3.json
@@ -5,6 +5,8 @@
   "chapter_num": 3,
   "title": "Daniel 3",
   "subtitle": "The Fiery Furnace",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "fiery-furnace",
     "text": "See on Timeline — The Fiery Furnace"

--- a/content/daniel/4.json
+++ b/content/daniel/4.json
@@ -5,6 +5,8 @@
   "chapter_num": 4,
   "title": "Daniel 4",
   "subtitle": "Nebuchadnezzar’s Madness and Restoration",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "daniel-statue-dream",
     "text": "See on Timeline — Nebuchadnezzar's Dream"

--- a/content/daniel/5.json
+++ b/content/daniel/5.json
@@ -5,6 +5,8 @@
   "chapter_num": 5,
   "title": "Daniel 5",
   "subtitle": "The Writing on the Wall",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "handwriting-wall",
     "text": "See on Timeline — Handwriting on the Wall"

--- a/content/daniel/6.json
+++ b/content/daniel/6.json
@@ -5,6 +5,8 @@
   "chapter_num": 6,
   "title": "Daniel 6",
   "subtitle": "Daniel in the Lion’s Den",
+  "chapter_genre_label": "Court Narrative",
+  "chapter_genre_guidance": "Faithful presence in pagan administration · God's sovereignty over Babylon · Diaspora wisdom under foreign rule",
   "timeline_link": {
     "event_id": "daniel-lions",
     "text": "See on Timeline — Daniel in the Lions' Den"

--- a/content/daniel/7.json
+++ b/content/daniel/7.json
@@ -5,6 +5,8 @@
   "chapter_num": 7,
   "title": "Daniel 7",
   "subtitle": "The Four Beasts and the Son of Man",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/daniel/8.json
+++ b/content/daniel/8.json
@@ -5,6 +5,8 @@
   "chapter_num": 8,
   "title": "Daniel 8",
   "subtitle": "The Ram and the Goat",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/daniel/9.json
+++ b/content/daniel/9.json
@@ -5,6 +5,8 @@
   "chapter_num": 9,
   "title": "Daniel 9",
   "subtitle": "The Seventy Weeks",
+  "chapter_genre_label": "Apocalyptic Vision",
+  "chapter_genre_guidance": "Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule",
   "timeline_link": {
     "event_id": "daniel-four-beasts",
     "text": "See on Timeline — Vision of Four Beasts"

--- a/content/genesis/1.json
+++ b/content/genesis/1.json
@@ -5,6 +5,8 @@
   "chapter_num": 1,
   "title": "Genesis 1",
   "subtitle": "The Creation of the Heavens and the Earth",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "creation",
     "text": "See on Timeline — Creation"

--- a/content/genesis/10.json
+++ b/content/genesis/10.json
@@ -5,6 +5,8 @@
   "chapter_num": 10,
   "title": "Genesis 10",
   "subtitle": "The Table of Nations",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "babel",
     "text": "See on Timeline — Tower of Babel"

--- a/content/genesis/11.json
+++ b/content/genesis/11.json
@@ -5,6 +5,8 @@
   "chapter_num": 11,
   "title": "Genesis 11",
   "subtitle": "The Tower of Babel; From Shem to Abram",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "babel",
     "text": "See on Timeline — Tower of Babel"

--- a/content/genesis/2.json
+++ b/content/genesis/2.json
@@ -5,6 +5,8 @@
   "chapter_num": 2,
   "title": "Genesis 2",
   "subtitle": "The Garden of Eden and the Making of Woman",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "creation",
     "text": "See on Timeline — Creation"

--- a/content/genesis/3.json
+++ b/content/genesis/3.json
@@ -5,6 +5,8 @@
   "chapter_num": 3,
   "title": "Genesis 3",
   "subtitle": "The Fall: Temptation, Disobedience, and Judgment",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "fall",
     "text": "See on Timeline — Fall"

--- a/content/genesis/4.json
+++ b/content/genesis/4.json
@@ -5,6 +5,8 @@
   "chapter_num": 4,
   "title": "Genesis 4",
   "subtitle": "Cain and Abel: Sin, Murder, and the Diverging Lines",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "cain-abel",
     "text": "See on Timeline — Cain and Abel"

--- a/content/genesis/5.json
+++ b/content/genesis/5.json
@@ -5,6 +5,8 @@
   "chapter_num": 5,
   "title": "Genesis 5",
   "subtitle": "The Genealogy from Adam to Noah",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "enoch-taken",
     "text": "See on Timeline — Enoch Taken"

--- a/content/genesis/6.json
+++ b/content/genesis/6.json
@@ -5,6 +5,8 @@
   "chapter_num": 6,
   "title": "Genesis 6",
   "subtitle": "The Corruption of the Earth; Noah Commissioned",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "flood",
     "text": "See on Timeline — Flood"

--- a/content/genesis/7.json
+++ b/content/genesis/7.json
@@ -5,6 +5,8 @@
   "chapter_num": 7,
   "title": "Genesis 7",
   "subtitle": "The Flood: Waters Cover the Earth",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "flood",
     "text": "See on Timeline — Flood"

--- a/content/genesis/8.json
+++ b/content/genesis/8.json
@@ -5,6 +5,8 @@
   "chapter_num": 8,
   "title": "Genesis 8",
   "subtitle": "The Flood Recedes; Noah's Altar and God's Promise",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "flood",
     "text": "See on Timeline — Noah's Flood"

--- a/content/genesis/9.json
+++ b/content/genesis/9.json
@@ -5,6 +5,8 @@
   "chapter_num": 9,
   "title": "Genesis 9",
   "subtitle": "The Noahic Covenant; the Table of Ham",
+  "chapter_genre_label": "Primeval History",
+  "chapter_genre_guidance": "Cosmic origins as ANE counter-narrative · Universal scope before national focus · Toledot formula introduces each section",
   "timeline_link": {
     "event_id": "noah-covenant",
     "text": "See on Timeline — Rainbow Covenant"


### PR DESCRIPTION
# Per-chapter genre overrides for sub-genre shifts

Closes #1724.

## What this does

Adds two optional fields to the chapter row — `chapter_genre_label` and `chapter_genre_guidance` — that override the book-level `genre_label` / `genre_guidance` when present. The override is **atomic**: both fields populated, or neither. Mixed sources (chapter label + book guidance) are never produced.

This unblocks chapters in books with sharply different sub-genres across chapter ranges. A reader on Daniel 7 now sees "Apocalyptic Vision · Symbolic beasts encode empires · Vision-then-interpretation form · Eschatological hope under foreign rule" instead of the book-overview "Apocalyptic · Court tales (1-6) + apocalyptic visions (7-12)…" that primes the wrong reading frame.

## Scope (this PR)

**Pipeline:**
- `_tools/build_sqlite_schema.py` — two new nullable TEXT columns on `chapters`
- `_tools/build_sqlite_loaders.py` — INSERT extended to bind `data.get('chapter_genre_label')` / `data.get('chapter_genre_guidance')`
- `_tools/schema_validator.py` — XOR check: a chapter with one field must set the other; non-empty-string check when both present

**App:**
- `app/src/utils/genre.ts` — new `resolveGenre(book, chapter)` helper. Single source of truth for the priority chain.
- `app/src/types/content.ts` — `Chapter` interface gains the two optional fields
- `app/src/screens/ChapterScreen.tsx` — replaces inline `??` chain at the `<GenreBanner>` render site with the helper
- `app/src/services/guidedStudy/plan.ts` — three call sites (`buildConceptChips`, `buildGuidedStudyPlan` genre + guidance, legacy `genrePrompt`) routed through `resolveGenre` so chapter overrides flow into Guided Study mode prompts and the genre concept chip too. **This is a deliberate scope expansion from the original card** — extending overrides to Guided Study costs ~3 lines and is the architecturally honest answer; splitting it would just guarantee a follow-up ticket.

**Tests:**
- `app/__tests__/utils/genre.test.ts` — 7 unit tests on the resolver: both-present, book-only, neither, half-state-label-only, half-state-guidance-only, book-half-state, empty-string guard
- `app/src/services/guidedStudy/__tests__/genreOverride.test.ts` — 4 integration tests on `buildGuidedStudyPlan` asserting overrides land in `sceneRows` Genre row + `conceptChips`, with a half-state defensive case

**Content:** 23 chapter overrides (Daniel 1–6 = Court Narrative, Daniel 7–12 = Apocalyptic Vision, Genesis 1–11 = Primeval History). Genesis 12–50 deliberately stays on book-level `Theological Narrative` — demonstrates that override is opt-in per range.

## Verification

- `python3 _tools/schema_validator.py` — no new failures (the 77 pre-existing topic cross-ref failures are unrelated)
- `python3 _tools/build_sqlite.py` — clean build, 102 MB
- `python3 _tools/validate_sqlite.py` — `101 passed, 0 failed, 2 warnings` (ALL CHECKS PASSED). Total chapters: 1,189. Chapters with `chapter_genre_label IS NOT NULL`: 23 (12 Daniel + 11 Genesis 1–11)
- New genre tests: 7/7 + 4/4 passing
- Guided Study regression suite: 55/55 + 20 snapshots, no drift

## Behavior change vs. master (production data)

None. All 66 books in `content/meta/books.json` already have both `genre_label` and `genre_guidance` populated, so the resolver's "both or neither" requirement at book-level matches reality exactly. The substitution of `compact(book.genre_label)` → `resolvedGenre?.label` in `plan.ts` is byte-for-byte identical for all current production data, which the parity snapshot confirms.

## Out of scope (file separately if/when prioritized)

- Mass-authoring overrides for the other ~6 books with strong sub-genre shifts (Exodus, Isaiah, Ezekiel, Zechariah, Proverbs, Matthew). Those are content tickets.
- Banner dismiss-state persistence — separate UX concern.
- A formal genre taxonomy — override labels stay free-form until the override set grows enough to want consistency.
- `useExploreRecommendations` chapter-aware mode — book-aggregate exploration recs are deliberately a different concern.

## Rollout

1. Merge PR
2. CI's `content-pipeline.yml` rebuilds `scripture.db` and uploads to R2
3. `eas update --branch production` from `app/` for JS-only app changes (no native rebuild — no plugins, no native deps changed)
4. New clients re-download `scripture.db` from R2 on next launch via `DbDownloadScreen.tsx`

## Rollback

Pure additive change. Revert this PR, rebuild `scripture.db` (the columns vanish from the schema), re-upload to R2. No data loss, no migration to undo. Old clients on old DB without the columns continue to work — `SELECT *` returns rows without the override fields, the resolver sees `undefined`, falls through to book-level. Graceful degradation in every direction.
