### PR TITLE
content: swap son_of_man art to Doré's Daniel's Vision of the Four Beasts

### DIFF
--- a/_tools/art_sources/_discovered.json
+++ b/_tools/art_sources/_discovered.json
@@ -82,17 +82,6 @@
       "size_bytes": 5621638
     },
     {
-      "r2_filename": "michelangelo-daniel.jpg",
-      "status": "ok",
-      "method": "first_guess",
-      "commons_title": "File:Michelangelo, profeti, Daniel 03.jpg",
-      "source_url": "https://upload.wikimedia.org/wikipedia/commons/1/16/Michelangelo%2C_profeti%2C_Daniel_03.jpg",
-      "width": 626,
-      "height": 1330,
-      "mime": "image/jpeg",
-      "size_bytes": 140744
-    },
-    {
       "r2_filename": "michelangelo-jeremiah.jpg",
       "status": "ok",
       "method": "search",

--- a/_tools/art_sources/michelangelo-daniel.jpg
+++ b/_tools/art_sources/michelangelo-daniel.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4edc2555628866a0bd281336e502a9d0bd7c65a191dd480272acdab18c28507f
-size 140744

--- a/_tools/discover_art_sources.py
+++ b/_tools/discover_art_sources.py
@@ -105,13 +105,13 @@ SUBJECTS = [
         'name_should_include': ['michelangelo', 'sistine'],
     },
     {
-        'r2_filename': 'michelangelo-daniel.jpg',
+        'r2_filename': 'dore-daniel-four-beasts.jpg',
         'first_guesses': [
-            'Michelangelo, profeti, Daniel 03.jpg',
+            "132.Daniel's Vision of the Four Beasts.jpg",
         ],
-        'search': 'Daniel Sistine Chapel Michelangelo prophet',
+        'search': "Daniel's Vision of the Four Beasts Doré",
         'name_must_include': ['daniel'],
-        'name_should_include': ['michelangelo', 'sistine'],
+        'name_should_include': ['four', 'beasts'],
     },
     {
         'r2_filename': 'michelangelo-jeremiah.jpg',

--- a/_tools/fix_missing_art.py
+++ b/_tools/fix_missing_art.py
@@ -141,9 +141,9 @@ TARGETS: list[ArtTarget] = [
         description='Prophecy/suffering_servant — Michelangelo: Prophet Isaiah',
     ),
     ArtTarget(
-        r2_filename='michelangelo-daniel.jpg',
-        source_url='https://upload.wikimedia.org/wikipedia/commons/1/16/Michelangelo%2C_profeti%2C_Daniel_03.jpg',
-        description='Prophecy/son_of_man — Michelangelo: Prophet Daniel',
+        r2_filename='dore-daniel-four-beasts.jpg',
+        source_url='https://upload.wikimedia.org/wikipedia/commons/5/5b/132.Daniel%27s_Vision_of_the_Four_Beasts.jpg',
+        description='Prophecy/son_of_man — Doré: Daniel\'s Vision of the Four Beasts (1866)',
     ),
     ArtTarget(
         r2_filename='michelangelo-jeremiah.jpg',

--- a/content/meta/prophecy-chains.json
+++ b/content/meta/prophecy-chains.json
@@ -639,9 +639,9 @@
     ],
     "images": [
       {
-        "url": "https://contentcompanionstudy.com/art/michelangelo-daniel.jpg",
-        "caption": "Daniel's vision of the Son of Man",
-        "credit": "Michelangelo · Public domain"
+        "url": "https://contentcompanionstudy.com/art/dore-daniel-four-beasts.jpg",
+        "caption": "Daniel's vision of the four beasts and the Ancient of Days",
+        "credit": "Gustave Doré · Public domain"
       }
     ]
   },


### PR DESCRIPTION
# Swap son_of_man prophecy art to Doré's Daniel's Vision of the Four Beasts

Replaces the `michelangelo-daniel.jpg` Sistine Chapel fresco (semi-draped Renaissance prophet) on the **Son of Man Coming with Clouds** prophecy chain with Doré's 1866 *Sainte Bible* engraving of the same scene. Lands in the modest visual lane already established by the Schnorr/Doré/Tissot art on the other 7 prophecy chains.

## Files changed (5, ~30 lines)

- `content/meta/prophecy-chains.json` — `son_of_man` image url, caption, credit
- `_tools/fix_missing_art.py` — `ArtTarget` rotated to `dore-daniel-four-beasts.jpg`
- `_tools/discover_art_sources.py` — `SUBJECTS` entry updated to match
- `_tools/art_sources/_discovered.json` — stale resolved entry removed (surgical, CRLF preserved)
- `_tools/art_sources/michelangelo-daniel.jpg` — deleted (no remaining references)

## Verification

- `python3 _tools/build_sqlite.py` rebuilds clean
- `content_images` row for `('prophecy','son_of_man')` now serves `dore-daniel-four-beasts.jpg`; **0** rows still reference `michelangelo-daniel`
- `python3 _tools/validate_sqlite.py` — `101 passed, 0 failed, 2 warnings` (ALL CHECKS PASSED)
- The bulk-curation entry in `_tools/download_explore_images.py` (line 198) is **deliberately left in place** — that file is dead inventory, not wired to anything that renders. Cleanup is a separate ticket if desired.

## Manual step required (Craig — egress to Wikimedia is blocked from CI sandbox and Claude Code)

After merge, from a machine with R2 creds:

```
python _tools/fix_missing_art.py --populate-sources --only dore-daniel
git add _tools/art_sources/dore-daniel-four-beasts.jpg
git commit -m "art: populate dore-daniel-four-beasts.jpg LFS source" && git push
python _tools/fix_missing_art.py --only dore-daniel
```

Or push the LFS source and trigger the `fix-missing-art.yml` manual-dispatch workflow. The first command seeds `_tools/art_sources/dore-daniel-four-beasts.jpg` from Wikimedia (`upload.wikimedia.org/wikipedia/commons/5/5b/132.Daniel%27s_Vision_of_the_Four_Beasts.jpg`, 2593×2049, ~4.85 MB). The second uploads to R2 under `art/dore-daniel-four-beasts.jpg`.

**Until that step runs, the prophecy chain card will render a placeholder** — the DB row will point at a URL whose bytes don't yet exist on R2. Same failure mode as any of the other Map/Prophecy assets pre-bytes-upload, recoverable by either step above.

## R2 cleanup (deferred)

The old `art/michelangelo-daniel.jpg` object remains on R2 (cached `public, max-age=31536000, immutable`). Harmless to leave — nothing references it. Delete in a follow-up cleanup ticket if storage hygiene matters; otherwise it's costing fractions of a cent.

## Rollback

Revert this PR, rebuild `scripture.db`, re-upload. The `art/michelangelo-daniel.jpg` R2 object is still there, so reverting `prophecy-chains.json` fully restores the prior state without any re-upload needed.
