### PR TITLE
feat(lenses): Phase 0 scaffolding for hermeneutic lenses (#820)

### DIFF
--- a/_tools/DEV_GUIDE.md
+++ b/_tools/DEV_GUIDE.md
@@ -434,10 +434,46 @@ Hard-won lessons from building 66 books. Still relevant for enrichment scripts.
 
 ---
 
-## Quick Reference: What Goes Where
+## 13. Hermeneutic Lenses (Epic #820)
 
-| I need to... | File |
-|--------------|------|
+Lens content is interpretive guidance, not biblical exposition. Different rules apply.
+
+**Directory layout:**
+```
+content/hermeneutic_lenses/
+├── lenses.json              # 8 lens defs: id, name, description, long_description, icon, display_order
+└── chapters/<chapter_id>.json  # one file per chapter that has any lens content
+```
+
+**Per-chapter file shape:**
+```json
+{ "lenses": [
+  { "lens_id": "grammatical",
+    "guidance": "80-280 chars, anchored to a real verse number or proper noun",
+    "panel_filter": ["heb", "hist", "ctx"],   // optional; subset of valid panel keys
+    "panel_order":  ["heb", "ctx", "hist"]    // optional; subset of panel_filter
+  }
+]}
+```
+
+**Coverage strategy: curated sparse.** Only add lenses that genuinely illuminate a chapter. Do not write a "Missional" entry for Leviticus 13 just to fill the grid. Empty `lenses` lists are fine; the in-chapter `LensToggleBar` only renders lenses with content for that chapter.
+
+**Quality bar (every entry, not samples):**
+1. `python3 _tools/schema_validator.py` — schema + panel-key allowlist
+2. `python3 _tools/lens_quality_scorer.py --chapter <id>` — DVCR floor 90
+3. `python3 _tools/accuracy_auditor.py --chapter meta_lens_<id> --tier 2` — verifies the guidance reflects a position the named hermeneutical school actually advocates
+
+**Banned filler patterns** (caught by Relevance scorer): "the lens reveals", "this lens shows", "through this lens", "this passage shows that", "this text teaches that", "in this chapter we see/learn".
+
+**Panel keys** for `panel_filter` / `panel_order`: section panels (`heb`, `cross`, `hist`, `tl`, `places`, `poi`, `ctx`), chapter panels (`lit`, `themes`, `ppl`, `trans`, `src`, `rec`, `hebtext`, `thread`, `tx`, `debate`, `discourse`), and any scholar key from `_tools/config.py:SCHOLAR_REGISTRY`. The validator imports these dynamically — adding a scholar doesn't break the allowlist.
+
+**App consumption:**
+- `LensBrowseScreen` reads `lenses.long_description` directly from DB. No hardcoded copy in the screen.
+- `ChapterScreen` consumes `lensContent.guidance` always; `panel_filter_json` and `panel_order_json` are wired in Phase 1 (sub-issue #820.2).
+- Premium-gated: lens toggle calls `showUpgrade('feature', 'Hermeneutic Lenses')` for free users.
+
+---
+
 | Add a user table/column | `db/userDatabase.ts` (new migration) |
 | Add a content table/column | `_tools/build_sqlite.py` + bump version |
 | Add a new screen | `navigation/types.ts` + stack file + screen file |

--- a/_tools/accuracy_meta_extractors.py
+++ b/_tools/accuracy_meta_extractors.py
@@ -55,6 +55,7 @@ class MetaClaimExtractor:
         claims.extend(self.extract_cross_refs())
         claims.extend(self.extract_extrabiblical())
         claims.extend(self.extract_canon_traditions())
+        claims.extend(self.extract_hermeneutic_lenses())
         return claims
 
     def _load(self, filename: str):
@@ -1149,4 +1150,63 @@ class MetaClaimExtractor:
                         verification_tier=2,
                     ))
 
+        return claims
+
+    # ── Hermeneutic Lenses (Epic #820) ─────────────────────────
+
+    def extract_hermeneutic_lenses(self) -> list[Claim]:
+        """Extract claims from content/hermeneutic_lenses/chapters/*.json.
+
+        Each (chapter, lens) entry produces one Tier-2 claim. The verifier
+        is asked to confirm the guidance reflects a position the named
+        hermeneutical school genuinely advocates — not a fabricated framework.
+
+        claim_type='historical' is the catch-all bucket for general assertions
+        (matches how topics.json descriptions are extracted). Adding a new
+        'hermeneutical' claim_type would require updating SCORING_WEIGHTS
+        in accuracy_config.py, which is out of scope for the extractor.
+        """
+        # Lenses live outside content/meta — walk up to ROOT/content/hermeneutic_lenses.
+        # self.meta_dir is content/meta, so its parent is content/.
+        lens_dir = self.meta_dir.parent / 'hermeneutic_lenses'
+        chapters_dir = lens_dir / 'chapters'
+        if not chapters_dir.is_dir():
+            return []
+
+        # Build lens name lookup so the prompt to the verifier mentions
+        # human-readable lens names (e.g. "Grammatical-Historical"), not IDs.
+        lens_names: dict[str, str] = {}
+        lenses_path = lens_dir / 'lenses.json'
+        if lenses_path.exists():
+            try:
+                for lens in json.load(open(lenses_path, encoding='utf-8')):
+                    lens_names[lens['id']] = lens.get('name', lens['id'])
+            except (json.JSONDecodeError, KeyError, OSError):
+                pass
+
+        claims = []
+        for json_file in sorted(chapters_dir.glob('*.json')):
+            chapter_id = json_file.stem
+            try:
+                data = json.load(open(json_file, encoding='utf-8'))
+            except (json.JSONDecodeError, OSError):
+                continue
+            for j, entry in enumerate(data.get('lenses', []) or []):
+                lens_id = entry.get('lens_id', '')
+                guidance = entry.get('guidance', '')
+                if not lens_id or len(guidance) < 30:
+                    continue
+                lens_name = lens_names.get(lens_id, lens_id)
+                claims.append(Claim(
+                    id=_meta_id('lens', f"{chapter_id}-{lens_id}", j),
+                    chapter_id=f"meta_lens_{chapter_id}",
+                    book_dir='meta',
+                    section_num=None,
+                    panel_type='hermeneutic_lens',
+                    claim_type='historical',
+                    claim_text=f"[{lens_name} lens, {chapter_id}] {guidance}",
+                    source_attribution=lens_name,
+                    verse_ref=None,
+                    verification_tier=2,
+                ))
         return claims

--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -21,6 +21,17 @@ PROOF_TEXT_GUARDS_PATH = META / 'proof-text-guards.json'
 AVAILABLE_TRANSLATIONS = {'kjv', 'asv'}
 BUNDLED_TRANSLATIONS = {'kjv', 'asv'}
 
+# Subdirectories of content/ that are NOT books — must be skipped by every
+# chapter-walk loop. Kept as a single source of truth to prevent the bug
+# where adding a new content directory (e.g. hermeneutic_lenses) silently
+# breaks loaders that don't get the skip-set updated. Mirrors the constant
+# of the same name in schema_validator.py and lens_quality_scorer.py.
+NON_BOOK_DIRS = frozenset({
+    'meta', 'verses', 'interlinear', 'archaeology', 'life_topics',
+    'historical_interpretations', 'grammar', 'map-styles',
+    'hermeneutic_lenses',
+})
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -218,7 +229,7 @@ def populate_chapters(cur):
 
     content_dir = ROOT / 'content'
     for book_dir in sorted(content_dir.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         book_id = book_dir.name
         for json_file in sorted(book_dir.glob('*.json')):
@@ -1338,9 +1349,10 @@ def populate_hermeneutic_lenses(cur):
             assert 'id' in lens and 'name' in lens and 'description' in lens, \
                 f"Lens missing required fields: {lens}"
             cur.execute(
-                'INSERT INTO hermeneutic_lenses (id, name, description, icon, display_order) '
-                'VALUES (?, ?, ?, ?, ?)',
+                'INSERT INTO hermeneutic_lenses (id, name, description, long_description, icon, display_order) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
                 (lens['id'], lens['name'], lens['description'],
+                 lens.get('long_description'),
                  lens.get('icon'), lens.get('display_order', 0))
             )
             lens_count += 1
@@ -1549,7 +1561,7 @@ def populate_content_library(cur):
     count = 0
     content_dir = ROOT / 'content'
     for book_dir in sorted(content_dir.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         book_id = book_dir.name
         info = book_info.get(book_id)

--- a/_tools/build_sqlite_schema.py
+++ b/_tools/build_sqlite_schema.py
@@ -554,6 +554,7 @@ CREATE TABLE IF NOT EXISTS hermeneutic_lenses (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
   description TEXT NOT NULL,
+  long_description TEXT,
   icon TEXT,
   display_order INTEGER NOT NULL
 );

--- a/_tools/lens_quality_scorer.py
+++ b/_tools/lens_quality_scorer.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+lens_quality_scorer.py — Quality scorer for hermeneutic lens guidance entries.
+
+Scores each (chapter, lens) entry 0-100 across four dimensions (25 pts each),
+mirroring the DVCR scheme used by quality_scorer.py:
+
+  1. DENSITY        — Guidance has a concrete chapter anchor (verse number,
+                      named character, named place, or motif keyword). No
+                      generic "this passage shows..." filler.
+  2. VERSE_COVERAGE — Any verse refs cited in guidance fall within the
+                      chapter's actual verse range (no out-of-bounds).
+  3. COMPLETENESS   — At least one rubric token from lens_rubrics.json for
+                      the active lens; soft-scored with partial credit.
+  4. RELEVANCE      — No filler phrases ("the lens reveals", etc.); guidance
+                      doesn't restate the chapter's themes panel verbatim;
+                      no `should_avoid` patterns from the rubric trigger.
+
+CI gate: chapters with any entry below 90 are flagged for fix.
+
+Usage:
+    python3 _tools/lens_quality_scorer.py                    # All chapters
+    python3 _tools/lens_quality_scorer.py --chapter gen1
+    python3 _tools/lens_quality_scorer.py --lens grammatical
+    python3 _tools/lens_quality_scorer.py --worst 20
+    python3 _tools/lens_quality_scorer.py --json             # machine output
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Iterable
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTENT = ROOT / 'content'
+LENS_DIR = CONTENT / 'hermeneutic_lenses'
+LENSES_JSON = LENS_DIR / 'lenses.json'
+CHAPTERS_DIR = LENS_DIR / 'chapters'
+RUBRICS_JSON = Path(__file__).resolve().parent / 'lens_rubrics.json'
+
+# Subdirectories of content/ that are NOT books — keep in sync with the
+# constant of the same name in schema_validator.py.
+NON_BOOK_DIRS = frozenset({
+    'meta', 'verses', 'interlinear', 'archaeology', 'life_topics',
+    'historical_interpretations', 'grammar', 'map-styles',
+    'hermeneutic_lenses',
+})
+
+# Bring panel taxonomy + scholar keys onto the path so we share the
+# panel-key allowlist with the rest of the pipeline. Keeps lens validation
+# in lockstep when scholars are added.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from panel_taxonomy import (  # noqa: E402
+    CORE_SECTION_PANELS,
+    CHAPTER_PANEL_TYPES,
+    load_scholar_keys,
+)
+
+
+# ─── Configuration ──────────────────────────────────────────────────
+
+QUALITY_FLOOR = 90
+
+GUIDANCE_MIN_LEN = 80
+GUIDANCE_MAX_LEN = 280
+
+# Banned filler patterns. Drop the score on Relevance.
+FILLER_PATTERNS = [
+    re.compile(r"\bthe lens reveals\b", re.IGNORECASE),
+    re.compile(r"\bthis lens shows\b", re.IGNORECASE),
+    re.compile(r"\bthrough this lens\b", re.IGNORECASE),
+    re.compile(r"\bthis passage shows that\b", re.IGNORECASE),
+    re.compile(r"\bthis text teaches that\b", re.IGNORECASE),
+    re.compile(r"\bin this chapter we (see|learn)\b", re.IGNORECASE),
+]
+
+VERSE_REF_RE = re.compile(r"\b(?:vv?\.?\s*)?(\d{1,3})(?:[\u2013\u2014:\-](\d{1,3}))?\b")
+PROPER_NOUN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+
+
+# ─── Data Classes ───────────────────────────────────────────────────
+
+@dataclass
+class Finding:
+    severity: str   # info | warn | fail
+    dimension: str
+    message: str
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass
+class EntryScore:
+    chapter_id: str
+    lens_id: str
+    density: int = 0
+    verse_coverage: int = 0
+    completeness: int = 0
+    relevance: int = 0
+    total: int = 0
+    findings: list[Finding] = field(default_factory=list)
+
+    def to_dict(self):
+        d = asdict(self)
+        d['findings'] = [f.to_dict() for f in self.findings]
+        return d
+
+
+# ─── Loaders ────────────────────────────────────────────────────────
+
+def _load_json(path: Path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def load_lens_ids() -> set[str]:
+    if not LENSES_JSON.exists():
+        return set()
+    return {l['id'] for l in _load_json(LENSES_JSON)}
+
+
+def load_rubrics() -> dict:
+    if not RUBRICS_JSON.exists():
+        return {}
+    raw = _load_json(RUBRICS_JSON)
+    raw.pop('_comment', None)
+    return raw
+
+
+def load_chapter_verse_max(chapter_id: str, content_dir: Path = CONTENT) -> int | None:
+    """Find the max verse number for a chapter by scanning its content JSON.
+
+    Returns None if the chapter file can't be found — verse-coverage scoring
+    will then skip the bounds check rather than penalize.
+    """
+    # chapter_id is like 'gen1', 'psa119'; need to find the matching content/{book}/{N}.json.
+    # We don't have a direct mapping from chapter_id to book_dir without books.json,
+    # so try the simplest scan: look for a chapter JSON whose chapter_id field matches.
+    for book_dir in content_dir.iterdir():
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
+            continue
+        for chap_file in book_dir.glob('*.json'):
+            try:
+                data = _load_json(chap_file)
+            except (json.JSONDecodeError, OSError):
+                continue
+            if data.get('chapter_id') == chapter_id:
+                # Collect verse_end across sections
+                max_v = 0
+                for section in data.get('sections', []):
+                    end = section.get('verse_end')
+                    if isinstance(end, int):
+                        max_v = max(max_v, end)
+                return max_v if max_v > 0 else None
+    return None
+
+
+def load_chapter_themes_text(chapter_id: str, content_dir: Path = CONTENT) -> str:
+    """Pull the chapter's themes panel text for plagiarism check."""
+    for book_dir in content_dir.iterdir():
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
+            continue
+        for chap_file in book_dir.glob('*.json'):
+            try:
+                data = _load_json(chap_file)
+            except (json.JSONDecodeError, OSError):
+                continue
+            if data.get('chapter_id') == chapter_id:
+                themes = (data.get('chapter_panels', {}) or {}).get('themes', {})
+                if isinstance(themes, dict):
+                    return ' '.join(str(v) for v in themes.values() if isinstance(v, str))
+                return str(themes) if themes else ''
+    return ''
+
+
+# ─── Scoring Logic ──────────────────────────────────────────────────
+
+def score_density(guidance: str) -> tuple[int, list[Finding]]:
+    """25 pts: concrete chapter anchor (verse number, proper noun, motif word)."""
+    findings = []
+    score = 25
+
+    if len(guidance) < GUIDANCE_MIN_LEN:
+        findings.append(Finding('fail', 'density',
+                                f'guidance too short ({len(guidance)} < {GUIDANCE_MIN_LEN})'))
+        score -= 15
+    elif len(guidance) > GUIDANCE_MAX_LEN:
+        findings.append(Finding('warn', 'density',
+                                f'guidance too long ({len(guidance)} > {GUIDANCE_MAX_LEN})'))
+        score -= 5
+
+    has_verse_ref = bool(VERSE_REF_RE.search(guidance))
+    has_proper_noun = bool(PROPER_NOUN_RE.search(guidance))
+
+    if not (has_verse_ref or has_proper_noun):
+        findings.append(Finding('fail', 'density',
+                                'no concrete anchor: no verse number or proper noun found'))
+        score -= 12
+
+    return max(0, score), findings
+
+
+def score_verse_coverage(guidance: str, max_verse: int | None) -> tuple[int, list[Finding]]:
+    """25 pts: any verse refs in guidance fall within the chapter's verse range."""
+    findings = []
+    if max_verse is None:
+        # Can't verify, give full credit but note it.
+        return 25, [Finding('info', 'verse_coverage', 'chapter verse range unknown; skipped bounds check')]
+
+    score = 25
+    for m in VERSE_REF_RE.finditer(guidance):
+        v_start = int(m.group(1))
+        v_end = int(m.group(2)) if m.group(2) else v_start
+        # Guard: 4-digit numbers etc. won't match (1-3 digits). v_start of 0 is bogus too.
+        if v_start == 0 or v_start > max_verse or v_end > max_verse:
+            findings.append(Finding('fail', 'verse_coverage',
+                                    f'verse ref {v_start}{f"-{v_end}" if v_end != v_start else ""} '
+                                    f'out of range (chapter has {max_verse} verses)'))
+            score -= 10
+    return max(0, score), findings
+
+
+def score_completeness(guidance: str, lens_id: str, rubric: dict) -> tuple[int, list[Finding]]:
+    """25 pts: at least one rubric `must_have_one_of` token present."""
+    findings = []
+    must_have = rubric.get('must_have_one_of', []) if rubric else []
+    if not must_have:
+        return 25, [Finding('info', 'completeness',
+                            f'no rubric tokens for lens "{lens_id}"; full credit')]
+    g_lower = guidance.lower()
+    matched = [t for t in must_have if t.lower() in g_lower]
+    if matched:
+        return 25, []
+    findings.append(Finding('fail', 'completeness',
+                            f'no rubric token from lens "{lens_id}" present in guidance'))
+    return 10, findings
+
+
+def score_relevance(guidance: str, rubric: dict, themes_text: str) -> tuple[int, list[Finding]]:
+    """25 pts: no filler phrases, no `should_avoid` matches, not echoing themes."""
+    findings = []
+    score = 25
+
+    for pat in FILLER_PATTERNS:
+        if pat.search(guidance):
+            findings.append(Finding('fail', 'relevance',
+                                    f'filler phrase matched: /{pat.pattern}/'))
+            score -= 8
+
+    for avoid in (rubric or {}).get('should_avoid', []):
+        if avoid.lower() in guidance.lower():
+            findings.append(Finding('warn', 'relevance',
+                                    f'lens-specific avoid phrase matched: "{avoid}"'))
+            score -= 5
+
+    # Plagiarism check: > 60% of guidance words also appear in the themes text.
+    if themes_text:
+        g_words = set(re.findall(r"\w+", guidance.lower()))
+        t_words = set(re.findall(r"\w+", themes_text.lower()))
+        if g_words:
+            overlap = len(g_words & t_words) / len(g_words)
+            if overlap > 0.6:
+                findings.append(Finding('warn', 'relevance',
+                                        f'guidance shares {overlap*100:.0f}% of words with themes panel; restate'))
+                score -= 7
+
+    return max(0, score), findings
+
+
+def score_panel_keys(entry: dict, all_panel_keys: set[str]) -> list[Finding]:
+    """Schema-style check on panel_filter / panel_order. Doesn't affect score
+    (the schema validator already gate-keeps for invalid keys), but surfaces
+    helpful warnings here too."""
+    findings = []
+    for field_name in ('panel_filter', 'panel_order'):
+        keys = entry.get(field_name)
+        if keys is None:
+            continue
+        if not isinstance(keys, list):
+            findings.append(Finding('fail', 'schema',
+                                    f'{field_name} must be a list'))
+            continue
+        for k in keys:
+            if k not in all_panel_keys:
+                findings.append(Finding('warn', 'schema',
+                                        f'{field_name} key "{k}" not in known panel set'))
+    if 'panel_filter' in entry and 'panel_order' in entry:
+        order_keys = set(entry.get('panel_order') or [])
+        filter_keys = set(entry.get('panel_filter') or [])
+        extra = order_keys - filter_keys
+        if extra:
+            findings.append(Finding('fail', 'schema',
+                                    f'panel_order contains keys not in panel_filter: {sorted(extra)}'))
+    return findings
+
+
+# ─── Entry & Aggregation ────────────────────────────────────────────
+
+def score_entry(chapter_id: str, entry: dict, rubrics: dict,
+                all_panel_keys: set[str]) -> EntryScore:
+    lens_id = entry.get('lens_id', '')
+    guidance = entry.get('guidance', '')
+    rubric = rubrics.get(lens_id, {})
+
+    max_verse = load_chapter_verse_max(chapter_id)
+    themes_text = load_chapter_themes_text(chapter_id)
+
+    score = EntryScore(chapter_id=chapter_id, lens_id=lens_id)
+    score.density, f1 = score_density(guidance)
+    score.verse_coverage, f2 = score_verse_coverage(guidance, max_verse)
+    score.completeness, f3 = score_completeness(guidance, lens_id, rubric)
+    score.relevance, f4 = score_relevance(guidance, rubric, themes_text)
+    score.total = score.density + score.verse_coverage + score.completeness + score.relevance
+    score.findings = f1 + f2 + f3 + f4 + score_panel_keys(entry, all_panel_keys)
+    return score
+
+
+def iter_entries(chapter_filter: str | None = None,
+                 lens_filter: str | None = None) -> Iterable[tuple[str, dict]]:
+    if not CHAPTERS_DIR.is_dir():
+        return
+    for json_file in sorted(CHAPTERS_DIR.glob('*.json')):
+        chapter_id = json_file.stem
+        if chapter_filter and chapter_id != chapter_filter:
+            continue
+        try:
+            data = _load_json(json_file)
+        except json.JSONDecodeError as err:
+            print(f"[ERROR] {json_file.name} invalid JSON: {err}")
+            continue
+        for entry in data.get('lenses', []):
+            if lens_filter and entry.get('lens_id') != lens_filter:
+                continue
+            yield chapter_id, entry
+
+
+# ─── CLI ────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description='Hermeneutic lens quality scorer')
+    parser.add_argument('--chapter', help='Limit to one chapter_id (e.g. gen1)')
+    parser.add_argument('--lens', help='Limit to one lens_id (e.g. grammatical)')
+    parser.add_argument('--worst', type=int, default=0,
+                        help='Show N lowest-scoring entries (default: all <90)')
+    parser.add_argument('--json', dest='as_json', action='store_true',
+                        help='Output JSON to stdout instead of human report')
+    parser.add_argument('--floor', type=int, default=QUALITY_FLOOR,
+                        help=f'Pass/fail floor (default: {QUALITY_FLOOR})')
+    args = parser.parse_args()
+
+    rubrics = load_rubrics()
+    valid_lens_ids = load_lens_ids()
+    scholar_keys = load_scholar_keys(CONTENT)
+    all_panel_keys = CORE_SECTION_PANELS | CHAPTER_PANEL_TYPES | scholar_keys
+
+    scores: list[EntryScore] = []
+    unknown_lens_count = 0
+    for chapter_id, entry in iter_entries(args.chapter, args.lens):
+        if entry.get('lens_id') not in valid_lens_ids:
+            unknown_lens_count += 1
+        scores.append(score_entry(chapter_id, entry, rubrics, all_panel_keys))
+
+    # Summary
+    total_entries = len(scores)
+    passing = sum(1 for s in scores if s.total >= args.floor)
+    failing = total_entries - passing
+    avg = (sum(s.total for s in scores) / total_entries) if total_entries else 0
+
+    if args.as_json:
+        out = {
+            'total': total_entries,
+            'passing': passing,
+            'failing': failing,
+            'avg': round(avg, 2),
+            'floor': args.floor,
+            'unknown_lens_count': unknown_lens_count,
+            'entries': [s.to_dict() for s in scores],
+        }
+        print(json.dumps(out, indent=2))
+        return 0 if failing == 0 else 1
+
+    # Human report
+    print(f"\n{'='*60}")
+    print(f"LENS QUALITY REPORT — {total_entries} entries")
+    print(f"{'='*60}")
+    if total_entries == 0:
+        print("No lens content yet — pipeline ready, awaiting Phase 2+.")
+        return 0
+
+    print(f"Passing (>= {args.floor}): {passing}")
+    print(f"Failing  (<  {args.floor}): {failing}")
+    print(f"Average:           {avg:.1f}/100")
+
+    by_lens = Counter(s.lens_id for s in scores)
+    print("\nBy lens:")
+    for lens_id, n in by_lens.most_common():
+        lens_avg = sum(s.total for s in scores if s.lens_id == lens_id) / n
+        print(f"  {lens_id:<15} {n:>4} entries, avg {lens_avg:.1f}")
+
+    failed_scores = sorted([s for s in scores if s.total < args.floor], key=lambda s: s.total)
+    if args.worst > 0:
+        failed_scores = failed_scores[:args.worst]
+    if failed_scores:
+        print(f"\n--- {len(failed_scores)} entries below floor ---")
+        for s in failed_scores:
+            print(f"\n[{s.total}/100] {s.chapter_id} / {s.lens_id} "
+                  f"(D:{s.density} V:{s.verse_coverage} C:{s.completeness} R:{s.relevance})")
+            for f in s.findings:
+                if f.severity == 'fail':
+                    print(f"  [FAIL] {f.dimension}: {f.message}")
+                elif f.severity == 'warn':
+                    print(f"  [WARN] {f.dimension}: {f.message}")
+
+    if unknown_lens_count:
+        print(f"\n[FAIL] {unknown_lens_count} entries reference unknown lens_id "
+              f"— check {LENSES_JSON.relative_to(ROOT)}")
+        return 1
+
+    return 0 if failing == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/_tools/lens_rubrics.json
+++ b/_tools/lens_rubrics.json
@@ -1,0 +1,79 @@
+{
+  "_comment": "Per-lens rubric tokens for lens_quality_scorer.py. Soft scoring: at least one token from `must_have_one_of` should appear in guidance to score full points on the Completeness dimension. `should_avoid` patterns trigger Relevance penalties. Edit freely; the scorer reloads on every run.",
+  "grammatical": {
+    "must_have_one_of": [
+      "grammar", "syntax", "verb", "noun", "imperative", "participle", "tense",
+      "aspect", "wordplay", "Hebrew", "Greek", "literal", "audience", "original",
+      "context", "background", "first hearers", "ancient", "rhetorical"
+    ],
+    "should_avoid": [
+      "modern application", "applies to us today", "this means for us"
+    ]
+  },
+  "literary": {
+    "must_have_one_of": [
+      "structure", "chiasm", "chiastic", "parallel", "parallelism", "inclusio",
+      "narrative", "poetry", "genre", "form", "repetition", "refrain", "motif",
+      "imagery", "symbol", "rhythm", "framing", "bookend", "envelope"
+    ],
+    "should_avoid": [
+      "the lens reveals", "this lens shows"
+    ]
+  },
+  "typological": {
+    "must_have_one_of": [
+      "type", "antitype", "foreshadow", "shadow", "pattern", "fulfillment",
+      "fulfilled", "anticipates", "prefigures", "points to Christ", "points forward",
+      "echoes", "preview", "model"
+    ],
+    "should_avoid": [
+      "merely historical", "no Christological"
+    ]
+  },
+  "redemptive": {
+    "must_have_one_of": [
+      "redemption", "redemptive", "salvation", "covenant", "promise",
+      "story of God", "story of redemption", "unfolding", "arc", "biblical theology",
+      "creation", "fall", "exodus", "exile", "restoration", "new creation",
+      "kingdom", "plan"
+    ],
+    "should_avoid": []
+  },
+  "christocentric": {
+    "must_have_one_of": [
+      "Christ", "Jesus", "Messiah", "Son of God", "Son of Man", "Lord",
+      "Savior", "fulfilled in Christ", "points to", "anticipates Christ",
+      "gospel", "cross", "resurrection", "incarnation"
+    ],
+    "should_avoid": [
+      "moralism", "merely an example"
+    ]
+  },
+  "canonical": {
+    "must_have_one_of": [
+      "canon", "canonical", "echoes", "echoed", "intertextual", "thread",
+      "throughout Scripture", "across Scripture", "elsewhere", "later",
+      "earlier", "compare", "alludes", "allusion", "Old Testament",
+      "New Testament", "whole Bible"
+    ],
+    "should_avoid": []
+  },
+  "devotional": {
+    "must_have_one_of": [
+      "pray", "prayer", "worship", "trust", "obey", "obedience", "repent",
+      "confess", "hope", "comfort", "heart", "today", "live", "respond",
+      "believe", "faith", "rest in", "draw near"
+    ],
+    "should_avoid": [
+      "merely emotional", "no doctrinal"
+    ]
+  },
+  "mission": {
+    "must_have_one_of": [
+      "mission", "missional", "nations", "witness", "send", "sent",
+      "outward", "the world", "every people", "gospel proclamation",
+      "evangelism", "ends of the earth", "calling", "vocation", "neighbor"
+    ],
+    "should_avoid": []
+  }
+}

--- a/_tools/schema_validator.py
+++ b/_tools/schema_validator.py
@@ -38,6 +38,15 @@ CONTENT = ROOT / 'content'
 META = CONTENT / 'meta'
 sys.path.insert(0, str(ROOT / '_tools'))
 
+# Subdirectories of content/ that are NOT books and must be skipped by every
+# chapter-walk loop. Kept as a single source of truth so adding a new content
+# directory (e.g. hermeneutic_lenses) only requires one edit, not eleven.
+NON_BOOK_DIRS = frozenset({
+    'meta', 'verses', 'interlinear', 'archaeology', 'life_topics',
+    'historical_interpretations', 'grammar', 'map-styles',
+    'hermeneutic_lenses',
+})
+
 passed = 0
 failed = 0
 warnings = 0
@@ -127,6 +136,177 @@ def _validate_meta_faq():
               f'article is {word_count} words; spec says under 500-ish, cap 700')
 
 
+def _validate_hermeneutic_lenses():
+    """Section 21 HERMENEUTIC LENSES (Epic #820) — validates lens definitions
+    and per-chapter guidance entries.
+
+    Required structure:
+        content/hermeneutic_lenses/
+        ├── lenses.json                    # 8 lens definitions
+        └── chapters/
+            └── <chapter_id>.json          # {lenses: [{lens_id, guidance, ...}]}
+
+    Gracefully passes if directory absent (Phase 0 ships the loader before
+    Phase 2+ writes content).
+    """
+    print("\n--- 21. HERMENEUTIC LENSES ---")
+    lens_dir = CONTENT / 'hermeneutic_lenses'
+    if not lens_dir.is_dir():
+        print("  (directory absent; skipping — expected before Phase 0)")
+        return
+
+    # ── lenses.json ──
+    lenses_path = lens_dir / 'lenses.json'
+    check("hermeneutic_lenses/lenses.json present", lenses_path.exists())
+    if not lenses_path.exists():
+        return
+
+    try:
+        lenses = json.loads(lenses_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as err:
+        check(f"lenses.json valid JSON", False, str(err))
+        return
+
+    check("lenses.json is a list", isinstance(lenses, list))
+    if not isinstance(lenses, list):
+        return
+
+    seen_ids: set[str] = set()
+    seen_orders: set[int] = set()
+    id_pattern = re.compile(r"^[a-z][a-z0-9_]*$")
+    for i, lens in enumerate(lenses):
+        ctx = f"lens[{i}]"
+        if not isinstance(lens, dict):
+            check(f"{ctx} is object", False)
+            continue
+        for required in ('id', 'name', 'description', 'display_order'):
+            check(f"{ctx} has '{required}'",
+                  required in lens and lens[required] not in (None, ''),
+                  f"missing or empty {required}")
+        lid = lens.get('id', '')
+        if lid:
+            check(f"{ctx} id '{lid}' format", bool(id_pattern.match(lid)),
+                  "must match ^[a-z][a-z0-9_]*$")
+            check(f"{ctx} id '{lid}' unique", lid not in seen_ids)
+            seen_ids.add(lid)
+        order = lens.get('display_order')
+        if isinstance(order, int):
+            check(f"{ctx} display_order {order} unique",
+                  order not in seen_orders)
+            seen_orders.add(order)
+        # Optional length checks for the description fields.
+        desc = lens.get('description', '')
+        if desc:
+            check(f"{ctx} description length 20-160", 20 <= len(desc) <= 160,
+                  f"got {len(desc)}")
+        long_desc = lens.get('long_description')
+        if long_desc:
+            check(f"{ctx} long_description length 80-500",
+                  80 <= len(long_desc) <= 500, f"got {len(long_desc)}")
+
+    valid_lens_ids = seen_ids
+
+    # ── chapter files ──
+    chapters_dir = lens_dir / 'chapters'
+    if not chapters_dir.is_dir():
+        print("  chapters/ directory absent (expected; Phase 2+ adds content)")
+        return
+
+    # Build the panel-key allowlist using the same source as lens_quality_scorer.
+    try:
+        from panel_taxonomy import (
+            CORE_SECTION_PANELS as _CORE,
+            CHAPTER_PANEL_TYPES as _CHTYPES,
+            load_scholar_keys as _lsk,
+        )
+        all_panel_keys = _CORE | _CHTYPES | _lsk(CONTENT)
+    except ImportError:
+        all_panel_keys = set()
+        warn("panel_taxonomy not importable — skipping panel-key allowlist check")
+
+    # Build the set of valid chapter_ids from books.json + chapter files.
+    valid_chapter_ids: set[str] = set()
+    for book_dir in CONTENT.iterdir():
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
+            continue
+        for chap_file in book_dir.glob('*.json'):
+            try:
+                cid = json.loads(chap_file.read_text(encoding='utf-8')).get('chapter_id')
+                if cid:
+                    valid_chapter_ids.add(cid)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    chapter_files = sorted(chapters_dir.glob('*.json'))
+    print(f"  chapter files: {len(chapter_files)}")
+    total_entries = 0
+    for cf in chapter_files:
+        chapter_id = cf.stem
+        if valid_chapter_ids:
+            check(f"chapters/{cf.name}: chapter_id '{chapter_id}' exists",
+                  chapter_id in valid_chapter_ids)
+        try:
+            data = json.loads(cf.read_text(encoding='utf-8'))
+        except json.JSONDecodeError as err:
+            check(f"chapters/{cf.name}: valid JSON", False, str(err))
+            continue
+        check(f"chapters/{cf.name}: has 'lenses' list",
+              isinstance(data.get('lenses'), list))
+        seen_lens_for_chapter: set[str] = set()
+        for j, entry in enumerate(data.get('lenses', []) or []):
+            ctx = f"chapters/{cf.name}#{j}"
+            if not isinstance(entry, dict):
+                check(f"{ctx} is object", False)
+                continue
+            lens_id = entry.get('lens_id', '')
+            check(f"{ctx} has lens_id", bool(lens_id))
+            if lens_id and valid_lens_ids:
+                check(f"{ctx} lens_id '{lens_id}' is registered",
+                      lens_id in valid_lens_ids)
+            check(f"{ctx} lens_id '{lens_id}' unique within chapter",
+                  lens_id not in seen_lens_for_chapter,
+                  "same lens listed twice for one chapter")
+            seen_lens_for_chapter.add(lens_id)
+
+            guidance = entry.get('guidance', '')
+            check(f"{ctx} has guidance", bool(guidance))
+            if guidance:
+                check(f"{ctx} guidance length 80-280",
+                      80 <= len(guidance) <= 280,
+                      f"got {len(guidance)}")
+
+            for field_name in ('panel_filter', 'panel_order'):
+                fval = entry.get(field_name)
+                if fval is None:
+                    continue
+                check(f"{ctx} {field_name} is list",
+                      isinstance(fval, list))
+                if not isinstance(fval, list):
+                    continue
+                check(f"{ctx} {field_name} non-empty",
+                      len(fval) > 0,
+                      "empty list would hide everything; omit instead")
+                check(f"{ctx} {field_name} values are strings",
+                      all(isinstance(k, str) for k in fval))
+                check(f"{ctx} {field_name} no duplicates",
+                      len(set(fval)) == len(fval))
+                if all_panel_keys:
+                    bad = [k for k in fval if k not in all_panel_keys]
+                    check(f"{ctx} {field_name} keys all valid",
+                          not bad,
+                          f"unknown keys: {bad}")
+
+            if 'panel_filter' in entry and 'panel_order' in entry:
+                f_set = set(entry.get('panel_filter') or [])
+                o_set = set(entry.get('panel_order') or [])
+                extra = o_set - f_set
+                check(f"{ctx} panel_order subset of panel_filter",
+                      not extra,
+                      f"order has keys missing from filter: {sorted(extra)}")
+            total_entries += 1
+    print(f"  total entries: {total_entries}")
+
+
 def main():
     """Run all content validation checks and print a summary.
 
@@ -179,7 +359,7 @@ def main():
     books_found = Counter()
 
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             total_files += 1
@@ -338,7 +518,7 @@ def main():
     valid_css = {'vhl-divine', 'vhl-place', 'vhl-person', 'vhl-time', 'vhl-key'}
     bad_css = set()
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             with open(json_file, encoding='utf-8') as f:
@@ -1084,7 +1264,7 @@ def main():
         tl_checked = 0
         tl_invalid = 0
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+            if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -1213,7 +1393,7 @@ def main():
 
     dup_count = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1250,7 +1430,7 @@ def main():
 
     oob_tips = 0
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1277,7 +1457,7 @@ def main():
     if scopes_path_11.exists():
         scopes_data = json.loads(scopes_path_11.read_text(encoding='utf-8'))
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+            if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -1308,7 +1488,7 @@ def main():
 
     word_glosses = defaultdict(set)
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1354,7 +1534,7 @@ def main():
         }
         unregistered = []
         for book_dir in sorted(CONTENT.iterdir()):
-            if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+            if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
                 continue
             for json_file in sorted(book_dir.glob('*.json')):
                 try:
@@ -1391,7 +1571,7 @@ def main():
     st2_panel_count = 0
 
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1450,7 +1630,7 @@ def main():
 
     overlaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1480,7 +1660,7 @@ def main():
 
     gaps = []
     for book_dir in sorted(CONTENT.iterdir()):
-        if not book_dir.is_dir() or book_dir.name in ('meta', 'verses', 'interlinear', 'archaeology', 'life_topics', 'historical_interpretations', 'grammar', 'map-styles'):
+        if not book_dir.is_dir() or book_dir.name in NON_BOOK_DIRS:
             continue
         for json_file in sorted(book_dir.glob('*.json')):
             try:
@@ -1980,6 +2160,9 @@ def main():
 
     # ── 20. META-FAQ (Amicus Card #1449) ──
     _validate_meta_faq()
+
+    # ── 21. HERMENEUTIC LENSES (Epic #820) ──
+    _validate_hermeneutic_lenses()
 
     # ── Summary ──
     print(f"\n{'='*60}")

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "f48d278bb65b8590",
-  "build_time": "2026-04-27T17:34:11.255976Z"
+  "content_hash": "b618a61a6912da58",
+  "build_time": "2026-04-27T22:06:12.641169Z"
 }

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -105,7 +105,7 @@ const SECTIONS: FeatureSection[] = [
   {
     id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
     features: [
-      { title: 'Hermeneutic Lenses', subtitle: 'Feminist, liberation, canonical & more',                color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
+      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
       { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
       { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
       { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional

--- a/app/src/screens/LensBrowseScreen.tsx
+++ b/app/src/screens/LensBrowseScreen.tsx
@@ -6,6 +6,10 @@
  * Card #1359 (UI polish phase 2): migrated from a raw ScrollView to the
  * BrowseScreenTemplate (FlatList). The intro paragraph is rendered via the
  * template's flatListProps.ListHeaderComponent so it scrolls with the list.
+ *
+ * Epic #820 / Phase 0: removed the hardcoded LENS_DETAILS map. Long-form
+ * lens descriptions now live in the `hermeneutic_lenses.long_description`
+ * column and are sourced from content/hermeneutic_lenses/lenses.json.
  */
 
 import React, { useCallback } from 'react';
@@ -21,19 +25,6 @@ import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 /** Sample chapter to navigate to for trying a lens. */
 const SAMPLE_CHAPTER = { bookId: 'genesis', chapterNum: 1 };
-
-const LENS_DETAILS: Record<string, string> = {
-  'historical-grammatical':
-    'Seeks the original meaning of the text by analyzing grammar, syntax, and historical context. This approach asks: "What did the author intend, and what did the original audience understand?"',
-  'redemptive-historical':
-    'Reads every passage within the grand story of God\'s plan of redemption unfolding across Scripture. Traces how each text contributes to the arc from creation to new creation.',
-  literary:
-    'Focuses on the literary artistry of the text: genre, structure, chiasm, parallelism, and narrative technique. Asks how the form of the text shapes its meaning.',
-  typological:
-    'Identifies patterns (types) in earlier Scripture that find their fulfillment (antitypes) in later revelation. Traces shadows and substance across the testaments.',
-  canonical:
-    'Reads each passage in light of the whole canon of Scripture, asking how earlier and later books illuminate and qualify one another. Emphasizes intertextual connections.',
-};
 
 function LensBrowseScreen() {
   const { base } = useTheme();
@@ -62,11 +53,11 @@ function LensBrowseScreen() {
       <Text style={[styles.cardDescription, { color: base.textDim }]}>
         {lens.description}
       </Text>
-      {LENS_DETAILS[lens.id] && (
+      {lens.long_description ? (
         <Text style={[styles.cardDetail, { color: base.textMuted }]}>
-          {LENS_DETAILS[lens.id]}
+          {lens.long_description}
         </Text>
-      )}
+      ) : null}
       <TouchableOpacity
         onPress={() => handleTry(lens.id)}
         activeOpacity={0.7}

--- a/app/src/types/explore.ts
+++ b/app/src/types/explore.ts
@@ -281,6 +281,8 @@ export interface HermeneuticLens {
   id: string;
   name: string;
   description: string;
+  /** Long-form explanation rendered on the lens browse card detail. */
+  long_description?: string;
   icon?: string;
   display_order: number;
 }

--- a/content/hermeneutic_lenses/lenses.json
+++ b/content/hermeneutic_lenses/lenses.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "grammatical",
+    "name": "Grammatical-Historical",
+    "description": "What did the text mean to its original audience?",
+    "long_description": "Seeks the original meaning of Scripture by analyzing grammar, syntax, genre, and historical setting. The interpreter asks what the human author intended to communicate and what the first hearers would have understood. Foundational for evangelical and reformed exegesis.",
+    "icon": "\ud83d\udcdc",
+    "display_order": 1
+  },
+  {
+    "id": "literary",
+    "name": "Literary",
+    "description": "How does the form of the text shape its meaning?",
+    "long_description": "Attends to the artistry of Scripture: genre, structure, chiasm, parallelism, repetition, and narrative technique. Asks how the way a passage is written carries meaning, treating the Bible as inspired literature whose form sermons its content.",
+    "icon": "\u270d\ufe0f",
+    "display_order": 2
+  },
+  {
+    "id": "typological",
+    "name": "Typological",
+    "description": "How do earlier persons, events, and institutions foreshadow Christ?",
+    "long_description": "Identifies divinely intended patterns (types) in earlier Scripture that find their fulfillment (antitypes) in later revelation, supremely in Christ. Reads Old Testament priests, sacrifices, and exodus events as shadows whose substance arrives in the New.",
+    "icon": "\ud83d\udd2e",
+    "display_order": 3
+  },
+  {
+    "id": "redemptive",
+    "name": "Redemptive-Historical",
+    "description": "Where does this passage fit in the unfolding story of redemption?",
+    "long_description": "Reads every passage within the grand narrative arc of God's redeeming work, from creation through fall, Israel, Christ, church, and new creation. Asks how each text contributes to the single story Scripture is telling.",
+    "icon": "\ud83d\udd04",
+    "display_order": 4
+  },
+  {
+    "id": "christocentric",
+    "name": "Christ-Centered",
+    "description": "How does this text point to, prepare for, or reflect Jesus?",
+    "long_description": "Reads all Scripture as testimony about Christ, following Jesus' own claim that the Law, Prophets, and Writings spoke of him (Luke 24:27, 44). Looks for direct prophecy, typological foreshadowing, and the contrast between human failure and Christ's faithfulness.",
+    "icon": "\u271d\ufe0f",
+    "display_order": 5
+  },
+  {
+    "id": "canonical",
+    "name": "Canonical",
+    "description": "How does this passage relate to the whole Bible's witness?",
+    "long_description": "Reads each text in light of the entire canon of Scripture, asking how earlier and later books illuminate and qualify one another. Emphasizes intertextual connections, theme threads, and the unity of the biblical witness across both testaments.",
+    "icon": "\ud83d\udcd6",
+    "display_order": 6
+  },
+  {
+    "id": "devotional",
+    "name": "Devotional",
+    "description": "What is God saying to me through this text today?",
+    "long_description": "Approaches Scripture as God's living word for the reader's formation and worship. Asks what is to be believed, repented of, hoped for, or obeyed. Application-focused but anchored in what the text actually says, not what we wish it said.",
+    "icon": "\ud83d\ude4f",
+    "display_order": 7
+  },
+  {
+    "id": "mission",
+    "name": "Missional",
+    "description": "How does this passage shape the church's witness to the world?",
+    "long_description": "Reads Scripture as the story of God gathering a people for himself from every nation, tribe, and tongue. Asks how each passage contributes to the church's vocation of bearing witness to Christ in word and deed across cultures.",
+    "icon": "\ud83c\udf0f",
+    "display_order": 8
+  }
+]


### PR DESCRIPTION
## Phase 0 of Epic #820 — Hermeneutic Lenses

Lays the full content + tooling + UI runway for the Hermeneutic Lenses feature. Ships safe with **zero chapter content** — the loader, scorer, and validator all gracefully no-op until Phase 2+ adds chapter entries. The Explore menu's "Hermeneutic Lenses" card was already wired and visible to users; it now resolves to a working browse screen sourced from the DB instead of the previous hardcoded mismatch.

## What's in this PR

### Schema
- `hermeneutic_lenses` gains a `long_description TEXT` column for browse-card detail copy. `chapter_lens_content` unchanged.

### Content
- `content/hermeneutic_lenses/lenses.json` — 8 canonical lens definitions: `grammatical`, `literary`, `typological`, `redemptive`, `christocentric`, `canonical`, `devotional`, `mission`. Foundation-first display order.

### Tooling
- `_tools/lens_quality_scorer.py` — DVCR-style scorer (Density, Verse Coverage, Completeness, Relevance — 25 pts each, 90-point floor) for chapter lens entries.
- `_tools/lens_rubrics.json` — per-lens "must have one of" + "should avoid" tokens, soft-scored against guidance text. Edit freely; the scorer reloads on every run.
- `_tools/schema_validator.py` — new **Section 21** validates `lenses.json` shape, chapter file structure, panel-key allowlist, and the `panel_order ⊆ panel_filter` constraint.
- `_tools/accuracy_meta_extractors.py` — `extract_hermeneutic_lenses()` produces Tier-2 claims so the accuracy auditor can verify guidance reflects real positions of the named hermeneutical school.

### Drive-by refactor (prevents the exact bug class that bit during this work)
All chapter-walk loops now share a single `NON_BOOK_DIRS` frozenset constant:

| File | Inline skip-sets before | After |
|---|---|---|
| `schema_validator.py` | 11 copies | 1 constant |
| `build_sqlite_loaders.py` | 2 copies | 1 constant |
| `lens_quality_scorer.py` | 2 copies | 1 constant |

Adding a new content directory (e.g. `hermeneutic_lenses` itself) now requires **one edit, not fifteen**. `hermeneutic_lenses` added to the canonical skip list.

### App
- `HermeneuticLens` type gains `long_description?: string`.
- `LensBrowseScreen` drops its hardcoded `LENS_DETAILS` map (5 entries, all using stale lens IDs that no longer match the data layer). Long copy now sourced from the DB column.
- `ExploreMenuScreen` subtitle: `"Feminist, liberation, canonical & more"` → `"Read Scripture through 8 interpretive frameworks"`. The old copy named lenses we don't ship.

### Docs
- `_tools/DEV_GUIDE.md` Section 13 documents the lens content directory layout, per-chapter file shape, curated-sparse coverage policy, banned filler patterns, and the three-step quality gate (schema → DVCR → accuracy).

## Verified locally

```
$ python3 _tools/schema_validator.py
RESULTS: 138040 passed, 0 failed, 19 warnings
[OK] ALL CONTENT CHECKS PASSED

$ python3 _tools/build_sqlite.py
[OK] hermeneutic_lenses: 8 lenses, 0 contents

$ python3 _tools/validate_sqlite.py
RESULTS: 101 passed, 0 failed, 2 warnings
[OK] ALL CHECKS PASSED

$ python3 _tools/lens_quality_scorer.py
LENS QUALITY REPORT — 0 entries
No lens content yet — pipeline ready, awaiting Phase 2+.

$ grep -rn LENS_DETAILS app/src/
app/src/screens/LensBrowseScreen.tsx:10: * Epic #820 / Phase 0: removed the hardcoded LENS_DETAILS map. (...)
# Only the docstring reference noting the removal remains.
```

## Out of scope (tracked as sibling sub-issues)

- **#820.2** — `ChapterScreen` consumption of `panel_filter_json` / `panel_order_json` (Phase 1, parallel-safe with this PR)
- **#820.3** — Genesis pilot batch (Phase 2 gate, ~50 chapters)
- **#820.4–820.11** — Genre rollout batches (Pentateuch, Historical, Wisdom, Major/Minor Prophets, Gospels, Acts+Epistles, Revelation)

## Rollback plan

Pure additive change to schema + tooling + content. Revert is a clean `git revert` — nothing depends on the new column or new directory yet. Existing lens UI (browse screen, in-chapter toggle) currently displays nothing because there's no chapter content; behavior was the same before this PR. The only user-visible change is the corrected Explore menu subtitle.

Closes scaffolding portion of #820. Sub-issues #820.2 through #820.11 will track the remaining phases.
