### PR TITLE
feat(lenses): wire panel_filter / panel_order in ChapterScreen (#1780)

### DIFF
--- a/app/__tests__/unit/lensPanelFilter.test.ts
+++ b/app/__tests__/unit/lensPanelFilter.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for lensPanelFilter — pure functions for filtering and reordering
+ * panel keys per active hermeneutic lens (Epic #820, #1780).
+ *
+ * Behaviour decisions documented in the source file are pinned here so a
+ * future refactor can't quietly change them. Watch out for the empty-filter
+ * case in particular — that one's deliberate.
+ */
+
+import {
+  parseLensJson,
+  filterPanelKeys,
+  orderPanelKeys,
+  applyLensToKeys,
+} from '@/utils/lensPanelFilter';
+
+describe('lensPanelFilter', () => {
+  // Silence the warn() calls during the malformed-JSON branch tests so the
+  // jest output stays clean. Restore after each test to avoid leak between
+  // suites.
+  let warnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('parseLensJson', () => {
+    it('returns undefined for null/undefined/empty', () => {
+      expect(parseLensJson(undefined)).toBeUndefined();
+      expect(parseLensJson(null)).toBeUndefined();
+      expect(parseLensJson('')).toBeUndefined();
+    });
+
+    it('parses a valid string array', () => {
+      expect(parseLensJson('["heb","cross"]')).toEqual(['heb', 'cross']);
+    });
+
+    it('parses an empty array (caller decides what to do with it)', () => {
+      expect(parseLensJson('[]')).toEqual([]);
+    });
+
+    it('returns undefined and logs on malformed JSON', () => {
+      expect(parseLensJson('not json')).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('returns undefined when JSON parses to a non-array', () => {
+      expect(parseLensJson('{"foo":"bar"}')).toBeUndefined();
+      expect(parseLensJson('"single string"')).toBeUndefined();
+      expect(parseLensJson('42')).toBeUndefined();
+    });
+
+    it('drops non-string entries and warns', () => {
+      expect(parseLensJson('["heb",1,"cross",null]')).toEqual(['heb', 'cross']);
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('filterPanelKeys', () => {
+    const keys = ['heb', 'cross', 'hist', 'ctx'];
+
+    it('returns keys unchanged when filter is undefined', () => {
+      expect(filterPanelKeys(keys, undefined)).toBe(keys);
+    });
+
+    it('returns keys unchanged when filter is empty (avoids hiding everything)', () => {
+      expect(filterPanelKeys(keys, [])).toBe(keys);
+    });
+
+    it('keeps only keys present in the filter', () => {
+      expect(filterPanelKeys(keys, ['heb', 'ctx'])).toEqual(['heb', 'ctx']);
+    });
+
+    it('preserves the original order of kept keys, not the filter order', () => {
+      // `keys` is [heb, cross, hist, ctx]; filter requests [ctx, heb] — but
+      // filterPanelKeys preserves original order. orderPanelKeys is what
+      // does reordering.
+      expect(filterPanelKeys(keys, ['ctx', 'heb'])).toEqual(['heb', 'ctx']);
+    });
+
+    it('silently drops filter entries not present in keys', () => {
+      expect(filterPanelKeys(keys, ['heb', 'nonexistent'])).toEqual(['heb']);
+    });
+
+    it('returns empty array when filter has no overlap with keys', () => {
+      expect(filterPanelKeys(keys, ['nope'])).toEqual([]);
+    });
+
+    it('does not mutate the input keys array', () => {
+      const input = [...keys];
+      filterPanelKeys(input, ['heb']);
+      expect(input).toEqual(keys);
+    });
+  });
+
+  describe('orderPanelKeys', () => {
+    const keys = ['heb', 'cross', 'hist', 'ctx'];
+
+    it('returns keys unchanged when order is undefined', () => {
+      expect(orderPanelKeys(keys, undefined)).toBe(keys);
+    });
+
+    it('returns keys unchanged when order is empty', () => {
+      expect(orderPanelKeys(keys, [])).toBe(keys);
+    });
+
+    it('reorders keys to match the order array', () => {
+      expect(orderPanelKeys(keys, ['ctx', 'heb', 'cross', 'hist'])).toEqual([
+        'ctx',
+        'heb',
+        'cross',
+        'hist',
+      ]);
+    });
+
+    it('appends keys not in the order array, preserving their original relative order', () => {
+      // order specifies heb first; cross/hist/ctx should follow in original order.
+      expect(orderPanelKeys(keys, ['heb'])).toEqual(['heb', 'cross', 'hist', 'ctx']);
+    });
+
+    it('silently drops order entries not present in keys', () => {
+      expect(orderPanelKeys(keys, ['heb', 'nonexistent', 'cross'])).toEqual([
+        'heb',
+        'cross',
+        'hist',
+        'ctx',
+      ]);
+    });
+
+    it('handles partial overlap: ordered keys first, unordered keys appended', () => {
+      // order specifies [ctx, heb]; hist and cross weren't mentioned — append
+      // those after, in their original relative order from `keys`.
+      expect(orderPanelKeys(keys, ['ctx', 'heb'])).toEqual([
+        'ctx',
+        'heb',
+        'cross',
+        'hist',
+      ]);
+    });
+
+    it('deduplicates the order array (first occurrence wins)', () => {
+      // Defensive: an order with duplicates shouldn't reorder twice.
+      expect(orderPanelKeys(['heb', 'cross'], ['heb', 'heb', 'cross'])).toEqual([
+        'heb',
+        'cross',
+      ]);
+    });
+
+    it('does not mutate the input keys array', () => {
+      const input = [...keys];
+      orderPanelKeys(input, ['ctx']);
+      expect(input).toEqual(keys);
+    });
+  });
+
+  describe('applyLensToKeys', () => {
+    const keys = ['heb', 'cross', 'hist', 'ctx', 'lit'];
+
+    it('applies filter then order in one call', () => {
+      // Filter to {heb, lit, ctx}, then order [lit, ctx, heb].
+      expect(applyLensToKeys(keys, ['heb', 'lit', 'ctx'], ['lit', 'ctx', 'heb'])).toEqual([
+        'lit',
+        'ctx',
+        'heb',
+      ]);
+    });
+
+    it('returns keys unchanged when both filter and order are undefined', () => {
+      expect(applyLensToKeys(keys)).toEqual(keys);
+    });
+
+    it('with only filter: filter applied, original order kept', () => {
+      expect(applyLensToKeys(keys, ['ctx', 'heb'])).toEqual(['heb', 'ctx']);
+    });
+
+    it('with only order: full key set, reordered', () => {
+      expect(applyLensToKeys(keys, undefined, ['lit'])).toEqual([
+        'lit',
+        'heb',
+        'cross',
+        'hist',
+        'ctx',
+      ]);
+    });
+
+    it('order keys outside of filter are silently dropped', () => {
+      // hist isn't in the filter, so even though order mentions it, it's gone.
+      expect(applyLensToKeys(keys, ['heb', 'cross'], ['cross', 'hist', 'heb'])).toEqual([
+        'cross',
+        'heb',
+      ]);
+    });
+  });
+
+  describe('end-to-end through parse', () => {
+    it('parses panel_filter_json + panel_order_json strings and applies them', () => {
+      const filterJson = '["heb","cross","ctx"]';
+      const orderJson = '["ctx","heb","cross"]';
+      const filter = parseLensJson(filterJson);
+      const order = parseLensJson(orderJson);
+      expect(applyLensToKeys(['heb', 'cross', 'hist', 'ctx'], filter, order)).toEqual([
+        'ctx',
+        'heb',
+        'cross',
+      ]);
+    });
+
+    it('falls back to no transformation when both JSON strings are malformed', () => {
+      const keys = ['heb', 'cross', 'hist'];
+      const filter = parseLensJson('not json');
+      const order = parseLensJson('also not json');
+      expect(applyLensToKeys(keys, filter, order)).toEqual(keys);
+    });
+  });
+});

--- a/app/__tests__/unit/lensPanelFilter.test.ts
+++ b/app/__tests__/unit/lensPanelFilter.test.ts
@@ -14,16 +14,27 @@ import {
   applyLensToKeys,
 } from '@/utils/lensPanelFilter';
 
+// Mock the logger module per project convention (see e.g.
+// useAmicusChipContext.test.tsx). Spying on console.warn doesn't work
+// reliably in CI because the project's jest setup may silence or replace
+// the global console.
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// Pull the mocked logger so individual tests can assert on its calls.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { logger: mockLogger } = require('@/utils/logger') as {
+  logger: { info: jest.Mock; warn: jest.Mock; error: jest.Mock };
+};
+
 describe('lensPanelFilter', () => {
-  // Silence the warn() calls during the malformed-JSON branch tests so the
-  // jest output stays clean. Restore after each test to avoid leak between
-  // suites.
-  let warnSpy: jest.SpyInstance;
   beforeEach(() => {
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-  });
-  afterEach(() => {
-    warnSpy.mockRestore();
+    jest.clearAllMocks();
   });
 
   describe('parseLensJson', () => {
@@ -43,7 +54,7 @@ describe('lensPanelFilter', () => {
 
     it('returns undefined and logs on malformed JSON', () => {
       expect(parseLensJson('not json')).toBeUndefined();
-      expect(warnSpy).toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalled();
     });
 
     it('returns undefined when JSON parses to a non-array', () => {
@@ -54,7 +65,7 @@ describe('lensPanelFilter', () => {
 
     it('drops non-string entries and warns', () => {
       expect(parseLensJson('["heb",1,"cross",null]')).toEqual(['heb', 'cross']);
-      expect(warnSpy).toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalled();
     });
   });
 

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -47,6 +47,7 @@ import { TTSControls } from '../components/TTSControls';
 import { useBookmarkedVerses } from '../hooks/useBookmarkedVerses';
 import { useAvailableLenses, useChapterLensContent } from '../hooks/useHermeneuticLens';
 import { LensToggleBar } from '../components/LensToggleBar';
+import { parseLensJson, applyLensToKeys } from '../utils/lensPanelFilter';
 import { TRANSLATION_MAP } from '../db/translationRegistry';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { usePremium } from '../hooks/usePremium';
@@ -162,9 +163,57 @@ function ChapterScreen() {
     chapterNum,
   );
 
+  // ── Hermeneutic lens data (Epic #820) ──
+  // Fetched here (before useChapterPanels) so the filter/reorder transformations
+  // can apply to the section + chapter panels that downstream consumers see.
+  const { data: availableLenses } = useAvailableLenses(chapter?.id);
+  const { data: lensContent } = useChapterLensContent(chapter?.id, activeLens);
+
+  const lensPanelFilter = useMemo(
+    () => parseLensJson(lensContent?.panel_filter_json),
+    [lensContent?.panel_filter_json],
+  );
+  const lensPanelOrder = useMemo(
+    () => parseLensJson(lensContent?.panel_order_json),
+    [lensContent?.panel_order_json],
+  );
+  const lensIsActive =
+    activeLens !== null && (lensPanelFilter !== undefined || lensPanelOrder !== undefined);
+
+  // Section panels: filter+reorder per the active lens. When no lens is active
+  // (or the active lens has neither filter nor order), `sections` passes through
+  // unchanged via referential equality so memoised consumers don't invalidate.
+  const lensFilteredSections = useMemo(() => {
+    if (!lensIsActive) return sections;
+    return sections.map((section) => {
+      const keys = section.panels.map((p) => p.panel_type);
+      const transformedKeys = applyLensToKeys(keys, lensPanelFilter, lensPanelOrder);
+      // Map the transformed key list back to panel objects, dropping any whose
+      // panel_type is no longer present.
+      const byType = new Map<string, typeof section.panels[number]>();
+      for (const p of section.panels) byType.set(p.panel_type, p);
+      const transformedPanels = transformedKeys
+        .map((k) => byType.get(k))
+        .filter((p): p is typeof section.panels[number] => p !== undefined);
+      return { ...section, panels: transformedPanels };
+    });
+  }, [sections, lensIsActive, lensPanelFilter, lensPanelOrder]);
+
+  // Chapter panels: same treatment, single flat list rather than per-section.
+  const lensFilteredChapterPanels = useMemo(() => {
+    if (!lensIsActive) return chapterPanels;
+    const keys = chapterPanels.map((p) => p.panel_type);
+    const transformedKeys = applyLensToKeys(keys, lensPanelFilter, lensPanelOrder);
+    const byType = new Map<string, typeof chapterPanels[number]>();
+    for (const p of chapterPanels) byType.set(p.panel_type, p);
+    return transformedKeys
+      .map((k) => byType.get(k))
+      .filter((p): p is typeof chapterPanels[number] => p !== undefined);
+  }, [chapterPanels, lensIsActive, lensPanelFilter, lensPanelOrder]);
+
   const panels = useChapterPanels({
     chapterId: chapter?.id,
-    sections,
+    sections: lensFilteredSections,
     isPremium,
     bookId,
     chapterNum,
@@ -174,17 +223,18 @@ function ChapterScreen() {
   });
 
   // ── Remaining screen-level logic ──
-  const { data: availableLenses } = useAvailableLenses(chapter?.id);
-  const { data: lensContent } = useChapterLensContent(chapter?.id, activeLens);
   const redLetterVerses = useRedLetter(bookId, chapterNum);
   const notedVerses = useNotedVerses(bookId, chapterNum);
   const { bookmarked, toggleBookmark } = useBookmarkedVerses(bookId, chapterNum);
   const proofTextGuard = useProofTextGuard(bookId, chapterNum, initialVerseNum);
   const guidedStudyState = useGuidedStudyChapterState(chapter?.id);
-  const allSectionPanels = useMemo(() => sections.flatMap((section) => section.panels), [sections]);
+  const allSectionPanels = useMemo(
+    () => lensFilteredSections.flatMap((section) => section.panels),
+    [lensFilteredSections],
+  );
   const studyEstimate = useMemo(
-    () => getStudyDepthEstimate(verses, allSectionPanels, chapterPanels),
-    [verses, allSectionPanels, chapterPanels],
+    () => getStudyDepthEstimate(verses, allSectionPanels, lensFilteredChapterPanels),
+    [verses, allSectionPanels, lensFilteredChapterPanels],
   );
 
   const handleInterlinearPress = useCallback(
@@ -533,8 +583,8 @@ function ChapterScreen() {
           display={{ tier: chapterMode }}
         >
           <ChapterVerseList
-            sections={sections}
-            chapterPanels={chapterPanels}
+            sections={lensFilteredSections}
+            chapterPanels={lensFilteredChapterPanels}
             prayerPrompt={chapter?.prayer_prompt}
             chapterMeta={
               chapter

--- a/app/src/utils/lensPanelFilter.ts
+++ b/app/src/utils/lensPanelFilter.ts
@@ -1,0 +1,102 @@
+/**
+ * utils/lensPanelFilter.ts — Filter and reorder panel keys per active lens.
+ *
+ * Epic #820 / Phase 1 (#1780). Lenses can carry two optional JSON-serialised
+ * string arrays in `chapter_lens_content`:
+ *   - `panel_filter_json` — render only these panel keys
+ *   - `panel_order_json`  — render in this order
+ *
+ * These pure functions parse and apply both transformations. They handle:
+ *   - missing or undefined JSON  → no transformation
+ *   - malformed JSON             → log + fall back to no transformation
+ *   - empty arrays               → treat as "no filter" (avoids hiding everything)
+ *   - keys not present in panels → silently dropped from order
+ *   - panels not in the order    → appended after ordered keys (preserve relative order)
+ *
+ * The filter/order operate on panel _keys_ (e.g. "heb", "cross", "sarna"),
+ * not on the rendering of individual panel content. Wider scoping (e.g.
+ * within-section reordering of panel content blocks) is out of scope.
+ */
+import { logger } from './logger';
+
+/**
+ * Parse a panel-filter or panel-order JSON string into a string array.
+ *
+ * Returns `undefined` when the input is missing, malformed, or not an
+ * array of strings — callers treat that as "no transformation".
+ */
+export function parseLensJson(json?: string | null): string[] | undefined {
+  if (!json) return undefined;
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (!Array.isArray(parsed)) {
+      logger.warn('lensPanelFilter', 'parsed value is not an array', { json });
+      return undefined;
+    }
+    const strings = parsed.filter((k): k is string => typeof k === 'string');
+    if (strings.length !== parsed.length) {
+      logger.warn('lensPanelFilter', 'dropped non-string entries', {
+        original: parsed.length,
+        kept: strings.length,
+      });
+    }
+    return strings;
+  } catch (err) {
+    logger.warn('lensPanelFilter', 'invalid JSON', { json, err: String(err) });
+    return undefined;
+  }
+}
+
+/**
+ * Filter a list of panel keys to those present in `filter`.
+ *
+ * - When `filter` is undefined: return `keys` unchanged.
+ * - When `filter` is empty: return `keys` unchanged. An empty filter would
+ *   render zero panels, which is almost certainly an authoring bug rather
+ *   than intent. The schema validator rejects empty `panel_filter` arrays
+ *   at content time; this is the runtime safety net.
+ */
+export function filterPanelKeys(keys: string[], filter?: string[]): string[] {
+  if (!filter || filter.length === 0) return keys;
+  const allowed = new Set(filter);
+  return keys.filter((k) => allowed.has(k));
+}
+
+/**
+ * Reorder a list of panel keys to follow `order`.
+ *
+ * - Keys present in `order` come first, in the order specified.
+ * - Keys not present in `order` come after, preserving their original
+ *   relative order from `keys`.
+ * - Keys in `order` but not in `keys` are silently dropped — content
+ *   authors may include `panel_order` entries optimistically.
+ * - When `order` is undefined or empty: return `keys` unchanged.
+ */
+export function orderPanelKeys(keys: string[], order?: string[]): string[] {
+  if (!order || order.length === 0) return keys;
+  const orderIndex = new Map<string, number>();
+  order.forEach((k, i) => {
+    if (!orderIndex.has(k)) orderIndex.set(k, i);
+  });
+
+  const ordered: string[] = [];
+  const unordered: string[] = [];
+  for (const k of keys) {
+    if (orderIndex.has(k)) ordered.push(k);
+    else unordered.push(k);
+  }
+  ordered.sort((a, b) => (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0));
+  return [...ordered, ...unordered];
+}
+
+/**
+ * Convenience: apply both filter and order in one pass.
+ * Filter first (drop hidden keys), then order (rearrange remaining).
+ */
+export function applyLensToKeys(
+  keys: string[],
+  filter?: string[],
+  order?: string[],
+): string[] {
+  return orderPanelKeys(filterPanelKeys(keys, filter), order);
+}


### PR DESCRIPTION
## Phase 1 of Epic #820 — wire panel_filter / panel_order in ChapterScreen

Closes #1780.

With Phase 0 (PR #1779) the schema, content directory, and loader for `chapter_lens_content.panel_filter_json` / `panel_order_json` shipped — but `ChapterScreen.tsx` consumed only `lensContent.guidance`, leaving the filter/order JSON columns dead. This PR makes them actually do something.

End user impact: when a chapter has lens content with a `panel_filter` or `panel_order`, activating that lens now hides non-listed panels and reorders the matching ones. The "Default" toggle restores the full view.

## Utility (new)

`app/src/utils/lensPanelFilter.ts` — four pure functions:

| Function | Behaviour |
|---|---|
| `parseLensJson(json)` | `JSON.parse` with `logger.warn` on failure; returns `undefined` for missing / malformed / non-array / non-string-array inputs |
| `filterPanelKeys(keys, filter)` | Empty filter is treated as **no filter** (avoids rendering zero panels from an authoring bug). Original key order preserved. |
| `orderPanelKeys(keys, order)` | Keys in `order` come first; keys not in `order` appended in original relative order; missing-from-actual-keys entries silently dropped |
| `applyLensToKeys(keys, filter, order)` | Convenience: filter then order in one pass |

## Tests (new)

`app/__tests__/unit/lensPanelFilter.test.ts` — **28 cases** covering:

- `parseLensJson`: undefined/null/empty → `undefined`; valid array → strings; empty array; malformed JSON → `undefined` + warn; non-array JSON → `undefined`; non-string entries dropped + warn
- `filterPanelKeys`: undefined filter; empty filter (deliberate no-op); kept-keys preserve original order; missing-from-keys filter entries dropped; no-overlap → `[]`; input not mutated
- `orderPanelKeys`: undefined/empty order; full reorder; partial order with appended unordered keys; missing-from-keys order entries dropped; duplicate order entries deduped; input not mutated
- `applyLensToKeys`: filter+order combined; only filter; only order; order keys outside filter dropped
- End-to-end: parsed JSON strings → applied; both malformed → keys unchanged

## Wiring in ChapterScreen

The lens-data hooks (`useAvailableLenses`, `useChapterLensContent`) were previously fetched **after** `useChapterPanels`. Moved them earlier so derived filtered sections / chapterPanels can flow into the panel hook.

- `lensPanelFilter` / `lensPanelOrder` — `useMemo`s wrapping `parseLensJson`
- `lensIsActive` — true when a lens is selected AND has filter or order data
- `lensFilteredSections` — `useMemo`. When inactive, returns `sections` by reference (memoised consumers don't invalidate). When active, each section gets a copy with its `panels[]` filtered + reordered by `panel_type`.
- `lensFilteredChapterPanels` — same treatment for the flat chapter-panels list

Downstream changes:
- `useChapterPanels({ sections: lensFilteredSections, ... })` — depth-tracking and panel-open handlers see the lens view
- `ChapterVerseList` receives both filtered versions
- `studyEstimate` uses the filtered panels so the chapter's depth estimate reflects the lens-trimmed view

## What's NOT changed

- `useChapterTTS` still receives the raw `sections` array — TTS reads verse text, not panels, so the lens filter has no relevance there.
- The destructured `sections` and `chapterPanels` from `useChapterData` remain raw. They're the source of truth; lens filtering is a presentation transform only.

## Behaviour decisions (pinned in tests)

- Empty `filter` array → treat as "no filter". An empty array would render zero panels, which is almost certainly an authoring bug rather than intent. The schema validator already rejects empty `panel_filter` arrays at content time; this is the runtime safety net.
- Order keys not present in panels → silently dropped, no crash
- Panels not present in `order` → appended after ordered keys, preserving original relative order
- Bad JSON in either column → `logger.warn` once, fallback to no transformation

## Out of scope

- Reordering panels within a section's individual content blocks (we operate at the `panel_type` key level only)
- New lens content (#1781 Genesis pilot delivers that)
- Animations on lens toggle (panels still appear/reorder instantly; if jank shows up in #1781 smoke testing we'll add `LayoutAnimation` in a follow-up)

## Rollback plan

Pure additive refactor. The behaviour when no lens is active is byte-identical to master (verified by referential equality in the `useMemo` short-circuits). `git revert` is clean — nothing depends on these new helpers yet outside of the screen itself.

## Note on bookkeeping

This issue was briefly closed on a false premise (I claimed PR #1779 contained this work; it didn't — see correction comment on #1780). Reopened, repeated, and shipping properly here.
