### PR TITLE
feat(lenses): Genesis 1 proof-of-concept (#820, #1781)

### DIFF
--- a/_tools/lens_quality_scorer.py
+++ b/_tools/lens_quality_scorer.py
@@ -82,7 +82,14 @@ FILLER_PATTERNS = [
     re.compile(r"\bin this chapter we (see|learn)\b", re.IGNORECASE),
 ]
 
-VERSE_REF_RE = re.compile(r"\b(?:vv?\.?\s*)?(\d{1,3})(?:[\u2013\u2014:\-](\d{1,3}))?\b")
+# In-chapter verse ref: requires explicit `v` or `vv` prefix to disambiguate
+# from cross-book citations like "Psalm 33:6" or "Heb 4:9-11" where the digits
+# after the colon are NOT verses of the current chapter. Bare-number refs
+# elsewhere in the guidance are not validated for chapter-bounds.
+VERSE_REF_RE = re.compile(r"\bvv?\.?\s*(\d{1,3})(?:[\u2013\u2014\-](\d{1,3}))?\b")
+# Loose density-anchor pattern: catches verse refs in any form for the
+# Density check ('does this guidance reference a verse at all?').
+ANY_VERSE_PATTERN = re.compile(r"\b(?:vv?\.?\s*)?(\d{1,3})(?:[\u2013\u2014:\-](\d{1,3}))?\b")
 PROPER_NOUN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
 
 
@@ -197,7 +204,7 @@ def score_density(guidance: str) -> tuple[int, list[Finding]]:
                                 f'guidance too long ({len(guidance)} > {GUIDANCE_MAX_LEN})'))
         score -= 5
 
-    has_verse_ref = bool(VERSE_REF_RE.search(guidance))
+    has_verse_ref = bool(ANY_VERSE_PATTERN.search(guidance))
     has_proper_noun = bool(PROPER_NOUN_RE.search(guidance))
 
     if not (has_verse_ref or has_proper_noun):

--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "b618a61a6912da58",
-  "build_time": "2026-04-27T22:06:12.641169Z"
+  "content_hash": "a10143c724c62134",
+  "build_time": "2026-04-28T11:07:02.180167Z"
 }

--- a/content/hermeneutic_lenses/chapters/gen1.json
+++ b/content/hermeneutic_lenses/chapters/gen1.json
@@ -1,0 +1,40 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "The sevenfold formula 'and there was evening, and there was morning' (vv 5, 8, 13, 19, 23, 31) marks each day; 'God said' opens each act of creation; 'it was good' closes each (climaxing in 'very good', v 31). The Hebrew bara (create) bookends the chapter at v 1 and v 27.",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter", "net"],
+      "panel_order": ["heb", "alter", "sarna", "net", "ctx", "hist"]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "Days 1-3 form three realms (light/dark, sky/sea, land); Days 4-6 fill them in matching order (luminaries, fish/birds, animals/humans). The forming-filling pattern is structural, not chronological narration — the chapter sermons that creation is an ordered cosmos, not chaos.",
+      "panel_filter": ["lit", "themes", "heb", "alter"],
+      "panel_order": ["lit", "alter", "heb", "themes"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The Spirit hovering over the waters (v 2) prefigures the Spirit's work in new creation (2 Cor 5:17). The seventh-day rest (Gen 2:1-3) becomes the type for the Sabbath rest awaiting God's people (Heb 4:9-11). Light's separation from darkness foreshadows Revelation 21.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Creation's good order (vv 1-31) sets the baseline that the fall will mar and that redemption will restore. The image-of-God commission to rule (vv 26-28) defines the human vocation that Israel, then Christ as the true image (Col 1:15), recovers and fulfils.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "John 1:1-3 reads Genesis 1 through the eternal Word, who is Christ: 'in the beginning was the Word, through him all things were made.' Colossians 1:16 makes the agency explicit. The divine speech summoning light in v 3 is the same Word who later becomes flesh (John 1:14).",
+      "panel_filter": ["cross", "thread", "calvin", "mac", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "mac", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Creation by speech echoes through Psalm 33:6, John 1:3, Hebrews 11:3, and 2 Peter 3:5. 'Image of God' (vv 26-27) is taken up at 1 Cor 11:7 and Col 3:10 for renewed humanity. Revelation 21-22 closes the canon by recapitulating Genesis 1-2 in a glorified key.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}


### PR DESCRIPTION
## Genesis 1 — proof-of-concept for Epic #820 / #1781

Single-chapter slice of the Genesis pilot. Ships **6 lens entries for Genesis 1** to validate the entire Phase 0 + Phase 1 + quality-gate pipeline against real content before scaling.

The remaining 49 Genesis chapters stay under #1781 — this PR is the smoke test that proves the pipeline works end-to-end. The regex bug it caught (see below) is exactly the kind of thing a single-chapter PoC is supposed to surface.

## Coverage decisions

Curated sparse: **6 of 8 lenses applied**. Skipped:

- **devotional** — Genesis 1 is theological foundation; devotional response is more naturally drawn from later texts. Forcing it here would invite filler.
- **mission** — the missional thread of Scripture is rooted in Genesis 12 (Abrahamic call), not Genesis 1. The accuracy auditor would flag a missional Genesis-1 entry as fabrication.

The 6 included:

| Lens | What it surfaces |
|---|---|
| `grammatical` | Sevenfold formula, opening/closing markers, `bara` bookending vv 1 and 27 |
| `literary` | Forming/filling structure across days 1-3 paired with 4-6 |
| `typological` | Spirit hovering, seventh-day rest, light/dark separation |
| `redemptive` | Image-of-God commission grounds the whole arc to Christ |
| `christocentric` | John 1:1-3, Col 1:16, divine speech as the same Word |
| `canonical` | Creation-by-speech echoes; Rev 21-22 recapitulation |

Each entry has a `panel_filter` and `panel_order` selected to surface the existing chapter panels that *that lens* most illuminates, in the order that best supports the reading.

## Quality gate results (local)

```
$ python3 _tools/schema_validator.py
RESULTS: 138138 passed, 0 failed, 19 warnings

$ python3 _tools/build_sqlite.py
[OK] hermeneutic_lenses: 8 lenses, 6 contents

$ python3 _tools/validate_sqlite.py
RESULTS: 101 passed, 0 failed, 2 warnings

$ python3 _tools/lens_quality_scorer.py --chapter gen1
LENS QUALITY REPORT — 6 entries
Passing (>= 90): 6
Failing  (<  90): 0
Average:           100.0/100
```

All entries 257–274 chars (within the 80–280 schema range). All score 25/25 on every DVCR dimension.

## Tier-2 accuracy audit

`accuracy_meta_extractors.extract_hermeneutic_lenses()` produces 6 claims from this content (one per lens entry), ready for `accuracy_auditor.py --tier 2` to verify in CI. I can't run the tier-2 audit locally (no API key in the dev container — that's CI's job).

If any claim fails the tier-2 verifier, the auditor will flag it as a position the named hermeneutical school doesn't actually advocate, and the entry needs revision before merge.

The exegesis I think is most likely to draw an audit flag (transparency note): the `typological` claim that **light/dark separation foreshadows Revelation 21** is defensible (Beale, *The Temple and the Church's Mission*; many patristic readings) but it's the closest to a stretch in this batch. The other two anchors in that entry — Spirit hovering → new creation, seventh-day rest → Hebrews 4 — are rock-solid. If the audit pushes back on the Rev 21 anchor, I'll trim it.

## Scorer fix included

`lens_quality_scorer.py` had a regex bug that this content surfaced: `VERSE_REF_RE` was matching numbers after a colon, so `Psalm 33:6` got parsed as a verse reference and flagged 33-6 as out-of-range for Genesis 1 (which has 31 verses).

Fixed by tightening `VERSE_REF_RE` to require an explicit `v` / `vv` prefix for in-chapter validation, and adding a separate looser `ANY_VERSE_PATTERN` for the Density "has any verse anchor?" check. Verified across 10 representative cases:

| Input | Should match? | Did match? |
|---|---|---|
| `v 5` | yes | ✓ |
| `vv 5-7` | yes | ✓ |
| `v. 31` | yes | ✓ |
| `(vv 26-28)` | yes | ✓ |
| `Psalm 33:6` | no | ✓ |
| `Heb 4:9-11` | no | ✓ |
| `Genesis 1:3` | no | ✓ |
| `Col 1:15` | no | ✓ |
| `verses 26 and 27` | no | ✓ (no v/vv prefix) |
| `vv. 5, 8, 13` | yes (first match) | ✓ |

This regex fix is part of the same PR because the lens content immediately depends on it — no point shipping content that would fail the scorer for the wrong reason.

## What this PR does NOT do

- The remaining 49 Genesis chapters (still tracked under #1781)
- The 8 genre batches (#1782 through #1789) — they were always going to wait for #1781 to ship clean
- Any tier-2 audit results (CI runs them)

## Rollback plan

Pure additive content + one-line scorer regex tightening. `git revert` is clean — nothing references the new content row except the app's lens-toggle UI, which currently shows a guidance string and (per #1790) optionally filters/reorders panels. Reverting just makes Genesis 1's lens toggle show no guidance, same as the rest of the corpus.

Refs #820, #1781.
