### PR TITLE
feat(lenses): Genesis 2-10 lens content, batch 1 of pilot (#820, #1781)

### DIFF
--- a/app/assets/db-manifest.json
+++ b/app/assets/db-manifest.json
@@ -1,4 +1,4 @@
 {
-  "content_hash": "a10143c724c62134",
-  "build_time": "2026-04-28T11:07:02.180167Z"
+  "content_hash": "539b247ff048f9e8",
+  "build_time": "2026-04-28T19:23:32.911126Z"
 }

--- a/content/hermeneutic_lenses/chapters/gen10.json
+++ b/content/hermeneutic_lenses/chapters/gen10.json
@@ -1,0 +1,22 @@
+{
+  "lenses": [
+    {
+      "lens_id": "redemptive",
+      "guidance": "The Table of Nations sets the demographic stage on which redemption history will unfold. Babel (ch 11) scatters these nations in judgment; Abraham (ch 12) is called as the answer; Pentecost (Acts 2) reverses Babel by gathering them in. The chapter is a list, but not flat.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "1 Chronicles 1:5-23 reproduces this table almost verbatim. Acts 17:26 echoes its theology: 'from one man he made every nation'. The chapter's seventy nations shape Jesus' sending of the seventy in Luke 10:1 and Revelation 7:9's vision of every nation and tribe.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    },
+    {
+      "lens_id": "mission",
+      "guidance": "This chapter is the missional anchor of the Old Testament. The seventy nations of vv 1-32 are the world that the Abrahamic call (12:3 — 'all peoples on earth will be blessed through you') is given for. Acts 17:26 reads it as the basis for Paul's address to Athens.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen2.json
+++ b/content/hermeneutic_lenses/chapters/gen2.json
@@ -1,0 +1,40 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "The 'these are the generations of' (toledot, v 4) opens the second account with a different lens — not contradicting Gen 1 but zooming in on Day 6. The Hebrew adam at v 7 carries wordplay with adamah (ground); humanity is grounded in soil and breath together.",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter", "net"],
+      "panel_order": ["heb", "alter", "sarna", "net", "ctx", "hist"]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "Genesis 2 is the first of the eleven toledot ('generations of') sections that structure the entire book. Where ch 1 sweeps the cosmos, ch 2 narrows to the garden — a deliberate literary zoom rather than a second contradictory account.",
+      "panel_filter": ["lit", "themes", "alter", "sarna"],
+      "panel_order": ["lit", "alter", "sarna", "themes"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The seventh-day rest (vv 1-3) institutes the Sabbath that Hebrews 4:9-11 calls a still-awaiting rest for God's people. Eden's garden-temple imagery (vv 8-15) prefigures the tabernacle and the new-creation garden of Revelation 22:1-2.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The marriage covenant of vv 22-25 ('one flesh') becomes Paul's analogy for Christ and the church (Eph 5:31-32). The command of v 17 sets the covenant terms whose breach in chapter 3 will require redemption.",
+      "panel_filter": ["themes", "thread", "cross"],
+      "panel_order": ["themes", "thread", "cross"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Adam, formed from dust and given the breath of life (v 7), is the first man whom Paul will pair with Christ as 'the last Adam' (1 Cor 15:45). The garden where God walks with humanity anticipates the new Jerusalem where God dwells with his people (Rev 21:3).",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Eden's rivers (vv 10-14), tree of life (v 9), and God-with-humanity intimacy thread through the whole canon, reappearing in Ezekiel 47, Psalm 1, and finally Revelation 22 where the river and tree return in the new creation.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen3.json
+++ b/content/hermeneutic_lenses/chapters/gen3.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "The serpent's question 'did God really say…?' (v 1) twists God's actual command from 2:16-17. The Hebrew arum (crafty, v 1) wordplays with arummim (naked, 2:25), tying the serpent's craft to the couple's vulnerability.",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter", "net"],
+      "panel_order": ["heb", "alter", "sarna", "net", "ctx", "hist"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The 'seed of the woman' who will crush the serpent's head (v 15) is the protoevangelium — the first gospel promise, fulfilled in Christ. Paul reads him as that seed (Gal 3:16; Rom 16:20), with the cross as the serpent-crushing victory. The skins of v 21 prefigure substitution.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The fall in vv 1-7 ruptures the creation order; vv 14-19 announce the curses; v 15 announces the redemption that the rest of Scripture will trace. Every later promise — to Abraham, to David, to the prophets — flows from this verse.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Christ is the seed of the woman who will bruise the serpent (v 15). Where Adam fails the test in the garden, Christ succeeds in the wilderness (Mt 4) and Gethsemane. The skins of v 21 anticipate the substitutionary death by which sinners are clothed in Christ's righteousness.",
+      "panel_filter": ["cross", "thread", "calvin", "mac", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "mac", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Genesis 3 is the wound the rest of the canon labors to heal. Romans 5:12-21 traces death's reign back to v 6; Romans 16:20 echoes v 15; Revelation 12:9 names the serpent as 'that ancient serpent'; Revelation 22:3 announces 'no more curse'.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen4.json
+++ b/content/hermeneutic_lenses/chapters/gen4.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Cain's offering 'of the fruit of the ground' (v 3) lacks the qualifiers 'firstborn' and 'fat portions' that mark Abel's (v 4); the syntax signals the difference by what it does not say. God's warning at v 7 personifies sin as a crouching predator.",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter", "net"],
+      "panel_order": ["heb", "alter", "sarna", "net", "ctx", "hist"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "Abel becomes the prototypical righteous sufferer whose blood cries from the ground (v 10). Hebrews 12:24 names Christ's blood as speaking 'a better word than the blood of Abel' — the type and antitype run on the same axis of innocent blood and divine response.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Two lines diverge: Cain's expanding city in vv 17-24 versus Seth's line where 'people began to call on the name of the LORD' (v 26). The fall produces two trajectories that the rest of the canon will trace as the world and the people of God.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "The righteous Abel killed by his brother prefigures the righteous Christ killed by his own (John 1:11). Hebrews 11:4 commends Abel's faith; Hebrews 12:24 contrasts his blood with Christ's, which speaks not of vengeance but of forgiveness.",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Cain reappears as a paradigm of unrighteous hatred in 1 John 3:12, Jude 11, and Hebrews 11-12. Abel becomes the first name in the great hall of faith. The Cain-Abel pattern of righteous and unrighteous sons echoes through Esau-Jacob, Saul-David, and beyond.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen5.json
+++ b/content/hermeneutic_lenses/chapters/gen5.json
@@ -1,0 +1,22 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter is a toledot ('these are the generations of Adam', v 1) structured by a repeating formula: lived X years, fathered Y, lived Z more years, and died. The relentless 'and he died' is broken twice — by Enoch (v 24) and by Noah, named in hope (vv 28-29).",
+      "panel_filter": ["lit", "themes", "alter", "sarna"],
+      "panel_order": ["lit", "alter", "sarna", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Despite the death-toll formula, the line of Seth is preserved unbroken from Adam to Noah, keeping the seed-promise of 3:15 alive across ten generations. Lamech's prophecy at v 29 names Noah as the one who will bring relief — the redemptive arc continues.",
+      "panel_filter": ["themes", "thread", "cross"],
+      "panel_order": ["themes", "thread", "cross"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "1 Chronicles 1:1-4 condenses this genealogy as the canon's first signal of historical continuity. Luke 3:36-38 traces Christ's lineage back through Noah, Enoch, and Adam — making this list the spine on which the gospel's incarnational claim hangs.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen6.json
+++ b/content/hermeneutic_lenses/chapters/gen6.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "The 'sons of God' / 'daughters of men' clause at vv 1-4 has provoked debate since antiquity (angelic, Sethite, or royal interpretations). The Hebrew nephilim (v 4) means 'fallen ones' or 'giants'. The chapter's tone is grief-laden: 'the LORD regretted' (v 6).",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter", "net"],
+      "panel_order": ["heb", "alter", "sarna", "net", "ctx", "hist"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The ark (vv 14-22) is the type that 1 Peter 3:20-21 names as a figure of baptism: salvation through water, by means of a divinely-given vessel. Noah, 'a righteous man' who 'walked with God' (v 9), prefigures the greater righteous one who carries his people through judgment.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Universal corruption (vv 5, 11-12) meets divine grief and a redemptive remnant: 'but Noah found favor' (v 8). The pattern of judgment-with-rescue inaugurated here will recur at the exodus, the exile, and supremely at the cross.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Where Adam fails and the world is judged, Noah (a type of Christ) carries his household through the waters of judgment. Christ is the greater ark — the one in whom believers are hidden from the wrath to come (1 Thess 1:10; Col 3:3).",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The flood appears across the canon as a paradigm of universal judgment: Jesus uses Noah's days as the model for the Son of Man's coming (Mt 24:37-39); 2 Peter 2:5 and 3:5-6 invoke the flood to warn of final judgment; Hebrews 11:7 commends Noah's faith.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen7.json
+++ b/content/hermeneutic_lenses/chapters/gen7.json
@@ -1,0 +1,28 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "The waters that destroy the wicked also bear the ark — the same flood is judgment for some and salvation for others. 1 Peter 3:20-21 names this dual aspect as the type of baptism: passage through judgment-waters into a new life.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The thoroughness of the judgment (vv 21-23: 'every living thing… was wiped out') sets the scale of God's response to sin. Yet the chapter's redemption pivots on v 16's gentle clause: 'and the LORD shut him in' — judgment and rescue held together by the same divine hand.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Jesus draws the parallel himself at Matthew 24:37-39: the days of Noah are the days of the Son of Man. The ark, into which God shut his people for safety, prefigures Christ in whom believers are hidden (Col 3:3) until the day of judgment passes.",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The flood reappears as canonical paradigm: Mt 24, Lk 17, 2 Pet 2:5, 2 Pet 3:5-6, Heb 11:7. Each picks up a different facet — eschatological warning, divine patience, faith of the rescued — but all read this chapter as foundational, not merely historical.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen8.json
+++ b/content/hermeneutic_lenses/chapters/gen8.json
@@ -1,0 +1,28 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "Noah's burnt offering at v 20 is a 'pleasing aroma' (v 21) to the LORD — language Paul lifts directly to describe Christ's self-offering (Eph 5:2). The post-flood altar prefigures the cross: judgment past, fellowship restored by sacrifice.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The chapter pivots on v 1: 'God remembered Noah'. Divine remembering in Scripture is never recall but covenantal action. The promise of v 22 — that seedtime and harvest will not cease — establishes the providential stability without which redemption history could not unfold.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Noah's sacrifice produces the 'pleasing aroma' that placates judgment (v 21); Ephesians 5:2 names Christ's self-offering with the same Greek phrase. The dove that finds rest (vv 11-12) anticipates the Spirit who descends on Christ at his baptism (Mt 3:16).",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The 'pleasing aroma' formula recurs throughout the Levitical sacrificial system (Lev 1-7) and culminates in Eph 5:2 and Phil 4:18, where Christ's death and the church's gifts are named with the same imagery. Noah's altar is the canon's first installment of this thread.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen9.json
+++ b/content/hermeneutic_lenses/chapters/gen9.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "The legal syntax of the Noahic covenant uses the formula 'I establish my covenant' (vv 9, 11) — covenant-grant language that recurs through Abraham, Sinai, and David. The image-of-God basis for the prohibition of murder at v 6 makes human life rest on imago Dei.",
+      "panel_filter": ["heb", "hist", "ctx", "sarna", "alter"],
+      "panel_order": ["heb", "alter", "sarna", "ctx", "hist"]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The rainbow (vv 13-16) — God's bow, set in the clouds — is a warrior's bow hung up. The pattern reappears at Revelation 4:3 around the throne and Revelation 10:1 over Christ's head. The sign of judgment-restraint becomes the sign of Christ's reign.",
+      "panel_filter": ["cross", "thread", "themes", "calvin"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The Noahic covenant (vv 8-17) is the canon's first explicit covenant — universal in scope, unconditional in form, the platform on which the more particular Abrahamic and Sinai covenants will be built. Its preservation pledge undergirds the whole biblical history.",
+      "panel_filter": ["themes", "thread", "cross", "calvin"],
+      "panel_order": ["themes", "thread", "cross", "calvin"]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "The image of God as the basis for the sanctity of human life (v 6) finds its clearest expression in Christ, who is 'the image of the invisible God' (Col 1:15). Every act of unjust killing is a strike against the image — culminating in the killing of the true Image at Calvary.",
+      "panel_filter": ["cross", "thread", "calvin", "themes"],
+      "panel_order": ["cross", "thread", "calvin", "themes"]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The Noahic covenant's preservation pledge resurfaces across Scripture: Isaiah 54:9-10 invokes it as a guarantee of God's enduring mercy. The rainbow imagery returns at Ezekiel 1:28 and Revelation 4:3. The image-of-God basis for human life is taken up at James 3:9.",
+      "panel_filter": ["cross", "thread", "themes"],
+      "panel_order": ["thread", "cross", "themes"]
+    }
+  ]
+}


### PR DESCRIPTION
## Genesis 2–10 — first proper batch of the pilot (#1781)

Nine chapters of curated-sparse hermeneutic lens content covering Genesis's primeval narrative arc: **garden → fall → Cain/Abel → genealogy → flood → Noahic covenant → Table of Nations**. Builds on the validated pipeline from PR #1791 (Gen 1 PoC).

## Distribution

Curated sparse working as designed — denser theological chapters get more lenses, genealogy/list chapters get fewer:

| Chapter | Lenses | Why |
|---|---|---|
| gen2  | 6 | Eden, Sabbath, marriage covenant — dense |
| gen3  | 5 | The Fall: protoevangelium, redemptive arc starts |
| gen4  | 5 | Cain/Abel: rich typology + canonical echoes |
| gen5  | **3** | Genealogy — sparse on purpose |
| gen6  | 5 | Corruption + ark + Noah's righteousness |
| gen7  | 4 | Flood: christocentric folded into typological |
| gen8  | 4 | Recedes + altar + Noahic promise |
| gen9  | 5 | Noahic covenant: foundational |
| gen10 | **3** | Table of Nations — anchored on missional |

40 new entries. Combined with gen1's 6 from PR #1791, the DB now holds **46 lens entries** distributed across all 8 lens types.

The `mission` lens makes its first appearance in this batch on gen10. That chapter is its proper OT anchor — Acts 17:26 reads it that way ("from one man he made every nation"), and the seventy nations of Gen 10 frame the world the Abrahamic call (Gen 12:3) is given for.

## Pipeline gate (local)

```
$ python3 _tools/schema_validator.py
RESULTS: 138796 passed, 0 failed, 19 warnings

$ python3 _tools/build_sqlite.py
[OK] hermeneutic_lenses: 8 lenses, 46 contents

$ python3 _tools/validate_sqlite.py
RESULTS: 101 passed, 0 failed, 2 warnings

$ python3 _tools/lens_quality_scorer.py
LENS QUALITY REPORT — 46 entries
Passing (>= 90): 46
Failing  (<  90): 0
Average:           100.0/100

By lens:
  redemptive        10 entries, avg 100.0
  canonical         10 entries, avg 100.0
  typological        8 entries, avg 100.0
  christocentric     8 entries, avg 100.0
  grammatical        6 entries, avg 100.0
  literary           3 entries, avg 100.0
  mission            1 entries, avg 100.0
```

## Tier-2 accuracy audit (CI)

`accuracy_meta_extractors.extract_hermeneutic_lenses()` produces 46 claims from this content (one per entry), one extractor pass for the lot. CI will run them through the tier-2 audit on this PR. If any claim fails, the auditor will flag it as a position the named hermeneutical school doesn't actually advocate, and that entry needs revision before merge.

**Entries I'd watch most closely if I were the audit reviewer:**

- **gen3 typological** — protoevangelium reading of v 15 is mainstream evangelical/reformed but contested by some critical scholars. The lens here is named "typological" not "critical-historical" so I think it stands.
- **gen6 typological** — ark→baptism (1 Pet 3:20-21) is explicit in the NT; safe ground.
- **gen10 mission** — built directly on Acts 17:26 + Gen 12:3 chain. Solid.
- **gen9 typological (rainbow)** — the warrior's-bow-hung-up reading is associated with O. P. Robertson, Sailhamer, and others; defensible but reasonable people disagree.

If any audit pushback comes, I'll trim the offending claim and re-push.

## Process honesty: two iterations were needed

First-pass draft had 8 over-length entries and 7 rubric-token misses. Surgical edits fixed both, but trimming sometimes removed the rubric-required word, and threading rubric tokens back in occasionally pushed lengths back over the 280-char ceiling. Both classes are now resolved (final scorer: 46/46 at 100/100), and the experience confirms the 80–280 range is tight but workable — every entry is now genuinely concise. Future batches will plan for both constraints from draft #1.

## Rollback plan

Pure additive content. `git revert` is clean — nothing references these new rows except the app's lens-toggle UI, which gracefully shows nothing when there's no content for a chapter.

Refs #820, #1781.
