### PR TITLE
feat(lenses): Genesis 41-50 lens content, batch 5 of pilot — closes Genesis (#820, #1781)

### DIFF
--- a/content/hermeneutic_lenses/chapters/gen41.json
+++ b/content/hermeneutic_lenses/chapters/gen41.json
@@ -1,0 +1,84 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Pharaoh renames Joseph 'Zaphenath-paneah' (v 45), an Egyptian title traditionally rendered 'revealer of secrets' or 'the god speaks and he lives'. The Hebrew narrator preserves the alien name: even imperial speech serves the covenant story.",
+      "panel_filter": [
+        "heb",
+        "hist",
+        "sarna",
+        "alter",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "sarna",
+        "alter",
+        "hist"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "Joseph rises from prison to Pharaoh's right hand in a single day (vv 14, 40-43) — the pattern of righteous suffering followed by exaltation. Philippians 2:8-9 names this shape in Christ; the chapter is its prophetic preview.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The interpreter Pharaoh's magicians could not produce (v 8) is found in a Hebrew prisoner. The covenant promise advances by placing the covenant-bearer inside Egyptian power — preparation for the larger redemptive arc Exodus reverses.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Joseph names his son Ephraim 'for God has made me fruitful in the land of my affliction' (v 52) — exaltation that does not forget the pit. Christ's resurrection wounds (Jn 20:27) carry the same grammar: glory bears the marks of suffering.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "'It is not in me; God will give Pharaoh a favourable answer' (v 16) — the man with the gift refuses the credit. Worship in success: name God when others applaud you, and trust that his providence has been arranging the long wait.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen42.json
+++ b/content/hermeneutic_lenses/chapters/gen42.json
@@ -1,0 +1,64 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The dreams of 37:5-11 are now enacted — brothers bow to Joseph (v 6). The narrative pivots on 'Joseph remembered the dreams' (v 9): the structure of gen 37's prophecy becomes gen 42's stage direction.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "The brothers' guilt finally surfaces — 'we are paying the penalty for what we did to our brother' (v 21) — twenty years on. Genuine repentance is part of the redemptive arc; covenant restoration requires moral change, not just grain.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Reuben's 'did I not tell you?' (v 22) and his offer of his two sons (v 37) echo throughout Scripture's pattern of inadequate intercession that prepares for adequate substitution — answered by Judah in gen 44 and by Christ.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Joseph weeps when he hears their confession (v 24), then resumes the test. Tears alongside truth-telling: holding people accountable can be heart-broken without being sentimental. Trust the slow work of repentance.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen43.json
+++ b/content/hermeneutic_lenses/chapters/gen43.json
@@ -1,0 +1,64 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "Reuben's failed pledge (42:37) is replaced by Judah's accepted one (v 9) — the narrative hands the leadership baton from firstborn to fourth-born. The structure previews 49:8-12: 'the sceptre will not depart from Judah'.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Jacob's prayer 'may God Almighty grant you mercy' (v 14) names what the chapter requires — covenant promise advancing through human terror. The patriarch finally entrusts Benjamin to the same God who took Joseph and gave salvation.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Judah's pledge of himself for Benjamin (v 9) anticipates Esther's 'if I perish, I perish' (Esth 4:16) and Paul's 'I could wish that I myself were accursed' (Rom 9:3). Surety for one's people is a thread across Scripture.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Jacob releases Benjamin with 'if I am bereaved, I am bereaved' (v 14) — surrender phrased as grief. Pray when the only available stance is consent to loss; trust without any certainty of return.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen44.json
+++ b/content/hermeneutic_lenses/chapters/gen44.json
@@ -1,0 +1,100 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Judah's plea (vv 18-34) is the longest single speech in Genesis — fourteen times he names 'my father' in a sustained Hebrew rhetorical climax. The grammar binds father, brother, and self into one web of substitution.",
+      "panel_filter": [
+        "heb",
+        "hist",
+        "sarna",
+        "alter",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "sarna",
+        "alter",
+        "hist"
+      ]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "The planted cup (v 2) and the planted silver of 42:25 form a narrative pair — both Joseph's contrivances, both surfacing the brothers' moral state. Repetition with intensification: silver tested guilt, the cup tests love.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "Judah's 'let me remain as a slave in his place' (v 33) prefigures substitutionary atonement — one in place of his brother, willing exchange. The pattern points to Christ: the Lion of Judah (49:9; Rev 5:5) takes the place of the guilty.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Judah's transformation completes — the man who said 'let us sell him' (37:26-27) now says 'let me bear it' (v 33). Repentance is reversed pattern, not regret; the redemptive arc bends through the same sinner becoming a saviour-figure.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Judah's substitution speech anticipates the Lion of Judah who substitutes himself in Gethsemane and at Golgotha — 'let this cup pass... not my will' (Mk 14:36) answered with 'into your hands' (Lk 23:46). The gospel pattern is fixed.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Judah speaks for seventeen verses (vv 18-34) without naming his own welfare once — the speech is entirely about his father and his brother. Pray, when you must plead for another, in this register: self emptied of self.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen45.json
+++ b/content/hermeneutic_lenses/chapters/gen45.json
@@ -1,0 +1,96 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "Joseph's threefold 'I am Joseph' / 'God sent me' / 'you sold me' (vv 4-8) restates the same fact in three theological registers — identity, providence, sin — without softening any. Narrative structure as theological exegesis.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "'God sent me before you to preserve life' (v 5) reframes the brothers' crime without erasing it. The covenant plan to preserve a remnant runs through, not around, human evil — the redemptive arc bends but does not break.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "'Hurry and bring my father here' (v 9) — the rejected son now lord of Egypt sends emissaries to gather his household into safety. The pattern foreshadows Christ sending his apostles to gather the Father's family from every nation.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "The rejected brother now lord receives his returning brothers with weeping and kisses (vv 14-15). Christ — rejected and exalted — receives the very ones whose sin sent him to the cross (Acts 2:36-38 names the same pattern).",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "'It was not you who sent me' (v 8) compresses canonical theology: human freedom and divine sovereignty operating on the same act. The thread runs to Acts 2:23 — Christ 'delivered up by God's deliberate plan' through human hands.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Joseph cannot wait — 'make all his servants leave!' (v 1) — and weeps so loudly Egypt hears (v 2). Forgiveness as bodily release. Repent today of the careful management of pain you call control; let the tears come when they come.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen46.json
+++ b/content/hermeneutic_lenses/chapters/gen46.json
@@ -1,0 +1,48 @@
+{
+  "lenses": [
+    {
+      "lens_id": "redemptive",
+      "guidance": "God speaks at Beersheba (v 3) — 'do not be afraid to go down to Egypt; I will make you into a great nation there' — the covenant promise extending into exile. The pattern Exodus and the prophets will exposit begins here.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The seventy who descend (v 27) anticipate the seventy elders at Sinai (Ex 24:1, 9), the seventy on whom the Spirit rests (Num 11:24-25), and the seventy Christ sends out (Lk 10:1) — a numerical thread across Scripture.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Israel 'offered sacrifices to the God of his father Isaac' before going down (v 1). Worship at the threshold of every major move; receive the promise on God's terms before boarding the cart.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen47.json
+++ b/content/hermeneutic_lenses/chapters/gen47.json
@@ -1,0 +1,64 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "Jacob blesses Pharaoh on entrance (v 7) and again on exit (v 10) — the patriarch frames his audience with the empire. The 'lesser blesses greater' narrative structure prepares Hebrews 7:7's later argument about Melchizedek and Christ.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Jacob calls his life 'few and difficult' and a sojourn (v 9) — covenant identity is the identity of pilgrims, not residents. The redemptive arc bends toward homecoming, not settlement; promise is held open, never closed.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Jacob's 'few and evil' pilgrim self-description (v 9) is later canonised by Hebrews 11:13 ('strangers and exiles on the earth') and 1 Peter 2:11 — sojourner identity becomes a thread across Scripture defining the church.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Jacob worships at his bed-head when Joseph swears to bury him in Canaan (v 31) — Hebrews 11:21 names this his final act of faith. Worship in the small mortal moments; faith carries you to the last word.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen48.json
+++ b/content/hermeneutic_lenses/chapters/gen48.json
@@ -1,0 +1,52 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "Jacob crosses his hands so the younger Ephraim receives the right-hand blessing (vv 13-14, 17-19) — the pattern that runs Abel-over-Cain, Isaac-over-Ishmael, Jacob-over-Esau, anticipating Christ as divine election against expectation.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Jacob's 'the God who has been my shepherd all my life long, the angel who has redeemed me from all evil' (vv 15-16) gathers the patriarchal experience under the language of covenant redemption. The arc ends with the patriarch's confession.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Jacob blesses through the second-born (v 19) — a Genesis-long pattern climaxing here in the covenant family, foreshadowing Christ the Last Adam (1 Cor 15:45) whose precedence comes by divine election, not chronological birth.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen49.json
+++ b/content/hermeneutic_lenses/chapters/gen49.json
@@ -1,0 +1,100 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "'Until Shiloh comes' (v 10) is Genesis's most contested crux — the Hebrew may read 'until tribute comes to him' or 'until he comes to whom it belongs'. The grammar's reach toward an unnamed sceptre-bearer is the prophecy's force.",
+      "panel_filter": [
+        "heb",
+        "hist",
+        "sarna",
+        "alter",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "sarna",
+        "alter",
+        "hist"
+      ]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "Reuben loses (vv 3-4), Simeon and Levi are scattered (vv 5-7), Judah ascends to lion-status (vv 8-12) — the structure inverts birth-order with moral reckoning. Tribal destinies follow the chapters' moral arc, not the genealogy.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The 'lion's cub' of Judah (v 9) and 'the sceptre' (v 10) prefigure the Davidic monarch and beyond — the Lion of the tribe of Judah of Revelation 5:5. The chapter is the anchor pattern for two millennia of messianic reading.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "Judah's blessing (vv 8-12) is the chapter's redemptive heart. The tribe that produced Judah-of-Tamar — the tribe Jacob refused to favour at its head — becomes the covenant line through which kingship and salvation arrive.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "'The obedience of the peoples shall be his' (v 10) is named Christological data by Hebrews 7:14 — 'our Lord descended from Judah' — and Revelation 5:5 closes the loop. The Shiloh verse points to Jesus across a thousand years.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The Joseph blessings (vv 22-26) invoke 'the God of your father' alongside 'the Almighty' with imagery of 'everlasting hills' — a canonical bridge between patriarchal naming and Sinai's covenant titles, threading Scripture.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/gen50.json
+++ b/content/hermeneutic_lenses/chapters/gen50.json
@@ -1,0 +1,80 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The book ends with two oaths — Joseph swearing to bury Jacob in Canaan (vv 5-6) and the brothers swearing to carry Joseph's bones (v 25). Genesis closes with framing promises about land, structurally linking patriarchal end to exodus.",
+      "panel_filter": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "alter",
+        "sarna",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "'You meant evil against me, but God meant it for good' (v 20) is the redemptive hermeneutic of the whole book — the covenant promise has steered through every fall, deception, and famine since Genesis 3.",
+      "panel_filter": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "thread",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Joseph's 'you meant evil... God meant good' (v 20) is the theological grammar of the cross. Acts 2:23 names the same logic — Christ 'delivered up by God's plan and by lawless hands'. The gospel is gen 50:20 enacted in Jesus.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "Joseph speaks kindly to them and provides for their families (v 21) — words and bread together. Forgive as you hope to be forgiven; let mercy flow into food, employment, and daily care for those you have released.",
+      "panel_filter": [
+        "themes",
+        "calvin",
+        "cross"
+      ],
+      "panel_order": [
+        "themes",
+        "calvin",
+        "cross"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "Joseph's bones in a coffin in Egypt (v 26) is Genesis's last word — and Hebrews 11:22 names this his act of faith. The bones travel later to Sinai (Ex 13:19) and Shechem (Josh 24:32), threading Genesis throughout Scripture.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Final batch of the Genesis pilot** (Epic #820, tracking #1781). Joseph cycle climax — Genesis 41–50: **46 entries across 10 chapters**, all scoring **100/100** on `lens_quality_scorer` after a single fix pass.

This PR closes the Genesis pilot. Combined with batches 0–4, the pilot now ships **214 lens entries across all 50 chapters of Genesis**.

## Per-chapter lens distribution

| Chapter | Lenses | Notes |
|---|---:|---|
| gen41 — Pharaoh's dreams; Joseph exalted | 5 | grammatical, typological, redemptive, christocentric, devotional |
| gen42 — First trip; brothers' guilt | 4 | literary, redemptive, canonical, devotional |
| gen43 — Judah's pledge; second trip | 4 | literary, redemptive, canonical, devotional |
| gen44 — Cup test; Judah's substitution speech | **6** | christocentric peak — substitutionary atonement |
| gen45 — "I am Joseph"; revelation | **6** | revelation, providence, reconciliation |
| gen46 — Descent to Egypt | **3** | redemptive, canonical, devotional — sparse transition |
| gen47 — Jacob blesses Pharaoh; famine policy | 4 | literary, redemptive, canonical, devotional |
| gen48 — Crossed-hands blessing | **3** | typological, redemptive, christocentric |
| gen49 — Jacob's blessings; Shiloh prophecy | **6** | messianic peak — Lion of Judah |
| gen50 — "You meant for evil"; Joseph's bones | 5 | capstone — gen 50:20 as theological thesis |

Total: **46 entries**. Average 4.6 lenses/chapter — within the curated-sparse band, with three chapters (44, 45, 49) at the 6-lens ceiling because they are theologically the densest in Genesis.

## Theological highlights

- **gen44 christocentric (substitution gold):** Judah's plea (vv 18–34, the longest single speech in Genesis) prefigures the Lion of Judah taking the place of the guilty. The chain runs **49:9 → Rev 5:5 → Mk 14:36 → Lk 23:46** — substitutionary atonement seen typologically in Joseph's brother before it is enacted in Joseph's greater Son.
- **gen49 christocentric (Shiloh prophecy):** "Until Shiloh comes" (v 10) is anchored to **Hebrews 7:14** ("our Lord descended from Judah") and **Revelation 5:5** — the chapter as the messianic anchor for two millennia of Christological reading.
- **gen50 christocentric (theological thesis):** "You meant evil… God meant good" (v 20) read with **Acts 2:23** as the theological grammar of the cross — human malice and divine purpose operating on the same act.
- **gen45 redemptive + canonical:** "God sent me before you to preserve life" (v 5) and "it was not you who sent me" (v 8) — providence as compressed canonical theology, threading forward to Acts 2:23.
- **gen41 typological:** Suffering→exaltation in a single day (vv 14, 40–43) anchored to **Philippians 2:8–9** — the chapter as a prophetic preview of the Christ-pattern.
- **gen48 typological:** The younger-over-elder pattern (Abel, Isaac, Jacob, Ephraim) climaxes here in the covenant family, foreshadowing Christ the Last Adam (1 Cor 15:45) — divine election against natural expectation.

## Pipeline gates (all green)

| Gate | Result |
|---|---|
| `schema_validator.py` | 141564 passed / **0 failed** / 19 unrelated content warnings |
| `lens_quality_scorer.py` | **46/46** entries at **100/100** (all four dimensions full marks) |
| `build_sqlite.py` | 8 lenses, **214 contents** (gen1–40 baseline 168 + 46 new) |
| `validate_sqlite.py` | 101 passed / **0 failed** |

## Drafting discipline — one fix pass needed (lesson for future batches)

The 250-char ceiling held — no entry exceeded 245 chars on first draft. But two `literary` entries needed a single `str_replace` fix, and the cause is worth flagging:

- The `lens_quality_scorer` checks rubric tokens via **substring match** (`token.lower() in guidance.lower()`).
- `"structural"` does **not** match `"structure"` (different ending — `-al` vs `-e`).
- `"narrator"` does **not** match `"narrative"` (different ending — `-or` vs `-ive`).
- gen42 and gen43 literary entries used `structural` / `narrator` and scored 88/100 on Completeness.
- Both fixed in seconds by replacing with the proper stems (`narrative`, `structure`). No content rewrite.

**Suggested addition to future batches' drafting checklist:** when using rubric tokens, prefer the exact stem (`structure`, `narrative`, `repetition`) rather than morphological variants (`structural`, `narrator`, `repeats`). Cheap insurance.

No banned filler patterns; no `should_avoid` matches; no plagiarism overlap above the 60% threshold (the gen45 and gen50 entries were the highest risk because v 5 / v 8 / v 20 are quoted in the source themes panels — phrased to keep word-set overlap below 50%).

## Watch list for tier-2 audit

Six entries flagged proactively for editor scrutiny on a deeper read.

1. **gen44 typological** — calling Judah's offer in v 33 "substitutionary atonement" is a confessionally Reformed framing. The text supports it; some traditions would prefer "self-substitution" or "vicarious offer". Acceptable as written, but worth the audit.
2. **gen44 christocentric** — Mk 14:36 and Lk 23:46 are linked tightly to v 33's "let me remain". The connection is homiletically standard but moves fast; an editor may want to slow the connection.
3. **gen49 grammatical** — calls "Until Shiloh comes" Genesis's "most contested crux"; that is defensible (Sarna, Hamilton, Wenham all flag it) but is an evaluative claim. If the auditor objects, soften to "one of Genesis's most contested cruces".
4. **gen49 typological** — claims the chapter is "the anchor pattern for two millennia of messianic reading". True historically (patristic through Reformed); calibrate if the auditor prefers narrower scholarly language.
5. **gen48 christocentric** — the Last Adam parallel (1 Cor 15:45) is a Pauline move applied here through younger-over-elder; sound but interpretive.
6. **gen50 redemptive** — close paraphrase of v 20; word overlap with the themes panel was checked and is well below 60%, but a future style pass might want to vary the phrasing further.

## Branch / merge notes

- Branched off latest `master` (post-merge of #1794 and #1795).
- No file overlaps with anything in flight; clean rebase if needed.

## Rollback plan

Revert the merge commit. The 10 new chapter files are additive and isolated under `content/hermeneutic_lenses/chapters/`; no existing content, schema, or app code is touched. SQLite rebuilds deterministically from JSON.

## After this lands

**Genesis pilot is complete.** Next steps for Epic #820 are out of scope for this PR but worth noting:

- Decide whether to roll the lens drafting cadence forward to Exodus (next OT book) or pivot to a different test corpus (a Pauline epistle, a Psalm cluster, or a Gospel would each stress the rubric differently).
- Consider extending the `lens_rubrics.json` `must_have_one_of` lists to include common morphological variants (`structural`, `narrator`, etc.) — a small change to the rubric file would have prevented today's two fixes.

Closes part of #1781. Refs #820. **Closes the Genesis pilot.**
