### PR TITLE
feat(lenses): Leviticus 1-10 lens content, batch 1 of Pentateuch-rest pilot (#820, #1782)

### DIFF
--- a/content/hermeneutic_lenses/chapters/lev1.json
+++ b/content/hermeneutic_lenses/chapters/lev1.json
@@ -1,0 +1,68 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "The 'olah goes up entirely in smoke (vv 6-9, 12-13) — wholly given is the type's signature. The pattern prefigures Christ offering himself wholly to God (Heb 10:5-10), no portion withheld for the offerer.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 3 and 10 require a male without blemish — Hebrew tamim, complete. Heb 9:14 takes that requirement up: Christ offered himself without blemish to God. The Sinai standard finds its perfection in Jesus.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ]
+    },
+    {
+      "lens_id": "grammatical",
+      "guidance": "Hebrew 'olah (vv 3, 6, 9) is built on the verb 'alah, to go up. The offering is itself a going-up — its smoke rises to God. The Hebrew names what the eye sees: ascent as worship.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "Three parallel descents from herd (vv 3-9), flock (vv 10-13), and bird (vv 14-17). The structure makes one point: the offering varies by means; the standard does not. Worship has tiers but no class.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev10.json
+++ b/content/hermeneutic_lenses/chapters/lev10.json
@@ -1,0 +1,66 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "v 1's esh zarah — strange or foreign fire — uses the adjective zar, what is alien, illegitimate. The same root appears at Num 3:4 and 26:61. The Hebrew warning travels: unauthorized worship, however well-meant, is foreign.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter pivots on vv 1-3: action, judgment, divine speech. The literary structure makes the speech of v 3 the chapter's center — not the death of the priests, but the meaning of holiness God assigns to it.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "v 3's 'those who come near me must regard me as holy' addresses today's worshipper too. To respond rightly is to obey God's pattern of approach, not to invent one. Reverent faith trusts the Word over the gut.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 3's principle — among those who approach me I will be sanctified — echoes throughout Scripture as a sober refrain: Acts 5:1-11 (Ananias and Sapphira), 1 Cor 11:30 (the Lord's table), Heb 12:28-29 (acceptable worship).",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev2.json
+++ b/content/hermeneutic_lenses/chapters/lev2.json
@@ -1,0 +1,52 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Hebrew minchah (v 1) is tribute, gift — used elsewhere for what Cain brought (Gen 4) and what kings bring vassal-style. The original audience would hear it as a fitting protocol: subject brings tribute to king.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 11-13 — no leaven, no honey, but salt of the covenant. Leaven anticipates Christ's warning against the leaven of the Pharisees (Mt 16:6); covenant-salt anticipates Mk 9:50's saltiness imperative.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "v 14's firstfruits — first and best, not the leftover. To respond as Israel did is to give God the head of the increase, not the tail. To trust the Giver of the harvest with the first sheaf is itself a worship-act today.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev3.json
+++ b/content/hermeneutic_lenses/chapters/lev3.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "Unlike olah and chattat, the shelamim ends in a meal (vv 1-5, 6-11): worshipper, priest, and God all share. The meal-pattern foreshadows the Lord's table — fellowship around a sacrifice, not around a feeling.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "The shelamim's shared-meal pattern echoes throughout Scripture — Ex 24:11 (elders eating before God), 1 Kgs 8:62-66 (temple-dedication peace offerings), and Lk 22:17-20 (the cup of the new covenant).",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Hebrew shelamim is from shalom — peace, wholeness. The peace offering names what Christ achieves: 'since we have been justified by faith, we have peace with God' (Rom 5:1). Sinai fellowship made permanent.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "themes"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev4.json
+++ b/content/hermeneutic_lenses/chapters/lev4.json
@@ -1,0 +1,68 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Hebrew chattat (vv 3, 14, 23, 28) carries both 'sin' and 'sin offering' — the same word names the problem and the remedy. The lexical doubling preaches: the offering takes the sinner's name on itself.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "Blood applied to the horns of the altar (vv 7, 18, 25, 30, 34) — the pattern is contact-atonement: where the worshipper meets God, the blood meets first. Fulfilled at the cross where Christ's blood opens approach.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 13-21 cover unintentional sin even of the whole congregation — none too small, none too corporate. 1 Jn 2:2 lifts that scope to its limit: Jesus is 'the propitiation… for the sins of the whole world.'",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 2, 13, 22, 27 — the unintentional sin still requires a sacrifice. Today the pattern teaches: ignorance is not innocence; we draw near in confession even of what we did not see at the time.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev5.json
+++ b/content/hermeneutic_lenses/chapters/lev5.json
@@ -1,0 +1,52 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "Hebrew asham (vv 6, 7, 15) means guilt — but the same word is the offering and the price paid. Isa 53:10 picks up this exact word for the Servant: his soul makes asham. The Hebrew sets the trajectory.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "milgrom",
+        "calvin",
+        "hebtext"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 14-19 require restitution plus a fifth (v 16) — covenant restoration costs more than the wrong, on purpose. The redemptive arc adds grace to justice: not breaking even, but more given back than was taken.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "The asham pattern — v 15's reparation 'for the wrong he has done' — foreshadows the Servant's substitutionary asham of Isa 53:10-11. Guilt-payment plus reparation, both fulfilled in Christ's offering.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev6.json
+++ b/content/hermeneutic_lenses/chapters/lev6.json
@@ -1,0 +1,36 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter shifts audience as a structural pivot: vv 1-7 still address the people, then vv 8-30 turn to Aaron and his sons (v 9). The form changes who is hearing — and therefore who must perform the procedures.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 12-13 — the fire on the altar shall be kept burning, it shall not go out. The pattern reads as a worship-discipline today: tend the fire of devotion before it dies. Continuity in obedience is itself an offering.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev7.json
+++ b/content/hermeneutic_lenses/chapters/lev7.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "Five offerings each get a Torah heading: guilt (v 1), fellowship (v 11), priests' due (vv 28-36), and a closing colophon (vv 37-38). The literary form is teaching-text; the chapter signals it is meant to be taught.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 11-15's todah (thanksgiving) fellowship offering echoes throughout Scripture — Pss 50:14, 100:4, and 116:17 each call worship a todah. The grateful-meal motif runs across the canon as a constant note.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev8.json
+++ b/content/hermeneutic_lenses/chapters/lev8.json
@@ -1,0 +1,52 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "Anointing oil (vv 10-12), blood on ear-thumb-toe (vv 23-24), and seven days of waiting (vv 33-35) — the ordination pattern foreshadows the qualified High Priest of Heb 5:1-10, anointed and consecrated.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "Blood applied to Aaron's right ear, thumb, and toe (v 24) consecrates hearing, action, and walk. Heb 9:11-14 takes the priestly-pattern to its head: Christ's blood consecrates a perfect High Priest forever.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ]
+    },
+    {
+      "lens_id": "literary",
+      "guidance": "Structured as ritual-narrative: command (v 1), gather (v 4), wash (v 6), clothe (vv 7-9), anoint (vv 10-12), sacrifice (vv 14-29), wait (v 33). Each step is a marked liturgical beat in the chapter's form.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev9.json
+++ b/content/hermeneutic_lenses/chapters/lev9.json
@@ -1,0 +1,66 @@
+{
+  "lenses": [
+    {
+      "lens_id": "typological",
+      "guidance": "v 1's eighth-day pattern foreshadows new beginning across the type-chain: circumcision on the eighth (Gen 17:12), Solomon's temple-dedication eighth (2 Chr 7:9), Christ's resurrection on the day after the seventh (Lk 24:1).",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "thread"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 22-23 — Aaron blesses the people, then he and Moses bless together. Heb 9:28 reads the priest-blessing pattern eschatologically: Christ 'will appear a second time… to bring salvation'. Blessing made permanent.",
+      "panel_filter": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ],
+      "panel_order": [
+        "cross",
+        "calvin",
+        "mac",
+        "heb"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 24's flame motif echoes across Scripture — Gen 15:17 (Abrahamic covenant), 1 Kgs 18:38 (Carmel contest), 2 Chr 7:1 (temple dedication), Acts 2:3 (Pentecost). Divine acceptance signed in flame, again and again.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 22-24 closes the inaugural day with flame and shouting — the people fall on their faces. To respond rightly today is to bow before commenting. Worship that has seen God act prostrates first; it speaks afterward.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
First batch of the Pentateuch-rest pilot for Epic #820. Leviticus 1–10, the sacrificial-system + ordination block.

Tracking issue: #1782 ([#820 / 3] Pentateuch rest — Exodus, Leviticus, Numbers, Deuteronomy). Exodus is now done; this kicks off Leviticus.

## Per-chapter distribution (32 entries total)

| Chapter | Lenses | Count | Notes |
|---|---|---|---|
| lev1 | typological, christocentric, grammatical, literary | 4 | Burnt offering — strong typological/christocentric pull |
| lev2 | grammatical, typological, devotional | 3 | Grain offering |
| lev3 | typological, canonical, christocentric | 3 | Fellowship offering — covenant-meal type |
| lev4 | grammatical, typological, christocentric, devotional | 4 | Sin offering — atonement peak |
| lev5 | grammatical, redemptive, typological | 3 | Guilt offering — Isa 53:10 asham anchor |
| lev6 | literary, devotional | 2 | Priestly procedures (sparse, procedural) |
| lev7 | literary, canonical | 2 | Priestly procedures cont. (sparse) |
| lev8 | typological, christocentric, literary | 3 | Aaron's ordination |
| lev9 | typological, christocentric, canonical, devotional | 4 | Eighth day, fire from heaven — theology peak |
| lev10 | grammatical, literary, devotional, canonical | 4 | Nadab and Abihu — holiness peak |

Sacrificial-system chapters (lev1–lev5) lean typological/christocentric per the brief's Lev genre profile. Procedural chapters (lev6, lev7) are sparse. lev9 and lev10 (the narrative theology peaks of the block) maxed at 4.

## Theological anchors

- **lev1 'olah** — Hebrew root 'alah ("to go up") drives the grammatical entry; christocentric anchor lands on Heb 9:14's *amomos* (without blemish) tracing Lev 1:3, 10's *tamim*.
- **lev3 shelamim** — peace offering pattern → Lord's table type → Rom 5:1 "peace with God." Three-lens triangulation on the same Hebrew root without overlap.
- **lev4 chattat** — grammatical entry surfaces the lexical pun (same word names problem and remedy); christocentric entry lifts vv 13-21's congregational scope to 1 Jn 2:2's "sins of the whole world."
- **lev5 asham** — the clearest Servant-song bridge in the early Levitical sacrifices. Isa 53:10's ʾāšām is *the same Hebrew word* used at v 6, 7, 15. Grammatical entry names this lexical fact; typological entry traces it to Christ.
- **lev8 ordination** — typological pattern (anointing oil, blood ear-thumb-toe, seven-day waiting) → Heb 5:1-10 high priest qualification. Christocentric entry lands on Heb 9:11-14.
- **lev9 fire-from-heaven** — typological lens recast around the *eighth-day* type (Gen 17:12 / 2 Chr 7:9 / Lk 24:1), not the fire — to leave the canonical lens free to thread fire across canon (Gen 15:17 / 1 Kgs 18:38 / 2 Chr 7:1 / Acts 2:3) without overlap.
- **lev10 esh zarah** — grammatical entry on the adjective *zar* (alien, illegitimate); canonical entry threads v 3's holiness principle through Acts 5, 1 Cor 11, Heb 12.

## Pipeline gates

| Gate | Result |
|---|---|
| `python3 _tools/schema_validator.py` | **0 failures**, 19 pre-existing ESV warnings |
| `python3 _tools/lens_quality_scorer.py --chapter lev{1..10} --floor 100` | **32/32 entries scoring 100/100** (after one fix — see below) |
| `python3 _tools/build_sqlite.py` | `hermeneutic_lenses: 8 lenses, 409 contents` (= 377 baseline + 32 new) |
| `python3 _tools/validate_sqlite.py` | **0 failures**, 2 pre-existing non-fatal warnings |

`app/assets/db-manifest.json` and `app/assets/explore-images.json` drift was reverted before staging — only the 10 chapter JSON files ship.

## Quality-fix log (transparent)

One first-pass miss. The lev9 typological entry originally read:
> v 1's eighth day marks new beginning — a *typological motif*: …

The scorer's `must_have_one_of` for typological is a substring match, and "type" is *not* a substring of "typological" (typ-OLOGICAL ≠ typ-E). The entry was rewritten to use "pattern foreshadows" + "type-chain" — both legitimate typological tokens — yielding 100/100. Recorded here in case the same trap bites a future batch.

## Scholar-set adaptation

Leviticus uses **Milgrom** (Jacob Milgrom, Anchor Bible Leviticus + Numbers) where Exodus used Alter and Sarna. All `panel_filter` arrays in this PR use `milgrom`/`calvin`/`mac` — Alter and Sarna do not appear, since they are scoped to Genesis/Exodus content and would surface no panel in these chapters even if technically valid against the global allowlist.

## Plagiarism guards

The Lev themes panels are unusually thin (single-sentence titles like "The Eighth Day: Fire from Heaven" + a six-tag scores list), so word-overlap risk is naturally low. Even so:

- **lev9** — themes title is "Fire from Heaven." Typological entry pivots to the eighth-day type-chain (different motif); canonical entry uses "flame motif echoes" rather than restating "fire from heaven" verbatim.
- **lev10** — themes title is "Strange Fire Before the Lord." Grammatical entry uses Hebrew *esh zarah* + adjective analysis; literary entry names the v 3 speech as the chapter's center; canonical entry threads v 3's holiness principle, not the calf-strange-fire framing.

## Tier-2 audit watch list

Cross-canonical and lexical claims that warrant tier-2 spot-check:

- `lev1 / christocentric` — Heb 9:14 *amomos* matches Lev 1:3, 10 *tamim*
- `lev2 / typological` — leaven (Mt 16:6) + covenant-salt (Mk 9:50) typology
- `lev3 / christocentric` — *shalom* root → Rom 5:1 "peace with God"
- `lev4 / grammatical` — chattat lexical doubling (sin / sin offering)
- `lev5 / grammatical + typological` — Lev 5:6, 7, 15 *asham* → Isa 53:10 *asham* lexical chain
- `lev8 / christocentric` — Heb 9:11-14 high priest typology
- `lev9 / typological` — eighth-day type-chain (Gen 17:12, 2 Chr 7:9, Lk 24:1)
- `lev9 / canonical` — fire-from-heaven motif (Gen 15:17, 1 Kgs 18:38, 2 Chr 7:1, Acts 2:3)
- `lev10 / canonical` — Acts 5:1-11, 1 Cor 11:30, Heb 12:28-29 holiness-violation thread

## Out of scope

- No `content/leviticus/*` changes
- No app code changes
- No db-manifest.json / explore-images.json drift (reverted)
- No new scholar entries — Milgrom already in `_tools/config.py`'s `SCHOLAR_REGISTRY` (verified)

## Rollback plan

Single-commit PR. Revert with `git revert <sha>` and rerun `_tools/build_sqlite.py` to roll the `hermeneutic_lenses` table back to 377 contents.
