### PR TITLE
feat(lenses): Leviticus 21-27 lens content, batch 3 of Pentateuch-rest pilot (#820, #1782)

### DIFF
--- a/content/hermeneutic_lenses/chapters/lev21.json
+++ b/content/hermeneutic_lenses/chapters/lev21.json
@@ -1,0 +1,66 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "vv 6-8's repeated qadosh / qodesh — 'be holy', 'the bread is holy', 'the priest is holy' — uses the Hebrew root in noun and adjective. The imperative tehyu qedoshim ('be holy') governs the chapter's priestly grammar.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "hebtext",
+        "calvin"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "milgrom",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 17-23's unblemished priest requirement — no defect at the altar — is what Heb 7:26 identifies in Christ: 'holy, blameless, pure, set apart from sinners.' The physical-perfection rule anticipates the moral perfection of Jesus.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 10-15's high priest restrictions — no torn clothes, no contact with the dead, no leaving the sanctuary — shape a type of unbroken access. Heb 7-9 reads them as foreshadowing Christ's once-for-all sanctuary entry.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 8's 'regard them as holy because they offer the food of your God' echoes throughout Scripture into the priestly identity of all believers — 1 Pet 2:9's 'royal priesthood' reads back across the canon to this verse.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev22.json
+++ b/content/hermeneutic_lenses/chapters/lev22.json
@@ -1,0 +1,34 @@
+{
+  "lenses": [
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 17-25's unblemished sacrifice requirement is what 1 Pet 1:19 names in Christ — 'a lamb without blemish or defect.' The disqualifying defects of vv 22-24 anticipate Jesus, by contrast, as the flawless offering.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 31-33's 'I am the LORD, who made you holy and brought you out of Egypt to be your God' echoes the exodus-holiness formula across Scripture — Lev 11:45, Lev 19:36, Lev 25:38, and Lev 26:13 all carry the same canonical refrain.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev23.json
+++ b/content/hermeneutic_lenses/chapters/lev23.json
@@ -1,0 +1,98 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter builds a calendar of seven appointed times: Sabbath (v 3), Passover (vv 4-8), Firstfruits (vv 9-14), Weeks (vv 15-22), Trumpets (vv 23-25), Atonement (vv 26-32), Tabernacles (vv 33-43). The form is a liturgical year.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 4-8's Passover — slain, blood-marked, eaten in haste — is what 1 Cor 5:7 names: 'Christ, our Passover lamb, has been sacrificed.' The first feast in Lev 23's cycle anchors the gospel's central vocabulary.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 9-14's Firstfruits — wave the first sheaf of the harvest — is the type 1 Cor 15:20-23 names: 'Christ has been raised from the dead, the firstfruits of those who have fallen asleep.' The pattern is resurrection.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 15-22's count of fifty days from Firstfruits sets the calendar Acts 2 enacts — the Spirit's outpouring lands on the day Israel celebrated covenant grain. The redemptive arc unfolds on Lev 23's clock.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 33-43's Tabernacles — booths, branches, the dwelling-with-the-people image — echoes throughout Scripture into Jn 7:37-39's living water and Rev 21:3's 'God's dwelling place is now among the people.'",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 39-43's command to live in booths recalls the LORD's wilderness provision. To worship today is to remember being delivered — the feast trains the heart to repent of self-sufficiency and trust the One who tabernacled among his people.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev24.json
+++ b/content/hermeneutic_lenses/chapters/lev24.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 1-4's seven-lamp lampstand, kept burning continually, echoes across Scripture into Zech 4:2-6's vision and Rev 1:12-13's seven golden lampstands. The threaded image of unfading light runs from tabernacle to throne room.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 5-9's bread of the Presence — twelve loaves, replaced sabbath after sabbath — anticipates Christ's 'I am the bread of life' (Jn 6:35). The pattern: bread perpetually before God, fulfilled in the bread that feeds eternally.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "grammatical",
+      "guidance": "vv 10-23's blasphemy case interrupts cult instructions with narrative. The Hebrew naqab (v 11) extends from 'to pierce' to 'to pronounce a name in curse' — verbal violation of the holy Name. The literal sense roots the figurative.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "hebtext",
+        "calvin"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "milgrom",
+        "calvin"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev25.json
+++ b/content/hermeneutic_lenses/chapters/lev25.json
@@ -1,0 +1,82 @@
+{
+  "lenses": [
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 8-13's Jubilee — proclaim liberty throughout the land — is what Jesus reads at Lk 4:18-19 from Isa 61:1-2, declaring 'the year of the Lord's favor' fulfilled. Messiah inaugurates Lev 25's economy in his hometown synagogue.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 23-28's land-redemption logic — 'the land is mine; you reside in it as foreigners' — makes property a covenant trust. The redemptive arc returns the alienated to their inheritance, a pattern of restoration in Israel's calendar.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 25-28's goel — kinsman-redeemer who buys back forfeited property — threads across Scripture from Boaz at Ruth 4 to Job 19:25's 'I know that my redeemer lives' to Christ as the great Goel. The canonical role is one continuous office.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "mission",
+      "guidance": "vv 47-55's case of a poor Israelite bought by a foreign sojourner — redeemed by kinsman or self — embeds the foreign sojourner inside Israel's economy. The covenant arrangement reaches outward to the nations within the law itself.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 18-22's 'I will send my blessing in the sixth year' calls trust where common sense calls for storage. To obey the sabbath year is to rest in the LORD's provision — the heart's posture today as much as Israel's then.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev26.json
+++ b/content/hermeneutic_lenses/chapters/lev26.json
@@ -1,0 +1,66 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "vv 3-13 (blessings) and vv 14-39 (curses, escalating in five waves of sevenfold judgment) frame a covenant-treaty form. vv 40-45's confession-and-restoration epilogue closes the structure — promise, threat, return.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 14-39's curses are the canonical template Deut 28 expands and that the prophets thread throughout exile literature — Jer 16:13, Dan 9:11-13, and Lam 1:5 each echo Lev 26's covenant-breach pattern across Scripture.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 40-45's confession-and-remembrance promise — 'I will remember my covenant with Jacob, with Isaac, with Abraham' — anchors the redemptive arc beyond exile. The promise to the patriarchs holds even when Sinai is broken.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 40-42's confession formula — 'they will confess their sins... and the sins of their ancestors' — models the worshipper today. To repent is not to bargain but to acknowledge, and to trust the covenant memory of the LORD.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/lev27.json
+++ b/content/hermeneutic_lenses/chapters/lev27.json
@@ -1,0 +1,36 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "vv 1-8's valuation table — male twenty to sixty: fifty shekels of silver — uses cardinal numbers to fix worth. The Hebrew erkecha ('your valuation') treats human dedication as a noun, vowed and priced — cult speech borrowing commerce.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "hebtext",
+        "calvin"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "milgrom",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 28-29's herem (devoted things, irredeemable) and vv 30-33's tithe close the book by framing surrender as covenant return. What Israel offers belongs already to the LORD — the redemptive logic is recognition, not transfer.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Batch 3 of the Pentateuch-rest pilot tracked under #1782. Adds 26 hermeneutic-lens entries across Leviticus 21–27, completing the Leviticus phase. Picks up after #1801 (lev1–10) and #1802 (lev11–20).

After this PR, **Leviticus is done.** Numbers (36 ch) and Deuteronomy (34 ch) remain to close the pilot.

## Per-chapter distribution (26 total)

| Chapter | Lenses | Why |
|---|---|---|
| **lev21 (priestly holiness)** | **4** | priesthood code peak — grammatical, christocentric, typological, canonical |
| lev22 (priestly purity, sacred food) | 2 | unblemished-sacrifice + exodus-holiness formula |
| **lev23 (sacred calendar / feasts)** | **6** | **maximum** — every feast carries a distinct NT fulfillment |
| lev24 (lampstand, bread, blasphemy) | 3 | three distinct movements — canonical, typological, grammatical |
| **lev25 (Sabbatical + Jubilee)** | **5** | **theology peak** — Jubilee + goel + sabbath rest |
| lev26 (blessings and curses) | 4 | covenant-treaty form + canon-wide curse template + restoration |
| lev27 (vows and dedications) | 2 | sparse appendix — valuation grammar + herem/tithe |

Avg 3.7 entries/ch — slightly higher than batches 1–2 (3.2 / 3.3) because three of the seven chapters are theology peaks. Pattern still holds: peaks fully spread, procedural chapters pared back.

## Theological highlights

- **lev21 (4 lenses):** unblemished-priest rule (vv 17–23) anticipating Heb 7:26's Christ "holy, blameless, pure"; high priest restrictions (vv 10–15) as type of unbroken sanctuary access fulfilled in Heb 7–9; v 8's holy-because-they-offer formula echoing into 1 Pet 2:9's royal priesthood.
- **lev23 (6 lenses, peak):** the seven appointed times mapped to NT fulfillments — Passover→1 Cor 5:7 (christocentric); Firstfruits→1 Cor 15:20–23 (typological); Pentecost-day count→Acts 2 (redemptive); Tabernacles→Jn 7:37–39 / Rev 21:3 (canonical). Devotional anchor on living-in-booths trains repentance from self-sufficiency.
- **lev24:** vv 1–4 lampstand threading from Zech 4 to Rev 1:12–13; vv 5–9 bread of the Presence anticipating Jn 6:35; the Hebrew naqab wordplay in v 11 ("to pierce" → "to pronounce in curse") for the blasphemy case.
- **lev25 (5 lenses, peak):** Jubilee proclamation (vv 8–13) cited by Christ at Lk 4:18–19 via Isa 61; the goel kinsman-redeemer (vv 25–28) threading from Boaz to Job 19:25 to Christ; v 18's sixth-year provision as devotional trust; the sojourner-redemption case (vv 47–55) for mission posture toward the nations.
- **lev26:** five-wave sevenfold curse escalation (vv 14–39) as canonical template Deut 28 expands and the prophets cite throughout exile literature; vv 40–45's patriarchal-covenant memory anchoring restoration beyond Sinai.

## Pipeline gate results

```
schema_validator.py        145762 passed, 0 failed, 19 warnings (pre-existing ESV downloadable warns)
lens_quality_scorer.py     26/26 entries at 100/100 (per-chapter run, floor=100)
build_sqlite.py            scripture.db green, hermeneutic_lenses chapter rows = 468
                           (= 442 baseline from #1802 + 26 batch 3; matches expected)
validate_sqlite.py         101 passed, 0 failed, 2 warnings (pre-existing embeddings/prompts)
```

Per-chapter SQLite distribution post-build (`chapter_lens_content`):
```
lev21: 4   lev22: 2   lev23: 6   lev24: 3   lev25: 5   lev26: 4   lev27: 2
```

## Length discipline

All entries authored to a 250-char target with 30-char headroom against the 280 schema ceiling. Actual range: **201–236 chars**. Median ~222.

## Filler / token guards

- All six banned filler patterns (`the lens reveals`, `this lens shows`, `through this lens`, `this passage shows that`, `this text teaches that`, `in this chapter we see/learn`) verified absent at authoring time.
- **Rubric-token trap (carried forward from batches 1–2):** every entry uses a token from its own lens's rubric, not a sibling lens's. Specifically verified: typological entries use `type` / `pattern` / `prefigures` / `anticipates`; canonical entries use `canon` / `echoes` / `thread` / `across Scripture`; christocentric entries name `Christ` / `Jesus` / `Messiah` explicitly; mission entries use `nations` / `outward`.

## Watch list for tier-2 audit

These are the entries most worth a human spot-check during accuracy auditing:

1. **lev21 typological** — "Heb 7–9 reads them as foreshadowing Christ's once-for-all sanctuary entry without departure." The high-priest-no-leaving-the-sanctuary detail (v 12) as type of unbroken access is a defensible move (Vos, Kline) but the Hebrews argument is more often made from the Day-of-Atonement entry. The link should be sharpened in audit if needed.
2. **lev23 redemptive** — "the calendar Acts 2 enacts." The Pentecost-fifty-day count from Lev 23:15–16 is the calendrical link to Acts 2:1, but the Acts text itself doesn't quote Lev 23. The connection is canonical-historical rather than citation-explicit. Wording is intentional shorthand.
3. **lev24 grammatical** — "The Hebrew naqab (v 11) extends from 'to pierce' to 'to pronounce a name in curse'." The semantic extension is well-attested (BDB, HALOT both list both senses; Milgrom develops it in the Anchor Bible volume) but some lexicons split into homonym roots. Defensible either way.
4. **lev25 canonical** — "Christ as the great Goel." The titular use of Goel-for-Christ is theological synthesis rather than a direct NT citation. Anchor Scriptures (Ruth 4, Job 19:25) are solid; the Christological extension is canonical reading rather than verse-cited.

## Out of scope

- No new content generation in `content/leviticus/{N}.json` itself (only the lens chapter files).
- No app code changes.
- No CI workflow changes.
- `app/assets/db-manifest.json` and `app/assets/explore-images.json` drift was checked out before staging.

## Rollback

`git revert <merge-commit>` is sufficient. No schema changes, no migration, no R2 mutation in this PR.

## Refs

- Epic: #820 (Hermeneutic Lenses)
- Tracker: #1782 (Pentateuch-rest pilot)
- Prior PRs in path: #1797 / #1798 / #1799 / #1800 (Exodus, all merged), #1801 (Leviticus 1–10, merged), #1802 (Leviticus 11–20, merged).

Leviticus complete with this PR. Numbers up next.
