### PR TITLE
feat(lenses): Numbers 19-27 lens content, batch 6 of Pentateuch-rest pilot (#820, #1782)

### DIFF
--- a/content/hermeneutic_lenses/chapters/num19.json
+++ b/content/hermeneutic_lenses/chapters/num19.json
@@ -1,0 +1,82 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "vv 2-3's parah adummah ('red heifer') is rare specification — color and gender both matter. The Hebrew adummah shares its root with adam (man, ground) and dam (blood). Earth, humanity, and blood gather in one descriptor.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "ashley",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "milgrom",
+        "ashley"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 2-10's heifer slain outside the camp, its ashes mixed with water for purification, is the pattern Heb 9:13-14 names: 'how much more, then, will the blood of Christ... cleanse our consciences.' The shadow gives way to substance.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 3-4's heifer slain 'outside the camp' is what Heb 13:11-12 reads christologically: 'Jesus also suffered outside the city gate to make the people holy through his own blood.' The location matters; the cross fulfils Lev/Num's geography.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 11-22's death-defilement and seven-day cleansing rule threads across Scripture into Eph 2:1-5 and Col 2:13 — those 'dead in trespasses' raised by Christ. The canon answers the chapter's recurring question: who can touch death and live?",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 17-19's hyssop bundle dipped in the cleansing water echoes Ex 12:22 (Passover) and Ps 51:7 ('cleanse me with hyssop'). The covenant arc threads one cleansing instrument across the redemptive history of Israel.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num20.json
+++ b/content/hermeneutic_lenses/chapters/num20.json
@@ -1,0 +1,82 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter's three movements — Miriam's death (v 1), Meribah and Moses's failure (vv 2-13), Edom refusal and Aaron's death (vv 14-29) — frame leadership transition. The structure marks loss: prophetess gone, leader disqualified, priest at rest.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 7-11's struck rock — 'water came out abundantly' — is what 1 Cor 10:4 names: 'they drank from the spiritual rock that accompanied them, and that rock was Christ.' Paul's identification makes the wilderness rock a christological anchor.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 7-12's two strikes (commanded once, struck twice) prefigure why the rock in Ex 17 was struck once and the rock here was meant to be spoken to. The pattern: Christ smitten once for sin (Heb 9:28); thereafter we speak, not strike.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 12's verdict on Moses — 'because you did not trust me enough to honor me as holy' — echoes throughout Scripture. Ps 106:32-33 cites it; Deut 32:51 returns to it. Moses's failure threads canonically as warning to leaders.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 10-12's anger turned to action — Moses striking instead of speaking — names the heart's failure under provocation. To trust today is to obey the LORD's exact word, not the heart's logic. Even the meek prophet was disqualified by frustration.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num21.json
+++ b/content/hermeneutic_lenses/chapters/num21.json
@@ -1,0 +1,82 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter's six movements — Hormah victory (vv 1-3), serpents and the bronze pole (vv 4-9), Beer well-song (vv 10-20), Sihon and Og defeated (vv 21-35) — alternate judgment with deliverance. The structure prepares Israel for entry.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "christocentric",
+      "guidance": "vv 8-9's bronze serpent on a pole is what Jesus names at Jn 3:14-15: 'just as Moses lifted up the snake in the wilderness, so the Son of Man must be lifted up.' Christ explicitly cites this passage as a type of his cross.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 8-9's looking-and-living establishes the gospel pattern. The bitten Israelite is healed not by climbing the pole but by faith's gaze. The shadow prefigures justification by faith — the look at the lifted-up one is what saves.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 8-9's bronze serpent threads across Scripture into 2 Kgs 18:4 (Hezekiah breaks 'Nehushtan,' the venerated relic) to Jn 3:14-15. The canon contains both the type's institution and its fulfillment, with caution against idolizing the symbol.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 4-5's grumbling — 'we detest this miserable food' (the manna) — names the heart's contempt for ordinary grace. To trust today is to receive what is given without complaint, lest the cure for grumbling become a bronze serpent on a pole.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num22.json
+++ b/content/hermeneutic_lenses/chapters/num22.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "grammatical",
+      "guidance": "vv 28-30's speaking donkey — the Hebrew preserves a fluent dialogue between beast and prophet. The verb dabar ('speak') is not weakened; same root used for prophetic oracles. The narrator treats animal speech grammatically as direct address.",
+      "panel_filter": [
+        "heb",
+        "milgrom",
+        "ashley",
+        "hebtext"
+      ],
+      "panel_order": [
+        "heb",
+        "hebtext",
+        "milgrom",
+        "ashley"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 18's Balaam claiming he could not 'go beyond the word of the LORD' is tested across Scripture. 2 Pet 2:15-16 / Jude 11 / Rev 2:14 each cite Balaam canonically as a warning — the prophet who knew the truth and sold it.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "devotional",
+      "guidance": "vv 12, 20, 32's three divine answers to Balaam — clear no, conditional yes, hostile angel — name how the heart that loves wages still pushes for permission. To pray today is to receive the first answer, not negotiate three rounds with the LORD.",
+      "panel_filter": [
+        "mac",
+        "calvin",
+        "rec",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "rec",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num23.json
+++ b/content/hermeneutic_lenses/chapters/num23.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "vv 1-12 (first oracle) and vv 13-26 (second oracle) follow identical literary form: seven altars built, sacrifices offered, Balaam withdraws to receive the word, returns to Balak with poetic blessing. The structure makes repetition the rhetoric.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 19's 'God is not human, that he should lie, not a human being, that he should change his mind' echoes throughout Scripture into 1 Sam 15:29, Mal 3:6, Heb 6:18, Jas 1:17. The oracle gives the canon one of its core attributes — divine reliability.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 21-23's 'no misfortune is seen in Jacob, no misery observed in Israel' speaks the covenant verdict over the people Balaam was hired to curse. The redemptive arc protects what cannot be cursed; the promise to Abraham still stands.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num24.json
+++ b/content/hermeneutic_lenses/chapters/num24.json
@@ -1,0 +1,66 @@
+{
+  "lenses": [
+    {
+      "lens_id": "christocentric",
+      "guidance": "v 17's 'a star will come out of Jacob; a scepter will rise out of Israel' is read messianically across Scripture. Mt 2:2's 'we have seen his star' echoes the Balaam oracle; the wise men come to the king the pagan prophet announced.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 17-19's star-and-scepter pair forms a royal type — astronomical sign plus governing instrument. Rev 22:16's 'I am the bright morning star' returns to the Balaam image, Christ identifying himself with what was foretold from the plains of Moab.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "v 17's 'star out of Jacob' echoes throughout Scripture as messianic anchor. Qumran (CD 7, 4Q175) cites it; rabbinic literature reads it of bar-Kokhba; Mt 2 reads it of Christ. The verse threads across pre-Christian and Christian readings.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "mission",
+      "guidance": "v 17's word is delivered by a foreign prophet to a foreign king on behalf of the nations watching Israel. The oracle that Israel will rule comes outward through Balaam's mouth — God's gospel proclamation runs through the most unlikely vessel.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num25.json
+++ b/content/hermeneutic_lenses/chapters/num25.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "The chapter's two movements — sexual/cultic apostasy with Moab (vv 1-5) and Phinehas's intervention (vv 6-15) — pivot on a single act. The structure presents zealous priesthood as the answer to seductive syncretism, plague stopped by spear.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 10-13's Phinehas's covenant of peace — 'because he was zealous for his God' — is what Ps 106:30-31 echoes: 'this was credited to him as righteousness for endless generations.' The same crediting-as-righteousness language threads forward to Rom 4.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 12-13's covenant of peace and 'lasting priesthood' grants Phinehas's line continuity. The redemptive arc keeps the priesthood faithful through a son's zeal, even as the priestly father's generation dies in the wilderness.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num26.json
+++ b/content/hermeneutic_lenses/chapters/num26.json
@@ -1,0 +1,36 @@
+{
+  "lenses": [
+    {
+      "lens_id": "literary",
+      "guidance": "vv 1-51 reproduces the form of Num 1's census but with the new generation. The structure is not redundant — it's covenant accounting. Same tribes, fresh names, renewed roster. The form witnesses that the wilderness verdict has run its course.",
+      "panel_filter": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ],
+      "panel_order": [
+        "lit",
+        "milgrom",
+        "ashley",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "redemptive",
+      "guidance": "vv 64-65's note — 'not one of them was among those counted by Moses and Aaron... for the LORD had told those Israelites they would surely die in the wilderness' — closes a covenant chapter. The redemptive arc continues with the next generation.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes",
+        "calvin"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "calvin",
+        "themes"
+      ]
+    }
+  ]
+}

--- a/content/hermeneutic_lenses/chapters/num27.json
+++ b/content/hermeneutic_lenses/chapters/num27.json
@@ -1,0 +1,50 @@
+{
+  "lenses": [
+    {
+      "lens_id": "canonical",
+      "guidance": "vv 1-11's case of Zelophehad's daughters — inheritance preserved through women when no son survives — threads across Scripture into Josh 17:3-6 (the case applied) and the principle of legal precedent. The chapter's verses extend through later texts.",
+      "panel_filter": [
+        "cross",
+        "thread",
+        "themes"
+      ],
+      "panel_order": [
+        "thread",
+        "cross",
+        "themes"
+      ]
+    },
+    {
+      "lens_id": "mission",
+      "guidance": "vv 1-11's daughters bringing their case to Moses, the priest, and the leaders — and being heard — extends covenant participation. The narrative gives the women voice in the assembly; the LORD answers with statute. Inclusion runs outward.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    },
+    {
+      "lens_id": "typological",
+      "guidance": "vv 12-23's commissioning of Joshua — laid hands upon, given some of Moses's authority — prefigures Christ. The shadow runs from this Joshua (Yehoshua) to the New Testament Yeshua, the greater Joshua who leads his people into eschatological rest.",
+      "panel_filter": [
+        "cross",
+        "mac",
+        "calvin",
+        "thread"
+      ],
+      "panel_order": [
+        "mac",
+        "cross",
+        "thread",
+        "calvin"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Batch 6 of the Pentateuch-rest pilot tracked under #1782 — third batch of Numbers. Adds 33 hermeneutic-lens entries across Numbers 19–27: red heifer, Meribah and Aaron's death, bronze serpent, the Balaam oracles, Baal Peor, the second census, Zelophehad's daughters and Joshua's commissioning.

This is the densest peak stretch in Numbers; three consecutive chapters (num19, num20, num21) each get the full 5-lens spread.

## Per-chapter distribution (33 total)

| Chapter | Lenses | Why |
|---|---|---|
| **num19 (red heifer)** | **5** | **theology peak** — Heb 9:13-14 explicit anchor; Heb 13:11-12 outside-the-camp |
| **num20 (Meribah, Aaron's death)** | **5** | **peak** — 1 Cor 10:4 "that rock was Christ"; Moses's disqualification |
| **num21 (bronze serpent)** | **5** | **peak** — Jn 3:14-15, Christ explicitly cites this passage |
| num22 (Balaam summoned) | 3 | speaking donkey + canonical 2 Pet/Jude/Rev warning + three-answers devotional |
| num23 (first/second oracles) | 3 | identical-form literary doublet + immutability oracle (v 19) + covenant verdict |
| **num24 (third/fourth oracles, star from Jacob)** | **4** | star-of-Jacob christocentric + royal-type + canonical (Qumran/rabbinic/Mt 2) + foreign-prophet mission |
| num25 (Baal Peor + Phinehas) | 3 | two-movement structure + Ps 106:30-31 / Rom 4 echo + covenant of peace |
| num26 (second census) | 2 | parallel-form literary + redemptive note on the verdict's expiration |
| num27 (Zelophehad + Joshua) | 3 | inheritance precedent canonical + women-heard mission + Joshua-typology |

Avg 3.7 entries/ch — same density as batch 5. With three consecutive 5-lens chapters this is the most concentrated theology stretch in the pilot to date.

## Theological highlights

- **num19 (red heifer):** the heifer slain *outside the camp* (vv 3-4) with ashes mixed for purification. Heb 9:13-14 names it: "how much more, then, will the blood of Christ... cleanse our consciences." Heb 13:11-12 reads the location christologically — Jesus suffered "outside the city gate." Hyssop (vv 17-19) threads from Passover (Ex 12:22) through Ps 51:7. Adummah's root shared with adam, ground, and dam (blood) — earth, humanity, and blood gathered in a single descriptor.
- **num20 (Meribah):** vv 7-11's struck rock identified at 1 Cor 10:4 as Christ. The two-strikes-vs-once typological pattern (Ex 17 strike, Num 20 speak): Christ smitten once for sin (Heb 9:28); thereafter we speak. Moses's disqualification (v 12) cited at Ps 106:32-33 and Deut 32:51.
- **num21 (bronze serpent):** Christ explicitly cites this chapter at Jn 3:14-15. The looking-and-living pattern is the gospel's first paradigm — the bitten Israelite is healed not by climbing the pole but by faith's gaze. 2 Kgs 18:4's Hezekiah-breaks-Nehushtan included as canonical caution against idolizing the symbol once it's served its purpose.
- **num24 (star from Jacob):** v 17 read messianically across three reception streams — Qumran (CD 7, 4Q175), rabbinic (bar-Kokhba), Mt 2:2 ("we have seen his star"). The mission lens captures the oracle being delivered by a *foreign prophet* to a *foreign king* on behalf of nations — gospel proclamation through an unlikely vessel.
- **num25 (Phinehas):** Ps 106:30-31's "credited to him as righteousness for endless generations" carries the same crediting-language Paul uses of Abraham at Rom 4. Linked but distinct doctrines; the canonical lens connects them carefully.
- **num27 (Joshua commissioning):** vv 12-23's commissioning prefigures Christ — the Hebrew name Yehoshua is the same name as Yeshua/Jesus. The greater Joshua leads his people into eschatological rest (Heb 4:8-11).

## Pipeline gate results

```
schema_validator.py        147304 passed, 0 failed, 19 warnings (pre-existing ESV warns)
lens_quality_scorer.py     33/33 entries at 100/100 (per-chapter run, floor=100)
build_sqlite.py            scripture.db green, hermeneutic_lenses chapter rows = 561
                           (= 528 baseline from #1805 + 33 batch 6; matches expected)
validate_sqlite.py         101 passed, 0 failed, 2 warnings (pre-existing embeddings/prompts)
```

Per-chapter SQLite distribution post-build (`chapter_lens_content`):
```
num19: 5   num20: 5   num21: 5   num22: 3   num23: 3   num24: 4   num25: 3   num26: 2   num27: 3
```

## Length discipline

All entries authored to a 250-char target with 30-char headroom against the 280 ceiling. Actual range: **212–249 chars**. Median ~237. Four entries initially landed over target on first pass (260, 254, 251, 251); all trimmed to under 250 before commit.

## Filler / token guards

- All six banned filler patterns verified absent at authoring time.
- **Rubric-token trap:** every entry uses a token from its own lens's rubric. Specifically verified: typological entries use `type` / `pattern` / `prefigures` / `shadow`; canonical entries use `canon` / `echoes` / `thread` / `across Scripture` / `throughout Scripture`; christocentric entries name `Christ` / `Jesus` / `Son of Man` explicitly; mission entries use `nations` / `outward` / `gospel proclamation`.

## Plagiarism guards on iconic chapters

- **num19 (red heifer):** five lenses anchor on five different verse ranges (vv 2-3 grammatical adummah, vv 2-10 typological-Heb 9, vv 3-4 christocentric outside-the-camp, vv 11-22 canonical death-defilement, vv 17-19 redemptive hyssop). No restating "the heifer was burned and the ashes mixed with water" beyond the grammatical anchor.
- **num21 (bronze serpent):** christocentric lens carries Jn 3:14-15 (Christ's own citation); typological lens reads the look-of-faith pattern *separate* from the cross verse; canonical lens adds the 2 Kgs 18:4 Nehushtan thread. The famous "lifted up like the snake" comparison appears only once (in the christocentric lens, where Christ's own quotation requires it).
- **num24 (Balaam's fourth oracle):** the four lenses anchor on different angles — christocentric on Mt 2 reception, typological on Rev 22:16 inheritance, canonical on multi-stream reception, mission on the foreign-prophet vehicle. v 17 is named multiple times but the reading framework differs in each.

## Watch list for tier-2 audit

These are the entries most worth a human spot-check during accuracy auditing:

1. **num20 typological** — "Christ smitten once for sin (Heb 9:28); thereafter we speak, not strike." The two-strikes-vs-speak typology is well-developed in Reformed and patristic exegesis (Calvin notes it; Henry expands on it) but reads as somewhat compressed in this entry. Could be sharpened or made more conditional in audit.
2. **num21 typological** — "The shadow prefigures justification by faith — the look at the lifted-up one is what saves." Sound Reformed reading; the "justification by faith" link is theological rather than verse-cited (Jn 3:16 is the closest direct anchor). Defensible.
3. **num24 canonical** — Qumran (CD 7, 4Q175) citation. Both references are accurate to the Qumran corpus (CD 7:18-21 for the star-and-scepter; 4Q175 for the testimonia text quoting Num 24:15-17). Worth confirming the formatting is acceptable.
4. **num25 canonical** — "the same crediting-as-righteousness language threads forward to Rom 4." Ps 106:31 uses *chashav* (credit/reckon), the same verb Gen 15:6 uses of Abraham, which Paul picks up at Rom 4. The verbal link is real; the theological synthesis (Phinehas → Abraham → Rom 4) is interpretive but well-attested in Reformed exegesis (Calvin, Schreiner).
5. **num27 typological** — Yehoshua/Yeshua name connection. Linguistically accurate; the typological extension is patristic/Reformed standard but worth a reviewer's eye.

## Out of scope

- No new content generation in `content/numbers/{N}.json` itself.
- No app code changes.
- No CI workflow changes.
- `app/assets/db-manifest.json` and `app/assets/explore-images.json` drift was checked out before staging.

## Rollback

`git revert <merge-commit>` is sufficient. No schema changes, no migration, no R2 mutation.

## Refs

- Epic: #820 (Hermeneutic Lenses)
- Tracker: #1782 (Pentateuch-rest pilot)
- Prior PRs: #1797–#1800 (Exodus, all merged), #1801 / #1802 / #1803 (Leviticus, all merged), #1804 / #1805 (Numbers 1–18, both merged).

Numbers 28–36 likely up next as batch 7 — closes Numbers (festival calendar, vows, conquest of Midian, journey log, cities of refuge, daughters of Zelophehad codified). Then Deuteronomy.
