### PR TITLE
fix(app): clear lint warnings breaking EAS deploy

### DIFF
--- a/app/src/hooks/useChapterData.ts
+++ b/app/src/hooks/useChapterData.ts
@@ -45,6 +45,7 @@ export function useChapterData(bookId: string | null, chapterNum: number): Chapt
     if (!bookId) {
       // No book to load: clear the initial loading flag so consumers can
       // render a not-found/empty state instead of an indefinite skeleton.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsLoading(false);
       return;
     }

--- a/app/src/hooks/useDifficultPassages.ts
+++ b/app/src/hooks/useDifficultPassages.ts
@@ -289,7 +289,10 @@ export function useDifficultPassage(passageId: string | undefined): DifficultPas
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadData();
-    // Invalidate any in-flight load on unmount / passageId change.
+    // Invalidate any in-flight load on unmount / passageId change. We
+    // intentionally mutate the live ref here (not a copied value) so a load
+    // still in flight sees the bumped generation and drops its result.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     return () => { genRef.current++; };
   }, [loadData]);
 

--- a/app/src/services/connectivity.ts
+++ b/app/src/services/connectivity.ts
@@ -16,7 +16,6 @@ type Listener = (connected: boolean) => void;
 let _connected = true;
 const _listeners = new Set<Listener>();
 let _started = false;
-let _polling = false;
 let _pollTimer: ReturnType<typeof setInterval> | null = null;
 let _netinfoUnsub: (() => void) | null = null;
 
@@ -79,7 +78,6 @@ export function startMonitoring(): void {
   // Polling fallback: check reachability every 15 seconds.
   // Require two consecutive failures before marking offline so a single
   // slow/blocked fetch on startup doesn't flash the banner incorrectly.
-  _polling = true;
   let _consecutiveFails = 0;
   const check = async () => {
     try {
@@ -116,7 +114,6 @@ export function stopMonitoring(): void {
     clearInterval(_pollTimer);
     _pollTimer = null;
   }
-  _polling = false;
   _started = false;
   _listeners.clear();
 }


### PR DESCRIPTION
## Problem

`master` is red: **App Deploy (EAS) / Lint and publish EAS update** failed. That job runs `npm run lint` (`eslint src/ --max-warnings 0`), which tripped on three warnings introduced by the code-review changes in #1827. The standalone PR `lint` check didn't gate on warnings the same way, so they slipped through on that PR.

## Fixes (3 warnings → 0)

- **`useChapterData.ts`** — synchronous `setIsLoading(false)` in the no-`bookId` effect branch tripped `react-hooks/set-state-in-effect`. Disabled inline, matching how the rest of the codebase handles intentional cases of this rule.
- **`useDifficultPassages.ts`** — the effect cleanup mutates the live `genRef.current` to invalidate an in-flight load, which `react-hooks/exhaustive-deps` flags as a ref-in-cleanup risk. The live ref is intentional (a copied value wouldn't invalidate the running load); disabled inline with a rationale comment.
- **`connectivity.ts`** — removed the now-unused `_polling` flag (the start guard became `_started` in the duplicate-listener fix), clearing `@typescript-eslint/no-unused-vars`.

## Verification

`npm run lint` → exit 0, `tsc --noEmit` clean, and the affected test suites (`useChapterData`, `useDifficultPassages`, `connectivity`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjYFnGX1vcGk4h5Lz3xmng)_